### PR TITLE
[WOOMOB-2019] Enable pull-to-refresh on POS search results view

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -51,6 +51,7 @@ fun WooPosItemsSearchScreen(
     )
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun WooPosItemsSearchScreen(
     modifier: Modifier = Modifier,
@@ -58,8 +59,25 @@ private fun WooPosItemsSearchScreen(
     onUIEvent: (WooPosItemsSearchUiEvent) -> Unit = {},
 ) {
     val listState = rememberLazyListState()
+
+    val ptrState = when (state) {
+        is WooPosItemsSearchViewState.Content -> state.pullToRefreshState
+        is WooPosItemsSearchViewState.Empty -> state.pullToRefreshState
+        else -> null
+    }
+
+    val pullRefreshState = rememberPullRefreshState(
+        refreshing = ptrState == WooPosPullToRefreshState.Refreshing,
+        onRefresh = { onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered) },
+    )
+
     Box(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .pullRefresh(
+                state = pullRefreshState,
+                enabled = ptrState == WooPosPullToRefreshState.Enabled,
+            ),
     ) {
         val stateClass by remember(state) {
             derivedStateOf {
@@ -90,7 +108,7 @@ private fun WooPosItemsSearchScreen(
 
                 WooPosItemsSearchViewState.Content::class.java -> {
                     if (state is WooPosItemsSearchViewState.Content) {
-                        WooPosItemsSearchContentWithPullToRefresh(
+                        WooPosItemsSearchContent(
                             modifier = Modifier.padding(
                                 horizontal = WooPosSpacing.Medium.value,
                             ),
@@ -149,39 +167,11 @@ private fun WooPosItemsSearchScreen(
                 else -> error("Unsupported state: $currentStateClass")
             }
         }
-    }
-}
 
-@OptIn(ExperimentalMaterialApi::class)
-@Composable
-private fun WooPosItemsSearchContentWithPullToRefresh(
-    modifier: Modifier = Modifier,
-    listState: LazyListState,
-    state: WooPosItemsSearchViewState.Content,
-    onUIEvent: (WooPosItemsSearchUiEvent) -> Unit
-) {
-    val pullToRefreshState = rememberPullRefreshState(
-        refreshing = state.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
-        onRefresh = { onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered) },
-    )
-
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .pullRefresh(
-                state = pullToRefreshState,
-                enabled = state.pullToRefreshState == WooPosPullToRefreshState.Enabled,
-            )
-    ) {
-        WooPosItemsSearchContent(
-            listState = listState,
-            state = state,
-            onUIEvent = onUIEvent
-        )
         PullRefreshIndicator(
             modifier = Modifier.align(Alignment.TopCenter),
-            refreshing = state.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
-            state = pullToRefreshState
+            refreshing = ptrState == WooPosPullToRefreshState.Refreshing,
+            state = pullRefreshState
         )
     }
 }
@@ -297,7 +287,7 @@ fun WooPosItemsSearchEmptyPreview() {
                 .padding(WooPosSpacing.Medium.value)
         ) {
             WooPosItemsSearchScreen(
-                state = WooPosItemsSearchViewState.Empty,
+                state = WooPosItemsSearchViewState.Empty(),
                 onUIEvent = {}
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -60,14 +60,8 @@ private fun WooPosItemsSearchScreen(
 ) {
     val listState = rememberLazyListState()
 
-    val ptrState = when (state) {
-        is WooPosItemsSearchViewState.Content -> state.pullToRefreshState
-        is WooPosItemsSearchViewState.Empty -> state.pullToRefreshState
-        else -> null
-    }
-
     val pullRefreshState = rememberPullRefreshState(
-        refreshing = ptrState == WooPosPullToRefreshState.Refreshing,
+        refreshing = state.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
         onRefresh = { onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered) },
     )
 
@@ -76,7 +70,7 @@ private fun WooPosItemsSearchScreen(
             .fillMaxSize()
             .pullRefresh(
                 state = pullRefreshState,
-                enabled = ptrState == WooPosPullToRefreshState.Enabled,
+                enabled = state.pullToRefreshState == WooPosPullToRefreshState.Enabled,
             ),
     ) {
         val stateClass by remember(state) {
@@ -170,7 +164,7 @@ private fun WooPosItemsSearchScreen(
 
         PullRefreshIndicator(
             modifier = Modifier.align(Alignment.TopCenter),
-            refreshing = ptrState == WooPosPullToRefreshState.Refreshing,
+            refreshing = state.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
             state = pullRefreshState
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -9,12 +9,17 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
@@ -85,7 +90,7 @@ private fun WooPosItemsSearchScreen(
 
                 WooPosItemsSearchViewState.Content::class.java -> {
                     if (state is WooPosItemsSearchViewState.Content) {
-                        WooPosItemsSearchContent(
+                        WooPosItemsSearchContentWithPullToRefresh(
                             modifier = Modifier.padding(
                                 horizontal = WooPosSpacing.Medium.value,
                             ),
@@ -144,6 +149,40 @@ private fun WooPosItemsSearchScreen(
                 else -> error("Unsupported state: $currentStateClass")
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun WooPosItemsSearchContentWithPullToRefresh(
+    modifier: Modifier = Modifier,
+    listState: LazyListState,
+    state: WooPosItemsSearchViewState.Content,
+    onUIEvent: (WooPosItemsSearchUiEvent) -> Unit
+) {
+    val pullToRefreshState = rememberPullRefreshState(
+        refreshing = state.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
+        onRefresh = { onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered) },
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .pullRefresh(
+                state = pullToRefreshState,
+                enabled = state.pullToRefreshState == WooPosPullToRefreshState.Enabled,
+            )
+    ) {
+        WooPosItemsSearchContent(
+            listState = listState,
+            state = state,
+            onUIEvent = onUIEvent
+        )
+        PullRefreshIndicator(
+            modifier = Modifier.align(Alignment.TopCenter),
+            refreshing = state.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
+            state = pullToRefreshState
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchUiEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchUiEvent.kt
@@ -8,4 +8,5 @@ sealed class WooPosItemsSearchUiEvent {
     data object LoadingErrorRetryButtonClicked : WooPosItemsSearchUiEvent()
     data class OnRecentSearchClicked(val recentSearch: String) : WooPosItemsSearchUiEvent()
     data class OnPopularItemClicked(val item: WooPosItemSelectionViewState) : WooPosItemsSearchUiEvent()
+    data object OnPullToRefreshTriggered : WooPosItemsSearchUiEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -151,9 +151,15 @@ class WooPosItemsSearchViewModel @Inject constructor(
                         is SearchProductsResult.Local -> {
                             analyticsTracker.storedLocalSearchResultIds(searchResult.products.map { it.remoteId })
 
-                            if (searchResult.products.isEmpty() && showLoadingState) {
-                                _viewState.value = WooPosItemsSearchViewState.Loading
-                            } else if (searchResult.products.isNotEmpty()) {
+                            if (searchResult.products.isEmpty()) {
+                                if (showLoadingState) {
+                                    _viewState.value = WooPosItemsSearchViewState.Loading
+                                } else {
+                                    _viewState.value = WooPosItemsSearchViewState.Empty(
+                                        pullToRefreshState = determinePullToRefreshState()
+                                    )
+                                }
+                            } else {
                                 _viewState.value = searchResult.products.toContentState(
                                     searchQuery = query,
                                 )
@@ -164,7 +170,9 @@ class WooPosItemsSearchViewModel @Inject constructor(
                             if (searchResult.productsResult.isSuccess) {
                                 val products = searchResult.productsResult.getOrThrow()
                                 if (products.isEmpty()) {
-                                    _viewState.value = WooPosItemsSearchViewState.Empty
+                                    _viewState.value = WooPosItemsSearchViewState.Empty(
+                                        pullToRefreshState = determinePullToRefreshState()
+                                    )
                                 } else {
                                     _viewState.value = products.toContentState(searchQuery = query)
                                 }
@@ -180,7 +188,9 @@ class WooPosItemsSearchViewModel @Inject constructor(
                 if (query == currentQuery.get()) {
                     childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
                     if (_viewState.value is WooPosItemsSearchViewState.Loading) {
-                        _viewState.value = WooPosItemsSearchViewState.Empty
+                        _viewState.value = WooPosItemsSearchViewState.Empty(
+                            pullToRefreshState = determinePullToRefreshState()
+                        )
                     }
                 }
             }
@@ -323,9 +333,13 @@ class WooPosItemsSearchViewModel @Inject constructor(
 
     private fun handlePullToRefresh() {
         val currentState = _viewState.value
-        if (currentState !is WooPosItemsSearchViewState.Content) return
-
-        _viewState.value = currentState.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
+        _viewState.value = when (currentState) {
+            is WooPosItemsSearchViewState.Content ->
+                currentState.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
+            is WooPosItemsSearchViewState.Empty ->
+                currentState.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
+            else -> return
+        }
 
         viewModelScope.launch {
             wooPosAnalyticsTracker.track(
@@ -342,7 +356,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
                 when (syncResult.value) {
                     is PosLocalCatalogSyncResult.Success -> {
                         performSearch(
-                            query = currentState.searchQuery,
+                            query = currentQuery.get(),
                             showLoadingState = false,
                             skipDebounce = true,
                         )
@@ -367,8 +381,12 @@ class WooPosItemsSearchViewModel @Inject constructor(
             )
         }
         val currentState = _viewState.value
-        if (currentState is WooPosItemsSearchViewState.Content) {
-            _viewState.value = currentState.copy(pullToRefreshState = determinePullToRefreshState())
+        _viewState.value = when (currentState) {
+            is WooPosItemsSearchViewState.Content ->
+                currentState.copy(pullToRefreshState = determinePullToRefreshState())
+            is WooPosItemsSearchViewState.Empty ->
+                currentState.copy(pullToRefreshState = determinePullToRefreshState())
+            else -> currentState
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -335,29 +335,21 @@ class WooPosItemsSearchViewModel @Inject constructor(
                 )
             )
 
-            val result = dataSource.refreshProducts()
-            result.onSuccess { syncResult ->
-                when (syncResult) {
-                    is PosLocalCatalogProductSyncResult -> {
-                        when (syncResult.value) {
-                            is PosLocalCatalogSyncResult.Success -> {
-                                performSearch(
-                                    query = currentState.searchQuery,
-                                    showLoadingState = false,
-                                    skipDebounce = true,
-                                )
-                            }
-                            is PosLocalCatalogSyncResult.Failure -> {
-                                handlePTRError()
-                            }
-                        }
-                    }
-                    else -> {
+            dataSource.refreshProducts().onSuccess { syncResult ->
+                check(syncResult is PosLocalCatalogProductSyncResult) {
+                    "PTR should be enabled/available only for Local Catalog: $syncResult"
+                }
+                when (syncResult.value) {
+                    is PosLocalCatalogSyncResult.Success -> {
                         performSearch(
                             query = currentState.searchQuery,
                             showLoadingState = false,
                             skipDebounce = true,
                         )
+                    }
+
+                    is PosLocalCatalogSyncResult.Failure -> {
+                        handlePTRError()
                     }
                 }
             }.onFailure {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -116,7 +116,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
         performSearch(currentState.searchQuery)
     }
 
-    @Suppress("CyclomaticComplexMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     private fun performSearch(
         query: String,
         showLoadingState: Boolean = true,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.home.items.search
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.SearchEvent.RecentSearchSelected
@@ -12,11 +13,17 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsSearchHelper
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.home.items.products.SearchProductsResult
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource.SyncStrategy
+import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogProductSyncResult
+import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -39,6 +46,8 @@ class WooPosItemsSearchViewModel @Inject constructor(
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver,
     private val searchHelper: WooPosItemsSearchHelper,
     private val analyticsTracker: WooPosItemsSearchAnalyticsTracker,
+    private val resourceProvider: ResourceProvider,
+    private val wooPosAnalyticsTracker: WooPosAnalyticsTracker,
 ) : ViewModel() {
     private val _viewState =
         MutableStateFlow<WooPosItemsSearchViewState>(
@@ -95,6 +104,8 @@ class WooPosItemsSearchViewModel @Inject constructor(
                     handleItemClicked(event.item, WooPosAnalyticsEventConstant.ItemsListSourceType.POPULAR_PRODUCTS)
                 }
             }
+
+            WooPosItemsSearchUiEvent.OnPullToRefreshTriggered -> handlePullToRefresh()
         }
     }
 
@@ -105,7 +116,12 @@ class WooPosItemsSearchViewModel @Inject constructor(
         performSearch(currentState.searchQuery)
     }
 
-    private fun performSearch(query: String) {
+    @Suppress("CyclomaticComplexMethod")
+    private fun performSearch(
+        query: String,
+        showLoadingState: Boolean = true,
+        skipDebounce: Boolean = false,
+    ) {
         searchJob?.cancel()
 
         currentQuery.set(query)
@@ -114,8 +130,12 @@ class WooPosItemsSearchViewModel @Inject constructor(
             setEmptySearchQueryState()
         } else {
             searchJob = viewModelScope.launch {
-                _viewState.value = WooPosItemsSearchViewState.Loading
-                delay(SEARCH_DEBOUNCING_TIME)
+                if (showLoadingState) {
+                    _viewState.value = WooPosItemsSearchViewState.Loading
+                }
+                if (!skipDebounce) {
+                    delay(SEARCH_DEBOUNCING_TIME)
+                }
 
                 if (query != currentQuery.get()) return@launch
 
@@ -131,9 +151,9 @@ class WooPosItemsSearchViewModel @Inject constructor(
                         is SearchProductsResult.Local -> {
                             analyticsTracker.storedLocalSearchResultIds(searchResult.products.map { it.remoteId })
 
-                            if (searchResult.products.isEmpty()) {
+                            if (searchResult.products.isEmpty() && showLoadingState) {
                                 _viewState.value = WooPosItemsSearchViewState.Loading
-                            } else {
+                            } else if (searchResult.products.isNotEmpty()) {
                                 _viewState.value = searchResult.products.toContentState(
                                     searchQuery = query,
                                 )
@@ -286,11 +306,79 @@ class WooPosItemsSearchViewModel @Inject constructor(
     private suspend fun List<WooPosProductModel>.toContentState(
         searchQuery: String,
         paginationState: WooPosPaginationState = WooPosPaginationState.None,
+        pullToRefreshState: WooPosPullToRefreshState = determinePullToRefreshState(),
     ) = WooPosItemsSearchViewState.Content(
         items = map { it.toViewModelProduct() },
         searchQuery = searchQuery,
         paginationState = paginationState,
+        pullToRefreshState = pullToRefreshState,
     )
+
+    private fun determinePullToRefreshState(): WooPosPullToRefreshState {
+        return when (dataSource.getCurrentSyncStrategy()) {
+            SyncStrategy.LOCAL_CATALOG -> WooPosPullToRefreshState.Enabled
+            SyncStrategy.REMOTE -> WooPosPullToRefreshState.Disabled
+        }
+    }
+
+    private fun handlePullToRefresh() {
+        val currentState = _viewState.value
+        if (currentState !is WooPosItemsSearchViewState.Content) return
+
+        _viewState.value = currentState.copy(pullToRefreshState = WooPosPullToRefreshState.Refreshing)
+
+        viewModelScope.launch {
+            wooPosAnalyticsTracker.track(
+                WooPosAnalyticsEvent.Event.PullToRefreshTriggered(
+                    WooPosAnalyticsEventConstant.ItemsListSource.PRODUCT,
+                    WooPosAnalyticsEventConstant.ItemsListSourceType.SEARCH_RESULT
+                )
+            )
+
+            val result = dataSource.refreshProducts()
+            result.onSuccess { syncResult ->
+                when (syncResult) {
+                    is PosLocalCatalogProductSyncResult -> {
+                        when (syncResult.value) {
+                            is PosLocalCatalogSyncResult.Success -> {
+                                performSearch(
+                                    query = currentState.searchQuery,
+                                    showLoadingState = false,
+                                    skipDebounce = true,
+                                )
+                            }
+                            is PosLocalCatalogSyncResult.Failure -> {
+                                handlePTRError()
+                            }
+                        }
+                    }
+                    else -> {
+                        performSearch(
+                            query = currentState.searchQuery,
+                            showLoadingState = false,
+                            skipDebounce = true,
+                        )
+                    }
+                }
+            }.onFailure {
+                handlePTRError()
+            }
+        }
+    }
+
+    private fun handlePTRError() {
+        viewModelScope.launch {
+            childToParentEventSender.sendToParent(
+                ChildToParentEvent.ToastMessageDisplayed(
+                    message = resourceProvider.getString(R.string.something_went_wrong_try_again)
+                )
+            )
+        }
+        val currentState = _viewState.value
+        if (currentState is WooPosItemsSearchViewState.Content) {
+            _viewState.value = currentState.copy(pullToRefreshState = determinePullToRefreshState())
+        }
+    }
 
     private suspend fun WooPosProductModel.toViewModelProduct(): WooPosItemSelectionViewState.Product =
         if (type == WooPosProductModel.WooPosProductType.VARIABLE) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -372,20 +372,20 @@ class WooPosItemsSearchViewModel @Inject constructor(
         }
     }
 
-    private fun handlePTRError() {
-        viewModelScope.launch {
-            childToParentEventSender.sendToParent(
-                ChildToParentEvent.ToastMessageDisplayed(
-                    message = resourceProvider.getString(R.string.something_went_wrong_try_again)
-                )
+    private suspend fun handlePTRError() {
+        childToParentEventSender.sendToParent(
+            ChildToParentEvent.ToastMessageDisplayed(
+                message = resourceProvider.getString(R.string.something_went_wrong_try_again)
             )
-        }
+        )
         val currentState = _viewState.value
         _viewState.value = when (currentState) {
             is WooPosItemsSearchViewState.Content ->
                 currentState.copy(pullToRefreshState = determinePullToRefreshState())
+
             is WooPosItemsSearchViewState.Empty ->
                 currentState.copy(pullToRefreshState = determinePullToRefreshState())
+
             else -> currentState
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
@@ -5,22 +5,24 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
-sealed class WooPosItemsSearchViewState {
+sealed class WooPosItemsSearchViewState(
+    open val pullToRefreshState: WooPosPullToRefreshState,
+) {
     data class EmptySearchQuery(
         val popularItems: List<WooPosItemSelectionViewState.Product>,
         val recentSearches: List<String>,
-    ) : WooPosItemsSearchViewState()
+    ) : WooPosItemsSearchViewState(WooPosPullToRefreshState.Disabled)
 
     data class Content(
         val searchQuery: String,
         override val items: List<WooPosItemSelectionViewState>,
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
         override val paginationState: WooPosPaginationState = WooPosPaginationState.None,
-    ) : WooPosItemsSearchViewState(), WooPosContentViewState
+    ) : WooPosItemsSearchViewState(pullToRefreshState), WooPosContentViewState
 
     data class Empty(
-        val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
-    ) : WooPosItemsSearchViewState()
-    data class Error(val searchQuery: String) : WooPosItemsSearchViewState()
-    data object Loading : WooPosItemsSearchViewState()
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    ) : WooPosItemsSearchViewState(pullToRefreshState)
+    data class Error(val searchQuery: String) : WooPosItemsSearchViewState(WooPosPullToRefreshState.Disabled)
+    data object Loading : WooPosItemsSearchViewState(WooPosPullToRefreshState.Disabled)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewState.kt
@@ -18,7 +18,9 @@ sealed class WooPosItemsSearchViewState {
         override val paginationState: WooPosPaginationState = WooPosPaginationState.None,
     ) : WooPosItemsSearchViewState(), WooPosContentViewState
 
-    data object Empty : WooPosItemsSearchViewState()
+    data class Empty(
+        val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+    ) : WooPosItemsSearchViewState()
     data class Error(val searchQuery: String) : WooPosItemsSearchViewState()
     data object Loading : WooPosItemsSearchViewState()
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -9,13 +9,18 @@ import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceive
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState.Product
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel.ItemClickedData
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.home.items.products.SearchProductsResult
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsDataSource
+import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogProductSyncResult
+import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.ui.woopos.util.generateWooPosProduct
+import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.emptyFlow
@@ -50,6 +55,8 @@ class WooPosItemsSearchViewModelTest {
     private val mockParentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock()
     private val mockSearchHelper: com.woocommerce.android.ui.woopos.home.items.WooPosItemsSearchHelper = mock()
     private val mockAnalyticsTracker: WooPosItemsSearchAnalyticsTracker = mock()
+    private val mockResourceProvider: ResourceProvider = mock()
+    private val mockWooPosAnalyticsTracker: WooPosAnalyticsTracker = mock()
 
     private val defaultQuery = "test query"
     private val defaultProduct = generateWooPosProduct(
@@ -66,6 +73,9 @@ class WooPosItemsSearchViewModelTest {
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(emptyFlow())
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
         whenever(mockPriceFormat(BigDecimal("20.0"))).thenReturn("$20.0")
+        whenever(
+            mockDataSource.getCurrentSyncStrategy()
+        ).thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
     }
 
     @Test
@@ -809,6 +819,133 @@ class WooPosItemsSearchViewModelTest {
             )
         }
 
+    @Test
+    fun `given local catalog sync strategy, when PTR triggered, then refresh products and rerun search`() = runTest {
+        // GIVEN
+        mockSuccessfulSearch(defaultQuery, listOf(defaultProduct))
+        whenever(
+            mockDataSource.getCurrentSyncStrategy()
+        ).thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
+        whenever(mockDataSource.refreshProducts()).thenReturn(
+            Result.success(PosLocalCatalogProductSyncResult(PosLocalCatalogSyncResult.Success(1, 0, 100L)))
+        )
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered)
+        advanceUntilIdle()
+
+        // THEN
+        viewModel.viewState.test {
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Content::class.java)
+            assertThat((state as WooPosItemsSearchViewState.Content).pullToRefreshState)
+                .isEqualTo(WooPosPullToRefreshState.Enabled)
+        }
+    }
+
+    @Test
+    fun `given remote sync strategy, when content state loaded, then PTR state is Disabled`() = runTest {
+        // GIVEN
+        mockSuccessfulSearch(defaultQuery, listOf(defaultProduct))
+        whenever(mockDataSource.getCurrentSyncStrategy()).thenReturn(WooPosProductsDataSource.SyncStrategy.REMOTE)
+
+        // WHEN
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        viewModel.viewState.test {
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Content::class.java)
+            assertThat((state as WooPosItemsSearchViewState.Content).pullToRefreshState)
+                .isEqualTo(WooPosPullToRefreshState.Disabled)
+        }
+    }
+
+    @Test
+    fun `given PTR triggered and sync fails, when error occurs, then toast shown and PTR state reset`() = runTest {
+        // GIVEN
+        mockSuccessfulSearch(defaultQuery, listOf(defaultProduct))
+        whenever(
+            mockDataSource.getCurrentSyncStrategy()
+        ).thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
+        whenever(mockDataSource.refreshProducts()).thenReturn(
+            Result.success(
+                PosLocalCatalogProductSyncResult(
+                    PosLocalCatalogSyncResult.Failure.NetworkError("Network error")
+                )
+            )
+        )
+        whenever(mockResourceProvider.getString(any())).thenReturn("Something went wrong")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered)
+        advanceUntilIdle()
+
+        // THEN
+        verify(mockChildToParentEventSender).sendToParent(any<ChildToParentEvent.ToastMessageDisplayed>())
+        viewModel.viewState.test {
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Content::class.java)
+            assertThat((state as WooPosItemsSearchViewState.Content).pullToRefreshState)
+                .isEqualTo(WooPosPullToRefreshState.Enabled)
+        }
+    }
+
+    @Test
+    fun `given PTR triggered, when event fired, then analytics event tracked`() = runTest {
+        // GIVEN
+        mockSuccessfulSearch(defaultQuery, listOf(defaultProduct))
+        whenever(
+            mockDataSource.getCurrentSyncStrategy()
+        ).thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
+        whenever(mockDataSource.refreshProducts()).thenReturn(
+            Result.success(PosLocalCatalogProductSyncResult(PosLocalCatalogSyncResult.Success(1, 0, 100L)))
+        )
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered)
+        advanceUntilIdle()
+
+        // THEN
+        verify(mockWooPosAnalyticsTracker).track(
+            WooPosAnalyticsEvent.Event.PullToRefreshTriggered(
+                WooPosAnalyticsEventConstant.ItemsListSource.PRODUCT,
+                WooPosAnalyticsEventConstant.ItemsListSourceType.SEARCH_RESULT
+            )
+        )
+    }
+
+    @Test
+    fun `given local catalog sync strategy, when content state loaded, then PTR state is Enabled`() = runTest {
+        // GIVEN
+        mockSuccessfulSearch(defaultQuery, listOf(defaultProduct))
+        whenever(
+            mockDataSource.getCurrentSyncStrategy()
+        ).thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
+
+        // WHEN
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        viewModel.viewState.test {
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Content::class.java)
+            assertThat((state as WooPosItemsSearchViewState.Content).pullToRefreshState)
+                .isEqualTo(WooPosPullToRefreshState.Enabled)
+        }
+    }
+
     private fun mockSuccessfulSearch(query: String, products: List<WooPosProductModel>) {
         whenever(mockDataSource.searchProducts(query)).thenReturn(
             flowOf(
@@ -872,5 +1009,7 @@ class WooPosItemsSearchViewModelTest {
         parentToChildrenEventReceiver = mockParentToChildrenEventReceiver,
         searchHelper = mockSearchHelper,
         analyticsTracker = mockAnalyticsTracker,
+        resourceProvider = mockResourceProvider,
+        wooPosAnalyticsTracker = mockWooPosAnalyticsTracker,
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -265,7 +265,8 @@ class WooPosItemsSearchViewModelTest {
 
         // THEN
         viewModel.viewState.test {
-            assertThat(awaitItem()).isEqualTo(WooPosItemsSearchViewState.Empty)
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Empty::class.java)
         }
     }
 
@@ -948,6 +949,136 @@ class WooPosItemsSearchViewModelTest {
                 .isEqualTo(WooPosPullToRefreshState.Enabled)
         }
     }
+
+    @Test
+    fun `given empty search results with local catalog sync, when PTR triggered, then refresh products and rerun search`() =
+        runTest {
+            // GIVEN
+            mockSuccessfulSearch(defaultQuery, emptyList())
+            whenever(
+                mockDataSource.getCurrentSyncStrategy()
+            ).thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
+            whenever(mockDataSource.refreshProducts()).thenReturn(
+                Result.success(PosLocalCatalogProductSyncResult(PosLocalCatalogSyncResult.Success(1, 0, 100L)))
+            )
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            // Verify we're in Empty state
+            viewModel.viewState.test {
+                val state = awaitItem()
+                assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Empty::class.java)
+            }
+
+            // WHEN
+            viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered)
+            advanceUntilIdle()
+
+            // THEN
+            verify(mockDataSource).refreshProducts()
+            verify(mockDataSource, times(2)).searchProducts(defaultQuery)
+            viewModel.viewState.test {
+                val state = awaitItem()
+                assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Empty::class.java)
+                assertThat((state as WooPosItemsSearchViewState.Empty).pullToRefreshState)
+                    .isEqualTo(WooPosPullToRefreshState.Enabled)
+            }
+        }
+
+    @Test
+    fun `given empty search results, when PTR triggered and sync finishes, then PTR indicator disappears`() =
+        runTest {
+            // GIVEN
+            mockSuccessfulSearch(defaultQuery, emptyList())
+            whenever(
+                mockDataSource.getCurrentSyncStrategy()
+            ).thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
+            whenever(mockDataSource.refreshProducts()).thenReturn(
+                Result.success(PosLocalCatalogProductSyncResult(PosLocalCatalogSyncResult.Success(1, 0, 100L)))
+            )
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.viewState.test {
+                val state = awaitItem()
+                assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Empty::class.java)
+                assertThat((state as WooPosItemsSearchViewState.Empty).pullToRefreshState)
+                    .isEqualTo(WooPosPullToRefreshState.Enabled)
+            }
+
+            // WHEN
+            viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered)
+            advanceUntilIdle()
+
+            // THEN
+            viewModel.viewState.test {
+                val state = awaitItem()
+                assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Empty::class.java)
+                assertThat((state as WooPosItemsSearchViewState.Empty).pullToRefreshState)
+                    .isNotEqualTo(WooPosPullToRefreshState.Refreshing)
+                assertThat(state.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
+            }
+        }
+
+    @Test
+    fun `given remote sync strategy, when empty search result shown, then PTR state is Disabled`() = runTest {
+        // GIVEN
+        mockSuccessfulSearch(defaultQuery, emptyList())
+        whenever(mockDataSource.getCurrentSyncStrategy()).thenReturn(WooPosProductsDataSource.SyncStrategy.REMOTE)
+
+        // WHEN
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        viewModel.viewState.test {
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Empty::class.java)
+            assertThat((state as WooPosItemsSearchViewState.Empty).pullToRefreshState)
+                .isEqualTo(WooPosPullToRefreshState.Disabled)
+        }
+    }
+
+    @Test
+    fun `given empty search results and PTR fails, when error occurs, then toast shown and PTR state reset`() =
+        runTest {
+            // GIVEN
+            mockSuccessfulSearch(defaultQuery, emptyList())
+            whenever(
+                mockDataSource.getCurrentSyncStrategy()
+            ).thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
+            whenever(mockDataSource.refreshProducts()).thenReturn(
+                Result.success(
+                    PosLocalCatalogProductSyncResult(
+                        PosLocalCatalogSyncResult.Failure.NetworkError("Network error")
+                    )
+                )
+            )
+            whenever(mockResourceProvider.getString(any())).thenReturn("Something went wrong")
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.viewState.test {
+                val state = awaitItem()
+                assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Empty::class.java)
+            }
+
+            // WHEN
+            viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered)
+            advanceUntilIdle()
+
+            // THEN
+            verify(mockChildToParentEventSender).sendToParent(any<ChildToParentEvent.ToastMessageDisplayed>())
+            viewModel.viewState.test {
+                val state = awaitItem()
+                assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Empty::class.java)
+                assertThat((state as WooPosItemsSearchViewState.Empty).pullToRefreshState)
+                    .isEqualTo(WooPosPullToRefreshState.Enabled)
+            }
+        }
 
     private fun mockSuccessfulSearch(query: String, products: List<WooPosProductModel>) {
         whenever(mockDataSource.searchProducts(query)).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -38,6 +38,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
@@ -838,6 +839,8 @@ class WooPosItemsSearchViewModelTest {
         advanceUntilIdle()
 
         // THEN
+        verify(mockDataSource).refreshProducts()
+        verify(mockDataSource, times(2)).searchProducts(defaultQuery)
         viewModel.viewState.test {
             val state = awaitItem()
             assertThat(state).isInstanceOf(WooPosItemsSearchViewState.Content::class.java)


### PR DESCRIPTION
Fixes WOOMOB-2019

### Description
Adds pull-to-refresh functionality to the POS search results view. PTR is:
- Enabled only when local catalog sync strategy is active (disabled for remote/hybrid sync)
- Available only in the Content state (actual search results), not in EmptySearchQuery (popular products)
- Triggers an incremental sync when pulled, then re-runs the search query to show updated data

### Test Steps
1. Ensure local catalog is enabled for the store (Settings -> Experimental Features -> Local Catalog)
2. Open POS, search for a product
3. Rename one of the search results on the backend (or hide it from POS if you have supported version of Woo installed on your store)
4. Pull to refresh on the search results → should trigger sync and re-search and should track PTR event `woocommerceandroid_pos_items_pull_to_refresh, Properties: {"source":"product","source_type":"search", ... }`
5. Verify the product is updated (appears/disappears or is renamed)

-------
1. Enter a query which doesn't return any results (e.g. aaa 123)
2. Update name of a product on the backend to `aaa 123`
3. Pull to refresh on the empty result list
4. Verify the product appears
5. Update name of the product on the backend to `Product A`
6. Pull to refresh 
7. Verify the product disappears and empty view is shown

----

1. Verify PTR is NOT available on popular products view (empty search query)
8. Verify PTR is NOT available when Local Catalog is disabled (Settings -> Experimental Features -> Local Catalog)

### Images/gif

https://github.com/user-attachments/assets/ef00cb57-8b99-4577-be03-a45fecd859ba



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.