### PR TITLE
[WOOMOB-2022] Add close button to Connecting state in card reader dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionState.kt
@@ -62,9 +62,7 @@ sealed interface WooPosCardReaderConnectionState {
         override val showCloseButton: Boolean = true
     }
 
-    data object Connecting : WooPosCardReaderConnectionState {
-        override val showCloseButton: Boolean = false
-    }
+    data object Connecting : WooPosCardReaderConnectionState
 
     data class ConnectingFailed(
         val errorMessage: String,


### PR DESCRIPTION
WOOMOB-2022

### Description

Adds the close (X) button to the Connecting state in the card reader connection dialog. Previously, the Connecting state had no visible dismiss control, but users could still dismiss by tapping outside the dialog. This change makes the dismiss behavior consistent with other dialog states like Scanning and ReaderFound.

### Test Steps

1. Go to WooPOS and initiate card reader connection
2. When the "Connecting to reader" dialog appears, verify the X button is visible in the top-right corner
3. Tap the X button and verify the dialog dismisses

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.