### PR TITLE
[WOOMOB-1950] Update POS promo deep link to /mobile/pos/learn-more

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -76,7 +76,7 @@
                 <data android:path="/mobile/payments" />
                 <data android:path="/mobile/payments/tap-to-pay" />
                 <data android:pathPrefix="/products/hardware/" />
-                <data android:pathPrefix="/in-person-payments" />
+                <data android:pathPrefix="/mobile/pos/learn-more" />
             </intent-filter>
 
             <intent-filter>

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/clientside/ClientSidePosBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/clientside/ClientSidePosBanner.kt
@@ -83,7 +83,7 @@ class ClientSidePosBanner @Inject constructor(
         private const val TARGETING_PERCENTAGE = 100
         private const val BANNER_ID = "woo_pos_client_banner"
         private const val FEATURE_CLASS = "woo_pos_promotion"
-        private const val BANNER_URL = "https://woocommerce.com/in-person-payments/"
+        private const val BANNER_URL = "https://woocommerce.com/mobile/pos/learn-more"
         private val ELIGIBLE_COUNTRIES = listOf("US", "GB")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/ResolveAppLink.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/ResolveAppLink.kt
@@ -21,7 +21,7 @@ class ResolveAppLink @Inject constructor(
             uri endsWith "mobile/payments" -> preparePaymentsAction(uri!!)
             uri endsWith "mobile/payments/tap-to-pay" -> prepareTapToPayAction(uri!!)
             uri startsWith "/products/hardware" -> prepareUrlInWebViewAction(uri!!)
-            uri startsWith "/in-person-payments" -> prepareWooPosPromoAction(uri!!)
+            uri startsWith "/mobile/pos/learn-more" -> prepareWooPosPromoAction(uri!!)
             else -> Action.DoNothing
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoDialogFragment.kt
@@ -11,9 +11,10 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
+import androidx.navigation.Navigation
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -45,7 +46,11 @@ class PosPromoDialogFragment : DialogFragment() {
                         onNextClick = viewModel::onNextClick,
                         onExploreClick = {
                             viewModel.onExploreClick()
-                            ChromeCustomTabUtils.launchUrl(requireContext(), PosPromoViewModel.WOO_POS_DOCS_URL)
+                            Navigation.findNavController(requireActivity(), R.id.nav_host_fragment_main).navigate(
+                                NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
+                                    urlToLoad = PosPromoViewModel.WOO_POS_DOCS_URL
+                                )
+                            )
                             dismiss()
                         }
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoDialogFragment.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
-import androidx.navigation.Navigation
+import androidx.navigation.findNavController
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -46,7 +46,7 @@ class PosPromoDialogFragment : DialogFragment() {
                         onNextClick = viewModel::onNextClick,
                         onExploreClick = {
                             viewModel.onExploreClick()
-                            Navigation.findNavController(requireActivity(), R.id.nav_host_fragment_main).navigate(
+                            requireActivity().findNavController(R.id.nav_host_fragment_main).navigate(
                                 NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
                                     urlToLoad = PosPromoViewModel.WOO_POS_DOCS_URL
                                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoViewModel.kt
@@ -41,6 +41,6 @@ class PosPromoViewModel @Inject constructor(
     }
 
     companion object {
-        const val WOO_POS_DOCS_URL = "https://woocommerce.com/document/woo-mobile-app-point-of-sale-mode/"
+        const val WOO_POS_DOCS_URL = "https://woocommerce.com/mobile/pos/learn-more"
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/ResolveAppLinkTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/ResolveAppLinkTest.kt
@@ -319,7 +319,7 @@ class ResolveAppLinkTest {
         blogId: String? = TEST_BLOG_ID.toString()
     ): Uri {
         val uri = mock<Uri> {
-            on { path } doReturn "/in-person-payments"
+            on { path } doReturn "/mobile/pos/learn-more"
             on { getQueryParameter("blog_id") } doReturn blogId
         }
         return uri


### PR DESCRIPTION
WOOMOB-1950

### Description

Updates the POS promotion deep link from `/in-person-payments` to `/mobile/pos/learn-more`:

- Updated the deep link path in AndroidManifest.xml
- Updated the URL handling in ResolveAppLink to match the new path
- Updated promotion URLs in ClientSidePosBanner and PosPromoViewModel
- Changed PosPromoDialogFragment to open the URL in an in-app WebView instead of Chrome Custom Tab to avoid circular deep link handling (opening via Chrome Custom Tab would trigger the app's deep link handler and reopen the promo dialog instead of showing the webpage)

The URL itself still doesn't have a redirect so it's 404

### Test Steps

1. Tap on POS promo banner or open POS promo dialog
2. Tap "Learn More" / explore button
3. Verify the webpage opens in an in-app WebView (not Chrome Custom Tab)
4. Test deep link externally:
   ```
   adb shell am start -a android.intent.action.VIEW -d "https://woocommerce.com/mobile/pos/learn-more"
   ```
5. Verify the app intercepts the link and shows the POS promo carousel

### Images/gif

N/A - No visual changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.