### PR TITLE
Stop using custom Develocity instance

### DIFF
--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -1,15 +1,12 @@
 develocity {
     buildScan {
-        server = "https://develocity.a8c-ci.services/"
-        accessKey = gradle.ext.secretProperties["develocityToken"]
-
         if (gradle.ext.isCi) {
+            termsOfUseUrl = 'https://gradle.com/terms-of-service'
+            termsOfUseAgree = 'yes'
+            tag 'CI'
             uploadInBackground = false
         } else {
-            obfuscation {
-                hostname { "" }
-                ipAddresses { it.collect { "0.0.0.0" } }
-            }
+            publishing.onlyIf { false }
         }
     }
 }


### PR DESCRIPTION
### Description

Our Develocity 360 trial has expired and we decided to not use the product. 

Internal ref paaHJt-99X-p2

Fixes https://linear.app/a8c/issue/AINFRA-1641

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
See CI in the test PR #15107 which touches a file to trigger the lint:

<img width="1066" height="298" alt="image" src="https://github.com/user-attachments/assets/de333858-ccf1-422a-8bc2-8df98c0bf80e" />

(_The failure in the screenshot is from `detkt` because I had two consecutive empty line in the code I added._)


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes. — N.A.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->