### PR TITLE
[Woo POS][Refunds] Manage Issue Refund button visibility

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
@@ -21,19 +21,19 @@ import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 
 sealed class LoadOrdersResult {
-    data class SuccessCache(val ordersWithRefunds: Map<Order, RefundFetchResult>) : LoadOrdersResult()
-    data class SuccessRemote(val ordersWithRefunds: Map<Order, RefundFetchResult>) : LoadOrdersResult()
+    data class SuccessCache(val ordersWithRefunds: Map<Order, RefundsFetchResult>) : LoadOrdersResult()
+    data class SuccessRemote(val ordersWithRefunds: Map<Order, RefundsFetchResult>) : LoadOrdersResult()
     data class Error(val message: String) : LoadOrdersResult()
 }
 
 sealed class SearchOrdersResult {
-    data class Success(val ordersWithRefunds: Map<Order, RefundFetchResult>) : SearchOrdersResult()
+    data class Success(val ordersWithRefunds: Map<Order, RefundsFetchResult>) : SearchOrdersResult()
     data class Error(val message: String) : SearchOrdersResult()
 }
 
-sealed class RefundFetchResult {
-    data class Success(val refunds: List<Refund>) : RefundFetchResult()
-    object Error : RefundFetchResult()
+sealed class RefundsFetchResult {
+    data class Success(val refunds: List<Refund>) : RefundsFetchResult()
+    object Error : RefundsFetchResult()
 }
 
 class WooPosOrdersDataSource @Inject constructor(
@@ -82,7 +82,7 @@ class WooPosOrdersDataSource @Inject constructor(
         )
     }
 
-    suspend fun loadMore(searchQuery: String? = null): Result<Map<Order, RefundFetchResult>> =
+    suspend fun loadMore(searchQuery: String? = null): Result<Map<Order, RefundsFetchResult>> =
         withContext(Dispatchers.IO) {
             loadNextPage(searchQuery).map { orders ->
                 fetchRefundsForOrders(orders)
@@ -167,13 +167,13 @@ class WooPosOrdersDataSource @Inject constructor(
     private fun WCOrderStore.OrderError.toThrowable(): Throwable =
         Throwable("[$type] $message")
 
-    private suspend fun fetchRefundsForOrders(orders: List<Order>): Map<Order, RefundFetchResult> =
+    private suspend fun fetchRefundsForOrders(orders: List<Order>): Map<Order, RefundsFetchResult> =
         coroutineScope {
             orders.map { order ->
                 async {
                     retrieveOrderRefunds(order).fold(
-                        onSuccess = { refunds -> order to RefundFetchResult.Success(refunds) },
-                        onFailure = { order to RefundFetchResult.Error }
+                        onSuccess = { refunds -> order to RefundsFetchResult.Success(refunds) },
+                        onFailure = { order to RefundsFetchResult.Error }
                     )
                 }
             }.awaitAll().toMap()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -31,7 +31,7 @@ sealed class WooPosOrdersState {
         data class Lazy(
             override val orderId: Long,
             val order: Order,
-            val refundResult: RefundFetchResult
+            val refundResult: RefundsFetchResult
         ) : OrderDetailsViewState()
 
         @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -44,7 +44,8 @@ class WooPosOrdersViewModel @Inject constructor(
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender,
     private val formatPrice: WooPosFormatPrice,
     private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds,
-    private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker
+    private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker,
+    private val getRefundableItems: WooPosGetRefundableItems
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<WooPosOrdersState>(
@@ -92,13 +93,24 @@ class WooPosOrdersViewModel @Inject constructor(
         }
     }
 
-    private fun getAvailableActions(orderId: Long): List<WooPosOrdersState.OrderAction> {
+    private fun getAvailableActions(
+        order: Order,
+        refundResult: RefundsFetchResult
+    ): List<WooPosOrdersState.OrderAction> {
         return buildList {
-            if (FeatureFlag.POS_REFUNDS.isEnabled()) {
-                add(WooPosOrdersState.OrderAction.IssueRefund(orderId))
+            if (FeatureFlag.POS_REFUNDS.isEnabled() && hasRefundableItems(order, refundResult)) {
+                add(WooPosOrdersState.OrderAction.IssueRefund(order.id))
             }
-            add(WooPosOrdersState.OrderAction.EmailReceipt(orderId))
+            add(WooPosOrdersState.OrderAction.EmailReceipt(order.id))
         }
+    }
+
+    private fun hasRefundableItems(order: Order, refundResult: RefundsFetchResult): Boolean {
+        val refunds = when (refundResult) {
+            is RefundsFetchResult.Success -> refundResult.refunds
+            is RefundsFetchResult.Error -> emptyList()
+        }
+        return getRefundableItems(order, refunds).isNotEmpty()
     }
 
     fun onOrderSelected(orderId: Long) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -337,14 +337,14 @@ class WooPosOrdersViewModel @Inject constructor(
         val current = _state.value as? WooPosOrdersState.Content ?: return
         val loaded = current.items as? WooPosOrdersState.Content.Items.Loaded ?: return
 
-        val refundResult = retrieveOrderRefunds(updated).fold(
-            onSuccess = { refunds -> RefundFetchResult.Success(refunds) },
-            onFailure = { RefundFetchResult.Error }
+        val historicalRefundsResult = retrieveOrderRefunds(updated).fold(
+            onSuccess = { refunds -> RefundsFetchResult.Success(refunds) },
+            onFailure = { RefundsFetchResult.Error }
         )
 
         val selectedId = loaded.items.keys.firstOrNull { it.isSelected }?.id
         val newItem = mapOrderItem(updated, selectedId)
-        val newDetailsViewState = mapOrderDetails(updated, refundResult)
+        val newDetailsViewState = mapOrderDetails(updated, historicalRefundsResult)
         val newDetails = WooPosOrdersState.OrderDetailsViewState.Computed(
             orderId = updated.id,
             details = newDetailsViewState
@@ -489,7 +489,7 @@ class WooPosOrdersViewModel @Inject constructor(
     }
 
     private suspend fun replaceOrders(
-        ordersWithRefunds: Map<Order, RefundFetchResult>,
+        ordersWithRefunds: Map<Order, RefundsFetchResult>,
         paginationState: WooPosPaginationState = WooPosPaginationState.None
     ) {
         val currentState = _state.value
@@ -531,7 +531,7 @@ class WooPosOrdersViewModel @Inject constructor(
     }
 
     private suspend fun appendOrders(
-        ordersWithRefunds: Map<Order, RefundFetchResult>,
+        ordersWithRefunds: Map<Order, RefundsFetchResult>,
         paginationState: WooPosPaginationState = WooPosPaginationState.None
     ) {
         val current = _state.value as WooPosOrdersState.Content
@@ -552,7 +552,7 @@ class WooPosOrdersViewModel @Inject constructor(
     }
 
     private suspend fun buildItemsMap(
-        ordersWithRefunds: Map<Order, RefundFetchResult>,
+        ordersWithRefunds: Map<Order, RefundsFetchResult>,
         selectedId: Long?
     ): Map<WooPosOrdersState.OrderItemViewState, WooPosOrdersState.OrderDetailsViewState> = coroutineScope {
         ordersWithRefunds.map { (order, refundResult) ->
@@ -597,13 +597,13 @@ class WooPosOrdersViewModel @Inject constructor(
 
     private suspend fun mapOrderDetails(
         order: Order,
-        refundResult: RefundFetchResult
+        historicalRefundsResult: RefundsFetchResult
     ): WooPosOrdersState.OrderDetailsViewState.Computed.Details = coroutineScope {
         val status = mapOrderStatus(order)
         val lineItems = buildLineItems(order)
-        val refundInfo = buildRefundInfo(order, refundResult)
+        val refundInfo = buildRefundInfo(order, historicalRefundsResult)
         val breakdown = buildTotalsBreakdown(order, refundInfo)
-        val actions = getAvailableActions(order.id)
+        val actions = getAvailableActions(order, historicalRefundsResult)
 
         WooPosOrdersState.OrderDetailsViewState.Computed.Details(
             id = order.id,
@@ -660,15 +660,15 @@ class WooPosOrdersViewModel @Inject constructor(
 
     private suspend fun buildRefundInfo(
         order: Order,
-        refundResult: RefundFetchResult
+        refundResult: RefundsFetchResult
     ): RefundInfo {
         return when (refundResult) {
-            is RefundFetchResult.Success -> {
+            is RefundsFetchResult.Success -> {
                 val amounts = refundResult.refunds.map { "-${formatPrice(it.amount)}" }
                 val total = refundResult.refunds.sumOf { it.amount }
                 RefundInfo(amounts, total)
             }
-            is RefundFetchResult.Error -> {
+            is RefundsFetchResult.Error -> {
                 val amounts =
                     if (order.refundTotal > BigDecimal.ZERO) {
                         listOf(resourceProvider.getString(R.string.woopos_orders_details_refund_error))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -51,6 +51,7 @@ class WooPosOrdersViewModelTest {
     private val providedLocale: Locale = Locale.US
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker = mock()
+    private val getRefundableItems: WooPosGetRefundableItems = mock()
 
     private fun order(id: Long = 1L): Order = OrderTestUtils.generateTestOrder(orderId = id)
 
@@ -66,7 +67,8 @@ class WooPosOrdersViewModelTest {
             childrenToParentEventSender = childrenToParentEventSender,
             formatPrice = formatPrice,
             retrieveOrderRefunds = retrieveOrderRefunds,
-            ordersAnalyticsTracker = ordersAnalyticsTracker
+            ordersAnalyticsTracker = ordersAnalyticsTracker,
+            getRefundableItems = getRefundableItems
         )
     }
 
@@ -78,6 +80,7 @@ class WooPosOrdersViewModelTest {
             whenever(formatPrice.invoke(any())).thenReturn("$0.00")
             whenever(getProductById.invoke(any())).thenReturn(null)
             whenever(retrieveOrderRefunds.invoke(any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(emptyList())
         }
 
         whenever(dataSource.loadOrders()).thenReturn(
@@ -1190,5 +1193,64 @@ class WooPosOrdersViewModelTest {
         assertThat(currentState.pullToRefreshState).isEqualTo(initialPullToRefreshState)
         assertThat(currentState.paginationState).isEqualTo(initialPaginationState)
         assertThat(currentState.searchInputState).isEqualTo(initialSearchInputState)
+    }
+
+    @Test
+    fun `given order with refundable items, when order details loaded, then Issue Refund action is available`() = runTest {
+        // GIVEN
+        val testOrder = order(1)
+        val refundableItem = WooPosRefundableItem(
+            orderItemId = 1L,
+            productId = 100L,
+            variationId = 0L,
+            name = "Test Product",
+            unitPrice = BigDecimal("10.00"),
+            unitTax = BigDecimal("1.00"),
+            formattedUnitPrice = "$10.00",
+            formattedUnitTax = "$1.00",
+            rowIndex = 0
+        )
+
+        runBlocking {
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(listOf(refundableItem))
+        }
+
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(testOrder))) }
+        )
+
+        // WHEN
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        val state = viewModel.state.value as WooPosOrdersState.Content
+        val details = state.selectedDetails!!
+        assertThat(details.actions).anyMatch { it is WooPosOrdersState.OrderAction.IssueRefund }
+        assertThat(details.actions).anyMatch { it is WooPosOrdersState.OrderAction.EmailReceipt }
+    }
+
+    @Test
+    fun `given order with no refundable items, when order details loaded, then Issue Refund action is absent`() = runTest {
+        // GIVEN
+        val testOrder = order(2)
+
+        runBlocking {
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(emptyList())
+        }
+
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(testOrder))) }
+        )
+
+        // WHEN
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        val state = viewModel.state.value as WooPosOrdersState.Content
+        val details = state.selectedDetails!!
+        assertThat(details.actions).noneMatch { it is WooPosOrdersState.OrderAction.IssueRefund }
+        assertThat(details.actions).anyMatch { it is WooPosOrdersState.OrderAction.EmailReceipt }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -73,15 +72,13 @@ class WooPosOrdersViewModelTest {
     }
 
     @Before
-    fun setUp() {
+    fun setUp() = runTest {
         whenever(resourceProvider.getString(R.string.date_time_connector)).thenReturn("at")
 
-        runBlocking {
-            whenever(formatPrice.invoke(any())).thenReturn("$0.00")
-            whenever(getProductById.invoke(any())).thenReturn(null)
-            whenever(retrieveOrderRefunds.invoke(any())).thenReturn(Result.success(emptyList()))
-            whenever(getRefundableItems.invoke(any(), any())).thenReturn(emptyList())
-        }
+        whenever(formatPrice.invoke(any())).thenReturn("$0.00")
+        whenever(getProductById.invoke(any())).thenReturn(null)
+        whenever(retrieveOrderRefunds.invoke(any())).thenReturn(Result.success(emptyList()))
+        whenever(getRefundableItems.invoke(any(), any())).thenReturn(emptyList())
 
         whenever(dataSource.loadOrders()).thenReturn(
             flow {
@@ -664,9 +661,7 @@ class WooPosOrdersViewModelTest {
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1)))) }
         )
-        runBlocking {
-            whenever(retrieveOrderRefunds.invoke(order(1))).thenReturn(Result.success(emptyList()))
-        }
+        whenever(retrieveOrderRefunds.invoke(order(1))).thenReturn(Result.success(emptyList()))
 
         // WHEN
         viewModel = createViewModel()
@@ -704,11 +699,8 @@ class WooPosOrdersViewModelTest {
             feeLines = emptyList()
         )
 
-        runBlocking {
-            whenever(formatPrice.invoke(BigDecimal("10.00"))).thenReturn("$10.00")
-            whenever(formatPrice.invoke(BigDecimal("5.00"))).thenReturn("$5.00")
-        }
-
+        whenever(formatPrice.invoke(BigDecimal("10.00"))).thenReturn("$10.00")
+        whenever(formatPrice.invoke(BigDecimal("5.00"))).thenReturn("$5.00")
         whenever(dataSource.loadOrders()).thenReturn(
             flow {
                 emit(
@@ -886,10 +878,8 @@ class WooPosOrdersViewModelTest {
         )
 
         // WHEN
-        runBlocking {
-            whenever(formatPrice.invoke(BigDecimal("3.50"))).thenReturn("$3.50")
-            whenever(formatPrice.invoke(BigDecimal("4.00"))).thenReturn("$4.00")
-        }
+        whenever(formatPrice.invoke(BigDecimal("3.50"))).thenReturn("$3.50")
+        whenever(formatPrice.invoke(BigDecimal("4.00"))).thenReturn("$4.00")
 
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(withValues))) }
@@ -1211,10 +1201,7 @@ class WooPosOrdersViewModelTest {
             rowIndex = 0
         )
 
-        runBlocking {
-            whenever(getRefundableItems.invoke(any(), any())).thenReturn(listOf(refundableItem))
-        }
-
+        whenever(getRefundableItems.invoke(any(), any())).thenReturn(listOf(refundableItem))
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(testOrder))) }
         )
@@ -1235,10 +1222,7 @@ class WooPosOrdersViewModelTest {
         // GIVEN
         val testOrder = order(2)
 
-        runBlocking {
-            whenever(getRefundableItems.invoke(any(), any())).thenReturn(emptyList())
-        }
-
+        whenever(getRefundableItems.invoke(any(), any())).thenReturn(emptyList())
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(testOrder))) }
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -54,8 +54,8 @@ class WooPosOrdersViewModelTest {
 
     private fun order(id: Long = 1L): Order = OrderTestUtils.generateTestOrder(orderId = id)
 
-    private fun ordersMap(vararg orders: Order): Map<Order, RefundFetchResult> =
-        orders.associateWith { RefundFetchResult.Success(emptyList()) }
+    private fun ordersMap(vararg orders: Order): Map<Order, RefundsFetchResult> =
+        orders.associateWith { RefundsFetchResult.Success(emptyList()) }
 
     private fun createViewModel(): WooPosOrdersViewModel {
         return WooPosOrdersViewModel(
@@ -711,7 +711,7 @@ class WooPosOrdersViewModelTest {
                 emit(
                     LoadOrdersResult.SuccessRemote(
                         mapOf(
-                            testOrder to RefundFetchResult.Success(listOf(refund1, refund2))
+                            testOrder to RefundsFetchResult.Success(listOf(refund1, refund2))
                         )
                     )
                 )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-1773

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR hides Issue Refund button in case there are no items available to refund in the order.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Check if the Issue Refund button is correctly hidden in case all the items in order have been refunded.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
* Refunded Order:
<img width="2304" height="1440" alt="image" src="https://github.com/user-attachments/assets/5c25c049-be87-43aa-8da0-7ff2eb3510bd" />

* Completed Order (not fully refunded):
<img width="2304" height="1440" alt="image" src="https://github.com/user-attachments/assets/226b2a0b-ac51-40dc-8818-1815c8a9e237" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
