### PR TITLE
[WOOMOB-2041] Open JITM URLs in Chrome Custom Tabs instead of external browser

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jitm/JitmFragment.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.jitm
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -17,6 +15,7 @@ import androidx.fragment.app.viewModels
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.jitm.JitmViewModel.Companion.JITM_MESSAGE_PATH_KEY
 import com.woocommerce.android.ui.payments.banner.Banner
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -43,14 +42,7 @@ class JitmFragment : Fragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is JitmViewModel.CtaClick -> {
-                    startActivity(
-                        Intent(
-                            Intent.ACTION_VIEW,
-                            Uri.parse(event.url)
-                        ).apply {
-                            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                        }
-                    )
+                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 }
                 else -> event.isHandled = false
             }


### PR DESCRIPTION
WOOMOB-2041

### Description

Opens JITM URLs in Chrome Custom Tabs instead of the external browser. This keeps users in the context of the app and provides a smoother UX with faster loading, matching the iOS approach.

### Test Steps

1. Use a site without Jetpack, located in US or GB, on a phone
2. Navigate to the dashboard screen
3. Tap a JITM banner CTA
4. Verify the URL opens in Chrome Custom Tabs (in-app browser) instead of external browser when it;s not universal link handled by the app and when it is - universal link handling still works

To test with regular URLs (not universal links handled by the app), modify `ClientSidePosBanner.BANNER_URL` in the code.

### Images/gif


https://github.com/user-attachments/assets/c5912381-6de8-4dbd-b9ae-83ce46112cc1

https://github.com/user-attachments/assets/73637917-98ee-4a53-b7cf-dd6277fab333


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.