### PR TITLE
[Bookings] Fix 12/24 hour system

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.ui.bookings.details.AttendanceUpdateStatus
 import com.woocommerce.android.ui.bookings.details.CancelStatus
 import com.woocommerce.android.ui.bookings.list.BookingListItem
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateFormatter
 import com.woocommerce.android.util.normalizeDuration
 import com.woocommerce.android.util.toHumanReadableFormat
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -33,23 +34,17 @@ import java.time.format.FormatStyle
 import javax.inject.Inject
 
 class BookingMapper @Inject constructor(
+    private val dateFormatter: DateFormatter,
     private val currencyFormatter: CurrencyFormatter,
     private val getLocations: GetLocations,
     private val resourceProvider: ResourceProvider
 ) {
-    private val summaryDateFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedDateTime(
-        FormatStyle.MEDIUM,
-        FormatStyle.SHORT
-    ).withZone(ZoneOffset.UTC)
-
     private val detailsDateFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
-        .withZone(ZoneOffset.UTC)
-    private val timeRangeFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
         .withZone(ZoneOffset.UTC)
 
     fun Booking.toBookingSummaryModel(attendanceUpdateStatus: AttendanceUpdateStatus): BookingSummaryModel {
         return BookingSummaryModel(
-            date = summaryDateFormatter.format(start),
+            date = dateFormatter.formatDateTime(start),
             name = order.productInfo?.name ?: "-",
             customerName = order.customerInfo?.fullName(),
             status = status.toUiModel(order.status, order.paymentInfo?.paymentMethodId),
@@ -74,7 +69,7 @@ class BookingMapper @Inject constructor(
             .toHumanReadableFormat(resourceProvider)
         return BookingAppointmentDetailsModel(
             date = detailsDateFormatter.format(start),
-            time = "${timeRangeFormatter.format(start)} - ${timeRangeFormatter.format(end)}",
+            time = "${dateFormatter.formatTime(start)} - ${dateFormatter.formatTime(end)}",
             staff = staffMemberStatus,
             // TODO replace mocked values when available from API
             location = "238 Willow Creek Drive, Montgomery AL 36109",
@@ -147,7 +142,7 @@ class BookingMapper @Inject constructor(
             ?: UiString.UiStringRes(R.string.customer_detail_guest_customer)
         val serviceName = booking.order.productInfo?.name ?: "-"
         val date = detailsDateFormatter.format(booking.start)
-        val time = timeRangeFormatter.format(booking.start)
+        val time = dateFormatter.formatTime(booking.start)
         return UiString.UiStringRes(
             R.string.booking_cancel_dialog_message_v2,
             listOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModel.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.filter.datetime.PickerDialogState.DateDialog
 import com.woocommerce.android.ui.bookings.filter.datetime.PickerDialogState.TimeDialog
 import com.woocommerce.android.ui.compose.component.Time
+import com.woocommerce.android.util.DateFormatter
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.assisted.Assisted
@@ -22,21 +23,17 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
 
 @HiltViewModel(assistedFactory = DateTimeFilterViewModel.Factory::class)
 class DateTimeFilterViewModel @AssistedInject constructor(
     savedStateHandle: SavedStateHandle,
     private val clock: Clock,
+    private val dateFormatter: DateFormatter,
     @Assisted private val initialRange: BookingsFilterOption.DateRange? = null,
     @Assisted private val onTypeFilterChanged: (BookingsFilterOption.DateRange) -> Unit,
 ) : ScopedViewModel(savedStateHandle) {
 
     private val zone: ZoneId = ZoneOffset.UTC
-
-    private val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
-    private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
 
     private val _uiState = MutableStateFlow(
         DateTimeFilterUiState(
@@ -255,8 +252,8 @@ class DateTimeFilterViewModel @AssistedInject constructor(
         )
     }
 
-    private fun LocalDateTime?.formatDate(): String = this?.let { dateFormatter.format(it) }.orEmpty()
-    private fun LocalDateTime?.formatTime(): String = this?.let { timeFormatter.format(it) }.orEmpty()
+    private fun LocalDateTime?.formatDate(): String = this?.let { dateFormatter.formatDate(it) }.orEmpty()
+    private fun LocalDateTime?.formatTime(): String = this?.let { dateFormatter.formatTime(it) }.orEmpty()
 
     @AssistedFactory
     interface Factory {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DateFormatter.kt
@@ -1,0 +1,55 @@
+package com.woocommerce.android.util
+
+import android.content.Context
+import android.text.format.DateFormat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+import javax.inject.Inject
+
+class DateFormatter @Inject constructor(@ApplicationContext private val context: Context) {
+
+    /**
+     * Formats date and time respecting system 12h/24h preference.
+     * Example: "Dec 12, 2025, 10:47 PM" or "Dec 12, 2025, 22:47"
+     */
+    fun formatDateTime(
+        instant: Instant
+    ): String = createSkeletonFormatter(skeleton = "MMMdyyyyhm", skeleton24h = "MMMdyyyyHm").format(instant)
+
+    /**
+     * Formats time only respecting system 12h/24h preference.
+     * Example: "10:47 PM" or "22:47"
+     */
+    fun formatTime(instant: Instant): String = getTimeFormatter().format(instant)
+
+    /**
+     * Formats date only using localized medium style.
+     * Example: "Dec 12, 2025"
+     */
+    fun formatDate(
+        localDateTime: LocalDateTime
+    ): String = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).format(localDateTime)
+
+    /**
+     * Formats time only respecting system 12h/24h preference.
+     * Example: "10:47 PM" or "22:47"
+     */
+    fun formatTime(localDateTime: LocalDateTime): String = getTimeFormatter().format(localDateTime)
+
+    private fun createSkeletonFormatter(skeleton: String, skeleton24h: String? = null): DateTimeFormatter {
+        val isSystem24h = DateFormat.is24HourFormat(context)
+
+        val finalSkeleton = if (isSystem24h && skeleton24h != null) skeleton24h else skeleton
+
+        val bestPattern = DateFormat.getBestDateTimePattern(Locale.getDefault(), finalSkeleton)
+
+        return DateTimeFormatter.ofPattern(bestPattern, Locale.getDefault()).withZone(ZoneOffset.UTC)
+    }
+
+    private fun getTimeFormatter() = createSkeletonFormatter(skeleton = "hm", skeleton24h = "Hm")
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/BookingMapperTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.bookings.compose.BookingStatus
 import com.woocommerce.android.ui.bookings.details.AttendanceUpdateStatus
 import com.woocommerce.android.ui.bookings.details.CancelStatus
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateFormatter
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -20,6 +21,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingCustomerInfo
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingOrderInfo
@@ -35,6 +37,12 @@ import java.time.format.FormatStyle
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BookingMapperTest : BaseUnitTest() {
+    companion object {
+        private const val FORMATTED_DATE_TIME = "Jul 5, 2025, 11:00 AM"
+        private const val FORMATTED_TIME = "11:00 AM"
+    }
+
+    private val dateFormatter = mock<DateFormatter>()
 
     private val currencyFormatter: CurrencyFormatter = mock {
         on { formatCurrency(any<BigDecimal>(), any(), eq(true)) } doAnswer {
@@ -72,7 +80,9 @@ class BookingMapperTest : BaseUnitTest() {
 
     @Before
     fun setup() {
-        mapper = BookingMapper(currencyFormatter, getLocations, resourceProvider)
+        whenever(dateFormatter.formatDateTime(any<Instant>())).thenReturn(FORMATTED_DATE_TIME)
+        whenever(dateFormatter.formatTime(any<Instant>())).thenReturn(FORMATTED_TIME)
+        mapper = BookingMapper(dateFormatter, currencyFormatter, getLocations, resourceProvider)
     }
 
     @Test
@@ -88,15 +98,11 @@ class BookingMapperTest : BaseUnitTest() {
             currency = "USD"
         )
 
-        val expectedDate = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)
-            .withZone(ZoneOffset.UTC)
-            .format(start)
-
         // WHEN
         val model = mapper.run { booking.toBookingSummaryModel(AttendanceUpdateStatus.Idle) }
 
         // THEN
-        assertThat(model.date).isEqualTo(expectedDate)
+        assertThat(model.date).isEqualTo(FORMATTED_DATE_TIME)
         assertThat(model.name).isEqualTo(booking.order.productInfo?.name)
         assertThat(model.customerName)
             .isEqualTo("${booking.order.customerInfo?.billingFirstName} ${booking.order.customerInfo?.billingLastName}")
@@ -121,8 +127,7 @@ class BookingMapperTest : BaseUnitTest() {
         val expectedDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
             .withZone(ZoneOffset.UTC)
             .format(start)
-        val timeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withZone(ZoneOffset.UTC)
-        val expectedTime = "${timeFormatter.format(start)} - ${timeFormatter.format(end)}"
+        val expectedTime = "$FORMATTED_TIME - $FORMATTED_TIME"
 
         // WHEN
         val model = mapper.run { booking.toAppointmentDetailsModel(staffMemberStatus, CancelStatus.Idle) }
@@ -202,7 +207,6 @@ class BookingMapperTest : BaseUnitTest() {
         val start = Instant.parse("2025-09-12T16:00:00Z")
         val booking = sampleBooking(start = start, end = start.plus(Duration.ofHours(1)))
         val expectedDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL).withZone(ZoneOffset.UTC).format(start)
-        val expectedTime = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withZone(ZoneOffset.UTC).format(start)
 
         // WHEN
         val message = mapper.buildCancelDialogMessage(booking)
@@ -218,7 +222,7 @@ class BookingMapperTest : BaseUnitTest() {
                         UiString.UiStringText(customerName),
                         UiString.UiStringText("${booking.order.productInfo?.name}"),
                         UiString.UiStringText(expectedDate),
-                        UiString.UiStringText(expectedTime)
+                        UiString.UiStringText(FORMATTED_TIME)
                     )
                 )
             )
@@ -230,7 +234,6 @@ class BookingMapperTest : BaseUnitTest() {
         val start = Instant.parse("2025-09-12T16:00:00Z")
         val booking = sampleBooking(start = start, customerInfo = null)
         val expectedDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL).withZone(ZoneOffset.UTC).format(start)
-        val expectedTime = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).withZone(ZoneOffset.UTC).format(start)
 
         // WHEN
         val message = mapper.buildCancelDialogMessage(booking)
@@ -244,7 +247,7 @@ class BookingMapperTest : BaseUnitTest() {
                         UiString.UiStringRes(R.string.customer_detail_guest_customer),
                         UiString.UiStringText("${booking.order.productInfo?.name}"),
                         UiString.UiStringText(expectedDate),
-                        UiString.UiStringText(expectedTime)
+                        UiString.UiStringText(FORMATTED_TIME)
                     )
                 )
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
 import com.woocommerce.android.ui.bookings.compose.BookingStaffMemberStatus
 import com.woocommerce.android.ui.compose.DialogState
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateFormatter
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -44,10 +45,11 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
     private val bookingFlow = MutableStateFlow(initialBooking)
     private val savedStateHandle = SavedStateHandle(mapOf("mode" to BookingDetailsFragment.Mode.ShowBooking(bookingId)))
 
+    private val dateFormatter = mock<DateFormatter>()
     private val currencyFormatter = mock<CurrencyFormatter>()
     private val resourceProvider = mock<ResourceProvider>()
     private val getLocations = mock<GetLocations>()
-    private val bookingMapper = BookingMapper(currencyFormatter, getLocations, resourceProvider)
+    private val bookingMapper = BookingMapper(dateFormatter, currencyFormatter, getLocations, resourceProvider)
     private val bookingsRepository = mock<BookingsRepository> {
         on { observeBooking(any()) } doReturn bookingFlow
         onBlocking { fetchBooking(any()) } doReturn Result.success(bookingFlow.value)
@@ -77,6 +79,9 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
             val qty = it.getArgument<Int>(0)
             if (qty == 1) "$qty day" else "$qty days"
         }
+
+        whenever(dateFormatter.formatDateTime(any<Instant>())).thenReturn("Dec 12, 2025, 11:00 AM")
+        whenever(dateFormatter.formatTime(any<Instant>())).thenReturn("12:00")
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/datetime/DateTimeFilterViewModelTest.kt
@@ -3,12 +3,16 @@ package com.woocommerce.android.ui.bookings.filter.datetime
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.Time
+import com.woocommerce.android.util.DateFormatter
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import java.time.Clock
 import java.time.Instant
@@ -20,6 +24,7 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
 
     private val zone = ZoneOffset.UTC
 
+    private val dateFormatter = mock<DateFormatter>()
     private val clock = Clock.fixed(
         LocalDateTime.of(2025, 11, 13, 10, 0)
             .toInstant(zone),
@@ -195,10 +200,13 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
             )
 
             // When
+            whenever(dateFormatter.formatDate(any<LocalDateTime>())).thenReturn("Dec 12, 2025")
+            whenever(dateFormatter.formatTime(any<LocalDateTime>())).thenReturn("12:00")
             val vm = DateTimeFilterViewModel(
                 onTypeFilterChanged = { _ -> },
                 savedStateHandle = SavedStateHandle(),
                 clock = clock,
+                dateFormatter = dateFormatter,
                 initialRange = range,
             )
 
@@ -281,10 +289,13 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
             // Given
             val fromInitial = LocalDateTime.of(2025, 1, 1, 9, 0)
             val toInitial = LocalDateTime.of(2025, 1, 1, 10, 0)
+            whenever(dateFormatter.formatDate(any<LocalDateTime>())).thenReturn("Dec 12, 2025")
+            whenever(dateFormatter.formatTime(any<LocalDateTime>())).thenReturn("12:00")
             val vm = DateTimeFilterViewModel(
                 onTypeFilterChanged = { _ -> },
                 savedStateHandle = SavedStateHandle(),
                 clock = clock,
+                dateFormatter = dateFormatter,
                 initialRange = BookingsFilterOption.DateRange(
                     after = fromInitial.toInstant(ZoneOffset.UTC),
                     before = toInitial.toInstant(ZoneOffset.UTC)
@@ -317,10 +328,13 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
             // Given
             val fromInitial = LocalDateTime.of(2025, 1, 1, 9, 0)
             val toInitial = LocalDateTime.of(2025, 1, 1, 10, 0)
+            whenever(dateFormatter.formatDate(any<LocalDateTime>())).thenReturn("Dec 12, 2025")
+            whenever(dateFormatter.formatTime(any<LocalDateTime>())).thenReturn("12:00")
             val vm = DateTimeFilterViewModel(
                 onTypeFilterChanged = { _ -> },
                 savedStateHandle = SavedStateHandle(),
                 clock = clock,
+                dateFormatter = dateFormatter,
                 initialRange = BookingsFilterOption.DateRange(
                     after = fromInitial.toInstant(ZoneOffset.UTC),
                     before = toInitial.toInstant(ZoneOffset.UTC)
@@ -419,10 +433,13 @@ class DateTimeFilterViewModelTest : BaseUnitTest() {
     }
 
     private fun createVm(): DateTimeFilterViewModel {
+        whenever(dateFormatter.formatDate(any<LocalDateTime>())).thenReturn("Dec 12, 2025")
+        whenever(dateFormatter.formatTime(any<LocalDateTime>())).thenReturn("12:00")
         return DateTimeFilterViewModel(
             onTypeFilterChanged = { _ -> },
             savedStateHandle = SavedStateHandle(),
             clock = clock,
+            dateFormatter = dateFormatter,
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.bookings.Booking
 import com.woocommerce.android.ui.bookings.BookingMapper
 import com.woocommerce.android.ui.bookings.filter.data.BookingFilterRepository
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateFormatter
 import com.woocommerce.android.util.IsWindowClassLargeThanCompact
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.getOrAwaitValue
@@ -53,10 +54,12 @@ class BookingListViewModelTest : BaseUnitTest() {
     }
     private val mockedNow = Instant.parse("2025-01-01T12:00:00Z")
     private val filtersBuilder = BookingListFiltersBuilder(Clock.fixed(mockedNow, ZoneId.of("UTC")))
+    private val dateFormatter = mock<DateFormatter>()
+
     private val currencyFormatter = mock<CurrencyFormatter>()
     private val getLocations = mock<GetLocations>()
     private val resourceProvider = mock<ResourceProvider>()
-    private val bookingMapper = BookingMapper(currencyFormatter, getLocations, resourceProvider)
+    private val bookingMapper = BookingMapper(dateFormatter, currencyFormatter, getLocations, resourceProvider)
     private val bookingFiltersFlow = MutableStateFlow(BookingFilters())
     private val bookingFilterRepository: BookingFilterRepository = mock {
         on { bookingFiltersFlow } doReturn bookingFiltersFlow
@@ -72,6 +75,7 @@ class BookingListViewModelTest : BaseUnitTest() {
     ) {
         whenever(bookingListHandler.bookingsFlow).thenReturn(flowOf(bookings))
         whenever(isWindowClassLargeThanCompact()).thenReturn(false)
+        whenever(dateFormatter.formatDateTime(any<Instant>())).thenReturn("Dec 12, 2025, 11:00 AM")
         prepareMocks()
         savedStateHandle = SavedStateHandle()
         viewModel = BookingListViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateFormatterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DateFormatterTest.kt
@@ -1,0 +1,118 @@
+package com.woocommerce.android.util
+
+import android.content.Context
+import android.text.format.DateFormat
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.Locale
+
+class DateFormatterTest {
+
+    private val context: Context = mock()
+
+    private lateinit var formatter: DateFormatter
+
+    private lateinit var dateFormatMock: MockedStatic<DateFormat>
+
+    private val fixedInstant = Instant.parse("2025-12-12T23:00:00Z")
+    private val fixedLocalDateTime = LocalDateTime.ofInstant(fixedInstant, ZoneOffset.UTC)
+
+    @Before
+    fun setup() {
+        dateFormatMock = Mockito.mockStatic(DateFormat::class.java)
+
+        formatter = DateFormatter(context)
+
+        Locale.setDefault(Locale.US)
+    }
+
+    @After
+    fun tearDown() {
+        dateFormatMock.close()
+    }
+
+    @Test
+    fun `when system is 12h, then formatDateTime uses 12h skeleton`() {
+        // GIVEN
+        whenever(DateFormat.is24HourFormat(context)).thenReturn(false)
+
+        whenever(DateFormat.getBestDateTimePattern(any(), eq("MMMdyyyyhm")))
+            .thenReturn("MMM d, yyyy h:mm a") // 12h Pattern
+
+        // WHEN
+        val result = formatter.formatDateTime(fixedInstant)
+
+        // THEN
+        assertThat(result).isEqualTo("Dec 12, 2025 11:00 PM")
+    }
+
+    @Test
+    fun `when system is 24h, then formatDateTime uses 24h skeleton`() {
+        // GIVEN
+        whenever(DateFormat.is24HourFormat(context)).thenReturn(true)
+
+        whenever(DateFormat.getBestDateTimePattern(any(), eq("MMMdyyyyHm")))
+            .thenReturn("MMM d, yyyy HH:mm") // 24h Pattern
+
+        // WHEN
+        val result = formatter.formatDateTime(fixedInstant)
+
+        // THEN
+        assertThat(result).isEqualTo("Dec 12, 2025 23:00")
+    }
+
+    @Test
+    fun `when system is 12h, then formatTime uses 12h skeleton`() {
+        // GIVEN
+        whenever(DateFormat.is24HourFormat(context)).thenReturn(false)
+
+        whenever(DateFormat.getBestDateTimePattern(any(), eq("hm")))
+            .thenReturn("h:mm a")
+
+        // WHEN
+        val result = formatter.formatTime(fixedInstant)
+
+        // THEN
+        assertThat(result).isEqualTo("11:00 PM")
+    }
+
+    @Test
+    fun `when system is 24h, then formatTime uses 24h skeleton`() {
+        // GIVEN
+        whenever(DateFormat.is24HourFormat(context)).thenReturn(true)
+
+        whenever(DateFormat.getBestDateTimePattern(any(), eq("Hm")))
+            .thenReturn("HH:mm")
+
+        // WHEN
+        val result = formatter.formatTime(fixedInstant)
+
+        // THEN
+        assertThat(result).isEqualTo("23:00")
+    }
+
+    @Test
+    fun `when formatTime invokes, then LocalDateTime respects 24h setting`() {
+        // GIVEN
+        whenever(DateFormat.is24HourFormat(context)).thenReturn(true)
+        whenever(DateFormat.getBestDateTimePattern(any(), eq("Hm")))
+            .thenReturn("HH:mm")
+
+        // WHEN
+        val result = formatter.formatTime(fixedLocalDateTime)
+
+        // THEN
+        assertThat(result).isEqualTo("23:00")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1816

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The date formatter used in `BookingMapper` and the view models wasn't respecting the device's 12/24-hour setting. I added a new `DateFormatter` class to ensure proper handling and use a single formatter across all screens. 
We already had `DateExt` and `DateUtils`, but `DateExt` only provides extension functions, which makes testing difficult, and  `DateUtils` contains an unnecessary `selectedSite` parameter and mostly tailored for `Date`. For these reasons, I introduced the new `DateFormatter` class.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Repeat steps below with both 12-hour format and 24-hour format.
1. Log in with a CIAB store.
2. Go to Bookings.
3. Verify times on booking items.
4. Select an item.
5. Verify times on the screen.
6. Navigate back.
7. Go to All tab. 
8. Tap Filters button.
9. Select Date & time.
10. Select a time from the picker.
11. Verify the selected time.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="360"  alt="before1" src="https://github.com/user-attachments/assets/4e0d66ea-ecc4-400c-9c2c-00a30e605801" />|<img width="360" alt="after1" src="https://github.com/user-attachments/assets/50cfa820-d897-43a5-a605-b9de567a93ed" />|
|<img width="360"  alt="before2" src="https://github.com/user-attachments/assets/f0c0e63b-f2d0-413a-b80d-c40844767db7" />|<img width="360" alt="after2" src="https://github.com/user-attachments/assets/8f986ee4-402d-4e37-9687-3d3b2b5c53cd" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
