### PR TITLE
[WOOMOB-2021] Fix Grant permission button unresponsive after repeated denials

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -120,9 +120,19 @@ class WooPosCardReaderConnectionController(
         }
     }
 
-    fun onPermissionResult(granted: Boolean) {
-        if (granted) {
-            checkRequirementsAndStartDiscovery()
+    fun onBluetoothPermissionResult(granted: Boolean, shouldShowRationale: Boolean) {
+        when {
+            granted -> checkRequirementsAndStartDiscovery()
+            !shouldShowRationale -> emitEvent(ControllerEvent.OpenAppSettings)
+            else -> checkRequirementsAndStartDiscovery()
+        }
+    }
+
+    fun onLocationPermissionResult(granted: Boolean, shouldShowRationale: Boolean) {
+        when {
+            granted -> checkRequirementsAndStartDiscovery()
+            !shouldShowRationale -> emitEvent(ControllerEvent.OpenAppSettings)
+            else -> checkRequirementsAndStartDiscovery()
         }
     }
 
@@ -183,6 +193,7 @@ class WooPosCardReaderConnectionController(
         data object RequestEnableBluetooth : ControllerEvent
         data object RequestLocationPermission : ControllerEvent
         data object RequestEnableLocation : ControllerEvent
+        data object OpenAppSettings : ControllerEvent
         data object Cancelled : ControllerEvent
         data class OnboardingRequired(val onboardingState: CardReaderOnboardingState) : ControllerEvent
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -67,6 +67,8 @@ class WooPosCardReaderConnectionController(
     private var selectedReader: CardReader? = null
     private var showUpdateCancelWarning = false
     private var isRequiredUpdate = true
+    private var isBluetoothPermissionPermanentlyDenied = false
+    private var isLocationPermissionPermanentlyDenied = false
 
     fun startConnectionFlow() {
         isRequiredUpdate = true
@@ -121,19 +123,13 @@ class WooPosCardReaderConnectionController(
     }
 
     fun onBluetoothPermissionResult(granted: Boolean, shouldShowRationale: Boolean) {
-        when {
-            granted -> checkRequirementsAndStartDiscovery()
-            !shouldShowRationale -> emitEvent(ControllerEvent.OpenAppSettings)
-            else -> checkRequirementsAndStartDiscovery()
-        }
+        isBluetoothPermissionPermanentlyDenied = !granted && !shouldShowRationale
+        checkRequirementsAndStartDiscovery()
     }
 
     fun onLocationPermissionResult(granted: Boolean, shouldShowRationale: Boolean) {
-        when {
-            granted -> checkRequirementsAndStartDiscovery()
-            !shouldShowRationale -> emitEvent(ControllerEvent.OpenAppSettings)
-            else -> checkRequirementsAndStartDiscovery()
-        }
+        isLocationPermissionPermanentlyDenied = !granted && !shouldShowRationale
+        checkRequirementsAndStartDiscovery()
     }
 
     fun onBluetoothEnabled() {
@@ -144,6 +140,15 @@ class WooPosCardReaderConnectionController(
         checkRequirementsAndStartDiscovery()
     }
 
+    fun recheckPermissions() {
+        val currentState = _state.value
+        if (currentState is WooPosCardReaderConnectionState.MissingBluetoothPermission ||
+            currentState is WooPosCardReaderConnectionState.MissingLocationPermission
+        ) {
+            checkRequirementsAndStartDiscovery()
+        }
+    }
+
     @Suppress("DEPRECATION")
     private fun checkRequirementsAndStartDiscovery() {
         when {
@@ -151,7 +156,13 @@ class WooPosCardReaderConnectionController(
                 !WooPermissionUtils.hasBluetoothConnectPermission(context) -> {
                 logger.d("Bluetooth permission not granted")
                 _state.value = WooPosCardReaderConnectionState.MissingBluetoothPermission(
-                    onRequestPermissionClicked = { emitEvent(ControllerEvent.RequestBluetoothPermission) },
+                    onRequestPermissionClicked = {
+                        if (isBluetoothPermissionPermanentlyDenied) {
+                            emitEvent(ControllerEvent.OpenAppSettings)
+                        } else {
+                            emitEvent(ControllerEvent.RequestBluetoothPermission)
+                        }
+                    },
                     onCancelClicked = { cancel() }
                 )
             }
@@ -165,7 +176,13 @@ class WooPosCardReaderConnectionController(
             !WooPermissionUtils.hasFineLocationPermission(context) -> {
                 logger.d("Location permission not granted")
                 _state.value = WooPosCardReaderConnectionState.MissingLocationPermission(
-                    onRequestPermissionClicked = { emitEvent(ControllerEvent.RequestLocationPermission) },
+                    onRequestPermissionClicked = {
+                        if (isLocationPermissionPermanentlyDenied) {
+                            emitEvent(ControllerEvent.OpenAppSettings)
+                        } else {
+                            emitEvent(ControllerEvent.RequestLocationPermission)
+                        }
+                    },
                     onCancelClicked = { cancel() }
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -164,6 +164,12 @@ private fun WooPosCardReaderDialogInternal(
     }
 
     LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            viewModel.onResume()
+        }
+    }
+
+    LaunchedEffect(lifecycleOwner) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             viewModel.event.collect { event ->
                 when (event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityOptionsCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -102,13 +103,28 @@ private fun WooPosCardReaderDialogInternal(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { permissions ->
         val allGranted = permissions.values.all { it }
-        viewModel.onPermissionResult(allGranted)
+        val shouldShowRationale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ActivityCompat.shouldShowRequestPermissionRationale(
+                context as Activity,
+                Manifest.permission.BLUETOOTH_SCAN
+            ) || ActivityCompat.shouldShowRequestPermissionRationale(
+                context,
+                Manifest.permission.BLUETOOTH_CONNECT
+            )
+        } else {
+            true
+        }
+        viewModel.onBluetoothPermissionResult(allGranted, shouldShowRationale)
     }
 
     val locationPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { granted ->
-        viewModel.onPermissionResult(granted)
+        val shouldShowRationale = ActivityCompat.shouldShowRequestPermissionRationale(
+            context as Activity,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        )
+        viewModel.onLocationPermissionResult(granted, shouldShowRationale)
     }
 
     val locationSettingsLauncher = rememberLauncherForActivityResult(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionViewModel.kt
@@ -126,6 +126,10 @@ class WooPosCardReaderConnectionViewModel @Inject constructor(
         controller.onOnboardingCompleted()
     }
 
+    fun onResume() {
+        controller.recheckPermissions()
+    }
+
     sealed interface Event {
         data object RequestBluetoothPermission : Event
         data object RequestEnableBluetooth : Event

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionViewModel.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.cardreader.connection
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState
+import com.woocommerce.android.ui.woopos.util.WooPosPermissionUtils
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,6 +14,7 @@ import javax.inject.Inject
 @HiltViewModel
 class WooPosCardReaderConnectionViewModel @Inject constructor(
     private val controllerFactory: WooPosCardReaderConnectionControllerFactory,
+    private val permissionUtils: WooPosPermissionUtils,
 ) : ViewModel() {
 
     private val controller: WooPosCardReaderConnectionController by lazy {
@@ -39,6 +41,9 @@ class WooPosCardReaderConnectionViewModel @Inject constructor(
                     }
                     WooPosCardReaderConnectionController.ControllerEvent.RequestEnableLocation -> {
                         _event.emit(Event.RequestEnableLocation)
+                    }
+                    WooPosCardReaderConnectionController.ControllerEvent.OpenAppSettings -> {
+                        permissionUtils.showAppSettings()
                     }
                     WooPosCardReaderConnectionController.ControllerEvent.Cancelled -> {
                         _event.emit(Event.Dismissed)
@@ -101,8 +106,12 @@ class WooPosCardReaderConnectionViewModel @Inject constructor(
         }
     }
 
-    fun onPermissionResult(granted: Boolean) {
-        controller.onPermissionResult(granted)
+    fun onBluetoothPermissionResult(granted: Boolean, shouldShowRationale: Boolean) {
+        controller.onBluetoothPermissionResult(granted, shouldShowRationale)
+    }
+
+    fun onLocationPermissionResult(granted: Boolean, shouldShowRationale: Boolean) {
+        controller.onLocationPermissionResult(granted, shouldShowRationale)
     }
 
     fun onLocationEnabled() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/WooPosPermissionUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/WooPosPermissionUtils.kt
@@ -1,0 +1,22 @@
+package com.woocommerce.android.ui.woopos.util
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import dagger.Reusable
+import javax.inject.Inject
+
+@Reusable
+class WooPosPermissionUtils @Inject constructor(
+    private val context: Context
+) {
+    fun showAppSettings() {
+        val intent = Intent().apply {
+            action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+            data = Uri.fromParts("package", context.packageName, null)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        context.startActivity(intent)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionViewModelTest.kt
@@ -1,0 +1,273 @@
+package com.woocommerce.android.ui.woopos.cardreader.connection
+
+import app.cash.turbine.test
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingState
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.WooPosPermissionUtils
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class WooPosCardReaderConnectionViewModelTest {
+
+    @Rule
+    @JvmField
+    val coroutineTestRule = WooPosCoroutineTestRule()
+
+    private val controller: WooPosCardReaderConnectionController = mock()
+    private val controllerFactory: WooPosCardReaderConnectionControllerFactory = mock {
+        on { create(any()) }.thenReturn(controller)
+    }
+    private val permissionUtils: WooPosPermissionUtils = mock()
+
+    private val controllerStateFlow = MutableStateFlow<WooPosCardReaderConnectionState>(
+        WooPosCardReaderConnectionState.Scanning
+    )
+    private val controllerEventFlow = MutableSharedFlow<WooPosCardReaderConnectionController.ControllerEvent>()
+
+    @Test
+    fun `given controller emits RequestBluetoothPermission, when event collected, then emits RequestBluetoothPermission`() =
+        runTest {
+            // GIVEN
+            setupControllerMocks()
+            val viewModel = createViewModel()
+
+            // WHEN
+            viewModel.event.test {
+                controllerEventFlow.emit(
+                    WooPosCardReaderConnectionController.ControllerEvent.RequestBluetoothPermission
+                )
+
+                // THEN
+                assertThat(awaitItem()).isEqualTo(
+                    WooPosCardReaderConnectionViewModel.Event.RequestBluetoothPermission
+                )
+            }
+        }
+
+    @Test
+    fun `given controller emits RequestLocationPermission, when event collected, then emits RequestLocationPermission`() =
+        runTest {
+            // GIVEN
+            setupControllerMocks()
+            val viewModel = createViewModel()
+
+            // WHEN
+            viewModel.event.test {
+                controllerEventFlow.emit(
+                    WooPosCardReaderConnectionController.ControllerEvent.RequestLocationPermission
+                )
+
+                // THEN
+                assertThat(awaitItem()).isEqualTo(
+                    WooPosCardReaderConnectionViewModel.Event.RequestLocationPermission
+                )
+            }
+        }
+
+    @Test
+    fun `given controller emits Cancelled, when event collected, then emits Dismissed`() = runTest {
+        // GIVEN
+        setupControllerMocks()
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.event.test {
+            controllerEventFlow.emit(WooPosCardReaderConnectionController.ControllerEvent.Cancelled)
+
+            // THEN
+            assertThat(awaitItem()).isEqualTo(WooPosCardReaderConnectionViewModel.Event.Dismissed)
+        }
+    }
+
+    @Test
+    fun `given controller emits OpenAppSettings, when event collected, then calls permissionUtils showAppSettings`() =
+        runTest {
+            // GIVEN
+            setupControllerMocks()
+            createViewModel()
+
+            // WHEN
+            controllerEventFlow.emit(WooPosCardReaderConnectionController.ControllerEvent.OpenAppSettings)
+            advanceUntilIdle()
+
+            // THEN
+            verify(permissionUtils).showAppSettings()
+        }
+
+    @Test
+    fun `given controller emits OnboardingRequired, when event collected, then emits NavigateToOnboarding`() =
+        runTest {
+            // GIVEN
+            setupControllerMocks()
+            val viewModel = createViewModel()
+            val onboardingState = mock<CardReaderOnboardingState>()
+
+            // WHEN
+            viewModel.event.test {
+                controllerEventFlow.emit(
+                    WooPosCardReaderConnectionController.ControllerEvent.OnboardingRequired(onboardingState)
+                )
+
+                // THEN
+                val event = awaitItem()
+                assertThat(event).isInstanceOf(
+                    WooPosCardReaderConnectionViewModel.Event.NavigateToOnboarding::class.java
+                )
+                assertThat((event as WooPosCardReaderConnectionViewModel.Event.NavigateToOnboarding).onboardingState)
+                    .isEqualTo(onboardingState)
+            }
+        }
+
+    @Test
+    fun `when startConnectionFlow called, then delegates to controller`() = runTest {
+        // GIVEN
+        setupControllerMocks()
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.startConnectionFlow()
+
+        // THEN
+        verify(controller).startConnectionFlow()
+    }
+
+    @Test
+    fun `when startUpdateFlow called, then delegates to controller`() = runTest {
+        // GIVEN
+        setupControllerMocks()
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.startUpdateFlow()
+
+        // THEN
+        verify(controller).startUpdateFlow()
+    }
+
+    @Test
+    fun `when dismissDialog called, then delegates to controller cancel`() = runTest {
+        // GIVEN
+        setupControllerMocks()
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.dismissDialog()
+
+        // THEN
+        verify(controller).cancel()
+    }
+
+    @Test
+    fun `given Scanning state, when onBackPressed, then calls controller cancel`() = runTest {
+        // GIVEN
+        setupControllerMocks()
+        controllerStateFlow.value = WooPosCardReaderConnectionState.Scanning
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onBackPressed()
+
+        // THEN
+        verify(controller).cancel()
+    }
+
+    @Test
+    fun `given Connected state, when onBackPressed, then calls controller cancel`() = runTest {
+        // GIVEN
+        setupControllerMocks()
+        controllerStateFlow.value = WooPosCardReaderConnectionState.Connected(readerName = "Reader")
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onBackPressed()
+
+        // THEN
+        verify(controller).cancel()
+    }
+
+    @Test
+    fun `when onBluetoothPermissionResult called, then delegates to controller`() = runTest {
+        // GIVEN
+        setupControllerMocks()
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onBluetoothPermissionResult(granted = true, shouldShowRationale = false)
+
+        // THEN
+        verify(controller).onBluetoothPermissionResult(granted = true, shouldShowRationale = false)
+    }
+
+    @Test
+    fun `when onLocationPermissionResult called, then delegates to controller`() = runTest {
+        // GIVEN
+        setupControllerMocks()
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onLocationPermissionResult(granted = false, shouldShowRationale = true)
+
+        // THEN
+        verify(controller).onLocationPermissionResult(granted = false, shouldShowRationale = true)
+    }
+
+    @Test
+    fun `when onBluetoothEnabled called, then delegates to controller`() = runTest {
+        // GIVEN
+        setupControllerMocks()
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onBluetoothEnabled()
+
+        // THEN
+        verify(controller).onBluetoothEnabled()
+    }
+
+    @Test
+    fun `when onLocationEnabled called, then delegates to controller`() = runTest {
+        // GIVEN
+        setupControllerMocks()
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onLocationEnabled()
+
+        // THEN
+        verify(controller).onLocationEnabled()
+    }
+
+    @Test
+    fun `when onOnboardingCompleted called, then delegates to controller`() = runTest {
+        // GIVEN
+        setupControllerMocks()
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onOnboardingCompleted()
+
+        // THEN
+        verify(controller).onOnboardingCompleted()
+    }
+
+    private fun setupControllerMocks() {
+        whenever(controller.state).thenReturn(controllerStateFlow)
+        whenever(controller.event).thenReturn(controllerEventFlow)
+    }
+
+    private fun createViewModel() = WooPosCardReaderConnectionViewModel(
+        controllerFactory = controllerFactory,
+        permissionUtils = permissionUtils,
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionViewModelTest.kt
@@ -111,7 +111,7 @@ class WooPosCardReaderConnectionViewModelTest {
             // GIVEN
             setupControllerMocks()
             val viewModel = createViewModel()
-            val onboardingState = mock<CardReaderOnboardingState>()
+            val onboardingState = CardReaderOnboardingState.GenericError
 
             // WHEN
             viewModel.event.test {


### PR DESCRIPTION
WOOMOB-2021

### Description

After declining permission requests multiple times, Android stops showing the permission dialog and immediately returns false. This made the "Grant permission" button appear unresponsive because nothing visible happened when tapped.

Now after a permission denial, we check `shouldShowRequestPermissionRationale`:
- If `true`: user can still grant permission via system dialog, so we request again
- If `false`: permission is permanently denied, so we open app settings instead

This follows the same pattern used in `CardReaderConnectViewModel`.

### Test Steps

1. Start card reader connection flow in WooPOS
2. When prompted for Bluetooth/Location permission, decline
3. Decline again (with "Don't ask again" if shown)
4. Tap "Grant permission" button
5. Verify app settings opens instead of doing nothing


https://github.com/user-attachments/assets/30b27442-67ac-43e0-a1a9-fd0f96f9c144


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.