### PR TITLE
Issue/woomob 1745 add pagination to fetch all the available bookable products

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -127,7 +127,7 @@ val BookingFilterPage.titleRes: Int
         BookingFilterPage.Customer -> R.string.bookings_filter_customer
         BookingFilterPage.Location -> R.string.bookings_filter_location
         BookingFilterPage.DateTime -> R.string.bookings_filter_title_date
-        BookingFilterPage.ServiceEvent -> R.string.bookings_filter_title_service_event
+        BookingFilterPage.ServiceEvent -> R.string.bookings_filter_title_service
         BookingFilterPage.List -> R.string.bookings_filters_default_title
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
@@ -49,7 +49,7 @@ fun BookingServiceEventFilterPage(state: BookingServiceEventFilterUiState) {
         WCSearchField(
             value = state.searchQuery,
             onValueChange = state.onSearchQueryChanged,
-            hint = stringResource(string.bookings_filter_search_service_event),
+            hint = stringResource(string.bookings_filter_search_service),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
@@ -1,9 +1,13 @@
 package com.woocommerce.android.ui.bookings.filter.productname
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
@@ -19,6 +23,7 @@ import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.bookings.filter.BookingsFilterSelectionPage
+import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.WCSearchField
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -57,7 +62,31 @@ fun BookingServiceEventFilterPage(state: BookingServiceEventFilterUiState) {
             ),
         )
         HorizontalDivider(thickness = 0.5.dp)
-        BookingsFilterSelectionPage(items = state.items)
+        if (state.isLoading && state.availableProducts.isEmpty()) {
+            BookingServiceEventFilterSkeletons()
+        } else {
+            BookingsFilterSelectionPage(items = state.items)
+        }
+    }
+}
+
+@Composable
+private fun BookingServiceEventFilterSkeletons() {
+    LazyColumn {
+        items(5) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dimensionResource(id = dimen.major_100)),
+                horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.major_100))
+            ) {
+                SkeletonView(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(64.dp)
+                )
+            }
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
@@ -6,19 +6,24 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Divider
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.woocommerce.android.R
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
 import com.woocommerce.android.model.UiString
@@ -77,15 +82,21 @@ private fun BookingServiceEventFilterSkeletons() {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                    .padding(18.dp),
                 horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.major_100))
             ) {
                 SkeletonView(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .height(64.dp)
+                        .width(200.dp)
+                        .height(18.dp)
                 )
             }
+            Divider(
+                modifier = Modifier
+                    .offset(x = dimensionResource(id = R.dimen.major_100)),
+                color = colorResource(id = R.color.divider_color),
+                thickness = dimensionResource(id = R.dimen.minor_10)
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
@@ -62,7 +62,7 @@ fun BookingServiceEventFilterPage(state: BookingServiceEventFilterUiState) {
             ),
         )
         HorizontalDivider(thickness = 0.5.dp)
-        if (state.isLoading && state.availableProducts.isEmpty()) {
+        if (state.isLoading) {
             BookingServiceEventFilterSkeletons()
         } else {
             BookingsFilterSelectionPage(items = state.items)
@@ -77,12 +77,12 @@ private fun BookingServiceEventFilterSkeletons() {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = dimensionResource(id = dimen.major_100)),
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.major_100))
             ) {
                 SkeletonView(
                     modifier = Modifier
-                        .weight(1f)
+                        .fillMaxWidth()
                         .height(64.dp)
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
@@ -59,7 +59,7 @@ fun BookingServiceEventFilterPage(state: BookingServiceEventFilterUiState) {
             ),
         )
         HorizontalDivider(thickness = 0.5.dp)
-        if (state.isLoading) {
+        if (state.skeletonVisible) {
             BookingServiceEventFilterSkeletons()
         } else {
             BookingsFilterSelectionPage(items = state.items)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterPage.kt
@@ -1,29 +1,21 @@
 package com.woocommerce.android.ui.bookings.filter.productname
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Divider
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import com.woocommerce.android.R
 import com.woocommerce.android.R.dimen
 import com.woocommerce.android.R.string
 import com.woocommerce.android.model.UiString
@@ -77,27 +69,37 @@ fun BookingServiceEventFilterPage(state: BookingServiceEventFilterUiState) {
 
 @Composable
 private fun BookingServiceEventFilterSkeletons() {
-    LazyColumn {
-        items(5) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(18.dp),
-                horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = dimen.major_100))
-            ) {
-                SkeletonView(
-                    modifier = Modifier
-                        .width(200.dp)
-                        .height(18.dp)
-                )
-            }
-            Divider(
-                modifier = Modifier
-                    .offset(x = dimensionResource(id = R.dimen.major_100)),
-                color = colorResource(id = R.color.divider_color),
-                thickness = dimensionResource(id = R.dimen.minor_10)
-            )
-        }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        SkeletonView(
+            modifier = Modifier
+                .size(62.dp, 64.dp)
+                .padding(horizontal = 16.dp, vertical = 24.dp)
+        )
+        HorizontalDivider(modifier = Modifier.padding(start = 16.dp), thickness = 0.5.dp)
+        SkeletonView(
+            modifier = Modifier
+                .size(175.dp, 64.dp)
+                .padding(horizontal = 16.dp, vertical = 24.dp)
+        )
+        HorizontalDivider(modifier = Modifier.padding(start = 16.dp), thickness = 0.5.dp)
+        SkeletonView(
+            modifier = Modifier
+                .size(130.dp, 64.dp)
+                .padding(horizontal = 16.dp, vertical = 24.dp)
+        )
+        HorizontalDivider(modifier = Modifier.padding(start = 16.dp), thickness = 0.5.dp)
+        SkeletonView(
+            modifier = Modifier
+                .size(167.dp, 64.dp)
+                .padding(horizontal = 16.dp, vertical = 24.dp)
+        )
+        HorizontalDivider(modifier = Modifier.padding(start = 16.dp), thickness = 0.5.dp)
+        SkeletonView(
+            modifier = Modifier
+                .size(166.dp, 64.dp)
+                .padding(horizontal = 16.dp, vertical = 24.dp)
+        )
+        HorizontalDivider(modifier = Modifier.padding(start = 16.dp), thickness = 0.5.dp)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterUiState.kt
@@ -40,6 +40,8 @@ data class BookingServiceEventFilterUiState(
     } else {
         selectedProducts.values.any { it.productId == product.id }
     }
+
+    val skeletonVisible: Boolean = isLoading && availableProducts.isEmpty()
 }
 
 data class BookableProduct(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterUiState.kt
@@ -11,6 +11,7 @@ data class BookingServiceEventFilterUiState(
     val availableProducts: List<BookableProduct> = emptyList(),
     val selectedProducts: BookingsFilterOption.ServiceEvents = BookingsFilterOption.ServiceEvents.DEFAULT,
     val searchQuery: String = "",
+    val isLoading: Boolean = false,
     val onProductSelected: (BookableProduct) -> Unit = {},
     val onSearchQueryChanged: (String) -> Unit = {},
 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
@@ -35,6 +35,11 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
 
     init {
         observeProducts()
+        // In parallel, fetch products from the network using pagination so the DB keeps getting
+        // populated with more booking products while the UI observes the DB changes.
+        launch {
+            paginateBookingProducts()
+        }
     }
 
     private fun observeProducts() = launch {
@@ -55,6 +60,31 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
                         }
                 )
             }
+        }
+    }
+
+    /**
+     * Fetch booking products from the network with pagination while the UI observes DB updates.
+     */
+    private suspend fun paginateBookingProducts() {
+        // First page
+        val firstPage = productListRepository.fetchProductList(
+            loadMore = false,
+            productFilterOptions = mapOf(WCProductStore.ProductFilterOption.TYPE to ProductType.BOOKABLE_SERVICE.value)
+        )
+
+        if (firstPage.isFailure) return
+
+        // Load subsequent pages while available
+        while (productListRepository.canLoadMoreProducts) {
+            val next = productListRepository.fetchProductList(
+                loadMore = true,
+                productFilterOptions = mapOf(
+                    WCProductStore.ProductFilterOption.TYPE to ProductType.BOOKABLE_SERVICE.value
+                ),
+                pageSize = BOOKABLE_PRODUCTS_FILTER_PAGE_SIZE
+            )
+            if (next.isFailure) break
         }
     }
 
@@ -92,5 +122,9 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
             initial: BookingsFilterOption.ServiceEvents?,
             onFilterChanged: (BookingsFilterOption.ServiceEvents) -> Unit
         ): BookingServiceEventFilterViewModel
+    }
+
+    companion object {
+        private const val BOOKABLE_PRODUCTS_FILTER_PAGE_SIZE = 100 //Setting big page size to minimise num of requests
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
@@ -124,6 +124,6 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
     }
 
     companion object {
-        private const val BOOKABLE_PRODUCTS_FILTER_PAGE_SIZE = 100 // Setting big page size to minimise num of requests
+        private const val BOOKABLE_PRODUCTS_FILTER_PAGE_SIZE = 100 // Setting big page size to minimize num of requests
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
@@ -55,7 +55,6 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
                                 name = UiStringText(product.name)
                             )
                         },
-                    isLoading = false
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
@@ -27,6 +27,7 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
     private val _uiState = MutableStateFlow(
         BookingServiceEventFilterUiState(
             selectedProducts = selectedServiceEvents ?: BookingsFilterOption.ServiceEvents.DEFAULT,
+            isLoading = true,
             onProductSelected = ::onProductSelected,
             onSearchQueryChanged = ::onSearchQueryChanged
         )
@@ -35,11 +36,7 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
 
     init {
         observeProducts()
-        // In parallel, fetch products from the network using pagination so the DB keeps getting
-        // populated with more booking products while the UI observes the DB changes.
-        launch {
-            paginateBookingProducts()
-        }
+        loadAllBookingProducts()
     }
 
     private fun observeProducts() = launch {
@@ -57,23 +54,25 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
                                 id = product.remoteId,
                                 name = UiStringText(product.name)
                             )
-                        }
+                        },
+                    isLoading = false
                 )
             }
         }
     }
 
     /**
-     * Fetch booking products from the network with pagination while the UI observes DB updates.
+     * Fetch booking products from the network with big page size to minimize request and ensure search bar
+     * has all available results
      */
-    private suspend fun paginateBookingProducts() {
-        // First page
+    private fun loadAllBookingProducts() = launch {
         val firstPage = productListRepository.fetchProductList(
             loadMore = false,
-            productFilterOptions = mapOf(WCProductStore.ProductFilterOption.TYPE to ProductType.BOOKABLE_SERVICE.value)
+            productFilterOptions = mapOf(WCProductStore.ProductFilterOption.TYPE to ProductType.BOOKABLE_SERVICE.value),
+            pageSize = BOOKABLE_PRODUCTS_FILTER_PAGE_SIZE
         )
 
-        if (firstPage.isFailure) return
+        if (firstPage.isFailure) return@launch
 
         // Load subsequent pages while available
         while (productListRepository.canLoadMoreProducts) {
@@ -125,6 +124,6 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
     }
 
     companion object {
-        private const val BOOKABLE_PRODUCTS_FILTER_PAGE_SIZE = 100 //Setting big page size to minimise num of requests
+        private const val BOOKABLE_PRODUCTS_FILTER_PAGE_SIZE = 100 // Setting big page size to minimise num of requests
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
@@ -55,6 +55,7 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
                                 name = UiStringText(product.name)
                             )
                         },
+                    isLoading = false
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModel.kt
@@ -55,7 +55,6 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
                                 name = UiStringText(product.name)
                             )
                         },
-                    isLoading = false
                 )
             }
         }
@@ -72,7 +71,10 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
             pageSize = BOOKABLE_PRODUCTS_FILTER_PAGE_SIZE
         )
 
-        if (firstPage.isFailure) return@launch
+        if (firstPage.isFailure) {
+            _uiState.update { currentState -> currentState.copy(isLoading = false) }
+            return@launch
+        }
 
         // Load subsequent pages while available
         while (productListRepository.canLoadMoreProducts) {
@@ -85,6 +87,7 @@ class BookingServiceEventFilterViewModel @AssistedInject constructor(
             )
             if (next.isFailure) break
         }
+        _uiState.update { currentState -> currentState.copy(isLoading = false) }
     }
 
     private fun onProductSelected(product: BookableProduct?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
@@ -93,7 +93,7 @@ class ProductListRepository @Inject constructor(
 
         return productStore.fetchProducts(
             site = selectedSite.get(),
-            pageSize = PRODUCT_PAGE_SIZE,
+            pageSize = pageSize,
             offset = offset,
             sortType = sortType ?: productSortingChoice,
             filterOptions = productFilterOptions,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListRepository.kt
@@ -84,9 +84,10 @@ class ProductListRepository @Inject constructor(
         loadMore: Boolean = false,
         productFilterOptions: Map<WCProductStore.ProductFilterOption, String> = emptyMap(),
         excludedProductIds: List<Long> = emptyList(),
-        sortType: WCProductStore.ProductSorting? = null
+        sortType: WCProductStore.ProductSorting? = null,
+        pageSize: Int = PRODUCT_PAGE_SIZE,
     ): Result<List<Product>> {
-        offset = if (loadMore) offset + PRODUCT_PAGE_SIZE else 0
+        offset = if (loadMore) offset + pageSize else 0
         lastSearchQuery = null
         lastIsSkuSearch = WCProductStore.SkuSearchOptions.Disabled
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4245,8 +4245,8 @@
     <string name="bookings_filter_customer">Customer</string>
     <string name="bookings_filter_location">Location</string>
     <string name="bookings_filter_title_date">Date &amp; time</string>
-    <string name="bookings_filter_title_service_event">Service / Event</string>
-    <string name="bookings_filter_search_service_event">Search service / event</string>
+    <string name="bookings_filter_title_service">Service</string>
+    <string name="bookings_filter_search_service">Search service</string>
     <string name="bookings_filter_default">Any</string>
     <string name="bookings_filter_type_service">Service</string>
     <string name="bookings_filter_type_event">Event</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModelTest.kt
@@ -37,6 +37,12 @@ class BookingServiceEventFilterViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when ViewModel is initialized, then loading state is true`() {
+        val state = viewModel.uiState.value
+        assertThat(state.isLoading).isTrue()
+    }
+
+    @Test
     fun `given an initial selection, when ViewModel is initialized, then state reflects it`() {
         val initial = BookingsFilterOption.ServiceEvents(
             values = setOf(BookingsFilterOption.ProductInfo(1L, "Haircut"))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/productname/BookingServiceEventFilterViewModelTest.kt
@@ -37,12 +37,6 @@ class BookingServiceEventFilterViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when ViewModel is initialized, then loading state is true`() {
-        val state = viewModel.uiState.value
-        assertThat(state.isLoading).isTrue()
-    }
-
-    @Test
     fun `given an initial selection, when ViewModel is initialized, then state reflects it`() {
         val initial = BookingsFilterOption.ServiceEvents(
             values = setOf(BookingsFilterOption.ProductInfo(1L, "Haircut"))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsTabVisibilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsTabVisibilityTest.kt
@@ -73,7 +73,8 @@ class ObserveBookingsTabVisibilityTest : BaseUnitTest() {
                 loadMore = any(),
                 productFilterOptions = eq(mapOf(ProductFilterOption.TYPE to ProductType.BOOKABLE_SERVICE.value)),
                 excludedProductIds = any(),
-                sortType = anyOrNull()
+                sortType = anyOrNull(),
+                pageSize = any()
             )
             verify(bookingsRepository).fetchBookings(any(), any(), anyOrNull(), anyOrNull(), any())
             cancelAndIgnoreRemainingEvents()


### PR DESCRIPTION
Closes WOOMOB-1745

### Description
These changes ensure that we load all available bookable-service products when opening the Booking > filters > Service screen. 
Additionally it updates the `Service / Event` product item to `Service` only, given event type bookings won't supported for now. 

### Test Steps
1. Log into a CIAB site with a few `bookable-service` products
2. Open bookings tab
3. Navigate to all tab
4. Tap on filters
5. Tap on `Service` filters
6. Check bookable-services are displayed correctly
7. Navigate back to booking filters
8. From `wc-admin` add a couple more bookable services
9. Open `Service` filter again and check the new bookable services are displayed

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/7810e69e-40f7-410c-adb2-61a4c3707e91

