### PR TITLE
[WOOMOB-1947] Update POS barcode scanner documentation URL

### DIFF
--- a/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/common/data/WooPosAppUrls.kt
+++ b/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/common/data/WooPosAppUrls.kt
@@ -1,6 +1,6 @@
 package com.woocommerce.android.ui.woopos.common.data
 
-const val WOO_POS_BARCODE_DOC_URL = "https://woocommerce.com/document/barcode-and-qr-code-scanner/"
+const val WOO_POS_BARCODE_DOC_URL = "https://woocommerce.com/document/point-of-sale-mode-barcode-scanning/"
 const val WOO_POS_DOCUMENTATION_URL = "https://woocommerce.com/document/woo-mobile-app-point-of-sale-mode/"
 
 const val WOO_POS_STRIPE_LEARN_MORE_ABOUT_PAYMENTS =


### PR DESCRIPTION
WOOMOB-1947

### Description

Update the barcode scanner documentation URL in Woo POS to point to the new POS-specific documentation page.

### Test Steps

1. Open Woo POS
2. Navigate to Settings > Hardware > Barcode scanner
3. Tap on "Read documentation" link
4. Verify it opens the new URL: `https://woocommerce.com/document/point-of-sale-mode-barcode-scanning/`

### Images/gif

N/A - URL change only

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.