### PR TITLE
[HACK] Add auto-login universal link for debug builds

### DIFF
--- a/WooCommerce/src/debug/AndroidManifest.xml
+++ b/WooCommerce/src/debug/AndroidManifest.xml
@@ -41,7 +41,7 @@
             android:name=".ui.login.auto.AutoLoginActivity"
             android:exported="true"
             android:theme="@style/Theme.Woo.Splash">
-            <intent-filter android:autoVerify="true">
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/WooCommerce/src/debug/AndroidManifest.xml
+++ b/WooCommerce/src/debug/AndroidManifest.xml
@@ -37,6 +37,22 @@
             android:exported="true"
             tools:replace="android:exported" />
 
+        <activity
+            android:name=".ui.login.auto.AutoLoginActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Woo.Splash">
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="https" />
+                <data android:host="woocommerce.com" />
+                <data android:path="/mobile/auto-login" />
+            </intent-filter>
+        </activity>
+
     </application>
 
 </manifest>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/auto/AutoLoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/auto/AutoLoginActivity.kt
@@ -1,0 +1,47 @@
+package com.woocommerce.android.ui.login.auto
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.lifecycleScope
+import com.woocommerce.android.ui.login.LoginActivity
+import com.woocommerce.android.ui.main.MainActivity
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.login.LoginMode
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class AutoLoginActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var autoLoginHandler: AutoLoginHandler
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
+        super.onCreate(savedInstanceState)
+
+        val uri = intent?.data
+        if (uri == null || !autoLoginHandler.isAutoLoginUri(uri)) {
+            finish()
+            return
+        }
+
+        autoLoginHandler.handleAutoLogin(
+            uri = uri,
+            scope = lifecycleScope,
+            onSuccess = {
+                startActivity(Intent(this, MainActivity::class.java))
+                finish()
+            },
+            onError = { message ->
+                Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+                val loginIntent = Intent(this, LoginActivity::class.java)
+                LoginMode.WOO_LOGIN_MODE.putInto(loginIntent)
+                startActivity(loginIntent)
+                finish()
+            }
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/auto/AutoLoginHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/auto/AutoLoginHandler.kt
@@ -1,0 +1,112 @@
+package com.woocommerce.android.ui.login.auto
+
+import android.net.Uri
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.WPApiSiteRepository
+import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class AutoLoginHandler @Inject constructor(
+    private val wpApiSiteRepository: WPApiSiteRepository,
+    private val selectedSite: SelectedSite
+) {
+    companion object {
+        private const val PARAM_SITE = "site"
+        private const val PARAM_USER = "user"
+        private const val PARAM_PASSWORD = "password"
+    }
+
+    fun isAutoLoginUri(uri: Uri?): Boolean {
+        return uri?.path == "/mobile/auto-login"
+    }
+
+    fun handleAutoLogin(
+        uri: Uri,
+        scope: CoroutineScope,
+        onSuccess: () -> Unit,
+        onError: (String) -> Unit
+    ) {
+        scope.launch {
+            val result = login(uri)
+            when (result) {
+                is AutoLoginResult.Success -> onSuccess()
+                is AutoLoginResult.AlreadyLoggedIn -> onSuccess()
+                is AutoLoginResult.Error -> onError(result.message)
+            }
+        }
+    }
+
+    private sealed class AutoLoginResult {
+        data object Success : AutoLoginResult()
+        data object AlreadyLoggedIn : AutoLoginResult()
+        data class Error(val message: String) : AutoLoginResult()
+    }
+
+    private suspend fun login(uri: Uri): AutoLoginResult = withContext(Dispatchers.IO) {
+        WooLog.d(WooLog.T.LOGIN, "AutoLoginHandler: Processing auto-login URI")
+
+        if (selectedSite.exists()) {
+            WooLog.d(WooLog.T.LOGIN, "AutoLoginHandler: User already logged in")
+            return@withContext AutoLoginResult.AlreadyLoggedIn
+        }
+
+        val siteUrl = uri.getQueryParameter(PARAM_SITE)
+        val username = uri.getQueryParameter(PARAM_USER)
+        val password = uri.getQueryParameter(PARAM_PASSWORD)
+
+        if (siteUrl.isNullOrBlank() || username.isNullOrBlank() || password.isNullOrBlank()) {
+            WooLog.e(WooLog.T.LOGIN, "AutoLoginHandler: Missing required parameters")
+            return@withContext AutoLoginResult.Error("Missing required parameters: site, user, or password")
+        }
+
+        WooLog.d(WooLog.T.LOGIN, "AutoLoginHandler: Fetching site $siteUrl")
+
+        val fetchSiteResult = wpApiSiteRepository.fetchSite(
+            url = siteUrl,
+            username = username,
+            password = password
+        )
+
+        fetchSiteResult.fold(
+            onSuccess = { site ->
+                if (!site.hasWooCommerce) {
+                    WooLog.e(WooLog.T.LOGIN, "AutoLoginHandler: Site does not have WooCommerce")
+                    return@withContext AutoLoginResult.Error("Site does not have WooCommerce installed")
+                }
+
+                WooLog.d(WooLog.T.LOGIN, "AutoLoginHandler: Saving application password")
+                wpApiSiteRepository.saveApplicationPassword(site.id, username, password)
+
+                WooLog.d(WooLog.T.LOGIN, "AutoLoginHandler: Checking user eligibility")
+                val eligibilityResult = wpApiSiteRepository.checkIfUserIsEligible(site)
+
+                eligibilityResult.fold(
+                    onSuccess = { isEligible ->
+                        if (!isEligible) {
+                            WooLog.e(WooLog.T.LOGIN, "AutoLoginHandler: User is not eligible")
+                            return@withContext AutoLoginResult.Error("User does not have required permissions")
+                        }
+
+                        WooLog.d(WooLog.T.LOGIN, "AutoLoginHandler: Setting selected site")
+                        selectedSite.set(site)
+
+                        WooLog.d(WooLog.T.LOGIN, "AutoLoginHandler: Login successful")
+                        AutoLoginResult.Success
+                    },
+                    onFailure = { exception ->
+                        WooLog.e(WooLog.T.LOGIN, "AutoLoginHandler: Failed to check user eligibility", exception)
+                        AutoLoginResult.Error("Failed to verify user: ${exception.message}")
+                    }
+                )
+            },
+            onFailure = { exception ->
+                WooLog.e(WooLog.T.LOGIN, "AutoLoginHandler: Failed to fetch site", exception)
+                AutoLoginResult.Error("Failed to connect to site: ${exception.message}")
+            }
+        )
+    }
+}


### PR DESCRIPTION
### Description

Adds support for a universal link that allows automatic login using application password credentials in debug builds. This is useful for developer and testing workflows.

**URL Format:**
```
https://woocommerce.com/mobile/auto-login?site=<encoded_site_url>&user=<username>&password=<app_password>
```

**Example (with placeholder credentials):**
```
adb shell "am start -a android.intent.action.VIEW -d 'https://woocommerce.com/mobile/auto-login?site=https%3A%2F%2Fexample.com&user=testuser&password=xxxx-xxxx-xxxx-xxxx'"
```

**Behavior:**
- Debug builds only (intent filter in debug manifest)
- If already logged in, navigates directly to main screen
- On success, navigates to main screen
- On error, shows toast and opens login screen

Do not merge, as I am not sure how valuable this is for anyone so I firstly would like to ask

### Test Steps

1. Install debug build
2. Clear app data to ensure logged out state
3. Run the adb command above with valid site credentials
4. Verify the app logs in and navigates to the main screen

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.