### PR TITLE
[WOOMOB-1988] Add POS products filtering: Non-local-catalog/Remote sync

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 24.0
 -----
+- [Internal][Woo POS] Apply POS product visibility filtering to remote/non-local-catalog sync [https://github.com/woocommerce/woocommerce-android/pull/15191]
 - [Internal][Woo POS] Remove products hidden from POS during local catalog sync [https://github.com/woocommerce/woocommerce-android/pull/15190]
 - [Internal] Show JITMs on Dashboard regardless of onboarding status [https://github.com/woocommerce/woocommerce-android/pull/15170]
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.ui.woopos.localcatalog.WooPosLocalCatalogSyncRepo
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosPerformInstantCatalogFullSync
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosSyncProductResult
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosSyncVariationResult
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -438,6 +439,7 @@ class WooPosProductsRemoteDataSource @Inject constructor(
             pageSize = pageSize,
             filterOptions = productsTypesFilterConfig.filters,
             includeTypes = productsTypesFilterConfig.includeTypes,
+            posProductsOnly = FeatureFlag.WOO_POS_PRODUCT_VISIBILITY_FILTERING.isEnabled(),
         )
     }
 
@@ -560,6 +562,7 @@ class WooPosProductsRemoteDataSource @Inject constructor(
             val remoteVariationsResult = productRestClient.fetchProductVariations(
                 site = selectedSite.get(),
                 productId = productId,
+                posProductsOnly = FeatureFlag.WOO_POS_PRODUCT_VISIBILITY_FILTERING.isEnabled(),
             )
 
             if (!remoteVariationsResult.isError) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSource.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilterConfig
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosWCProductToWooPosProductModelMapper
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -80,6 +81,7 @@ class WooPosSearchProductsDataSource @Inject constructor(
             filterOptions = productsTypesFilterConfig.filters,
             includeTypes = productsTypesFilterConfig.includeTypes,
             searchFields = SEARCH_FIELDS,
+            posProductsOnly = FeatureFlag.WOO_POS_PRODUCT_VISIBILITY_FILTERING.isEnabled(),
         ).let { result ->
             if (result.isError) {
                 WooLog.w(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsRemoteDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsRemoteDataSourceTest.kt
@@ -197,7 +197,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = any(),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(WooResult(listOf()))
             whenever(productsIndex.getProductList()).thenReturn(sampleProducts)
@@ -224,7 +225,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = any(),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(WooResult(listOf<WCProductModel>()))
             whenever(productsIndex.getProductList()).thenReturn(sampleProducts)
@@ -249,7 +251,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = any(),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(WooResult(listOf()))
             whenever(productsIndex.getProductList()).thenReturn(emptyList())
@@ -278,7 +281,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = any(),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(
                 WooResult(
@@ -334,6 +338,7 @@ class WooPosProductsRemoteDataSourceTest {
                     sortType = any(),
                     filterOptions = any<Map<WCProductStore.ProductFilterOption, String>>(),
                     includeTypes = eq(productsTypesFilterConfig.includeTypes),
+                    posProductsOnly = any()
                 )
             ).thenReturn(WooResult(wooError))
             whenever(productsCache.getAll()).thenReturn(sampleProducts)
@@ -363,7 +368,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = any(),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(
                 WooResult(
@@ -416,7 +422,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = any(),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(
                 WooResult(
@@ -455,7 +462,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = any(),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(
                 WooResult(
@@ -493,6 +501,7 @@ class WooPosProductsRemoteDataSourceTest {
                     sortType = any(),
                     filterOptions = any(),
                     includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(WooResult(emptyList()))
             val sut = createSUT()
@@ -533,7 +542,8 @@ class WooPosProductsRemoteDataSourceTest {
                 pageSize = any(),
                 sortType = any(),
                 filterOptions = any(),
-                includeTypes = any()
+                includeTypes = any(),
+                posProductsOnly = any()
             )
         ).thenReturn(WooResult(listOf()))
 
@@ -579,7 +589,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = eq(100),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(WooResult(firstPageProducts))
 
@@ -590,7 +601,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = eq(100),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(WooResult(secondPageProducts))
 
@@ -630,7 +642,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = eq(100),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(WooResult(firstPageProducts))
 
@@ -641,7 +654,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = eq(100),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(WooResult(wooError))
 
@@ -672,7 +686,8 @@ class WooPosProductsRemoteDataSourceTest {
                 pageSize = eq(100),
                 sortType = any(),
                 filterOptions = any(),
-                includeTypes = any()
+                includeTypes = any(),
+                posProductsOnly = any()
             )
         ).thenReturn(WooResult(wooError))
 
@@ -715,7 +730,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = eq(100),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(WooResult(firstPageProducts))
 
@@ -726,7 +742,8 @@ class WooPosProductsRemoteDataSourceTest {
                     pageSize = eq(100),
                     sortType = any(),
                     filterOptions = any(),
-                    includeTypes = any()
+                    includeTypes = any(),
+                    posProductsOnly = any()
                 )
             ).thenReturn(WooResult(secondPageProducts))
 
@@ -745,7 +762,8 @@ class WooPosProductsRemoteDataSourceTest {
                 pageSize = any(),
                 sortType = any(),
                 filterOptions = any(),
-                includeTypes = any()
+                includeTypes = any(),
+                posProductsOnly = any()
             )
         }
 
@@ -1143,7 +1161,7 @@ class WooPosProductsRemoteDataSourceTest {
             // THEN
             assertThat(result).isNotNull
             assertThat(result).isEqualTo(cachedVariation)
-            verify(productRestClient, never()).fetchProductVariations(any(), any(), any(), any())
+            verify(productRestClient, never()).fetchProductVariations(any(), any(), any(), any(), any())
         }
 
     @Test
@@ -1173,7 +1191,7 @@ class WooPosProductsRemoteDataSourceTest {
             )
 
             whenever(variationsCache.get(productId)).thenReturn(variationsSampleProducts)
-            whenever(productRestClient.fetchProductVariations(siteModel, productId))
+            whenever(productRestClient.fetchProductVariations(eq(siteModel), eq(productId), any(), any(), any()))
                 .thenReturn(remotePayload)
             whenever(variationMapper.fromWCProductVariationModel(wcVariation)).thenReturn(expectedVariation)
             whenever(selectedSite.get()).thenReturn(siteModel)
@@ -1185,7 +1203,7 @@ class WooPosProductsRemoteDataSourceTest {
             // THEN
             assertThat(result).isNotNull
             assertThat(result?.remoteVariationId).isEqualTo(variationId)
-            verify(productRestClient).fetchProductVariations(siteModel, productId)
+            verify(productRestClient).fetchProductVariations(eq(siteModel), eq(productId), any(), any(), any())
             verify(variationsCache).put(eq(productId), any())
         }
 
@@ -1204,7 +1222,7 @@ class WooPosProductsRemoteDataSourceTest {
 
             // THEN
             assertThat(result).isNull()
-            verify(productRestClient, never()).fetchProductVariations(any(), any(), any(), any())
+            verify(productRestClient, never()).fetchProductVariations(any(), any(), any(), any(), any())
             verify(variationsCache, never()).put(any(), any())
         }
 
@@ -1221,7 +1239,7 @@ class WooPosProductsRemoteDataSourceTest {
             )
 
             whenever(variationsCache.get(productId)).thenReturn(variationsSampleProducts)
-            whenever(productRestClient.fetchProductVariations(siteModel, productId))
+            whenever(productRestClient.fetchProductVariations(eq(siteModel), eq(productId), any(), any(), any()))
                 .thenReturn(errorPayload)
             whenever(selectedSite.get()).thenReturn(siteModel)
             val sut = createSUT()
@@ -1231,7 +1249,7 @@ class WooPosProductsRemoteDataSourceTest {
 
             // THEN
             assertThat(result).isNull()
-            verify(productRestClient).fetchProductVariations(siteModel, productId)
+            verify(productRestClient).fetchProductVariations(eq(siteModel), eq(productId), any(), any(), any())
             verify(variationsCache, never()).put(any(), any())
         }
 
@@ -1262,7 +1280,7 @@ class WooPosProductsRemoteDataSourceTest {
             )
 
             whenever(variationsCache.get(productId)).thenReturn(variationsSampleProducts)
-            whenever(productRestClient.fetchProductVariations(siteModel, productId))
+            whenever(productRestClient.fetchProductVariations(eq(siteModel), eq(productId), any(), any(), any()))
                 .thenReturn(remotePayload)
             whenever(variationMapper.fromWCProductVariationModel(wcVariation)).thenReturn(expectedVariation)
             whenever(selectedSite.get()).thenReturn(siteModel)
@@ -1274,7 +1292,7 @@ class WooPosProductsRemoteDataSourceTest {
             // THEN
             assertThat(result).isNotNull
             assertThat(result?.remoteVariationId).isEqualTo(variationId)
-            verify(productRestClient).fetchProductVariations(siteModel, productId)
+            verify(productRestClient).fetchProductVariations(eq(siteModel), eq(productId), any(), any(), any())
             verify(variationsCache).put(eq(productId), any())
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
@@ -106,6 +106,7 @@ class WooPosSearchProductsDataSourceTest {
                     filterOptions = anyOrNull(),
                     includeTypes = anyOrNull(),
                     searchFields = anyOrNull(),
+                    posProductsOnly = anyOrNull(),
                 )
             ).thenReturn(WooResult(ProductSearchResult(emptyList(), true)))
 
@@ -136,6 +137,7 @@ class WooPosSearchProductsDataSourceTest {
                 filterOptions = anyOrNull(),
                 includeTypes = anyOrNull(),
                 searchFields = anyOrNull(),
+                posProductsOnly = anyOrNull(),
             )
         ).thenReturn(WooResult(error))
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClient.kt
@@ -577,6 +577,7 @@ class ProductRestClient @Inject constructor(
         includeTypes: List<WCProductStore.IncludeType> = emptyList(),
         orderCurrency: String? = null,
         searchFields: List<String>? = null,
+        posProductsOnly: Boolean = false,
     ): WooPayload<List<ProductWithMetaData>> {
         val params = buildProductParametersMap(
             pageSize = pageSize,
@@ -591,7 +592,8 @@ class ProductRestClient @Inject constructor(
             filterOptions = filterOptions,
             includeTypes = includeTypes,
             orderCurrency = orderCurrency,
-            searchFields = searchFields
+            searchFields = searchFields,
+            posProductsOnly = posProductsOnly,
         )
 
         val url = WOOCOMMERCE.products.pathV3
@@ -638,6 +640,7 @@ class ProductRestClient @Inject constructor(
         includeTypes: List<WCProductStore.IncludeType> = emptyList(),
         orderCurrency: String? = null,
         searchFields: List<String>? = null,
+        posProductsOnly: Boolean = false,
     ): MutableMap<String, String> {
         val params = buildBaseParams(pageSize, sortType, offset, includeTypes, orderCurrency)
 
@@ -650,6 +653,9 @@ class ProductRestClient @Inject constructor(
         params.putIfNotEmpty("search_name_or_sku" to searchNameOrSkuQuery)
         if (searchFields != null) {
             params.putIfNotEmpty("search_fields" to searchFields.joinToString(","))
+        }
+        if (posProductsOnly) {
+            params["pos_products_only"] = "true"
         }
 
         return params
@@ -919,7 +925,8 @@ class ProductRestClient @Inject constructor(
         site: SiteModel,
         productId: Long,
         pageSize: Int = DEFAULT_PRODUCT_VARIATIONS_PAGE_SIZE,
-        offset: Int = 0
+        offset: Int = 0,
+        posProductsOnly: Boolean = false,
     ): RemoteProductVariationsPayload {
         val url = WOOCOMMERCE.products.id(productId).variations.pathV3
         val params = mutableMapOf(
@@ -928,6 +935,9 @@ class ProductRestClient @Inject constructor(
             "order" to "asc",
             "orderby" to "menu_order"
         )
+        if (posProductsOnly) {
+            params["pos_products_only"] = "true"
+        }
 
         val response = wooNetwork.executeGetGsonRequest(
             site = site,
@@ -985,6 +995,7 @@ class ProductRestClient @Inject constructor(
         excludedVariationIds: List<Long> = emptyList(),
         filterOptions: Map<WCProductStore.VariationFilterOption, String>? = null,
         orderCurrency: String? = null,
+        posProductsOnly: Boolean = false,
     ): WooPayload<List<WCProductVariationModel>> {
         val params = mutableMapOf(
             "per_page" to pageSize.toString(),
@@ -998,6 +1009,9 @@ class ProductRestClient @Inject constructor(
 
         filterOptions?.let { options ->
             params.putAll(options.map { it.key.toString() to it.value })
+        }
+        if (posProductsOnly) {
+            params["pos_products_only"] = "true"
         }
 
         val url = WOOCOMMERCE.products.id(productId).variations.pathV3

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1684,6 +1684,7 @@ class WCProductStore @Inject internal constructor(
         includeTypes: List<IncludeType> = emptyList(),
         forceRefresh: Boolean = true,
         orderCurrency: String? = null,
+        posProductsOnly: Boolean = false,
     ): WooResult<Boolean> {
         return coroutineEngine.withDefaultContext(API, this, "fetchProducts") {
             val response = wcProductRestClient.fetchProductsWithSyncRequest(
@@ -1696,6 +1697,7 @@ class WCProductStore @Inject internal constructor(
                 filterOptions = filterOptions,
                 includeTypes = includeTypes,
                 orderCurrency = orderCurrency,
+                posProductsOnly = posProductsOnly,
             )
             when {
                 response.isError -> WooResult(response.error)
@@ -1737,6 +1739,7 @@ class WCProductStore @Inject internal constructor(
         sortType: ProductSorting = DEFAULT_PRODUCT_SORTING,
         filterOptions: Map<ProductFilterOption, String> = emptyMap(),
         includeTypes: List<IncludeType> = emptyList(),
+        posProductsOnly: Boolean = false,
     ): WooResult<List<WCProductModel>> {
         return coroutineEngine.withDefaultContext(API, this, "fetchProductsList") {
             val response = wcProductRestClient.fetchProductsWithSyncRequest(
@@ -1746,6 +1749,7 @@ class WCProductStore @Inject internal constructor(
                 filterOptions = filterOptions,
                 includeTypes = includeTypes,
                 sortType = sortType,
+                posProductsOnly = posProductsOnly,
             )
 
             when {
@@ -1764,6 +1768,7 @@ class WCProductStore @Inject internal constructor(
         filterOptions: Map<ProductFilterOption, String> = emptyMap(),
         includeTypes: List<IncludeType> = emptyList(),
         searchFields: List<String>? = null,
+        posProductsOnly: Boolean = false,
     ): WooResult<ProductSearchResult> {
         return coroutineEngine.withDefaultContext(API, this, "searchProductsByNameAndSku") {
             val response = wcProductRestClient.fetchProductsWithSyncRequest(
@@ -1774,7 +1779,8 @@ class WCProductStore @Inject internal constructor(
                 searchNameOrSkuQuery = searchNameOrSkuQuery,
                 filterOptions = filterOptions,
                 includeTypes = includeTypes,
-                searchFields = searchFields
+                searchFields = searchFields,
+                posProductsOnly = posProductsOnly,
             )
             when {
                 response.isError -> WooResult(response.error)


### PR DESCRIPTION
Fixes WOOMOB-1988

Remove `do not merge` label when the target branch is trunk.

### Description
Products hidden from POS were still appearing in the product grid and search results when local catalog was disabled. This PR ensures that the `pos_products_only` filtering is also applied when using the remote sync strategy, so hidden products are properly excluded regardless of the catalog mode.

### Test Steps
1. Use a store with more than 1000 products and variations, or disable local catalog in Menu → Settings → Experimental Features
2. Use Jetpack Beta or similar and switch your store to the bleeding edge version (trunk)
3. Open POS and note a visible product
4. Open that product in WPAdmin → Advanced → Disable 'Show in POS' → Save
5. Pull to refresh in POS product grid
6. Verify the product disappears from the grid
7. Search for the product by name
8. Verify the product does not appear in search results (Note: It currently appears for a bit unless the user leaves the POS mode - considering it's an edge case in code that will be removed in a few months, I wouldn't worry about it.)
9. Open product in WPAdmin → Advanced → Enable 'Show in POS' → Save
10. Pull to refresh in POS product grid
11. Verify the product reappears

### Images/gif
N/A - No UI changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.