### PR TITLE
[WOOMOB-2008] Add local feature flag for client-side POS banner

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/clientside/ClientSidePosBanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/clientside/ClientSidePosBanner.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.jitm.JitmMessagePathsProvider
 import com.woocommerce.android.ui.woopos.WooPosIsScreenSizeAllowed
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.IsRemoteFeatureFlagEnabled
 import com.woocommerce.android.util.RemoteFeatureFlag
 import dagger.Reusable
@@ -29,6 +30,7 @@ class ClientSidePosBanner @Inject constructor(
 
     @Suppress("ReturnCount")
     suspend fun shouldShow(): Boolean {
+        if (!FeatureFlag.WOO_POS_CLIENT_SIDE_BANNER.isEnabled()) return false
         if (!isRemoteFeatureFlagEnabled(RemoteFeatureFlag.WOO_POS_TABLET_PROMO_BANNER)) return false
 
         val site = selectedSite.getIfExists() ?: return false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -14,7 +14,8 @@ enum class FeatureFlag {
     POS_REFUNDS,
     WOO_POS_LOCAL_CATALOG_FILE_APPROACH,
     WOO_PUSH_NOTIFICATIONS_SYSTEM,
-    WOO_POS_PRODUCT_VISIBILITY_FILTERING;
+    WOO_POS_PRODUCT_VISIBILITY_FILTERING,
+    WOO_POS_CLIENT_SIDE_BANNER;
 
     fun isEnabled(context: Context? = null): Boolean {
         return when (this) {
@@ -31,6 +32,8 @@ enum class FeatureFlag {
 
             WOO_POS_LOCAL_CATALOG_FILE_APPROACH,
             WOO_PUSH_NOTIFICATIONS_SYSTEM -> false
+
+            WOO_POS_CLIENT_SIDE_BANNER -> true
         }
     }
 }


### PR DESCRIPTION
WOOMOB-2008

### Description

Add a local feature flag `WOO_POS_CLIENT_SIDE_BANNER` that controls the visibility of the client-side POS promo banner. The banner now requires both the local flag and the remote flag (`WOO_POS_TABLET_PROMO_BANNER`) to be enabled before showing.

This needed to make sure that when the remote FF enabled we won't show text that not A/B tested on the older versions of the app

### Test Steps

1. Verify the banner shows on a phone device (not tablet) in an eligible country (US or GB)
2. Set `WOO_POS_CLIENT_SIDE_BANNER` to `false` in `FeatureFlag.kt`
3. Verify the banner no longer shows

### Images/gif

N/A - No UI changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.