### PR TITLE
[WOOMOB-1966] Add pos_products_only parameter to POS products and variations endpoints

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCheckCatalogSizeAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCheckCatalogSizeAction.kt
@@ -10,6 +10,9 @@ class WooPosCheckCatalogSizeAction @Inject constructor(
     private val posLocalCatalogStore: WooPosLocalCatalogStore,
     private val logger: WooPosLogWrapper,
 ) {
+    private val posProductsOnly: Boolean
+        get() = FeatureFlag.WOO_POS_PRODUCT_VISIBILITY_FILTERING.isEnabled()
+
     sealed class WooPosCheckCatalogSizeResult {
         object SizeAcceptable : WooPosCheckCatalogSizeResult()
         object SizeUnknown : WooPosCheckCatalogSizeResult()
@@ -26,7 +29,7 @@ class WooPosCheckCatalogSizeAction @Inject constructor(
         }
         logger.d("Checking catalog size before sync")
 
-        val productsCountResult = posLocalCatalogStore.fetchProductsCount(site, modifiedAfterGmt)
+        val productsCountResult = posLocalCatalogStore.fetchProductsCount(site, modifiedAfterGmt, posProductsOnly)
         if (productsCountResult.isFailure) {
             logger.w(
                 "Failed to fetch products count: ${productsCountResult.exceptionOrNull()?.message}. " +
@@ -35,7 +38,7 @@ class WooPosCheckCatalogSizeAction @Inject constructor(
             return WooPosCheckCatalogSizeResult.SizeUnknown
         }
 
-        val variationsCountResult = posLocalCatalogStore.fetchVariationsCount(site, modifiedAfterGmt)
+        val variationsCountResult = posLocalCatalogStore.fetchVariationsCount(site, modifiedAfterGmt, posProductsOnly)
         if (variationsCountResult.isFailure) {
             logger.w(
                 "Failed to fetch variations count: ${variationsCountResult.exceptionOrNull()?.message}. " +

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCheckCatalogSizeAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCheckCatalogSizeAction.kt
@@ -29,7 +29,7 @@ class WooPosCheckCatalogSizeAction @Inject constructor(
         }
         logger.d("Checking catalog size before sync")
 
-        val productsCountResult = posLocalCatalogStore.fetchProductsCount(site, modifiedAfterGmt, posProductsOnly)
+        val productsCountResult = posLocalCatalogStore.fetchProductsCount(site, posProductsOnly, modifiedAfterGmt)
         if (productsCountResult.isFailure) {
             logger.w(
                 "Failed to fetch products count: ${productsCountResult.exceptionOrNull()?.message}. " +
@@ -38,7 +38,7 @@ class WooPosCheckCatalogSizeAction @Inject constructor(
             return WooPosCheckCatalogSizeResult.SizeUnknown
         }
 
-        val variationsCountResult = posLocalCatalogStore.fetchVariationsCount(site, modifiedAfterGmt, posProductsOnly)
+        val variationsCountResult = posLocalCatalogStore.fetchVariationsCount(site, posProductsOnly, modifiedAfterGmt)
         if (variationsCountResult.isFailure) {
             logger.w(
                 "Failed to fetch variations count: ${variationsCountResult.exceptionOrNull()?.message}. " +

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import com.woocommerce.android.util.FeatureFlag
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.wordpress.android.fluxc.model.SiteModel
@@ -16,6 +17,9 @@ class WooPosSyncAction @Inject constructor(
     private val posLocalCatalogStore: WooPosLocalCatalogStore,
     private val logger: WooPosLogWrapper,
 ) {
+    private val posProductsOnly: Boolean
+        get() = FeatureFlag.WOO_POS_PRODUCT_VISIBILITY_FILTERING.isEnabled()
+
     suspend fun syncCatalog(
         site: SiteModel,
         modifiedAfterGmt: String? = null,
@@ -145,6 +149,7 @@ class WooPosSyncAction @Inject constructor(
                     pageSize = pageSize,
                     modifiedAfterGmt = modifiedAfterGmt,
                     page = page,
+                    posProductsOnly = posProductsOnly,
                 )
             }
         )
@@ -167,6 +172,7 @@ class WooPosSyncAction @Inject constructor(
                     modifiedAfterGmt = modifiedAfterGmt,
                     page = page,
                     pageSize = pageSize,
+                    posProductsOnly = posProductsOnly,
                 )
             }
         )
@@ -190,7 +196,8 @@ class WooPosSyncAction @Inject constructor(
                     pageSize = pageSize,
                     modifiedAfterGmt = modifiedAfterGmt,
                     page = page,
-                    includeStatus = listOf(CoreProductStatus.TRASH)
+                    includeStatus = listOf(CoreProductStatus.TRASH),
+                    posProductsOnly = posProductsOnly,
                 )
             }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
@@ -169,10 +169,10 @@ class WooPosSyncAction @Inject constructor(
             fetchPage = { page ->
                 posLocalCatalogStore.fetchRecentlyModifiedVariations(
                     site = site,
+                    posProductsOnly = posProductsOnly,
                     modifiedAfterGmt = modifiedAfterGmt,
                     page = page,
                     pageSize = pageSize,
-                    posProductsOnly = posProductsOnly,
                 )
             }
         )
@@ -194,10 +194,10 @@ class WooPosSyncAction @Inject constructor(
                 posLocalCatalogStore.fetchRecentlyModifiedProducts(
                     site = site,
                     pageSize = pageSize,
+                    posProductsOnly = posProductsOnly,
                     modifiedAfterGmt = modifiedAfterGmt,
                     page = page,
                     includeStatus = listOf(CoreProductStatus.TRASH),
-                    posProductsOnly = posProductsOnly,
                 )
             }
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCheckCatalogSizeActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosCheckCatalogSizeActionTest.kt
@@ -214,22 +214,22 @@ class WooPosCheckCatalogSizeActionTest {
     }
 
     private suspend fun givenProductsCount(count: Int) {
-        whenever(posLocalCatalogStore.fetchProductsCount(any(), anyOrNull()))
+        whenever(posLocalCatalogStore.fetchProductsCount(any(), any(), anyOrNull()))
             .thenReturn(KotlinResult.success(count))
     }
 
     private suspend fun givenVariationsCount(count: Int) {
-        whenever(posLocalCatalogStore.fetchVariationsCount(any(), anyOrNull()))
+        whenever(posLocalCatalogStore.fetchVariationsCount(any(), any(), anyOrNull()))
             .thenReturn(KotlinResult.success(count))
     }
 
     private suspend fun givenProductsCountFails(errorMessage: String) {
-        whenever(posLocalCatalogStore.fetchProductsCount(any(), anyOrNull()))
+        whenever(posLocalCatalogStore.fetchProductsCount(any(), any(), anyOrNull()))
             .thenReturn(KotlinResult.failure(Exception(errorMessage)))
     }
 
     private suspend fun givenVariationsCountFails(errorMessage: String) {
-        whenever(posLocalCatalogStore.fetchVariationsCount(any(), anyOrNull()))
+        whenever(posLocalCatalogStore.fetchVariationsCount(any(), any(), anyOrNull()))
             .thenReturn(KotlinResult.failure(Exception(errorMessage)))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
@@ -72,6 +72,7 @@ class WooPosSyncActionTest {
         assertThat((result as WooPosSyncResult.Success).productsSynced).isEqualTo(100)
         verify(posLocalCatalogStore, times(3)).fetchRecentlyModifiedProducts(
             eq(site),
+            any(),
             anyOrNull(),
             any(),
             any(),
@@ -148,6 +149,7 @@ class WooPosSyncActionTest {
         assertThat((result as WooPosSyncResult.Success).productsSynced).isEqualTo(0)
         verify(posLocalCatalogStore, times(1)).fetchRecentlyModifiedProducts(
             eq(site),
+            any(),
             anyOrNull(),
             eq(1),
             any(),
@@ -181,7 +183,10 @@ class WooPosSyncActionTest {
 
         // THEN
         assertThat((result as WooPosSyncResult.Success).variationsSynced).isEqualTo(50)
-        verify(posLocalCatalogStore, times(3)).fetchRecentlyModifiedVariations(eq(site), anyOrNull(), any(), any())
+        verify(
+            posLocalCatalogStore,
+            times(3)
+        ).fetchRecentlyModifiedVariations(eq(site), any(), anyOrNull(), any(), any())
     }
 
     @Test
@@ -248,7 +253,10 @@ class WooPosSyncActionTest {
 
         // THEN
         assertThat((result as WooPosSyncResult.Success).variationsSynced).isEqualTo(0)
-        verify(posLocalCatalogStore, times(1)).fetchRecentlyModifiedVariations(eq(site), anyOrNull(), eq(1), any())
+        verify(
+            posLocalCatalogStore,
+            times(1)
+        ).fetchRecentlyModifiedVariations(eq(site), any(), anyOrNull(), eq(1), any())
     }
 
     // === TRASH PRODUCTS SYNC TESTS ===
@@ -267,6 +275,7 @@ class WooPosSyncActionTest {
         // THEN
         verify(posLocalCatalogStore).fetchRecentlyModifiedProducts(
             eq(site),
+            any(),
             eq(modifiedAfter),
             any(),
             any(),
@@ -289,6 +298,7 @@ class WooPosSyncActionTest {
         assertThat((result as WooPosSyncResult.Success).productsSynced).isEqualTo(13) // 10 + 3 trash
         verify(posLocalCatalogStore).fetchRecentlyModifiedProducts(
             eq(site),
+            any(),
             eq(modifiedAfter),
             any(),
             any(),
@@ -307,6 +317,7 @@ class WooPosSyncActionTest {
 
         // THEN
         verify(posLocalCatalogStore, never()).fetchRecentlyModifiedProducts(
+            any(),
             any(),
             anyOrNull(),
             any(),
@@ -329,6 +340,7 @@ class WooPosSyncActionTest {
         assertThat((result as WooPosSyncResult.Success).productsSynced).isEqualTo(18) // 10 + 5 + 3 trash
         verify(posLocalCatalogStore, times(2)).fetchRecentlyModifiedProducts(
             eq(site),
+            any(),
             anyOrNull(),
             any(),
             any(),
@@ -741,6 +753,7 @@ class WooPosSyncActionTest {
             whenever(
                 posLocalCatalogStore.fetchRecentlyModifiedProducts(
                     eq(site),
+                    any(),
                     anyOrNull(),
                     eq(pageNumber),
                     any(),
@@ -765,7 +778,13 @@ class WooPosSyncActionTest {
         pages.forEachIndexed { index, count ->
             val pageNumber = index + 1
             whenever(
-                posLocalCatalogStore.fetchRecentlyModifiedVariations(eq(site), anyOrNull(), eq(pageNumber), any())
+                posLocalCatalogStore.fetchRecentlyModifiedVariations(
+                    eq(site),
+                    any(),
+                    anyOrNull(),
+                    eq(pageNumber),
+                    any()
+                )
             ).thenReturn(
                 KotlinResult.success(
                     WooPosPaginatedFetchResult(
@@ -785,6 +804,7 @@ class WooPosSyncActionTest {
         whenever(
             posLocalCatalogStore.fetchRecentlyModifiedProducts(
                 eq(site),
+                any(),
                 anyOrNull(),
                 any(),
                 any(),
@@ -810,6 +830,7 @@ class WooPosSyncActionTest {
             whenever(
                 posLocalCatalogStore.fetchRecentlyModifiedProducts(
                     eq(site),
+                    any(),
                     anyOrNull(),
                     eq(pageNumber),
                     any(),
@@ -834,6 +855,7 @@ class WooPosSyncActionTest {
         whenever(
             posLocalCatalogStore.fetchRecentlyModifiedProducts(
                 eq(site),
+                any(),
                 anyOrNull(),
                 any(),
                 any(),
@@ -846,24 +868,24 @@ class WooPosSyncActionTest {
         whenever(
             posLocalCatalogStore.fetchRecentlyModifiedProducts(
                 eq(site),
+                any(),
                 anyOrNull(),
                 eq(page),
                 any(),
-                eq(null),
-                any()
+                eq(null)
             )
         ).thenReturn(KotlinResult.failure(Exception(errorMessage ?: "Generic error")))
     }
 
     private fun givenVariationFetchFails(page: Int, errorMessage: String?) = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedVariations(eq(site), anyOrNull(), eq(page), any())
+            posLocalCatalogStore.fetchRecentlyModifiedVariations(eq(site), any(), anyOrNull(), eq(page), any())
         ).thenReturn(KotlinResult.failure(Exception(errorMessage ?: "Generic error")))
     }
 
     private fun givenProductCatalogTooLarge(totalPages: Int) = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(1), any(), eq(null))
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), any(), anyOrNull(), eq(1), any(), eq(null))
         ).thenReturn(
             KotlinResult.success(
                 WooPosPaginatedFetchResult(
@@ -880,7 +902,7 @@ class WooPosSyncActionTest {
 
     private fun givenVariationCatalogTooLarge(totalPages: Int) = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedVariations(eq(site), anyOrNull(), eq(1), any())
+            posLocalCatalogStore.fetchRecentlyModifiedVariations(eq(site), any(), anyOrNull(), eq(1), any())
         ).thenReturn(
             KotlinResult.success(
                 WooPosPaginatedFetchResult(
@@ -897,7 +919,7 @@ class WooPosSyncActionTest {
 
     private fun givenProductPageWithZeroItemsButHasMore() = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(1), any(), eq(null))
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), any(), anyOrNull(), eq(1), any(), eq(null))
         ).thenReturn(
             KotlinResult.success(
                 WooPosPaginatedFetchResult(
@@ -914,7 +936,7 @@ class WooPosSyncActionTest {
 
     private fun givenVariationPageWithZeroItemsButHasMore() = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedVariations(eq(site), anyOrNull(), eq(1), any())
+            posLocalCatalogStore.fetchRecentlyModifiedVariations(eq(site), any(), anyOrNull(), eq(1), any())
         ).thenReturn(
             KotlinResult.success(
                 WooPosPaginatedFetchResult(
@@ -980,7 +1002,7 @@ class WooPosSyncActionTest {
 
     private fun givenProductFetchFailsWithNetworkError(page: Int, errorMessage: String) = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(page), any(), eq(null))
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), any(), anyOrNull(), eq(page), any(), eq(null))
         ).thenReturn(
             KotlinResult.failure(
                 WooPosLocalCatalogError.NetworkError(errorMessage = errorMessage)
@@ -990,7 +1012,7 @@ class WooPosSyncActionTest {
 
     private fun givenProductFetchFailsWithDatabaseError(page: Int, errorMessage: String) = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(page), any(), eq(null))
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), any(), anyOrNull(), eq(page), any(), eq(null))
         ).thenReturn(
             KotlinResult.failure(
                 WooPosLocalCatalogError.DatabaseError(errorMessage = errorMessage)
@@ -1000,7 +1022,7 @@ class WooPosSyncActionTest {
 
     private fun givenProductFetchFailsWithInvalidResponse(page: Int, errorMessage: String) = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(page), any(), eq(null))
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), any(), anyOrNull(), eq(page), any(), eq(null))
         ).thenReturn(
             KotlinResult.failure(
                 WooPosLocalCatalogError.InvalidResponse(errorMessage = errorMessage)
@@ -1010,7 +1032,7 @@ class WooPosSyncActionTest {
 
     private fun givenProductFetchFailsWithEmptyResponse(page: Int) = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(page), any(), eq(null))
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), any(), anyOrNull(), eq(page), any(), eq(null))
         ).thenReturn(
             KotlinResult.failure(WooPosLocalCatalogError.EmptyResponse)
         )
@@ -1021,7 +1043,7 @@ class WooPosSyncActionTest {
         errorMessage: String
     ) = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedVariations(eq(site), anyOrNull(), eq(page), any())
+            posLocalCatalogStore.fetchRecentlyModifiedVariations(eq(site), any(), anyOrNull(), eq(page), any())
         ).thenReturn(
             KotlinResult.failure(
                 WooPosLocalCatalogError.NetworkError(errorMessage = errorMessage)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
@@ -844,7 +844,14 @@ class WooPosSyncActionTest {
 
     private fun givenProductFetchFails(page: Int, errorMessage: String?) = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(page), any(), eq(null), posProductsOnly = any())
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(
+                eq(site),
+                anyOrNull(),
+                eq(page),
+                any(),
+                eq(null),
+                any()
+            )
         ).thenReturn(KotlinResult.failure(Exception(errorMessage ?: "Generic error")))
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
@@ -844,7 +844,7 @@ class WooPosSyncActionTest {
 
     private fun givenProductFetchFails(page: Int, errorMessage: String?) = runBlocking {
         whenever(
-            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(page), any(), eq(null))
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(eq(site), anyOrNull(), eq(page), any(), eq(null), posProductsOnly = any())
         ).thenReturn(KotlinResult.failure(Exception(errorMessage ?: "Generic error")))
     }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -125,7 +125,8 @@ class WooPosProductRestClient @Inject constructor(
             "per_page" to pageSize.toString(),
             "page" to page.toString(),
             "_fields" to fields,
-            ).also {
+            "pos_products_only" to "true",
+        ).also {
             modifiedAfter?.let { modified ->
                 it["modified_after"] = modified
             }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -32,6 +32,7 @@ class WooPosProductRestClient @Inject constructor(
         page: Int,
         pageSize: Int,
         includeStatus: List<CoreProductStatus>? = null,
+        posProductsOnly: Boolean = false,
     ): WooResult<Array<ProductApiResponse>> {
         val url = WOOCOMMERCE.products.pathV3
         val params = buildBaseParams(
@@ -39,7 +40,8 @@ class WooPosProductRestClient @Inject constructor(
             page = page,
             modifiedAfter = modifiedAfter,
             fields = PRODUCT_FIELDS,
-            includeStatus = includeStatus
+            includeStatus = includeStatus,
+            posProductsOnly = posProductsOnly
         )
 
         val response = wooNetwork.executeGetGsonRequest(
@@ -65,9 +67,16 @@ class WooPosProductRestClient @Inject constructor(
         modifiedAfter: String? = null,
         page: Int,
         pageSize: Int,
+        posProductsOnly: Boolean = false,
     ): WooResult<Array<WooPosVariationApiResponse>> {
         val url = WOOCOMMERCE.variations.pathV3
-        val params = buildBaseParams(pageSize, page, VARIATIONS_FIELDS, modifiedAfter)
+        val params = buildBaseParams(
+            pageSize = pageSize,
+            page = page,
+            fields = VARIATIONS_FIELDS,
+            modifiedAfter = modifiedAfter,
+            posProductsOnly = posProductsOnly
+        )
 
         val response = wooNetwork.executeGetGsonRequest(
             site = site,
@@ -120,18 +129,21 @@ class WooPosProductRestClient @Inject constructor(
         fields: String,
         modifiedAfter: String?,
         includeStatus: List<CoreProductStatus>? = null,
+        posProductsOnly: Boolean = false,
     ): MutableMap<String, String> {
         return mutableMapOf(
             "per_page" to pageSize.toString(),
             "page" to page.toString(),
             "_fields" to fields,
-            "pos_products_only" to "true",
         ).also {
             modifiedAfter?.let { modified ->
                 it["modified_after"] = modified
             }
             includeStatus?.let { statuses ->
                 it["include_status"] = statusListToString(statuses)
+            }
+            if (posProductsOnly) {
+                it["pos_products_only"] = "true"
             }
         }
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -28,11 +28,11 @@ class WooPosProductRestClient @Inject constructor(
 
     suspend fun fetchProducts(
         site: SiteModel,
-        modifiedAfter: String? = null,
         page: Int,
         pageSize: Int,
+        posProductsOnly: Boolean,
+        modifiedAfter: String? = null,
         includeStatus: List<CoreProductStatus>? = null,
-        posProductsOnly: Boolean = false,
     ): WooResult<Array<ProductApiResponse>> {
         val url = WOOCOMMERCE.products.pathV3
         val params = buildBaseParams(
@@ -64,10 +64,10 @@ class WooPosProductRestClient @Inject constructor(
 
     suspend fun fetchVariations(
         site: SiteModel,
-        modifiedAfter: String? = null,
         page: Int,
         pageSize: Int,
-        posProductsOnly: Boolean = false,
+        posProductsOnly: Boolean,
+        modifiedAfter: String? = null,
     ): WooResult<Array<WooPosVariationApiResponse>> {
         val url = WOOCOMMERCE.variations.pathV3
         val params = buildBaseParams(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -162,7 +162,8 @@ class WooPosLocalCatalogStore @Inject constructor(
      */
     suspend fun fetchProductsCount(
         site: SiteModel,
-        modifiedAfterGmt: String? = null
+        modifiedAfterGmt: String? = null,
+        posProductsOnly: Boolean = false,
     ): Result<Int> =
         coroutineEngine.withDefaultContext(API, this, "fetchProductsCount") {
             val response = posProductRestClient.fetchProducts(
@@ -170,7 +171,8 @@ class WooPosLocalCatalogStore @Inject constructor(
                 modifiedAfter = modifiedAfterGmt,
                 page = 1,
                 pageSize = 1,
-                includeStatus = null
+                includeStatus = null,
+                posProductsOnly = posProductsOnly
             )
 
             when {
@@ -206,6 +208,7 @@ class WooPosLocalCatalogStore @Inject constructor(
         page: Int = 1,
         pageSize: Int = DEFAULT_PAGE_SIZE,
         includeStatus: List<CoreProductStatus>? = null,
+        posProductsOnly: Boolean = false,
     ): Result<WooPosPaginatedFetchResult<WooPosProductEntity>> =
         coroutineEngine.withDefaultContext(API, this, "fetchRecentlyModifiedProducts") {
             val validPageSize = pageSize.coerceIn(1, MAX_PAGE_SIZE)
@@ -215,7 +218,8 @@ class WooPosLocalCatalogStore @Inject constructor(
                 modifiedAfter = modifiedAfterGmt,
                 page = page,
                 pageSize = validPageSize,
-                includeStatus = includeStatus
+                includeStatus = includeStatus,
+                posProductsOnly = posProductsOnly
             )
 
             val serverDate = headersParser.getServerDate(response)
@@ -392,13 +396,15 @@ class WooPosLocalCatalogStore @Inject constructor(
     suspend fun fetchVariationsCount(
         site: SiteModel,
         modifiedAfterGmt: String? = null,
+        posProductsOnly: Boolean = false,
     ): Result<Int> =
         coroutineEngine.withDefaultContext(API, this, "fetchVariationsCount") {
             val response = posProductRestClient.fetchVariations(
                 site = site,
                 modifiedAfter = modifiedAfterGmt,
                 page = 1,
-                pageSize = 1
+                pageSize = 1,
+                posProductsOnly = posProductsOnly
             )
 
             when {
@@ -434,6 +440,7 @@ class WooPosLocalCatalogStore @Inject constructor(
         modifiedAfterGmt: String?,
         page: Int = 1,
         pageSize: Int = DEFAULT_PAGE_SIZE,
+        posProductsOnly: Boolean = false,
     ): Result<WooPosPaginatedFetchResult<WooPosVariationEntity>> =
         coroutineEngine.withDefaultContext(API, this, "fetchRecentlyModifiedVariations") {
             require(page > 0) { "Page number must be 1 or greater" }
@@ -443,7 +450,8 @@ class WooPosLocalCatalogStore @Inject constructor(
                 site = site,
                 modifiedAfter = modifiedAfterGmt,
                 page = page,
-                pageSize = validPageSize
+                pageSize = validPageSize,
+                posProductsOnly = posProductsOnly
             )
 
             val serverDate = headersParser.getServerDate(response)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -162,8 +162,8 @@ class WooPosLocalCatalogStore @Inject constructor(
      */
     suspend fun fetchProductsCount(
         site: SiteModel,
+        posProductsOnly: Boolean,
         modifiedAfterGmt: String? = null,
-        posProductsOnly: Boolean = false,
     ): Result<Int> =
         coroutineEngine.withDefaultContext(API, this, "fetchProductsCount") {
             val response = posProductRestClient.fetchProducts(
@@ -172,7 +172,7 @@ class WooPosLocalCatalogStore @Inject constructor(
                 page = 1,
                 pageSize = 1,
                 includeStatus = null,
-                posProductsOnly = posProductsOnly
+                posProductsOnly = posProductsOnly,
             )
 
             when {
@@ -204,11 +204,11 @@ class WooPosLocalCatalogStore @Inject constructor(
      */
     suspend fun fetchRecentlyModifiedProducts(
         site: SiteModel,
-        modifiedAfterGmt: String?,
+        posProductsOnly: Boolean,
+        modifiedAfterGmt: String? = null,
         page: Int = 1,
         pageSize: Int = DEFAULT_PAGE_SIZE,
         includeStatus: List<CoreProductStatus>? = null,
-        posProductsOnly: Boolean = false,
     ): Result<WooPosPaginatedFetchResult<WooPosProductEntity>> =
         coroutineEngine.withDefaultContext(API, this, "fetchRecentlyModifiedProducts") {
             val validPageSize = pageSize.coerceIn(1, MAX_PAGE_SIZE)
@@ -218,8 +218,8 @@ class WooPosLocalCatalogStore @Inject constructor(
                 modifiedAfter = modifiedAfterGmt,
                 page = page,
                 pageSize = validPageSize,
+                posProductsOnly = posProductsOnly,
                 includeStatus = includeStatus,
-                posProductsOnly = posProductsOnly
             )
 
             val serverDate = headersParser.getServerDate(response)
@@ -395,8 +395,8 @@ class WooPosLocalCatalogStore @Inject constructor(
      */
     suspend fun fetchVariationsCount(
         site: SiteModel,
+        posProductsOnly: Boolean,
         modifiedAfterGmt: String? = null,
-        posProductsOnly: Boolean = false,
     ): Result<Int> =
         coroutineEngine.withDefaultContext(API, this, "fetchVariationsCount") {
             val response = posProductRestClient.fetchVariations(
@@ -404,7 +404,7 @@ class WooPosLocalCatalogStore @Inject constructor(
                 modifiedAfter = modifiedAfterGmt,
                 page = 1,
                 pageSize = 1,
-                posProductsOnly = posProductsOnly
+                posProductsOnly = posProductsOnly,
             )
 
             when {
@@ -437,10 +437,10 @@ class WooPosLocalCatalogStore @Inject constructor(
     @Suppress("LongMethod")
     suspend fun fetchRecentlyModifiedVariations(
         site: SiteModel,
-        modifiedAfterGmt: String?,
+        posProductsOnly: Boolean,
+        modifiedAfterGmt: String? = null,
         page: Int = 1,
         pageSize: Int = DEFAULT_PAGE_SIZE,
-        posProductsOnly: Boolean = false,
     ): Result<WooPosPaginatedFetchResult<WooPosVariationEntity>> =
         coroutineEngine.withDefaultContext(API, this, "fetchRecentlyModifiedVariations") {
             require(page > 0) { "Page number must be 1 or greater" }
@@ -451,7 +451,7 @@ class WooPosLocalCatalogStore @Inject constructor(
                 modifiedAfter = modifiedAfterGmt,
                 page = page,
                 pageSize = validPageSize,
-                posProductsOnly = posProductsOnly
+                posProductsOnly = posProductsOnly,
             )
 
             val serverDate = headersParser.getServerDate(response)

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreTest.kt
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -145,11 +146,11 @@ class WooPosLocalCatalogStoreTest {
             createTestApiResponse(id = 1L, name = "Coffee Mug"),
             createTestApiResponse(id = 2L, name = "Laptop Stand")
         )
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 1, 100))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(remoteProducts))
 
         // WHEN
-        val syncResult = store.fetchRecentlyModifiedProducts(testSite, validDateString, 1, 100).getOrThrow()
+        val syncResult = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 1, 100).getOrThrow()
 
         // THEN
         assertThat(syncResult.items.size).isEqualTo(remoteProducts.size)
@@ -164,11 +165,11 @@ class WooPosLocalCatalogStoreTest {
         val fullPageOfProducts = Array(100) { index ->
             createTestApiResponse(id = index.toLong() + 1, name = "Product ${index + 1}")
         }
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 1, 100))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(fullPageOfProducts))
 
         // WHEN
-        val syncResult = store.fetchRecentlyModifiedProducts(testSite, validDateString, 1, 100).getOrThrow()
+        val syncResult = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 1, 100).getOrThrow()
 
         // THEN
         assertThat(syncResult.hasMore).isTrue()
@@ -179,11 +180,11 @@ class WooPosLocalCatalogStoreTest {
     @Test
     fun `given no remote products, when fetching, then completes`() = runTest {
         // GIVEN
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 1, 100))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(emptyArray()))
 
         // WHEN
-        val syncResult = store.fetchRecentlyModifiedProducts(testSite, validDateString, 1, 100).getOrThrow()
+        val syncResult = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 1, 100).getOrThrow()
 
         // THEN
         assertThat(syncResult.syncedCount).isEqualTo(0)
@@ -199,11 +200,11 @@ class WooPosLocalCatalogStoreTest {
             original = org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NO_CONNECTION,
             message = "Connection failed"
         )
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(connectivityError))
 
         // WHEN
-        val result = store.fetchRecentlyModifiedProducts(testSite, validDateString, 0, 100)
+        val result = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 0, 100)
 
         // THEN
         assertThat(result.isFailure).isTrue()
@@ -216,15 +217,15 @@ class WooPosLocalCatalogStoreTest {
     fun `given oversized page request, when syncing, then constrains to maximum page size`() = runTest {
         // GIVEN
         val remoteProducts = arrayOf(createTestApiResponse(id = 1L, name = "Product 1"))
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(remoteProducts))
 
         // WHEN
-        val result = store.fetchRecentlyModifiedProducts(testSite, validDateString, 0, 500)
+        val result = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 0, 500)
 
         // THEN
         assertThat(result.isSuccess).isTrue()
-        verify(posProductRestClient).fetchProducts(testSite, validDateString, 0, 100)
+        verify(posProductRestClient).fetchProducts(testSite, 0, 100, false, validDateString, null)
     }
 
     @Test
@@ -233,11 +234,11 @@ class WooPosLocalCatalogStoreTest {
         val partialPageProducts = Array(50) { index ->
             createTestApiResponse(id = index.toLong() + 1, name = "Product ${index + 1}")
         }
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 1, 100))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(partialPageProducts))
 
         // WHEN
-        val syncResult = store.fetchRecentlyModifiedProducts(testSite, validDateString, 1, 100).getOrThrow()
+        val syncResult = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 1, 100).getOrThrow()
 
         // THEN
         assertThat(syncResult.hasMore).isFalse()
@@ -249,15 +250,15 @@ class WooPosLocalCatalogStoreTest {
     fun `given negative page size, when syncing, then constrains to minimum page size`() = runTest {
         // GIVEN
         val remoteProducts = arrayOf(createTestApiResponse(id = 1L, name = "Product 1"))
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 1))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(remoteProducts))
 
         // WHEN
-        val result = store.fetchRecentlyModifiedProducts(testSite, validDateString, 0, -5)
+        val result = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 0, -5)
 
         // THEN
         assertThat(result.isSuccess).isTrue()
-        verify(posProductRestClient).fetchProducts(testSite, validDateString, 0, 1)
+        verify(posProductRestClient).fetchProducts(testSite, 0, 1, false, validDateString, null)
     }
 
     @Test
@@ -268,11 +269,11 @@ class WooPosLocalCatalogStoreTest {
             original = org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.TIMEOUT,
             message = "Request timeout"
         )
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(WooResult(timeoutError))
 
         // WHEN
-        val result = store.fetchRecentlyModifiedProducts(testSite, validDateString, 0, 100)
+        val result = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 0, 100)
 
         // THEN
         assertThat(result.isFailure).isTrue()
@@ -342,11 +343,11 @@ class WooPosLocalCatalogStoreTest {
     @Test
     fun `given no remote variations, when syncing, then completes without saving`() = runTest {
         // GIVEN
-        whenever(posProductRestClient.fetchVariations(testSite, validDateString, 1, 100))
+        whenever(posProductRestClient.fetchVariations(any(), any(), any(), any(), anyOrNull()))
             .thenReturn(WooResult(emptyArray()))
 
         // WHEN
-        val syncResult = store.fetchRecentlyModifiedVariations(testSite, validDateString, 1, 100).getOrThrow()
+        val syncResult = store.fetchRecentlyModifiedVariations(testSite, false, validDateString, 1, 100).getOrThrow()
 
         // THEN
         verifyNoInteractions(posVariationsDao)
@@ -363,11 +364,11 @@ class WooPosLocalCatalogStoreTest {
             original = org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR,
             message = "Network error"
         )
-        whenever(posProductRestClient.fetchVariations(testSite, validDateString, 1, 100))
+        whenever(posProductRestClient.fetchVariations(any(), any(), any(), any(), anyOrNull()))
             .thenReturn(WooResult(networkError))
 
         // WHEN
-        val result = store.fetchRecentlyModifiedVariations(testSite, validDateString, 1, 100)
+        val result = store.fetchRecentlyModifiedVariations(testSite, false, validDateString, 1, 100)
 
         // THEN
         assertThat(result.isFailure).isTrue()
@@ -380,11 +381,11 @@ class WooPosLocalCatalogStoreTest {
     fun `given full page of variations, when sync called, then pagination indicates more pages`() = runTest {
         // GIVEN
         val variations = Array(100) { createTestVariationApiResponse(id = it.toLong()) }
-        whenever(posProductRestClient.fetchVariations(testSite, validDateString, 1, 100))
+        whenever(posProductRestClient.fetchVariations(any(), any(), any(), any(), anyOrNull()))
             .thenReturn(WooResult(variations))
 
         // WHEN
-        val result = store.fetchRecentlyModifiedVariations(testSite, validDateString, 1, 100)
+        val result = store.fetchRecentlyModifiedVariations(testSite, false, validDateString, 1, 100)
 
         // THEN
         assertThat(result.isSuccess).isTrue()
@@ -413,14 +414,14 @@ class WooPosLocalCatalogStoreTest {
     fun `given page size over limit for variations, when sync called, then max page size enforced`() = runTest {
         // GIVEN
         val variations = Array(100) { createTestVariationApiResponse() }
-        whenever(posProductRestClient.fetchVariations(testSite, validDateString, 1, 100))
+        whenever(posProductRestClient.fetchVariations(any(), any(), any(), any(), anyOrNull()))
             .thenReturn(WooResult(variations))
 
         // WHEN
-        store.fetchRecentlyModifiedVariations(testSite, validDateString, 1, 200)
+        store.fetchRecentlyModifiedVariations(testSite, false, validDateString, 1, 200)
 
         // THEN
-        verify(posProductRestClient).fetchVariations(testSite, validDateString, 1, 100)
+        verify(posProductRestClient).fetchVariations(testSite, 1, 100, false, validDateString)
     }
 
     @Test
@@ -514,13 +515,13 @@ class WooPosLocalCatalogStoreTest {
         // GIVEN
         val remoteProducts = arrayOf(createTestApiResponse(id = 1L, name = "Product"))
         val response = WooResult(remoteProducts)
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(response)
         whenever(headersParser.getServerDate(response))
             .thenReturn(null)
 
         // WHEN
-        val result = store.fetchRecentlyModifiedProducts(testSite, validDateString, 0, 100)
+        val result = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 0, 100)
 
         // THEN
         assertThat(result.isFailure).isTrue()
@@ -538,13 +539,13 @@ class WooPosLocalCatalogStoreTest {
                 message = "API error"
             )
         )
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(response)
         whenever(headersParser.getServerDate(response))
             .thenReturn(null)
 
         // WHEN
-        val result = store.fetchRecentlyModifiedProducts(testSite, validDateString, 0, 100)
+        val result = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 0, 100)
 
         // THEN
         assertThat(result.isFailure).isTrue()
@@ -557,7 +558,7 @@ class WooPosLocalCatalogStoreTest {
         // GIVEN
         val remoteProducts = arrayOf(createTestApiResponse(id = 1L, name = "Product"))
         val response = WooResult(remoteProducts)
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(response)
         whenever(headersParser.getServerDate(response))
             .thenReturn("2024-01-01T00:00:00Z")
@@ -565,7 +566,7 @@ class WooPosLocalCatalogStoreTest {
             .thenReturn(null) // Missing total pages
 
         // WHEN
-        val result = store.fetchRecentlyModifiedProducts(testSite, validDateString, 0, 100)
+        val result = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 0, 100)
 
         // THEN
         assertThat(result.isFailure).isTrue()
@@ -581,7 +582,7 @@ class WooPosLocalCatalogStoreTest {
         val expectedServerDate = "2024-03-15T10:30:00Z"
         val expectedTotalPages = 3
 
-        whenever(posProductRestClient.fetchProducts(testSite, validDateString, 0, 100))
+        whenever(posProductRestClient.fetchProducts(any(), any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(response)
         whenever(headersParser.getServerDate(response))
             .thenReturn(expectedServerDate)
@@ -589,7 +590,7 @@ class WooPosLocalCatalogStoreTest {
             .thenReturn(expectedTotalPages)
 
         // WHEN
-        val syncResult = store.fetchRecentlyModifiedProducts(testSite, validDateString, 0, 100).getOrThrow()
+        val syncResult = store.fetchRecentlyModifiedProducts(testSite, false, validDateString, 0, 100).getOrThrow()
 
         // THEN
         assertThat(syncResult.serverDate).isEqualTo(expectedServerDate)


### PR DESCRIPTION
Fixes WOOMOB-1966

Remove `do not merge` label when the target branch is trunk.

### Description
Adds the `pos_products_only=true` query parameter to the `/products` and `/variations` API endpoints used by the POS local catalog sync. This parameter is only passed when the `WOO_POS_PRODUCT_VISIBILITY_FILTERING` feature flag is enabled.

### Test Steps
1. Enable the `WOO_POS_PRODUCT_VISIBILITY_FILTERING` feature flag (debug build)
2. Launch the POS feature
3. Trigger an incremental sync
4. Verify in network logs that `/products` and `/variations` API calls include `pos_products_only=true`

### Images/gif
N/A - No UI changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.