### PR TITLE
When shipping rates loaded, preselect firs option

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -503,7 +503,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                         val sortedShippingRates = sortShippingRates(selectedRatesSortOrders[index], map)
                         if (selectedRates[index] == null) {
                             val defaultSelectedRate = sortedShippingRates[sortedShippingRates.keys.first()]?.first()
-                            selectedRatesFlow.update { it.toMutableList().apply { set(selectedShipmentIndex, defaultSelectedRate) } }
+                            selectedRatesFlow.update {
+                                it.toMutableList().apply {
+                                    set(
+                                        selectedShipmentIndex,
+                                        defaultSelectedRate
+                                    )
+                                }
+                            }
                         }
                         ShippingRatesState.DataState(
                             selectedRatesSortOrder = selectedRatesSortOrders[index],

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -501,17 +501,7 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                         ShippingRatesState.NoAvailable
                     } else {
                         val sortedShippingRates = sortShippingRates(selectedRatesSortOrders[index], map)
-                        if (selectedRates[index] == null) {
-                            val defaultSelectedRate = sortedShippingRates[sortedShippingRates.keys.first()]?.first()
-                            selectedRatesFlow.update {
-                                it.toMutableList().apply {
-                                    set(
-                                        selectedShipmentIndex,
-                                        defaultSelectedRate
-                                    )
-                                }
-                            }
-                        }
+                        preselectShippingRateIfNoneSelected(selectedRates, index, sortedShippingRates)
                         ShippingRatesState.DataState(
                             selectedRatesSortOrder = selectedRatesSortOrders[index],
                             shippingRates = sortedShippingRates,
@@ -524,6 +514,24 @@ class WooShippingLabelCreationViewModel @Inject constructor(
             }.collectLatest {
                 shippingRatesStatesFlow.value = it
             }
+    }
+
+    private fun preselectShippingRateIfNoneSelected(
+        selectedRates: List<ShippingRateUI?>,
+        index: Int,
+        sortedShippingRates: Map<CarrierUI, List<ShippingRateUI>>
+    ) {
+        if (selectedRates[index] == null) {
+            val defaultSelectedRate = sortedShippingRates[sortedShippingRates.keys.first()]?.first()
+            selectedRatesFlow.update {
+                it.toMutableList().apply {
+                    set(
+                        selectedShipmentIndex,
+                        defaultSelectedRate
+                    )
+                }
+            }
+        }
     }
 
     @OptIn(FlowPreview::class)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -500,9 +500,14 @@ class WooShippingLabelCreationViewModel @Inject constructor(
                     if (map.isEmpty()) {
                         ShippingRatesState.NoAvailable
                     } else {
+                        val sortedShippingRates = sortShippingRates(selectedRatesSortOrders[index], map)
+                        if (selectedRates[index] == null) {
+                            val defaultSelectedRate = sortedShippingRates[sortedShippingRates.keys.first()]?.first()
+                            selectedRatesFlow.update { it.toMutableList().apply { set(selectedShipmentIndex, defaultSelectedRate) } }
+                        }
                         ShippingRatesState.DataState(
                             selectedRatesSortOrder = selectedRatesSortOrders[index],
-                            shippingRates = sortShippingRates(selectedRatesSortOrders[index], map),
+                            shippingRates = sortedShippingRates,
                             selectedRate = selectedRates[index],
                             onSelectedShippingRateChanged = ::onSelectedShippingRateChanged,
                             onSelectedRateOptionChanged = ::onSelectedRateOptionChanged

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -245,12 +245,12 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     )
 
     private val defaultShippingRates = mapOf(
-        defaultCarrier to defaultShippableItems.map {
+        defaultCarrier to defaultShippableItems.mapIndexed { index, _ ->
             ShippingRateUI(
-                title = defaultCarrier.name,
-                formattedBasePrice = "10",
+                title = "${defaultCarrier.name} - Rate $index",
+                formattedBasePrice = "${10 + index}",
                 shippingRateIncludedOptions = emptyList(),
-                formattedEstimatedDays = "1 day",
+                formattedEstimatedDays = "${1 + index} day",
                 options = mapOf(ShippingRateOption.DEFAULT to defaultShippableItemUI),
                 selectedOption = ShippingRateOption.DEFAULT,
                 additionalSelectedOptions = emptyList()
@@ -960,7 +960,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     fun `when shipping rate selected, then track selected event`() = testBlocking {
         createViewModel()
 
-        val selectedRate = defaultShippingRates.values.first().first()
+        val selectedRate = defaultShippingRates.values.first().last()
 
         val ratesState = sut.viewState.runAndCaptureValues {
             sut.onPackageSelected(defaultPackageData)
@@ -973,7 +973,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
 
         advanceUntilIdle()
 
-        verify(analyticsTracker).track(AnalyticsEvent.WCS_RATE_SELECTION_STEP, mapOf(KEY_STATE to "selected"))
+        verify(analyticsTracker, times(1)).track(AnalyticsEvent.WCS_RATE_SELECTION_STEP, mapOf(KEY_STATE to "selected"))
     }
 
     @Test


### PR DESCRIPTION
Closes WOOMOB-1476

### Description
This change updates WooShippingLabelCreationViewModel so that, after shipping rates are fetched and sorted, the first available rate for a shipment is preselected when no rate has been chosen yet. The previous behavior left selectedRates[index] as null, forcing merchants to manually select a rate option even when only one reasonable default existed. By preselecting the first sorted rate, the shipping label purchase flow becomes faster and less error-prone for merchants.
​
### Test Steps
1. Open an order eligible for Woo Shipping Labels and start the shipping label purchase flow on Android.
2. Proceed to the step where shipping rates are loaded for a shipment. Verify that once rates finish loading, the first rate option is already selected instead of showing no selection.
3. Change the selected rate manually and confirm the UI and state update correctly without overriding the user’s choice.
​
### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/04255c48-e561-4d6f-b78c-2a8cea3b6ee5


