### PR TITLE
Test for Develocity change

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shortcuts/AppShortcut.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/shortcuts/AppShortcut.kt
@@ -1,5 +1,8 @@
 package com.woocommerce.android.ui.shortcuts
 
+
+// Adding this to trigger file change check and lint in CI
+
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.woocommerce.android.R

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -1,15 +1,12 @@
 develocity {
     buildScan {
-        server = "https://develocity.a8c-ci.services/"
-        accessKey = gradle.ext.secretProperties["develocityToken"]
-
         if (gradle.ext.isCi) {
+            termsOfUseUrl = 'https://gradle.com/terms-of-service'
+            termsOfUseAgree = 'yes'
+            tag 'CI'
             uploadInBackground = false
         } else {
-            obfuscation {
-                hostname { "" }
-                ipAddresses { it.collect { "0.0.0.0" } }
-            }
+            publishing.onlyIf { false }
         }
     }
 }


### PR DESCRIPTION
See https://github.com/woocommerce/woocommerce-android/pull/15106

<img width="1066" height="298" alt="image" src="https://github.com/user-attachments/assets/de333858-ccf1-422a-8bc2-8df98c0bf80e" />

_The failure in the screenshot is from `detkt` because I had two consecutive empty line in the code I added._