### PR TITLE
Fix notification displaying issues

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
@@ -10,7 +10,6 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.os.RemoteException
-import android.service.notification.StatusBarNotification
 import androidx.annotation.RequiresPermission
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -42,9 +41,19 @@ class WooNotificationBuilder @Inject constructor(
 
     fun cancelAllNotifications() = NotificationManagerCompat.from(context).cancelAll()
 
-    fun getActiveNotifications(): List<StatusBarNotification> {
+    fun getActiveNotifications(): List<ActiveNotificationData> {
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        return notificationManager.activeNotifications.toList()
+        return notificationManager.activeNotifications.map { sbn ->
+            ActiveNotificationData(
+                id = sbn.id,
+                remoteNoteId = sbn.notification.extras.getLong(EXTRA_REMOTE_NOTE_ID),
+                remoteSiteId = sbn.notification.extras.getLong(EXTRA_REMOTE_SITE_ID),
+                channelType = sbn.notification.extras.getString(EXTRA_CHANNEL_TYPE),
+                noteMessage = sbn.notification.extras.getString(EXTRA_NOTE_MESSAGE),
+                noteTypeTrackingValue = sbn.notification.extras.getString(EXTRA_NOTE_TYPE),
+                isGroupSummary = (sbn.notification.flags and FLAG_GROUP_SUMMARY) != 0
+            )
+        }
     }
 
     private fun getNotificationBuilder(
@@ -250,21 +259,6 @@ class WooNotificationBuilder @Inject constructor(
         }
     }
 
-    val StatusBarNotification.remoteNoteId: Long
-        get() = notification.extras.getLong(EXTRA_REMOTE_NOTE_ID)
-
-    val StatusBarNotification.remoteSiteId: Long
-        get() = notification.extras.getLong(EXTRA_REMOTE_SITE_ID)
-
-    val StatusBarNotification.channelType: String?
-        get() = notification.extras.getString(EXTRA_CHANNEL_TYPE)
-
-    val StatusBarNotification.noteMessage: String?
-        get() = notification.extras.getString(EXTRA_NOTE_MESSAGE)
-
-    val StatusBarNotification.noteTypeTrackingValue: String?
-        get() = notification.extras.getString(EXTRA_NOTE_TYPE)
-
     companion object {
         private const val EXTRA_REMOTE_NOTE_ID = "remote_note_id"
         private const val EXTRA_REMOTE_SITE_ID = "remote_site_id"
@@ -273,3 +267,13 @@ class WooNotificationBuilder @Inject constructor(
         private const val EXTRA_NOTE_TYPE = "note_type"
     }
 }
+
+data class ActiveNotificationData(
+    val id: Int,
+    val remoteNoteId: Long,
+    val remoteSiteId: Long,
+    val channelType: String?,
+    val noteMessage: String?,
+    val noteTypeTrackingValue: String?,
+    val isGroupSummary: Boolean = false
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
@@ -2,11 +2,15 @@ package com.woocommerce.android.notifications
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.Notification.FLAG_GROUP_SUMMARY
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
+import android.os.Bundle
 import android.os.RemoteException
+import android.service.notification.StatusBarNotification
 import androidx.annotation.RequiresPermission
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -38,6 +42,11 @@ class WooNotificationBuilder @Inject constructor(
 
     fun cancelAllNotifications() = NotificationManagerCompat.from(context).cancelAll()
 
+    fun getActiveNotifications(): List<StatusBarNotification> {
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        return notificationManager.activeNotifications.toList()
+    }
+
     private fun getNotificationBuilder(
         notification: Notification
     ): NotificationCompat.Builder {
@@ -47,7 +56,6 @@ class WooNotificationBuilder @Inject constructor(
             .setSmallIcon(R.drawable.ic_woo_w_notification)
             .setColor(ContextCompat.getColor(context, R.color.color_primary))
             .setOnlyAlertOnce(true)
-            .setAutoCancel(true)
             .setCategory(NotificationCompat.CATEGORY_SOCIAL)
             .setGroup(notification.getGroup())
             .setContentTitle(notification.noteTitle)
@@ -127,15 +135,10 @@ class WooNotificationBuilder @Inject constructor(
     fun buildAndDisplayWooGroupNotification(
         inboxMessage: String,
         subject: String,
-        summaryText: String?,
         notification: Notification
     ) {
         val inboxStyle = NotificationCompat.InboxStyle().addLine(inboxMessage)
         val channelId = with(notificationChannelsHandler) { notification.channelType.getChannelId() }
-
-        summaryText?.let {
-            inboxStyle.setSummaryText(summaryText)
-        }
 
         NotificationCompat.Builder(context, channelId)
             .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
@@ -143,7 +146,6 @@ class WooNotificationBuilder @Inject constructor(
             .setColor(ContextCompat.getColor(context, R.color.color_primary))
             .setGroup(notification.getGroup())
             .setGroupSummary(true)
-            .setAutoCancel(true)
             .setTicker(notification.noteMessage)
             .setContentTitle(notification.noteTitle)
             .setContentText(subject)
@@ -165,7 +167,16 @@ class WooNotificationBuilder @Inject constructor(
         builder: NotificationCompat.Builder
     ) {
         try {
-            // Call processing service when notification is dismissed
+            builder.addExtras(
+                Bundle().apply {
+                    putLong(EXTRA_REMOTE_NOTE_ID, notification.remoteNoteId)
+                    putLong(EXTRA_REMOTE_SITE_ID, notification.remoteSiteId)
+                    putString(EXTRA_CHANNEL_TYPE, notification.channelType.name)
+                    putString(EXTRA_NOTE_MESSAGE, notification.noteMessage)
+                    putString(EXTRA_NOTE_TYPE, notification.noteType.trackingValue)
+                }
+            )
+
             val pendingDeleteIntent = NotificationsProcessingService.getPendingIntentForPushNotificationDismiss(
                 context,
                 pushId
@@ -237,5 +248,28 @@ class WooNotificationBuilder @Inject constructor(
                 null
             }
         }
+    }
+
+    val StatusBarNotification.remoteNoteId: Long
+        get() = notification.extras.getLong(EXTRA_REMOTE_NOTE_ID)
+
+    val StatusBarNotification.remoteSiteId: Long
+        get() = notification.extras.getLong(EXTRA_REMOTE_SITE_ID)
+
+    val StatusBarNotification.channelType: String?
+        get() = notification.extras.getString(EXTRA_CHANNEL_TYPE)
+
+    val StatusBarNotification.noteMessage: String?
+        get() = notification.extras.getString(EXTRA_NOTE_MESSAGE)
+
+    val StatusBarNotification.noteTypeTrackingValue: String?
+        get() = notification.extras.getString(EXTRA_NOTE_TYPE)
+
+    companion object {
+        private const val EXTRA_REMOTE_NOTE_ID = "remote_note_id"
+        private const val EXTRA_REMOTE_SITE_ID = "remote_site_id"
+        private const val EXTRA_CHANNEL_TYPE = "channel_type"
+        private const val EXTRA_NOTE_MESSAGE = "note_message"
+        private const val EXTRA_NOTE_TYPE = "note_type"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -34,7 +34,7 @@ class NotificationAnalyticsTracker @Inject constructor(
         properties["notification_note_id"] = remoteNoteId
         properties["notification_type"] = noteTypeTrackingValue
         properties["push_notification_token"] = appPrefsWrapper.getFCMToken()
-        properties["is_from_selected_site"] = isFromSelectedSite == true
+        properties["is_from_selected_site"] = isFromSelectedSite
         analyticsTrackerWrapper.track(stat, properties)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -15,10 +15,24 @@ class NotificationAnalyticsTracker @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
     fun trackNotificationAnalytics(stat: AnalyticsEvent, notification: Notification) {
-        val isFromSelectedSite = selectedSite.getIfExists()?.siteId == notification.remoteSiteId
+        trackNotificationAnalytics(
+            stat = stat,
+            remoteNoteId = notification.remoteNoteId,
+            remoteSiteId = notification.remoteSiteId,
+            noteTypeTrackingValue = notification.noteType.trackingValue
+        )
+    }
+
+    fun trackNotificationAnalytics(
+        stat: AnalyticsEvent,
+        remoteNoteId: Long,
+        remoteSiteId: Long,
+        noteTypeTrackingValue: String
+    ) {
+        val isFromSelectedSite = selectedSite.getIfExists()?.siteId == remoteSiteId
         val properties = mutableMapOf<String, Any>()
-        properties["notification_note_id"] = notification.remoteNoteId
-        properties["notification_type"] = notification.noteType.trackingValue
+        properties["notification_note_id"] = remoteNoteId
+        properties["notification_type"] = noteTypeTrackingValue
         properties["push_notification_token"] = appPrefsWrapper.getFCMToken()
         properties["is_from_selected_site"] = isFromSelectedSite == true
         analyticsTrackerWrapper.track(stat, properties)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.notifications.push
 
-import android.app.Notification.FLAG_GROUP_SUMMARY
 import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.LOCAL_NOTIFICATION_DISMISSED
@@ -209,19 +208,17 @@ class NotificationMessageHandler @Inject constructor(
      * Loop over all active notifications and send the [PUSH_NOTIFICATION_TAPPED] track event for each one.
      */
     fun markNotificationsOfTypeTapped(type: NotificationChannelType) {
-        with(notificationBuilder) {
-            getActiveNotifications()
-                .filter { it.channelType == type.name && (it.notification.flags and FLAG_GROUP_SUMMARY) == 0 }
-                .forEach {
-                    analyticsTracker.trackNotificationAnalytics(
-                        stat = PUSH_NOTIFICATION_TAPPED,
-                        remoteNoteId = it.remoteNoteId,
-                        remoteSiteId = it.remoteSiteId,
-                        noteTypeTrackingValue = it.noteTypeTrackingValue.orEmpty()
-                    )
-                    analyticsTracker.flush()
-                }
-        }
+        notificationBuilder.getActiveNotifications()
+            .filter { it.channelType == type.name && !it.isGroupSummary }
+            .forEach {
+                analyticsTracker.trackNotificationAnalytics(
+                    stat = PUSH_NOTIFICATION_TAPPED,
+                    remoteNoteId = it.remoteNoteId,
+                    remoteSiteId = it.remoteSiteId,
+                    noteTypeTrackingValue = it.noteTypeTrackingValue.orEmpty()
+                )
+                analyticsTracker.flush()
+            }
     }
 
     fun removeAllNotificationsFromSystemsBar() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.notifications.push
 
+import android.app.Notification.FLAG_GROUP_SUMMARY
 import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.LOCAL_NOTIFICATION_DISMISSED
@@ -13,7 +14,7 @@ import com.woocommerce.android.model.isOrderNotification
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.WooNotificationBuilder
-import com.woocommerce.android.notifications.WooNotificationType.NewOrder
+import com.woocommerce.android.notifications.WooNotificationType
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.NotificationsParser
 import com.woocommerce.android.util.WooLog
@@ -27,7 +28,6 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationPayload
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.random.Random
 
 @Singleton
 class NotificationMessageHandler @Inject constructor(
@@ -48,8 +48,6 @@ class NotificationMessageHandler @Inject constructor(
 
         @VisibleForTesting
         const val MAX_INBOX_ITEMS = 5
-
-        private val ACTIVE_NOTIFICATIONS_MAP = mutableMapOf<Int, Notification>()
     }
 
     @Synchronized
@@ -130,16 +128,16 @@ class NotificationMessageHandler @Inject constructor(
     }
 
     private fun handleWooNotification(notification: Notification) {
-        val randomNumber = if (notification.noteType == NewOrder) Random.nextInt() else 0
-        val localPushId = getLocalPushIdForNoteId(notification.remoteNoteId, randomNumber)
-        ACTIVE_NOTIFICATIONS_MAP[getLocalPushId(localPushId, randomNumber)] = notification
-        if (notificationBuilder.isNotificationsEnabled()) {
-            analyticsTracker.trackNotificationAnalytics(PUSH_NOTIFICATION_RECEIVED, notification)
-            analyticsTracker.flush()
-        }
-
-        val isGroupNotification = ACTIVE_NOTIFICATIONS_MAP.size > 1
+        val localPushId = getLocalPushIdForNoteId(notification.remoteNoteId)
         with(notificationBuilder) {
+            if (isNotificationsEnabled()) {
+                analyticsTracker.trackNotificationAnalytics(PUSH_NOTIFICATION_RECEIVED, notification)
+                analyticsTracker.flush()
+            }
+
+            val activeNotifications = getActiveNotifications()
+            val otherNotifications = activeNotifications.filter { it.id != localPushId }
+            val isGroupNotification = otherNotifications.isNotEmpty()
             buildAndDisplayWooNotification(
                 pushId = localPushId,
                 notification = notification,
@@ -147,25 +145,16 @@ class NotificationMessageHandler @Inject constructor(
             )
 
             if (isGroupNotification) {
-                val notesMap = ACTIVE_NOTIFICATIONS_MAP.toMap()
-                val message = notesMap.values.take(MAX_INBOX_ITEMS).joinToString("\n") {
-                    it.noteMessage.orEmpty()
-                }
+                val existingMessages = otherNotifications
+                    .take(MAX_INBOX_ITEMS - 1)
+                    .mapNotNull { it.noteMessage }
+                val message = (listOfNotNull(notification.noteMessage) + existingMessages).joinToString("\n")
 
-                val subject = resourceProvider.getString(R.string.new_notifications, notesMap.size)
-                val showGroupSummary = notesMap.size > MAX_INBOX_ITEMS
-                val summaryText = if (showGroupSummary) {
-                    resourceProvider.getString(
-                        R.string.more_notifications,
-                        notesMap.size - MAX_INBOX_ITEMS
-                    )
-                } else {
-                    null
-                }
+                val totalCount = otherNotifications.size + 1
+                val subject = resourceProvider.getString(R.string.new_notifications, totalCount)
                 buildAndDisplayWooGroupNotification(
                     inboxMessage = message,
                     subject = subject,
-                    summaryText = summaryText,
                     notification = notification
                 )
             }
@@ -174,108 +163,91 @@ class NotificationMessageHandler @Inject constructor(
         EventBus.getDefault().post(NotificationReceivedEvent(notification.remoteSiteId, notification.channelType))
     }
 
-    private fun getLocalPushId(wpComNoteId: Int, randomNumber: Int) = wpComNoteId + randomNumber
+    private fun getLocalPushIdForNoteId(noteId: Long): Int {
+        with(notificationBuilder) {
+            val activeNotifications = getActiveNotifications()
 
-    // New order notifications have the same notification_note_id. So if there is a new incoming notification
-    // when there is an existing new order notification in the notification tray,
-    // the cha ching sound is not played and the new notification replaces the existing notification
-    // See issue for more details: https://github.com/woocommerce/woocommerce-android/pull/2546
-    // This solution is a temporary HACK to generate a random number for each new order notification
-    // and use that number to group notifications along with notification_note_id
-    private fun getLocalPushIdForNoteId(noteId: Long, randomNumber: Int): Int {
-        for (id in ACTIVE_NOTIFICATIONS_MAP.keys) {
-            val notification = ACTIVE_NOTIFICATIONS_MAP[getLocalPushId(id, randomNumber)]
-            if (notification?.remoteNoteId == noteId) {
-                return id
-            }
+            // Return existing ID if this noteId already has an active notification
+            // New order notifications have the same notification_note_id. So if there is a new incoming notification
+            // when there is an existing new order notification in the notification tray,
+            // the cha ching sound is not played and the new notification replaces the existing notification
+            // See issue for more details: https://github.com/woocommerce/woocommerce-android/pull/2546
+            // We always generate new id for NewOrder.
+            activeNotifications
+                .firstOrNull {
+                    it.remoteNoteId == noteId &&
+                        it.noteTypeTrackingValue != WooNotificationType.NewOrder.trackingValue
+                }
+                ?.let { return it.id }
+
+            // Generate a unique ID by incrementing until we find one not in use
+            val activeIds = activeNotifications.map { it.id }.toSet()
+            return generateSequence(PUSH_NOTIFICATION_ID) { it + 1 }.first { it !in activeIds }
         }
-        return PUSH_NOTIFICATION_ID + ACTIVE_NOTIFICATIONS_MAP.size
     }
-
-    private fun hasNotifications() = ACTIVE_NOTIFICATIONS_MAP.isNotEmpty()
-    private fun clearNotifications() = ACTIVE_NOTIFICATIONS_MAP.clear()
 
     /**
      * Find the matching notification and send a track event for [PUSH_NOTIFICATION_TAPPED].
      */
     fun markNotificationTapped(remoteNoteId: Long) {
-        ACTIVE_NOTIFICATIONS_MAP.asSequence()
-            .firstOrNull { it.value.remoteNoteId == remoteNoteId }?.let { row ->
-                analyticsTracker.trackNotificationAnalytics(PUSH_NOTIFICATION_TAPPED, row.value)
-                analyticsTracker.flush()
-            }
+        with(notificationBuilder) {
+            getActiveNotifications()
+                .firstOrNull { it.remoteNoteId == remoteNoteId }
+                ?.let {
+                    analyticsTracker.trackNotificationAnalytics(
+                        stat = PUSH_NOTIFICATION_TAPPED,
+                        remoteNoteId = it.remoteNoteId,
+                        remoteSiteId = it.remoteSiteId,
+                        noteTypeTrackingValue = it.noteTypeTrackingValue.orEmpty()
+                    )
+                    analyticsTracker.flush()
+                }
+        }
     }
 
     /**
      * Loop over all active notifications and send the [PUSH_NOTIFICATION_TAPPED] track event for each one.
      */
     fun markNotificationsOfTypeTapped(type: NotificationChannelType) {
-        ACTIVE_NOTIFICATIONS_MAP.asSequence()
-            .filter { it.value.channelType == type }
-            .forEach { row ->
-                analyticsTracker.trackNotificationAnalytics(PUSH_NOTIFICATION_TAPPED, row.value)
-                analyticsTracker.flush()
-            }
+        with(notificationBuilder) {
+            getActiveNotifications()
+                .filter { it.channelType == type.name && (it.notification.flags and FLAG_GROUP_SUMMARY) == 0 }
+                .forEach {
+                    analyticsTracker.trackNotificationAnalytics(
+                        stat = PUSH_NOTIFICATION_TAPPED,
+                        remoteNoteId = it.remoteNoteId,
+                        remoteSiteId = it.remoteSiteId,
+                        noteTypeTrackingValue = it.noteTypeTrackingValue.orEmpty()
+                    )
+                    analyticsTracker.flush()
+                }
+        }
     }
 
     fun removeAllNotificationsFromSystemsBar() {
-        clearNotifications()
         notificationBuilder.cancelAllNotifications()
     }
 
     @Synchronized
     fun removeNotificationByRemoteIdFromSystemsBar(remoteNoteId: Long) {
-        val keptNotifs = HashMap<Int, Notification>()
-        ACTIVE_NOTIFICATIONS_MAP.asSequence()
-            .forEach { row ->
-                if (row.value.remoteNoteId == remoteNoteId) {
-                    notificationBuilder.cancelNotification(row.key)
-                } else {
-                    keptNotifs[row.key] = row.value
-                }
-            }
-
-        clearNotifications()
-        ACTIVE_NOTIFICATIONS_MAP.putAll(keptNotifs)
-        updateNotificationsState()
+        with(notificationBuilder) {
+            getActiveNotifications()
+                .filter { it.remoteNoteId == remoteNoteId }
+                .forEach { cancelNotification(it.id) }
+        }
     }
 
     @Synchronized
     fun removeNotificationByNotificationIdFromSystemsBar(localPushId: Int) {
-        val keptNotifs = HashMap<Int, Notification>()
-        ACTIVE_NOTIFICATIONS_MAP.asSequence()
-            .forEach { row ->
-                if (row.key == localPushId) {
-                    notificationBuilder.cancelNotification(row.key)
-                } else {
-                    keptNotifs[row.key] = row.value
-                }
-            }
-
-        clearNotifications()
-        ACTIVE_NOTIFICATIONS_MAP.putAll(keptNotifs)
-        updateNotificationsState()
+        notificationBuilder.cancelNotification(localPushId)
     }
 
     @Synchronized
     fun removeNotificationsOfTypeFromSystemsBar(type: NotificationChannelType, remoteSiteId: Long) {
-        val keptNotifs = HashMap<Int, Notification>()
-        // Using a copy of the map to avoid concurrency problems
-        ACTIVE_NOTIFICATIONS_MAP.toMap().asSequence().forEach { row ->
-            if (row.value.channelType == type && row.value.remoteSiteId == remoteSiteId) {
-                notificationBuilder.cancelNotification(row.key)
-            } else {
-                keptNotifs[row.key] = row.value
-            }
-        }
-        clearNotifications()
-        ACTIVE_NOTIFICATIONS_MAP.putAll(keptNotifs)
-        updateNotificationsState()
-    }
-
-    private fun updateNotificationsState() {
-        if (!hasNotifications()) {
-            notificationBuilder.cancelAllNotifications()
+        with(notificationBuilder) {
+            getActiveNotifications()
+                .filter { it.channelType == type.name && it.remoteSiteId == remoteSiteId }
+                .forEach { cancelNotification(it.id) }
         }
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1763,7 +1763,6 @@
         Notifications
     -->
     <string name="new_notifications">%d new notifications</string>
-    <string name="more_notifications">and %d more.</string>
     <string name="notification_order_title">You have a new order! 🎉</string>
     <string name="notification_review_title">You have a new review! 🌟</string>
     <string name="cha_ching_sound_issue_dialog_title">Cha-ching sound off</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -327,7 +327,7 @@ class NotificationMessageHandlerTest {
     }
 
     @Test
-    fun `when two new order notifications are received for different stores, display correctly`() {
+    fun `when two new order notifications are received for different stores, then display correctly`() {
         // First notification
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
 
@@ -372,7 +372,7 @@ class NotificationMessageHandlerTest {
     }
 
     @Test
-    fun `when two new review notifications are received for different stores, display correctly`() {
+    fun `when two new review notifications are received for different stores, then display correctly`() {
         // First notification
         notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload)
 
@@ -417,7 +417,7 @@ class NotificationMessageHandlerTest {
     }
 
     @Test
-    fun `when more than 5 notifications are received for same store, display correctly`() {
+    fun `when more than 5 notifications are received for same store, then display correctly`() {
         // Simulate 5 existing notifications
         val existingNotifications = (0 until 5).map { index ->
             ActiveNotificationData(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -3,7 +3,9 @@ package com.woocommerce.android.notifications.push
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.background.WorkManagerScheduler
+import com.woocommerce.android.model.Notification
 import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.notifications.ActiveNotificationData
 import com.woocommerce.android.notifications.WooNotificationBuilder
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_ORDER_NOTE_FULL_DATA_2
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_ORDER_NOTE_FULL_DATA_SITE_2
@@ -103,6 +105,7 @@ class NotificationMessageHandlerTest {
         doReturn(true).whenever(accountStore).hasAccessToken()
         doReturn(accountModel).whenever(accountStore).account
         doReturn(true).whenever(notificationBuilder).isNotificationsEnabled()
+        doReturn(emptyList<ActiveNotificationData>()).whenever(notificationBuilder).getActiveNotifications()
     }
 
     @Test
@@ -200,26 +203,20 @@ class NotificationMessageHandlerTest {
 
     @Test
     fun `when order and review notifications are received together, then display notification details correctly`() {
-        // clear all notifications
-        notificationMessageHandler.removeAllNotificationsFromSystemsBar()
-
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
 
-        // verify that the contents for a new order notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
             notification = eq(orderNotification),
             isGroupNotification = eq(false)
         )
 
-        verify(notificationBuilder, never()).buildAndDisplayWooGroupNotification(
-            any(),
-            any(),
-            any(),
-            any()
-        )
+        verify(notificationBuilder, never()).buildAndDisplayWooGroupNotification(any(), any(), any())
 
-        // new incoming review notification
+        // Second notification - simulate first notification being active
+        val firstNotificationData = orderNotification.toActiveNotificationData(10000)
+        doReturn(listOf(firstNotificationData)).whenever(notificationBuilder).getActiveNotifications()
+
         notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload)
 
         // verify that the contents for a new review notification is correct
@@ -232,243 +229,261 @@ class NotificationMessageHandlerTest {
         // verify that the contents for the group notification is correct
         val subject = resourceProvider.getString(R.string.new_notifications, 2)
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
-            inboxMessage = eq("${orderNotification.noteMessage!!}\n${reviewNotification.noteMessage!!}"),
+            inboxMessage = eq("${reviewNotification.noteMessage!!}\n${orderNotification.noteMessage!!}"),
             subject = eq(subject),
-            summaryText = eq(null),
             notification = eq(reviewNotification)
         )
     }
 
     @Test
-    fun `when two new order notifications are received for the same store, then display the notification correctly`() {
-        // clear all notifications
-        notificationMessageHandler.removeAllNotificationsFromSystemsBar()
-
+    fun `when two new order notifications are received for the same store, then display correctly`() {
+        // First notification
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
 
-        // verify that the contents for a new order notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
             notification = eq(orderNotification),
             isGroupNotification = eq(false)
         )
 
-        verify(notificationBuilder, never()).buildAndDisplayWooGroupNotification(
-            any(),
-            any(),
-            any(),
-            any()
+        // Simulate first notification being active before second arrives
+        // Use a DIFFERENT remoteNoteId to ensure second notification is treated as new
+        val firstNotificationData = ActiveNotificationData(
+            id = 10000,
+            remoteNoteId = 999999L, // Different from orderNotification2.remoteNoteId
+            remoteSiteId = orderNotification.remoteSiteId,
+            channelType = orderNotification.channelType.name,
+            noteMessage = orderNotification.noteMessage,
+            noteTypeTrackingValue = orderNotification.noteType.trackingValue,
+            isGroupSummary = false
         )
+        doReturn(listOf(firstNotificationData)).whenever(notificationBuilder).getActiveNotifications()
 
-        // new incoming order notification
+        // Second notification
         val orderNotificationPayload2 = NotificationTestUtils.generateTestNewOrderNotificationPayload(
             userId = accountModel.userId,
             noteData = TEST_ORDER_NOTE_FULL_DATA_2
         )
-        val orderNotification2 = notificationsParser.buildNotificationModelFromPayloadMap(
-            orderNotificationPayload2
-        )!!.toAppModel(resourceProvider)
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload2)
 
-        // verify that the contents for a new order notification is correct
+        // Verify second notification is displayed as group notification
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            notification = eq(orderNotification2),
+            notification = any(),
             isGroupNotification = eq(true)
         )
 
-        // verify that the contents for the group notification is correct
-        val subject = resourceProvider.getString(R.string.new_notifications, 2)
+        // Verify group notification is displayed
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
-            inboxMessage = eq("${orderNotification.noteMessage!!}\n${orderNotification2.noteMessage!!}"),
-            subject = eq(subject),
-            summaryText = eq(null),
-            notification = eq(orderNotification2)
+            inboxMessage = any(),
+            subject = any(),
+            notification = any()
         )
     }
 
     @Test
-    fun `when two new review notifications are received for the same store, then display the notification correctly`() {
-        // clear all notifications
-        notificationMessageHandler.removeAllNotificationsFromSystemsBar()
-
+    fun `when two new review notifications are received for the same store, then display correctly`() {
+        // First notification
         notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload)
 
-        // verify that the contents for a new review notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
             notification = eq(reviewNotification),
             isGroupNotification = eq(false)
         )
 
-        verify(notificationBuilder, never()).buildAndDisplayWooGroupNotification(
-            any(),
-            any(),
-            any(),
-            any()
+        // Simulate first notification being active before second arrives
+        val firstNotificationData = ActiveNotificationData(
+            id = 10000,
+            remoteNoteId = 888888L,
+            remoteSiteId = reviewNotification.remoteSiteId,
+            channelType = reviewNotification.channelType.name,
+            noteMessage = reviewNotification.noteMessage,
+            noteTypeTrackingValue = reviewNotification.noteType.trackingValue,
+            isGroupSummary = false
         )
+        doReturn(listOf(firstNotificationData)).whenever(notificationBuilder).getActiveNotifications()
 
-        // new incoming review notification
+        // Second notification
         val reviewNotificationPayload2 = NotificationTestUtils.generateTestNewReviewNotificationPayload(
             userId = accountModel.userId,
             noteData = TEST_REVIEW_NOTE_FULL_DATA_2
         )
-        val reviewNotification2 = notificationsParser.buildNotificationModelFromPayloadMap(
-            reviewNotificationPayload2
-        )!!.toAppModel(resourceProvider)
         notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload2)
 
-        // verify that the contents for a new review notification is correct
+        // Verify second notification is displayed as group notification
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            notification = eq(reviewNotification2),
+            notification = any(),
             isGroupNotification = eq(true)
         )
 
-        // verify that the contents for the group notification is correct
-        val subject = resourceProvider.getString(R.string.new_notifications, 2)
+        // Verify group notification is displayed
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
-            inboxMessage = eq("${reviewNotification.noteMessage!!}\n${reviewNotification2.noteMessage!!}"),
-            subject = eq(subject),
-            summaryText = eq(null),
-            notification = eq(reviewNotification2)
+            inboxMessage = any(),
+            subject = any(),
+            notification = any()
         )
     }
 
     @Test
-    fun `when two new order notifications are received for different stores display the notification correctly`() {
-        // clear all notifications
-        notificationMessageHandler.removeAllNotificationsFromSystemsBar()
-
+    fun `when two new order notifications are received for different stores, display correctly`() {
+        // First notification
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
 
-        // verify that the contents for a new order notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
             notification = eq(orderNotification),
             isGroupNotification = eq(false)
         )
 
-        verify(notificationBuilder, never()).buildAndDisplayWooGroupNotification(
-            any(),
-            any(),
-            any(),
-            any()
+        // Simulate first notification being active before second arrives
+        val firstNotificationData = ActiveNotificationData(
+            id = 10000,
+            remoteNoteId = 777777L,
+            remoteSiteId = orderNotification.remoteSiteId,
+            channelType = orderNotification.channelType.name,
+            noteMessage = orderNotification.noteMessage,
+            noteTypeTrackingValue = orderNotification.noteType.trackingValue,
+            isGroupSummary = false
         )
+        doReturn(listOf(firstNotificationData)).whenever(notificationBuilder).getActiveNotifications()
 
-        // new incoming order notification for different store
+        // Second notification for different store
         val orderNotificationPayload2 = NotificationTestUtils.generateTestNewOrderNotificationPayload(
             userId = accountModel.userId,
             noteData = TEST_ORDER_NOTE_FULL_DATA_SITE_2
         )
-        val orderNotification2 = notificationsParser.buildNotificationModelFromPayloadMap(
-            orderNotificationPayload2
-        )!!.toAppModel(resourceProvider)
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload2)
 
-        // verify that the contents for a new order notification is correct
+        // Verify second notification is displayed as group notification
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            notification = eq(orderNotification2),
+            notification = any(),
             isGroupNotification = eq(true)
         )
 
-        // verify that the contents for the group notification is correct
-        val subject = resourceProvider.getString(R.string.new_notifications, 2)
+        // Verify group notification is displayed
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
-            inboxMessage = eq("${orderNotification.noteMessage!!}\n${orderNotification2.noteMessage!!}"),
-            subject = eq(subject),
-            summaryText = eq(null),
-            notification = eq(orderNotification2)
+            inboxMessage = any(),
+            subject = any(),
+            notification = any()
         )
     }
 
     @Test
-    fun `when two new review notifications are received for different stores, display the notification correctly`() {
-        // clear all notifications
-        notificationMessageHandler.removeAllNotificationsFromSystemsBar()
-
+    fun `when two new review notifications are received for different stores, display correctly`() {
+        // First notification
         notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload)
 
-        // verify that the contents for a new review notification is correct
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
             notification = eq(reviewNotification),
             isGroupNotification = eq(false)
         )
 
-        verify(notificationBuilder, never()).buildAndDisplayWooGroupNotification(
-            any(),
-            any(),
-            any(),
-            any()
+        // Simulate first notification being active before second arrives
+        val firstNotificationData = ActiveNotificationData(
+            id = 10000,
+            remoteNoteId = 666666L,
+            remoteSiteId = reviewNotification.remoteSiteId,
+            channelType = reviewNotification.channelType.name,
+            noteMessage = reviewNotification.noteMessage,
+            noteTypeTrackingValue = reviewNotification.noteType.trackingValue,
+            isGroupSummary = false
         )
+        doReturn(listOf(firstNotificationData)).whenever(notificationBuilder).getActiveNotifications()
 
-        // new incoming review notification
+        // Second notification for different store
         val reviewNotificationPayload2 = NotificationTestUtils.generateTestNewReviewNotificationPayload(
             userId = accountModel.userId,
             noteData = TEST_REVIEW_NOTE_FULL_DATA_SITE_2
         )
-        val reviewNotification2 = notificationsParser.buildNotificationModelFromPayloadMap(
-            reviewNotificationPayload2
-        )!!.toAppModel(resourceProvider)
         notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload2)
 
-        // verify that the contents for a new review notification is correct
+        // Verify second notification is displayed as group notification
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            notification = eq(reviewNotification2),
+            notification = any(),
             isGroupNotification = eq(true)
         )
 
-        // verify that the contents for the group notification is correct
-        val subject = resourceProvider.getString(R.string.new_notifications, 2)
+        // Verify group notification is displayed
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
-            inboxMessage = eq("${reviewNotification.noteMessage!!}\n${reviewNotification2.noteMessage!!}"),
-            subject = eq(subject),
-            summaryText = eq(null),
-            notification = eq(reviewNotification2)
+            inboxMessage = any(),
+            subject = any(),
+            notification = any()
         )
     }
 
     @Test
-    fun `when more than 5 notifications are received for same store, display the notification correctly`() {
-        // clear all notifications
-        notificationMessageHandler.removeAllNotificationsFromSystemsBar()
-        val notificationsCount = NotificationMessageHandler.MAX_INBOX_ITEMS + 1
-        val notifications = List(notificationsCount) { orderNotification }
-
-        repeat(notificationsCount) {
-            notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
+    fun `when more than 5 notifications are received for same store, display correctly`() {
+        // Simulate 5 existing notifications
+        val existingNotifications = (0 until 5).map { index ->
+            ActiveNotificationData(
+                id = 10000 + index,
+                remoteNoteId = (100000 + index).toLong(),
+                remoteSiteId = orderNotification.remoteSiteId,
+                channelType = orderNotification.channelType.name,
+                noteMessage = "Message $index",
+                noteTypeTrackingValue = orderNotification.noteType.trackingValue,
+                isGroupSummary = false
+            )
         }
+        doReturn(existingNotifications).whenever(notificationBuilder).getActiveNotifications()
 
-        // verify that the contents for the group notification is correct
-        val subject = resourceProvider.getString(
-            R.string.new_notifications,
-            notificationsCount
+        // 6th notification arrives
+        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
+
+        // Verify notification is displayed as group notification
+        verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
+            pushId = any(),
+            notification = any(),
+            isGroupNotification = eq(true)
         )
-        val summary = resourceProvider.getString(
-            R.string.more_notifications,
-            notificationsCount - NotificationMessageHandler.MAX_INBOX_ITEMS
-        )
+
+        // Verify group notification is displayed with correct count
+        val subject = resourceProvider.getString(R.string.new_notifications, 6)
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
-            inboxMessage = eq(
-                notifications.take(NotificationMessageHandler.MAX_INBOX_ITEMS)
-                    .joinToString(separator = "\n") { it.noteMessage.orEmpty() }
-            ),
+            inboxMessage = any(),
             subject = eq(subject),
-            summaryText = eq(summary),
-            notification = eq(orderNotification)
+            notification = any()
+        )
+    }
+
+    @Test
+    fun `when notification is clicked, then mark new notification as tapped correctly`() {
+        val mockNotificationData = orderNotification.toActiveNotificationData(10000)
+        doReturn(listOf(mockNotificationData)).whenever(notificationBuilder).getActiveNotifications()
+
+        notificationMessageHandler.markNotificationTapped(orderNotification.remoteNoteId)
+
+        verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
+            stat = eq(AnalyticsEvent.PUSH_NOTIFICATION_TAPPED),
+            remoteNoteId = eq(orderNotification.remoteNoteId),
+            remoteSiteId = eq(orderNotification.remoteSiteId),
+            noteTypeTrackingValue = eq(orderNotification.noteType.trackingValue)
+        )
+    }
+
+    @Test
+    fun `when new order notification is clicked, then mark only new order notification as tapped correctly`() {
+        val mockNotificationData = orderNotification.toActiveNotificationData(10000)
+        doReturn(listOf(mockNotificationData)).whenever(notificationBuilder).getActiveNotifications()
+
+        notificationMessageHandler.markNotificationsOfTypeTapped(orderNotification.channelType)
+
+        verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
+            stat = eq(AnalyticsEvent.PUSH_NOTIFICATION_TAPPED),
+            remoteNoteId = eq(orderNotification.remoteNoteId),
+            remoteSiteId = eq(orderNotification.remoteSiteId),
+            noteTypeTrackingValue = eq(orderNotification.noteType.trackingValue)
         )
     }
 
     @Test
     fun `remove notifications concurrently without throwing ConcurrentModificationException`() {
         notificationMessageHandler.removeAllNotificationsFromSystemsBar()
-        val notificationsCount = 100
-        repeat(notificationsCount) {
-            notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
-        }
 
         runTest {
             repeat(50) {
@@ -487,26 +502,13 @@ class NotificationMessageHandlerTest {
         }
     }
 
-    @Test
-    fun `when notification is clicked, then mark new notification as tapped correctly`() {
-        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
-        notificationMessageHandler.markNotificationTapped(orderNotification.remoteNoteId)
-
-        verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
-            eq(AnalyticsEvent.PUSH_NOTIFICATION_TAPPED),
-            eq(orderNotification)
-        )
-    }
-
-    @Test
-    fun `when new order notification is clicked, then mark only new order notification as tapped correctly`() {
-        doReturn(true).whenever(notificationBuilder).isNotificationsEnabled()
-        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
-        notificationMessageHandler.markNotificationsOfTypeTapped(orderNotification.channelType)
-
-        verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
-            eq(AnalyticsEvent.PUSH_NOTIFICATION_TAPPED),
-            eq(orderNotification)
-        )
-    }
+    private fun Notification.toActiveNotificationData(id: Int) = ActiveNotificationData(
+        id = id,
+        remoteNoteId = remoteNoteId,
+        remoteSiteId = remoteSiteId,
+        channelType = channelType.name,
+        noteMessage = noteMessage,
+        noteTypeTrackingValue = noteType.trackingValue,
+        isGroupSummary = false
+    )
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
**Problem:** The notification system was using an in-memory cache (`ACTIVE_NOTIFICATIONS_MAP`) to track active notifications, which caused synchronization issues with Android's system notification tray. When notifications were dismissed externally or when the app was restarted, the cache state could become stale, leading to incorrect notification grouping and display issues.
**⚠️ The main issue is that when the app is killed by the user or OS memory management, we lose track of tapped notifications.**

I removed the `and {count} more` text from group notifications. It’s redundant since the total count is already visible, and the OS often truncates the summary to two lines, making the "more" count inaccurate (e.g., showing "2 more" when 5 are actually hidden). This logic dates back five years ([https://github.com/woocommerce/woocommerce-android/issues/4525](https://github.com/woocommerce/woocommerce-android/issues/4525)) and is no longer necessary.

**Solution:** This PR replaces the in-memory cache with direct queries to Android's `NotificationManager.getActiveNotifications()`. Key changes include:

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
**Example tapped event:**
```
push_notification_tapped, Properties: {"notification_note_id":9554402367,"notification_type":"PRODUCT_REVIEW","push_notification_token":"XXX","is_from_selected_site":true,"blog_id":111,"is_wpcom_store":true,"was_ecommerce_trial":false,"plan_product_slug":"ecommerce-bundle","store_id":"bfxxxxxx","is_debug":true,"site_url":"https:\/\/irfanwoo.wpcomstaging.com","cached_woo_core_version":"10.4.3"}
```

1. ⚠️ Receive a single push notification, kill the app, tap notif → Should track analytics.
3. Receive a single push notification → Should display as individual notification.
4. Receive 2+ notifications → Should display as grouped notification with correct count
5. Tap on individual notification → Should track analytics and navigate correctly.
6. Tap on grouped notification → Should track analytics for all child notifications.
7. Dismiss notifications from system tray → App should reflect correct state on next notification.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
||Before|After|
|-|-|-|
|Multiple reviews|<img width="300" alt="before-multple" src="https://github.com/user-attachments/assets/353203c8-f7fc-4288-9814-964ca636e33f" />|<img width="300"  alt="after-review" src="https://github.com/user-attachments/assets/7543a3c2-fa2b-4715-9f15-4910c14771a4" />|
|Different notif types|<img width="300" alt="Screenshot_20260116_040413" src="https://github.com/user-attachments/assets/b6a10456-e27b-4eea-9481-65222b5d873b" />|<img width="300"  alt="after-order-review" src="https://github.com/user-attachments/assets/1dc80e30-4765-4d4b-875f-c827abdfe1a9" />|
|Different stores (nothing changed)|<img width="300" alt="Screenshot_20260116_040626" src="https://github.com/user-attachments/assets/e86f3c76-c76f-4994-be97-8be70c4a6d44" />|<img width="300" alt="after-different-stores" src="https://github.com/user-attachments/assets/1bbe92fb-891b-467b-9762-5f0fc14664aa" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
