### PR TITLE
[WOOMOB-1581] Fix broken Compose previews in WooPos screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -161,13 +161,15 @@ private fun WooPosHomeScreen(
             )
         }
 
-        WooPosHomeScreenToolbar(
-            modifier = Modifier
-                .padding(WooPosSpacing.Large.value)
-                .align(Alignment.BottomStart),
-        )
+        if (!isPreviewMode()) {
+            WooPosHomeScreenToolbar(
+                modifier = Modifier
+                    .padding(WooPosSpacing.Large.value)
+                    .align(Alignment.BottomStart),
+            )
 
-        Dialogs(state.dialogState, onHomeUIEvent)
+            Dialogs(state.dialogState, onHomeUIEvent)
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -29,9 +29,13 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab.Products
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.SearchChanged
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreen
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreenContentPreview
+import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchContentPreview
 import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchScreen
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosItemsScreenPreview
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsScreen
 import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
+import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreenPreview
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsNavigationData
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsScreen
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -62,6 +66,10 @@ private fun WooPosItemsScreen(
     productsViewState: LazyListState,
     couponsListState: LazyListState,
     onUIEvent: (WooPosItemsUIEvent) -> Unit,
+    productsContent: (@Composable () -> Unit)? = null,
+    couponsContent: (@Composable () -> Unit)? = null,
+    productsSearchContent: (@Composable () -> Unit)? = null,
+    couponsSearchContent: (@Composable () -> Unit)? = null,
 ) {
     val state = itemsStateFlow.collectAsState()
     val catalogSyncOverdueBannerState = catalogSyncOverdueBannerStateFlow.collectAsState()
@@ -92,6 +100,20 @@ private fun WooPosItemsScreen(
         onTabClicked = { onUIEvent(WooPosItemsUIEvent.OnTabClicked(it)) },
         onBackClicked = { onUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked) },
         onSyncWarningBannerDismissed = { onUIEvent(WooPosItemsUIEvent.SyncOverdueBannerDismissed) },
+        productsContent = productsContent ?: {
+            WooPosProductsScreen(
+                modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+                listState = productsViewState
+            )
+        },
+        couponsContent = couponsContent ?: {
+            WooPosCouponsScreen(
+                modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+                listState = couponsListState,
+            )
+        },
+        productsSearchContent = productsSearchContent ?: { WooPosItemsSearchScreen() },
+        couponsSearchContent = couponsSearchContent ?: { WooPosCouponsSearchScreen() },
     )
 }
 
@@ -108,6 +130,20 @@ private fun MainItemsList(
     onAddCouponEvent: () -> Unit,
     onBackClicked: () -> Unit,
     onSyncWarningBannerDismissed: () -> Unit,
+    productsContent: @Composable () -> Unit = {
+        WooPosProductsScreen(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+            listState = productsViewState
+        )
+    },
+    couponsContent: @Composable () -> Unit = {
+        WooPosCouponsScreen(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+            listState = couponsListState,
+        )
+    },
+    productsSearchContent: @Composable () -> Unit = { WooPosItemsSearchScreen() },
+    couponsSearchContent: @Composable () -> Unit = { WooPosCouponsSearchScreen() },
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         Column(modifier.fillMaxHeight()) {
@@ -148,21 +184,9 @@ private fun MainItemsList(
                 ),
             ) { screenState ->
                 when (screenState) {
-                    ScreenState.Products -> WooPosProductsScreen(
-                        modifier = Modifier.padding(
-                            horizontal = WooPosSpacing.Medium.value,
-                        ),
-                        listState = productsViewState
-                    )
-
-                    ScreenState.ProductsSearch -> WooPosItemsSearchScreen()
-                    ScreenState.Coupons -> WooPosCouponsScreen(
-                        modifier = Modifier.padding(
-                            horizontal = WooPosSpacing.Medium.value,
-                        ),
-                        listState = couponsListState,
-                    )
-
+                    ScreenState.Products -> productsContent()
+                    ScreenState.ProductsSearch -> productsSearchContent()
+                    ScreenState.Coupons -> couponsContent()
                     is ScreenState.Variations -> {
                         WooPosVariationsScreen(
                             modifier = Modifier.padding(
@@ -172,7 +196,7 @@ private fun MainItemsList(
                             onBackClicked = { onBackClicked() },
                         )
                     }
-                    is ScreenState.CouponsSearch -> WooPosCouponsSearchScreen()
+                    ScreenState.CouponsSearch -> couponsSearchContent()
                 }
             }
         }
@@ -225,10 +249,7 @@ fun WooPosItemsScreenSearchVisiblePreview(modifier: Modifier = Modifier) {
     val productState = MutableStateFlow(
         WooPosItemsToolbarViewState.ProductList(
             search = WooPosItemsToolbarViewState.SearchState.Visible(
-                state = WooPosSearchInputState.Open(
-                    input = WooPosSearchInputState.Open.Input.Query("", 0),
-                    isLoading = false,
-                )
+                state = WooPosSearchInputState.Closed
             ),
             tabs = tabs()
         )
@@ -242,6 +263,10 @@ fun WooPosItemsScreenSearchVisiblePreview(modifier: Modifier = Modifier) {
             productsViewState = rememberLazyListState(),
             couponsListState = rememberLazyListState(),
             onUIEvent = {},
+            productsContent = { WooPosItemsScreenPreview() },
+            couponsContent = { WooPosCouponsScreenContentPreview() },
+            productsSearchContent = { WooPosItemsSearchScreenPreview() },
+            couponsSearchContent = { WooPosCouponsSearchContentPreview() },
         )
     }
 }
@@ -252,12 +277,7 @@ fun WooPosItemsScreenSearchVisiblePreview(modifier: Modifier = Modifier) {
 fun WooPosItemsScreenSearchHiddenPreview(modifier: Modifier = Modifier) {
     val productState = MutableStateFlow(
         WooPosItemsToolbarViewState.ProductList(
-            search = WooPosItemsToolbarViewState.SearchState.Visible(
-                state = WooPosSearchInputState.Open(
-                    input = WooPosSearchInputState.Open.Input.Query("", 0),
-                    isLoading = false,
-                )
-            ),
+            search = WooPosItemsToolbarViewState.SearchState.Hidden,
             tabs = tabs()
         )
     )
@@ -270,6 +290,10 @@ fun WooPosItemsScreenSearchHiddenPreview(modifier: Modifier = Modifier) {
             productsViewState = rememberLazyListState(),
             couponsListState = rememberLazyListState(),
             onUIEvent = {},
+            productsContent = { WooPosItemsScreenPreview() },
+            couponsContent = { WooPosCouponsScreenContentPreview() },
+            productsSearchContent = { WooPosItemsSearchScreenPreview() },
+            couponsSearchContent = { WooPosCouponsSearchContentPreview() },
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/WooPosSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/WooPosSettingsScreen.kt
@@ -2,9 +2,13 @@ package com.woocommerce.android.ui.woopos.settings
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -12,14 +16,18 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.compose.ui.text.font.FontWeight
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToolbar
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 import com.woocommerce.android.ui.woopos.settings.categories.WooPosSettingsCategoriesPaneScreen
+import com.woocommerce.android.ui.woopos.settings.categories.WooPosSettingsCategoriesPaneScreenContent
 import com.woocommerce.android.ui.woopos.settings.categories.WooPosSettingsCategory
 import com.woocommerce.android.ui.woopos.settings.details.WooPosSettingsDetailPaneScreen
 import com.woocommerce.android.ui.woopos.settings.details.localcatalog.WooPosSyncErrorDialog
@@ -121,9 +129,57 @@ private fun WooPosSettingsContent(
 @WooPosPreview
 @Composable
 fun WooPosSettingsScreenPreview() {
+    val state = WooPosSettingsState()
     WooPosTheme {
-        WooPosSettingsScreen(
-            onNavigationEvent = {}
-        )
+        Row(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Column(
+                modifier = Modifier
+                    .weight(0.3f)
+                    .background(MaterialTheme.colorScheme.surfaceBright)
+            ) {
+                WooPosToolbar(
+                    titleText = stringResource(R.string.woopos_settings_title),
+                    onBackClicked = {},
+                )
+
+                WooPosSettingsCategoriesPaneScreenContent(
+                    scrollableCategories = listOf(
+                        WooPosSettingsCategory.STORE,
+                        WooPosSettingsCategory.HARDWARE,
+                        WooPosSettingsCategory.LOCAL_CATALOG,
+                    ),
+                    fixedCategories = listOf(WooPosSettingsCategory.HELP),
+                    selectedCategory = state.selectedCategory,
+                    onCategorySelected = {},
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .weight(0.7f)
+                    .background(MaterialTheme.colorScheme.surface)
+                    .fillMaxSize()
+            ) {
+                WooPosToolbar(
+                    modifier = Modifier
+                        .padding(
+                            top = WooPosSpacing.None.value,
+                            start = WooPosSpacing.Medium.value,
+                            end = WooPosSpacing.Medium.value,
+                        ),
+                    titleText = stringResource(state.currentDestination.titleRes),
+                    onBackClicked = null,
+                    titleStyle = WooPosTypography.Heading,
+                    titleFontWeight = FontWeight.Bold
+                )
+
+                Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
+
+                Box(modifier = Modifier.fillMaxSize())
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/WooPosSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/WooPosSettingsScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToolbar

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/categories/WooPosSettingsCategoriesPaneScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/categories/WooPosSettingsCategoriesPaneScreen.kt
@@ -49,7 +49,7 @@ fun WooPosSettingsCategoriesPaneScreen(
 }
 
 @Composable
-private fun WooPosSettingsCategoriesPaneScreenContent(
+internal fun WooPosSettingsCategoriesPaneScreenContent(
     modifier: Modifier = Modifier,
     scrollableCategories: List<WooPosSettingsCategory>,
     fixedCategories: List<WooPosSettingsCategory>,


### PR DESCRIPTION
WOOMOB-1581

### Description

Fixes broken Compose previews in WooPos screens that were failing due to ViewModel instantiation attempts during preview rendering.

Changes:
- Fix WooPosSettingsScreen preview by using the stateless composable overload instead of the one that requires a ViewModel
- Fix WooPosItemsScreen previews by adding content slot parameters to MainItemsList, allowing previews to inject mock content instead of screens that require ViewModels
- Fix WooPosHomeScreen preview by skipping toolbar and dialogs rendering in preview mode using `isPreviewMode()` check

### Test Steps

1. Open WooPosSettingsScreen.kt and verify the preview renders without errors
2. Open WooPosItemsScreen.kt and verify both previews render without errors
3. Open WooPosHomeScreen.kt and verify the preview renders without errors

### Images/gif

<img width="678" height="870" alt="image" src="https://github.com/user-attachments/assets/964e30b1-7247-4249-a979-1f40b3013412" />
<img width="948" height="953" alt="image" src="https://github.com/user-attachments/assets/ec68ace9-a5ae-4012-8b7a-0d0a31aa1c02" />
<img width="939" height="934" alt="image" src="https://github.com/user-attachments/assets/fc943db1-9259-413f-91ca-0131096127fc" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.