### PR TITLE
[Bookings] Unify Bookings tab entry animation with other tabs 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [*] Fixed a rare crash in the refund flow [https://github.com/woocommerce/woocommerce-android/pull/15109]
 - [*][Woo POS] Prepopulate orders cache after opening POS to improve performance [https://github.com/woocommerce/woocommerce-android/pull/15066]
 - [*][Internal] Migrated legacy Material Icons to Material Symbols [https://github.com/woocommerce/woocommerce-android/pull/15081]
+- [*] Unified transition animations across screens [https://github.com/woocommerce/woocommerce-android/pull/15128]
 
 23.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -30,7 +30,6 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.transition.TransitionManager
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.transition.MaterialFadeThrough
 import com.woocommerce.android.AppConstants
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.NavGraphMainDirections
@@ -199,12 +198,6 @@ class OrderListFragment :
                 }
             }
         )
-
-        val transitionDuration = resources.getInteger(R.integer.default_fragment_transition).toLong()
-        val fadeThroughTransition = MaterialFadeThrough().apply { duration = transitionDuration }
-        enterTransition = fadeThroughTransition
-        exitTransition = fadeThroughTransition
-        reenterTransition = fadeThroughTransition
     }
 
     private fun getSearchQueryHint(): String {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/list/ProductListFragment.kt
@@ -22,7 +22,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.transition.MaterialFadeThrough
 import com.woocommerce.android.FeedbackPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
@@ -151,12 +150,6 @@ class ProductListFragment :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        val transitionDuration = resources.getInteger(R.integer.default_fragment_transition).toLong()
-        val fadeThroughTransition = MaterialFadeThrough().apply { duration = transitionDuration }
-        enterTransition = fadeThroughTransition
-        exitTransition = fadeThroughTransition
-        reenterTransition = fadeThroughTransition
 
         twoPanesWereShownBeforeConfigChange = savedInstanceState?.getBoolean(
             TWO_PANES_WERE_SHOWN_BEFORE_CONFIG_CHANGE_KEY,
@@ -309,6 +302,7 @@ class ProductListFragment :
                         new.filterCount?.compareTo(0) == 1 -> binding.emptyView.show(
                             WCEmptyView.EmptyViewType.FILTER_RESULTS
                         )
+
                         else -> {
                             binding.emptyView.show(WCEmptyView.EmptyViewType.PRODUCT_LIST) {
                                 showAddProductBottomSheet()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1815

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This change removes the custom transition animations from the Orders and Products list screens to unify transition behavior with the Booking tabs.

Instead of updating the Booking tab, I removed the custom transitions from the Orders and Products screens. After removing them, these screens still have transition animations, but with a different (shorter) duration. Previously, the animations were more exaggerated. You'll notice it while testing with increased animation duration.

I think the transitions look nicer now and are consistent across these screens.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Enable developer mode.
2. From developer options, change  animator duration scale to 5x.
3. Log in with a CIAB store.
4. Change tabs.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

The animation duration has been increased by 5×.

[before.webm](https://github.com/user-attachments/assets/7117d660-546b-4216-a90f-152e4fca3537)

[after.webm](https://github.com/user-attachments/assets/b1c82b72-44c1-4246-9702-2357f1f4d795)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
