### PR TITLE
Increase detekt ReturnCount limit to 4

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/FetchJetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/FetchJetpackStatus.kt
@@ -38,7 +38,7 @@ class FetchJetpackStatus @Inject constructor(
         object ConnectionForbidden : JetpackStatusFetchResponse
     }
 
-    @Suppress("ReturnCount", "NestedBlockDepth")
+    @Suppress("NestedBlockDepth")
     suspend operator fun invoke(
         site: SiteModel,
         useApplicationPasswords: Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/AccountRepository.kt
@@ -58,7 +58,6 @@ class AccountRepository @Inject constructor(
             (selectedSite.connectionType == SiteConnectionType.ApplicationPasswords)
     }
 
-    @Suppress("ReturnCount")
     suspend fun logout(): Boolean {
         if (!isUserLoggedIn()) return true
         return if (accountStore.hasAccessToken()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepository.kt
@@ -188,7 +188,7 @@ class JetpackActivationRepository @Inject constructor(
         }
     }
 
-    @Suppress("ReturnCount", "MagicNumber")
+    @Suppress("MagicNumber")
     private suspend fun <T> runWithRetry(
         maxAttempts: Int = DEFAULT_MAX_RETRY,
         block: suspend () -> Result<T>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPostLoginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/wpcom/JetpackActivationWPComPostLoginViewModel.kt
@@ -18,7 +18,6 @@ open class JetpackActivationWPComPostLoginViewModel(
     private val jetpackActivationRepository: JetpackActivationRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
-    @Suppress("ReturnCount")
     protected suspend fun onLoginSuccess(jetpackStatus: JetpackStatus): Result<Unit> {
         analyticsTrackerWrapper.track(JETPACK_SETUP_LOGIN_COMPLETED)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -969,7 +969,7 @@ class OrderCreateEditViewModel @Inject constructor(
         )
     }
 
-    @Suppress("LongMethod", "ReturnCount")
+    @Suppress("LongMethod")
     private fun addScannedProduct(
         product: ModelProduct,
         selectedItems: List<SelectedItem>,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/product/discount/OrderCreateEditProductDiscountViewModel.kt
@@ -97,7 +97,6 @@ class OrderCreateEditProductDiscountViewModel @Inject constructor(
         if (this > BigDecimal.ZERO) this else null
     }
 
-    @Suppress("ReturnCount")
     private fun checkDiscountValidationState(discount: BigDecimal?, type: DiscountType): DiscountAmountValidationState {
         if (discount == null) return DiscountAmountValidationState.Valid
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -919,7 +919,6 @@ class OrderDetailViewModel @Inject constructor(
         return ListInfo(isVisible = true, list = getWooShippingShipments(awaitOrder()))
     }
 
-    @Suppress("ReturnCount")
     private suspend fun loadOrderShippingLabels(): ListInfo<ShippingLabelModel> {
         if (isRevampWooShippingEnabled) return ListInfo(isVisible = false)
         orderDetailRepository.getOrderShippingLabels(navArgs.orderId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepository.kt
@@ -43,7 +43,6 @@ class ShippingLabelOnboardingRepository @Inject constructor(
         }
     }
 
-    @Suppress("ReturnCount")
     private fun getShippingLabelSupport(): ShippingLabelSupport {
         orderDetailRepository.getWooShippingPluginInfo()
             .takeIf {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/ShouldUpdateOrdersList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/ShouldUpdateOrdersList.kt
@@ -13,7 +13,6 @@ class ShouldUpdateOrdersList @Inject constructor(
     private val listStore: ListStore,
     private val appPrefs: AppPrefsWrapper
 ) {
-    @Suppress("ReturnCount")
     suspend operator fun invoke(listDescriptor: ListDescriptor): Boolean {
         // 23-07-2025: Consider removing this in the future
         // AINFRA-986

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModel.kt
@@ -931,7 +931,6 @@ class WooShippingLabelCreationViewModel @Inject constructor(
     }
 
     fun onUPSTermsAccepted() {
-        @Suppress("ReturnCount")
         fun selectMatchingRate(
             newRates: Map<CarrierUI, List<ShippingRateUI>>,
             previouslySelectedRate: ShippingRateUI,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubAdapter.kt
@@ -68,7 +68,6 @@ class PaymentsHubAdapter :
         submitList(rows)
     }
 
-    @Suppress("ReturnCount")
     object ListItemDiffCallback : DiffUtil.ItemCallback<PaymentsHubViewState.ListItem>() {
         override fun areItemsTheSame(
             oldItem: PaymentsHubViewState.ListItem,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/payoutsummary/PaymentsHubPayoutSummaryStateMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/hub/payoutsummary/PaymentsHubPayoutSummaryStateMapper.kt
@@ -72,7 +72,6 @@ class PaymentsHubPayoutSummaryStateMapper @Inject constructor(
             currencyCode = currency,
         )
 
-    @Suppress("ReturnCount")
     private fun WooPaymentsDepositsOverview.Account?.fundsAvailableIn(): PaymentsHubPayoutSummaryState.Info.Interval? {
         return when (this?.depositsSchedule?.interval?.lowercase()) {
             "daily" -> PaymentsHubPayoutSummaryState.Info.Interval.Daily

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierLocal.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierLocal.kt
@@ -30,7 +30,6 @@ class WooPosSearchByIdentifierLocal @Inject constructor(
         }
     }
 
-    @Suppress("ReturnCount")
     private suspend fun searchInLocalCatalog(
         identifier: String,
         siteId: LocalOrRemoteId.LocalId

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierVariationFetch.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierVariationFetch.kt
@@ -20,7 +20,6 @@ class WooPosSearchByIdentifierVariationFetch @Inject constructor(
         data class Failure(val error: WooPosSearchByIdentifierResult.Error) : VariationFetchResult()
     }
 
-    @Suppress("ReturnCount")
     suspend operator fun invoke(variationId: Long, parentId: Long): VariationFetchResult {
         val variationResult = productStore.fetchSingleVariation(
             selectedSite.get(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -100,7 +100,6 @@ class WooPosCartViewModel @Inject constructor(
         soundHelper.onCleanup()
     }
 
-    @Suppress("ReturnCount")
     fun onUIEvent(event: WooPosCartUIEvent) {
         when (event) {
             is WooPosCartUIEvent.CheckoutClicked -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -549,7 +549,6 @@ class WooPosProductsRemoteDataSource @Inject constructor(
             }
         }
 
-    @Suppress("ReturnCount")
     override suspend fun getVariationById(productId: Long, variationId: Long): WooPosVariation? {
         val cachedVariations = getCachedVariations(productId)
         val cachedVariation = cachedVariations.find { it.remoteVariationId == variationId }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosProductSearchPredicate.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosProductSearchPredicate.kt
@@ -50,7 +50,6 @@ class WooPosProductSearchPredicate @Inject constructor(
         }
     }
 
-    @Suppress("ReturnCount")
     private fun isWooCoreSupportsNameOrSkuSearch(): Boolean {
         cachedSupportsNameOrSkuSearch?.let { return it }
         val wooCoreVersion = getWooCoreVersion() ?: return false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCheckCatalogSizeAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCheckCatalogSizeAction.kt
@@ -16,7 +16,6 @@ class WooPosCheckCatalogSizeAction @Inject constructor(
         class CatalogTooLarge(val error: String) : WooPosCheckCatalogSizeResult()
     }
 
-    @Suppress("ReturnCount")
     suspend fun execute(
         site: SiteModel,
         modifiedAfterGmt: String? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncAction.kt
@@ -22,7 +22,6 @@ class WooPosFileBasedSyncAction @Inject constructor(
         private const val BACKOFF_MULTIPLIER = 1.3
     }
 
-    @Suppress("ReturnCount")
     suspend fun syncCatalog(
         site: SiteModel
     ): Result<FileBasedSyncResult> {
@@ -71,7 +70,6 @@ class WooPosFileBasedSyncAction @Inject constructor(
         val completedAt: String?
     )
 
-    @Suppress("ReturnCount")
     private fun processPollingResult(result: WooPosGenerateCatalogResult): Result<FileBasedSyncResult>? {
         return when (result.state) {
             WooPosGenerateCatalogState.COMPLETED -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
@@ -140,7 +140,6 @@ class WooPosLocalCatalogSyncRepository @Inject constructor(
         )
     }
 
-    @Suppress("ReturnCount")
     private suspend fun performSync(
         site: SiteModel,
         pageSize: Int,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWorker.kt
@@ -36,7 +36,6 @@ constructor(
         private const val DAYS_SINCE_LAST_USE_THRESHOLD = 30L
     }
 
-    @Suppress("ReturnCount")
     override suspend fun doWork(): Result {
         if (isPosInactive()) {
             logger.d("POS has been inactive recently, skipping local catalog sync")
@@ -91,7 +90,6 @@ constructor(
         }
     }
 
-    @Suppress("ReturnCount")
     private suspend fun validateSyncStatus(): Result? {
         val syncRequirement = syncStatusChecker.checkSyncRequirement()
         return when (syncRequirement) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -237,7 +237,6 @@ class WooPosOrdersViewModel @Inject constructor(
         }
     }
 
-    @Suppress("ReturnCount")
     fun loadMoreIfPossible() {
         if (loadingJob?.isActive == true || loadingMoreOrdersJob?.isActive == true) return
         if (!ordersDataSource.hasMorePages) return

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavControllerExts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavControllerExts.kt
@@ -8,7 +8,6 @@ fun NavController.navigateOnce(route: String) {
     }
 }
 
-@Suppress("ReturnCount")
 private fun NavController.currentRouteWithParams(): String {
     val currentRoute = currentDestination?.route ?: return ""
     val arguments = currentBackStackEntry?.arguments ?: return currentRoute

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -39,7 +39,6 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
         }
     }
 
-    @Suppress("ReturnCount")
     private suspend fun checkLaunchability(forceRefresh: Boolean = false): WooPosLaunchability {
         val site = selectedSite.getOrNull()
             ?: return WooPosLaunchability.NotLaunchable(

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -41,6 +41,8 @@ formatting:
 
 
 style:
+  ReturnCount:
+    max: 4
   UnnecessaryAbstractClass:
     active: true
     ignoreAnnotated: [ 'Module' ]

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductModel.kt
@@ -182,7 +182,6 @@ data class WCProductModel(
     /**
      * Returns true if this product has the same attributes as the passed product
      */
-    @Suppress("ReturnCount")
     fun hasSameAttributes(otherProduct: WCProductModel): Boolean {
         // do a quick string comparison first so we can avoid parsing the attributes when possible
         if (this.attributes == otherProduct.attributes) {
@@ -420,7 +419,6 @@ data class WCProductModel(
      * Compares this product's images with the passed product's images, returns true only if both
      * lists contain the same images in the same order
      */
-    @Suppress("ReturnCount")
     fun hasSameImages(updatedProduct: WCProductModel): Boolean {
         val updatedImages = updatedProduct.getImageListOrEmpty()
         val thisImages = getImageListOrEmpty()
@@ -439,7 +437,6 @@ data class WCProductModel(
      * Compares this product's categories with the passed product's categories, returns true only if both
      * lists contain the same categories in the same order
      */
-    @Suppress("ReturnCount")
     fun hasSameCategories(updatedProduct: WCProductModel): Boolean {
         val updatedCategories = updatedProduct.getCategoryList()
         val storedCategories = getCategoryList()
@@ -458,7 +455,6 @@ data class WCProductModel(
      * Compares this product's tags with the passed product's tags, returns true only if both
      * lists contain the same tags in the same order
      */
-    @Suppress("ReturnCount")
     fun hasSameTags(updatedProduct: WCProductModel): Boolean {
         val updatedTags = updatedProduct.getTagList()
         val storedTags = getTagList()

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/WCProductVariationModel.kt
@@ -11,7 +11,6 @@ import org.wordpress.android.fluxc.network.utils.getLong
 import org.wordpress.android.fluxc.network.utils.getString
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
-import java.lang.IllegalStateException
 
 typealias VariationAttributes = List<ProductVariantOption>
 
@@ -86,7 +85,6 @@ data class WCProductVariationModel(
     /**
      * Parses the images json array into a list of product images
      */
-    @Suppress("ReturnCount")
     fun getImageModel(): WCProductImageModel? {
         if (image.isNotBlank()) {
             try {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/converters/WCMetaDataConverter.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/converters/WCMetaDataConverter.kt
@@ -8,7 +8,6 @@ import org.wordpress.android.fluxc.model.metadata.WCMetaData
 
 internal class WCMetaDataConverter {
     @TypeConverter
-    @Suppress("ReturnCount")
     fun metaDataListToString(value: List<WCMetaData>?): String? {
         if (value == null) {
             return null
@@ -25,7 +24,6 @@ internal class WCMetaDataConverter {
     }
 
     @TypeConverter
-    @Suppress("ReturnCount")
     fun stringToMetaDataList(value: String?): List<WCMetaData>? {
         if (value == null) {
             return null

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -106,7 +106,6 @@ open class WooCommerceStore @Inject internal constructor(
         return withContext(Dispatchers.IO) { WooResult(getWooCommerceSites()) }
     }
 
-    @Suppress("ReturnCount")
     suspend fun fetchWooCommerceSite(site: SiteModel): WooResult<SiteModel> {
         val fetchResult = siteStore.fetchSite(site)
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsManager.kt
@@ -43,7 +43,6 @@ internal class ApplicationPasswordsManager @Inject constructor(
         get() = origin == SiteModel.ORIGIN_WPCOM_REST ||
             (!username.isNullOrEmpty() && !password.isNullOrEmpty())
 
-    @Suppress("ReturnCount")
     suspend fun getApplicationCredentials(
         site: SiteModel
     ): ApplicationPasswordCreationResult = mutexLock.withLock {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsNetwork.kt
@@ -37,7 +37,7 @@ class ApplicationPasswordsNetwork @Inject constructor(
     @Inject
     internal lateinit var mApplicationPasswordsManager: ApplicationPasswordsManager
 
-    @Suppress("ReturnCount", "ComplexMethod")
+    @Suppress("ComplexMethod")
     private suspend fun <T> executeGsonRequest(
         site: SiteModel,
         method: HttpMethod,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -242,7 +242,6 @@ abstract class BaseWPV2MediaRestClient(
         }
     }
 
-    @Suppress("ReturnCount")
     private fun Response.parseUploadError(): MediaError {
         val mediaError = MediaError(MediaErrorType.fromHttpStatusCode(code))
         mediaError.statusCode = code

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/SiteSqlUtils.kt
@@ -93,7 +93,7 @@ class SiteSqlUtils
      * 5. Exists in the DB, originally an XML-RPC site, and matches by XMLRPC_URL -> UPDATE
      * 6. Not matching any previous cases -> INSERT
      */
-    @Suppress("LongMethod", "ReturnCount", "ComplexMethod")
+    @Suppress("LongMethod", "ComplexMethod")
     @Throws(DuplicateSiteException::class)
     fun insertOrUpdateSite(site: SiteModel?): Int {
         if (site == null) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -828,7 +828,6 @@ open class SiteStore @Inject constructor(
         GENERIC_ERROR;
 
         companion object {
-            @Suppress("ReturnCount")
             fun fromString(string: String): DeleteSiteErrorType {
                 if (!TextUtils.isEmpty(string)) {
                     if (string == "unauthorized") {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/media/MediaErrorSubType.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/media/MediaErrorSubType.kt
@@ -27,7 +27,6 @@ sealed class MediaErrorSubType(val category: MediaErrorSubtypeCategory, val subT
         }
 
         @JvmStatic
-        @Suppress("ReturnCount")
         fun deserialize(name: String?): MediaErrorSubType {
             if (name == null) return UndefinedSubType
 


### PR DESCRIPTION
### Description

Based on this slack discussion p1760608104909809-slack-CGPNUU63E we democratically opted for increasing the `ReturnCount` limit from 2 to 4.

This PR updates the detekt configuration and removes the now-unnecessary `@Suppress("ReturnCount")` annotations from methods that have 4 or fewer return statements.

### Test Steps

Green CI is enough as a test.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.