### PR TITLE
Woomob 1702 basic auth better error handling and tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator
 import org.wordpress.android.fluxc.network.rest.wpapi.CookieNonceAuthenticator.CookieNonceAuthenticationResult.Error
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.BASIC_AUTH_REQUIRED
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.INVALID_CREDENTIALS
@@ -193,10 +194,13 @@ class WPApiSiteRepository @Inject constructor(
             }?.let { HTTP_SUCCESS }
 
     private fun Error.mapToUiString() = when (type) {
-        INVALID_CREDENTIALS -> message?.let { UiStringText(it) } ?: UiStringRes(string.login_invalid_credentials_message)
+        INVALID_CREDENTIALS -> message?.let { UiStringText(it) }
+            ?: UiStringRes(string.login_invalid_credentials_message)
+
         INVALID_RESPONSE -> UiStringRes(string.login_site_credentials_invalid_response)
         CUSTOM_LOGIN_URL -> UiStringRes(string.login_site_credentials_custom_login_url)
         CUSTOM_ADMIN_URL -> UiStringRes(string.login_site_credentials_custom_admin_url)
+        BASIC_AUTH_REQUIRED -> UiStringRes(string.login_site_credentials_http_basic_auth_error)
         else -> message?.takeIf { it.isNotEmpty() }?.let { UiStringText(it) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsScreen.kt
@@ -126,10 +126,10 @@ fun LoginSiteCredentialsScreen(
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         }
 
-        if (viewState.errorDialogMessage != null) {
+        if (viewState.authenticationError != null) {
             AlertDialog(
                 text = {
-                    Text(text = viewState.errorDialogMessage.getText())
+                    Text(text = viewState.authenticationError.errorMessage.getText())
                 },
                 onDismissRequest = onErrorDialogDismissed,
                 buttons = {
@@ -155,10 +155,12 @@ fun LoginSiteCredentialsScreen(
                                 textAlign = TextAlign.End
                             )
                         }
-                        WCTextButton(
-                            onClick = onStartWebAuthorizationClick
-                        ) {
-                            Text(text = stringResource(id = R.string.login_site_credentials_use_web_authorization))
+                        if (viewState.authenticationError.showWpAdminFallbackOption) {
+                            WCTextButton(
+                                onClick = onStartWebAuthorizationClick
+                            ) {
+                                Text(text = stringResource(id = R.string.login_site_credentials_use_web_authorization))
+                            }
                         }
                     }
                 }
@@ -198,7 +200,10 @@ private fun LoginSiteCredentialsScreenWithErrorPreview() {
         LoginSiteCredentialsScreen(
             viewState = LoginSiteCredentialsViewModel.ViewState(
                 siteUrl = "https://wordpress.com",
-                errorDialogMessage = UiString.UiStringRes(R.string.login_site_credentials_fetching_site_failed)
+                authenticationError = LoginSiteCredentialsViewModel.AuthenticationError(
+                    errorMessage = UiString.UiStringRes(R.string.login_site_credentials_fetching_site_failed),
+                    showWpAdminFallbackOption = true
+                )
             ),
             onUsernameChanged = {},
             onPasswordChanged = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -22,6 +22,7 @@ import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -37,6 +38,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.BASIC_AUTH_REQUIRED
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.INVALID_CREDENTIALS
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
@@ -219,6 +221,10 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
                 when (authenticationError?.errorType) {
                     INVALID_CREDENTIALS -> errorDialogMessage.value = authenticationError.errorMessage
+                    BASIC_AUTH_REQUIRED -> {
+                        // TODO REMOVE COMMENT AND PROVIDE PROPER ERROR AND TRACKING
+                        WooLog.w(WooLog.T.LOGIN, "Authentication failed, error: Basic auth required")
+                    }
                     else -> {
                         fetchSiteForTutorial(detectedErrorMessage = authenticationError?.errorMessage)
                         analyticsTracker.track(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_INVALID_LOGIN_PAGE_DETECTED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -22,7 +22,6 @@ import com.woocommerce.android.model.UiString.UiStringText
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
-import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -220,11 +219,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 val authenticationError = exception as? CookieNonceAuthenticationException
 
                 when (authenticationError?.errorType) {
-                    INVALID_CREDENTIALS -> errorDialogMessage.value = authenticationError.errorMessage
-                    BASIC_AUTH_REQUIRED -> {
-                        // TODO REMOVE COMMENT AND PROVIDE PROPER ERROR AND TRACKING
-                        WooLog.w(WooLog.T.LOGIN, "Authentication failed, error: Basic auth required")
-                    }
+                    INVALID_CREDENTIALS,
+                    BASIC_AUTH_REQUIRED -> errorDialogMessage.value = authenticationError.errorMessage
                     else -> {
                         fetchSiteForTutorial(detectedErrorMessage = authenticationError?.errorMessage)
                         analyticsTracker.track(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_INVALID_LOGIN_PAGE_DETECTED)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.sitecredentials
 
+import android.os.Parcelable
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
@@ -36,6 +37,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.BASIC_AUTH_REQUIRED
 import org.wordpress.android.fluxc.network.rest.wpapi.Nonce.CookieNonceErrorType.INVALID_CREDENTIALS
@@ -71,11 +73,11 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     private val siteAddress: String = savedStateHandle[SITE_ADDRESS_KEY]!!
 
-    private val errorDialogMessage = savedStateHandle.getNullableStateFlow(
+    private val authError = savedStateHandle.getNullableStateFlow(
         scope = viewModelScope,
         initialValue = null,
-        clazz = UiString::class.java,
-        key = "error-message"
+        clazz = AuthenticationError::class.java,
+        key = "site-credentials-auth-error"
     )
     private val fetchedSiteId = savedStateHandle.getStateFlow(viewModelScope, -1, "site-id")
 
@@ -92,14 +94,14 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         savedStateHandle.getStateFlow(USERNAME_KEY, ""),
         savedStateHandle.getStateFlow(PASSWORD_KEY, ""),
         loadingMessage.map { message -> message.takeIf { it != 0 } },
-        errorDialogMessage
-    ) { siteAddress, username, password, loadingMessage, errorDialog ->
+        authError
+    ) { siteAddress, username, password, loadingMessage, authError ->
         ViewState(
             siteUrl = siteAddress,
             username = username,
             password = password,
             loadingMessage = loadingMessage,
-            errorDialogMessage = errorDialog
+            authenticationError = authError
         )
     }.asLiveData()
 
@@ -139,7 +141,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     }
 
     fun onErrorDialogDismissed() {
-        errorDialogMessage.value = null
+        authError.value = null
     }
 
     fun onResetPasswordClick() {
@@ -148,7 +150,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
 
     fun onStartWebAuthorizationClick() {
         launch {
-            errorDialogMessage.value = null
+            authError.value = null
             fetchSiteForTutorial()
         }
     }
@@ -219,8 +221,16 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 val authenticationError = exception as? CookieNonceAuthenticationException
 
                 when (authenticationError?.errorType) {
-                    INVALID_CREDENTIALS,
-                    BASIC_AUTH_REQUIRED -> errorDialogMessage.value = authenticationError.errorMessage
+                    INVALID_CREDENTIALS -> authError.value = AuthenticationError(
+                        errorMessage = authenticationError.errorMessage,
+                        showWpAdminFallbackOption = true
+                    )
+
+                    BASIC_AUTH_REQUIRED -> authError.value = AuthenticationError(
+                        errorMessage = authenticationError.errorMessage,
+                        showWpAdminFallbackOption = false
+                    )
+
                     else -> {
                         fetchSiteForTutorial(detectedErrorMessage = authenticationError?.errorMessage)
                         analyticsTracker.track(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_INVALID_LOGIN_PAGE_DETECTED)
@@ -300,7 +310,9 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     private fun handleSiteFetchingError(exception: Throwable) {
         val siteError = (exception as? OnChangedException)?.error as? SiteError
 
-        this.errorDialogMessage.value = UiStringRes(R.string.login_site_credentials_fetching_site_failed)
+        this.authError.value = AuthenticationError(
+            errorMessage = UiStringRes(R.string.login_site_credentials_fetching_site_failed)
+        )
 
         val error = (exception as? OnChangedException)?.error ?: exception
         trackLoginFailure(
@@ -389,10 +401,16 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         val username: String = "",
         val password: String = "",
         @StringRes val loadingMessage: Int? = null,
-        val errorDialogMessage: UiString? = null
+        val authenticationError: AuthenticationError? = null
     ) {
         val isValid = username.isNotBlank() && password.isNotBlank()
     }
+
+    @Parcelize
+    data class AuthenticationError(
+        val errorMessage: UiString,
+        val showWpAdminFallbackOption: Boolean = true
+    ) : Parcelable
 
     @VisibleForTesting
     enum class Step {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -315,6 +315,7 @@
     <string name="login_site_credentials_custom_admin_url">Unable to login because we cannot identify your store\'s admin URL</string>
     <string name="login_site_credentials_http_error">Login failed with status code %1$s</string>
     <string name="login_site_credentials_use_web_authorization">Try again with WP Admin page</string>
+    <string name="login_site_credentials_http_basic_auth_error">Basic Authentication is enabled on your site. Basic Authentication is unsupported in WooCommerce mobile. Please disable it or contact support for troubleshooting</string>
     <string name="login_site_credentials_fetching_site_failed">An error occurred while fetching your website</string>
     <string name="login_site_credentials_fetching_site">Fetching site…</string>
     <string name="login_site_credentials_web_authorization_connection_rejected">Unable to login because application password creation is not approved.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -315,7 +315,7 @@
     <string name="login_site_credentials_custom_admin_url">Unable to login because we cannot identify your store\'s admin URL</string>
     <string name="login_site_credentials_http_error">Login failed with status code %1$s</string>
     <string name="login_site_credentials_use_web_authorization">Try again with WP Admin page</string>
-    <string name="login_site_credentials_http_basic_auth_error">Basic Authentication is enabled on your site. Basic Authentication is unsupported in WooCommerce mobile. Please disable it or contact support for troubleshooting</string>
+    <string name="login_site_credentials_http_basic_auth_error">Basic Authentication is enabled on your site. Basic Authentication is unsupported in the WooCommerce mobile app. Please disable it, or contact support for troubleshooting.</string>
     <string name="login_site_credentials_fetching_site_failed">An error occurred while fetching your website</string>
     <string name="login_site_credentials_fetching_site">Fetching site…</string>
     <string name="login_site_credentials_web_authorization_connection_rejected">Unable to login because application password creation is not approved.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -227,7 +227,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             viewModel.onContinueClick()
         }.last()
 
-        assertThat(state.errorDialogMessage).isEqualTo(expectedError.errorMessage)
+        assertThat(state.authenticationError?.errorMessage).isEqualTo(expectedError.errorMessage)
         verify(analyticsTracker).track(
             stat = eq(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_LOGIN_FAILED),
             properties = argThat {

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
@@ -233,7 +233,7 @@ class NonceRestClientTest {
     }
 
     @Test
-    fun `basic auth required error returns correct error type`() = test {
+    fun `when basic auth required, then NetworkResponse returns correct error type`() = test {
         val error = WPAPINetworkError(
             BaseNetworkError(
                 VolleyError(

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
@@ -232,6 +232,34 @@ class NonceRestClientTest {
         assertEquals(Nonce.CookieNonceErrorType.CUSTOM_ADMIN_URL, actual.type)
     }
 
+    @Test
+    fun `basic auth required error returns correct error type`() = test {
+        val error = WPAPINetworkError(
+            BaseNetworkError(
+                VolleyError(
+                    NetworkResponse(
+                        401,
+                        byteArrayOf(),
+                        false,
+                        System.currentTimeMillis(),
+                        listOf(
+                            com.android.volley.Header(
+                                "www-Authenticate",
+                                "Basic realm=token24433434"
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        givenLoginResponse(WPAPIResponse.Error(error))
+
+        val actual = subject.requestNonce(site)
+
+        assertIs<Nonce.FailedRequest>(actual)
+        assertEquals(Nonce.CookieNonceErrorType.BASIC_AUTH_REQUIRED, actual.type)
+    }
+
     private suspend fun givenLoginResponse(response: WPAPIResponse<String>) {
         val body = mapOf(
             "log" to site.username,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/Nonce.kt
@@ -22,6 +22,7 @@ sealed interface Nonce {
         CUSTOM_LOGIN_URL,
         CUSTOM_ADMIN_URL,
         INVALID_NONCE,
+        BASIC_AUTH_REQUIRED,
         GENERIC_ERROR,
         UNKNOWN
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpapi
 
+import com.android.volley.NetworkResponse
 import com.android.volley.NoConnectionError
 import com.android.volley.RequestQueue
 import org.wordpress.android.fluxc.Dispatcher
@@ -97,9 +98,7 @@ class NonceRestClient @Inject constructor(
                         FailedRequest(
                             timeOfResponse = currentTimeProvider.currentDate().time,
                             username = username,
-                            type = if (networkResponse?.statusCode == NOT_FOUND_STATUS_CODE) {
-                                Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL
-                            } else Nonce.CookieNonceErrorType.GENERIC_ERROR,
+                            type = getErrorType(networkResponse),
                             networkError = response.error,
                             errorMessage = response.error.message,
                         )
@@ -111,6 +110,22 @@ class NonceRestClient @Inject constructor(
             nonceMap[siteUrl] = it
         }
     }
+
+    private fun getErrorType(networkResponse: NetworkResponse?): Nonce.CookieNonceErrorType = when {
+        networkResponse?.statusCode == NOT_FOUND_STATUS_CODE -> {
+            Nonce.CookieNonceErrorType.CUSTOM_LOGIN_URL
+        }
+
+        isBasicAuthError(networkResponse) -> Nonce.CookieNonceErrorType.BASIC_AUTH_REQUIRED
+
+        else -> {
+            Nonce.CookieNonceErrorType.GENERIC_ERROR
+        }
+    }
+
+    private fun isBasicAuthError(networkResponse: NetworkResponse?): Boolean =
+        networkResponse?.headers?.keys?.any { it.equals(AUTH_HEADER_KEY, ignoreCase = true) } == true &&
+            networkResponse?.headers?.values?.any { it.contains(BASIC_AUTH_REALM, ignoreCase = true) } == true
 
     private suspend fun requestNonce(redirectUrl: String, username: String): Nonce {
         return when (
@@ -158,5 +173,7 @@ class NonceRestClient @Inject constructor(
 
     companion object {
         const val INVALID_CREDENTIAL_HTML_PATTERN = "document.querySelector('form').classList.add('shake')"
+        const val AUTH_HEADER_KEY = "WWW-Authenticate"
+        const val BASIC_AUTH_REALM = "Basic realm"
     }
 }


### PR DESCRIPTION
Closes WOOMOB-1702

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Coming from this P2 were it was surfaced several issues about not supporting basic auth: p91TBi-dC6-p2
This PR addresses a few changes we agreed on prior to implementing basic auth support in the apps: 
- Better tracking to learn the real impact about this. To properly determine how many users are experiencing such issues
- Better error handling providing users a proper hint of why the app is failing to log in. 
- Adding better console logs so that HE can easily troubleshoot when basic out issues are the cause of users not being able to log in. 

### Test Steps
Enable basic auth on you test site prior to following the next testing steps. To enable basic auth on any existing Pressable site just navigate to the site > Advanced > Basic Authentication. 
Or use this site url to run the tests: https://woocommerce-android-realapi-tests.mystagingwebsite.com/

**Test case 1: Site creds with basic auth**
1. Enter a site address with basic auth enabled
2. In the site credentials screen enter any random credentials
3. See the basic auth error displayed: 

<img width="455" height="402" alt="Screenshot 2025-12-23 at 17 16 39" src="https://github.com/user-attachments/assets/701bc86b-803b-4316-8c6d-c011dbf797a3" />

4. Check the following event is tracked when this happens:
```
woocommerceandroid_login_site_credentials_login_failed, Properties: {"step":"authentication","network_status_code":"401","error_context":"CookieNonceAuthenticationException","error_type":"BASIC_AUTH_REQUIRED"
```
Important thing here is the "error_type":"BASIC_AUTH_REQUIRED"

5. Check the following log is show in the logcat: `Authentication failed, error: BASIC_AUTH_REQUIRED,`

**Test case 2: Log in normally with site credentials**
Just test that login with site credentials for any other site were basic auth is not enabled works as expected. 


### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/d5d1b556-7426-43ea-a55b-79362f67ad17


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
