### PR TITLE
WOOMOB-1876 Fix First Product Celebration Dialog Layout on Tablets

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 23.9
 -----
+- [*] Fixed First Product Created celebration dialog layout on tablets to eliminate excessive white space [https://github.com/woocommerce/woocommerce-android/pull/15116]
 - [Internal][Woo POS] Add analytics tracking for stale catalog warning dialog display [https://github.com/woocommerce/woocommerce-android/pull/15055]
 - [*][Woo POS] Fixed loading indicator colors to match the design [https://github.com/woocommerce/woocommerce-android/pull/15043]
 - [**][Woo POS] Fixed crash when deleted products are in cart during checkout [https://github.com/woocommerce/woocommerce-android/pull/15083]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/FirstProductCelebrationDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/FirstProductCelebrationDialog.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
 class FirstProductCelebrationDialog : DialogFragment() {
     companion object {
         private const val TABLET_LANDSCAPE_WIDTH_RATIO = 0.35f
-        private const val TABLET_LANDSCAPE_HEIGHT_RATIO = 0.8f
+        private const val TABLET_PORTRAIT_WIDTH_RATIO = 0.7f
     }
 
     @Inject lateinit var navigator: ProductNavigator
@@ -59,14 +59,19 @@ class FirstProductCelebrationDialog : DialogFragment() {
 
     override fun onStart() {
         super.onStart()
-        if (isTabletLandscape()) {
+        if (isTablet()) {
+            val widthRatio = if (DisplayUtils.isLandscape(context)) {
+                TABLET_LANDSCAPE_WIDTH_RATIO
+            } else {
+                TABLET_PORTRAIT_WIDTH_RATIO
+            }
+
             requireDialog().window!!.setLayout(
-                (DisplayUtils.getWindowPixelWidth(requireContext()) * TABLET_LANDSCAPE_WIDTH_RATIO).toInt(),
-                (DisplayUtils.getWindowPixelHeight(requireContext()) * TABLET_LANDSCAPE_HEIGHT_RATIO).toInt()
+                (DisplayUtils.getWindowPixelWidth(requireContext()) * widthRatio).toInt(),
+                ViewGroup.LayoutParams.WRAP_CONTENT
             )
         }
     }
 
-    private fun isTabletLandscape() = (DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)) &&
-        DisplayUtils.isLandscape(context)
+    private fun isTablet() = DisplayUtils.isTablet(context) || DisplayUtils.isXLargeTablet(context)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/FirstProductCelebrationScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/FirstProductCelebrationScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
@@ -47,6 +48,7 @@ fun FirstProductCelebrationScreen(
     Column(
         modifier = Modifier
             .background(MaterialTheme.colors.surface)
+            .wrapContentHeight()
             .padding(dimensionResource(id = R.dimen.major_150))
     ) {
         Column(


### PR DESCRIPTION
WOOMOB-1876

  ### Description
  Fixes the broken layout of the First Product Created celebration dialog on tablets. The issue was that the dialog displayed excessive white space below the content, making it look broken.

  **Root cause:** The dialog window was using fixed height ratios (70% for portrait, 80% for landscape) regardless of content size, and only handled landscape orientation on tablets.

  **Solution:**
  - Updated dialog window sizing to use `WRAP_CONTENT` for height instead of fixed percentages
  - Added `wrapContentHeight()` modifier to the Compose content to ensure proper wrapping
  - Extended tablet support to handle both portrait and landscape orientations

  ### Test Steps
  1. Open the WooCommerce app on a tablet device (or tablet emulator)
  2. Navigate to Products and create a new product
  3. Save the product to trigger the "First product created" celebration dialog (you can comment out [this line](https://github.com/woocommerce/woocommerce-android/blob/a9281181dacf94579ad852d615f21adab520c246/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt#L1078) to always trigger the dialog)  
  5. Verify the dialog appears with content-appropriate height 
  6. Test in both portrait and landscape orientations on a tablet and a phone

  ### Images/gif

| Landscape | Portrait |
|--|--|
| <img width="400" alt="Screenshot_1765903324" src="https://github.com/user-attachments/assets/056c6f6f-09e9-4923-981d-ebec251c847e" /> | <img width="400" alt="Screenshot_1765903329" src="https://github.com/user-attachments/assets/410e024f-e6c1-4063-9655-0072c2dfcad7" /> 
| <img width="400" alt="Screenshot_1765903463" src="https://github.com/user-attachments/assets/63a723e9-2e6c-443c-a47d-246c4414cbd6" /> | <img width="400" alt="Screenshot_1765903459" src="https://github.com/user-attachments/assets/43ee5cd3-af23-45ed-bc85-2a6e809db2ac" />


  - [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
