### PR TITLE
Add new logic and network layer to register PN token using the new endpoint

### DIFF
--- a/libs/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
+++ b/libs/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WCWPAPIEndpoint.java
@@ -23,6 +23,8 @@ public class WCWPAPIEndpoint {
 
     private static final String WC_PREFIX_V2_BOOKINGS = "wc-bookings/v2";
 
+    private static final String WC_PREFIX_PUSH_NOTIFICATIONS = "wc-push-notifications";
+
     private final String mEndpoint;
 
     public WCWPAPIEndpoint(String endpoint) {
@@ -85,4 +87,7 @@ public class WCWPAPIEndpoint {
         return "/" + WC_PREFIX_V2_BOOKINGS + mEndpoint;
     }
 
+    public String getPathPushNotifications() {
+        return "/" + WC_PREFIX_PUSH_NOTIFICATIONS + mEndpoint;
+    }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsRestClient.kt
@@ -1,0 +1,45 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications
+
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.utils.toWooPayload
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PushNotificationsRestClient @Inject constructor(private val wooNetwork: WooNetwork) {
+
+    suspend fun registerPushToken(
+        site: SiteModel,
+        token: String,
+        origin: String,
+        deviceUuid: String
+    ): WooPayload<PushTokenIdResponse> {
+        val path = WOOCOMMERCE.push_tokens.pathPushNotifications
+        val body = mapOf(
+            "token" to token,
+            "platform" to "android",
+            "origin" to origin,
+            "device_uuid" to deviceUuid,
+        )
+        return wooNetwork.executePostGsonRequest(
+            site = site,
+            path = path,
+            clazz = PushTokenIdResponse::class.java,
+            body = body
+        ).toWooPayload()
+    }
+
+    suspend fun deletePushToken(site: SiteModel, id: Int): WooPayload<Unit> = wooNetwork.executeDeleteGsonRequest(
+        site = site,
+        path = WOOCOMMERCE.push_tokens.id(id.toLong()).pathPushNotifications,
+        clazz = Unit::class.java,
+    ).toWooPayload()
+
+    /**
+     * @param id The unique ID of the push token record in Woo Core
+     */
+    data class PushTokenIdResponse(val id: Int)
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsRestClient.kt
@@ -32,9 +32,12 @@ class PushNotificationsRestClient @Inject constructor(private val wooNetwork: Wo
         ).toWooPayload()
     }
 
-    suspend fun deletePushToken(site: SiteModel, id: Int): WooPayload<Unit> = wooNetwork.executeDeleteGsonRequest(
+    suspend fun deletePushToken(
+        site: SiteModel,
+        pushTokenId: Int
+    ): WooPayload<Unit> = wooNetwork.executeDeleteGsonRequest(
         site = site,
-        path = WOOCOMMERCE.push_tokens.id(id.toLong()).pathPushNotifications,
+        path = WOOCOMMERCE.push_tokens.id(pushTokenId.toLong()).pathPushNotifications,
         clazz = Unit::class.java,
     ).toWooPayload()
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStore.kt
@@ -1,0 +1,44 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications
+
+import org.wordpress.android.fluxc.BuildConfig
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.util.AppLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PushNotificationsStore @Inject internal constructor(
+    private val pushNotificationsRestClient: PushNotificationsRestClient,
+    private val coroutineEngine: CoroutineEngine,
+) {
+    suspend fun registerPushToken(
+        site: SiteModel,
+        token: String,
+        deviceUuid: String
+    ): WooResult<Unit> = coroutineEngine.withDefaultContext(AppLog.T.API, this, "deletePushToken") {
+        val origin = if (BuildConfig.DEBUG) ORIGIN_DEV else ORIGIN
+        val result = pushNotificationsRestClient.registerPushToken(site, token, origin, deviceUuid)
+
+        if (result.isError) {
+            WooResult(result.error)
+        } else {
+            // TODO persist push token id
+            WooResult(Unit)
+        }
+    }
+
+    suspend fun deletePushToken(
+        site: SiteModel
+    ): WooResult<Unit> = coroutineEngine.withDefaultContext(AppLog.T.API, this, "deletePushToken") {
+        // TODO Retrieve persisted id
+        val dummyId = 0
+        pushNotificationsRestClient.deletePushToken(site, dummyId).asWooResult()
+    }
+
+    companion object {
+        private const val ORIGIN = "com.woocommerce.android"
+        private const val ORIGIN_DEV = "com.woocommerce.android:dev"
+    }
+}

--- a/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -138,3 +138,6 @@
 /bookings/<id>/
 /resources/team-members/
 /resources/team-members/<id>/
+
+/push-tokens
+/push-tokens/<id>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds new endpoints for the new PN project: 
- POST `/wp-json/wc-push-notifications/push-tokens`
- DELETE `/wp-json/wc-push-notifications/push-tokens/{id}`

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Check here, p91TBi-dyW-p2 to verify agreed endpoints. It's not possible to make a real call from the app for now.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->