### PR TITLE
Attempt to fix a double "cha-ching" issue when creating group notific…

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [Internal][Woo POS] Apply POS product visibility filtering to remote/non-local-catalog sync [https://github.com/woocommerce/woocommerce-android/pull/15191]
 - [Internal][Woo POS] Remove products hidden from POS during local catalog sync [https://github.com/woocommerce/woocommerce-android/pull/15190]
 - [Internal] Show JITMs on Dashboard regardless of onboarding status [https://github.com/woocommerce/woocommerce-android/pull/15170]
+- [Internal] Fix push notification double "cha-ching" issue [https://github.com/woocommerce/woocommerce-android/pull/15208]
 
 23.9
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
@@ -119,6 +119,9 @@ class WooNotificationBuilder @Inject constructor(
             if (!isGroupNotification) {
                 setGroupSummary(true)
                 setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
+                setDefaults(0)
+                setSound(null)
+                setVibrate(null)
                 showNotification(notification.getGroupPushId(), notification, this)
             }
         }


### PR DESCRIPTION
Coming from this external contributor [PR fix attempt](https://github.com/woocommerce/woocommerce-android/pull/15165)

### Description
Will copy paste my [comment](https://github.com/woocommerce/woocommerce-android/pull/15165#issuecomment-3759765934) in the external contributor PR: 

I was not able to reproduce the double "cha-ching" issue, so I suspect it is likely an issue with how different OEM/Android devices handle some push notification code. 

The fix attempt you provided though, I don't think will make any difference. Have you tested that it fixed the bug? Because changing the order on how some values are applied in `builder` pattern shouldn't really matter, because it is not until `showNotification()` is called that the values actually take effect. 

That being said this is what I suspect is happening is the following:

1. handleWooNotification() is called with isGroupNotification = false
2. buildAndDisplayWooNotification() is called:
  - Sets setDefaults(NotificationCompat.DEFAULT_ALL) → enables sound
  - showNotification() → First cha-ching (from channel)
  - Since isGroupNotification = false:
      - Sets setGroupSummary(true) and setGroupAlertBehavior(GROUP_ALERT_CHILDREN)
      - showNotification() again → Should NOT play sound due to GROUP_ALERT_CHILDREN

**Why GROUP_ALERT_CHILDREN Might Not Work:**
The issue is that GROUP_ALERT_CHILDREN is set on the same builder that was already used to show the first notification. The builder still has:
- Segfaults(NotificationCompat.DEFAULT_ALL)
- The notification channel with cha-ching sound
 
Possible causes:

1. Builder reuse issue: The builder is reused and .build() is called twice. The second call might still inherit properties that cause sound.
2. Channel-level sound override: On some Android versions/OEMs, the channel's sound setting might play regardless of GROUP_ALERT_CHILDREN.
3. setDefaults(DEFAULT_ALL) conflict: This might override or conflict with GROUP_ALERT_CHILDREN on some devices.

I think adding the following code: 
```kotlin
            if (!isGroupNotification) {
                setGroupSummary(true)
                setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
                setDefaults(0)
                setSound(null)
                setVibrate(null)
                showNotification(notification.getGroupPushId(), notification, this)
            }
```
Will fix the issue for all OEMs. I've opened a new PR with those changes. 

### Test Steps
I haven't been able to reproduce the issue neither in emulator nor in Pixel 10 device. However the way to  have the changes code called is: 
1. From a clean install of the app, log in and accept notification permissions
2. Purchase an item using the storefront
3. Wait for the notification to come in. A single cha-ching should sound. 
4. Tap on the received notification to clear any "active" notification so that `isGroupNotification` is set to false in subsequent pushes
5. Repeat steps 1-3 if need to re-test

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
