### PR TITLE
[WOOMOB-2027] Refactor performSearch method in POS search ViewModel

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -122,7 +122,6 @@ class WooPosItemsSearchViewModel @Inject constructor(
         skipDebounce: Boolean = false,
     ) {
         searchJob?.cancel()
-
         currentQuery.set(query)
 
         if (query.isEmpty()) {
@@ -135,36 +134,42 @@ class WooPosItemsSearchViewModel @Inject constructor(
                 if (!skipDebounce) {
                     delay(SEARCH_DEBOUNCING_TIME)
                 }
-
                 if (query != currentQuery.get()) return@launch
 
-                childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
+                executeSearch(query, showLoadingState)
+            }
+        }
+    }
 
-                dataSource.searchProducts(query).collectLatest { searchResult ->
-                    if (query != currentQuery.get()) {
-                        childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
-                        return@collectLatest
-                    }
+    private suspend fun executeSearch(
+        query: String,
+        showLoadingState: Boolean,
+    ) {
+        childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Started)
 
-                    when (searchResult) {
-                        is SearchProductsResult.Local -> {
-                            handleLocalSearchResult(searchResult, query, showLoadingState)
-                        }
+        dataSource.searchProducts(query).collectLatest { searchResult ->
+            if (query != currentQuery.get()) {
+                childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+                return@collectLatest
+            }
 
-                        is SearchProductsResult.Remote -> {
-                            handleRemoteSearchResult(searchResult, query)
-                        }
-                    }
+            when (searchResult) {
+                is SearchProductsResult.Local -> {
+                    handleLocalSearchResult(searchResult, query, showLoadingState)
                 }
 
-                if (query == currentQuery.get()) {
-                    childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
-                    if (_viewState.value is WooPosItemsSearchViewState.Loading) {
-                        _viewState.value = WooPosItemsSearchViewState.Empty(
-                            pullToRefreshState = determinePullToRefreshState()
-                        )
-                    }
+                is SearchProductsResult.Remote -> {
+                    handleRemoteSearchResult(searchResult, query)
                 }
+            }
+        }
+
+        if (query == currentQuery.get()) {
+            childToParentEventSender.sendToParent(ChildToParentEvent.SearchEvent.Finished)
+            if (_viewState.value is WooPosItemsSearchViewState.Loading) {
+                _viewState.value = WooPosItemsSearchViewState.Empty(
+                    pullToRefreshState = determinePullToRefreshState()
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -116,7 +116,6 @@ class WooPosItemsSearchViewModel @Inject constructor(
         performSearch(currentState.searchQuery)
     }
 
-    @Suppress("CyclomaticComplexMethod", "LongMethod")
     private fun performSearch(
         query: String,
         showLoadingState: Boolean = true,
@@ -149,38 +148,11 @@ class WooPosItemsSearchViewModel @Inject constructor(
 
                     when (searchResult) {
                         is SearchProductsResult.Local -> {
-                            analyticsTracker.storedLocalSearchResultIds(searchResult.products.map { it.remoteId })
-
-                            if (searchResult.products.isEmpty()) {
-                                if (showLoadingState) {
-                                    _viewState.value = WooPosItemsSearchViewState.Loading
-                                } else {
-                                    _viewState.value = WooPosItemsSearchViewState.Empty(
-                                        pullToRefreshState = determinePullToRefreshState()
-                                    )
-                                }
-                            } else {
-                                _viewState.value = searchResult.products.toContentState(
-                                    searchQuery = query,
-                                )
-                            }
+                            handleLocalSearchResult(searchResult, query, showLoadingState)
                         }
 
                         is SearchProductsResult.Remote -> {
-                            if (searchResult.productsResult.isSuccess) {
-                                val products = searchResult.productsResult.getOrThrow()
-                                if (products.isEmpty()) {
-                                    _viewState.value = WooPosItemsSearchViewState.Empty(
-                                        pullToRefreshState = determinePullToRefreshState()
-                                    )
-                                } else {
-                                    _viewState.value = products.toContentState(searchQuery = query)
-                                }
-
-                                analyticsTracker.trackSearchPerformance(searchResult.searchTimeMillis)
-                            } else {
-                                _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = query)
-                            }
+                            handleRemoteSearchResult(searchResult, query)
                         }
                     }
                 }
@@ -194,6 +166,41 @@ class WooPosItemsSearchViewModel @Inject constructor(
                     }
                 }
             }
+        }
+    }
+
+    private suspend fun handleLocalSearchResult(
+        searchResult: SearchProductsResult.Local,
+        query: String,
+        showLoadingState: Boolean
+    ) {
+        analyticsTracker.storedLocalSearchResultIds(searchResult.products.map { it.remoteId })
+
+        if (searchResult.products.isEmpty()) {
+            _viewState.value = if (showLoadingState) {
+                WooPosItemsSearchViewState.Loading
+            } else {
+                WooPosItemsSearchViewState.Empty(pullToRefreshState = determinePullToRefreshState())
+            }
+        } else {
+            _viewState.value = searchResult.products.toContentState(searchQuery = query)
+        }
+    }
+
+    private suspend fun handleRemoteSearchResult(
+        searchResult: SearchProductsResult.Remote,
+        query: String
+    ) {
+        if (searchResult.productsResult.isSuccess) {
+            val products = searchResult.productsResult.getOrThrow()
+            _viewState.value = if (products.isEmpty()) {
+                WooPosItemsSearchViewState.Empty(pullToRefreshState = determinePullToRefreshState())
+            } else {
+                products.toContentState(searchQuery = query)
+            }
+            analyticsTracker.trackSearchPerformance(searchResult.searchTimeMillis)
+        } else {
+            _viewState.value = WooPosItemsSearchViewState.Error(searchQuery = query)
         }
     }
 


### PR DESCRIPTION
Fixes WOOMOB-2027

### Description
Refactored the `performSearch` method in `WooPosItemsSearchViewModel` to improve code readability and maintainability. The changes extract the search execution logic and result handling into separate dedicated methods:
- `executeSearch` - handles the main search flow
- `handleLocalSearchResult` - processes local search results
- `handleRemoteSearchResult` - processes remote search results

This removes the `CyclomaticComplexMethod` and `LongMethod` suppressions as the code is now properly decomposed.

### Test Steps
1. Smoke test POS search

### Images/gif
N/A - refactoring only, no UI changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.