### PR TITLE
Refresh selected order after refund dialog is dismissed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -227,6 +227,7 @@ class WooPosOrdersViewModel @Inject constructor(
         _state.value = currentState.copy(
             dialogState = WooPosOrdersState.Content.DialogState.Hidden
         )
+        refreshSelectedOrder()
     }
 
     fun onOrdersEmptyActionClicked() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -1267,34 +1267,4 @@ class WooPosOrdersViewModelTest {
         assertThat(state.selectedDetails?.id).isEqualTo(200L)
         verify(dataSource).refreshOrderById(200L)
     }
-
-    @Test
-    fun `given refund dialog dismissed, when refresh fails, then dialog is hidden and details remain unchanged`() = runTest {
-        // GIVEN
-        whenever(dataSource.loadOrders()).thenReturn(
-            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1), order(2)))) }
-        )
-        viewModel = createViewModel()
-        advanceUntilIdle()
-
-        viewModel.onOrderSelected(1L)
-        advanceUntilIdle()
-
-        viewModel.onIssueRefundButtonClicked(1L)
-        advanceUntilIdle()
-
-        val beforeDetails = (viewModel.state.value as WooPosOrdersState.Content).selectedDetails
-
-        whenever(dataSource.refreshOrderById(1L)).thenReturn(Result.failure(RuntimeException("boom")))
-
-        // WHEN
-        viewModel.onIssueRefundDialogDismissed()
-        advanceUntilIdle()
-
-        // THEN
-        val after = viewModel.state.value as WooPosOrdersState.Content
-        assertThat(after.dialogState).isEqualTo(WooPosOrdersState.Content.DialogState.Hidden)
-        assertThat(after.selectedDetails).isEqualTo(beforeDetails)
-        verify(dataSource).refreshOrderById(1L)
-    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -1239,4 +1239,62 @@ class WooPosOrdersViewModelTest {
         assertThat(details.actions).noneMatch { it is WooPosOrdersState.OrderAction.IssueRefund }
         assertThat(details.actions).anyMatch { it is WooPosOrdersState.OrderAction.EmailReceipt }
     }
+
+    @Test
+    fun `when refund dialog is dismissed, then refreshes selected order`() = runTest {
+        // GIVEN
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(100), order(200)))) }
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onOrderSelected(200L)
+        advanceUntilIdle()
+
+        viewModel.onIssueRefundButtonClicked(200L)
+        advanceUntilIdle()
+
+        whenever(dataSource.refreshOrderById(200L)).thenReturn(Result.success(order(200)))
+
+        // WHEN
+        viewModel.onIssueRefundDialogDismissed()
+        advanceUntilIdle()
+
+        // THEN
+        val state = viewModel.state.value as WooPosOrdersState.Content
+        assertThat(state.dialogState).isEqualTo(WooPosOrdersState.Content.DialogState.Hidden)
+        assertThat(state.selectedDetails?.id).isEqualTo(200L)
+        verify(dataSource).refreshOrderById(200L)
+    }
+
+    @Test
+    fun `given refund dialog dismissed, when refresh fails, then dialog is hidden and details remain unchanged`() = runTest {
+        // GIVEN
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1), order(2)))) }
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onOrderSelected(1L)
+        advanceUntilIdle()
+
+        viewModel.onIssueRefundButtonClicked(1L)
+        advanceUntilIdle()
+
+        val beforeDetails = (viewModel.state.value as WooPosOrdersState.Content).selectedDetails
+
+        whenever(dataSource.refreshOrderById(1L)).thenReturn(Result.failure(RuntimeException("boom")))
+
+        // WHEN
+        viewModel.onIssueRefundDialogDismissed()
+        advanceUntilIdle()
+
+        // THEN
+        val after = viewModel.state.value as WooPosOrdersState.Content
+        assertThat(after.dialogState).isEqualTo(WooPosOrdersState.Content.DialogState.Hidden)
+        assertThat(after.selectedDetails).isEqualTo(beforeDetails)
+        verify(dataSource).refreshOrderById(1L)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-1955

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
After creating a refund in WooPos Orders, the selected order was not being refreshed when the refund dialog was dismissed. This meant the order details shown to the user didn't reflect the newly created refund, requiring manual refresh or reselection to see the updated state.

This PR adds a call to `refreshSelectedOrder()` when the refund dialog is dismissed, ensuring the order details are automatically updated to reflect the refund that was just created.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
  1. Open WooPos and navigate to Orders
  2. Select an order that can be refunded
  3. Tap "Issue Refund" button
  4. Complete the refund creation process
  5. Dismiss the refund dialog
  6. Verify that the order details automatically refresh and display the newly created refund

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
—

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
