### PR TITLE
Pass screen dimensions in JITM query params

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmQueryParamsEncoder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmQueryParamsEncoder.kt
@@ -21,6 +21,8 @@ class JitmQueryParamsEncoder @Inject constructor(
             .appendKeyValue("device", deviceInfo.name)
             .appendKeyValue("nfc", deviceFeatures.isNFCAvailable().toString())
             .appendKeyValue("locale", deviceInfo.locale ?: "unknown")
+            .appendKeyValue("screen_width", deviceInfo.screenWidthDp.toString())
+            .appendKeyValue("screen_height", deviceInfo.screenHeightDp.toString())
             .replace("\\s".toRegex(), "_")
             .removePrefix("&")
         return URLEncoder.encode(query, Charsets.UTF_8.name())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceInfo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceInfo.kt
@@ -38,4 +38,8 @@ class DeviceInfoWrapper @Inject constructor() {
         get() = DeviceInfo.name
     val locale: String?
         get() = DeviceInfo.locale
+    val screenWidthDp: Int
+        get() = Resources.getSystem().configuration.screenWidthDp
+    val screenHeightDp: Int
+        get() = Resources.getSystem().configuration.screenHeightDp
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/JitmQueryParamsEncoderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/JitmQueryParamsEncoderTest.kt
@@ -26,6 +26,8 @@ class JitmQueryParamsEncoderTest {
         whenever(deviceInfo.name).thenReturn("Pixel 3")
         whenever(deviceFeatures.isNFCAvailable()).thenReturn(true)
         whenever(deviceInfo.locale).thenReturn("en_US")
+        whenever(deviceInfo.screenWidthDp).thenReturn(411)
+        whenever(deviceInfo.screenHeightDp).thenReturn(731)
 
         // WHEN
         val encoderQueryParams = encoder.getEncodedQueryParams()
@@ -38,7 +40,9 @@ class JitmQueryParamsEncoderTest {
                     "&os_version=29" +
                     "&device=Pixel_3" +
                     "&nfc=true" +
-                    "&locale=en_US",
+                    "&locale=en_US" +
+                    "&screen_width=411" +
+                    "&screen_height=731",
                 Charsets.UTF_8.name()
             )
         )
@@ -52,6 +56,8 @@ class JitmQueryParamsEncoderTest {
         whenever(deviceInfo.name).thenReturn("Pixel 2")
         whenever(deviceFeatures.isNFCAvailable()).thenReturn(false)
         whenever(deviceInfo.locale).thenReturn("ru_RU")
+        whenever(deviceInfo.screenWidthDp).thenReturn(360)
+        whenever(deviceInfo.screenHeightDp).thenReturn(640)
 
         // WHEN
         val encoderQueryParams = encoder.getEncodedQueryParams()
@@ -64,7 +70,9 @@ class JitmQueryParamsEncoderTest {
                     "&os_version=27" +
                     "&device=Pixel_2" +
                     "&nfc=false" +
-                    "&locale=ru_RU",
+                    "&locale=ru_RU" +
+                    "&screen_width=360" +
+                    "&screen_height=640",
                 Charsets.UTF_8.name()
             )
         )


### PR DESCRIPTION
WOOMOB-1933

### Description

Add screen width and height (in dp) to the JITM query parameters. This allows the server to make decisions based on device screen size.

New parameters added:
- `screen_width` - screen width in density-independent pixels
- `screen_height` - screen height in density-independent pixels

### Test Steps

1. Open the app on a device or emulator
2. Navigate to any screen that triggers JITM requests (e.g., My Store)
3. Verify in network logs that JITM requests include `screen_width` and `screen_height` parameters

### Images/gif

N/A - No UI changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.