### PR TITLE
[WOOMOB-1860] Update POS catalog generation endpoint to match backend changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -400,6 +400,7 @@ class WooPosCartViewModel @Inject constructor(
                 is BarcodeInputDetector.BarcodeResult.Success -> {
                     processBarcodeSuccess(result.barcode)
                 }
+
                 is BarcodeInputDetector.BarcodeResult.Error -> {
                     processBarcodeError(result)
                 }
@@ -439,6 +440,7 @@ class WooPosCartViewModel @Inject constructor(
             BarcodeInputDetector.FailureReason.TOO_SHORT -> {
                 resourceProvider.getString(R.string.woopos_cart_barcode_scan_result_too_short)
             }
+
             BarcodeInputDetector.FailureReason.NO_TERMINATOR -> {
                 resourceProvider.getString(R.string.woopos_cart_barcode_scan_result_no_terminator)
             }

--- a/libs/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
+++ b/libs/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
@@ -15,7 +15,7 @@ public class WCWPAPIEndpoint {
 
     private static final String WC_PREFIX_V1_ADDONS = "wc-product-add-ons/v1";
 
-    private static final String WC_PREFIX_POS_V1 = "pos/v1";
+    private static final String WC_PREFIX_POS_V1 = "wc/pos/v1";
 
     private static final String WC_PREFIX_TELEMETRY = "wc-telemetry";
 

--- a/libs/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
+++ b/libs/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
@@ -15,6 +15,8 @@ public class WCWPAPIEndpoint {
 
     private static final String WC_PREFIX_V1_ADDONS = "wc-product-add-ons/v1";
 
+    private static final String WC_PREFIX_POS_V1 = "pos/v1";
+
     private static final String WC_PREFIX_TELEMETRY = "wc-telemetry";
 
     private static final String WC_PREFIX_ADMIN = "wc-admin";
@@ -65,6 +67,10 @@ public class WCWPAPIEndpoint {
 
     public String getPathV1Addons() {
         return "/" + WC_PREFIX_V1_ADDONS + mEndpoint;
+    }
+
+    public String getPathPosV1() {
+        return "/" + WC_PREFIX_POS_V1 + mEndpoint;
     }
 
     public String getPathWcTelemetry() {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosGenerateCatalogResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosGenerateCatalogResponse.kt
@@ -3,6 +3,27 @@ package org.wordpress.android.fluxc.model.pos
 import com.google.gson.annotations.SerializedName
 
 data class WooPosGenerateCatalogResponse(
-    @SerializedName("job_id")
-    val jobId: Long? = null,
+    @SerializedName("scheduled_at")
+    val scheduledAt: String? = null,
+    @SerializedName("completed_at")
+    val completedAt: String? = null,
+    @SerializedName("state")
+    val state: String? = null,
+    @SerializedName("progress")
+    val progress: Int? = null,
+    @SerializedName("processed")
+    val processed: Int? = null,
+    @SerializedName("total")
+    val total: Int? = null,
+    @SerializedName("args")
+    val args: WooPosGenerateCatalogArgs? = null,
+    @SerializedName("url")
+    val url: String? = null,
+)
+
+data class WooPosGenerateCatalogArgs(
+    @SerializedName("_product_fields")
+    val productFields: List<String>? = null,
+    @SerializedName("_variation_fields")
+    val variationFields: List<String>? = null,
 )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos
 
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.pos.WooPosCatalogStatusResponse
 import org.wordpress.android.fluxc.model.pos.WooPosGenerateCatalogResponse
 import org.wordpress.android.fluxc.model.pos.WooPosVariationApiResponse
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
@@ -102,33 +101,6 @@ class WooPosProductRestClient @Inject constructor(
             path = url,
             body = params,
             clazz = WooPosGenerateCatalogResponse::class.java
-        )
-
-        return when (response) {
-            is WPAPIResponse.Success -> {
-                WooResult(response.data)
-            }
-
-            is WPAPIResponse.Error -> {
-                WooResult(response.error.toWooError())
-            }
-        }
-    }
-
-    suspend fun getCatalogStatus(
-        site: SiteModel,
-        jobId: String,
-    ): WooResult<WooPosCatalogStatusResponse> {
-        val url = WOOCOMMERCE.catalog.status.id(jobId).pathV3
-        val params = mutableMapOf(
-            "_fields" to PRODUCT_FIELDS
-        )
-
-        val response = wooNetwork.executeGetGsonRequest(
-            site = site,
-            path = url,
-            params = params,
-            clazz = WooPosCatalogStatusResponse::class.java
         )
 
         return when (response) {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -91,9 +91,10 @@ class WooPosProductRestClient @Inject constructor(
     suspend fun postGenerateCatalog(
         site: SiteModel,
     ): WooResult<WooPosGenerateCatalogResponse> {
-        val url = WOOCOMMERCE.catalog.pathV3
+        val url = WOOCOMMERCE.product_catalog.create.pathPosV1
         val params = mutableMapOf(
-            "_fields" to PRODUCT_FIELDS
+            "_product_fields" to PRODUCT_FIELDS,
+            "_variation_fields" to VARIATIONS_FIELDS
         )
 
         val response = wooNetwork.executePostGsonRequest(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosGenerateCatalogResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosGenerateCatalogResult.kt
@@ -1,5 +1,13 @@
 package org.wordpress.android.fluxc.store.pos.localcatalog
 
 data class WooPosGenerateCatalogResult(
-    val jobId: String,
+    val scheduledAt: String? = null,
+    val completedAt: String? = null,
+    val state: String? = null,
+    val progress: Int? = null,
+    val processed: Int? = null,
+    val total: Int? = null,
+    val url: String? = null,
+    val productFields: List<String>? = null,
+    val variationFields: List<String>? = null,
 )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -492,7 +492,7 @@ class WooPosLocalCatalogStore @Inject constructor(
      * Generates a new catalog on the server.
      *
      * @param [site] The site to generate catalog for
-     * @return [Result] containing PosGenerateCatalogResult with job ID or error
+     * @return [Result] containing PosGenerateCatalogResult with catalog generation details or error
      */
     suspend fun generateCatalog(
         site: SiteModel
@@ -511,14 +511,19 @@ class WooPosLocalCatalogStore @Inject constructor(
                     Result.failure(WooPosLocalCatalogError.EmptyResponse)
                 }
 
-                response.model.jobId == null -> {
-                    Result.failure(WooPosLocalCatalogError.InvalidResponse("Missing job ID in response"))
-                }
-
                 else -> {
-                    val jobId = response.model.jobId.toString()
                     Result.success(
-                        WooPosGenerateCatalogResult(jobId = jobId)
+                        WooPosGenerateCatalogResult(
+                            scheduledAt = response.model.scheduledAt,
+                            completedAt = response.model.completedAt,
+                            state = response.model.state,
+                            progress = response.model.progress,
+                            processed = response.model.processed,
+                            total = response.model.total,
+                            url = response.model.url,
+                            productFields = response.model.args?.productFields,
+                            variationFields = response.model.args?.variationFields,
+                        )
                     )
                 }
             }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -529,46 +529,6 @@ class WooPosLocalCatalogStore @Inject constructor(
             }
         }
 
-    /**
-     * Fetches the status of a catalog generation job.
-     *
-     * @param [site] The site to check catalog status for
-     * @param [jobId] The job ID from generateCatalog
-     * @return [Result] containing PosCatalogStatusResult with status and download URL or error
-     */
-    suspend fun fetchCatalogStatus(
-        site: SiteModel,
-        jobId: String
-    ): Result<WooPosCatalogStatusResult> =
-        coroutineEngine.withDefaultContext(API, this, "fetchCatalogStatus") {
-            val response = posProductRestClient.getCatalogStatus(site, jobId)
-
-            when {
-                response.isError -> {
-                    Result.failure(
-                        mapResponseError(response.error)
-                    )
-                }
-
-                response.model == null -> {
-                    Result.failure(WooPosLocalCatalogError.EmptyResponse)
-                }
-
-                response.model.status.isNullOrEmpty() -> {
-                    Result.failure(WooPosLocalCatalogError.InvalidResponse("Missing job ID in response"))
-                }
-
-                else -> {
-                    Result.success(
-                        WooPosCatalogStatusResult(
-                            status = response.model.status,
-                            downloadUrl = response.model.downloadUrl
-                        )
-                    )
-                }
-            }
-        }
-
     private fun mapResponseError(error: WooError?): WooPosLocalCatalogError {
         return when (error?.type) {
             WooErrorType.TIMEOUT -> WooPosLocalCatalogError.NetworkError(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -16,7 +16,6 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.pos.WooPosCatalogStatusResponse
 import org.wordpress.android.fluxc.model.pos.WooPosGenerateCatalogArgs
 import org.wordpress.android.fluxc.model.pos.WooPosGenerateCatalogResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -495,84 +494,6 @@ class WooPosLocalCatalogStoreTest {
     }
 
     @Test
-    fun `when fetching catalog status successfully, then returns status and download URL`() = runTest {
-        // GIVEN
-        val jobId = "12345"
-        val expectedStatus = "completed"
-        val expectedDownloadUrl = "https://example.com/catalog.zip"
-        val response = WooPosCatalogStatusResponse(
-            status = expectedStatus,
-            downloadUrl = expectedDownloadUrl
-        )
-        whenever(posProductRestClient.getCatalogStatus(testSite, jobId))
-            .thenReturn(WooResult(response))
-
-        // WHEN
-        val result = store.fetchCatalogStatus(testSite, jobId).getOrThrow()
-
-        // THEN
-        assertThat(result.status).isEqualTo(expectedStatus)
-        assertThat(result.downloadUrl).isEqualTo(expectedDownloadUrl)
-        verify(posProductRestClient).getCatalogStatus(testSite, jobId)
-    }
-
-    @Test
-    fun `when fetching catalog status returns null response, then returns empty response error`() = runTest {
-        // GIVEN
-        val jobId = "12345"
-        whenever(posProductRestClient.getCatalogStatus(testSite, jobId))
-            .thenReturn(WooResult(null))
-
-        // WHEN
-        val result = store.fetchCatalogStatus(testSite, jobId)
-
-        // THEN
-        assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isInstanceOf(WooPosLocalCatalogError.EmptyResponse::class.java)
-    }
-
-    @Test
-    fun `when fetching catalog status fails with timeout, then returns timeout error`() = runTest {
-        // GIVEN
-        val jobId = "12345"
-        val timeoutError = WooError(
-            type = WooErrorType.TIMEOUT,
-            original = org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.TIMEOUT,
-            message = "Request timed out"
-        )
-        whenever(posProductRestClient.getCatalogStatus(testSite, jobId))
-            .thenReturn(WooResult(timeoutError))
-
-        // WHEN
-        val result = store.fetchCatalogStatus(testSite, jobId)
-
-        // THEN
-        assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as WooPosLocalCatalogError.NetworkError
-        assertThat(error.errorMessage).contains("Request timed out")
-        assertThat(error.code).isEqualTo("TIMEOUT")
-    }
-
-    @Test
-    fun `when fetching catalog status for in-progress job, then returns processing status`() = runTest {
-        // GIVEN
-        val jobId = "12345"
-        val response = WooPosCatalogStatusResponse(
-            status = "processing",
-            downloadUrl = null
-        )
-        whenever(posProductRestClient.getCatalogStatus(testSite, jobId))
-            .thenReturn(WooResult(response))
-
-        // WHEN
-        val result = store.fetchCatalogStatus(testSite, jobId).getOrThrow()
-
-        // THEN
-        assertThat(result.status).isEqualTo("processing")
-        assertThat(result.downloadUrl).isNull()
-    }
-
-    @Test
     fun `when generating catalog returns partial response, then returns catalog details with null fields`() = runTest {
         // GIVEN
         val response = WooPosGenerateCatalogResponse(
@@ -592,46 +513,6 @@ class WooPosLocalCatalogStoreTest {
         assertThat(result.progress).isNull()
         assertThat(result.url).isNull()
         verify(posProductRestClient).postGenerateCatalog(testSite)
-    }
-
-    @Test
-    fun `when fetching catalog status with null status field, then returns invalid response error`() = runTest {
-        // GIVEN
-        val jobId = "12345"
-        val response = WooPosCatalogStatusResponse(
-            status = null,
-            downloadUrl = "https://example.com/catalog.zip"
-        )
-        whenever(posProductRestClient.getCatalogStatus(testSite, jobId))
-            .thenReturn(WooResult(response))
-
-        // WHEN
-        val result = store.fetchCatalogStatus(testSite, jobId)
-
-        // THEN
-        assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
-        assertThat(error.message).isEqualTo("Missing job ID in response")
-    }
-
-    @Test
-    fun `when fetching catalog status with empty status field, then returns invalid response error`() = runTest {
-        // GIVEN
-        val jobId = "12345"
-        val response = WooPosCatalogStatusResponse(
-            status = "",
-            downloadUrl = "https://example.com/catalog.zip"
-        )
-        whenever(posProductRestClient.getCatalogStatus(testSite, jobId))
-            .thenReturn(WooResult(response))
-
-        // WHEN
-        val result = store.fetchCatalogStatus(testSite, jobId)
-
-        // THEN
-        assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
-        assertThat(error.message).isEqualTo("Missing job ID in response")
     }
 
     @Test

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.pos.WooPosCatalogStatusResponse
+import org.wordpress.android.fluxc.model.pos.WooPosGenerateCatalogArgs
 import org.wordpress.android.fluxc.model.pos.WooPosGenerateCatalogResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
@@ -424,10 +425,21 @@ class WooPosLocalCatalogStoreTest {
     }
 
     @Test
-    fun `when generating catalog successfully, then returns job ID`() = runTest {
+    fun `when generating catalog successfully, then returns catalog details`() = runTest {
         // GIVEN
-        val expectedJobId = 12345L
-        val response = WooPosGenerateCatalogResponse(jobId = expectedJobId)
+        val response = WooPosGenerateCatalogResponse(
+            scheduledAt = "2025-12-10T11:21:48",
+            completedAt = "2025-12-10T11:21:55",
+            state = "completed",
+            progress = 100,
+            processed = 881,
+            total = 881,
+            url = "https://example.com/catalog.json",
+            args = WooPosGenerateCatalogArgs(
+                productFields = listOf("id", "name", "price"),
+                variationFields = listOf("id", "parent_id")
+            )
+        )
         whenever(posProductRestClient.postGenerateCatalog(testSite))
             .thenReturn(WooResult(response))
 
@@ -435,7 +447,15 @@ class WooPosLocalCatalogStoreTest {
         val result = store.generateCatalog(testSite).getOrThrow()
 
         // THEN
-        assertThat(result.jobId).isEqualTo(expectedJobId.toString())
+        assertThat(result.scheduledAt).isEqualTo("2025-12-10T11:21:48")
+        assertThat(result.completedAt).isEqualTo("2025-12-10T11:21:55")
+        assertThat(result.state).isEqualTo("completed")
+        assertThat(result.progress).isEqualTo(100)
+        assertThat(result.processed).isEqualTo(881)
+        assertThat(result.total).isEqualTo(881)
+        assertThat(result.url).isEqualTo("https://example.com/catalog.json")
+        assertThat(result.productFields).containsExactly("id", "name", "price")
+        assertThat(result.variationFields).containsExactly("id", "parent_id")
         verify(posProductRestClient).postGenerateCatalog(testSite)
     }
 
@@ -553,19 +573,25 @@ class WooPosLocalCatalogStoreTest {
     }
 
     @Test
-    fun `when generating catalog returns null job ID, then returns invalid response error`() = runTest {
+    fun `when generating catalog returns partial response, then returns catalog details with null fields`() = runTest {
         // GIVEN
-        val response = WooPosGenerateCatalogResponse(jobId = null)
+        val response = WooPosGenerateCatalogResponse(
+            scheduledAt = "2025-12-10T11:21:48",
+            state = "scheduled"
+        )
         whenever(posProductRestClient.postGenerateCatalog(testSite))
             .thenReturn(WooResult(response))
 
         // WHEN
-        val result = store.generateCatalog(testSite)
+        val result = store.generateCatalog(testSite).getOrThrow()
 
         // THEN
-        assertThat(result.isFailure).isTrue()
-        val error = result.exceptionOrNull() as WooPosLocalCatalogError.InvalidResponse
-        assertThat(error.message).isEqualTo("Missing job ID in response")
+        assertThat(result.scheduledAt).isEqualTo("2025-12-10T11:21:48")
+        assertThat(result.state).isEqualTo("scheduled")
+        assertThat(result.completedAt).isNull()
+        assertThat(result.progress).isNull()
+        assertThat(result.url).isNull()
+        verify(posProductRestClient).postGenerateCatalog(testSite)
     }
 
     @Test

--- a/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -36,7 +36,6 @@
 /variations/
 
 /product-catalog/create
-/catalog/status/<id>#String/
 
 /product-add-ons/
 

--- a/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -35,7 +35,7 @@
 
 /variations/
 
-/catalog/
+/product-catalog/create
 /catalog/status/<id>#String/
 
 /product-add-ons/


### PR DESCRIPTION
Fixes WOOMOB-1860

### Description
Updates the POS local catalog generation code to match the recent backend API changes. The generate catalog endpoint now returns different fields and the status endpoint has been removed from the backend.

### Test Steps
This endpoint is not currently used in the app. It will be tested when the feature is integrated.

### Images/gif
N/A - Backend/API changes only