### PR TITLE
[Bookings] Unify Filters screen enter animation

### DIFF
--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
@@ -19,7 +19,11 @@
         </action>
         <action
             android:id="@+id/action_bookingListFragment_to_bookingFilterList"
-            app:destination="@id/bookingFilterListFragment" />
+            app:destination="@id/bookingFilterListFragment"
+            app:enterAnim="@anim/activity_fade_in"
+            app:exitAnim="@null"
+            app:popEnterAnim="@null"
+            app:popExitAnim="@anim/activity_fade_out" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The Booking filter screen was sliding in from the right when opening. I think the enter animation used for the Order and Product filters looks better, so I copied the [same animation](https://github.com/woocommerce/woocommerce-android/blob/02ab920a4d4aa44f7b138ed245ebadc002a70629/WooCommerce/src/main/res/navigation/nav_graph_main.xml#L116-L119) to the Booking filters.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Log in with a CIAB store.
2. Go to Bookings.
3. Go to All tab.
4. Tap Filters.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

[before.webm](https://github.com/user-attachments/assets/8bbc6c9e-3f91-4b1f-9942-6f9aa6bafe56)

[after.webm](https://github.com/user-attachments/assets/0fe565bb-4ad1-42a5-b0da-143c05598112)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
