### PR TITLE
[WOOMOB-1889] Woo POS catalog file download - step 2

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCatalogFileDownloader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCatalogFileDownloader.kt
@@ -1,0 +1,111 @@
+package com.woocommerce.android.ui.woopos.localcatalog
+
+import android.content.Context
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import com.woocommerce.android.util.CoroutineDispatchers
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooPosCatalogFileDownloader @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val dispatchers: CoroutineDispatchers,
+    private val logger: WooPosLogWrapper,
+) {
+    private val okHttpClient = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .writeTimeout(60, TimeUnit.SECONDS)
+        .build()
+
+    suspend fun downloadCatalogFile(
+        fileUrl: String,
+        localSiteId: LocalOrRemoteId.LocalId,
+    ): Result<File> = withContext(dispatchers.io) {
+        val file =
+            File(context.cacheDir, "${FILE_NAME_PREFIX}_site_${localSiteId.value}_${System.currentTimeMillis()}")
+
+        try {
+            logger.d("WooPosCatalogFileDownloader: Starting catalog file download from: $fileUrl")
+            logger.d("WooPosCatalogFileDownloader: Destination: ${file.absolutePath}")
+
+            val request = Request.Builder()
+                .url(fileUrl)
+                .build()
+
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    val error = "Download failed with code: ${response.code}"
+                    logger.e(error)
+                    return@withContext Result.failure(IOException(error))
+                }
+
+                val responseBody = response.body
+
+                val contentLength = responseBody.contentLength()
+                logger.d("WooPosCatalogFileDownloader: Content length: $contentLength bytes")
+
+                responseBody.byteStream().use { inputStream ->
+                    file.outputStream().use { outputStream ->
+                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                        var bytesRead: Int
+                        var totalBytesRead = 0L
+
+                        while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                            outputStream.write(buffer, 0, bytesRead)
+                            totalBytesRead += bytesRead
+                        }
+
+                        logger.d("WooPosCatalogFileDownloader: Download complete. Total bytes: $totalBytesRead")
+                    }
+                }
+            }
+
+            if (!file.exists() || file.length() == 0L) {
+                val error = "Downloaded file is empty or doesn't exist"
+                logger.e(error)
+                file.delete()
+                return@withContext Result.failure(IOException(error))
+            }
+
+            logger.d("WooPosCatalogFileDownloader: Catalog file downloaded successfully: ${file.absolutePath}")
+            Result.success(file)
+        } catch (e: IOException) {
+            logger.e("Error downloading catalog file", e)
+            if (file.exists()) {
+                file.delete()
+            }
+            Result.failure(e)
+        }
+    }
+
+    fun cleanupOldCatalogFiles(keepLatest: File? = null) {
+        try {
+            val catalogFiles = context.cacheDir.listFiles { file ->
+                file.name.startsWith(FILE_NAME_PREFIX) && file.name.endsWith(".json")
+            } ?: return
+
+            catalogFiles.forEach { file ->
+                if (file != keepLatest) {
+                    val deleted = file.delete()
+                    logger.d("WooPosCatalogFileDownloader: Deleted old catalog file: ${file.name}, success: $deleted")
+                }
+            }
+        } catch (e: IOException) {
+            logger.e("Error cleaning up old catalog files", e)
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_BUFFER_SIZE = 128 * 1024
+        private const val FILE_NAME_PREFIX = "woopos_catalog_"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCatalogFileDownloader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCatalogFileDownloader.kt
@@ -12,9 +12,7 @@ import java.io.File
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class WooPosCatalogFileDownloader @Inject constructor(
     @ApplicationContext private val context: Context,
     private val dispatchers: CoroutineDispatchers,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCatalogFileDownloader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCatalogFileDownloader.kt
@@ -31,7 +31,7 @@ class WooPosCatalogFileDownloader @Inject constructor(
         localSiteId: LocalOrRemoteId.LocalId,
     ): Result<File> = withContext(dispatchers.io) {
         val file =
-            File(context.cacheDir, "${FILE_NAME_PREFIX}_site_${localSiteId.value}_${System.currentTimeMillis()}")
+            File(context.cacheDir, "${FILE_NAME_PREFIX}_site_${localSiteId.value}_${System.currentTimeMillis()}.json")
 
         try {
             logger.d("WooPosCatalogFileDownloader: Starting catalog file download from: $fileUrl")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCatalogFileDownloader.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCatalogFileDownloader.kt
@@ -87,11 +87,11 @@ class WooPosCatalogFileDownloader @Inject constructor(
         }
     }
 
-    fun cleanupOldCatalogFiles(keepLatest: File? = null) {
+    suspend fun cleanupOldCatalogFiles(keepLatest: File? = null) = withContext(dispatchers.io) {
         try {
             val catalogFiles = context.cacheDir.listFiles { file ->
                 file.name.startsWith(FILE_NAME_PREFIX) && file.name.endsWith(".json")
-            } ?: return
+            } ?: return@withContext
 
             catalogFiles.forEach { file ->
                 if (file != keepLatest) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCheckCatalogSizeAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCheckCatalogSizeAction.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import com.woocommerce.android.util.FeatureFlag
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.pos.localcatalog.WooPosLocalCatalogStore
 import javax.inject.Inject
@@ -21,6 +22,9 @@ class WooPosCheckCatalogSizeAction @Inject constructor(
         modifiedAfterGmt: String? = null,
         maxTotalItems: Int,
     ): WooPosCheckCatalogSizeResult {
+        if (FeatureFlag.WOO_POS_LOCAL_CATALOG_FILE_APPROACH.isEnabled()) {
+            return WooPosCheckCatalogSizeResult.SizeAcceptable
+        }
         logger.d("Checking catalog size before sync")
 
         val productsCountResult = posLocalCatalogStore.fetchProductsCount(site, modifiedAfterGmt)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncAction.kt
@@ -70,8 +70,6 @@ class WooPosFileBasedSyncAction @Inject constructor(
 
     data class FileBasedSyncResult(
         val fileUrl: String,
-        val productFields: List<String>?,
-        val variationFields: List<String>?,
         val totalProducts: Int?,
         val completedAt: String?
     )
@@ -100,8 +98,6 @@ class WooPosFileBasedSyncAction @Inject constructor(
     ): FileBasedSyncResult {
         return FileBasedSyncResult(
             fileUrl = fileUrl,
-            productFields = result.productFields,
-            variationFields = result.variationFields,
             totalProducts = result.total,
             completedAt = result.completedAt
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncActionTest.kt
@@ -170,7 +170,7 @@ class WooPosFileBasedSyncActionTest : BaseUnitTest() {
         // GIVEN
         val inProgressResult = WooPosGenerateCatalogResult(
             state = WooPosGenerateCatalogState.IN_PROGRESS,
-            progress = 50,
+            progress = 50f,
             total = 100
         )
         whenever(posLocalCatalogStore.generateCatalog(site))

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosGenerateCatalogResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosGenerateCatalogResponse.kt
@@ -15,15 +15,6 @@ data class WooPosGenerateCatalogResponse(
     val processed: Int? = null,
     @SerializedName("total")
     val total: Int? = null,
-    @SerializedName("args")
-    val args: WooPosGenerateCatalogArgs? = null,
     @SerializedName("url")
     val url: String? = null,
-)
-
-data class WooPosGenerateCatalogArgs(
-    @SerializedName("_product_fields")
-    val productFields: List<String>? = null,
-    @SerializedName("_variation_fields")
-    val variationFields: List<String>? = null,
 )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosGenerateCatalogResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosGenerateCatalogResponse.kt
@@ -10,7 +10,7 @@ data class WooPosGenerateCatalogResponse(
     @SerializedName("state")
     val state: String? = null,
     @SerializedName("progress")
-    val progress: Int? = null,
+    val progress: Float? = null,
     @SerializedName("processed")
     val processed: Int? = null,
     @SerializedName("total")

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -16,7 +16,7 @@ class WooPosProductRestClient @Inject constructor(
     private val wooNetwork: WooNetwork,
 ) {
     companion object {
-        private const val PRODUCT_FIELDS = "localSiteId,id,name,sku,global_unique_id,type,price,downloadable," +
+        private const val PRODUCT_FIELDS = "id,name,sku,global_unique_id,type,price,downloadable," +
             "images,attributes,parent_id,status,regular_price,sale_price,on_sale,description," +
             "short_description,manage_stock,stock_quantity,stock_status,backorders_allowed," +
             "backordered,categories,tags,date_modified"

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -90,7 +90,7 @@ class WooPosProductRestClient @Inject constructor(
     suspend fun postGenerateCatalog(
         site: SiteModel,
     ): WooResult<WooPosGenerateCatalogResponse> {
-        val url = WOOCOMMERCE.product_catalog.create.pathPosV1
+        val url = WOOCOMMERCE.catalog.create.pathPosV1
         val params = mutableMapOf(
             "_product_fields" to PRODUCT_FIELDS,
             "_variation_fields" to VARIATIONS_FIELDS

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosGenerateCatalogResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosGenerateCatalogResult.kt
@@ -4,7 +4,7 @@ data class WooPosGenerateCatalogResult(
     val scheduledAt: String? = null,
     val completedAt: String? = null,
     val state: WooPosGenerateCatalogState,
-    val progress: Int? = null,
+    val progress: Float? = null,
     val processed: Int? = null,
     val total: Int? = null,
     val url: String? = null,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosGenerateCatalogResult.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosGenerateCatalogResult.kt
@@ -8,8 +8,6 @@ data class WooPosGenerateCatalogResult(
     val processed: Int? = null,
     val total: Int? = null,
     val url: String? = null,
-    val productFields: List<String>? = null,
-    val variationFields: List<String>? = null,
 )
 
 enum class WooPosGenerateCatalogState(val rawValue: String) {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -521,8 +521,6 @@ class WooPosLocalCatalogStore @Inject constructor(
                             processed = response.model.processed,
                             total = response.model.total,
                             url = response.model.url,
-                            productFields = response.model.args?.productFields,
-                            variationFields = response.model.args?.variationFields,
                         )
                     )
                 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -16,7 +16,6 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.pos.WooPosGenerateCatalogArgs
 import org.wordpress.android.fluxc.model.pos.WooPosGenerateCatalogResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
@@ -431,14 +430,10 @@ class WooPosLocalCatalogStoreTest {
             scheduledAt = "2025-12-10T11:21:48",
             completedAt = "2025-12-10T11:21:55",
             state = "completed",
-            progress = 100,
+            progress = 100f,
             processed = 881,
             total = 881,
             url = "https://example.com/catalog.json",
-            args = WooPosGenerateCatalogArgs(
-                productFields = listOf("id", "name", "price"),
-                variationFields = listOf("id", "parent_id")
-            )
         )
         whenever(posProductRestClient.postGenerateCatalog(testSite))
             .thenReturn(WooResult(response))
@@ -450,12 +445,10 @@ class WooPosLocalCatalogStoreTest {
         assertThat(result.scheduledAt).isEqualTo("2025-12-10T11:21:48")
         assertThat(result.completedAt).isEqualTo("2025-12-10T11:21:55")
         assertThat(result.state).isEqualTo(WooPosGenerateCatalogState.COMPLETED)
-        assertThat(result.progress).isEqualTo(100)
+        assertThat(result.progress).isEqualTo(100f)
         assertThat(result.processed).isEqualTo(881)
         assertThat(result.total).isEqualTo(881)
         assertThat(result.url).isEqualTo("https://example.com/catalog.json")
-        assertThat(result.productFields).containsExactly("id", "name", "price")
-        assertThat(result.variationFields).containsExactly("id", "parent_id")
         verify(posProductRestClient).postGenerateCatalog(testSite)
     }
 

--- a/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -35,7 +35,7 @@
 
 /variations/
 
-/product-catalog/create
+/catalog/create
 
 /product-add-ons/
 


### PR DESCRIPTION
Fixes WOOMOB-1889

### Description
This PR implements the next step of the catalog file download functionality for WooCommerce POS. The changes include:
- Added `WooPosCatalogFileDownloader` to handle streaming file downloads for POS catalog data
- Removed `localSiteId` from API requests
- Updated API endpoint path for catalog generation
- Enabled catalog sync for stores of any size by removing size restrictions

Note: The downloader doesn't have tests since mocking the low level API felt off.

### Test Steps
- the code isn't used yet, green CI is enough

### Images/gif
N/A - Backend functionality changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.