### PR TITLE
[WOOMOB-1969] Handle products hidden from POS in local catalog sync

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 24.0
 -----
+- [Internal][Woo POS] Remove products hidden from POS during local catalog sync [https://github.com/woocommerce/woocommerce-android/pull/15190]
 - [Internal] Show JITMs on Dashboard regardless of onboarding status [https://github.com/woocommerce/woocommerce-android/pull/15170]
 
 23.9

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
@@ -18,7 +18,7 @@ class WooPosSyncAction @Inject constructor(
     private val posLocalCatalogStore: WooPosLocalCatalogStore,
     private val logger: WooPosLogWrapper,
 ) {
-    private val posProductsOnly: Boolean
+    private val posProductsOnlyFeatureFlag: Boolean
         get() = FeatureFlag.WOO_POS_PRODUCT_VISIBILITY_FILTERING.isEnabled()
 
     suspend fun syncCatalog(
@@ -46,7 +46,13 @@ class WooPosSyncAction @Inject constructor(
         isFullSync: Boolean
     ): FetchResults = coroutineScope {
         val posProductsDeferred = async {
-            fetchAllProductPages(site, modifiedAfterGmt, pageSize, maxPages, this@WooPosSyncAction.posProductsOnly)
+            fetchAllProductPages(
+                site,
+                modifiedAfterGmt,
+                pageSize,
+                maxPages,
+                this@WooPosSyncAction.posProductsOnlyFeatureFlag
+            )
         }
         val trashProductsDeferred = async {
             if (isFullSync) {
@@ -58,7 +64,7 @@ class WooPosSyncAction @Inject constructor(
         }
 
         val allProductsDeferred = async {
-            if (!FeatureFlag.WOO_POS_PRODUCT_VISIBILITY_FILTERING.isEnabled() || isFullSync) {
+            if (!posProductsOnlyFeatureFlag || isFullSync) {
                 emptyList()
             } else {
                 fetchAllProductPages(
@@ -87,7 +93,7 @@ class WooPosSyncAction @Inject constructor(
          * This logic is skipped for full sync, since full sync always purges the whole database.
          */
         val productsRecentlyMarkedAsHiddenInPos =
-            if (!FeatureFlag.WOO_POS_PRODUCT_VISIBILITY_FILTERING.isEnabled() || isFullSync) {
+            if (!posProductsOnlyFeatureFlag || isFullSync) {
                 emptyList()
             } else {
                 findProductsMarkedAsHiddenInPos(
@@ -218,7 +224,7 @@ class WooPosSyncAction @Inject constructor(
             fetchPage = { page ->
                 posLocalCatalogStore.fetchRecentlyModifiedVariations(
                     site = site,
-                    posProductsOnly = posProductsOnly,
+                    posProductsOnly = posProductsOnlyFeatureFlag,
                     modifiedAfterGmt = modifiedAfterGmt,
                     page = page,
                     pageSize = pageSize,
@@ -243,7 +249,7 @@ class WooPosSyncAction @Inject constructor(
                 posLocalCatalogStore.fetchRecentlyModifiedProducts(
                     site = site,
                     pageSize = pageSize,
-                    posProductsOnly = posProductsOnly,
+                    posProductsOnly = posProductsOnlyFeatureFlag,
                     modifiedAfterGmt = modifiedAfterGmt,
                     page = page,
                     includeStatus = listOf(CoreProductStatus.TRASH),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.util.FeatureFlag
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
@@ -44,8 +45,8 @@ class WooPosSyncAction @Inject constructor(
         maxPages: Int,
         isFullSync: Boolean
     ): FetchResults = coroutineScope {
-        val regularProductsDeferred = async {
-            fetchAllProductPages(site, modifiedAfterGmt, pageSize, maxPages)
+        val posProductsDeferred = async {
+            fetchAllProductPages(site, modifiedAfterGmt, pageSize, maxPages, this@WooPosSyncAction.posProductsOnly)
         }
         val trashProductsDeferred = async {
             if (isFullSync) {
@@ -55,15 +56,54 @@ class WooPosSyncAction @Inject constructor(
                 fetchAllTrashProducts(site, modifiedAfterGmt, pageSize)
             }
         }
+
+        val allProductsDeferred = async {
+            if (!FeatureFlag.WOO_POS_PRODUCT_VISIBILITY_FILTERING.isEnabled() || isFullSync) {
+                emptyList()
+            } else {
+                fetchAllProductPages(
+                    site,
+                    modifiedAfterGmt,
+                    pageSize,
+                    maxPages,
+                    posProductsOnly = false
+                ).first
+            }
+        }
         val variationsDeferred = async {
             fetchAllVariationPages(site, modifiedAfterGmt, pageSize, maxPages)
         }
 
-        val (products, productsServerDate) = regularProductsDeferred.await()
+        val (posProducts, productsServerDate) = posProductsDeferred.await()
         val trashProducts = trashProductsDeferred.await()
+        val allProducts = allProductsDeferred.await()
         val (variations, variationsServerDate) = variationsDeferred.await()
 
-        FetchResults(products, trashProducts, productsServerDate, variations, variationsServerDate)
+        /**
+         * Products hidden from POS don't appear in the pos_products_only=true response—they're simply omitted.
+         * To detect these, we compare against a second request without the flag: items present there but
+         * missing from the pos_products_only=true response have been hidden and should be removed from the local DB.
+         *
+         * This logic is skipped for full sync, since full sync always purges the whole database.
+         */
+        val productsRecentlyMarkedAsHiddenInPos =
+            if (!FeatureFlag.WOO_POS_PRODUCT_VISIBILITY_FILTERING.isEnabled() || isFullSync) {
+                emptyList()
+            } else {
+                findProductsMarkedAsHiddenInPos(
+                    posProducts = posProducts,
+                    allProducts = allProducts
+                )
+            }
+
+        FetchResults(
+            products = posProducts,
+            trashProducts = trashProducts,
+            productsToRemove = productsRecentlyMarkedAsHiddenInPos,
+            productsServerDate = productsServerDate,
+            variations = variations,
+            variationsServerDate = variationsServerDate
+        )
     }
 
     private suspend fun updateDatabaseWithFetchedItems(
@@ -77,6 +117,13 @@ class WooPosSyncAction @Inject constructor(
             if (isFullSync) {
                 posLocalCatalogStore.deleteAllProducts(site.localId()).getOrThrow()
                 posLocalCatalogStore.deleteAllVariations(site.localId()).getOrThrow()
+            }
+
+            if (fetchResults.productsToRemove.isNotEmpty()) {
+                posLocalCatalogStore.deleteProducts(
+                    site.localId(),
+                    fetchResults.productsToRemove
+                ).getOrThrow()
             }
 
             posLocalCatalogStore.upsertProducts(allProducts).getOrThrow()
@@ -129,6 +176,7 @@ class WooPosSyncAction @Inject constructor(
     private data class FetchResults(
         val products: List<WooPosProductEntity>,
         val trashProducts: List<WooPosProductEntity>,
+        val productsToRemove: List<RemoteId>,
         val productsServerDate: String,
         val variations: List<WooPosVariationEntity>,
         val variationsServerDate: String
@@ -138,7 +186,8 @@ class WooPosSyncAction @Inject constructor(
         site: SiteModel,
         modifiedAfterGmt: String?,
         pageSize: Int,
-        maxPages: Int
+        maxPages: Int,
+        posProductsOnly: Boolean
     ): Pair<List<WooPosProductEntity>, ServerDate> {
         val helper = PaginatedSyncHelper(
             logger = logger,
@@ -204,6 +253,16 @@ class WooPosSyncAction @Inject constructor(
 
         val (trashProducts, _) = helper.fetchAllPages(Int.MAX_VALUE)
         return trashProducts
+    }
+
+    private fun findProductsMarkedAsHiddenInPos(
+        posProducts: List<WooPosProductEntity>,
+        allProducts: List<WooPosProductEntity>
+    ): List<RemoteId> {
+        val posProductIds = posProducts.map { it.remoteId }.toSet()
+        return allProducts
+            .filter { it.remoteId !in posProductIds }
+            .map { it.remoteId }
     }
 
     private fun handleTransactionError(error: Throwable): WooPosSyncResult {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
@@ -745,6 +745,88 @@ class WooPosSyncActionTest {
         assertThat(databaseError.errorMessage).isEqualTo("Transaction rollback due to constraint violation")
     }
 
+    @Test
+    fun `when full sync, then deleteProducts is not called`() = runTest {
+        // GIVEN
+        mockFetchProductsSuccess(pages = listOf(10), serverDate = "2024-01-01T12:00:00Z")
+        mockFetchVariationsSuccess(pages = listOf(5), serverDate = "2024-01-01T12:00:00Z")
+
+        // WHEN
+        sut.syncCatalog(site, null, PAGE_SIZE, 10)
+
+        // THEN
+        verify(posLocalCatalogStore, never()).deleteProducts(any(), any())
+    }
+
+    @Test
+    fun `when incremental sync with no products to remove, then deleteProducts is not called`() = runTest {
+        // GIVEN
+        mockFetchProductsSuccess(pages = listOf(10), serverDate = "2024-01-01T12:00:00Z")
+        mockFetchVariationsSuccess(pages = listOf(5), serverDate = "2024-01-01T12:00:00Z")
+        givenTrashProducts(count = 0)
+        givenAllModifiedProductsMatchPosProducts(count = 10)
+
+        // WHEN
+        sut.syncCatalog(site, "2024-01-01T12:00:00Z", PAGE_SIZE, 10)
+
+        // THEN
+        verify(posLocalCatalogStore, never()).deleteProducts(any(), any())
+    }
+
+    @Test
+    fun `when incremental sync with products to remove, then deleteProducts is called`() = runTest {
+        // GIVEN
+        givenPosOnlyProductsFetch(
+            posProductIds = listOf(1L, 2L, 3L),
+            serverDate = "2024-01-01T12:00:00Z"
+        )
+        givenAllProductsFetch(
+            allProductIds = listOf(1L, 2L, 3L, 4L, 5L),
+            serverDate = "2024-01-01T12:00:00Z"
+        )
+        mockFetchVariationsSuccess(pages = listOf(0), serverDate = "2024-01-01T12:00:00Z")
+        givenTrashProducts(count = 0)
+
+        // WHEN
+        sut.syncCatalog(site, "2024-01-01T12:00:00Z", PAGE_SIZE, 10)
+
+        // THEN
+        verify(posLocalCatalogStore).deleteProducts(
+            eq(LocalOrRemoteId.LocalId(site.id)),
+            eq(listOf(LocalOrRemoteId.RemoteId(4L), LocalOrRemoteId.RemoteId(5L)))
+        )
+    }
+
+    @Test
+    fun `when incremental sync with all products now non-POS, then deleteProducts removes all`() = runTest {
+        // GIVEN
+        givenPosOnlyProductsFetch(
+            posProductIds = emptyList(),
+            serverDate = "2024-01-01T12:00:00Z"
+        )
+        givenAllProductsFetch(
+            allProductIds = listOf(1L, 2L, 3L),
+            serverDate = "2024-01-01T12:00:00Z"
+        )
+        mockFetchVariationsSuccess(pages = listOf(0), serverDate = "2024-01-01T12:00:00Z")
+        givenTrashProducts(count = 0)
+
+        // WHEN
+        sut.syncCatalog(site, "2024-01-01T12:00:00Z", PAGE_SIZE, 10)
+
+        // THEN
+        verify(posLocalCatalogStore).deleteProducts(
+            eq(LocalOrRemoteId.LocalId(site.id)),
+            eq(
+                listOf(
+                    LocalOrRemoteId.RemoteId(1L),
+                    LocalOrRemoteId.RemoteId(2L),
+                    LocalOrRemoteId.RemoteId(3L)
+                )
+            )
+        )
+    }
+
     // === HELPER METHODS ===
 
     private fun mockFetchProductsSuccess(pages: List<Int>, serverDate: String) = runBlocking {
@@ -961,6 +1043,7 @@ class WooPosSyncActionTest {
         }
         whenever(posLocalCatalogStore.deleteAllProducts(any())).thenReturn(KotlinResult.success(Unit))
         whenever(posLocalCatalogStore.deleteAllVariations(any())).thenReturn(KotlinResult.success(Unit))
+        whenever(posLocalCatalogStore.deleteProducts(any(), any())).thenReturn(KotlinResult.success(Unit))
         whenever(posLocalCatalogStore.upsertProducts(any())).thenReturn(KotlinResult.success(Unit))
         whenever(posLocalCatalogStore.upsertVariations(any())).thenReturn(KotlinResult.success(Unit))
     }
@@ -1057,6 +1140,90 @@ class WooPosSyncActionTest {
             posLocalCatalogStore.executeInTransaction(any<suspend () -> KotlinResult<Unit>>())
         ).thenReturn(
             KotlinResult.failure(WooPosLocalCatalogError.DatabaseError(errorMessage = errorMessage))
+        )
+    }
+
+    private fun givenAllModifiedProductsMatchPosProducts(count: Int) = runBlocking {
+        whenever(
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(
+                eq(site),
+                eq(false),
+                anyOrNull(),
+                eq(1),
+                any(),
+                eq(null)
+            )
+        ).thenReturn(
+            KotlinResult.success(
+                WooPosPaginatedFetchResult(
+                    items = generateProducts(count),
+                    totalPages = 1,
+                    hasMore = false,
+                    nextPage = 1,
+                    syncedCount = count,
+                    serverDate = "2024-01-01T12:00:00Z"
+                )
+            )
+        )
+    }
+
+    private fun givenPosOnlyProductsFetch(posProductIds: List<Long>, serverDate: String) = runBlocking {
+        val products = posProductIds.map { id ->
+            WooPosProductEntity(
+                remoteId = LocalOrRemoteId.RemoteId(id),
+                name = "Product $id"
+            )
+        }
+        whenever(
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(
+                eq(site),
+                eq(true),
+                anyOrNull(),
+                eq(1),
+                any(),
+                eq(null)
+            )
+        ).thenReturn(
+            KotlinResult.success(
+                WooPosPaginatedFetchResult(
+                    items = products,
+                    totalPages = 1,
+                    hasMore = false,
+                    nextPage = 1,
+                    syncedCount = products.size,
+                    serverDate = serverDate
+                )
+            )
+        )
+    }
+
+    private fun givenAllProductsFetch(allProductIds: List<Long>, serverDate: String) = runBlocking {
+        val products = allProductIds.map { id ->
+            WooPosProductEntity(
+                remoteId = LocalOrRemoteId.RemoteId(id),
+                name = "Product $id"
+            )
+        }
+        whenever(
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(
+                eq(site),
+                eq(false),
+                anyOrNull(),
+                eq(1),
+                any(),
+                eq(null)
+            )
+        ).thenReturn(
+            KotlinResult.success(
+                WooPosPaginatedFetchResult(
+                    items = products,
+                    totalPages = 1,
+                    hasMore = false,
+                    nextPage = 1,
+                    syncedCount = products.size,
+                    serverDate = serverDate
+                )
+            )
         )
     }
 }


### PR DESCRIPTION
Fixes WOOMOB-1969

Remove `do not merge` label when the target branch is trunk.

### Description
During incremental local catalog sync, products that have been marked as hidden from POS are now detected and removed from the local database. This ensures the POS catalog stays in sync with product visibility settings. Variations are automatically handled since removing a parent product also removes all its variations.

### Test Steps
1. Use store that has less than 1000 products and variations (to ensure local catalog is used)
2. Use Jetpack Beta or similar and switch your store to the bleeding edge version (trunk)
3. Open POS
4. Pick a product
5. Open product detail in WPAdmin -> Advanced -> Disable 'Show in POS' -> Save
6. Trigger an incremental sync in the POS
7. Verify the product disappears
8. Open product detail in WPAdmin -> Advanced -> Enable 'Show in POS' -> Save
9. Trigger an incremental sync in the POS
10. Verify the product appears

### Images/gif
N/A - backend logic change

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary.