### PR TITLE
Update JITM banner design

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 23.9
 -----
+- [Internal] Updated JITM banner design and migrated to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/15155]
 - [*] Fixed First Product Created celebration dialog layout on tablets to eliminate excessive white space [https://github.com/woocommerce/woocommerce-android/pull/15116]
 - [Internal][Woo POS] Add analytics tracking for stale catalog warning dialog display [https://github.com/woocommerce/woocommerce-android/pull/15055]
 - [*][Woo POS] Fixed loading indicator colors to match the design [https://github.com/woocommerce/woocommerce-android/pull/15043]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/OverflowMenu.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/OverflowMenu.kt
@@ -22,8 +22,6 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 
 @Composable
@@ -45,10 +43,6 @@ fun <T> WCOverflowMenu(
             )
         }
         DropdownMenu(
-            offset = DpOffset(
-                x = dimensionResource(id = R.dimen.major_100),
-                y = 0.dp
-            ),
             expanded = showMenu,
             onDismissRequest = { showMenu = false }
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmState.kt
@@ -11,7 +11,7 @@ sealed interface JitmState {
         val description: UiString,
         val primaryActionLabel: UiString,
         val backgroundImage: LocalOrRemoteImage,
-        val badgeIcon: LabelOrRemoteIcon,
+        val badgeIcon: LabelOrRemoteIcon?,
     ) : JitmState {
         sealed class LocalOrRemoteImage {
             data class Local(@DrawableRes val drawableId: Int) : LocalOrRemoteImage()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmViewModel.kt
@@ -135,16 +135,21 @@ class JitmViewModel @Inject constructor(
             )
         } ?: JitmState.Banner.LocalOrRemoteImage.Local(R.drawable.ic_banner_upsell_card_reader_illustration)
 
-    private fun Assets.getBadgeIcon() =
-        this?.get(JITM_ASSETS_BADGE_IMAGE_LIGHT_THEME_KEY)?.let {
-            JitmState.Banner.LabelOrRemoteIcon.Remote(
-                urlLightMode = it,
-                urlDarkMode = this[JITM_ASSETS_BADGE_IMAGE_DARK_THEME_KEY] ?: it
+    private fun Assets.getBadgeIcon(): JitmState.Banner.LabelOrRemoteIcon? {
+        val badgeUrl = this?.get(JITM_ASSETS_BADGE_IMAGE_LIGHT_THEME_KEY)
+        return when {
+            badgeUrl.isNullOrEmpty().not() -> JitmState.Banner.LabelOrRemoteIcon.Remote(
+                urlLightMode = badgeUrl,
+                urlDarkMode = this[JITM_ASSETS_BADGE_IMAGE_DARK_THEME_KEY] ?: badgeUrl
             )
-        }
-            ?: JitmState.Banner.LabelOrRemoteIcon.Label(
+
+            this?.containsKey(JITM_ASSETS_BADGE_IMAGE_LIGHT_THEME_KEY) == true -> null
+
+            else -> JitmState.Banner.LabelOrRemoteIcon.Label(
                 UiString.UiStringRes(R.string.card_reader_upsell_card_reader_banner_new)
             )
+        }
+    }
 
     data class CtaClick(val url: String) : MultiLiveEvent.Event()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -3,11 +3,7 @@ package com.woocommerce.android.ui.payments.banner
 import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,7 +16,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
@@ -33,6 +28,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
 import coil.compose.AsyncImage
 import coil.decode.SvgDecoder
 import coil.request.ImageRequest
@@ -47,16 +44,17 @@ fun Banner(bannerState: JitmState.Banner) {
     Card(
         modifier = Modifier.fillMaxWidth(),
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    start = dimensionResource(id = R.dimen.major_100),
-                ),
-            horizontalArrangement = Arrangement.End
+        ConstraintLayout(
+            modifier = Modifier.fillMaxWidth()
         ) {
+            val (closeButton, badge, title, description, ctaButton, backgroundImage) = createRefs()
+
             IconButton(
-                onClick = bannerState.onDismissClicked
+                onClick = bannerState.onDismissClicked,
+                modifier = Modifier.constrainAs(closeButton) {
+                    top.linkTo(parent.top)
+                    end.linkTo(parent.end)
+                }
             ) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_close),
@@ -67,68 +65,86 @@ fun Banner(bannerState: JitmState.Banner) {
                     modifier = Modifier.size(24.dp)
                 )
             }
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    start = dimensionResource(id = R.dimen.major_100),
-                ),
-            verticalAlignment = Alignment.Bottom,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Column(
-                modifier = Modifier.weight(1f)
-            ) {
-                Spacer(modifier = Modifier.height(16.dp))
-                BadgeIcon(bannerState)
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = UiHelpers.getTextOfUiString(LocalContext.current, bannerState.title),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(
-                        bottom = dimensionResource(id = R.dimen.minor_100)
-                    )
+
+            if (bannerState.badgeIcon != null) {
+                BadgeIcon(
+                    bannerState = bannerState,
+                    modifier = Modifier.constrainAs(badge) {
+                        top.linkTo(parent.top, margin = 16.dp)
+                        start.linkTo(parent.start, margin = 16.dp)
+                    }
                 )
-                Text(
-                    text = UiHelpers.getTextOfUiString(LocalContext.current, bannerState.description),
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(
-                        bottom = dimensionResource(id = R.dimen.minor_100)
-                    )
-                )
-                TextButton(
-                    modifier = Modifier
-                        .padding(
-                            top = dimensionResource(id = R.dimen.minor_100),
-                        ),
-                    contentPadding = PaddingValues(start = dimensionResource(id = R.dimen.minor_00)),
-                    onClick = bannerState.onPrimaryActionClicked
-                ) {
-                    Text(
-                        text = UiHelpers.getTextOfUiString(LocalContext.current, bannerState.primaryActionLabel),
-                        color = colorResource(id = R.color.color_primary),
-                        style = MaterialTheme.typography.titleMedium,
-                    )
+            }
+
+            Text(
+                text = UiHelpers.getTextOfUiString(LocalContext.current, bannerState.title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier
+                    .constrainAs(title) {
+                        if (bannerState.badgeIcon != null) {
+                            top.linkTo(badge.bottom, margin = 8.dp)
+                        } else {
+                            top.linkTo(parent.top, margin = 16.dp)
+                        }
+                        start.linkTo(parent.start, margin = 16.dp)
+                        end.linkTo(backgroundImage.start, margin = 8.dp)
+                        width = Dimension.fillToConstraints
+                    }
+                    .padding(bottom = dimensionResource(id = R.dimen.minor_100))
+            )
+
+            Text(
+                text = UiHelpers.getTextOfUiString(LocalContext.current, bannerState.description),
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .constrainAs(description) {
+                        top.linkTo(title.bottom)
+                        start.linkTo(parent.start, margin = 16.dp)
+                        end.linkTo(backgroundImage.start, margin = 8.dp)
+                        width = Dimension.fillToConstraints
+                    }
+                    .padding(bottom = dimensionResource(id = R.dimen.minor_100))
+            )
+
+            TextButton(
+                onClick = bannerState.onPrimaryActionClicked,
+                contentPadding = PaddingValues(start = dimensionResource(id = R.dimen.minor_00)),
+                modifier = Modifier.constrainAs(ctaButton) {
+                    top.linkTo(description.bottom)
+                    start.linkTo(parent.start, margin = 16.dp)
                 }
+            ) {
+                Text(
+                    text = UiHelpers.getTextOfUiString(LocalContext.current, bannerState.primaryActionLabel),
+                    color = colorResource(id = R.color.color_primary),
+                    style = MaterialTheme.typography.titleMedium,
+                )
             }
-            Column {
-                BackgroundImage(bannerState)
-            }
+
+            BackgroundImage(
+                bannerState = bannerState,
+                modifier = Modifier.constrainAs(backgroundImage) {
+                    end.linkTo(parent.end)
+                    bottom.linkTo(parent.bottom)
+                }
+            )
         }
     }
 }
 
 @Composable
-private fun BackgroundImage(bannerState: JitmState.Banner) {
+private fun BackgroundImage(
+    bannerState: JitmState.Banner,
+    modifier: Modifier = Modifier
+) {
     when (val icon = bannerState.backgroundImage) {
         is JitmState.Banner.LocalOrRemoteImage.Local -> {
             Image(
                 painter = painterResource(id = icon.drawableId),
                 contentDescription = null,
                 contentScale = ContentScale.Inside,
-                modifier = Modifier.width(154.dp)
+                modifier = modifier.width(154.dp)
             )
         }
         is JitmState.Banner.LocalOrRemoteImage.Remote -> {
@@ -144,14 +160,17 @@ private fun BackgroundImage(bannerState: JitmState.Banner) {
                     .decoderFactory(SvgDecoder.Factory())
                     .build(),
                 contentDescription = null,
-                modifier = Modifier.width(154.dp)
+                modifier = modifier.width(154.dp)
             )
         }
     }
 }
 
 @Composable
-private fun BadgeIcon(bannerState: JitmState.Banner) {
+private fun BadgeIcon(
+    bannerState: JitmState.Banner,
+    modifier: Modifier = Modifier
+) {
     when (val icon = bannerState.badgeIcon) {
         is JitmState.Banner.LabelOrRemoteIcon.Label -> {
             val bcgColor = colorResource(id = R.color.woo_purple_0)
@@ -160,7 +179,7 @@ private fun BadgeIcon(bannerState: JitmState.Banner) {
                 color = colorResource(id = R.color.woo_purple_60),
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier
+                modifier = modifier
                     .drawBehind {
                         drawRoundRect(
                             color = bcgColor,
@@ -186,7 +205,7 @@ private fun BadgeIcon(bannerState: JitmState.Banner) {
                     .decoderFactory(SvgDecoder.Factory())
                     .build(),
                 contentDescription = null,
-                modifier = Modifier.height(26.dp)
+                modifier = modifier.height(26.dp)
             )
         }
         null -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
@@ -63,7 +64,8 @@ fun Banner(bannerState: JitmState.Banner) {
                     contentDescription = stringResource(
                         id = R.string.card_reader_upsell_card_reader_banner_dismiss
                     ),
-                    tint = colorResource(id = R.color.color_on_surface)
+                    tint = colorResource(id = R.color.color_on_surface),
+                    modifier = Modifier.size(24.dp)
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -102,7 +102,6 @@ fun Banner(bannerState: JitmState.Banner) {
                     modifier = Modifier
                         .padding(
                             top = dimensionResource(id = R.dimen.minor_100),
-                            bottom = dimensionResource(id = R.dimen.minor_100),
                         ),
                     contentPadding = PaddingValues(start = dimensionResource(id = R.dimen.minor_00)),
                     onClick = bannerState.onPrimaryActionClicked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -109,9 +109,8 @@ fun Banner(bannerState: JitmState.Banner) {
                 ) {
                     Text(
                         text = UiHelpers.getTextOfUiString(LocalContext.current, bannerState.primaryActionLabel),
-                        color = colorResource(id = R.color.color_secondary),
+                        color = colorResource(id = R.color.color_primary),
                         style = MaterialTheme.typography.subtitle1,
-                        fontWeight = FontWeight.Bold,
                     )
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -7,11 +7,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -35,6 +32,7 @@ import coil.decode.SvgDecoder
 import coil.request.ImageRequest
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
+import com.woocommerce.android.ui.compose.component.WCOverflowMenu
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.jitm.JitmState
 import com.woocommerce.android.util.UiHelpers
@@ -47,29 +45,22 @@ fun Banner(bannerState: JitmState.Banner) {
         ConstraintLayout(
             modifier = Modifier.fillMaxWidth()
         ) {
-            val closeButton = createRef()
+            val overflowMenu = createRef()
             val badge = createRef()
             val title = createRef()
             val description = createRef()
             val ctaButton = createRef()
             val backgroundImage = createRef()
 
-            IconButton(
-                onClick = bannerState.onDismissClicked,
-                modifier = Modifier.constrainAs(closeButton) {
+            WCOverflowMenu(
+                items = listOf(stringResource(R.string.card_reader_upsell_card_reader_banner_hide_content)),
+                onSelected = { bannerState.onDismissClicked() },
+                tint = colorResource(id = R.color.color_on_surface),
+                modifier = Modifier.constrainAs(overflowMenu) {
                     top.linkTo(parent.top)
                     end.linkTo(parent.end)
                 }
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_close),
-                    contentDescription = stringResource(
-                        id = R.string.card_reader_upsell_card_reader_banner_dismiss
-                    ),
-                    tint = colorResource(id = R.color.color_on_surface),
-                    modifier = Modifier.size(24.dp)
-                )
-            }
+            )
 
             if (bannerState.badgeIcon != null) {
                 BadgeIcon(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -39,6 +39,9 @@ import com.woocommerce.android.util.UiHelpers
 
 @Composable
 fun Banner(bannerState: JitmState.Banner) {
+    val majorMargin = dimensionResource(id = R.dimen.major_100)
+    val minorMargin = dimensionResource(id = R.dimen.minor_100)
+
     Card(
         modifier = Modifier.fillMaxWidth(),
     ) {
@@ -66,8 +69,8 @@ fun Banner(bannerState: JitmState.Banner) {
                 BadgeIcon(
                     bannerState = bannerState,
                     modifier = Modifier.constrainAs(badge) {
-                        top.linkTo(parent.top, margin = 16.dp)
-                        start.linkTo(parent.start, margin = 16.dp)
+                        top.linkTo(parent.top, margin = majorMargin)
+                        start.linkTo(parent.start, margin = majorMargin)
                     }
                 )
             }
@@ -79,15 +82,15 @@ fun Banner(bannerState: JitmState.Banner) {
                 modifier = Modifier
                     .constrainAs(title) {
                         if (bannerState.badgeIcon != null) {
-                            top.linkTo(badge.bottom, margin = 8.dp)
+                            top.linkTo(badge.bottom, margin = minorMargin)
                         } else {
-                            top.linkTo(parent.top, margin = 16.dp)
+                            top.linkTo(parent.top, margin = majorMargin)
                         }
-                        start.linkTo(parent.start, margin = 16.dp)
-                        end.linkTo(backgroundImage.start, margin = 8.dp)
+                        start.linkTo(parent.start, margin = majorMargin)
+                        end.linkTo(backgroundImage.start, margin = minorMargin)
                         width = Dimension.fillToConstraints
                     }
-                    .padding(bottom = dimensionResource(id = R.dimen.minor_100))
+                    .padding(bottom = minorMargin)
             )
 
             Text(
@@ -96,11 +99,11 @@ fun Banner(bannerState: JitmState.Banner) {
                 modifier = Modifier
                     .constrainAs(description) {
                         top.linkTo(title.bottom)
-                        start.linkTo(parent.start, margin = 16.dp)
-                        end.linkTo(backgroundImage.start, margin = 8.dp)
+                        start.linkTo(parent.start, margin = majorMargin)
+                        end.linkTo(backgroundImage.start, margin = minorMargin)
                         width = Dimension.fillToConstraints
                     }
-                    .padding(bottom = dimensionResource(id = R.dimen.minor_100))
+                    .padding(bottom = minorMargin)
             )
 
             TextButton(
@@ -108,7 +111,7 @@ fun Banner(bannerState: JitmState.Banner) {
                 contentPadding = PaddingValues(start = dimensionResource(id = R.dimen.minor_00)),
                 modifier = Modifier.constrainAs(ctaButton) {
                     top.linkTo(description.bottom)
-                    start.linkTo(parent.start, margin = 16.dp)
+                    start.linkTo(parent.start, margin = majorMargin)
                 }
             ) {
                 Text(
@@ -134,13 +137,14 @@ private fun BackgroundImage(
     bannerState: JitmState.Banner,
     modifier: Modifier = Modifier
 ) {
+    val imageWidth = dimensionResource(id = R.dimen.image_major_150)
     when (val icon = bannerState.backgroundImage) {
         is JitmState.Banner.LocalOrRemoteImage.Local -> {
             Image(
                 painter = painterResource(id = icon.drawableId),
                 contentDescription = null,
                 contentScale = ContentScale.Inside,
-                modifier = modifier.width(154.dp)
+                modifier = modifier.width(imageWidth)
             )
         }
         is JitmState.Banner.LocalOrRemoteImage.Remote -> {
@@ -156,7 +160,7 @@ private fun BackgroundImage(
                     .decoderFactory(SvgDecoder.Factory())
                     .build(),
                 contentDescription = null,
-                modifier = modifier.width(154.dp)
+                modifier = modifier.width(imageWidth)
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -47,7 +47,12 @@ fun Banner(bannerState: JitmState.Banner) {
         ConstraintLayout(
             modifier = Modifier.fillMaxWidth()
         ) {
-            val (closeButton, badge, title, description, ctaButton, backgroundImage) = createRefs()
+            val closeButton = createRef()
+            val badge = createRef()
+            val title = createRef()
+            val description = createRef()
+            val ctaButton = createRef()
+            val backgroundImage = createRef()
 
             IconButton(
                 onClick = bannerState.onDismissClicked,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -13,12 +13,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.Card
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -85,7 +85,7 @@ fun Banner(bannerState: JitmState.Banner) {
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = UiHelpers.getTextOfUiString(LocalContext.current, bannerState.title),
-                    style = MaterialTheme.typography.subtitle1,
+                    style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(
                         bottom = dimensionResource(id = R.dimen.minor_100)
@@ -93,7 +93,7 @@ fun Banner(bannerState: JitmState.Banner) {
                 )
                 Text(
                     text = UiHelpers.getTextOfUiString(LocalContext.current, bannerState.description),
-                    style = MaterialTheme.typography.subtitle1,
+                    style = MaterialTheme.typography.bodyLarge,
                     modifier = Modifier.padding(
                         bottom = dimensionResource(id = R.dimen.minor_100)
                     )
@@ -109,7 +109,7 @@ fun Banner(bannerState: JitmState.Banner) {
                     Text(
                         text = UiHelpers.getTextOfUiString(LocalContext.current, bannerState.primaryActionLabel),
                         color = colorResource(id = R.color.color_primary),
-                        style = MaterialTheme.typography.subtitle1,
+                        style = MaterialTheme.typography.titleMedium,
                     )
                 }
             }
@@ -158,7 +158,7 @@ private fun BadgeIcon(bannerState: JitmState.Banner) {
             Text(
                 text = UiHelpers.getTextOfUiString(LocalContext.current, icon.label),
                 color = colorResource(id = R.color.woo_purple_60),
-                style = MaterialTheme.typography.caption,
+                style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier
                     .drawBehind {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/banner/Banner.kt
@@ -52,7 +52,6 @@ fun Banner(bannerState: JitmState.Banner) {
                 .fillMaxWidth()
                 .padding(
                     start = dimensionResource(id = R.dimen.major_100),
-                    top = dimensionResource(id = R.dimen.minor_100)
                 ),
             horizontalArrangement = Arrangement.End
         ) {
@@ -74,7 +73,6 @@ fun Banner(bannerState: JitmState.Banner) {
                 .fillMaxWidth()
                 .padding(
                     start = dimensionResource(id = R.dimen.major_100),
-                    top = dimensionResource(id = R.dimen.minor_100)
                 ),
             verticalAlignment = Alignment.Bottom,
             horizontalArrangement = Arrangement.SpaceBetween
@@ -192,6 +190,7 @@ private fun BadgeIcon(bannerState: JitmState.Banner) {
                 modifier = Modifier.height(26.dp)
             )
         }
+        null -> Unit
     }
 }
 
@@ -215,6 +214,27 @@ fun PaymentScreenBannerPreview() {
                         R.string.card_reader_upsell_card_reader_banner_new
                     )
                 ),
+            )
+        )
+    }
+}
+
+@Preview(name = "No badge - Light mode")
+@Preview(name = "No badge - Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PaymentScreenBannerNoBadgePreview() {
+    WooThemeWithBackground {
+        Banner(
+            JitmState.Banner(
+                onPrimaryActionClicked = {},
+                onDismissClicked = {},
+                title = UiString.UiStringRes(R.string.card_reader_upsell_card_reader_banner_title),
+                description = UiString.UiStringRes(R.string.card_reader_upsell_card_reader_banner_description),
+                primaryActionLabel = UiString.UiStringRes(R.string.card_reader_upsell_card_reader_banner_cta),
+                backgroundImage = JitmState.Banner.LocalOrRemoteImage.Local(
+                    R.drawable.ic_banner_upsell_card_reader_illustration
+                ),
+                badgeIcon = null,
             )
         )
     }

--- a/WooCommerce/src/main/res/layout/fragment_dashboard.xml
+++ b/WooCommerce/src/main/res/layout/fragment_dashboard.xml
@@ -12,6 +12,7 @@
     tools:context="com.woocommerce.android.ui.dashboard.DashboardFragment">
 
     <androidx.fragment.app.FragmentContainerView
+        android:layout_marginVertical="@dimen/minor_50"
         android:id="@+id/jitmFragment"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1383,6 +1383,7 @@
         -->
 
     <string name="card_reader_upsell_card_reader_banner_dismiss">Dismiss</string>
+    <string name="card_reader_upsell_card_reader_banner_hide_content">Hide this content</string>
     <string name="card_reader_upsell_card_reader_banner_new">NEW</string>
     <string name="card_reader_upsell_card_reader_banner_title">Accept payments easily</string>
     <string name="card_reader_upsell_card_reader_banner_description">Start selling in person in under 20 minutes with our card reader.</string>


### PR DESCRIPTION
WOOMOB-1934

### Description

Updates the JITM banner design with several improvements:

- Update primary action button color
- Increase dismiss button size for better tap target
- Allow hiding badge icon from backend (send empty string or null to hide)
- Remove bottom padding from CTA button
- Migrate to Material 3
- Refactor layout to use ConstraintLayout
- Add vertical margin to JITM fragment container
- Replace close (X) button with overflow menu showing "Hide this content" option
- Remove offset from WCOverflowMenu for better positioning

### Test Steps

1. Navigate to My Store dashboard (if you don't have a site with JITM I can invite you)
2. Verify JITM banner displays correctly with updated styling
3. Tap the 3-dot overflow menu and verify "Hide this content" option appears
4. Tap "Hide this content" and verify banner is dismissed
5. Test CTA button works correctly

### Images/gif
<img width="359" height="264" alt="Screenshot 2026-01-02 at 15 26 27" src="https://github.com/user-attachments/assets/dac5b2b8-09c6-4c6d-9d37-bc0b910a0ed2" />
<img width="281" height="167" alt="image" src="https://github.com/user-attachments/assets/09771513-8eb8-4739-ac6c-a909ff754f12" />



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.