### PR TITLE
Revert too long app names

### DIFF
--- a/fastlane/metadata/android/ar/title.txt
+++ b/fastlane/metadata/android/ar/title.txt
@@ -1,1 +1,1 @@
-متجر WooCommerce: إدارة المتاجر ونقاط البيع
+WooCommerce

--- a/fastlane/metadata/android/de-DE/title.txt
+++ b/fastlane/metadata/android/de-DE/title.txt
@@ -1,1 +1,1 @@
-WooCommerce: Shop-Verwaltung und POS
+WooCommerce

--- a/fastlane/metadata/android/es-ES/title.txt
+++ b/fastlane/metadata/android/es-ES/title.txt
@@ -1,1 +1,1 @@
-WooCommerce: gestión de tiendas y puntos de venta
+WooCommerce

--- a/fastlane/metadata/android/fr-FR/title.txt
+++ b/fastlane/metadata/android/fr-FR/title.txt
@@ -1,1 +1,1 @@
-WooCommerce : Gestion de boutique et PDV
+WooCommerce

--- a/fastlane/metadata/android/id/title.txt
+++ b/fastlane/metadata/android/id/title.txt
@@ -1,1 +1,1 @@
-WooCommerce: Manajemen & POS Toko
+WooCommerce

--- a/fastlane/metadata/android/it-IT/title.txt
+++ b/fastlane/metadata/android/it-IT/title.txt
@@ -1,1 +1,1 @@
-WooCommerce: gestione del negozio e POS
+WooCommerce

--- a/fastlane/metadata/android/nl-NL/title.txt
+++ b/fastlane/metadata/android/nl-NL/title.txt
@@ -1,1 +1,1 @@
-WooCommerce: Winkelbeheer en POS
+WooCommerce

--- a/fastlane/metadata/android/pt-BR/title.txt
+++ b/fastlane/metadata/android/pt-BR/title.txt
@@ -1,1 +1,1 @@
-WooCommerce: PDV e gerenciamento da loja
+WooCommerce

--- a/fastlane/metadata/android/ru-RU/title.txt
+++ b/fastlane/metadata/android/ru-RU/title.txt
@@ -1,1 +1,1 @@
-WooCommerce: управление магазином и POS
+WooCommerce

--- a/fastlane/metadata/android/sv-SE/title.txt
+++ b/fastlane/metadata/android/sv-SE/title.txt
@@ -1,1 +1,1 @@
-WooCommerce: Butikshantering och POS
+WooCommerce

--- a/fastlane/metadata/android/tr-TR/title.txt
+++ b/fastlane/metadata/android/tr-TR/title.txt
@@ -1,1 +1,1 @@
-WooCommerce: Mağaza Yönetimi ve POS
+WooCommerce


### PR DESCRIPTION
Follow up for https://github.com/woocommerce/woocommerce-android/pull/15096. Non-english translations were still exceeding the app name. However, for these, I opted for reverting the name change, as translating them requires i18n team.