### PR TITLE
[WOOMOB-1989] Add posProductsOnly parameter to barcode scanning search

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierGlobalUniqueSearch.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierGlobalUniqueSearch.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.common.data.searchbyidentifier
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosWCProductToWooPosProductModelMapper
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import com.woocommerce.android.util.FeatureFlag
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.API_NOT_FOUND
@@ -33,7 +34,8 @@ class WooPosSearchByIdentifierGlobalUniqueSearch @Inject constructor(
             globalUniqueIdSearchQuery = globalUniqueId,
             offset = 0,
             pageSize = WCProductStore.DEFAULT_PRODUCT_PAGE_SIZE,
-            filterOptions = emptyMap()
+            filterOptions = emptyMap(),
+            posProductsOnly = FeatureFlag.WOO_POS_PRODUCT_VISIBILITY_FILTERING.isEnabled(),
         )
 
         return when {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierGlobalUniqueSearchTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/searchbyidentifier/WooPosSearchByIdentifierGlobalUniqueSearchTest.kt
@@ -67,6 +67,7 @@ class WooPosSearchByIdentifierGlobalUniqueSearchTest {
                     anyOrNull(),
                     anyOrNull(),
                     anyOrNull(),
+                    anyOrNull(),
                 )
             ).thenReturn(result)
 
@@ -91,6 +92,7 @@ class WooPosSearchByIdentifierGlobalUniqueSearchTest {
             val result = WooResult(searchResult)
             whenever(
                 productStore.searchProducts(
+                    anyOrNull(),
                     anyOrNull(),
                     anyOrNull(),
                     anyOrNull(),
@@ -132,6 +134,7 @@ class WooPosSearchByIdentifierGlobalUniqueSearchTest {
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
+                anyOrNull(),
             )
         ).thenReturn(result)
 
@@ -152,6 +155,7 @@ class WooPosSearchByIdentifierGlobalUniqueSearchTest {
         val result: WooResult<WCProductStore.ProductSearchResult> = WooResult(model = null)
         whenever(
             productStore.searchProducts(
+                anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
@@ -198,6 +202,7 @@ class WooPosSearchByIdentifierGlobalUniqueSearchTest {
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
+                anyOrNull(),
             )
         ).thenReturn(result)
 
@@ -232,6 +237,7 @@ class WooPosSearchByIdentifierGlobalUniqueSearchTest {
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
+                anyOrNull(),
             )
         ).thenReturn(result)
 
@@ -256,6 +262,7 @@ class WooPosSearchByIdentifierGlobalUniqueSearchTest {
         val result: WooResult<WCProductStore.ProductSearchResult> = WooResult(error = error)
         whenever(
             productStore.searchProducts(
+                anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
@@ -299,6 +306,7 @@ class WooPosSearchByIdentifierGlobalUniqueSearchTest {
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
+                anyOrNull(),
             )
         ).thenReturn(result)
 
@@ -324,6 +332,7 @@ class WooPosSearchByIdentifierGlobalUniqueSearchTest {
         val result: WooResult<WCProductStore.ProductSearchResult> = WooResult(error = error)
         whenever(
             productStore.searchProducts(
+                anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
@@ -365,6 +374,7 @@ class WooPosSearchByIdentifierGlobalUniqueSearchTest {
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
+                anyOrNull(),
             )
         ).thenReturn(result)
 
@@ -389,6 +399,7 @@ class WooPosSearchByIdentifierGlobalUniqueSearchTest {
         val result: WooResult<WCProductStore.ProductSearchResult> = WooResult(error = error)
         whenever(
             productStore.searchProducts(
+                anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosSearchProductsDataSourceTest.kt
@@ -171,6 +171,7 @@ class WooPosSearchProductsDataSourceTest {
                 includeTypes = anyOrNull(),
                 orderCurrency = anyOrNull(),
                 globalUniqueIdSearchQuery = anyOrNull(),
+                posProductsOnly = anyOrNull(),
             )
         }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCProductStore.kt
@@ -1812,6 +1812,7 @@ class WCProductStore @Inject internal constructor(
         includeTypes: List<IncludeType> = emptyList(),
         orderCurrency: String? = null,
         globalUniqueIdSearchQuery: String? = null,
+        posProductsOnly: Boolean = false,
     ): WooResult<ProductSearchResult> {
         return coroutineEngine.withDefaultContext(API, this, "searchProducts") {
             val response = wcProductRestClient.fetchProductsWithSyncRequest(
@@ -1823,7 +1824,8 @@ class WCProductStore @Inject internal constructor(
                 globalUniqueIdSearchQuery = globalUniqueIdSearchQuery,
                 filterOptions = filterOptions,
                 includeTypes = includeTypes,
-                orderCurrency = orderCurrency
+                orderCurrency = orderCurrency,
+                posProductsOnly = posProductsOnly,
             )
             when {
                 response.isError -> WooResult(response.error)


### PR DESCRIPTION
Fixes WOOMOB-1989

Remove `do not merge` label when the target branch is trunk.

### Description
Barcode scanning in POS without local catalog was returning products marked as hidden in POS. While the regular product sync and name/SKU search correctly pass the `pos_products_only` flag to the API, the barcode scanning search (global unique ID search) was missing this parameter.

This PR adds the `posProductsOnly` parameter to `WCProductStore.searchProducts()` and passes it from `WooPosSearchByIdentifierGlobalUniqueSearch` when the feature flag is enabled.

### Test Steps
1. Use a store with more than 1000 products and variations, or disable local catalog in Menu → Settings → Experimental Features
2. Use Jetpack Beta or similar and switch your store to the bleeding edge version (trunk)
2. Have a product with a barcode that is hidden from POS
3. Open POS and scan the product's barcode
4. Verify the product is NOT found (previously it would be added to cart)
5. Have a product with a barcode that is visible in POS
6. Scan that product's barcode
7. Verify it IS found and added to cart

### Images/gif
N/A - No UI changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.