### PR TITLE
[Bookings] Refactor caching strategy to handle stale data cleanup for all filters

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingDto.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingDto.kt
@@ -21,6 +21,6 @@ data class BookingDto(
     @SerializedName("parent_id") val parentId: Long,
     @SerializedName("person_counts") val personCounts: List<Int>?,
     @SerializedName("local_timezone") val localTimezone: String,
-    @SerializedName("attendance_status") val attendanceStatus: String = "",
+    @SerializedName("attendance_status") val attendanceStatus: String?,
     @SerializedName("note") val note: String? = null,
 )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingDtoMapper.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingDtoMapper.kt
@@ -49,7 +49,7 @@ internal class BookingDtoMapper @Inject constructor(
         parentId = parentId,
         personCounts = personCounts?.map { it.toLong() },
         localTimezone = localTimezone,
-        attendanceStatus = BookingEntity.AttendanceStatus.fromKey(attendanceStatus),
+        attendanceStatus = BookingEntity.AttendanceStatus.fromKey(attendanceStatus.orEmpty()),
         note = note.orEmpty(),
         order = orderEntity?.toBookingOrderInfo(orderItemId) ?: BookingOrderInfo(
             productInfo = productsDao.getProduct(localSiteId.value, productId)?.let {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.HeadersParser
 import org.wordpress.android.util.AppLog
-import java.time.Clock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -27,7 +26,6 @@ class BookingsStore @Inject internal constructor(
     private val bookingDtoMapper: BookingDtoMapper,
     private val headersParser: HeadersParser,
     private val coroutineEngine: CoroutineEngine,
-    private val clock: Clock,
 ) {
     suspend fun fetchBookings(
         site: SiteModel,
@@ -60,22 +58,17 @@ class BookingsStore @Inject internal constructor(
                     // If filters are applied, only clear entries that match the applied filters,
                     // otherwise (no filters) clear all entries for the site.
                     if (page == 1 && query.isNullOrEmpty()) {
-                        when {
-                            filters == BookingFilters.EMPTY -> {
+                        when (filters) {
+                            BookingFilters.EMPTY -> {
                                 bookingsDao.replaceAllForSite(site.localId(), entities)
                             }
 
-                            filters.dateRange != null && filters.isTodayOrUpcoming -> {
+                            else -> {
                                 bookingsDao.cleanAndUpsertBookings(
                                     site.localId(),
-                                    filters.dateRange,
+                                    filters,
                                     entities
                                 )
-                            }
-
-                            else -> {
-                                // For any other filters, avoid deletions to prevent removing unrelated cached items
-                                bookingsDao.insertOrReplace(entities)
                             }
                         }
                     } else {
@@ -97,13 +90,6 @@ class BookingsStore @Inject internal constructor(
             }
         }
     }
-
-    private val BookingFilters.isTodayOrUpcoming: Boolean
-        get() {
-            val today = BookingsDateRangePresets.today(clock)
-            val upcoming = BookingsDateRangePresets.upcoming(clock)
-            return (dateRange == today || dateRange == upcoming) && enabledFiltersCount == 1
-        }
 
     fun observeBookings(
         site: SiteModel,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -67,8 +67,7 @@ class BookingsStore @Inject internal constructor(
                         }
 
                         else -> {
-                            // Paging or Searching: just insert or update the new data.
-                            bookingsDao.insertOrReplace(entities)
+                            bookingsDao.upsert(entities)
                         }
                     }
 
@@ -134,7 +133,7 @@ class BookingsStore @Inject internal constructor(
                             orderEntity = orderResult?.model,
                         )
                     }
-                    bookingsDao.insertOrReplace(listOf(entity))
+                    bookingsDao.upsert(listOf(entity))
                     WooResult(entity)
                 }
 
@@ -170,7 +169,7 @@ class BookingsStore @Inject internal constructor(
                 val entity = with(bookingDtoMapper) {
                     response.result.toEntity(site.localId())
                 }
-                bookingsDao.insertOrReplace(entity)
+                bookingsDao.upsert(entity)
                 WooResult(entity)
             }
 
@@ -214,7 +213,7 @@ class BookingsStore @Inject internal constructor(
                     if (updatedBookingEntity == null) {
                         return@withDefaultContext WooResult(WooError(GENERIC_ERROR, UNKNOWN))
                     } else {
-                        bookingsDao.insertOrReplace(updatedBookingEntity)
+                        bookingsDao.upsert(updatedBookingEntity)
                         return@withDefaultContext WooResult(updatedBookingEntity)
                     }
                 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -54,26 +54,24 @@ class BookingsStore @Inject internal constructor(
                             )
                         }
                     }
-                    // Clear existing bookings when fetching the first page.
-                    // If filters are applied, only clear entries that match the applied filters,
-                    // otherwise (no filters) clear all entries for the site.
-                    if (page == 1 && query.isNullOrEmpty()) {
-                        when (filters) {
-                            BookingFilters.EMPTY -> {
-                                bookingsDao.replaceAllForSite(site.localId(), entities)
-                            }
 
-                            else -> {
-                                bookingsDao.cleanAndUpsertBookings(
-                                    site.localId(),
-                                    filters,
-                                    entities
-                                )
-                            }
+                    when {
+                        page == 1 && query.isNullOrEmpty() && filters == BookingFilters.EMPTY -> {
+                            // Refreshing with no filters applied: perform a bulk delete.
+                            bookingsDao.replaceAllForSite(site.localId(), entities)
                         }
-                    } else {
-                        bookingsDao.insertOrReplace(entities)
+
+                        page == 1 && query.isNullOrEmpty() -> {
+                            // Refreshing with filters applied: selectively remove only the stale entries.
+                            bookingsDao.cleanAndUpsertBookings(site.localId(), filters, entities)
+                        }
+
+                        else -> {
+                            // Paging or Searching: just insert or update the new data.
+                            bookingsDao.insertOrReplace(entities)
+                        }
                     }
+
                     val totalPages = headersParser.getTotalPages(response.headers)
                     // Determine if we can load more from the total pages header if available, otherwise
                     // infer it from the number of items returned

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -8,7 +8,6 @@ import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsOrderOption
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import org.wordpress.android.fluxc.persistence.entity.BookingResourceEntity
@@ -78,44 +77,67 @@ interface BookingsDao {
             WHERE localSiteId = :localSiteId
             AND (:startDateBefore IS NULL OR start <= :startDateBefore)
             AND (:startDateAfter IS NULL OR start >= :startDateAfter)
-            AND ((:idsSize = 0) OR id NOT IN (:ids))
+            AND (:customerId IS NULL OR customerId = :customerId)
+            AND ((:attendanceStatusesSize = 0) OR attendanceStatus IN (:attendanceStatuses))
+            AND ((:resourceIdsSize = 0) OR resourceId IN (:resourceIds))
+            AND ((:productIdsSize = 0) OR productId IN (:productIds))
+            AND ((:keepIdsSize = 0) OR id NOT IN (:keepIds))
         """
     )
-    suspend fun deleteForSiteWithDateRangeFilter(
+    suspend fun deleteStaleBookings(
         localSiteId: LocalId,
         startDateBefore: Long?,
         startDateAfter: Long?,
-        ids: List<Long>,
-        idsSize: Int,
+        customerId: Long?,
+        resourceIds: List<Long>,
+        resourceIdsSize: Int,
+        attendanceStatuses: List<String>,
+        attendanceStatusesSize: Int,
+        productIds: List<Long>,
+        productIdsSize: Int,
+        keepIds: List<Long>,
+        keepIdsSize: Int,
     )
 
-    private suspend fun deleteForSiteWithDateRangeFilter(
+    private suspend fun deleteStaleBookings(
         localSiteId: LocalId,
-        dateRange: BookingsFilterOption.DateRange,
-        ids: List<Long>
+        filters: BookingFilters,
+        keepIds: List<Long>
     ) {
-        deleteForSiteWithDateRangeFilter(
+        val resourceIdsKeySet = filters.teamMembers.values.map { it.value }
+        val attendanceStatusKeySet = filters.attendanceStatuses.values.map { it.key }
+        val productIds = filters.serviceEvents.values.map { it.productId }
+
+        deleteStaleBookings(
             localSiteId = localSiteId,
-            startDateBefore = dateRange.before?.epochSecond,
-            startDateAfter = dateRange.after?.epochSecond,
-            ids = ids,
-            idsSize = ids.size,
+            startDateBefore = filters.dateRange.before?.epochSecond,
+            startDateAfter = filters.dateRange.after?.epochSecond,
+            customerId = filters.customer?.customerId,
+            resourceIds = resourceIdsKeySet.toList(),
+            resourceIdsSize = resourceIdsKeySet.size,
+            attendanceStatuses = attendanceStatusKeySet.toList(),
+            attendanceStatusesSize = attendanceStatusKeySet.size,
+            productIds = productIds,
+            productIdsSize = productIds.size,
+            keepIds = keepIds,
+            keepIdsSize = keepIds.size
         )
     }
 
     /**
-     * Delete Booking entities that are not present in the new list and then insert the new entities
+     * Delete Booking entities that match the filters but are not present in the new list,
+     * and then insert the new entities.
      */
     @Transaction
     suspend fun cleanAndUpsertBookings(
         localSiteId: LocalId,
-        dateRange: BookingsFilterOption.DateRange,
+        filters: BookingFilters,
         entities: List<BookingEntity>,
     ) {
-        deleteForSiteWithDateRangeFilter(
+        deleteStaleBookings(
             localSiteId = localSiteId,
-            dateRange = dateRange,
-            ids = entities.map { it.id.value },
+            filters = filters,
+            keepIds = entities.map { it.id.value },
         )
         insertOrReplace(entities)
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -56,10 +56,10 @@ interface BookingsDao {
     fun observeBookingsCount(localSiteId: LocalId): Flow<Long>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertOrReplace(entity: BookingEntity): Long
+    suspend fun upsert(entity: BookingEntity): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertOrReplace(entities: List<BookingEntity>)
+    suspend fun upsert(entities: List<BookingEntity>)
 
     @Query("DELETE FROM Bookings WHERE localSiteId = :localSiteId")
     suspend fun deleteAllForSite(localSiteId: LocalId)
@@ -67,7 +67,7 @@ interface BookingsDao {
     @Transaction
     suspend fun replaceAllForSite(siteId: LocalId, entities: List<BookingEntity>) {
         deleteAllForSite(siteId)
-        insertOrReplace(entities)
+        upsert(entities)
     }
 
     @Suppress("LongParameterList")
@@ -139,7 +139,7 @@ interface BookingsDao {
             filters = filters,
             keepIds = entities.map { it.id.value },
         )
-        insertOrReplace(entities)
+        upsert(entities)
     }
 
     fun observeBookings(
@@ -183,10 +183,10 @@ interface BookingsDao {
     suspend fun getResource(localSiteId: LocalId, resourceId: Long): BookingResourceEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertOrReplace(resource: BookingResourceEntity): Long
+    suspend fun upsert(resource: BookingResourceEntity): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertOrReplaceResources(resources: List<BookingResourceEntity>)
+    suspend fun upsertResources(resources: List<BookingResourceEntity>)
 
     @Query("DELETE FROM BookingResources WHERE localSiteId = :localSiteId")
     suspend fun deleteAllResourcesForSite(localSiteId: LocalId)
@@ -194,6 +194,6 @@ interface BookingsDao {
     @Transaction
     suspend fun replaceAllResourcesForSite(siteId: LocalId, resources: List<BookingResourceEntity>) {
         deleteAllResourcesForSite(siteId)
-        insertOrReplaceResources(resources)
+        upsertResources(resources)
     }
 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingDtoMapperTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingDtoMapperTest.kt
@@ -270,7 +270,8 @@ class BookingDtoMapperTest {
         orderItemId = orderItemId,
         parentId = parentId,
         personCounts = personCounts,
-        localTimezone = localTimezone
+        localTimezone = localTimezone,
+        attendanceStatus = null,
     )
 
     private fun createSampleOrderEntity() = OrderEntity(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
@@ -50,7 +50,6 @@ class BookingsStoreTest {
             bookingDtoMapper = bookingDtoMapper,
             headersParser = headersParser,
             coroutineEngine = CoroutineEngine(EmptyCoroutineContext, mock()),
-            clock = clock,
         )
     }
 

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
@@ -209,14 +209,14 @@ class BookingsStoreTest {
             // We delete only matching filtered rows then insert the fetched page
             verify(bookingsDao).cleanAndUpsertBookings(
                 any(),
-                any<BookingsFilterOption.DateRange>(),
+                any<BookingFilters>(),
                 any<List<BookingEntity>>()
             )
             verify(bookingsDao, never()).replaceAllForSite(any(), any())
         }
 
     @Test
-    fun `given page 1, today date filter, customer filter and no query, when fetchBookings, then only insertOrReplace is called`(): Unit =
+    fun `given page 1, today date filter, customer filter and no query, when fetchBookings, then cleanAndUpsertBookings is called`(): Unit =
         runBlocking {
             // given
             val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
@@ -250,12 +250,12 @@ class BookingsStoreTest {
             // then
             assertThat(result.isError).isFalse()
             // We delete only matching filtered rows then insert the fetched page
-            verify(bookingsDao).upsert(any<List<BookingEntity>>())
-            verify(bookingsDao, never()).cleanAndUpsertBookings(
+            verify(bookingsDao).cleanAndUpsertBookings(
                 any(),
-                any<BookingsFilterOption.DateRange>(),
+                any<BookingFilters>(),
                 any<List<BookingEntity>>()
             )
+            verify(bookingsDao, never()).upsert(any<List<BookingEntity>>())
             verify(bookingsDao, never()).replaceAllForSite(any(), any())
         }
 
@@ -295,7 +295,7 @@ class BookingsStoreTest {
             // We delete only matching filtered rows then insert the fetched page
             verify(bookingsDao).cleanAndUpsertBookings(
                 any(),
-                any<BookingsFilterOption.DateRange>(),
+                any<BookingFilters>(),
                 any<List<BookingEntity>>()
             )
             verify(bookingsDao, never()).replaceAllForSite(any(), any())
@@ -339,7 +339,7 @@ class BookingsStoreTest {
             verify(bookingsDao).upsert(any<List<BookingEntity>>())
             verify(bookingsDao, never()).replaceAllForSite(any(), any())
             verify(bookingsDao, never())
-                .cleanAndUpsertBookings(any(), any<BookingsFilterOption.DateRange>(), any<List<BookingEntity>>())
+                .cleanAndUpsertBookings(any(), any<BookingFilters>(), any<List<BookingEntity>>())
         }
 
     @Test
@@ -376,13 +376,13 @@ class BookingsStoreTest {
             verify(bookingsDao).replaceAllForSite(any(), any())
             verify(bookingsDao, never()).cleanAndUpsertBookings(
                 any(),
-                any<BookingsFilterOption.DateRange>(),
+                any<BookingFilters>(),
                 any<List<BookingEntity>>()
             )
         }
 
     @Test
-    fun `given page 1 with custom date range filter and no query, when fetchBookings, then only insertOrReplace is called`(): Unit =
+    fun `given page 1 with custom date range filter and no query, when fetchBookings, then cleanAndUpsertBookings is called`(): Unit =
         runBlocking {
             // given
             val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
@@ -415,11 +415,9 @@ class BookingsStoreTest {
 
             // then
             assertThat(result.isError).isFalse()
-            verify(bookingsDao).upsert(any<List<BookingEntity>>())
-            verify(bookingsDao, never()).replaceAllForSite(any(), any())
-            verify(bookingsDao, never()).cleanAndUpsertBookings(
+            verify(bookingsDao).cleanAndUpsertBookings(
                 any(),
-                any<BookingsFilterOption.DateRange>(),
+                any<BookingFilters>(),
                 any<List<BookingEntity>>()
             )
         }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
@@ -63,7 +63,7 @@ class BookingsStoreTest {
             whenever(bookingsDao.getBooking(TEST_LOCAL_SITE_ID, dto.id)).thenReturn(storedBooking)
             whenever(bookingsRestClient.updateBooking(site, dto.id, BookingUpdatePayload(note = "n")))
                 .thenReturn(WooPayload(dto))
-            whenever(bookingsDao.insertOrReplace(any<BookingEntity>())).thenReturn(1L)
+            whenever(bookingsDao.upsert(any<BookingEntity>())).thenReturn(1L)
 
             // when
             val result = sut.updateBooking(
@@ -77,7 +77,7 @@ class BookingsStoreTest {
             assertThat(result.isError).isFalse()
             assertThat(result.model).isNotNull
             // The store preserves the stored order on the mapped entity
-            verify(bookingsDao).insertOrReplace(argThat<BookingEntity> { this.order == storedBooking.order })
+            verify(bookingsDao).upsert(argThat<BookingEntity> { this.order == storedBooking.order })
         }
 
     @Test
@@ -91,7 +91,7 @@ class BookingsStoreTest {
             whenever(orderStore.fetchSingleOrderSync(site, dto.orderId)).thenReturn(WooResult(fetchedOrder))
             whenever(bookingsRestClient.updateBooking(site, dto.id, BookingUpdatePayload(status = Status.Confirmed)))
                 .thenReturn(WooPayload(dto))
-            whenever(bookingsDao.insertOrReplace(any<BookingEntity>())).thenReturn(1L)
+            whenever(bookingsDao.upsert(any<BookingEntity>())).thenReturn(1L)
 
             // when
             val result = sut.updateBooking(
@@ -105,7 +105,7 @@ class BookingsStoreTest {
             assertThat(result.isError).isFalse()
             val expected = with(bookingDtoMapper) { dto.toEntity(TEST_LOCAL_SITE_ID, fetchedOrder) }
             assertThat(result.model).isEqualTo(expected)
-            verify(bookingsDao).insertOrReplace(expected)
+            verify(bookingsDao).upsert(expected)
             verify(bookingsDao, never()).getBooking(TEST_LOCAL_SITE_ID, dto.id)
         }
 
@@ -127,7 +127,7 @@ class BookingsStoreTest {
 
         // then
         assertThat(result.isError).isTrue()
-        verify(bookingsDao, never()).insertOrReplace(any<BookingEntity>())
+        verify(bookingsDao, never()).upsert(any<BookingEntity>())
     }
 
     @Test
@@ -170,7 +170,7 @@ class BookingsStoreTest {
             assertThat(result.isError).isFalse
             verify(bookingsDao).getBooking(TEST_LOCAL_SITE_ID, dto.id)
             // The store preserves the stored order on the mapped entity
-            verify(bookingsDao).insertOrReplace(argThat<BookingEntity> { this.order == storedBooking.order })
+            verify(bookingsDao).upsert(argThat<BookingEntity> { this.order == storedBooking.order })
         }
 
     @Test
@@ -250,7 +250,7 @@ class BookingsStoreTest {
             // then
             assertThat(result.isError).isFalse()
             // We delete only matching filtered rows then insert the fetched page
-            verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
+            verify(bookingsDao).upsert(any<List<BookingEntity>>())
             verify(bookingsDao, never()).cleanAndUpsertBookings(
                 any(),
                 any<BookingsFilterOption.DateRange>(),
@@ -336,7 +336,7 @@ class BookingsStoreTest {
 
             // then
             assertThat(result.isError).isFalse()
-            verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
+            verify(bookingsDao).upsert(any<List<BookingEntity>>())
             verify(bookingsDao, never()).replaceAllForSite(any(), any())
             verify(bookingsDao, never())
                 .cleanAndUpsertBookings(any(), any<BookingsFilterOption.DateRange>(), any<List<BookingEntity>>())
@@ -415,7 +415,7 @@ class BookingsStoreTest {
 
             // then
             assertThat(result.isError).isFalse()
-            verify(bookingsDao).insertOrReplace(any<List<BookingEntity>>())
+            verify(bookingsDao).upsert(any<List<BookingEntity>>())
             verify(bookingsDao, never()).replaceAllForSite(any(), any())
             verify(bookingsDao, never()).cleanAndUpsertBookings(
                 any(),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR addresses a data consistency issue where stale booking data could persist in the local cache when applying filters.

Previously, when fetching filtered bookings, we used a simple `insertOrReplace` strategy. This updated existing bookings but failed to remove bookings that were no longer present in the server response (e.g., deleted bookings or bookings that no longer matched the filter). 

While we had previously addressed this issue specifically for **Today** and **Upcoming** tabs (#15022), this fix extends that same robust cleanup logic to all filter types. It uses a single optimized SQL query to:

1. Identify local bookings that match the current filter criteria.
2. Delete those that are missing from the fresh server response.
3. Insert/Update the new bookings.

**Pagination & Data Sync Strategy**
To ensure data integrity, **we clear the entire cache for the active filter when refreshing the list (page 1).**
Why clear pages 2, 3, etc.? Without backend support for deleted items, we can't reliably sync a shifting list client-side.
- _The Risk:_ If a new booking is added, items shift from Page 1 to Page 2. If we only update Page 1, our logic would see the shifted item as "missing" from Page 1 and delete it, causing accidental data loss.
- _The Solution:_ We prioritize data accuracy over retaining offline data for older pages.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Make sure you have some bookings in the Today and Upcoming tabs
2. Launch the app
5. Go to Today and load the bookings
6. Trash one of the booking from the Today tab via the web
7. Refresh the Today tab in the app
8. Verify the booking was removed
9. Repeat 3-6 for the **All** tab.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

**Before**

https://github.com/user-attachments/assets/9f328a8d-1431-4eef-addd-62a7ca50723e

**After**

https://github.com/user-attachments/assets/fbbe07b5-6429-4098-8cc8-15da490129f2

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
