### PR TITLE
[WOOMOB-2033] Update POS promotion modal title

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4358,7 +4358,7 @@
     <string name="about_automattic_app_icon_description">App icon</string>
 
     <!-- Woo POS Promo Carousel -->
-    <string name="woo_pos_promo_title">Run POS with the\nWooCommerce mobile app</string>
+    <string name="woo_pos_promo_title">Point of Sale from WooCommerce</string>
     <string name="woo_pos_promo_page1_description">Take payments in person and connect everything back to your store — all through the WooCommerce mobile app.</string>
     <string name="woo_pos_promo_page2_description">Real-time syncing for inventory, customer, and order data between online and in-person channels.</string>
     <string name="woo_pos_promo_page3_description">Quick and simple to learn.</string>


### PR DESCRIPTION
WOOMOB-2033

### Description

Updates the POS promotion modal title from "Run POS with the WooCommerce mobile app" to "Point of Sale from WooCommerce" to align with iOS.

### Test Steps

1. Set up a network proxy to return a client-side JITM banner
2. Tap the banner to open the promotion modal
3. Verify the title displays "Point of Sale from WooCommerce"

@joshheald just to validate, are the only copy changes you expect?

### Images/gif

<img width="325" height="576" alt="image" src="https://github.com/user-attachments/assets/a26834b1-7fd2-4438-858a-294a90d704a0" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.