### PR TITLE
Hide the Jetpack benefits banner if the push token is registered

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications.PushNotificationsStore
 import java.util.Calendar
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.days
@@ -65,6 +66,7 @@ class DashboardViewModel @Inject constructor(
     dashboardTransactionLauncher: DashboardTransactionLauncher,
     shouldShowPrivacyBanner: ShouldShowPrivacyBanner,
     dashboardRepository: DashboardRepository,
+    private val pushNotificationsStore: PushNotificationsStore,
     private val feedbackPrefs: FeedbackPrefs,
 ) : ScopedViewModel(savedState) {
     companion object {
@@ -294,7 +296,8 @@ class DashboardViewModel @Inject constructor(
             .map {
                 val durationSinceDismissal =
                     (System.currentTimeMillis() - appPrefsWrapper.getJetpackBenefitsDismissalDate()).milliseconds
-                val showBanner = durationSinceDismissal >= DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER.days
+                val showBanner = !pushNotificationsStore.hasPushToken() &&
+                    durationSinceDismissal >= DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER.days
                 JetpackBenefitsBannerUiModel(
                     show = showBanner,
                     onDismiss = {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -25,6 +25,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications.PushNotificationsStore
 
 @ExperimentalCoroutinesApi
 class DashboardViewModelTest : BaseUnitTest() {
@@ -53,6 +54,8 @@ class DashboardViewModelTest : BaseUnitTest() {
         )
         on { hasNewWidgets } doReturn flowOf(false)
     }
+
+    private val pushNotificationsStore: PushNotificationsStore = mock { on { hasPushToken() } doReturn true }
     private val feedbackPrefs: FeedbackPrefs = mock {
         onBlocking { userFeedbackIsDueObservable } doReturn flowOf(false)
     }
@@ -72,6 +75,7 @@ class DashboardViewModelTest : BaseUnitTest() {
             selectedSite = selectedSite,
             shouldShowPrivacyBanner = shouldShowPrivacyBanner,
             dashboardRepository = dashboardRepository,
+            pushNotificationsStore = pushNotificationsStore,
             feedbackPrefs = feedbackPrefs,
         )
     }
@@ -325,5 +329,27 @@ class DashboardViewModelTest : BaseUnitTest() {
             val jetpackBenefitsBannerState = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()
 
             assertThat(jetpackBenefitsBannerState).isNull()
+        }
+
+    @Test
+    fun `given push notification token registered, when screen starts, then hide Jetpack benefits banner`() =
+        testBlocking {
+            setup {
+                whenever(selectedSite.observe()).thenReturn(
+                    flowOf(
+                        SiteModel().apply {
+                            origin = SiteModel.ORIGIN_WPCOM_REST
+                            setIsJetpackCPConnected(true)
+                            setIsJetpackConnected(false)
+                        }
+                    )
+                )
+                whenever(pushNotificationsStore.hasPushToken()).thenReturn(true)
+            }
+
+            val jetpackBenefitsBanner = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()
+
+            assertThat(jetpackBenefitsBanner).isNotNull()
+            assertThat(jetpackBenefitsBanner!!.show).isFalse()
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -110,6 +110,7 @@ class DashboardViewModelTest : BaseUnitTest() {
                     }
                 )
             )
+            whenever(pushNotificationsStore.hasPushToken()).thenReturn(false)
         }
 
         val jetpackBenefitsBanner = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()
@@ -129,6 +130,7 @@ class DashboardViewModelTest : BaseUnitTest() {
                         }
                     )
                 )
+                whenever(pushNotificationsStore.hasPushToken()).thenReturn(false)
             }
 
             val jetpackBenefitsBanner = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStore.kt
@@ -65,6 +65,8 @@ class PushNotificationsStore @Inject internal constructor(
         }
     }
 
+    fun hasPushToken(): Boolean = getPersistedPushTokenId() != null
+
     companion object {
         private const val ORIGIN = "com.woocommerce.android"
         private const val ORIGIN_DEV = "com.woocommerce.android:dev"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This hides the Jetpack benefits banner if the push notification token is registered using the new endpoint. The new endpoint hasn’t been implemented yet, but I’m using the `push_token_id` key in SharedPreferences to determine whether the push token is registered.

This won't affect production since the banner will still be visible because there won't be persisted push token id.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
It’s not possible to test this yet. Once we implement the new endpoint, we’ll retest and verify the behavior. I’m not closing the issue until we confirm it works as expected.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Before|After|
|-|-|
|<img width="360" alt="before" src="https://github.com/user-attachments/assets/24e0a510-9051-4237-ad51-fcaee1a30e2f" />|<img width="360" alt="after" src="https://github.com/user-attachments/assets/5e7f8529-b5c7-4cd5-8a94-eea826dfa222" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
