### PR TITLE
Fix `siteComponent!!` crash on the dashboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 - [*][Internal] Migrated legacy Material Icons to Material Symbols [https://github.com/woocommerce/woocommerce-android/pull/15081]
 - [*] Fix widget sizing issues and improve refresh rate upon switching site or logging out [https://github.com/woocommerce/woocommerce-android/pull/15127]
 - [*] Unified transition animations across screens [https://github.com/woocommerce/woocommerce-android/pull/15128]
+- [*] Fixed a rare NullPointerException crash on the Dashboard screen [https://github.com/woocommerce/woocommerce-android/pull/15138]
 
 23.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/tools/SelectedSite.kt
@@ -87,18 +87,18 @@ class SelectedSite @Inject constructor(
     @Suppress("DEPRECATION")
     @Synchronized
     fun set(siteModel: SiteModel) {
+        // Create a new site component tied to the lifecycle of the selected site
+        siteComponent = siteComponentProvider.get()
+            .setSite(siteModel)
+            .setCoroutineScope(createSiteCoroutineScope())
+            .build()
+
         wasReset = false
         state.value = siteModel
         PreferenceUtils.setInt(getPreferences(), SELECTED_SITE_LOCAL_ID, siteModel.id)
 
         // Notify listeners
         getEventBus().post(SelectedSiteChangedEvent(siteModel))
-
-        // Create a new site component tied to the lifecycle of the selected site
-        siteComponent = siteComponentProvider.get()
-            .setSite(get())
-            .setCoroutineScope(createSiteCoroutineScope())
-            .build()
     }
 
     @Synchronized

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.dashboard.data
 
+import androidx.annotation.VisibleForTesting
 import androidx.datastore.core.DataStore
 import com.woocommerce.android.di.SiteComponentEntryPoint
 import com.woocommerce.android.model.DashboardWidget
@@ -53,7 +54,8 @@ class DashboardDataStore @Inject constructor(
         }
     }
 
-    private fun getDefaultWidgets(): List<DashboardWidgetDataModel> {
+    @VisibleForTesting
+    internal fun getDefaultWidgets(): List<DashboardWidgetDataModel> {
         fun DashboardWidget.Type.shouldBeEnabledByDefault() =
             this == DashboardWidget.Type.STATS ||
                 this == DashboardWidget.Type.POPULAR_PRODUCTS ||

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
@@ -10,22 +10,29 @@ import com.woocommerce.android.ui.mystore.data.DashboardWidgetDataModel
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import dagger.hilt.EntryPoints
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import java.io.IOException
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DashboardDataStore @Inject constructor(
-    selectedSite: SelectedSite
+    private val selectedSite: SelectedSite
 ) {
-    private val dataStore: DataStore<DashboardDataModel> = EntryPoints.get(
-        selectedSite.siteComponent!!,
-        SiteComponentEntryPoint::class.java
-    ).dashboardDataStore()
+    private val dataStoreFlow: Flow<DataStore<DashboardDataModel>?> = selectedSite.observe().map {
+        selectedSite.siteComponent?.let { component ->
+            EntryPoints.get(component, SiteComponentEntryPoint::class.java).dashboardDataStore()
+        }
+    }
 
-    val widgets: Flow<List<DashboardWidgetDataModel>> = dataStore.data
-        .catch { exception ->
+    val widgets: Flow<List<DashboardWidgetDataModel>> = dataStoreFlow.flatMapLatest { dataStore ->
+        val flow = dataStore?.data ?: flow { throw IOException("Site component is null") }
+        flow.catch { exception ->
             // dataStore.data throws an IOException when an error is encountered when reading data
             if (exception is IOException) {
                 WooLog.e(T.DASHBOARD, "Error reading dashboard data.", exception)
@@ -33,8 +40,7 @@ class DashboardDataStore @Inject constructor(
             } else {
                 throw exception
             }
-        }
-        .map {
+        }.map {
             if (it == DashboardDataModel.getDefaultInstance()) {
                 DashboardDataModel.newBuilder().addAllWidgets(getDefaultWidgets()).build()
             } else {
@@ -45,12 +51,18 @@ class DashboardDataStore @Inject constructor(
                 DashboardWidget.Type.supportedWidgets.any { type -> type.name == widget.type }
             }
         }
+    }
 
     suspend fun updateDashboard(dashboard: DashboardDataModel) {
-        runCatching {
-            dataStore.updateData { dashboard }
-        }.onFailure {
-            WooLog.e(T.DASHBOARD, "Failed to update dashboard data")
+        val dataStore = dataStoreFlow.first()
+        if (dataStore == null) {
+            WooLog.e(T.DASHBOARD, "Cannot update dashboard data: Site component is null")
+        } else {
+            runCatching {
+                dataStore.updateData { dashboard }
+            }.onFailure {
+                WooLog.e(T.DASHBOARD, "Failed to update dashboard data")
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
@@ -31,7 +31,10 @@ class DashboardDataStore @Inject constructor(
     }
 
     val widgets: Flow<List<DashboardWidgetDataModel>> = dataStoreFlow.flatMapLatest { dataStore ->
-        val flow = dataStore?.data ?: flow { throw IOException("Site component is null") }
+        val flow = dataStore?.data ?: flow {
+            WooLog.e(T.DASHBOARD, "DashboardDataStore: Site component is null, providing default widgets.")
+            emit(DashboardDataModel.getDefaultInstance())
+        }
         flow.catch { exception ->
             // dataStore.data throws an IOException when an error is encountered when reading data
             if (exception is IOException) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
@@ -10,14 +10,19 @@ import com.woocommerce.android.ui.mystore.data.DashboardDataModel
 import com.woocommerce.android.ui.mystore.data.DashboardWidgetDataModel
 import dagger.hilt.EntryPoints
 import dagger.hilt.android.scopes.ActivityRetainedScoped
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @ActivityRetainedScoped
 @Suppress("LongParameterList")
+@OptIn(ExperimentalCoroutinesApi::class)
 class DashboardRepository @Inject constructor(
     selectedSite: SelectedSite,
     private val dashboardDataStore: DashboardDataStore,
@@ -27,45 +32,32 @@ class DashboardRepository @Inject constructor(
     observeStockWidgetStatus: ObserveStockWidgetStatus,
     observeGoogleAdsWidgetStatus: ObserveGoogleAdsWidgetStatus
 ) {
-    private val siteCoroutineScope = EntryPoints.get(
-        selectedSite.siteComponent!!,
-        SiteComponentEntryPoint::class.java
-    ).siteCoroutineScope()
+    private val siteCoroutineScopeFlow = selectedSite.observe().map {
+        selectedSite.siteComponent?.let { component ->
+            EntryPoints.get(component, SiteComponentEntryPoint::class.java).siteCoroutineScope()
+        }
+    }
 
-    private val siteOrdersState = observeSiteOrdersState()
-        .stateIn(
-            scope = siteCoroutineScope,
-            started = SharingStarted.Lazily,
-            initialValue = DashboardWidget.Status.Unavailable(R.string.my_store_widget_unavailable)
-        )
+    private fun widgetStatusFlow(
+        started: SharingStarted = SharingStarted.WhileSubscribed(),
+        initialValue: DashboardWidget.Status = DashboardWidget.Status.Hidden,
+        flowProvider: () -> Flow<DashboardWidget.Status>
+    ) = siteCoroutineScopeFlow.flatMapLatest { scope ->
+        scope?.let { flowProvider().stateIn(it, started, initialValue) } ?: flowOf(initialValue)
+    }
 
-    private val blazeWidgetStatus = observeBlazeWidgetStatus()
-        .stateIn(
-            scope = siteCoroutineScope,
-            started = SharingStarted.WhileSubscribed(),
-            initialValue = DashboardWidget.Status.Hidden
-        )
+    private val siteOrdersState = widgetStatusFlow(
+        started = SharingStarted.Lazily,
+        initialValue = DashboardWidget.Status.Unavailable(R.string.my_store_widget_unavailable)
+    ) { observeSiteOrdersState() }
 
-    private val onboardingWidgetStatus = observeOnboardingWidgetStatus()
-        .stateIn(
-            scope = siteCoroutineScope,
-            started = SharingStarted.WhileSubscribed(),
-            initialValue = DashboardWidget.Status.Hidden
-        )
+    private val blazeWidgetStatus = widgetStatusFlow { observeBlazeWidgetStatus() }
 
-    private val stockWidgetStatus = observeStockWidgetStatus()
-        .stateIn(
-            scope = siteCoroutineScope,
-            started = SharingStarted.WhileSubscribed(),
-            initialValue = DashboardWidget.Status.Hidden
-        )
+    private val onboardingWidgetStatus = widgetStatusFlow { observeOnboardingWidgetStatus() }
 
-    private val googleAdsWidgetStatus = observeGoogleAdsWidgetStatus()
-        .stateIn(
-            scope = siteCoroutineScope,
-            started = SharingStarted.WhileSubscribed(),
-            initialValue = DashboardWidget.Status.Hidden
-        )
+    private val stockWidgetStatus = widgetStatusFlow { observeStockWidgetStatus() }
+
+    private val googleAdsWidgetStatus = widgetStatusFlow { observeGoogleAdsWidgetStatus() }
 
     val widgets = combine(
         dashboardDataStore.widgets,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStoreTest.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class DashboardDataStoreTest {
+    private val selectedSite: SelectedSite = mock()
+
+    @Test
+    fun `given site is null, when widgets observed, then default widgets are emitted`() = runBlocking {
+        // Given
+        whenever(selectedSite.siteComponent).thenReturn(null)
+        whenever(selectedSite.observe()).thenReturn(flowOf(null))
+
+        val dashboardDataStore = DashboardDataStore(selectedSite)
+
+        // When
+        val widgets = dashboardDataStore.widgets.first()
+
+        // Then
+        assertEquals(dashboardDataStore.getDefaultWidgets(), widgets)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepositoryTest.kt
@@ -1,0 +1,41 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class DashboardRepositoryTest {
+    private val selectedSite: SelectedSite = mock()
+    private val dashboardDataStore: DashboardDataStore = mock()
+    private val observeSiteOrdersState: ObserveSiteOrdersState = mock()
+    private val observeBlazeWidgetStatus: ObserveBlazeWidgetStatus = mock()
+    private val observeOnboardingWidgetStatus: ObserveOnboardingWidgetStatus = mock()
+    private val observeStockWidgetStatus: ObserveStockWidgetStatus = mock()
+    private val observeGoogleAdsWidgetStatus: ObserveGoogleAdsWidgetStatus = mock()
+
+    @Test
+    fun `given site component is null, when repository is initialized, then it completes without crash`() = runTest {
+        // Given
+        whenever(dashboardDataStore.widgets).thenReturn(flowOf(emptyList()))
+        whenever(selectedSite.observe()).thenReturn(flowOf(null))
+        whenever(selectedSite.siteComponent).thenReturn(null)
+
+        // When
+        val repository = DashboardRepository(
+            selectedSite,
+            dashboardDataStore,
+            observeSiteOrdersState,
+            observeBlazeWidgetStatus,
+            observeOnboardingWidgetStatus,
+            observeStockWidgetStatus,
+            observeGoogleAdsWidgetStatus
+        )
+
+        // Then
+        assertNotNull(repository)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1843

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR resolves a long-standing `NullPointerException` crash in `DashboardDataStore` and `DashboardRepository` occurring during app initialization or site switching.  

`DashboardDataStore` and `DashboardRepository` were attempting to access `selectedSite.siteComponent` using the non-null assertion operator (!!) during their initialization.

If the application started in a state where no site was strictly selected (e.g., fresh install, after logout, or race conditions during startup. I'm not sure  because I couldn't reproduce it), `siteComponent` would be null, causing an immediate crash.

Instead of assuming a site exists at initialization time, I refactored both classes to be Reactive:

Also I updated `SelectedSite` to support this reactive approach.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Since I can't reproduce the crash, it's not possible to test this PR on running app. But I wrote unit tests to reproduce crash cases.

- [DashboardDataStoreTest](https://github.com/woocommerce/woocommerce-android/commit/77b6bd1611b613a8aa80d1e9d463fe52d807dceb): If you check out this commit and run the test, you can reproduce a `NullPointerException` crash at  `selectedSite.siteComponent!!,` line. Then check out the latest commit and confirm the crash was fixed.
- [Add DashboardRepositoryTest for initialization without crash](https://github.com/woocommerce/woocommerce-android/commit/26c709fa0a97c39e7090ead415b0e2182b66c9b2): If you check out this commit and run the test, you can reproduce a `NullPointerException` crash at  `selectedSite.siteComponent!!,` line. Then checkout the latest commit and confirm the crash was fixed.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
