### PR TITLE
Fix notification group summary behavior (double cha-ching) in WooNoti…

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
@@ -117,8 +117,8 @@ class WooNotificationBuilder @Inject constructor(
             // Also add a group summary notification, which is required for non-wearable devices
             // Do not need to play the sound again. We've already played it in the individual builder.
             if (!isGroupNotification) {
-                setGroupSummary(true)
                 setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
+                setGroupSummary(true)
                 showNotification(notification.getGroupPushId(), notification, this)
             }
         }


### PR DESCRIPTION
Attempt to fix double cha-ching for every order.

Summary
The problem was in WooNotificationBuilder.kt. When the first order notification arrives:

An individual notification is created and displayed (plays sound ✓)
A group summary notification is also created for non-wearable devices (was playing sound again ✗)
The fix was to call setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN) before setting the group summary. This tells Android to only alert (play sound) for the child notifications, not the summary.

The key change was moving the line from after setGroupSummary(true) to before it, which ensures the alert behavior is set before the summary is created. This prevents the duplicate sound while still maintaining proper notification grouping functionality.