### PR TITLE
Fix WellException for the Wear app

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/app/WooCommerceWear.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/app/WooCommerceWear.kt
@@ -8,7 +8,6 @@ import dagger.hilt.android.HiltAndroidApp
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.persistence.WellSqlConfig
-import org.wordpress.android.fluxc.persistence.WellSqlConfig.Companion.ADDON_WOOCOMMERCE
 import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError
 import javax.inject.Inject
 
@@ -20,7 +19,7 @@ open class WooCommerceWear : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        WellSql.init(WellSqlConfig(applicationContext, ADDON_WOOCOMMERCE))
+        WellSql.init(WellSqlConfig(applicationContext))
         crashLogging.get().initialize()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
To prevent `WellException: Generated classes for addon not found.` error, we removed `ADDON_WOOCOMMERCE` from `WooWellSqlConfig` (https://github.com/woocommerce/woocommerce-android/commit/73d75eea0b953d080f3c689da7a1d4cc4008df09) for the phone app, but we forgot to do the same for the Wear app. I removed it here.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Ensure you can build the Wear app.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
