### PR TITLE
Replace /bin/sh calls with /bin/bash

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.

--- a/gradlew
+++ b/gradlew
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Copyright © 2015-2021 the original authors.


### PR DESCRIPTION
As we upgrade the builders, /bin/sh is now dash which does not support all the features bash does.

Switch to explicitly using bash to ensure things continue to work

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
