### PR TITLE
Persist push notification token id

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsRestClient.kt
@@ -34,7 +34,7 @@ class PushNotificationsRestClient @Inject constructor(private val wooNetwork: Wo
 
     suspend fun deletePushToken(
         site: SiteModel,
-        pushTokenId: Int
+        pushTokenId: String
     ): WooPayload<Unit> = wooNetwork.executeDeleteGsonRequest(
         site = site,
         path = WOOCOMMERCE.push_tokens.id(pushTokenId.toLong()).pathPushNotifications,
@@ -44,5 +44,5 @@ class PushNotificationsRestClient @Inject constructor(private val wooNetwork: Wo
     /**
      * @param id The unique ID of the push token record in Woo Core
      */
-    data class PushTokenIdResponse(val id: Int)
+    data class PushTokenIdResponse(val id: String)
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStore.kt
@@ -1,44 +1,96 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications
 
+import androidx.core.content.edit
 import org.wordpress.android.fluxc.BuildConfig
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.tools.CoroutineEngine
-import org.wordpress.android.util.AppLog
+import org.wordpress.android.fluxc.utils.PreferenceUtils
+import org.wordpress.android.util.AppLog.T
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class PushNotificationsStore @Inject internal constructor(
     private val pushNotificationsRestClient: PushNotificationsRestClient,
+    private val prefsWrapper: PreferenceUtils.PreferenceUtilsWrapper,
     private val coroutineEngine: CoroutineEngine,
 ) {
+    private val preferences by lazy { prefsWrapper.getFluxCPreferences() }
+
     suspend fun registerPushToken(
         site: SiteModel,
         token: String,
         deviceUuid: String
-    ): WooResult<Unit> = coroutineEngine.withDefaultContext(AppLog.T.API, this, "deletePushToken") {
+    ): WooResult<Unit> = coroutineEngine.withDefaultContext(T.API, this, "registerPushToken") {
         val origin = if (BuildConfig.DEBUG) ORIGIN_DEV else ORIGIN
-        val result = pushNotificationsRestClient.registerPushToken(site, token, origin, deviceUuid)
+        val payload = pushNotificationsRestClient.registerPushToken(site, token, origin, deviceUuid)
 
-        if (result.isError) {
-            WooResult(result.error)
+        if (payload.isError || payload.result == null) {
+            WooResult(payload.error)
         } else {
-            // TODO persist push token id
+            persistPushToken(site, payload.result.id)
             WooResult(Unit)
         }
     }
 
     suspend fun deletePushToken(
         site: SiteModel
-    ): WooResult<Unit> = coroutineEngine.withDefaultContext(AppLog.T.API, this, "deletePushToken") {
-        // TODO Retrieve persisted id
-        val dummyId = 0
-        pushNotificationsRestClient.deletePushToken(site, dummyId).asWooResult()
+    ): WooResult<Unit> = coroutineEngine.withDefaultContext(T.API, this, "deletePushToken") {
+        getPersistedPushToken(site)?.let { pushTokenId ->
+            val result = pushNotificationsRestClient.deletePushToken(site, pushTokenId).asWooResult()
+            if (!result.isError) {
+                clearPersistedPushToken(site)
+            }
+            result
+        } ?: WooResult(
+            WooError(
+                WooErrorType.GENERIC_ERROR,
+                BaseRequest.GenericErrorType.NOT_FOUND,
+                "No persisted push token found for site ${site.id}"
+            )
+        )
     }
+
+    @Synchronized
+    private fun getPersistedPushToken(site: SiteModel): Int? = getPersistedTokenSet()
+        .firstOrNull { it.startsWith(getSiteTokenPrefix(site)) }
+        ?.substringAfter(getSiteTokenPrefix(site))
+        ?.toIntOrNull()
+
+    @Synchronized
+    private fun persistPushToken(site: SiteModel, tokenId: Int) {
+        val persistedPushTokens = getPersistedTokenSet()
+
+        val updatedPushTokens = persistedPushTokens.filterNot { it.startsWith(getSiteTokenPrefix(site)) }.toMutableSet()
+        updatedPushTokens.add(getSiteTokenPrefix(site) + tokenId)
+
+        if (persistedPushTokens != updatedPushTokens) {
+            preferences.edit { putStringSet(PUSH_TOKENS, updatedPushTokens) }
+        }
+    }
+
+    @Synchronized
+    private fun clearPersistedPushToken(site: SiteModel) {
+        val persistedPushTokens = getPersistedTokenSet()
+
+        val updatedPushTokens = persistedPushTokens.filterNot { it.startsWith(getSiteTokenPrefix(site)) }.toSet()
+
+        if (persistedPushTokens != updatedPushTokens) {
+            preferences.edit { putStringSet(PUSH_TOKENS, updatedPushTokens) }
+        }
+    }
+
+    private fun getPersistedTokenSet() = preferences.getStringSet(PUSH_TOKENS, null) ?: setOf()
+
+    private fun getSiteTokenPrefix(site: SiteModel) = "${site.id}:"
 
     companion object {
         private const val ORIGIN = "com.woocommerce.android"
         private const val ORIGIN_DEV = "com.woocommerce.android:dev"
+        private const val PUSH_TOKENS = "push_tokens"
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStore.kt
@@ -32,7 +32,7 @@ class PushNotificationsStore @Inject internal constructor(
         if (payload.isError || payload.result == null) {
             WooResult(payload.error)
         } else {
-            persistPushToken(site, payload.result.id)
+            persistPushTokenId(payload.result.id)
             WooResult(Unit)
         }
     }
@@ -40,57 +40,34 @@ class PushNotificationsStore @Inject internal constructor(
     suspend fun deletePushToken(
         site: SiteModel
     ): WooResult<Unit> = coroutineEngine.withDefaultContext(T.API, this, "deletePushToken") {
-        getPersistedPushToken(site)?.let { pushTokenId ->
+        getPersistedPushTokenId()?.let { pushTokenId ->
             val result = pushNotificationsRestClient.deletePushToken(site, pushTokenId).asWooResult()
             if (!result.isError) {
-                clearPersistedPushToken(site)
+                preferences.edit { remove(PUSH_TOKEN_ID) }
             }
             result
         } ?: WooResult(
             WooError(
                 WooErrorType.GENERIC_ERROR,
                 BaseRequest.GenericErrorType.NOT_FOUND,
-                "No persisted push token found for site ${site.id}"
+                "No persisted push token id found"
             )
         )
     }
 
     @Synchronized
-    private fun getPersistedPushToken(site: SiteModel): Int? = getPersistedTokenSet()
-        .firstOrNull { it.startsWith(getSiteTokenPrefix(site)) }
-        ?.substringAfter(getSiteTokenPrefix(site))
-        ?.toIntOrNull()
+    private fun getPersistedPushTokenId(): String? = preferences.getString(PUSH_TOKEN_ID, null)
 
     @Synchronized
-    private fun persistPushToken(site: SiteModel, tokenId: Int) {
-        val persistedPushTokens = getPersistedTokenSet()
-
-        val updatedPushTokens = persistedPushTokens.filterNot { it.startsWith(getSiteTokenPrefix(site)) }.toMutableSet()
-        updatedPushTokens.add(getSiteTokenPrefix(site) + tokenId)
-
-        if (persistedPushTokens != updatedPushTokens) {
-            preferences.edit { putStringSet(PUSH_TOKENS, updatedPushTokens) }
+    private fun persistPushTokenId(tokenId: String) {
+        if (getPersistedPushTokenId() != tokenId) {
+            preferences.edit { putString(PUSH_TOKEN_ID, tokenId) }
         }
     }
-
-    @Synchronized
-    private fun clearPersistedPushToken(site: SiteModel) {
-        val persistedPushTokens = getPersistedTokenSet()
-
-        val updatedPushTokens = persistedPushTokens.filterNot { it.startsWith(getSiteTokenPrefix(site)) }.toSet()
-
-        if (persistedPushTokens != updatedPushTokens) {
-            preferences.edit { putStringSet(PUSH_TOKENS, updatedPushTokens) }
-        }
-    }
-
-    private fun getPersistedTokenSet() = preferences.getStringSet(PUSH_TOKENS, null) ?: setOf()
-
-    private fun getSiteTokenPrefix(site: SiteModel) = "${site.id}:"
 
     companion object {
         private const val ORIGIN = "com.woocommerce.android"
         private const val ORIGIN_DEV = "com.woocommerce.android:dev"
-        private const val PUSH_TOKENS = "push_tokens"
+        private const val PUSH_TOKEN_ID = "push_token_id"
     }
 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStoreTest.kt
@@ -44,8 +44,8 @@ class PushNotificationsStoreTest {
         runBlocking {
             // GIVEN
             val site = SiteModel().apply { id = 123 }
-            val newTokenId = 101
-            whenever(prefs.getStringSet(eq("push_tokens"), anyOrNull())).thenReturn(emptySet())
+            val newTokenId = "101"
+            whenever(prefs.getString(eq("push_token_id"), anyOrNull())).thenReturn(null)
             whenever(restClient.registerPushToken(any(), any(), any(), any()))
                 .thenReturn(WooPayload(PushTokenIdResponse(newTokenId)))
 
@@ -53,30 +53,9 @@ class PushNotificationsStoreTest {
             sut.registerPushToken(site, "token", "uuid")
 
             // THEN
-            val captor = argumentCaptor<Set<String>>()
-            verify(editor).putStringSet(eq("push_tokens"), captor.capture())
-            assertThat(captor.firstValue).containsExactly("${site.id}:$newTokenId")
-        }
-    }
-
-    @Test
-    fun `given existing token, when registerPushToken succeeds, then updates existing token`() {
-        runBlocking {
-            // GIVEN
-            val site = SiteModel().apply { id = 123 }
-            val oldTokenId = 100
-            val newTokenId = 101
-            whenever(prefs.getStringSet(eq("push_tokens"), anyOrNull())).thenReturn(setOf("${site.id}:$oldTokenId"))
-            whenever(restClient.registerPushToken(any(), any(), any(), any()))
-                .thenReturn(WooPayload(PushTokenIdResponse(newTokenId)))
-
-            // WHEN
-            sut.registerPushToken(site, "token", "uuid")
-
-            // THEN
-            val captor = argumentCaptor<Set<String>>()
-            verify(editor).putStringSet(eq("push_tokens"), captor.capture())
-            assertThat(captor.firstValue).containsExactly("${site.id}:$newTokenId")
+            val captor = argumentCaptor<String>()
+            verify(editor).putString(eq("push_token_id"), captor.capture())
+            assertThat(captor.firstValue).isEqualTo(newTokenId)
         }
     }
 
@@ -85,23 +64,20 @@ class PushNotificationsStoreTest {
         runBlocking {
             // GIVEN
             val site = SiteModel().apply { id = 123 }
-            val existingTokenId = 100
-            val otherToken = "999:200"
+            val existingTokenId = "100"
             whenever(
-                prefs.getStringSet(
-                    eq("push_tokens"),
+                prefs.getString(
+                    eq("push_token_id"),
                     anyOrNull()
                 )
-            ).thenReturn(setOf("${site.id}:$existingTokenId", otherToken))
+            ).thenReturn(existingTokenId)
             whenever(restClient.deletePushToken(any(), any())).thenReturn(WooPayload(Unit))
 
             // WHEN
             sut.deletePushToken(site)
 
             // THEN
-            val captor = argumentCaptor<Set<String>>()
-            verify(editor).putStringSet(eq("push_tokens"), captor.capture())
-            assertThat(captor.firstValue).containsExactly(otherToken)
+            verify(editor).remove(eq("push_token_id"))
         }
     }
 
@@ -110,7 +86,7 @@ class PushNotificationsStoreTest {
         runBlocking {
             // GIVEN
             val site = SiteModel().apply { id = 123 }
-            whenever(prefs.getStringSet(eq("push_tokens"), anyOrNull())).thenReturn(emptySet())
+            whenever(prefs.getString(eq("push_token_id"), anyOrNull())).thenReturn(null)
 
             // WHEN
             val result = sut.deletePushToken(site)

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStoreTest.kt
@@ -1,0 +1,122 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications.PushNotificationsRestClient.PushTokenIdResponse
+import org.wordpress.android.fluxc.utils.PreferenceUtils
+import org.wordpress.android.fluxc.utils.initCoroutineEngine
+
+class PushNotificationsStoreTest {
+    private val restClient: PushNotificationsRestClient = mock()
+    private val prefsWrapper: PreferenceUtils.PreferenceUtilsWrapper = mock()
+    private val prefs: SharedPreferences = mock()
+    private val editor: SharedPreferences.Editor = mock()
+
+    private lateinit var sut: PushNotificationsStore
+
+    @Before
+    fun setUp() {
+        whenever(prefsWrapper.getFluxCPreferences()).thenReturn(prefs)
+        whenever(prefs.edit()).thenReturn(editor)
+        whenever(editor.putStringSet(any(), any())).thenReturn(editor)
+
+        sut = PushNotificationsStore(
+            pushNotificationsRestClient = restClient,
+            prefsWrapper = prefsWrapper,
+            coroutineEngine = initCoroutineEngine()
+        )
+    }
+
+    @Test
+    fun `given no token, when registerPushToken succeeds, then saves new token`() {
+        runBlocking {
+            // GIVEN
+            val site = SiteModel().apply { id = 123 }
+            val newTokenId = 101
+            whenever(prefs.getStringSet(eq("push_tokens"), anyOrNull())).thenReturn(emptySet())
+            whenever(restClient.registerPushToken(any(), any(), any(), any()))
+                .thenReturn(WooPayload(PushTokenIdResponse(newTokenId)))
+
+            // WHEN
+            sut.registerPushToken(site, "token", "uuid")
+
+            // THEN
+            val captor = argumentCaptor<Set<String>>()
+            verify(editor).putStringSet(eq("push_tokens"), captor.capture())
+            assertThat(captor.firstValue).containsExactly("${site.id}:$newTokenId")
+        }
+    }
+
+    @Test
+    fun `given existing token, when registerPushToken succeeds, then updates existing token`() {
+        runBlocking {
+            // GIVEN
+            val site = SiteModel().apply { id = 123 }
+            val oldTokenId = 100
+            val newTokenId = 101
+            whenever(prefs.getStringSet(eq("push_tokens"), anyOrNull())).thenReturn(setOf("${site.id}:$oldTokenId"))
+            whenever(restClient.registerPushToken(any(), any(), any(), any()))
+                .thenReturn(WooPayload(PushTokenIdResponse(newTokenId)))
+
+            // WHEN
+            sut.registerPushToken(site, "token", "uuid")
+
+            // THEN
+            val captor = argumentCaptor<Set<String>>()
+            verify(editor).putStringSet(eq("push_tokens"), captor.capture())
+            assertThat(captor.firstValue).containsExactly("${site.id}:$newTokenId")
+        }
+    }
+
+    @Test
+    fun `given existing token, when deletePushToken succeeds, then clears token`() {
+        runBlocking {
+            // GIVEN
+            val site = SiteModel().apply { id = 123 }
+            val existingTokenId = 100
+            val otherToken = "999:200"
+            whenever(
+                prefs.getStringSet(
+                    eq("push_tokens"),
+                    anyOrNull()
+                )
+            ).thenReturn(setOf("${site.id}:$existingTokenId", otherToken))
+            whenever(restClient.deletePushToken(any(), any())).thenReturn(WooPayload(Unit))
+
+            // WHEN
+            sut.deletePushToken(site)
+
+            // THEN
+            val captor = argumentCaptor<Set<String>>()
+            verify(editor).putStringSet(eq("push_tokens"), captor.capture())
+            assertThat(captor.firstValue).containsExactly(otherToken)
+        }
+    }
+
+    @Test
+    fun `given no existing token, when deletePushToken called, then returns error`() {
+        runBlocking {
+            // GIVEN
+            val site = SiteModel().apply { id = 123 }
+            whenever(prefs.getStringSet(eq("push_tokens"), anyOrNull())).thenReturn(emptySet())
+
+            // WHEN
+            val result = sut.deletePushToken(site)
+
+            // THEN
+            assertThat(result.isError).isTrue()
+        }
+    }
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/utils/PreferenceUtils.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/utils/PreferenceUtils.kt
@@ -12,8 +12,6 @@ object PreferenceUtils {
 
     class PreferenceUtilsWrapper
     @Inject constructor(private val context: Context) {
-        fun getFluxCPreferences(): SharedPreferences {
-            return PreferenceUtils.getFluxCPreferences(context)
-        }
+        fun getFluxCPreferences(): SharedPreferences = getFluxCPreferences(context)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1903

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We need to store the push token IDs we receive from the `wc-push-notifications/push-tokens` endpoint. This PR handles storing and removing the push token IDs.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
`PushNotificationsStore` isn't usable in the app for now, so just run `PushNotificationsStoreTest`.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
