### PR TITLE
[Tooling] Migrate release pipelines to mac-metal queue

### DIFF
--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -16,7 +16,7 @@ steps:
       echo '--- :snowflake: Complete Code Freeze'
       bundle exec fastlane complete_code_freeze skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
-        queue: "tumblr-metal"
+        queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/download-release-translations.yml
+++ b/.buildkite/release-pipelines/download-release-translations.yml
@@ -16,7 +16,7 @@ steps:
       echo '--- :globe_with_meridians: Download Release Translations'
       bundle exec fastlane download_release_translations skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
-        queue: "tumblr-metal"
+        queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -16,7 +16,7 @@ steps:
       echo '--- :fire: Finalize Hotfix Release'
       bundle exec fastlane finalize_hotfix_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
-        queue: "tumblr-metal"
+        queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -16,7 +16,7 @@ steps:
       echo '--- :shipit: Finalize Release'
       bundle exec fastlane finalize_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
-        queue: "tumblr-metal"
+        queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -16,7 +16,7 @@ steps:
       echo '--- :shipit: New Beta Release'
       bundle exec fastlane new_beta_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
-        queue: "tumblr-metal"
+        queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -14,7 +14,7 @@ steps:
       echo '--- :fire: Start New Hotfix Release'
       bundle exec fastlane new_hotfix_release version_name:"$RELEASE_VERSION" version_code:"$VERSION_CODE" skip_confirm:true
     agents:
-        queue: "tumblr-metal"
+        queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -14,7 +14,7 @@ steps:
       echo '--- :package: Publish Release'
       bundle exec fastlane publish_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
-      queue: "tumblr-metal"
+      queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -14,7 +14,7 @@ steps:
       echo '--- :snowflake: Start Code Freeze'
       bundle exec fastlane start_code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     agents:
-        queue: "tumblr-metal"
+        queue: "mac-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite


### PR DESCRIPTION
Fixes AINFRA-1664

Migrate release pipeline jobs from `tumblr-metal` to `mac-metal` queue.