### PR TITLE
Prevent unnecessary booking fetches on search close

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -179,7 +179,7 @@ class BookingListViewModel @Inject constructor(
                 filters
             ) { tab, query, sort, filters ->
                 FetchParams(
-                    searchQuery = query,
+                    searchQuery = query?.takeUnless { it.isEmpty() },
                     sortOption = sort,
                     selectedTab = tab,
                     filters = filters
@@ -193,17 +193,15 @@ class BookingListViewModel @Inject constructor(
                 bookingsFetchJob?.cancel()
                 bookingsLoadMoreJob?.cancel()
 
+                if (!isRefreshing && lastFetchParams == fetchParams) return@collectLatest
+
                 val initialLoadingState = if (isRefreshing) {
                     BookingListLoadingState.Refreshing
+                } else if (lastFetchParams != null && lastFetchParams?.sortOption != fetchParams.sortOption) {
+                    // When sort option changes, force refreshing state to indicate data reload
+                    BookingListLoadingState.Refreshing
                 } else {
-                    lastFetchParams.let { lastFetchParams ->
-                        if (lastFetchParams != null && lastFetchParams.sortOption != fetchParams.sortOption) {
-                            // When sort option changes, force refreshing state to indicate data reload
-                            BookingListLoadingState.Refreshing
-                        } else {
-                            BookingListLoadingState.Loading
-                        }
-                    }
+                    BookingListLoadingState.Loading
                 }
 
                 lastFetchParams = fetchParams

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -195,10 +195,9 @@ class BookingListViewModel @Inject constructor(
 
                 if (!isRefreshing && lastFetchParams == fetchParams) return@collectLatest
 
-                val initialLoadingState = if (isRefreshing) {
-                    BookingListLoadingState.Refreshing
-                } else if (lastFetchParams != null && lastFetchParams?.sortOption != fetchParams.sortOption) {
-                    // When sort option changes, force refreshing state to indicate data reload
+                val initialLoadingState = if (isRefreshing ||
+                    (lastFetchParams != null && lastFetchParams?.sortOption != fetchParams.sortOption)
+                ) {
                     BookingListLoadingState.Refreshing
                 } else {
                     BookingListLoadingState.Loading

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings.list
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppConstants
 import com.woocommerce.android.R
 import com.woocommerce.android.model.GetLocations
 import com.woocommerce.android.ui.bookings.Booking
@@ -16,6 +17,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.kotlin.any
@@ -299,6 +301,7 @@ class BookingListViewModelTest : BaseUnitTest() {
         // WHEN
         val initialState = viewModel.state.getOrAwaitValue()
         initialState.searchState.onQueryChanged("test query")
+        advanceTimeBy(AppConstants.SEARCH_TYPING_DELAY_MS + 1)
         val stateWithQuery = viewModel.state.getOrAwaitValue()
         stateWithQuery.searchState.onQueryChanged(null)
         advanceUntilIdle()
@@ -406,6 +409,31 @@ class BookingListViewModelTest : BaseUnitTest() {
         val navigations = events.filterIsInstance<BookingListViewModel.NavigateToBookingDetails>()
         assertThat(navigations.last().bookingId).isEqualTo(1234L)
         assertThat(savedStateHandle.get<Long>(BookingListViewModel.KEY_BOOKING_SELECTED_ON_BIG_SCREEN)).isEqualTo(1234L)
+    }
+
+    @Test
+    fun `when search query is opened and closed without typing, then bookings are NOT refetched`() = testBlocking {
+        // GIVEN
+        setup()
+
+        // WHEN
+        val initialState = viewModel.state.getOrAwaitValue()
+        // Search opened -> query starts empty
+        initialState.searchState.onQueryChanged("")
+        advanceUntilIdle()
+
+        val stateWithEmptyQuery = viewModel.state.getOrAwaitValue()
+        // Search closed -> query becomes null
+        stateWithEmptyQuery.searchState.onQueryChanged(null)
+        advanceUntilIdle()
+
+        // THEN
+        // Should only be called once for the initial load
+        verify(bookingListHandler, times(1)).loadBookings(
+            searchQuery = anyOrNull(),
+            filters = any(),
+            sortBy = any()
+        )
     }
 
     private fun getSampleBooking(id: Int): Booking {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1819

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
 Optimized `BookingListViewModel` to avoid triggering a network request when the search view is closed without any query changes.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Log in with a CIAB store.
2. Go to Bookings.
3. Tap the Search button.
4. Tap the back button to exit search mode.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
Before video is in the issue.

#### After
[Screen_recording_20251212_113752.webm](https://github.com/user-attachments/assets/5a75ba22-b1ba-4efc-81f5-2ef30db57a2f)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
