### PR TITLE
[WOOMOB-2010] Add UTM params to POS promotion modal Explore link

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooCommerceComUTMProviderTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/WooCommerceComUTMProviderTest.kt
@@ -38,13 +38,11 @@ class WooCommerceComUTMProviderTest {
     @Test
     fun `testUtmQueryParamsAreAddedToTheUrlProperly`() {
         val utmCampaign = "feature_announcement_card"
-        val jitmPrefixUtmCampaign = "jitm_group_feature_announcement_card"
         val utmSource = "orders_list"
         val utmContent = "upsell_card_readers"
-        val jitmPrefixUtmContent = "jitm_upsell_card_readers"
         val url = "https://www.woocommerce.com?utm_campaign=$utmCampaign&utm_source=$utmSource"
-        val expectedUrl = "https://www.woocommerce.com?utm_campaign=$jitmPrefixUtmCampaign&utm_source=$utmSource" +
-            "&utm_content=$jitmPrefixUtmContent&utm_term=1234&utm_medium=woo_android"
+        val expectedUrl = "https://www.woocommerce.com?utm_campaign=$utmCampaign&utm_source=$utmSource" +
+            "&utm_content=$utmContent&utm_term=1234&utm_medium=woo_android"
         val defaultUTMMedium = "woo_android"
 
         val urlWithUTM = provideUTMProvider(
@@ -55,19 +53,18 @@ class WooCommerceComUTMProviderTest {
         ).getUrlWithUtmParams(url)
 
         assertThat(urlWithUTM.toUri().getQueryParameter("utm_medium")).isEqualTo(defaultUTMMedium)
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(jitmPrefixUtmCampaign)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(utmCampaign)
         assertThat(urlWithUTM.toUri().getQueryParameter("utm_source")).isEqualTo(utmSource)
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_content")).isEqualTo(jitmPrefixUtmContent)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_content")).isEqualTo(utmContent)
         assertThat(urlWithUTM).isEqualTo(expectedUrl)
     }
 
     @Test
     fun `testUtmQueriesAreExcludedInTheUrlIfTheyAreNullOrEmpty`() {
         val utmCampaign = "feature_announcement_card"
-        val jitmPrefixUtmCampaign = "jitm_group_feature_announcement_card"
         val defaultUTMMedium = "woo_android"
         val url = "https://www.woocommerce.com/us/hw"
-        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$jitmPrefixUtmCampaign" +
+        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$utmCampaign" +
             "&utm_term=1234&utm_medium=$defaultUTMMedium"
 
         val urlWithUTM = provideUTMProvider(
@@ -78,7 +75,7 @@ class WooCommerceComUTMProviderTest {
         ).getUrlWithUtmParams(url)
 
         assertThat(urlWithUTM.toUri().getQueryParameter("utm_medium")).isEqualTo(defaultUTMMedium)
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(jitmPrefixUtmCampaign)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(utmCampaign)
         assertFalse(urlWithUTM.contains("utm_source"))
         assertFalse(urlWithUTM.contains("utm_content"))
         assertThat(urlWithUTM).isEqualTo(expectedUrl)
@@ -89,15 +86,13 @@ class WooCommerceComUTMProviderTest {
         val existingUtmCampaign = "payments_menu_item"
         val existingUtmSource = "payments_menu"
         val utmCampaign = "feature_announcement_card"
-        val jitmPrefixUtmCampaign = "jitm_group_feature_announcement_card"
         val utmSource = "orders_list"
         val utmContent = "upsell_card_readers"
-        val jitmPrefixUtmContent = "jitm_upsell_card_readers"
         val defaultUTMMedium = "woo_android"
         val url = "https://www.woocommerce.com/us/hw?utm_campaign=$existingUtmCampaign" +
             "&utm_source=$existingUtmSource"
-        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$jitmPrefixUtmCampaign" +
-            "&utm_source=$utmSource&utm_content=$jitmPrefixUtmContent&utm_term=1234&utm_medium=$defaultUTMMedium"
+        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$utmCampaign" +
+            "&utm_source=$utmSource&utm_content=$utmContent&utm_term=1234&utm_medium=$defaultUTMMedium"
 
         val urlWithUTM = provideUTMProvider(
             campaign = utmCampaign,
@@ -107,9 +102,9 @@ class WooCommerceComUTMProviderTest {
         ).getUrlWithUtmParams(url)
 
         assertThat(urlWithUTM.toUri().getQueryParameter("utm_medium")).isEqualTo(defaultUTMMedium)
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(jitmPrefixUtmCampaign)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(utmCampaign)
         assertThat(urlWithUTM.toUri().getQueryParameter("utm_source")).isEqualTo(utmSource)
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_content")).isEqualTo(jitmPrefixUtmContent)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_content")).isEqualTo(utmContent)
         assertThat(urlWithUTM).isEqualTo(expectedUrl)
     }
 
@@ -180,12 +175,11 @@ class WooCommerceComUTMProviderTest {
     }
 
     @Test
-    fun `testCampaignPrefixIsAddedWhileAddingUtmParams`() {
+    fun `testCampaignIsAddedAsRawValueWithoutPrefix`() {
         val utmCampaign = "feature_announcement_card"
-        val jitmPrefixUtmCampaign = "jitm_group_$utmCampaign"
         val defaultUTMMedium = "woo_android"
         val url = "https://www.woocommerce.com/us/hw"
-        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$jitmPrefixUtmCampaign" +
+        val expectedUrl = "https://www.woocommerce.com/us/hw?utm_campaign=$utmCampaign" +
             "&utm_term=1234&utm_medium=$defaultUTMMedium"
 
         val urlWithUTM = provideUTMProvider(
@@ -195,18 +189,17 @@ class WooCommerceComUTMProviderTest {
             siteId = 1234L
         ).getUrlWithUtmParams(url)
 
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(jitmPrefixUtmCampaign)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_campaign")).isEqualTo(utmCampaign)
         assertThat(urlWithUTM).isEqualTo(expectedUrl)
     }
 
     @Test
-    fun `testContentPrefixIsAddedWhileAddingUtmParams`() {
+    fun `testContentIsAddedAsRawValueWithoutPrefix`() {
         val utmContent = "test_content"
-        val jitmPrefixedUtmContent = "jitm_$utmContent"
         val defaultUTMMedium = "woo_android"
         val url = "https://www.woocommerce.com/us/hw"
         val expectedUrl = "https://www.woocommerce.com/us/hw?" +
-            "utm_content=$jitmPrefixedUtmContent&utm_term=1234&utm_medium=$defaultUTMMedium"
+            "utm_content=$utmContent&utm_term=1234&utm_medium=$defaultUTMMedium"
 
         val urlWithUTM = provideUTMProvider(
             campaign = "",
@@ -215,7 +208,7 @@ class WooCommerceComUTMProviderTest {
             siteId = 1234L
         ).getUrlWithUtmParams(url)
 
-        assertThat(urlWithUTM.toUri().getQueryParameter("utm_content")).isEqualTo(jitmPrefixedUtmContent)
+        assertThat(urlWithUTM.toUri().getQueryParameter("utm_content")).isEqualTo(utmContent)
         assertThat(urlWithUTM).isEqualTo(expectedUrl)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmUtmProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmUtmProvider.kt
@@ -17,9 +17,9 @@ class JitmUtmProvider @Inject constructor() {
         url: String
     ): String {
         return UtmProvider(
-            campaign = featureClass,
+            campaign = if (featureClass.isNotEmpty()) "jitm_group_$featureClass" else featureClass,
             source = source,
-            content = id,
+            content = if (id.isNotEmpty()) "jitm_$id" else id,
             siteId = siteId
         ).getUrlWithUtmParams(url)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoDialogFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoDialogFragment.kt
@@ -44,16 +44,23 @@ class PosPromoDialogFragment : DialogFragment() {
                             dismiss()
                         },
                         onNextClick = viewModel::onNextClick,
-                        onExploreClick = {
-                            viewModel.onExploreClick()
-                            requireActivity().findNavController(R.id.nav_host_fragment_main).navigate(
-                                NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
-                                    urlToLoad = PosPromoViewModel.WOO_POS_DOCS_URL
-                                )
-                            )
-                            dismiss()
-                        }
+                        onExploreClick = viewModel::onExploreClick
                     )
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is PosPromoViewModel.NavigateToExplore -> {
+                    requireActivity().findNavController(R.id.nav_host_fragment_main).navigate(
+                        NavGraphMainDirections.actionGlobalAuthenticatedWebViewFragment(
+                            urlToLoad = event.url
+                        )
+                    )
+                    dismiss()
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoUtmProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoUtmProvider.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.ui.pospromo
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.UtmProvider
+import dagger.Reusable
+import javax.inject.Inject
+
+@Reusable
+class PosPromoUtmProvider @Inject constructor(
+    private val selectedSite: SelectedSite,
+) {
+    fun getUrlWithUtmParams(url: String): String {
+        return UtmProvider(
+            campaign = UTM_CAMPAIGN,
+            source = UTM_SOURCE,
+            content = UTM_CONTENT,
+            siteId = selectedSite.getIfExists()?.siteId
+        ).getUrlWithUtmParams(url)
+    }
+
+    companion object {
+        private const val UTM_CAMPAIGN = "pos_promotion_modal"
+        private const val UTM_SOURCE = "my_store"
+        private const val UTM_CONTENT = "pos_promotion_cta"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pospromo/PosPromoViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.pospromo
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,6 +13,7 @@ import javax.inject.Inject
 class PosPromoViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val analyticsTracker: PosPromoAnalyticsTracker,
+    private val utmProvider: PosPromoUtmProvider,
 ) : ScopedViewModel(savedStateHandle) {
 
     private val _state = MutableStateFlow(PosPromoState())
@@ -38,9 +40,13 @@ class PosPromoViewModel @Inject constructor(
 
     fun onExploreClick() {
         analyticsTracker.trackExploreClicked()
+        val url = utmProvider.getUrlWithUtmParams(WOO_POS_DOCS_URL)
+        triggerEvent(NavigateToExplore(url))
     }
 
+    data class NavigateToExplore(val url: String) : MultiLiveEvent.Event()
+
     companion object {
-        const val WOO_POS_DOCS_URL = "https://woocommerce.com/mobile/pos/learn-more"
+        private const val WOO_POS_DOCS_URL = "https://woocommerce.com/mobile/pos/learn-more"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UtmProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/UtmProvider.kt
@@ -18,17 +18,9 @@ class UtmProvider(
     val parameters: Map<String, Any?>
         get() {
             return mapOf<String, Any?>(
-                "utm_campaign" to if (campaign.isNotEmpty()) {
-                    "jitm_group_$campaign"
-                } else {
-                    campaign
-                },
+                "utm_campaign" to campaign,
                 "utm_source" to source,
-                "utm_content" to if (!content.isNullOrEmpty()) {
-                    "jitm_$content"
-                } else {
-                    content
-                },
+                "utm_content" to content,
                 "utm_term" to siteId,
                 "utm_medium" to defaultUTMMedium
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pospromo/PosPromoViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pospromo/PosPromoViewModelTest.kt
@@ -4,19 +4,24 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PosPromoViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: PosPromoViewModel
     private val analyticsTracker: PosPromoAnalyticsTracker = mock()
+    private val utmProvider: PosPromoUtmProvider = mock()
 
     private fun createViewModel() {
+        whenever(utmProvider.getUrlWithUtmParams(any())).thenReturn("https://test.url")
         viewModel = PosPromoViewModel(
             savedStateHandle = mock(),
-            analyticsTracker = analyticsTracker
+            analyticsTracker = analyticsTracker,
+            utmProvider = utmProvider
         )
     }
 
@@ -87,5 +92,15 @@ class PosPromoViewModelTest : BaseUnitTest() {
         viewModel.onExploreClick()
 
         verify(analyticsTracker).trackExploreClicked()
+    }
+
+    @Test
+    fun `when onExploreClick called, then NavigateToExplore event is triggered with UTM url`() = testBlocking {
+        val expectedUrl = "https://test.url"
+        createViewModel()
+
+        viewModel.onExploreClick()
+
+        assertThat(viewModel.event.value).isEqualTo(PosPromoViewModel.NavigateToExplore(expectedUrl))
     }
 }


### PR DESCRIPTION
WOOMOB-2010

### Description

Adds UTM tracking parameters to the Explore link in the POS promotion modal. This matches the iOS implementation and allows tracking conversions from the modal.

UTM parameters added:
- `campaign`: pos_promotion_modal
- `source`: my_store
- `content`: pos_promotion_cta

Also refactors `UtmProvider` to use raw values, moving the JITM-specific prefix logic (`jitm_group_`, `jitm_`) to `JitmUtmProvider`.

### Test Steps

1. Open the app on a phone (not tablet, GB/US and site without JP or JPC)
2. Navigate to My Store tab to trigger the POS promotion modal
3. Tap "Explore" button at the end of the modal flow
4. Verify the URL contains UTM parameters: `utm_campaign=pos_promotion_modal`, `utm_source=my_store`, `utm_content=pos_promotion_cta` (debugger can be used for that)

### Images/gif

N/A - no visual changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.