### PR TITLE
Fix site specific push token id storage

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.WooNotificationBuilder
 import com.woocommerce.android.notifications.WooNotificationType
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.NotificationsParser
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.NOTIFS
@@ -23,6 +24,7 @@ import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.model.notification.NotificationModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications.PushNotificationsStore
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationPayload
 import javax.inject.Inject
@@ -34,6 +36,7 @@ class NotificationMessageHandler @Inject constructor(
     private val analyticsTracker: NotificationAnalyticsTracker,
     private val notificationsParser: NotificationsParser,
     private val accountStore: AccountStore,
+    private val pushNotificationsStore: PushNotificationsStore,
     private val wooLog: WooLog,
     private val dispatcher: Dispatcher,
     private val resourceProvider: ResourceProvider,
@@ -82,7 +85,9 @@ class NotificationMessageHandler @Inject constructor(
 
         val pushUserId = messageData[PUSH_ARG_USER]
         // pushUserId is always set server side, but better to double check it here.
-        if (accountStore.account.userId.toString() != pushUserId) {
+        if (!FeatureFlag.WOO_PUSH_NOTIFICATIONS_SYSTEM.isEnabled() &&
+            accountStore.account.userId.toString() != pushUserId
+        ) {
             wooLog.e(NOTIFS, "WP.com userId found in the app doesn't match with the ID in the PN. Aborting.")
             return
         }
@@ -94,10 +99,20 @@ class NotificationMessageHandler @Inject constructor(
         }
 
         val notification = notificationModel.toAppModel(resourceProvider)
-        if (notification.remoteNoteId == 0L) {
-            // At this point 'note_id' is always available in the notification bundle.
-            wooLog.e(NOTIFS, "Push notification received without a valid note_id in the payload!")
-            return
+
+        // We need to filter out duplicate notifications from the WPCOM system
+        if (FeatureFlag.WOO_PUSH_NOTIFICATIONS_SYSTEM.isEnabled()) {
+            val isFromWPcom = notification.remoteNoteId > 0L
+            if (isFromWPcom && pushNotificationsStore.hasPushToken()) {
+                wooLog.d(NOTIFS, "Skipping WPCOM notification, already registered with Woo Core")
+                return
+            }
+        } else {
+            if (notification.remoteNoteId == 0L) {
+                // At this point 'note_id' is always available in the notification bundle.
+                wooLog.e(NOTIFS, "Push notification received without a valid note_id in the payload!")
+                return
+            }
         }
 
         dispatchBackgroundEvents(notificationModel)
@@ -174,7 +189,7 @@ class NotificationMessageHandler @Inject constructor(
             // We always generate new id for NewOrder.
             activeNotifications
                 .firstOrNull {
-                    it.remoteNoteId == noteId &&
+                    noteId != 0L && it.remoteNoteId == noteId &&
                         it.noteTypeTrackingValue != WooNotificationType.NewOrder.trackingValue
                 }
                 ?.let { return it.id }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -103,7 +103,7 @@ class NotificationMessageHandler @Inject constructor(
         // We need to filter out duplicate notifications from the WPCOM system
         if (FeatureFlag.WOO_PUSH_NOTIFICATIONS_SYSTEM.isEnabled()) {
             val isFromWPcom = notification.remoteNoteId > 0L
-            if (isFromWPcom && pushNotificationsStore.hasPushToken()) {
+            if (isFromWPcom && pushNotificationsStore.hasPushToken(selectedSite.get())) {
                 wooLog.d(NOTIFS, "Skipping WPCOM notification, already registered with Woo Core")
                 return
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -291,12 +291,13 @@ class DashboardViewModel @Inject constructor(
         }
 
         val dismissTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+        val site = selectedSite.getIfExists() ?: return flowOf(null)
 
         return dismissTrigger.onStart { emit(Unit) }
             .map {
                 val durationSinceDismissal =
                     (System.currentTimeMillis() - appPrefsWrapper.getJetpackBenefitsDismissalDate()).milliseconds
-                val showBanner = !pushNotificationsStore.hasPushToken() &&
+                val showBanner = !pushNotificationsStore.hasPushToken(site) &&
                     durationSinceDismissal >= DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER.days
                 JetpackBenefitsBannerUiModel(
                     show = showBanner,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.notification.NotificationModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications.PushNotificationsStore
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.NotificationStore.FetchNotificationPayload
 
@@ -52,6 +53,7 @@ class NotificationMessageHandlerTest {
     private val accountStore: AccountStore = mock {
         on { account } doReturn accountModel
     }
+    private val pushNotificationsStore: PushNotificationsStore = mock()
     private val dispatcher: Dispatcher = mock()
     private val actionCaptor: KArgumentCaptor<Action<*>> = argumentCaptor()
     private val wooLog: WooLog = mock()
@@ -91,13 +93,14 @@ class NotificationMessageHandlerTest {
     @Before
     fun setUp() {
         notificationMessageHandler = NotificationMessageHandler(
-            accountStore = accountStore,
-            wooLog = wooLog,
-            dispatcher = dispatcher,
-            resourceProvider = resourceProvider,
             notificationBuilder = notificationBuilder,
             analyticsTracker = notificationAnalyticsTracker,
             notificationsParser = notificationsParser,
+            accountStore = accountStore,
+            pushNotificationsStore = pushNotificationsStore,
+            wooLog = wooLog,
+            dispatcher = dispatcher,
+            resourceProvider = resourceProvider,
             selectedSite = selectedSite,
             workManagerScheduler = workManagerScheduler,
         )

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStore.kt
@@ -32,7 +32,7 @@ class PushNotificationsStore @Inject internal constructor(
         if (payload.isError || payload.result == null) {
             WooResult(payload.error)
         } else {
-            persistPushTokenId(payload.result.id)
+            persistPushTokenId(site, payload.result.id)
             WooResult(Unit)
         }
     }
@@ -40,36 +40,59 @@ class PushNotificationsStore @Inject internal constructor(
     suspend fun deletePushToken(
         site: SiteModel
     ): WooResult<Unit> = coroutineEngine.withDefaultContext(T.API, this, "deletePushToken") {
-        getPersistedPushTokenId()?.let { pushTokenId ->
+        getPersistedPushTokenId(site)?.let { pushTokenId ->
             val result = pushNotificationsRestClient.deletePushToken(site, pushTokenId).asWooResult()
             if (!result.isError) {
-                preferences.edit { remove(PUSH_TOKEN_ID) }
+                clearPersistedPushTokenId(site)
             }
             result
         } ?: WooResult(
             WooError(
                 WooErrorType.GENERIC_ERROR,
                 BaseRequest.GenericErrorType.NOT_FOUND,
-                "No persisted push token id found"
+                "No persisted push token found for site ${site.id}"
             )
         )
     }
 
     @Synchronized
-    private fun getPersistedPushTokenId(): String? = preferences.getString(PUSH_TOKEN_ID, null)
+    private fun getPersistedPushTokenId(site: SiteModel): String? = getPersistedTokenIdSet()
+        .firstOrNull { it.startsWith(getSiteTokenIdPrefix(site)) }
+        ?.substringAfter(getSiteTokenIdPrefix(site))
 
     @Synchronized
-    private fun persistPushTokenId(tokenId: String) {
-        if (getPersistedPushTokenId() != tokenId) {
-            preferences.edit { putString(PUSH_TOKEN_ID, tokenId) }
+    private fun persistPushTokenId(site: SiteModel, tokenId: String) {
+        val persistedPushTokenIds = getPersistedTokenIdSet()
+
+        val updatedPushTokenIds =
+            persistedPushTokenIds.filterNot { it.startsWith(getSiteTokenIdPrefix(site)) }.toMutableSet()
+        updatedPushTokenIds.add(getSiteTokenIdPrefix(site) + tokenId)
+
+        if (persistedPushTokenIds != updatedPushTokenIds) {
+            preferences.edit { putStringSet(PUSH_TOKEN_IDS, updatedPushTokenIds) }
         }
     }
 
-    fun hasPushToken(): Boolean = getPersistedPushTokenId() != null
+    @Synchronized
+    private fun clearPersistedPushTokenId(site: SiteModel) {
+        val persistedPushTokens = getPersistedTokenIdSet()
+
+        val updatedPushTokens = persistedPushTokens.filterNot { it.startsWith(getSiteTokenIdPrefix(site)) }.toSet()
+
+        if (persistedPushTokens != updatedPushTokens) {
+            preferences.edit { putStringSet(PUSH_TOKEN_IDS, updatedPushTokens) }
+        }
+    }
+
+    private fun getPersistedTokenIdSet() = preferences.getStringSet(PUSH_TOKEN_IDS, null) ?: setOf()
+
+    private fun getSiteTokenIdPrefix(site: SiteModel) = "${site.id}:"
+
+    fun hasPushToken(site: SiteModel): Boolean = getPersistedPushTokenId(site) != null
 
     companion object {
         private const val ORIGIN = "com.woocommerce.android"
         private const val ORIGIN_DEV = "com.woocommerce.android:dev"
-        private const val PUSH_TOKEN_ID = "push_token_id"
+        private const val PUSH_TOKEN_IDS = "push_token_ids"
     }
 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStoreTest.kt
@@ -45,7 +45,7 @@ class PushNotificationsStoreTest {
             // GIVEN
             val site = SiteModel().apply { id = 123 }
             val newTokenId = "101"
-            whenever(prefs.getString(eq("push_token_id"), anyOrNull())).thenReturn(null)
+            whenever(prefs.getStringSet(eq("push_token_ids"), anyOrNull())).thenReturn(emptySet())
             whenever(restClient.registerPushToken(any(), any(), any(), any()))
                 .thenReturn(WooPayload(PushTokenIdResponse(newTokenId)))
 
@@ -53,9 +53,30 @@ class PushNotificationsStoreTest {
             sut.registerPushToken(site, "token", "uuid")
 
             // THEN
-            val captor = argumentCaptor<String>()
-            verify(editor).putString(eq("push_token_id"), captor.capture())
-            assertThat(captor.firstValue).isEqualTo(newTokenId)
+            val captor = argumentCaptor<Set<String>>()
+            verify(editor).putStringSet(eq("push_token_ids"), captor.capture())
+            assertThat(captor.firstValue).containsExactly("${site.id}:$newTokenId")
+        }
+    }
+
+    @Test
+    fun `given existing token, when registerPushToken succeeds, then updates existing token`() {
+        runBlocking {
+            // GIVEN
+            val site = SiteModel().apply { id = 123 }
+            val oldTokenId = "100"
+            val newTokenId = "101"
+            whenever(prefs.getStringSet(eq("push_token_ids"), anyOrNull())).thenReturn(setOf("${site.id}:$oldTokenId"))
+            whenever(restClient.registerPushToken(any(), any(), any(), any()))
+                .thenReturn(WooPayload(PushTokenIdResponse(newTokenId)))
+
+            // WHEN
+            sut.registerPushToken(site, "token", "uuid")
+
+            // THEN
+            val captor = argumentCaptor<Set<String>>()
+            verify(editor).putStringSet(eq("push_token_ids"), captor.capture())
+            assertThat(captor.firstValue).containsExactly("${site.id}:$newTokenId")
         }
     }
 
@@ -65,19 +86,22 @@ class PushNotificationsStoreTest {
             // GIVEN
             val site = SiteModel().apply { id = 123 }
             val existingTokenId = "100"
+            val otherToken = "999:200"
             whenever(
-                prefs.getString(
-                    eq("push_token_id"),
+                prefs.getStringSet(
+                    eq("push_token_ids"),
                     anyOrNull()
                 )
-            ).thenReturn(existingTokenId)
+            ).thenReturn(setOf("${site.id}:$existingTokenId", otherToken))
             whenever(restClient.deletePushToken(any(), any())).thenReturn(WooPayload(Unit))
 
             // WHEN
             sut.deletePushToken(site)
 
             // THEN
-            verify(editor).remove(eq("push_token_id"))
+            val captor = argumentCaptor<Set<String>>()
+            verify(editor).putStringSet(eq("push_token_ids"), captor.capture())
+            assertThat(captor.firstValue).containsExactly(otherToken)
         }
     }
 
@@ -86,7 +110,7 @@ class PushNotificationsStoreTest {
         runBlocking {
             // GIVEN
             val site = SiteModel().apply { id = 123 }
-            whenever(prefs.getString(eq("push_token_id"), anyOrNull())).thenReturn(null)
+            whenever(prefs.getStringSet(eq("push_token_ids"), anyOrNull())).thenReturn(emptySet())
 
             // WHEN
             val result = sut.deletePushToken(site)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR reverts the push token storage back to site-specific. In #15141, I initially implemented site-specific storage correctly, but later changed it to global storage thinking token IDs weren't site-specific. That was a mistake, token IDs should indeed be stored per site. This PR restores the original behavior using a `siteId:tokenId` format in `SharedPreferences`.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Set up a store with the new Woo Core endpoints by following these steps: p91TBi-dyW-p2#comment-14564
2 Apply this patch to enable the feature flag: [Enable_WOO_PUSH_NOTIFICATIONS_SYSTEM_feature_flag_for_debug_builds.patch](https://github.com/user-attachments/files/24753586/Enable_.WOO_PUSH_NOTIFICATIONS_SYSTEM._feature_flag_for_debug_builds.patch)
3. Install the app and log into your store.
4. Monitor shared_prefs from any tool. I used Device Explorer (`/data/data/com.woocommerce.android/shared_prefs/com.woocommerce.android_fluxc-preferences.xml`)
<img width="393" height="188" alt="image" src="https://github.com/user-attachments/assets/0b423cd2-1f58-4103-ba99-d344f65aa606" />

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->