### PR TITLE
[WOOMOB-2032] Display specific error message for no internet connection on POS PTR

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -325,7 +325,7 @@ class WooPosProductsViewModel @Inject constructor(
                                 _viewState.value = hidePTRIndicator()
                             }
                             is PosLocalCatalogSyncResult.Failure -> {
-                                handlePTRError()
+                                handlePTRError(syncResult.value)
                             }
                         }
                     }
@@ -339,22 +339,25 @@ class WooPosProductsViewModel @Inject constructor(
                                 WooPosProductsViewState.Empty()
                             }
                         } else {
-                            handlePTRError()
+                            handlePTRError(failure = null)
                         }
                     }
                 }
             }.onFailure { _ ->
-                handlePTRError()
+                handlePTRError(failure = null)
             }
         }
     }
 
-    private fun handlePTRError() {
+    private fun handlePTRError(failure: PosLocalCatalogSyncResult.Failure?) {
+        val messageResId = if (failure is PosLocalCatalogSyncResult.Failure.NetworkError) {
+            R.string.woo_pos_ptr_offline_error
+        } else {
+            R.string.something_went_wrong_try_again
+        }
         sendEventToParent(
             ChildToParentEvent.ToastMessageDisplayed(
-                message = resourceProvider.getString(
-                    R.string.something_went_wrong_try_again
-                )
+                message = resourceProvider.getString(messageResId)
             )
         )
         _viewState.value = hidePTRIndicator()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.home.items.products
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.WooException
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
@@ -32,6 +33,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import javax.inject.Inject
 
 @HiltViewModel
@@ -325,7 +327,7 @@ class WooPosProductsViewModel @Inject constructor(
                                 _viewState.value = hidePTRIndicator()
                             }
                             is PosLocalCatalogSyncResult.Failure -> {
-                                handlePTRError(syncResult.value)
+                                handlePTRError(isNetworkError = isNetworkError(syncResult.value))
                             }
                         }
                     }
@@ -339,18 +341,30 @@ class WooPosProductsViewModel @Inject constructor(
                                 WooPosProductsViewState.Empty()
                             }
                         } else {
-                            handlePTRError(failure = null)
+                            handlePTRError(
+                                isNetworkError = isNetworkError(syncResult.productsResult.exceptionOrNull())
+                            )
                         }
                     }
                 }
-            }.onFailure { _ ->
-                handlePTRError(failure = null)
+            }.onFailure { error ->
+                handlePTRError(isNetworkError = isNetworkError(error))
             }
         }
     }
 
-    private fun handlePTRError(failure: PosLocalCatalogSyncResult.Failure?) {
-        val messageResId = if (failure is PosLocalCatalogSyncResult.Failure.NetworkError) {
+    private fun isNetworkError(error: Any?): Boolean {
+        return when (error) {
+            is WooException ->
+                error.error.type == WooErrorType.TIMEOUT ||
+                    error.error.type == WooErrorType.NO_CONNECTION
+            is PosLocalCatalogSyncResult.Failure.NetworkError -> true
+            else -> false
+        }
+    }
+
+    private fun handlePTRError(isNetworkError: Boolean) {
+        val messageResId = if (isNetworkError) {
             R.string.woo_pos_ptr_offline_error
         } else {
             R.string.something_went_wrong_try_again

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -363,19 +363,24 @@ class WooPosItemsSearchViewModel @Inject constructor(
                     }
 
                     is PosLocalCatalogSyncResult.Failure -> {
-                        handlePTRError()
+                        handlePTRError(syncResult.value)
                     }
                 }
             }.onFailure {
-                handlePTRError()
+                handlePTRError(failure = null)
             }
         }
     }
 
-    private suspend fun handlePTRError() {
+    private suspend fun handlePTRError(failure: PosLocalCatalogSyncResult.Failure?) {
+        val messageResId = if (failure is PosLocalCatalogSyncResult.Failure.NetworkError) {
+            R.string.woo_pos_ptr_offline_error
+        } else {
+            R.string.something_went_wrong_try_again
+        }
         childToParentEventSender.sendToParent(
             ChildToParentEvent.ToastMessageDisplayed(
-                message = resourceProvider.getString(R.string.something_went_wrong_try_again)
+                message = resourceProvider.getString(messageResId)
             )
         )
         val currentState = _viewState.value

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="set_up_now">Set up now</string>
     <string name="offline_message">Offline \u2014 using cached data</string>
     <string name="offline_error">Your network is unavailable. Check your data or wifi connection.</string>
+    <string name="woo_pos_ptr_offline_error">No internet connection. Please check your network and try again.</string>
     <string name="product">Product</string>
     <string name="today">Today</string>
     <string name="this_week">This Week</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.items.products
 
 import app.cash.turbine.test
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
@@ -11,6 +12,8 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemSelectionViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosProductsViewState
+import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogProductSyncResult
+import com.woocommerce.android.ui.woopos.localcatalog.PosLocalCatalogSyncResult
 import com.woocommerce.android.ui.woopos.localcatalog.ProductsResult
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosPerformLocalCatalogIncrementalSync
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
@@ -554,6 +557,52 @@ class WooPosProductsViewModelTest {
                 source = WooPosAnalyticsEventConstant.ItemsListSource.PRODUCT,
                 sourceType = WooPosAnalyticsEventConstant.ItemsListSourceType.LIST
             )
+        )
+    }
+
+    @Test
+    fun `given network error on PTR, when pull to refresh fails, then show offline error message`() = runTest {
+        // GIVEN
+        val offlineErrorMessage = "No internet connection. Please check your network and try again."
+        whenever(resourceProvider.getString(R.string.woo_pos_ptr_offline_error)).thenReturn(offlineErrorMessage)
+        whenever(productsDataSource.refreshProducts()).thenReturn(
+            Result.success(
+                PosLocalCatalogProductSyncResult(
+                    PosLocalCatalogSyncResult.Failure.NetworkError("Network unavailable")
+                )
+            )
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+        viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
+
+        // THEN
+        verify(fromChildToParentEventSender).sendToParent(
+            eq(ChildToParentEvent.ToastMessageDisplayed(message = offlineErrorMessage))
+        )
+    }
+
+    @Test
+    fun `given non-network error on PTR, when pull to refresh fails, then show generic error message`() = runTest {
+        // GIVEN
+        val genericErrorMessage = "Something went wrong, Please try again later."
+        whenever(resourceProvider.getString(R.string.something_went_wrong_try_again)).thenReturn(genericErrorMessage)
+        whenever(productsDataSource.refreshProducts()).thenReturn(
+            Result.success(
+                PosLocalCatalogProductSyncResult(
+                    PosLocalCatalogSyncResult.Failure.DatabaseError("Database error")
+                )
+            )
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+        viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
+
+        // THEN
+        verify(fromChildToParentEventSender).sendToParent(
+            eq(ChildToParentEvent.ToastMessageDisplayed(message = genericErrorMessage))
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.home.items.products
 
 import app.cash.turbine.test
 import com.woocommerce.android.R
+import com.woocommerce.android.WooException
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
@@ -41,6 +42,9 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import java.math.BigDecimal
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -605,6 +609,104 @@ class WooPosProductsViewModelTest {
             eq(ChildToParentEvent.ToastMessageDisplayed(message = genericErrorMessage))
         )
     }
+
+    @Test
+    fun `given remote sync network error on PTR, when pull to refresh fails, then show offline error message`() =
+        runTest {
+            // GIVEN
+            val offlineErrorMessage = "No internet connection. Please check your network and try again."
+            whenever(resourceProvider.getString(R.string.woo_pos_ptr_offline_error)).thenReturn(offlineErrorMessage)
+            whenever(productsDataSource.refreshProducts()).thenReturn(
+                Result.success(
+                    ProductsResult.Remote(
+                        Result.failure(
+                            WooException(
+                                WooError(
+                                    type = WooErrorType.NO_CONNECTION,
+                                    original = GenericErrorType.NO_CONNECTION,
+                                    message = "No network"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            // WHEN
+            val viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
+
+            // THEN
+            verify(fromChildToParentEventSender).sendToParent(
+                eq(ChildToParentEvent.ToastMessageDisplayed(message = offlineErrorMessage))
+            )
+        }
+
+    @Test
+    fun `given remote sync timeout error on PTR, when pull to refresh fails, then show offline error message`() =
+        runTest {
+            // GIVEN
+            val offlineErrorMessage = "No internet connection. Please check your network and try again."
+            whenever(resourceProvider.getString(R.string.woo_pos_ptr_offline_error)).thenReturn(offlineErrorMessage)
+            whenever(productsDataSource.refreshProducts()).thenReturn(
+                Result.success(
+                    ProductsResult.Remote(
+                        Result.failure(
+                            WooException(
+                                WooError(
+                                    type = WooErrorType.TIMEOUT,
+                                    original = GenericErrorType.TIMEOUT,
+                                    message = "Request timed out"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            // WHEN
+            val viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
+
+            // THEN
+            verify(fromChildToParentEventSender).sendToParent(
+                eq(ChildToParentEvent.ToastMessageDisplayed(message = offlineErrorMessage))
+            )
+        }
+
+    @Test
+    fun `given remote sync generic error on PTR, when pull to refresh fails, then show generic error message`() =
+        runTest {
+            // GIVEN
+            val genericErrorMessage = "Something went wrong, Please try again later."
+            whenever(
+                resourceProvider.getString(R.string.something_went_wrong_try_again)
+            ).thenReturn(genericErrorMessage)
+            whenever(productsDataSource.refreshProducts()).thenReturn(
+                Result.success(
+                    ProductsResult.Remote(
+                        Result.failure(
+                            WooException(
+                                WooError(
+                                    type = WooErrorType.GENERIC_ERROR,
+                                    original = GenericErrorType.UNKNOWN,
+                                    message = "Something went wrong"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            // WHEN
+            val viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosProductsUIEvent.PullToRefreshTriggered)
+
+            // THEN
+            verify(fromChildToParentEventSender).sendToParent(
+                eq(ChildToParentEvent.ToastMessageDisplayed(message = genericErrorMessage))
+            )
+        }
 
     private fun createViewModel(): WooPosProductsViewModel {
         return WooPosProductsViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.items.search
 
 import app.cash.turbine.test
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
@@ -74,9 +75,12 @@ class WooPosItemsSearchViewModelTest {
         whenever(mockParentToChildrenEventReceiver.events).thenReturn(emptyFlow())
         whenever(mockPriceFormat(BigDecimal("10.0"))).thenReturn("$10.0")
         whenever(mockPriceFormat(BigDecimal("20.0"))).thenReturn("$20.0")
-        whenever(
-            mockDataSource.getCurrentSyncStrategy()
-        ).thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
+        whenever(mockDataSource.getCurrentSyncStrategy())
+            .thenReturn(WooPosProductsDataSource.SyncStrategy.LOCAL_CATALOG)
+        whenever(mockResourceProvider.getString(R.string.something_went_wrong_try_again))
+            .thenReturn("Something went wrong")
+        whenever(mockResourceProvider.getString(R.string.woo_pos_ptr_offline_error))
+            .thenReturn("No internet connection")
     }
 
     @Test
@@ -1079,6 +1083,52 @@ class WooPosItemsSearchViewModelTest {
                     .isEqualTo(WooPosPullToRefreshState.Enabled)
             }
         }
+
+    @Test
+    fun `given network error on PTR, when pull to refresh triggered, then show offline error message`() = runTest {
+        // GIVEN
+        mockSuccessfulSearch(defaultQuery, listOf(defaultProduct))
+        whenever(mockDataSource.refreshProducts()).thenReturn(
+            Result.success(
+                PosLocalCatalogProductSyncResult(
+                    PosLocalCatalogSyncResult.Failure.NetworkError("Network unavailable")
+                )
+            )
+        )
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered)
+        advanceUntilIdle()
+
+        // THEN
+        verify(mockChildToParentEventSender).sendToParent(
+            eq(ChildToParentEvent.ToastMessageDisplayed(message = "No internet connection"))
+        )
+    }
+
+    @Test
+    fun `given database error on PTR, when pull to refresh triggered, then show generic error message`() = runTest {
+        // GIVEN
+        mockSuccessfulSearch(defaultQuery, listOf(defaultProduct))
+        whenever(mockDataSource.refreshProducts()).thenReturn(
+            Result.success(
+                PosLocalCatalogProductSyncResult(
+                    PosLocalCatalogSyncResult.Failure.DatabaseError("Database error")
+                )
+            )
+        )
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered)
+        advanceUntilIdle()
+
+        // THEN
+        verify(mockChildToParentEventSender).sendToParent(
+            eq(ChildToParentEvent.ToastMessageDisplayed(message = "Something went wrong"))
+        )
+    }
 
     private fun mockSuccessfulSearch(query: String, products: List<WooPosProductModel>) {
         whenever(mockDataSource.searchProducts(query)).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -1096,10 +1096,10 @@ class WooPosItemsSearchViewModelTest {
             )
         )
         val viewModel = createViewModel()
+        advanceUntilIdle()
 
         // WHEN
         viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered)
-        advanceUntilIdle()
 
         // THEN
         verify(mockChildToParentEventSender).sendToParent(
@@ -1119,10 +1119,10 @@ class WooPosItemsSearchViewModelTest {
             )
         )
         val viewModel = createViewModel()
+        advanceUntilIdle()
 
         // WHEN
         viewModel.onUIEvent(WooPosItemsSearchUiEvent.OnPullToRefreshTriggered)
-        advanceUntilIdle()
 
         // THEN
         verify(mockChildToParentEventSender).sendToParent(


### PR DESCRIPTION
Fixes WOOMOB-2032

### Description
When pull-to-refresh (PTR) fails in the POS product list or search views, the app now displays a more helpful message when the failure is specifically due to lack of internet connection, rather than showing a generic "Something went wrong" message for all error types.

Changes:
- Added new string resource `woo_pos_ptr_offline_error` for offline-specific error message
- Updated `handlePTRError()` in both `WooPosProductsViewModel` and `WooPosItemsSearchViewModel` to check if the failure is a `NetworkError` and display the appropriate message
- Added unit tests to verify correct error messages are shown for network vs non-network errors

### Test Steps
1. Open POS and navigate to the product list
2. Enable airplane mode on device
3. Pull to refresh
4. Verify the message "No internet connection. Please check your network and try again." appears
5. Disable airplane mode
6. Pull to refresh again
7. Verify it succeeds without error
8. Repeat steps 2-7 in the search view

### Images/gif
<img width="300" alt="Screenshot_1769004687" src="https://github.com/user-attachments/assets/39803a5f-e5cd-4efe-b1d7-2fbcab5e706e" />
<img width="300" alt="Screenshot_1769004715" src="https://github.com/user-attachments/assets/a45f8c0d-e07e-495d-bbef-d4476e7c2a2f" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.