### PR TITLE
[WOOMOB-2003] Hide non-POS products from popular items in search

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProvider.kt
@@ -39,6 +39,7 @@ class WooPosPopularProductsProvider @Inject constructor(
             filterOptions = productsTypesFilterConfig.filters,
             includeTypes = productsTypesFilterConfig.includeTypes,
             sortType = ProductSorting.POPULARITY_DESC,
+            posProductsOnly = true,
         )
 
         return if (result.isError) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosPopularProductsProviderTest.kt
@@ -68,7 +68,8 @@ class WooPosPopularProductsProviderTest {
                 pageSize = 10,
                 filterOptions = emptyMap(),
                 includeTypes = emptyList(),
-                sortType = ProductSorting.POPULARITY_DESC
+                sortType = ProductSorting.POPULARITY_DESC,
+                posProductsOnly = true
             )
         ).thenReturn(successResult)
 
@@ -93,7 +94,8 @@ class WooPosPopularProductsProviderTest {
                 pageSize = 10,
                 filterOptions = emptyMap(),
                 includeTypes = emptyList(),
-                sortType = ProductSorting.POPULARITY_DESC
+                sortType = ProductSorting.POPULARITY_DESC,
+                posProductsOnly = true
             )
         ).thenReturn(successResult)
 
@@ -124,7 +126,8 @@ class WooPosPopularProductsProviderTest {
                 pageSize = 10,
                 filterOptions = emptyMap(),
                 includeTypes = emptyList(),
-                sortType = ProductSorting.POPULARITY_DESC
+                sortType = ProductSorting.POPULARITY_DESC,
+                posProductsOnly = true
             )
         ).thenReturn(errorResult)
 
@@ -151,7 +154,8 @@ class WooPosPopularProductsProviderTest {
                     pageSize = 10,
                     filterOptions = emptyMap(),
                     includeTypes = emptyList(),
-                    sortType = ProductSorting.POPULARITY_DESC
+                    sortType = ProductSorting.POPULARITY_DESC,
+                    posProductsOnly = true
                 )
             ).thenReturn(successResult)
 
@@ -177,7 +181,8 @@ class WooPosPopularProductsProviderTest {
                     pageSize = 10,
                     filterOptions = emptyMap(),
                     includeTypes = emptyList(),
-                    sortType = ProductSorting.POPULARITY_DESC
+                    sortType = ProductSorting.POPULARITY_DESC,
+                    posProductsOnly = true
                 )
             ).thenReturn(emptyResult)
 


### PR DESCRIPTION
Fixes WOOMOB-2003

### Description
Popular products in the POS search screen were not respecting the POS visibility filter, causing products marked as hidden from POS to still appear in the popular items section. This fix adds `posProductsOnly = true` to the popular products fetch, ensuring only POS-visible products are shown.

### Test Steps
1. Mark some popular products as hidden from POS in WooCommerce admin
2. Open POS and navigate to the search screen (without typing anything)
3. Verify the hidden products do not appear in the "Popular items" section

### Images/gif
N/A - No visual changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary.