### PR TITLE
Fix/invalidate whats new cache on version change

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -373,6 +373,8 @@ class MainActivity :
             viewModel.handleShortcutAction(intent?.action?.lowercase(Locale.ROOT))
             handleIncomingImages()
         }
+
+        viewModel.showFeatureAnnouncementIfNeeded()
     }
 
     private fun setOnBackNavigationCallback() {
@@ -430,7 +432,6 @@ class MainActivity :
         }
 
         checkConnection()
-        viewModel.showFeatureAnnouncementIfNeeded()
     }
 
     override fun onPause() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -66,11 +66,6 @@ class MainActivityViewModel @Inject constructor(
     unseenReviewsCountHandler: UnseenReviewsCountHandler,
     determineTrialStatusBarState: DetermineTrialStatusBarState,
 ) : ScopedViewModel(savedState) {
-    init {
-        launch {
-            featureAnnouncementRepository.getFeatureAnnouncements(fromCache = false)
-        }
-    }
 
     val startDestination = if (selectedSite.exists()) R.id.dashboard else R.id.nav_graph_site_picker
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -232,7 +232,6 @@ class MainActivityViewModel @Inject constructor(
             }
 
             val announcement = featureAnnouncementRepository.getLatestFeatureAnnouncement(fromCache = false)
-            prefs.setLastVersionWithAnnouncement(buildConfigWrapper.versionName)
 
             announcement?.let {
                 if (announcement.canBeDisplayedOnAppUpgrade(buildConfigWrapper.versionName)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -227,15 +227,15 @@ class MainActivityViewModel @Inject constructor(
 
     fun showFeatureAnnouncementIfNeeded() {
         launch {
-            val cachedAnnouncement = featureAnnouncementRepository.getLatestFeatureAnnouncement(fromCache = true)
+            if (prefs.getLastVersionWithAnnouncement() == buildConfigWrapper.versionName) {
+                return@launch
+            }
 
-            // Feature Announcement dialog can be shown on app resume, if these criteria are filled:
-            // 1. Current version is different from the last version where announcement was shown
-            // 2. Announcement content is valid and can be displayed
-            cachedAnnouncement?.let {
-                if (prefs.getLastVersionWithAnnouncement() != buildConfigWrapper.versionName &&
-                    cachedAnnouncement.canBeDisplayedOnAppUpgrade(buildConfigWrapper.versionName)
-                ) {
+            val announcement = featureAnnouncementRepository.getLatestFeatureAnnouncement(fromCache = false)
+            prefs.setLastVersionWithAnnouncement(buildConfigWrapper.versionName)
+
+            announcement?.let {
+                if (announcement.canBeDisplayedOnAppUpgrade(buildConfigWrapper.versionName)) {
                     WooLog.i(T.DEVICE, "Displaying Feature Announcement on main activity")
                     analyticsTrackerWrapper.track(
                         AnalyticsEvent.FEATURE_ANNOUNCEMENT_SHOWN,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -326,7 +326,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given existing announcement cache, when app is upgraded and announcement is valid, then show announcement`() =
+    fun `given announcement is available on remote, when app is upgraded and announcement is valid, then show announcement`() =
         testBlocking {
             doReturn(
                 testAnnouncement
@@ -339,7 +339,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given existing announcement cache, when app is upgraded and announcement is valid, track event is tracked`() =
+    fun `given announcement is available on remote, when app is upgraded and announcement is valid, track event is tracked`() =
         testBlocking {
             doReturn(
                 testAnnouncement

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -328,7 +328,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `given existing announcement cache, when app is upgraded and announcement is valid, then show announcement`() =
         testBlocking {
-            doReturn(testAnnouncement).whenever(featureAnnouncementRepository).getLatestFeatureAnnouncement(true)
+            doReturn(testAnnouncement).whenever(featureAnnouncementRepository).getLatestFeatureAnnouncement(fromCache = true)
             doReturn("14.0").whenever(prefs).getLastVersionWithAnnouncement()
             doReturn("14.2").whenever(buildConfigWrapper).versionName
 
@@ -353,6 +353,41 @@ class MainActivityViewModelTest : BaseUnitTest() {
                 )
             )
         }
+
+    @Test
+    fun `when app version changes, then fetch fresh announcements from API`() = testBlocking {
+        doReturn("19.0").whenever(prefs).getLastVersionWithAnnouncement()
+        doReturn("20.0").whenever(buildConfigWrapper).versionName
+
+        viewModel.showFeatureAnnouncementIfNeeded()
+
+        verify(featureAnnouncementRepository).getLatestFeatureAnnouncement(fromCache = false)
+        verify(prefs).setLastVersionWithAnnouncement("20.0")
+    }
+
+    @Test
+    fun `when app version unchanged, then do not fetch announcements`() = testBlocking {
+        doReturn("20.0").whenever(prefs).getLastVersionWithAnnouncement()
+        doReturn("20.0").whenever(buildConfigWrapper).versionName
+
+        viewModel.showFeatureAnnouncementIfNeeded()
+
+        verify(featureAnnouncementRepository, never()).getLatestFeatureAnnouncement(any())
+    }
+
+    @Test
+    fun `when version changes but no new announcements available, then still update preference`() = testBlocking {
+        val oldAnnouncement = testAnnouncement.copy(appVersionTargets = listOf("19.0"))
+        doReturn("19.0").whenever(prefs).getLastVersionWithAnnouncement()
+        doReturn("20.0").whenever(buildConfigWrapper).versionName
+        doReturn(oldAnnouncement).whenever(featureAnnouncementRepository)
+            .getLatestFeatureAnnouncement(fromCache = false)
+
+        viewModel.showFeatureAnnouncementIfNeeded()
+
+        verify(featureAnnouncementRepository).getLatestFeatureAnnouncement(fromCache = false)
+        verify(prefs).setLastVersionWithAnnouncement("20.0")
+    }
 
     @Test
     fun `given zero unseen reviews and no new features, when listening badge state, then hidden returned`() =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -366,7 +366,6 @@ class MainActivityViewModelTest : BaseUnitTest() {
         viewModel.showFeatureAnnouncementIfNeeded()
 
         verify(featureAnnouncementRepository).getLatestFeatureAnnouncement(fromCache = false)
-        verify(prefs).setLastVersionWithAnnouncement("20.0")
     }
 
     @Test
@@ -377,20 +376,6 @@ class MainActivityViewModelTest : BaseUnitTest() {
         viewModel.showFeatureAnnouncementIfNeeded()
 
         verify(featureAnnouncementRepository, never()).getLatestFeatureAnnouncement(any())
-    }
-
-    @Test
-    fun `when version changes but no new announcements available, then still update preference`() = testBlocking {
-        val oldAnnouncement = testAnnouncement.copy(appVersionTargets = listOf("19.0"))
-        doReturn("19.0").whenever(prefs).getLastVersionWithAnnouncement()
-        doReturn("20.0").whenever(buildConfigWrapper).versionName
-        doReturn(oldAnnouncement).whenever(featureAnnouncementRepository)
-            .getLatestFeatureAnnouncement(fromCache = false)
-
-        viewModel.showFeatureAnnouncementIfNeeded()
-
-        verify(featureAnnouncementRepository).getLatestFeatureAnnouncement(fromCache = false)
-        verify(prefs).setLastVersionWithAnnouncement("20.0")
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -328,7 +328,9 @@ class MainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `given existing announcement cache, when app is upgraded and announcement is valid, then show announcement`() =
         testBlocking {
-            doReturn(testAnnouncement).whenever(featureAnnouncementRepository).getLatestFeatureAnnouncement(fromCache = true)
+            doReturn(
+                testAnnouncement
+            ).whenever(featureAnnouncementRepository).getLatestFeatureAnnouncement(fromCache = false)
             doReturn("14.0").whenever(prefs).getLastVersionWithAnnouncement()
             doReturn("14.2").whenever(buildConfigWrapper).versionName
 
@@ -339,7 +341,9 @@ class MainActivityViewModelTest : BaseUnitTest() {
     @Test
     fun `given existing announcement cache, when app is upgraded and announcement is valid, track event is tracked`() =
         testBlocking {
-            doReturn(testAnnouncement).whenever(featureAnnouncementRepository).getLatestFeatureAnnouncement(true)
+            doReturn(
+                testAnnouncement
+            ).whenever(featureAnnouncementRepository).getLatestFeatureAnnouncement(fromCache = false)
             doReturn("14.0").whenever(prefs).getLastVersionWithAnnouncement()
             doReturn("14.2").whenever(buildConfigWrapper).versionName
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -339,7 +339,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given announcement is available on remote, when app is upgraded and announcement is valid, track event is tracked`() =
+    fun `given announcement is available on remote, when app is upgraded and announcement is valid, then track event is tracked`() =
         testBlocking {
             doReturn(
                 testAnnouncement


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes: [AINFRA-1635: Feature announcements are never refreshed when app version changes](https://linear.app/a8c/issue/AINFRA-1635/feature-announcements-are-never-refreshed-when-app-version-changes)

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a bug in which, after initial fetch, the app never again requestes "what's new" announcements. 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

<details><summary>Clean Shared Preferences <code>LAST_VERSION_WITH_ANNOUNCEMENT</code></summary>

```shell
adb shell "run-as com.woocommerce.android.dev sed -i '/<string name=\"LAST_VERSION_WITH_ANNOUNCEMENT\"/d' /data/data/com.woocommerce.android.dev/shared_prefs/com.woocommerce.android.dev_preferences.xml" && adb shell am force-stop com.woocommerce.android.dev
```

</details> 

<details><summary>API Faker payload</summary>

```json
[
  {
    "request": {
      "httpMethod": "GET",
      "id": 0,
      "path": "/wpcom/v2/mobile/feature-announcements",
      "queryParameters": [],
      "type": {
        "type": "wp-com"
      }
    },
    "response": {
      "body": "{\n    \"announcements\": [\n      {\n        \"appVersionName\": \"19.8\",\n        \"announcementVersion\": 1,\n        \"minimumAppVersion\": \"1.0\",\n        \"maximumAppVersion\": \"99.0\",\n        \"appVersionTargets\": [\"19.0\"],\n        \"detailsUrl\": \"\",\n        \"isLocalized\": true,\n        \"responseLocale\": \"en\",\n        \"features\": [\n          {\n            \"title\": \"New Feature Title\",\n            \"subtitle\": \"Description of the new feature\",\n            \"iconBase64\": \"\",\n            \"iconUrl\": \"https://s0.wordpress.com/i/store/mobile/plans-premium.png\"\n          },\n          {\n            \"title\": \"Another Feature\",\n            \"subtitle\": \"Another cool feature description\",\n            \"iconBase64\": \"\",\n            \"iconUrl\": \"https://s0.wordpress.com/i/store/mobile/plans-premium.png\"\n          }\n        ]\n      }\n    ]\n  }",
      "endpointId": 0,
      "statusCode": 200
    }
  }
]
```

</details> 

#### Reproduction

1. In `com.woocommerce.android.util.BuildConfigWrapper` set `versionName` to any constant value, e.g. `19.0`
1. Install app from `trunk`
1. Import the above payload to API Faker
2. Close the app
3. Run `Clean Shared Preferences` from the snippet above (just to have a clean state before tests)
4. Open the app
  - ✅ Assert that you can see "What's new" announcement
5. Go to API Faker settings
6. Update the payload e.g. rename "New Feature Title" to "Test"
7. Save the updated payload
8. In Android Studio, increase `BuildConfigWrapper#versionName` (to simulate new app installation)
9. Install the app
  - ❌ See that "What's New in WooCommerce" shows OLD values

#### Test fix

Repeat above steps but on this branch and see that at the end you see the updated values.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
