### PR TITLE
Ignore `MPAndroidChart` in Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,4 @@ updates:
       - dependency-name: "commons-fileupload:commons-fileupload"
       - dependency-name: "org.wordpress:wellsql"
       - dependency-name: "org.wordpress.wellsql:wellsql-processor"
+      - dependency-name: "com.github.PhilJay:MPAndroidChart"


### PR DESCRIPTION
Fixes `The following private package registry was used and caused the update to fail: https://jitpack.io.`

This is maybe blocking other update PRs from creation. Internal discussion: p1768481900806949-slack-C6H8C3G23

### History of recent Dependabot jobs 
<img width="704" height="629" alt="Screenshot 2026-01-15 at 14 50 46" src="https://github.com/user-attachments/assets/7f32c62f-85dc-494f-8c2b-0873509bd224" />

### Error details
<img width="947" height="248" alt="Screenshot 2026-01-15 at 14 48 55" src="https://github.com/user-attachments/assets/bfb9d8c2-46ea-4d42-9821-b4ca0929f82d" />