### PR TITLE
WOOMOB-1626 Fix WooPos preferences not updating when switching sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepository.kt
@@ -17,8 +17,10 @@ class WooPosPreferencesRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val dataStore: DataStore<Preferences>
 ) {
-    private val recentProductSearchesSiteSpecificKey = buildSiteSpecificKey(RECENT_PRODUCT_SEARCHES_KEY)
-    private val recentCouponSearchesSiteSpecificKey = buildSiteSpecificKey(RECENT_COUPON_SEARCHES_KEY)
+    private val recentProductSearchesSiteSpecificKey: Preferences.Key<String>
+        get() = buildSiteSpecificKey(RECENT_PRODUCT_SEARCHES_KEY)
+    private val recentCouponSearchesSiteSpecificKey: Preferences.Key<String>
+        get() = buildSiteSpecificKey(RECENT_COUPON_SEARCHES_KEY)
     private val wasOpenedOnceKey = booleanPreferencesKey(POS_WAS_OPENED_ONCE_KEY)
     private val lastUsedTimestampKey = longPreferencesKey(POS_LAST_USED_TIMESTAMP_KEY)
     private val allowCellularDataUpdateKey = booleanPreferencesKey(ALLOW_FULL_SYNC_ON_CELLULAR_DATA_KEY)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepositorySiteSwitchTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/util/datastore/WooPosPreferencesRepositorySiteSwitchTest.kt
@@ -1,0 +1,115 @@
+package com.woocommerce.android.ui.woopos.util.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+
+class WooPosPreferencesRepositorySiteSwitchTest {
+    private lateinit var selectedSite: SelectedSite
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var repository: WooPosPreferencesRepository
+    private lateinit var site1: SiteModel
+    private lateinit var site2: SiteModel
+    private lateinit var tempFile: Path
+
+    @Before
+    fun setup() {
+        selectedSite = mock()
+        tempFile = Files.createTempFile("woopos_prefs_test", ".preferences_pb")
+        dataStore = PreferenceDataStoreFactory.createWithPath(
+            produceFile = { tempFile.toString().toPath() }
+        )
+
+        site1 = SiteModel().apply { id = 1 }
+        site2 = SiteModel().apply { id = 2 }
+
+        whenever(selectedSite.getOrNull()).thenReturn(site1)
+        repository = WooPosPreferencesRepository(selectedSite, dataStore)
+    }
+
+    @After
+    fun tearDown() {
+        try {
+            Files.deleteIfExists(tempFile)
+        } catch (_: Exception) {
+            // Ignore cleanup errors
+        }
+    }
+
+    @Test
+    fun `given product searches saved for site1, when switching to site2, then site2 has empty searches`() = runTest {
+        repository.addRecentProductSearch("product_site1")
+
+        val site1Searches = repository.recentProductSearches.first()
+        assertEquals(listOf("product_site1"), site1Searches)
+
+        whenever(selectedSite.getOrNull()).thenReturn(site2)
+
+        val site2SearchesBeforeAdding = repository.recentProductSearches.first()
+        assertEquals(emptyList(), site2SearchesBeforeAdding)
+
+        repository.addRecentProductSearch("product_site2")
+
+        val site2SearchesAfterAdding = repository.recentProductSearches.first()
+        assertEquals(listOf("product_site2"), site2SearchesAfterAdding)
+
+        whenever(selectedSite.getOrNull()).thenReturn(site1)
+
+        val site1SearchesAfterSwitchBack = repository.recentProductSearches.first()
+        assertEquals(listOf("product_site1"), site1SearchesAfterSwitchBack)
+    }
+
+    @Test
+    fun `given coupon searches saved for site1, when switching to site2, then site2 has empty searches`() = runTest {
+        repository.addRecentCouponSearch("coupon_site1")
+
+        val site1Searches = repository.recentCouponSearches.first()
+        assertEquals(listOf("coupon_site1"), site1Searches)
+
+        whenever(selectedSite.getOrNull()).thenReturn(site2)
+
+        val site2SearchesBeforeAdding = repository.recentCouponSearches.first()
+        assertEquals(emptyList(), site2SearchesBeforeAdding)
+
+        repository.addRecentCouponSearch("coupon_site2")
+
+        val site2SearchesAfterAdding = repository.recentCouponSearches.first()
+        assertEquals(listOf("coupon_site2"), site2SearchesAfterAdding)
+
+        whenever(selectedSite.getOrNull()).thenReturn(site1)
+
+        val site1SearchesAfterSwitchBack = repository.recentCouponSearches.first()
+        assertEquals(listOf("coupon_site1"), site1SearchesAfterSwitchBack)
+    }
+
+    @Test
+    fun `given searches saved for multiple sites, when switching between sites, then each site shows only its own searches`() = runTest {
+        repository.addRecentProductSearch("laptop")
+        repository.addRecentCouponSearch("discount10")
+
+        whenever(selectedSite.getOrNull()).thenReturn(site2)
+        repository.addRecentProductSearch("phone")
+        repository.addRecentCouponSearch("sale20")
+
+        whenever(selectedSite.getOrNull()).thenReturn(site1)
+        assertEquals(listOf("laptop"), repository.recentProductSearches.first())
+        assertEquals(listOf("discount10"), repository.recentCouponSearches.first())
+
+        whenever(selectedSite.getOrNull()).thenReturn(site2)
+        assertEquals(listOf("phone"), repository.recentProductSearches.first())
+        assertEquals(listOf("sale20"), repository.recentCouponSearches.first())
+    }
+}


### PR DESCRIPTION
WOOMOB-1626

### Description
Fixed a theoretical issue that could cause WooPos preferences (recent product and coupon searches) showing data from the previous site after switching sites - it's theoretical since the WooPosPreferencesRepository is not injected into a singleton and is always re-created upon site switch. However, there is no guarantee someone won't inject it into a singleton leading to hard-to-debug/reproduce issues.

The problem was that site-specific preference keys were initialized once at class instantiation and never updated when the site changed. The fix changes the site-specific keys from eagerly-initialized `val` properties to lazily-evaluated `get()` properties, ensuring they always use the current site ID.

### Test Steps
- The unit tests are enough.

### Images/gif
N/A - Backend data fix with no UI changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.