### PR TITLE
[WOOMOB-1953] Show JITMs regardless of onboarding status

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,10 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 
+24.0
+-----
+- [Internal] Show JITMs on Dashboard regardless of onboarding status [https://github.com/woocommerce/woocommerce-android/pull/15170]
+
 23.9
 -----
 - [Internal] Updated JITM banner design and migrated to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/15155]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardFragment.kt
@@ -33,7 +33,6 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.showDateRangePicker
 import com.woocommerce.android.extensions.startHelpActivity
 import com.woocommerce.android.extensions.verticalOffsetChanges
-import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
@@ -54,7 +53,6 @@ import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.Op
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.RefreshJitm
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShareStore
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.ShowPrivacyBanner
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel
 import com.woocommerce.android.ui.google.webview.GoogleAdsWebViewFragment
 import com.woocommerce.android.ui.jitm.JitmFragment
 import com.woocommerce.android.ui.jitm.JitmMessagePathsProvider
@@ -152,6 +150,7 @@ class DashboardFragment :
 
         setupStateObservers()
         setupResultHandlers()
+        initJitm()
     }
 
     @Suppress("ComplexMethod", "MagicNumber", "LongMethod")
@@ -196,18 +195,6 @@ class DashboardFragment :
         }
         dashboardViewModel.jetpackBenefitsBannerState.observe(viewLifecycleOwner) { jetpackBenefitsBanner ->
             onVisitorStatsUnavailable(jetpackBenefitsBanner)
-        }
-        dashboardViewModel.dashboardCardsState.observe(viewLifecycleOwner) { state ->
-            // Show banners only if onboarding list is NOT displayed
-            if (
-                state.widgets.none {
-                    val configurableWidget = it as? DashboardWidgetUiModel.ConfigurableWidget
-                    configurableWidget?.widget?.type == DashboardWidget.Type.ONBOARDING &&
-                        configurableWidget.widget.isVisible
-                }
-            ) {
-                initJitm()
-            }
         }
         dashboardViewModel.hasNewWidgets.observe(viewLifecycleOwner) { hasNewWidgets ->
             editButtonBadge.isVisible = hasNewWidgets


### PR DESCRIPTION
WOOMOB-1953

### Description

Previously, JITMs (Just-In-Time Messages) were only displayed on the Dashboard when the onboarding widget was not visible. This change removes that condition so JITMs are always requested and shown regardless of whether onboarding is in progress.

### Test Steps

1. Open the app with a fresh install or reset onboarding
2. Go to the Dashboard (My Store tab)
3. Verify that JITMs appear even when the onboarding checklist is visible

<img width="502" height="902" alt="image" src="https://github.com/user-attachments/assets/75f85242-c3f8-496d-bf70-aa4d0d35cace" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.