### PR TITLE
Add forgotten RELEASE-NOTES to include a fix for group notification fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [Internal] Show JITMs on Dashboard regardless of onboarding status [https://github.com/woocommerce/woocommerce-android/pull/15170]
 - [Internal] Fix push notification double "cha-ching" issue [https://github.com/woocommerce/woocommerce-android/pull/15208]
 - [Internal] Remove `MediaXMLRPCClient` [https://github.com/woocommerce/woocommerce-android/pull/15178]
+- [*] Fixed group notification displaying issues [https://github.com/woocommerce/woocommerce-android/pull/15205]
 
 23.9
 -----


### PR DESCRIPTION
I forgot the release notes for #15205. Adding it here.

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
