### PR TITLE
[WOOMOB-1992] Optimize SQL queries in WooPosLocalCatalogStore

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 24.0
 -----
+- [Internal][Woo POS] Optimize SQL queries for batch deletion in local catalog store [https://github.com/woocommerce/woocommerce-android/pull/15199]
 - [Internal][Woo POS] Apply POS product visibility filtering to remote/non-local-catalog sync [https://github.com/woocommerce/woocommerce-android/pull/15191]
 - [Internal][Woo POS] Remove products hidden from POS during local catalog sync [https://github.com/woocommerce/woocommerce-android/pull/15190]
 - [Internal] Show JITMs on Dashboard regardless of onboarding status [https://github.com/woocommerce/woocommerce-android/pull/15170]

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
@@ -36,9 +36,6 @@ abstract class WooPosProductsDao {
     @Upsert
     abstract suspend fun upsertProducts(products: List<WooPosProductEntity>)
 
-    @Query("DELETE FROM PosProductEntity WHERE localSiteId = :localSiteId AND remoteId = :remoteId")
-    abstract suspend fun deleteProduct(localSiteId: LocalId, remoteId: RemoteId)
-
     @Query("DELETE FROM PosProductEntity WHERE localSiteId = :localSiteId AND remoteId IN (:remoteIds)")
     abstract suspend fun deleteProducts(localSiteId: LocalId, remoteIds: List<RemoteId>)
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
@@ -39,6 +39,9 @@ abstract class WooPosProductsDao {
     @Query("DELETE FROM PosProductEntity WHERE localSiteId = :localSiteId AND remoteId = :remoteId")
     abstract suspend fun deleteProduct(localSiteId: LocalId, remoteId: RemoteId)
 
+    @Query("DELETE FROM PosProductEntity WHERE localSiteId = :localSiteId AND remoteId IN (:remoteIds)")
+    abstract suspend fun deleteProducts(localSiteId: LocalId, remoteIds: List<RemoteId>)
+
     @Query("DELETE FROM PosProductEntity WHERE localSiteId = :localSiteId")
     abstract suspend fun deleteAllProductsForSite(localSiteId: LocalId)
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
@@ -47,8 +47,14 @@ abstract class WooPosVariationsDao {
     @Query("DELETE FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId AND remoteVariationId = :variationId")
     abstract suspend fun deleteVariation(localSiteId: LocalId, productId: RemoteId, variationId: RemoteId)
 
+    @Query("DELETE FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteVariationId IN (:variationIds)")
+    abstract suspend fun deleteVariationsByIds(localSiteId: LocalId, variationIds: List<RemoteId>)
+
     @Query("DELETE FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId")
     abstract suspend fun deleteVariationsForProduct(localSiteId: LocalId, productId: RemoteId)
+
+    @Query("DELETE FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId IN (:productIds)")
+    abstract suspend fun deleteVariationsForProducts(localSiteId: LocalId, productIds: List<RemoteId>)
 
     @Query("DELETE FROM PosVariationEntity WHERE localSiteId = :localSiteId")
     abstract suspend fun deleteAllVariationsForSite(localSiteId: LocalId)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDao.kt
@@ -44,14 +44,8 @@ abstract class WooPosVariationsDao {
     @Upsert
     abstract suspend fun upsertVariation(variation: WooPosVariationEntity)
 
-    @Query("DELETE FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId AND remoteVariationId = :variationId")
-    abstract suspend fun deleteVariation(localSiteId: LocalId, productId: RemoteId, variationId: RemoteId)
-
     @Query("DELETE FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteVariationId IN (:variationIds)")
     abstract suspend fun deleteVariationsByIds(localSiteId: LocalId, variationIds: List<RemoteId>)
-
-    @Query("DELETE FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId = :productId")
-    abstract suspend fun deleteVariationsForProduct(localSiteId: LocalId, productId: RemoteId)
 
     @Query("DELETE FROM PosVariationEntity WHERE localSiteId = :localSiteId AND remoteProductId IN (:productIds)")
     abstract suspend fun deleteVariationsForProducts(localSiteId: LocalId, productIds: List<RemoteId>)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -306,10 +306,8 @@ class WooPosLocalCatalogStore @Inject constructor(
     ): Result<Unit> =
         runCatching {
             database.executeInTransaction {
-                productIds.forEach { remoteId ->
-                    posProductDao.deleteProduct(siteId, remoteId)
-                    posVariationsDao.deleteVariationsForProduct(siteId, remoteId)
-                }
+                posProductDao.deleteProducts(siteId, productIds)
+                posVariationsDao.deleteVariationsForProducts(siteId, productIds)
             }
         }
 
@@ -318,11 +316,8 @@ class WooPosLocalCatalogStore @Inject constructor(
         variations: List<Pair<LocalOrRemoteId.RemoteId, LocalOrRemoteId.RemoteId>>
     ): Result<Unit> =
         runCatching {
-            database.executeInTransaction {
-                variations.forEach { (productId, variationId) ->
-                    posVariationsDao.deleteVariation(siteId, productId, variationId)
-                }
-            }
+            val variationIds = variations.map { it.second }
+            posVariationsDao.deleteVariationsByIds(siteId, variationIds)
         }
 
     suspend fun upsertVariations(variations: List<WooPosVariationEntity>): Result<Unit> =

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -316,8 +316,10 @@ class WooPosLocalCatalogStore @Inject constructor(
         variations: List<Pair<LocalOrRemoteId.RemoteId, LocalOrRemoteId.RemoteId>>
     ): Result<Unit> =
         runCatching {
-            val variationIds = variations.map { it.second }
-            posVariationsDao.deleteVariationsByIds(siteId, variationIds)
+            database.executeInTransaction {
+                val variationIds = variations.map { it.second }
+                posVariationsDao.deleteVariationsByIds(siteId, variationIds)
+            }
         }
 
     suspend fun upsertVariations(variations: List<WooPosVariationEntity>): Result<Unit> =

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDaoTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDaoTest.kt
@@ -181,6 +181,69 @@ class WooPosProductsDaoTest {
     }
 
     @Test
+    fun `given multiple products, when batch deleting products, then all specified products are removed`() = runTest {
+        // GIVEN
+        val products = listOf(
+            generatePosProduct(remoteId = 100L),
+            generatePosProduct(remoteId = 101L),
+            generatePosProduct(remoteId = 102L),
+            generatePosProduct(remoteId = 103L)
+        )
+        sut.upsertProducts(products)
+
+        // WHEN
+        sut.deleteProducts(LocalId(1), listOf(RemoteId(100L), RemoteId(102L)))
+
+        // THEN
+        val remainingProducts = sut.observeAllProducts(LocalId(1)).first()
+        assertEquals(2, remainingProducts.size)
+        assertTrue(remainingProducts.any { it.remoteId.value == 101L })
+        assertTrue(remainingProducts.any { it.remoteId.value == 103L })
+        assertTrue(remainingProducts.none { it.remoteId.value == 100L })
+        assertTrue(remainingProducts.none { it.remoteId.value == 102L })
+    }
+
+    @Test
+    fun `when batch deleting with empty list, then no products are removed`() = runTest {
+        // GIVEN
+        val products = listOf(
+            generatePosProduct(remoteId = 100L),
+            generatePosProduct(remoteId = 101L)
+        )
+        sut.upsertProducts(products)
+
+        // WHEN
+        sut.deleteProducts(LocalId(1), emptyList())
+
+        // THEN
+        val remainingProducts = sut.observeAllProducts(LocalId(1)).first()
+        assertEquals(2, remainingProducts.size)
+    }
+
+    @Test
+    fun `given products from multiple sites, when batch deleting for one site, then only that site products are removed`() = runTest {
+        // GIVEN
+        val site1Products = listOf(
+            generatePosProduct(siteId = 1, remoteId = 100L),
+            generatePosProduct(siteId = 1, remoteId = 101L)
+        )
+        val site2Products = listOf(
+            generatePosProduct(siteId = 2, remoteId = 100L),
+            generatePosProduct(siteId = 2, remoteId = 101L)
+        )
+        sut.upsertProducts(site1Products + site2Products)
+
+        // WHEN
+        sut.deleteProducts(LocalId(1), listOf(RemoteId(100L), RemoteId(101L)))
+
+        // THEN
+        val site1Results = sut.observeAllProducts(LocalId(1)).first()
+        val site2Results = sut.observeAllProducts(LocalId(2)).first()
+        assertTrue(site1Results.isEmpty())
+        assertEquals(2, site2Results.size)
+    }
+
+    @Test
     fun `when observing products, then flow emits current products`() = runTest {
         // GIVEN
         val products = listOf(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDaoTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDaoTest.kt
@@ -140,47 +140,6 @@ class WooPosProductsDaoTest {
     }
 
     @Test
-    fun `given existing product, when deleting product, then product is removed`() = runTest {
-        // GIVEN
-        val product = generatePosProduct(remoteId = 100L)
-        sut.upsertProducts(listOf(product))
-
-        // WHEN
-        sut.deleteProduct(product.localSiteId, product.remoteId)
-
-        // THEN
-        val result = sut.getProduct(product.localSiteId, product.remoteId)
-        assertNull(result)
-    }
-
-    @Test
-    fun `given multiple products, when deleting one product, then only that product is removed`() = runTest {
-        // GIVEN
-        val products = listOf(
-            generatePosProduct(remoteId = 100L),
-            generatePosProduct(remoteId = 101L),
-            generatePosProduct(remoteId = 102L)
-        )
-        sut.upsertProducts(products)
-
-        // WHEN
-        sut.deleteProduct(products.first().localSiteId, RemoteId(101L))
-
-        // THEN
-        val remainingProducts = sut.observeAllProducts(products.first().localSiteId).first()
-        assertEquals(2, remainingProducts.size)
-        assertTrue(remainingProducts.any { it.remoteId.value == 100L })
-        assertTrue(remainingProducts.any { it.remoteId.value == 102L })
-        assertTrue(remainingProducts.none { it.remoteId.value == 101L })
-    }
-
-    @Test
-    fun `when deleting non-existent product, then no error occurs`() = runTest {
-        // WHEN & THEN - Should not throw exception
-        sut.deleteProduct(LocalId(1), RemoteId(999L))
-    }
-
-    @Test
     fun `given multiple products, when batch deleting products, then all specified products are removed`() = runTest {
         // GIVEN
         val products = listOf(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDaoTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDaoTest.kt
@@ -183,92 +183,6 @@ class WooPosVariationsDaoTest {
     }
 
     @Test
-    fun `given existing variation, when deleting variation, then variation is removed`() = runTest {
-        // GIVEN
-        val variation = generatePosVariation(productId = 100L, variationId = 1001L)
-        sut.upsertVariation(variation)
-
-        // WHEN
-        sut.deleteVariation(
-            variation.localSiteId,
-            variation.remoteProductId,
-            variation.remoteVariationId
-        )
-
-        // THEN
-        val result = sut.getVariation(
-            variation.localSiteId.value,
-            variation.remoteProductId.value,
-            variation.remoteVariationId.value
-        )
-        assertNull(result)
-    }
-
-    @Test
-    fun `given multiple variations for product, when deleting one variation, then only that variation is removed`() = runTest {
-        // GIVEN
-        val productId = 100L
-        val variations = listOf(
-            generatePosVariation(productId = productId, variationId = 1001L),
-            generatePosVariation(productId = productId, variationId = 1002L),
-            generatePosVariation(productId = productId, variationId = 1003L)
-        )
-        sut.upsertVariations(variations)
-
-        // WHEN
-        sut.deleteVariation(LocalId(1), RemoteId(productId), RemoteId(1002L))
-
-        // THEN
-        val remainingVariations = sut.observeVariationsForProduct(1, productId).first()
-        assertEquals(2, remainingVariations.size)
-        assertTrue(remainingVariations.any { it.remoteVariationId.value == 1001L })
-        assertTrue(remainingVariations.any { it.remoteVariationId.value == 1003L })
-        assertTrue(remainingVariations.none { it.remoteVariationId.value == 1002L })
-    }
-
-    @Test
-    fun `given variations for product, when deleting all product variations, then all are removed`() = runTest {
-        // GIVEN
-        val productId = 100L
-        val variations = listOf(
-            generatePosVariation(productId = productId, variationId = 1001L),
-            generatePosVariation(productId = productId, variationId = 1002L),
-            generatePosVariation(productId = productId, variationId = 1003L)
-        )
-        sut.upsertVariations(variations)
-
-        // WHEN
-        sut.deleteVariationsForProduct(LocalId(1), RemoteId(productId))
-
-        // THEN
-        val remainingVariations = sut.observeVariationsForProduct(1, productId).first()
-        assertTrue(remainingVariations.isEmpty())
-    }
-
-    @Test
-    fun `given variations for multiple products, when deleting one product variations, then only those are removed`() = runTest {
-        // GIVEN
-        val product1Variations = listOf(
-            generatePosVariation(productId = 100L, variationId = 1001L),
-            generatePosVariation(productId = 100L, variationId = 1002L)
-        )
-        val product2Variations = listOf(
-            generatePosVariation(productId = 200L, variationId = 2001L),
-            generatePosVariation(productId = 200L, variationId = 2002L)
-        )
-        sut.upsertVariations(product1Variations + product2Variations)
-
-        // WHEN
-        sut.deleteVariationsForProduct(LocalId(1), RemoteId(100L))
-
-        // THEN
-        val product1Results = sut.observeVariationsForProduct(1, 100L).first()
-        val product2Results = sut.observeVariationsForProduct(1, 200L).first()
-        assertTrue(product1Results.isEmpty())
-        assertEquals(2, product2Results.size)
-    }
-
-    @Test
     fun `given variations for site, when deleting all site variations, then all are removed`() = runTest {
         // GIVEN
         val variations = listOf(
@@ -286,12 +200,6 @@ class WooPosVariationsDaoTest {
         val product2Results = sut.observeVariationsForProduct(1, 200L).first()
         assertTrue(product1Results.isEmpty())
         assertTrue(product2Results.isEmpty())
-    }
-
-    @Test
-    fun `when deleting non-existent variation, then no error occurs`() = runTest {
-        // WHEN & THEN - Should not throw exception
-        sut.deleteVariation(LocalId(1), RemoteId(100L), RemoteId(999L))
     }
 
     @Test

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDaoTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/dao/pos/WooPosVariationsDaoTest.kt
@@ -295,6 +295,120 @@ class WooPosVariationsDaoTest {
     }
 
     @Test
+    fun `given multiple variations, when batch deleting by ids, then all specified variations are removed`() = runTest {
+        // GIVEN
+        val productId = 100L
+        val variations = listOf(
+            generatePosVariation(productId = productId, variationId = 1001L),
+            generatePosVariation(productId = productId, variationId = 1002L),
+            generatePosVariation(productId = productId, variationId = 1003L),
+            generatePosVariation(productId = productId, variationId = 1004L)
+        )
+        sut.upsertVariations(variations)
+
+        // WHEN
+        sut.deleteVariationsByIds(LocalId(1), listOf(RemoteId(1001L), RemoteId(1003L)))
+
+        // THEN
+        val remainingVariations = sut.observeVariationsForProduct(1, productId).first()
+        assertEquals(2, remainingVariations.size)
+        assertTrue(remainingVariations.any { it.remoteVariationId.value == 1002L })
+        assertTrue(remainingVariations.any { it.remoteVariationId.value == 1004L })
+        assertTrue(remainingVariations.none { it.remoteVariationId.value == 1001L })
+        assertTrue(remainingVariations.none { it.remoteVariationId.value == 1003L })
+    }
+
+    @Test
+    fun `when batch deleting variations with empty list, then no variations are removed`() = runTest {
+        // GIVEN
+        val productId = 100L
+        val variations = listOf(
+            generatePosVariation(productId = productId, variationId = 1001L),
+            generatePosVariation(productId = productId, variationId = 1002L)
+        )
+        sut.upsertVariations(variations)
+
+        // WHEN
+        sut.deleteVariationsByIds(LocalId(1), emptyList())
+
+        // THEN
+        val remainingVariations = sut.observeVariationsForProduct(1, productId).first()
+        assertEquals(2, remainingVariations.size)
+    }
+
+    @Test
+    fun `given variations from multiple sites, when batch deleting by ids for one site, then only that site variations are removed`() = runTest {
+        // GIVEN
+        val productId = 100L
+        val site1Variations = listOf(
+            generatePosVariation(siteId = 1, productId = productId, variationId = 1001L),
+            generatePosVariation(siteId = 1, productId = productId, variationId = 1002L)
+        )
+        val site2Variations = listOf(
+            generatePosVariation(siteId = 2, productId = productId, variationId = 1001L),
+            generatePosVariation(siteId = 2, productId = productId, variationId = 1002L)
+        )
+        sut.upsertVariations(site1Variations + site2Variations)
+
+        // WHEN
+        sut.deleteVariationsByIds(LocalId(1), listOf(RemoteId(1001L), RemoteId(1002L)))
+
+        // THEN
+        val site1Results = sut.observeVariationsForProduct(1, productId).first()
+        val site2Results = sut.observeVariationsForProduct(2, productId).first()
+        assertTrue(site1Results.isEmpty())
+        assertEquals(2, site2Results.size)
+    }
+
+    @Test
+    fun `given variations for multiple products, when batch deleting for products, then all variations for those products are removed`() = runTest {
+        // GIVEN
+        val product1Variations = listOf(
+            generatePosVariation(productId = 100L, variationId = 1001L),
+            generatePosVariation(productId = 100L, variationId = 1002L)
+        )
+        val product2Variations = listOf(
+            generatePosVariation(productId = 200L, variationId = 2001L),
+            generatePosVariation(productId = 200L, variationId = 2002L)
+        )
+        val product3Variations = listOf(
+            generatePosVariation(productId = 300L, variationId = 3001L),
+            generatePosVariation(productId = 300L, variationId = 3002L)
+        )
+        sut.upsertVariations(product1Variations + product2Variations + product3Variations)
+
+        // WHEN
+        sut.deleteVariationsForProducts(LocalId(1), listOf(RemoteId(100L), RemoteId(300L)))
+
+        // THEN
+        val product1Results = sut.observeVariationsForProduct(1, 100L).first()
+        val product2Results = sut.observeVariationsForProduct(1, 200L).first()
+        val product3Results = sut.observeVariationsForProduct(1, 300L).first()
+        assertTrue(product1Results.isEmpty())
+        assertEquals(2, product2Results.size)
+        assertTrue(product3Results.isEmpty())
+    }
+
+    @Test
+    fun `when batch deleting variations for products with empty list, then no variations are removed`() = runTest {
+        // GIVEN
+        val variations = listOf(
+            generatePosVariation(productId = 100L, variationId = 1001L),
+            generatePosVariation(productId = 200L, variationId = 2001L)
+        )
+        sut.upsertVariations(variations)
+
+        // WHEN
+        sut.deleteVariationsForProducts(LocalId(1), emptyList())
+
+        // THEN
+        val product1Results = sut.observeVariationsForProduct(1, 100L).first()
+        val product2Results = sut.observeVariationsForProduct(1, 200L).first()
+        assertEquals(1, product1Results.size)
+        assertEquals(1, product2Results.size)
+    }
+
+    @Test
     fun `when observing variations for product, then flow emits current variations`() = runTest {
         // GIVEN
         val productId = 100L


### PR DESCRIPTION
Fixes WOOMOB-1992

### Description
Optimized batch deletion operations in `WooPosLocalCatalogStore` by replacing N individual SQL queries with single batch queries using `IN` clauses.

**Performance improvement:**
| Method | Before | After |
|--------|--------|-------|
| `deleteProducts(N items)` | 2N queries | 2 queries |
| `deleteVariations(N items)` | N queries | 1 query |

### Test Steps
1. Open POS and note the variable products
2. In WP Admin, mark the variable product as invisible in POS (in Advanced tab)
3. Pull to refresh in the POS product list
4. Verify the product and its variations are removed from the list

### Images/gif
N/A - Internal optimization with no UI changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.