### PR TITLE
Update app name

### DIFF
--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-WooCommerce: Store Management & POS
+WooCommerce: Store & POS


### PR DESCRIPTION
The app name doesn't meet Google Play's limit of 30 characters, so this PR updates it to meet this constraints.