### PR TITLE
Give Claude CI step a shorter name to fix canvas

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -143,7 +143,7 @@ steps:
   - wait: ~
     continue_on_failure: true
 
-  - label: ":claude: 🕵️ Check for Build Failures and Run Claude Analysis"
+  - label: ":claude: 🕵️ Build Analysis"
     command: |
       source .buildkite/shared-pipeline-vars
       buildkite-agent pipeline upload .buildkite/claude-analysis.yml


### PR DESCRIPTION

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Working on https://github.com/woocommerce/woocommerce-android/pull/15197 I noticed the build analysis step label is much longer than all the others and also gets cropped

Before:

<img width="3378" height="1154" alt="image" src="https://github.com/user-attachments/assets/562ae24b-e906-4d6d-ae4f-807ac6c3e42f" />

After:

<img width="1625" height="606" alt="image" src="https://github.com/user-attachments/assets/6834264b-04bb-4114-a56f-6dd0379895cf" />


This PR propose as shorter name, just so the Buildkite canvas looks neat.

I appreciated this is my personal sensibility, feel free to reject or edit if it doesn't seem worthy.
