### PR TITLE
[WOOMOB-1967] Add feature flag for POS product visibility filtering

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -13,7 +13,8 @@ enum class FeatureFlag {
     BOOKINGS_MVP,
     CLIENT_SIDE_POS_BANNER,
     POS_REFUNDS,
-    WOO_POS_LOCAL_CATALOG_FILE_APPROACH;
+    WOO_POS_LOCAL_CATALOG_FILE_APPROACH,
+    WOO_POS_PRODUCT_VISIBILITY_FILTERING;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -26,7 +27,8 @@ enum class FeatureFlag {
             ORDER_CREATION_AUTO_TAX_RATE,
             CLIENT_SIDE_POS_BANNER,
             BOOKINGS_MVP,
-            POS_REFUNDS -> PackageUtils.isDebugBuild()
+            POS_REFUNDS,
+            WOO_POS_PRODUCT_VISIBILITY_FILTERING -> PackageUtils.isDebugBuild()
 
             WOO_POS_LOCAL_CATALOG_FILE_APPROACH -> false
         }


### PR DESCRIPTION
Fixes WOOMOB-1967

### Description
Adds a new feature flag `WOO_POS_PRODUCT_VISIBILITY_FILTERING` to control POS product visibility filtering. The flag is enabled in debug builds only, following the same pattern as other POS-related feature flags.

### Test Steps
Green CI is enough

### Images/gif
N/A - No UI changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.