### PR TITLE
[WOOMOB-2020] Fix tracking events firing incorrectly during POS connection flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingChecker.kt
@@ -107,9 +107,8 @@ class CardReaderOnboardingChecker @Inject constructor(
                         state.preferredPlugin,
                         version
                     )
+                    paymentsFlowTracker.trackOnboardingState(state)
                 }
-        }.also {
-            paymentsFlowTracker.trackOnboardingState(it)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/update/CardReaderUpdateViewModel.kt
@@ -95,7 +95,7 @@ class CardReaderUpdateViewModel @Inject constructor(
     }
 
     private fun onUpdateStatusUnknown() {
-        tracker.trackSoftwareUpdateUnknownStatus()
+        // Unknown is an idle state, not a failure - no need to track
     }
 
     private fun onUpdateSucceeded() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/tracking/PaymentsFlowTracker.kt
@@ -277,13 +277,6 @@ class PaymentsFlowTracker @Inject constructor(
         track(eventProvider.CARD_READER_SOFTWARE_UPDATE_ALERT_INSTALL_CLICKED)
     }
 
-    fun trackSoftwareUpdateUnknownStatus() {
-        track(
-            eventProvider.CARD_READER_SOFTWARE_UPDATE_FAILED,
-            errorDescription = "Unknown software update status"
-        )
-    }
-
     fun trackSoftwareUpdateSucceeded(requiredUpdate: Boolean) {
         trackSoftwareUpdateEvent(eventProvider.CARD_READER_SOFTWARE_UPDATE_SUCCESS, requiredUpdate)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -460,7 +460,6 @@ class WooPosCardReaderConnectionController(
             }
             is SoftwareUpdateStatus.Unknown -> {
                 showUpdateCancelWarning = false
-                tracker.trackSoftwareUpdateUnknownStatus()
                 logger.d("Software update status unknown")
             }
         }


### PR DESCRIPTION
Closes WOOMOB-2020

### Description

Fixes two tracking issues during the card reader connection flow:

1. **`card_present_onboarding_completed` firing multiple times**
   - The event was tracked every time `getOnboardingState()` was called, including when returning cached results
   - Fixed by moving tracking inside the fetch block so it only fires when state is freshly fetched from server

2. **`software_update_failed` firing incorrectly with "Unknown software update status"**
   - The `Unknown` status is the initial/idle state of the `SoftwareUpdateStatus` StateFlow, not an actual failure
   - When `listenToSoftwareUpdateStatus()` started collecting, it immediately received this initial `Unknown` value and tracked it as a failure
   - Removed tracking for `Unknown` status entirely since it only occurs:
     - As the initial StateFlow value (before any update starts)
     - When `resetConnectionState()` is called after reader disconnection (cleanup)
   - Neither case represents an actual update failure. @malinajirka wdyt about that? It changes tracking for the card reader flow as well

### Test Steps

1. Connect to a card reader in POS
2. Verify `card_present_onboarding_completed` fires only once (not on every `getOnboardingState()` call)
3. Verify `software_update_failed` does not fire with "Unknown software update status" during normal connection flow

### Images/gif

N/A - Analytics tracking changes only

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.