### PR TITLE
[Woo POS][Refunds] Add "Review refund" step in POS refund flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -91,7 +91,10 @@ fun WooPosIssueRefundDialog(
                         ReviewRefundContent(
                             state = currentState,
                             onDismissRequest = onDismissRequest,
-                            onContinue = onDismissRequest,
+                            onContinue = {
+                                viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToConfirmRefundClicked)
+                                onDismissRequest()
+                            },
                             onEditRefund = {
                                 viewModel.onUIEvent(WooPosRefundUIEvent.BackToSelectItemsClicked)
                             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -401,7 +401,7 @@ private fun ReviewRefundContent(
                     isTotal = true
                 )
                 WooPosText(
-                    text = stringResource(R.string.woopos_orders_via_payment_card),
+                    text = "Via payment card ••••1456",
                     style = WooPosTypography.BodyMedium,
                     fontWeight = FontWeight.Normal,
                     color = WooPosTheme.colors.onSurfaceVariantHighest
@@ -436,7 +436,7 @@ private fun ReviewRefundContent(
                     )
                 }
                 WooPosText(
-                    text = stringResource(R.string.woopos_orders_refund_reason_default),
+                    text = "Customer bought an extra item.",
                     style = WooPosTypography.BodyMedium,
                     fontWeight = FontWeight.Normal,
                     color = WooPosTheme.colors.onSurfaceVariantHighest

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -394,7 +394,7 @@ private fun ReviewRefundContent(
                 )
             }
 
-            HorizontalDivider()
+            Divider()
 
             Column(
                 verticalArrangement = Arrangement.spacedBy(WooPosSpacing.XSmall.value)
@@ -425,8 +425,6 @@ private fun ReviewRefundContent(
                 )
             }
         }
-
-        Divider(modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value))
 
         ReviewActionButtons(
             onContinue = onContinue,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -371,10 +372,10 @@ private fun ReviewRefundContent(
                 .padding(horizontal = WooPosSpacing.XLarge.value),
             verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
         ) {
-            // Items subtotal and tax
             ReviewSummaryRow(
-                label = stringResource(
-                    R.string.woopos_orders_items_subtotal_count,
+                label = pluralStringResource(
+                    R.plurals.woopos_orders_items_subtotal_count_plural,
+                    state.itemsCount,
                     state.itemsCount
                 ),
                 value = state.formattedSubtotal,
@@ -391,7 +392,6 @@ private fun ReviewRefundContent(
                 thickness = 0.25.dp
             )
 
-            // Refund total section
             Column(
                 verticalArrangement = Arrangement.spacedBy(WooPosSpacing.XSmall.value)
             ) {
@@ -413,7 +413,6 @@ private fun ReviewRefundContent(
                 thickness = 0.25.dp
             )
 
-            // Refund reason section
             Column(
                 verticalArrangement = Arrangement.spacedBy(WooPosSpacing.XSmall.value)
             ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -78,15 +78,19 @@ fun WooPosIssueRefundDialog(
                         SelectItemsContent(
                             state = currentState,
                             onDismissRequest = onDismissRequest,
-                            onContinue = viewModel::onContinueToReview
+                            onContinue = {
+                                viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+                            }
                         )
                     }
                     WooPosRefundState.Content.RefundStep.ReviewRefund -> {
                         ReviewRefundContent(
                             state = currentState,
                             onDismissRequest = onDismissRequest,
-                            onIssueRefund = onDismissRequest,
-                            onEditRefund = viewModel::onBackToSelectItems
+                            onContinue = onDismissRequest,
+                            onEditRefund = {
+                                viewModel.onUIEvent(WooPosRefundUIEvent.BackToSelectItemsClicked)
+                            }
                         )
                     }
                 }
@@ -352,7 +356,7 @@ private fun RefundableItemRow(item: WooPosRefundableItem) {
 private fun ReviewRefundContent(
     state: WooPosRefundState.Content,
     onDismissRequest: () -> Unit,
-    onIssueRefund: () -> Unit,
+    onContinue: () -> Unit,
     onEditRefund: () -> Unit
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -444,7 +448,7 @@ private fun ReviewRefundContent(
         )
 
         ReviewActionButtons(
-            onIssueRefund = onIssueRefund,
+            onContinue = onContinue,
             onEditRefund = onEditRefund
         )
     }
@@ -507,7 +511,7 @@ private fun ReviewSummaryRow(
 
 @Composable
 private fun ReviewActionButtons(
-    onIssueRefund: () -> Unit,
+    onContinue: () -> Unit,
     onEditRefund: () -> Unit
 ) {
     Column(
@@ -518,7 +522,7 @@ private fun ReviewActionButtons(
     ) {
         WooPosButton(
             text = stringResource(R.string.continue_button),
-            onClick = onIssueRefund,
+            onClick = onContinue,
             modifier = Modifier.fillMaxWidth()
         )
         WooPosOutlinedButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -189,11 +189,7 @@ private fun SelectItemsContent(
 
         ItemsHeaderRow(itemsCount = state.itemsCount)
 
-        HorizontalDivider(
-            modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
-            color = WooPosTheme.colors.outlineVariant,
-            thickness = 0.25.dp
-        )
+        Divider(modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value))
 
         LazyColumn(
             modifier = Modifier
@@ -206,19 +202,12 @@ private fun SelectItemsContent(
             itemsIndexed(state.refundableItems) { index, item ->
                 RefundableItemRow(item = item)
                 if (index < state.refundableItems.lastIndex) {
-                    HorizontalDivider(
-                        color = WooPosTheme.colors.outlineVariant,
-                        thickness = 0.25.dp
-                    )
+                    Divider()
                 }
             }
         }
 
-        HorizontalDivider(
-            modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
-            color = WooPosTheme.colors.outlineVariant,
-            thickness = 0.25.dp
-        )
+        Divider(modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value))
 
         WooPosButton(
             text = stringResource(R.string.continue_button),
@@ -387,10 +376,7 @@ private fun ReviewRefundContent(
                 isTotal = false
             )
 
-            HorizontalDivider(
-                color = WooPosTheme.colors.outlineVariant,
-                thickness = 0.25.dp
-            )
+            Divider()
 
             Column(
                 verticalArrangement = Arrangement.spacedBy(WooPosSpacing.XSmall.value)
@@ -408,10 +394,7 @@ private fun ReviewRefundContent(
                 )
             }
 
-            HorizontalDivider(
-                color = WooPosTheme.colors.outlineVariant,
-                thickness = 0.25.dp
-            )
+            HorizontalDivider()
 
             Column(
                 verticalArrangement = Arrangement.spacedBy(WooPosSpacing.XSmall.value)
@@ -443,11 +426,7 @@ private fun ReviewRefundContent(
             }
         }
 
-        HorizontalDivider(
-            modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
-            color = WooPosTheme.colors.outlineVariant,
-            thickness = 0.25.dp
-        )
+        Divider(modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value))
 
         ReviewActionButtons(
             onContinue = onContinue,
@@ -533,6 +512,15 @@ private fun ReviewActionButtons(
             modifier = Modifier.fillMaxWidth()
         )
     }
+}
+
+@Composable
+private fun Divider(modifier: Modifier = Modifier) {
+    HorizontalDivider(
+        modifier = modifier,
+        color = WooPosTheme.colors.outlineVariant,
+        thickness = 0.25.dp
+    )
 }
 
 @WooPosPreview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -56,7 +56,7 @@ fun WooPosIssueRefundDialog(
     onDismissRequest: () -> Unit
 ) {
     val viewModel: WooPosRefundViewModel =
-        hiltViewModel<WooPosRefundViewModel, WooPosRefundViewModel.Factory> { factory ->
+        hiltViewModel<WooPosRefundViewModel, WooPosRefundViewModel.Factory>(key = "refund_$orderId") { factory ->
             factory.create(orderId)
         }
     val state by viewModel.state.collectAsStateWithLifecycle()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosItemImage
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
@@ -52,8 +53,7 @@ import java.math.BigDecimal
 @Composable
 fun WooPosIssueRefundDialog(
     orderId: Long,
-    onDismissRequest: () -> Unit,
-    onContinue: () -> Unit
+    onDismissRequest: () -> Unit
 ) {
     val viewModel: WooPosRefundViewModel =
         hiltViewModel<WooPosRefundViewModel, WooPosRefundViewModel.Factory> { factory ->
@@ -73,11 +73,23 @@ fun WooPosIssueRefundDialog(
                 LoadingContent()
             }
             is WooPosRefundState.Content -> {
-                RefundDialogContent(
-                    state = currentState,
-                    onDismissRequest = onDismissRequest,
-                    onContinue = onContinue
-                )
+                when (currentState.step) {
+                    WooPosRefundState.Content.RefundStep.SelectItems -> {
+                        SelectItemsContent(
+                            state = currentState,
+                            onDismissRequest = onDismissRequest,
+                            onContinue = viewModel::onContinueToReview
+                        )
+                    }
+                    WooPosRefundState.Content.RefundStep.ReviewRefund -> {
+                        ReviewRefundContent(
+                            state = currentState,
+                            onDismissRequest = onDismissRequest,
+                            onIssueRefund = onDismissRequest,
+                            onEditRefund = viewModel::onBackToSelectItems
+                        )
+                    }
+                }
             }
             is WooPosRefundState.Error -> {
                 ErrorContent(
@@ -159,7 +171,7 @@ private fun NoItemsContent(onDismissRequest: () -> Unit) {
 }
 
 @Composable
-private fun RefundDialogContent(
+private fun SelectItemsContent(
     state: WooPosRefundState.Content,
     onDismissRequest: () -> Unit,
     onContinue: () -> Unit
@@ -336,6 +348,188 @@ private fun RefundableItemRow(item: WooPosRefundableItem) {
     }
 }
 
+@Composable
+private fun ReviewRefundContent(
+    state: WooPosRefundState.Content,
+    onDismissRequest: () -> Unit,
+    onIssueRefund: () -> Unit,
+    onEditRefund: () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        ReviewRefundHeader(onDismissRequest = onDismissRequest)
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(horizontal = WooPosSpacing.XLarge.value),
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
+        ) {
+            // Items subtotal and tax
+            ReviewSummaryRow(
+                label = stringResource(
+                    R.string.woopos_orders_items_subtotal_count,
+                    state.itemsCount
+                ),
+                value = state.formattedSubtotal,
+                isTotal = false
+            )
+            ReviewSummaryRow(
+                label = stringResource(R.string.taxes),
+                value = state.formattedTaxes,
+                isTotal = false
+            )
+
+            HorizontalDivider(
+                color = WooPosTheme.colors.outlineVariant,
+                thickness = 0.25.dp
+            )
+
+            // Refund total section
+            Column(
+                verticalArrangement = Arrangement.spacedBy(WooPosSpacing.XSmall.value)
+            ) {
+                ReviewSummaryRow(
+                    label = stringResource(R.string.woopos_orders_refund_total),
+                    value = state.formattedTotal,
+                    isTotal = true
+                )
+                WooPosText(
+                    text = stringResource(R.string.woopos_orders_via_payment_card),
+                    style = WooPosTypography.BodyMedium,
+                    fontWeight = FontWeight.Normal,
+                    color = WooPosTheme.colors.onSurfaceVariantHighest
+                )
+            }
+
+            HorizontalDivider(
+                color = WooPosTheme.colors.outlineVariant,
+                thickness = 0.25.dp
+            )
+
+            // Refund reason section
+            Column(
+                verticalArrangement = Arrangement.spacedBy(WooPosSpacing.XSmall.value)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    WooPosText(
+                        text = stringResource(R.string.woopos_orders_refund_reason),
+                        style = WooPosTypography.BodyLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    WooPosText(
+                        text = stringResource(R.string.woopos_orders_edit_reason),
+                        style = WooPosTypography.BodyMedium,
+                        fontWeight = FontWeight.Normal,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+                WooPosText(
+                    text = stringResource(R.string.woopos_orders_refund_reason_default),
+                    style = WooPosTypography.BodyMedium,
+                    fontWeight = FontWeight.Normal,
+                    color = WooPosTheme.colors.onSurfaceVariantHighest
+                )
+            }
+        }
+
+        HorizontalDivider(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
+            color = WooPosTheme.colors.outlineVariant,
+            thickness = 0.25.dp
+        )
+
+        ReviewActionButtons(
+            onIssueRefund = onIssueRefund,
+            onEditRefund = onEditRefund
+        )
+    }
+}
+
+@Composable
+private fun ReviewRefundHeader(onDismissRequest: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(WooPosSpacing.XLarge.value),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        WooPosText(
+            text = stringResource(R.string.woopos_orders_review_refund),
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        IconButton(
+            modifier = Modifier.size(48.dp),
+            onClick = onDismissRequest,
+        ) {
+            Icon(
+                modifier = Modifier.size(32.dp),
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(R.string.close),
+                tint = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReviewSummaryRow(
+    label: String,
+    value: String,
+    isTotal: Boolean
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        WooPosText(
+            text = label,
+            style = if (isTotal) WooPosTypography.BodyLarge else WooPosTypography.BodyMedium,
+            fontWeight = if (isTotal) FontWeight.Bold else FontWeight.Normal,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        WooPosText(
+            text = value,
+            style = if (isTotal) WooPosTypography.BodyLarge else WooPosTypography.BodyMedium,
+            fontWeight = if (isTotal) FontWeight.Bold else FontWeight.Normal,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+@Composable
+private fun ReviewActionButtons(
+    onIssueRefund: () -> Unit,
+    onEditRefund: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(WooPosSpacing.XLarge.value),
+        verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
+    ) {
+        WooPosButton(
+            text = stringResource(R.string.continue_button),
+            onClick = onIssueRefund,
+            modifier = Modifier.fillMaxWidth()
+        )
+        WooPosOutlinedButton(
+            text = stringResource(R.string.woopos_orders_edit_refund),
+            onClick = onEditRefund,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
 @WooPosPreview
 @Composable
 fun WooPosIssueRefundDialogPreview() {
@@ -383,11 +577,15 @@ fun WooPosIssueRefundDialogPreview() {
         itemsCount = 3,
         subtotal = BigDecimal("57.00"),
         taxes = BigDecimal("5.65"),
-        total = BigDecimal("62.65")
+        total = BigDecimal("62.65"),
+        formattedSubtotal = "$57.00",
+        formattedTaxes = "$5.65",
+        formattedTotal = "$62.65",
+        step = WooPosRefundState.Content.RefundStep.SelectItems
     )
 
     WooPosTheme {
-        RefundDialogContent(
+        SelectItemsContent(
             state = state,
             onDismissRequest = {},
             onContinue = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -66,7 +66,10 @@ fun WooPosIssueRefundDialog(
         dialogBackgroundContentDescription = stringResource(
             R.string.woopos_orders_issue_refund_content_description
         ),
-        onDismissRequest = onDismissRequest
+        onDismissRequest = {
+            viewModel.onUIEvent(WooPosRefundUIEvent.DialogDismissed)
+            onDismissRequest()
+        }
     ) {
         when (val currentState = state) {
             is WooPosRefundState.Loading -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -176,7 +176,7 @@ private fun SelectItemsContent(
     onDismissRequest: () -> Unit,
     onContinue: () -> Unit
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxWidth()) {
         RefundDialogHeader(onDismissRequest = onDismissRequest)
 
         ItemsHeaderRow(itemsCount = state.itemsCount)
@@ -189,7 +189,7 @@ private fun SelectItemsContent(
 
         LazyColumn(
             modifier = Modifier
-                .weight(1f)
+                .weight(1f, fill = false)
                 .fillMaxWidth()
                 .padding(horizontal = WooPosSpacing.XLarge.value)
                 .padding(vertical = WooPosSpacing.Medium.value),
@@ -355,12 +355,11 @@ private fun ReviewRefundContent(
     onIssueRefund: () -> Unit,
     onEditRefund: () -> Unit
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxWidth()) {
         ReviewRefundHeader(onDismissRequest = onDismissRequest)
 
         Column(
             modifier = Modifier
-                .weight(1f)
                 .fillMaxWidth()
                 .padding(horizontal = WooPosSpacing.XLarge.value),
             verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosIssueRefundDialog.kt
@@ -390,7 +390,7 @@ private fun ReviewRefundContent(
                     isTotal = true
                 )
                 WooPosText(
-                    text = "Via payment card ••••1456",
+                    text = "TEST: Via payment card ••••1456",
                     style = WooPosTypography.BodyMedium,
                     fontWeight = FontWeight.Normal,
                     color = WooPosTheme.colors.onSurfaceVariantHighest
@@ -421,7 +421,7 @@ private fun ReviewRefundContent(
                     )
                 }
                 WooPosText(
-                    text = "Customer bought an extra item.",
+                    text = "TEST: Customer bought an extra item.",
                     style = WooPosTypography.BodyMedium,
                     fontWeight = FontWeight.Normal,
                     color = WooPosTheme.colors.onSurfaceVariantHighest

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -177,8 +177,7 @@ private fun WooPosOrdersScreen(
                 is WooPosOrdersState.Content.DialogState.IssueRefund -> {
                     WooPosIssueRefundDialog(
                         orderId = dialogState.orderId,
-                        onDismissRequest = onIssueRefundDialogDismissed,
-                        onContinue = onIssueRefundDialogDismissed
+                        onDismissRequest = onIssueRefundDialogDismissed
                     )
                 }
                 WooPosOrdersState.Content.DialogState.Hidden -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundState.kt
@@ -17,8 +17,21 @@ sealed class WooPosRefundState {
         val itemsCount: Int,
         val subtotal: BigDecimal,
         val taxes: BigDecimal,
-        val total: BigDecimal
-    ) : WooPosRefundState()
+        val total: BigDecimal,
+        val formattedSubtotal: String,
+        val formattedTaxes: String,
+        val formattedTotal: String,
+        val step: RefundStep
+    ) : WooPosRefundState() {
+        @Immutable
+        sealed class RefundStep {
+            @Immutable
+            data object SelectItems : RefundStep()
+
+            @Immutable
+            data object ReviewRefund : RefundStep()
+        }
+    }
 
     @Immutable
     data class Error(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundUIEvent.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.ui.woopos.orders
+
+sealed class WooPosRefundUIEvent {
+    data object ContinueToReviewClicked : WooPosRefundUIEvent()
+    data object BackToSelectItemsClicked : WooPosRefundUIEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundUIEvent.kt
@@ -3,5 +3,7 @@ package com.woocommerce.android.ui.woopos.orders
 sealed class WooPosRefundUIEvent {
     data object ContinueToReviewClicked : WooPosRefundUIEvent()
     data object BackToSelectItemsClicked : WooPosRefundUIEvent()
+
+    data object ContinueToConfirmRefundClicked: WooPosRefundUIEvent()
     data object DialogDismissed : WooPosRefundUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundUIEvent.kt
@@ -4,6 +4,6 @@ sealed class WooPosRefundUIEvent {
     data object ContinueToReviewClicked : WooPosRefundUIEvent()
     data object BackToSelectItemsClicked : WooPosRefundUIEvent()
 
-    data object ContinueToConfirmRefundClicked: WooPosRefundUIEvent()
+    data object ContinueToConfirmRefundClicked : WooPosRefundUIEvent()
     data object DialogDismissed : WooPosRefundUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundUIEvent.kt
@@ -3,4 +3,5 @@ package com.woocommerce.android.ui.woopos.orders
 sealed class WooPosRefundUIEvent {
     data object ContinueToReviewClicked : WooPosRefundUIEvent()
     data object BackToSelectItemsClicked : WooPosRefundUIEvent()
+    data object DialogDismissed : WooPosRefundUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
@@ -108,6 +108,8 @@ class WooPosRefundViewModel @AssistedInject constructor(
                 WooPosRefundState.Content.RefundStep.SelectItems
             WooPosRefundUIEvent.DialogDismissed ->
                 WooPosRefundState.Content.RefundStep.SelectItems
+
+            WooPosRefundUIEvent.ContinueToConfirmRefundClicked -> WooPosRefundState.Content.RefundStep.SelectItems
         }
 
         _state.value = currentState.copy(step = newStep)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
@@ -106,6 +106,8 @@ class WooPosRefundViewModel @AssistedInject constructor(
                 WooPosRefundState.Content.RefundStep.ReviewRefund
             WooPosRefundUIEvent.BackToSelectItemsClicked ->
                 WooPosRefundState.Content.RefundStep.SelectItems
+            WooPosRefundUIEvent.DialogDismissed ->
+                WooPosRefundState.Content.RefundStep.SelectItems
         }
 
         _state.value = currentState.copy(step = newStep)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.PriceUtils
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -21,7 +23,8 @@ class WooPosRefundViewModel @AssistedInject constructor(
     private val ordersDataSource: WooPosOrdersDataSource,
     private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds,
     private val getRefundableItems: WooPosGetRefundableItems,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val currencyFormatter: CurrencyFormatter
 ) : ViewModel() {
 
     @AssistedFactory
@@ -87,7 +90,25 @@ class WooPosRefundViewModel @AssistedInject constructor(
             itemsCount = refundableItems.size,
             subtotal = subtotal,
             taxes = taxes,
-            total = total
+            total = total,
+            formattedSubtotal = PriceUtils.formatCurrency(subtotal, order.currency, currencyFormatter),
+            formattedTaxes = PriceUtils.formatCurrency(taxes, order.currency, currencyFormatter),
+            formattedTotal = PriceUtils.formatCurrency(total, order.currency, currencyFormatter),
+            step = WooPosRefundState.Content.RefundStep.SelectItems
+        )
+    }
+
+    fun onContinueToReview() {
+        val currentState = _state.value as? WooPosRefundState.Content ?: return
+        _state.value = currentState.copy(
+            step = WooPosRefundState.Content.RefundStep.ReviewRefund
+        )
+    }
+
+    fun onBackToSelectItems() {
+        val currentState = _state.value as? WooPosRefundState.Content ?: return
+        _state.value = currentState.copy(
+            step = WooPosRefundState.Content.RefundStep.SelectItems
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModel.kt
@@ -98,17 +98,16 @@ class WooPosRefundViewModel @AssistedInject constructor(
         )
     }
 
-    fun onContinueToReview() {
+    fun onUIEvent(event: WooPosRefundUIEvent) {
         val currentState = _state.value as? WooPosRefundState.Content ?: return
-        _state.value = currentState.copy(
-            step = WooPosRefundState.Content.RefundStep.ReviewRefund
-        )
-    }
 
-    fun onBackToSelectItems() {
-        val currentState = _state.value as? WooPosRefundState.Content ?: return
-        _state.value = currentState.copy(
-            step = WooPosRefundState.Content.RefundStep.SelectItems
-        )
+        val newStep = when (event) {
+            WooPosRefundUIEvent.ContinueToReviewClicked ->
+                WooPosRefundState.Content.RefundStep.ReviewRefund
+            WooPosRefundUIEvent.BackToSelectItemsClicked ->
+                WooPosRefundState.Content.RefundStep.SelectItems
+        }
+
+        _state.value = currentState.copy(step = newStep)
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3803,6 +3803,21 @@
     <string name="woopos_orders_items_selected_count">(%1$d SELECTED)</string>
     <string name="woopos_orders_loading_refund_items">Loading refundable items</string>
     <string name="woopos_orders_no_items_available_for_refund">No items available for refund</string>
+    <string name="woopos_orders_review_refund_content_description">Review refund details</string>
+    <string name="woopos_orders_review_refund">Review refund</string>
+    <string name="woopos_orders_refund_for_order">Refund for %1$s</string>
+    <string name="woopos_orders_issue_refund">Issue Refund</string>
+    <string name="woopos_orders_items_subtotal_count">Items subtotal (%1$d item)</string>
+    <plurals name="woopos_orders_items_subtotal_count_plural">
+        <item quantity="one">Items subtotal (%d item)</item>
+        <item quantity="other">Items subtotal (%d items)</item>
+    </plurals>
+    <string name="woopos_orders_refund_total">Refund total</string>
+    <string name="woopos_orders_via_payment_card">Via payment card ••••1456</string>
+    <string name="woopos_orders_refund_reason">Refund reason</string>
+    <string name="woopos_orders_edit_reason">Edit reason</string>
+    <string name="woopos_orders_refund_reason_default">Customer bought an extra item.</string>
+    <string name="woopos_orders_edit_refund">Edit refund</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>
     <string name="woopos_orders_details_placeholder_message">Choose an order from the list to view details.</string>
     <string name="woopos_orders_details_products_title">Products</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3803,9 +3803,7 @@
     <string name="woopos_orders_items_selected_count">(%1$d SELECTED)</string>
     <string name="woopos_orders_loading_refund_items">Loading refundable items</string>
     <string name="woopos_orders_no_items_available_for_refund">No items available for refund</string>
-    <string name="woopos_orders_review_refund_content_description">Review refund details</string>
     <string name="woopos_orders_review_refund">Review refund</string>
-    <string name="woopos_orders_refund_for_order">Refund for %1$s</string>
     <string name="woopos_orders_issue_refund">Issue Refund</string>
     <plurals name="woopos_orders_items_subtotal_count_plural">
         <item quantity="one">Items subtotal (%d item)</item>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3807,7 +3807,6 @@
     <string name="woopos_orders_review_refund">Review refund</string>
     <string name="woopos_orders_refund_for_order">Refund for %1$s</string>
     <string name="woopos_orders_issue_refund">Issue Refund</string>
-    <string name="woopos_orders_items_subtotal_count">Items subtotal (%1$d item)</string>
     <plurals name="woopos_orders_items_subtotal_count_plural">
         <item quantity="one">Items subtotal (%d item)</item>
         <item quantity="other">Items subtotal (%d items)</item>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3813,10 +3813,8 @@
         <item quantity="other">Items subtotal (%d items)</item>
     </plurals>
     <string name="woopos_orders_refund_total">Refund total</string>
-    <string name="woopos_orders_via_payment_card">Via payment card ••••1456</string>
     <string name="woopos_orders_refund_reason">Refund reason</string>
     <string name="woopos_orders_edit_reason">Edit reason</string>
-    <string name="woopos_orders_refund_reason_default">Customer bought an extra item.</string>
     <string name="woopos_orders_edit_refund">Edit refund</string>
     <string name="woopos_orders_details_placeholder_title">Select an order</string>
     <string name="woopos_orders_details_placeholder_message">Choose an order from the list to view details.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.Refund
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -30,6 +31,7 @@ class WooPosRefundViewModelTest {
     private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds = mock()
     private val getRefundableItems: WooPosGetRefundableItems = mock()
     private val resourceProvider: ResourceProvider = mock()
+    private val currencyFormatter: CurrencyFormatter = mock()
 
     private val testOrderId = 123L
     private val testOrder = OrderTestUtils.generateTestOrder(orderId = testOrderId).copy(
@@ -79,7 +81,8 @@ class WooPosRefundViewModelTest {
             ordersDataSource = ordersDataSource,
             retrieveOrderRefunds = retrieveOrderRefunds,
             getRefundableItems = getRefundableItems,
-            resourceProvider = resourceProvider
+            resourceProvider = resourceProvider,
+            currencyFormatter = currencyFormatter
         )
     }
 
@@ -297,4 +300,120 @@ class WooPosRefundViewModelTest {
             assertThat(state.taxes).isEqualTo(BigDecimal("3.55")) // 1 + 1 + 1.55
             assertThat(state.total).isEqualTo(BigDecimal("39.05")) // 35.50 + 3.55
         }
+
+    @Test
+    fun `given content state at SelectItems step, when ContinueToReviewClicked event, then step changes to ReviewRefund`() =
+        runTest {
+            // GIVEN
+            val refundableItems = listOf(testRefundableItem)
+            whenever(ordersDataSource.getOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(testOrder)).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(testOrder, emptyList())).thenReturn(refundableItems)
+
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            val initialState = viewModel.state.value as WooPosRefundState.Content
+            assertThat(initialState.step).isEqualTo(WooPosRefundState.Content.RefundStep.SelectItems)
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+
+            // THEN
+            val updatedState = viewModel.state.value as WooPosRefundState.Content
+            assertThat(updatedState.step).isEqualTo(WooPosRefundState.Content.RefundStep.ReviewRefund)
+        }
+
+    @Test
+    fun `given content state at ReviewRefund step, when BackToSelectItemsClicked event, then step changes to SelectItems`() =
+        runTest {
+            // GIVEN
+            val refundableItems = listOf(testRefundableItem)
+            whenever(ordersDataSource.getOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(testOrder)).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(testOrder, emptyList())).thenReturn(refundableItems)
+
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            // Navigate to ReviewRefund step
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            val reviewState = viewModel.state.value as WooPosRefundState.Content
+            assertThat(reviewState.step).isEqualTo(WooPosRefundState.Content.RefundStep.ReviewRefund)
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.BackToSelectItemsClicked)
+
+            // THEN
+            val updatedState = viewModel.state.value as WooPosRefundState.Content
+            assertThat(updatedState.step).isEqualTo(WooPosRefundState.Content.RefundStep.SelectItems)
+        }
+
+    @Test
+    fun `given content state at ReviewRefund step, when DialogDismissed event, then step resets to SelectItems`() =
+        runTest {
+            // GIVEN
+            val refundableItems = listOf(testRefundableItem)
+            whenever(ordersDataSource.getOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(testOrder)).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(testOrder, emptyList())).thenReturn(refundableItems)
+
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            // Navigate to ReviewRefund step
+            viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+            val reviewState = viewModel.state.value as WooPosRefundState.Content
+            assertThat(reviewState.step).isEqualTo(WooPosRefundState.Content.RefundStep.ReviewRefund)
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.DialogDismissed)
+
+            // THEN
+            val updatedState = viewModel.state.value as WooPosRefundState.Content
+            assertThat(updatedState.step).isEqualTo(WooPosRefundState.Content.RefundStep.SelectItems)
+        }
+
+    @Test
+    fun `given content state at SelectItems step, when DialogDismissed event, then step remains at SelectItems`() =
+        runTest {
+            // GIVEN
+            val refundableItems = listOf(testRefundableItem)
+            whenever(ordersDataSource.getOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(testOrder)).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(testOrder, emptyList())).thenReturn(refundableItems)
+
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            val initialState = viewModel.state.value as WooPosRefundState.Content
+            assertThat(initialState.step).isEqualTo(WooPosRefundState.Content.RefundStep.SelectItems)
+
+            // WHEN
+            viewModel.onUIEvent(WooPosRefundUIEvent.DialogDismissed)
+
+            // THEN
+            val updatedState = viewModel.state.value as WooPosRefundState.Content
+            assertThat(updatedState.step).isEqualTo(WooPosRefundState.Content.RefundStep.SelectItems)
+        }
+
+    @Test
+    fun `given non-content state, when onUIEvent called, then state remains unchanged`() = runTest {
+        // GIVEN
+        whenever(ordersDataSource.getOrderById(testOrderId)).thenReturn(
+            Result.failure(Exception("Network error"))
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val errorState = viewModel.state.value
+        assertThat(errorState).isInstanceOf(WooPosRefundState.Error::class.java)
+
+        // WHEN
+        viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
+
+        // THEN - State should remain unchanged
+        assertThat(viewModel.state.value).isEqualTo(errorState)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosRefundViewModelTest.kt
@@ -336,7 +336,6 @@ class WooPosRefundViewModelTest {
             viewModel = createViewModel()
             advanceUntilIdle()
 
-            // Navigate to ReviewRefund step
             viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
             val reviewState = viewModel.state.value as WooPosRefundState.Content
             assertThat(reviewState.step).isEqualTo(WooPosRefundState.Content.RefundStep.ReviewRefund)
@@ -361,7 +360,6 @@ class WooPosRefundViewModelTest {
             viewModel = createViewModel()
             advanceUntilIdle()
 
-            // Navigate to ReviewRefund step
             viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
             val reviewState = viewModel.state.value as WooPosRefundState.Content
             assertThat(reviewState.step).isEqualTo(WooPosRefundState.Content.RefundStep.ReviewRefund)
@@ -413,7 +411,7 @@ class WooPosRefundViewModelTest {
         // WHEN
         viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
 
-        // THEN - State should remain unchanged
+        // THEN
         assertThat(viewModel.state.value).isEqualTo(errorState)
     }
 }


### PR DESCRIPTION
WOOMOB-1826

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR introduces 2nd step in the POS refund flow. The "Review refund" step is shown after clicking "Continue" button in the item selection step. The changes include state management enhancements with a new step enum, formatted price fields for currency display, and test coverage for step navigation.

What's not included:
* Refund reason - it's hardcoded for now, though the text style should match design specs
* Edit reason button - it's not working yet
* Via (payment method) - hardcoded text for now

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Go to Woo POS > Orders
2. Tap "Issue refund" button and explore the refund flow 

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="800" src="https://github.com/user-attachments/assets/1431f0c6-d17c-47ab-90da-098a58b4ee92" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
