### PR TITLE
Don't call `connect/label` endpoint if the legacy plugin isn't activated

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 - [*] Fix widget sizing issues and improve refresh rate upon switching site or logging out [https://github.com/woocommerce/woocommerce-android/pull/15127]
 - [*] Unified transition animations across screens [https://github.com/woocommerce/woocommerce-android/pull/15128]
 - [*] Fixed a rare NullPointerException crash on the Dashboard screen [https://github.com/woocommerce/woocommerce-android/pull/15138]
+- [*][Internal] Remove the network call to the Woo Services plugin when it’s not supported [https://github.com/woocommerce/woocommerce-android/pull/15142]
 
 23.8
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -874,7 +874,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun fetchOrderShippingLabelsAsync() = async {
-        if (shippingLabelOnboardingRepository.shippingPluginSupport.isWooServicesSupported()) {
+        if (shippingLabelOnboardingRepository.shippingPluginSupport.isWooTaxLegacySupported()) {
             orderDetailRepository.fetchOrderShippingLabels(navArgs.orderId, isRevampWooShippingEnabled)
         }
         orderDetailsTransactionLauncher.onShippingLabelFetchingCompleted()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -874,7 +874,7 @@ class OrderDetailViewModel @Inject constructor(
     }
 
     private fun fetchOrderShippingLabelsAsync() = async {
-        if (shippingLabelOnboardingRepository.shippingPluginSupport.isSupported()) {
+        if (shippingLabelOnboardingRepository.shippingPluginSupport.isWooServicesSupported()) {
             orderDetailRepository.fetchOrderShippingLabels(navArgs.orderId, isRevampWooShippingEnabled)
         }
         orderDetailsTransactionLauncher.onShippingLabelFetchingCompleted()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepository.kt
@@ -70,5 +70,6 @@ class ShippingLabelOnboardingRepository @Inject constructor(
 
         fun isSupported() = this == WCS_SUPPORTED || this == WC_SHIPPING_SUPPORTED
         fun isWooShippingSupported() = this == WC_SHIPPING_SUPPORTED
+        fun isWooServicesSupported() = this == WCS_SUPPORTED
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepository.kt
@@ -69,7 +69,7 @@ class ShippingLabelOnboardingRepository @Inject constructor(
         WCS_SUPPORTED;
 
         fun isSupported() = this == WCS_SUPPORTED || this == WC_SHIPPING_SUPPORTED
+        fun isWooTaxLegacySupported() = this == WCS_SUPPORTED
         fun isWooShippingSupported() = this == WC_SHIPPING_SUPPORTED
-        fun isWooServicesSupported() = this == WCS_SUPPORTED
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-1895

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We were calling the `/connect/label/` endpoint even when the legacy Woo Services plugin wasn’t activated. I updated the logic so we call `/connect/label/` only when the Woo Services plugin is supported.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Use a site that has both the WC Shipping and Woo Services plugins, but with WC Shipping activated.
2. Go to Orders.
3. Select an order that has purchased shipping labels.
4. Verify that there is no call to the `/connect/label/` endpoint. I used `Network Inspector` to monitor network calls.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
