### PR TITLE
[Tooling] Expand Claude analysis to any failing build job

### DIFF
--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# This pipeline is dynamically uploaded at the end of the build after a wait step
+
+agents:
+  queue: default
+
+steps:
+  - label: ":claude: Claude Build Analysis"
+    key: claude-analysis
+    if: build.state == "failing"
+    command: "exit 0"
+    plugins:
+      - $CLAUDE_PLUGIN:
+          api_key: "$ANTHROPIC_API_KEY"
+          buildkite_api_token: "$BUILDKITE_TOKEN_FOR_CLAUDE"
+          analysis_level: "build"
+          trigger: "always"
+          model: "claude-sonnet-4-5"
+
+  - label: ":claude: 💬 Comment Claude Analysis"
+    command: .buildkite/commands/comment-claude-analysis.sh
+    depends_on: claude-analysis
+    allow_dependency_failure: true
+    if: build.pull_request.id != null
+    plugins:
+      - $CI_TOOLKIT

--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -10,13 +10,15 @@ steps:
   - label: ":claude: Claude Build Analysis"
     key: claude-analysis
     if: build.state == "failing"
-    command: "exit 0"
+    soft_fail: true
+    command: "exit 1"
     plugins:
       - $CLAUDE_PLUGIN:
           api_key: "$ANTHROPIC_API_KEY"
           buildkite_api_token: "$BUILDKITE_TOKEN_FOR_CLAUDE"
           analysis_level: "build"
           trigger: "always"
+          custom_prompt: "Do not mention successful points, focus on failures and recovery to keep the analysis succint. Only add the `Best Practices` section if the changes in this PR are directly relevant to it. Only add a `Root Cause` section when you're sure about the issues' causes."
           model: "claude-sonnet-4-5"
 
   - label: ":claude: 💬 Comment Claude Analysis"

--- a/.buildkite/commands/comment-claude-analysis.sh
+++ b/.buildkite/commands/comment-claude-analysis.sh
@@ -1,11 +1,14 @@
 #!/bin/bash -eu
 
-# Check if unit tests failed (matches both hard_failed and soft_failed outcomes)
-if buildkite-agent step get outcome --step unit-tests | grep -q "failed"; then
-  comment_on_pr --id claude-test-analysis "## 🤖 Test Failure Analysis
+# The claude-analysis step only runs when there are build failures,
+# so if it ran (and soft_failed), it means there were failures that Claude analyzed.
+CLAUDE_OUTCOME=$(buildkite-agent step get outcome --step claude-analysis 2>/dev/null || echo "not_run")
 
-Your tests failed. Claude has analyzed the failures - <a href=\"${BUILDKITE_BUILD_URL}/annotations#annotation-claude-analysis-${BUILDKITE_BUILD_ID}\" target=\"_blank\">check the annotation</a> for details."
+if [[ "${CLAUDE_OUTCOME}" == "soft_failed" ]]; then
+  comment_on_pr --id claude-build-analysis "## 🤖 Build Failure Analysis
+
+This build has failures. Claude has analyzed them - <a href=\"${BUILDKITE_BUILD_URL}\" target=\"_blank\">check the build annotations</a> for details."
 else
-  # Remove the comment if tests are now passing
-  comment_on_pr --id claude-test-analysis --if-exist delete
+  # Remove the comment if the build is now passing (claude-analysis did not run)
+  comment_on_pr --id claude-build-analysis --if-exist delete
 fi

--- a/.buildkite/commands/comment-claude-analysis.sh
+++ b/.buildkite/commands/comment-claude-analysis.sh
@@ -7,7 +7,7 @@ CLAUDE_OUTCOME=$(buildkite-agent step get outcome --step claude-analysis 2>/dev/
 if [[ "${CLAUDE_OUTCOME}" == "soft_failed" ]]; then
   comment_on_pr --id claude-build-analysis "## 🤖 Build Failure Analysis
 
-This build has failures. Claude has analyzed them - <a href=\"${BUILDKITE_BUILD_URL}\" target=\"_blank\">check the build annotations</a> for details."
+This build has failures. Claude has analyzed them - <a href=\"${BUILDKITE_BUILD_URL}/annotations\" target=\"_blank\">check the build annotations</a> for details."
 else
   # Remove the comment if the build is now passing (claude-analysis did not run)
   comment_on_pr --id claude-build-analysis --if-exist delete

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -90,19 +90,8 @@ steps:
           - $TEST_COLLECTOR :
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS"
-          - $CLAUDE_PLUGIN:
-              api_key: "$ANTHROPIC_API_KEY"
-              buildkite_api_token: "$BUILDKITE_TOKEN_FOR_CLAUDE"
         artifact_paths:
           - "**/build/test-results/merged-test-results.xml"
-
-      - label: "💬 Comment Claude Analysis"
-        command: .buildkite/commands/comment-claude-analysis.sh
-        depends_on: unit-tests
-        allow_dependency_failure: true
-        if: build.pull_request.id != null
-        plugins:
-          - $CI_TOOLKIT
 
       - label: "Instrumented tests"
         command: .buildkite/commands/run-instrumented-tests.sh
@@ -147,3 +136,16 @@ steps:
         artifact_paths:
           - "WooCommerce/build/outputs/apk/**/*"
           - "WooCommerce-Wear/build/outputs/apk/**/*"
+
+  ########################################
+  # Claude Build Analysis - dynamically uploaded so Build result conditions evaluate at runtime after the wait
+  ########################################
+  - wait: ~
+    continue_on_failure: true
+
+  - label: ":claude: 🕵️ Check for Build Failures and Run Claude Analysis"
+    command: |
+      source .buildkite/shared-pipeline-vars
+      buildkite-agent pipeline upload .buildkite/claude-analysis.yml
+    agents:
+      queue: upload


### PR DESCRIPTION
### Description
This PR follows-up https://github.com/woocommerce/woocommerce-android/pull/14669 by running Claude in the entire build and generating a report considering all jobs that failed.

### Test Steps
You can create PRs on top of the present PR to check how the analysis report is going to look like.
I've run some tests on https://github.com/woocommerce/woocommerce-android/pull/15068, and you can check a failing build for it [here](https://buildkite.com/automattic/woocommerce-android/builds/34325).

### Images/gif
<img width="800" alt="Screenshot 2025-12-09 at 12 49 07" src="https://github.com/user-attachments/assets/3463bccc-b707-4b11-a1ce-4aa7e7987723" />
