### PR TITLE
Add push notification tracking for Milestone 1

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -766,6 +766,7 @@ enum class AnalyticsEvent(override val siteless: Boolean = false) : IAnalyticsEv
     NEW_ORDER_PUSH_NOTIFICATION_FIX_DISMISSED,
     WOO_PUSH_TOKEN_REGISTER_SUCCESS,
     WOO_PUSH_TOKEN_REGISTER_ERROR,
+    WPCOM_DEVICE_DISABLE_PUSH_NOTIFICATIONS_SUCCESS,
 
     // -- Notifications List
     NOTIFICATION_OPEN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -767,6 +767,7 @@ enum class AnalyticsEvent(override val siteless: Boolean = false) : IAnalyticsEv
     WOO_PUSH_TOKEN_REGISTER_SUCCESS,
     WOO_PUSH_TOKEN_REGISTER_ERROR,
     WPCOM_DEVICE_DISABLE_PUSH_NOTIFICATIONS_SUCCESS,
+    WPCOM_DEVICE_DISABLE_PUSH_NOTIFICATIONS_ERROR,
 
     // -- Notifications List
     NOTIFICATION_OPEN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -764,6 +764,7 @@ enum class AnalyticsEvent(override val siteless: Boolean = false) : IAnalyticsEv
     NEW_ORDER_PUSH_NOTIFICATION_FIX_SHOWN,
     NEW_ORDER_PUSH_NOTIFICATION_FIX_TAPPED,
     NEW_ORDER_PUSH_NOTIFICATION_FIX_DISMISSED,
+    WOO_PUSH_TOKEN_REGISTER_SUCCESS,
 
     // -- Notifications List
     NOTIFICATION_OPEN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -765,6 +765,7 @@ enum class AnalyticsEvent(override val siteless: Boolean = false) : IAnalyticsEv
     NEW_ORDER_PUSH_NOTIFICATION_FIX_TAPPED,
     NEW_ORDER_PUSH_NOTIFICATION_FIX_DISMISSED,
     WOO_PUSH_TOKEN_REGISTER_SUCCESS,
+    WOO_PUSH_TOKEN_REGISTER_ERROR,
 
     // -- Notifications List
     NOTIFICATION_OPEN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -115,29 +115,20 @@ class AnalyticsTracker private constructor(
 
     private fun Map<String, *>.buildFinalProperties(siteLess: Boolean): MutableMap<String, Any?> {
         val finalProperties = this.toMutableMap()
-
         val selectedSiteModel = selectedSite.getOrNull()
-        if (!siteLess) {
-            selectedSiteModel?.let {
-                if (!finalProperties.containsKey(KEY_BLOG_ID)) finalProperties[KEY_BLOG_ID] = it.siteId
-                finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
-                finalProperties[KEY_PLAN_PRODUCT_SLUG] = it.planProductSlug
-                appPrefs.getWCStoreID(it.siteId)?.let { id -> finalProperties[KEY_STORE_ID] = id }
-                if (!finalProperties.containsKey(IS_JETPACK_INSTALLED)) {
-                    finalProperties[IS_JETPACK_INSTALLED] = it.isJetpackInstalled
-                }
-                if (!finalProperties.containsKey(IS_JETPACK_CONNECTED)) {
-                    finalProperties[IS_JETPACK_CONNECTED] = it.isJetpackConnected
-                }
-                if (!finalProperties.containsKey(IS_JETPACK_CP_CONNECTED)) {
-                    finalProperties[IS_JETPACK_CP_CONNECTED] = it.isJetpackCPConnected
-                }
-                if (!finalProperties.containsKey(IS_CIAB)) finalProperties[IS_CIAB] = it.isCIABSite()
-                if (!finalProperties.containsKey(GARDEN_PARTNER)) {
-                    it.gardenPartner?.let { gardenPartner -> finalProperties[GARDEN_PARTNER] = gardenPartner }
-                }
-            }
+
+        if (!siteLess && selectedSiteModel != null) {
+            finalProperties.putIfAbsent(KEY_BLOG_ID, selectedSiteModel.siteId)
+            finalProperties[KEY_IS_WPCOM_STORE] = selectedSiteModel.isWpComStore
+            finalProperties[KEY_PLAN_PRODUCT_SLUG] = selectedSiteModel.planProductSlug
+            appPrefs.getWCStoreID(selectedSiteModel.siteId)?.let { finalProperties[KEY_STORE_ID] = it }
+            finalProperties.putIfAbsent(IS_JETPACK_INSTALLED, selectedSiteModel.isJetpackInstalled)
+            finalProperties.putIfAbsent(IS_JETPACK_CONNECTED, selectedSiteModel.isJetpackConnected)
+            finalProperties.putIfAbsent(IS_JETPACK_CP_CONNECTED, selectedSiteModel.isJetpackCPConnected)
+            finalProperties.putIfAbsent(IS_CIAB, selectedSiteModel.isCIABSite())
+            selectedSiteModel.gardenPartner?.let { finalProperties.putIfAbsent(GARDEN_PARTNER, it) }
         }
+
         finalProperties[IS_DEBUG] = BuildConfig.DEBUG
         selectedSiteModel?.url?.let { finalProperties[KEY_SITE_URL] = it }
         getWooVersion()?.let { finalProperties[KEY_CACHED_WOO_VERSION] = it }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -120,7 +120,6 @@ class AnalyticsTracker private constructor(
             selectedSiteModel?.let {
                 if (!finalProperties.containsKey(KEY_BLOG_ID)) finalProperties[KEY_BLOG_ID] = it.siteId
                 finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
-                finalProperties[KEY_WAS_ECOMMERCE_TRIAL] = it.wasEcommerceTrial
                 finalProperties[KEY_PLAN_PRODUCT_SLUG] = it.planProductSlug
                 appPrefs.getWCStoreID(it.siteId)?.let { id -> finalProperties[KEY_STORE_ID] = id }
             }
@@ -335,7 +334,6 @@ class AnalyticsTracker private constructor(
         const val KEY_IS_GIFT_CARD_REMOVED = "removed"
         const val KEY_SHIPPING_LINES_COUNT = "shipping_lines_count"
 
-        const val KEY_WAS_ECOMMERCE_TRIAL = "was_ecommerce_trial"
         const val KEY_PLAN_PRODUCT_SLUG = "plan_product_slug"
         const val KEY_CACHED_WOO_VERSION = "cached_woo_core_version"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsEvent.BACK_PRESSED
 import com.woocommerce.android.analytics.AnalyticsEvent.VIEW_SHOWN
+import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.PackageUtils
@@ -122,6 +123,19 @@ class AnalyticsTracker private constructor(
                 finalProperties[KEY_IS_WPCOM_STORE] = it.isWpComStore
                 finalProperties[KEY_PLAN_PRODUCT_SLUG] = it.planProductSlug
                 appPrefs.getWCStoreID(it.siteId)?.let { id -> finalProperties[KEY_STORE_ID] = id }
+                if (!finalProperties.containsKey(IS_JETPACK_INSTALLED)) {
+                    finalProperties[IS_JETPACK_INSTALLED] = it.isJetpackInstalled
+                }
+                if (!finalProperties.containsKey(IS_JETPACK_CONNECTED)) {
+                    finalProperties[IS_JETPACK_CONNECTED] = it.isJetpackConnected
+                }
+                if (!finalProperties.containsKey(IS_JETPACK_CP_CONNECTED)) {
+                    finalProperties[IS_JETPACK_CP_CONNECTED] = it.isJetpackCPConnected
+                }
+                if (!finalProperties.containsKey(IS_CIAB)) finalProperties[IS_CIAB] = it.isCIABSite()
+                if (!finalProperties.containsKey(GARDEN_PARTNER)) {
+                    it.gardenPartner?.let { gardenPartner -> finalProperties[GARDEN_PARTNER] = gardenPartner }
+                }
             }
         }
         finalProperties[IS_DEBUG] = BuildConfig.DEBUG
@@ -168,6 +182,11 @@ class AnalyticsTracker private constructor(
         private const val EVENTS_PREFIX = "woocommerceandroid_"
         private const val POS_EVENTS_PREFIX = "woocommerceandroid_pos_"
         const val KEY_SITE_URL = "site_url"
+        const val IS_JETPACK_INSTALLED = "is_jetpack_installed"
+        const val IS_JETPACK_CONNECTED = "is_jetpack_connected"
+        const val IS_JETPACK_CP_CONNECTED = "is_jetpack_cp_connected"
+        const val IS_CIAB = "is_ciab"
+        const val GARDEN_PARTNER = "garden_partner"
 
         const val IS_DEBUG = "is_debug"
         const val KEY_ALREADY_READ = "already_read"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.notifications.push
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.tools.SelectedSite
@@ -37,6 +38,22 @@ class NotificationAnalyticsTracker @Inject constructor(
             "push_notification_token" to appPrefsWrapper.getFCMToken(),
             "is_from_selected_site" to isFromSelectedSite
         ).addCommonSiteProperties(site)
+        analyticsTrackerWrapper.track(stat, properties)
+    }
+
+    fun trackError(
+        stat: AnalyticsEvent,
+        siteId: Long,
+        errorDescription: String?,
+        errorType: String?,
+        errorCode: String? = null
+    ) {
+        val site = siteStore.getSiteBySiteId(siteId) ?: return
+        val properties = mutableMapOf<String, Any>().apply {
+            errorDescription?.let { this[AnalyticsTracker.KEY_ERROR_DESC] = it }
+            errorType?.let { this[AnalyticsTracker.KEY_ERROR_TYPE] = it }
+            errorCode?.let { this[AnalyticsTracker.KEY_ERROR_CODE] = it }
+        }.addCommonSiteProperties(site)
         analyticsTrackerWrapper.track(stat, properties)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -17,13 +17,10 @@ class NotificationAnalyticsTracker @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
-    fun trackNotificationAnalytics(stat: AnalyticsEvent, notification: Notification) {
-        trackNotificationAnalytics(
-            stat = stat,
-            remoteNoteId = notification.remoteNoteId,
-            remoteSiteId = notification.remoteSiteId,
-            noteTypeTrackingValue = notification.noteType.trackingValue
-        )
+    fun track(stat: AnalyticsEvent, siteId: Long) {
+        val site = siteStore.getSiteBySiteId(siteId) ?: return
+        val properties = mutableMapOf<String, Any>().addCommonSiteProperties(site)
+        analyticsTrackerWrapper.track(stat, properties)
     }
 
     fun trackNotificationAnalytics(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -3,13 +3,16 @@ package com.woocommerce.android.notifications.push
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.model.Notification
+import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class NotificationAnalyticsTracker @Inject constructor(
+    private val siteStore: SiteStore,
     private val selectedSite: SelectedSite,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
@@ -25,17 +28,27 @@ class NotificationAnalyticsTracker @Inject constructor(
 
     fun trackNotificationAnalytics(
         stat: AnalyticsEvent,
+        siteId: Long,
         remoteNoteId: Long,
-        remoteSiteId: Long,
         noteTypeTrackingValue: String
     ) {
-        val isFromSelectedSite = selectedSite.getIfExists()?.siteId == remoteSiteId
-        val properties = mutableMapOf<String, Any>()
-        properties["notification_note_id"] = remoteNoteId
-        properties["notification_type"] = noteTypeTrackingValue
-        properties["push_notification_token"] = appPrefsWrapper.getFCMToken()
-        properties["is_from_selected_site"] = isFromSelectedSite
+        val site = siteStore.getSiteBySiteId(siteId) ?: return
+        val isFromSelectedSite = selectedSite.getIfExists()?.siteId == siteId
+        val properties = mutableMapOf<String, Any>(
+            "notification_note_id" to remoteNoteId,
+            "notification_type" to noteTypeTrackingValue,
+            "push_notification_token" to appPrefsWrapper.getFCMToken(),
+            "is_from_selected_site" to isFromSelectedSite
+        ).addCommonSiteProperties(site)
         analyticsTrackerWrapper.track(stat, properties)
+    }
+
+    private fun MutableMap<String, Any>.addCommonSiteProperties(site: SiteModel) = apply {
+        this["is_jetpack_installed"] = site.isJetpackInstalled
+        this["is_jetpack_connected"] = site.isJetpackConnected
+        this["is_jetpack_cp_connected"] = site.isJetpackCPConnected
+        this["is_ciab"] = site.isCIABSite()
+        site.gardenPartner?.let { this["garden_partner"] = it }
     }
 
     fun flush() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -58,11 +58,11 @@ class NotificationAnalyticsTracker @Inject constructor(
     }
 
     private fun MutableMap<String, Any>.addCommonSiteProperties(site: SiteModel) = apply {
-        this["is_jetpack_installed"] = site.isJetpackInstalled
-        this["is_jetpack_connected"] = site.isJetpackConnected
-        this["is_jetpack_cp_connected"] = site.isJetpackCPConnected
-        this["is_ciab"] = site.isCIABSite()
-        site.gardenPartner?.let { this["garden_partner"] = it }
+        this[AnalyticsTracker.IS_JETPACK_INSTALLED] = site.isJetpackInstalled
+        this[AnalyticsTracker.IS_JETPACK_CONNECTED] = site.isJetpackConnected
+        this[AnalyticsTracker.IS_JETPACK_CP_CONNECTED] = site.isJetpackCPConnected
+        this[AnalyticsTracker.IS_CIAB] = site.isCIABSite()
+        site.gardenPartner?.let { this[AnalyticsTracker.GARDEN_PARTNER] = it }
     }
 
     fun flush() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -130,7 +130,12 @@ class NotificationMessageHandler @Inject constructor(
         val localPushId = getLocalPushIdForNoteId(notification.remoteNoteId)
         with(notificationBuilder) {
             if (isNotificationsEnabled()) {
-                analyticsTracker.trackNotificationAnalytics(PUSH_NOTIFICATION_RECEIVED, notification)
+                analyticsTracker.trackNotificationAnalytics(
+                    stat = PUSH_NOTIFICATION_RECEIVED,
+                    siteId = notification.remoteSiteId,
+                    remoteNoteId = notification.remoteNoteId,
+                    noteTypeTrackingValue = notification.noteType.trackingValue
+                )
                 analyticsTracker.flush()
             }
 
@@ -195,8 +200,8 @@ class NotificationMessageHandler @Inject constructor(
                 ?.let {
                     analyticsTracker.trackNotificationAnalytics(
                         stat = PUSH_NOTIFICATION_TAPPED,
+                        siteId = it.remoteSiteId,
                         remoteNoteId = it.remoteNoteId,
-                        remoteSiteId = it.remoteSiteId,
                         noteTypeTrackingValue = it.noteTypeTrackingValue.orEmpty()
                     )
                     analyticsTracker.flush()
@@ -213,8 +218,8 @@ class NotificationMessageHandler @Inject constructor(
             .forEach {
                 analyticsTracker.trackNotificationAnalytics(
                     stat = PUSH_NOTIFICATION_TAPPED,
+                    siteId = it.remoteSiteId,
                     remoteNoteId = it.remoteNoteId,
-                    remoteSiteId = it.remoteSiteId,
                     noteTypeTrackingValue = it.noteTypeTrackingValue.orEmpty()
                 )
                 analyticsTracker.flush()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType
 import com.woocommerce.android.extensions.orNullIfEmpty
@@ -29,7 +30,8 @@ class PushNotificationRepository @Inject constructor(
     private val wpComPushNotificationStore: WpComPushNotificationStore,
     private val wooCommerceStore: WooCommerceStore,
     @DataStoreQualifier(DataStoreType.WOO_CORE_PUSH_NOTIFICATIONS_TOKENS)
-    private val pushNotificationsDataStore: DataStore<Preferences>
+    private val pushNotificationsDataStore: DataStore<Preferences>,
+    private val notificationAnalyticsTracker: NotificationAnalyticsTracker
 ) {
 
     suspend fun registerPushTokenInWpComSystem(token: String) {
@@ -54,6 +56,10 @@ class PushNotificationRepository @Inject constructor(
             )
             if (!result.isError) {
                 result.model?.let { pushToken ->
+                    notificationAnalyticsTracker.track(
+                        stat = AnalyticsEvent.WOO_PUSH_TOKEN_REGISTER_SUCCESS,
+                        siteId = site.siteId
+                    )
                     savePushTokenForSite(site.siteId, pushToken)
                     disableWpComNotificationsForSite(site.siteId)
                 } ?: run {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -63,11 +63,23 @@ class PushNotificationRepository @Inject constructor(
                     savePushTokenForSite(site.siteId, pushToken)
                     disableWpComNotificationsForSite(site.siteId)
                 } ?: run {
-                    WooLog.w(
-                        WooLog.T.NOTIFICATIONS,
-                        "Push token registration in Woo Core succeeded but API returned null token;"
+                    val errorMsg = "Push token registration in Woo Core succeeded but API returned null token"
+                    WooLog.w(WooLog.T.NOTIFICATIONS, errorMsg)
+                    notificationAnalyticsTracker.trackError(
+                        stat = AnalyticsEvent.WOO_PUSH_TOKEN_REGISTER_ERROR,
+                        siteId = site.siteId,
+                        errorDescription = errorMsg,
+                        errorType = WooErrorType.EMPTY_RESPONSE.name
                     )
                 }
+            } else {
+                notificationAnalyticsTracker.trackError(
+                    stat = AnalyticsEvent.WOO_PUSH_TOKEN_REGISTER_ERROR,
+                    siteId = site.siteId,
+                    errorDescription = result.error?.message,
+                    errorType = result.error?.type?.name,
+                    errorCode = result.error?.apiErrorCode
+                )
             }
         } ?: run { WooLog.w(WooLog.T.NOTIFICATIONS, "No selected site, skipping PN registration") }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -95,6 +95,10 @@ class PushNotificationRepository @Inject constructor(
             WooLog.w(WooLog.T.NOTIFICATIONS, "Failed to disable WPCom notifications for site $siteId")
         } else {
             WooLog.d(WooLog.T.NOTIFICATIONS, "WPCom notifications disabled for site $siteId")
+            notificationAnalyticsTracker.track(
+                stat = AnalyticsEvent.WPCOM_DEVICE_DISABLE_PUSH_NOTIFICATIONS_SUCCESS,
+                siteId = siteId
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.pushnotifications.WooPushNotificationsStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore
@@ -92,7 +93,14 @@ class PushNotificationRepository @Inject constructor(
         )
         val result = wpComPushNotificationStore.updateNotificationSettingsFor(listOf(setting))
         if (result.isFailure) {
+            val error = result.exceptionOrNull() as? WpComPushNotificationStore.NotificationSettingsUpdateError
             WooLog.w(WooLog.T.NOTIFICATIONS, "Failed to disable WPCom notifications for site $siteId")
+            notificationAnalyticsTracker.trackError(
+                stat = AnalyticsEvent.WPCOM_DEVICE_DISABLE_PUSH_NOTIFICATIONS_ERROR,
+                siteId = siteId,
+                errorDescription = error?.message,
+                errorType = error?.type?.let { it::class.simpleName }
+            )
         } else {
             WooLog.d(WooLog.T.NOTIFICATIONS, "WPCom notifications disabled for site $siteId")
             notificationAnalyticsTracker.track(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -460,8 +460,8 @@ class NotificationMessageHandlerTest {
 
         verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
             stat = eq(AnalyticsEvent.PUSH_NOTIFICATION_TAPPED),
+            siteId = eq(orderNotification.remoteSiteId),
             remoteNoteId = eq(orderNotification.remoteNoteId),
-            remoteSiteId = eq(orderNotification.remoteSiteId),
             noteTypeTrackingValue = eq(orderNotification.noteType.trackingValue)
         )
     }
@@ -475,8 +475,8 @@ class NotificationMessageHandlerTest {
 
         verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
             stat = eq(AnalyticsEvent.PUSH_NOTIFICATION_TAPPED),
+            siteId = eq(orderNotification.remoteSiteId),
             remoteNoteId = eq(orderNotification.remoteNoteId),
-            remoteSiteId = eq(orderNotification.remoteSiteId),
             noteTypeTrackingValue = eq(orderNotification.noteType.trackingValue)
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -12,6 +13,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -37,6 +39,7 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val wpComPushNotificationStore: WpComPushNotificationStore = mock()
     private val wooCommerceStore: WooCommerceStore = mock()
+    private val notificationAnalyticsTracker: NotificationAnalyticsTracker = mock()
     private val siteModel: SiteModel = mock()
     private val preferences: Preferences = mock()
     private val pushNotificationsDataStore: DataStore<Preferences> = mock {
@@ -53,7 +56,8 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
             appPrefsWrapper,
             wpComPushNotificationStore,
             wooCommerceStore,
-            pushNotificationsDataStore
+            pushNotificationsDataStore,
+            notificationAnalyticsTracker
         )
     }
 
@@ -203,6 +207,51 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
             val result = sut.isWooPushTokenRegisteredForSite(SITE_ID)
 
             assertThat(result).isFalse()
+        }
+
+    @Test
+    fun `given registration succeeds, when registering push token, then tracks success event`() =
+        testBlocking {
+            whenever(selectedSite.getIfExists()).thenReturn(siteModel)
+            whenever(siteModel.siteId).thenReturn(SITE_ID)
+            whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
+            whenever(wooPushNotificationsStore.registerPushToken(siteModel, "token", "stored-uuid"))
+                .thenReturn(WooResult(RETURNED_TOKEN))
+
+            val mutablePreferences: MutablePreferences = mock()
+            whenever(preferences.toMutablePreferences()).thenReturn(mutablePreferences)
+            whenever(pushNotificationsDataStore.updateData(any())).thenAnswer { invocation ->
+                val transform = invocation.getArgument<suspend (Preferences) -> Preferences>(0)
+                testBlocking { transform(preferences) }
+                preferences
+            }
+
+            sut.registerPushTokenInWooCoreSystem("token")
+
+            verify(notificationAnalyticsTracker).track(
+                stat = eq(AnalyticsEvent.WOO_PUSH_TOKEN_REGISTER_SUCCESS),
+                siteId = eq(SITE_ID)
+            )
+        }
+
+    @Test
+    fun `given registration fails, when registering push token, then tracks error event`() =
+        testBlocking {
+            whenever(selectedSite.getIfExists()).thenReturn(siteModel)
+            whenever(siteModel.siteId).thenReturn(SITE_ID)
+            whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
+            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any()))
+                .thenReturn(PN_REGISTRATION_ERROR)
+
+            sut.registerPushTokenInWooCoreSystem("token")
+
+            verify(notificationAnalyticsTracker).trackError(
+                stat = eq(AnalyticsEvent.WOO_PUSH_TOKEN_REGISTER_ERROR),
+                siteId = eq(SITE_ID),
+                errorDescription = anyOrNull(),
+                errorType = anyOrNull(),
+                errorCode = anyOrNull()
+            )
         }
 
     private companion object {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/WpComPushNotificationStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/WpComPushNotificationStore.kt
@@ -654,10 +654,10 @@ class WpComPushNotificationStore @Inject constructor(
 
     data class NotificationSettingsUpdateError(
         val type: NotificationSettingErrorType
-    ) : Exception()
+    ) : Exception(type.message)
 
-    sealed interface NotificationSettingErrorType {
-        object UnregisteredDevice : NotificationSettingErrorType
-        data class ApiError(val message: String) : NotificationSettingErrorType
+    sealed class NotificationSettingErrorType(val message: String) {
+        object UnregisteredDevice : NotificationSettingErrorType("Device not registered.")
+        data class ApiError(val apiErrorMessage: String) : NotificationSettingErrorType(apiErrorMessage)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Implements Milestone 1 push notification tracking as outlined in the pe5sF9-4Xn-p2.

**New Events:**
- `woo_push_token_register_success` - Tracked when Woo Core push token registration succeeds
- `woo_push_token_register_error` - Tracked when registration fails, includes error details
- `wpcom_device_disable_push_notifications_success` - Tracked when WPCOM notifications are disabled*
- `wpcom_device_disable_push_notifications_error` - Tracked when disabling fails*
* I didn't add disable events to the site list screen because it updates all sites in a single API call and already tracks specific success and error events.

**Updated Events:**
- `push_notification_received` - Added common properties (`is_jetpack_installed`, `is_jetpack_connected`, `is_jetpack_cp_connected`, `is_ciab`, `garden_partner`
)
- `push_notification_tapped` - Added common properties

**Refactoring:**
- `NotificationAnalyticsTracker` now uses `siteId` parameter instead of `SiteModel`
- Added `trackError()` method for error event tracking with error details
- Removed `SiteStore` dependency from `NotificationMessageHandler`

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
#### 1. Test `woo_push_token_register_success`

**Preconditions:**
- A test site with WooCommerce 10.4.0-dev (supports Woo Core push endpoint)
- Feature flag `WOO_PUSH_NOTIFICATIONS_SYSTEM` enabled

**Steps:**
1. Build the app with feature flag enabled
2. Login to a site with WooCommerce 10.4.0-dev.
3. Check logcat for the event.

**Verify:**
`woocommerceandroid_woo_push_token_register_success` Properties: `is_jetpack_installed`, `is_jetpack_connected`, `is_jetpack_cp_connected`, `is_ciab`, `garden_partner`.

---

#### 2. Test `woo_push_token_register_error`

**Preconditions:**
- A test site with WooCommerce version below 10.4.3 (no push endpoint support)
- Feature flag `WOO_PUSH_NOTIFICATIONS_SYSTEM` enabled

**Steps:**
1. Build the app with feature flag enabled.
2. Login to the site.
3. Check logcat for the event.

**Verify:**
`woocommerceandroid_woo_push_token_register_error` Properties: `is_jetpack_installed`, `is_jetpack_connected`, `is_jetpack_cp_connected`, `is_ciab`, `garden_partner`, `error_description`, `error_type`, `error_code`.

---

#### 3. Test `wpcom_device_disable_push_notifications_success`
**Preconditions:**
- A test site with WooCommerce 10.4.0-dev
- Previously logged in with feature flag **disabled** (WPCOM device registered)

**Steps:**
1. Build the app with feature flag **disabled**.
2. Login to a site (this registers WPCOM device).
3. Enable feature flag and rebuild the app.
4. Login to the same site again.
5. Check logcat for the event.

**Verify:**
`woocommerceandroid_wpcom_device_disable_push_notifications_success` Properties: `is_jetpack_installed`, `is_jetpack_connected`, `is_jetpack_cp_connected`, `is_ciab`, `garden_partner`.

---

#### 4. Test `wpcom_device_disable_push_notifications_error`
**Preconditions:**
- Fresh install or WPCOM device was never registered

**Steps:**
1. Fresh install the app with feature flag **enabled**
2. Login to a site with WooCommerce 10.4+
3. Check logcat for the event.

**Verify:**
`woocommerceandroid_wpcom_device_disable_push_notifications_error` Properties: `error_description` ("Device not registered."), `error_type` ("UnregisteredDevice"), `is_jetpack_installed`, `is_jetpack_connected`, `is_jetpack_cp_connected`, `is_ciab`, `garden_partner`.

---

#### 5. Test `push_notification_received`

**Preconditions:**
- Push notifications enabled for the site
- Push notification permissions granted

**Steps:**
1. Login to a site with push notifications enabled.
2. Trigger a notification (e.g., create a product review from another device/browser)
3. Receive the push notification
4. Check logcat for the event

**Verify:**
`woocommerceandroid_push_notification_received` Properties: `is_jetpack_installed`, `is_jetpack_connected`, `is_jetpack_cp_connected`, `is_ciab`, `garden_partner`

---

#### 6. Test `push_notification_tapped`

**Preconditions:**
- A push notification is displayed

**Steps:**
1. Receive a push notification (see step 5)
2. Tap on the notification
3. Check logcat for the event

**Verify:**
woocommerceandroid_push_notification_tapped: Properties: `is_jetpack_installed`, `is_jetpack_connected`, `is_jetpack_cp_connected`, `is_ciab`, `garden_partner`

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->