### PR TITLE
[WOOMOB-2022] Add consistent close button and padding to POS dialogs

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
@@ -8,27 +8,42 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 
 @Composable
 fun WooPosDialogWrapper(
     modifier: Modifier = Modifier,
     isVisible: Boolean,
     dialogBackgroundContentDescription: String,
+    onCloseClick: (() -> Unit)? = null,
     onDismissRequest: () -> Unit,
     content: @Composable AnimatedVisibilityScope.() -> Unit
 ) {
+    val closeContentDescription = stringResource(R.string.close)
+
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -60,7 +75,29 @@ fun WooPosDialogWrapper(
                 elevation = WooPosElevation.Medium,
                 modifier = modifier.fillMaxWidth(0.75f),
             ) {
-                content()
+                Column(
+                    modifier = Modifier.padding(WooPosSpacing.XLarge.value)
+                ) {
+                    if (onCloseClick != null) {
+                        Box(modifier = Modifier.fillMaxWidth()) {
+                            IconButton(
+                                onClick = onCloseClick,
+                                modifier = Modifier.align(Alignment.TopEnd)
+                            ) {
+                                Icon(
+                                    imageVector = ImageVector.vectorResource(R.drawable.ic_close_24dp),
+                                    contentDescription = closeContentDescription,
+                                    modifier = Modifier.size(40.dp),
+                                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.size(WooPosSpacing.XLarge.value))
+                    }
+
+                    content()
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosExitConfirmationDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosExitConfirmationDialog.kt
@@ -1,24 +1,16 @@
 package com.woocommerce.android.ui.woopos.common.composeui.component
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
@@ -44,55 +36,37 @@ fun WooPosExitConfirmationDialog(
         dialogBackgroundContentDescription = stringResource(
             id = R.string.woopos_dialog_exit_confirmation_background_content_description
         ),
+        onCloseClick = onDismissRequest,
         onDismissRequest = onDismissRequest,
     ) {
-        Box(
-            modifier = modifier.padding(WooPosSpacing.XLarge.value)
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Spacer(modifier = modifier.height(WooPosSpacing.XXXLarge.value))
-                WooPosText(
-                    text = title,
-                    style = WooPosTypography.Heading,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-                Spacer(modifier = modifier.height(WooPosSpacing.Medium.value))
-                WooPosText(
-                    text = message,
-                    style = WooPosTypography.BodyLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-                Spacer(modifier = modifier.height(WooPosSpacing.XXXLarge.value))
-                WooPosButton(
-                    modifier = modifier
-                        .fillMaxWidth(),
-                    onClick = {
-                        scope.launch {
-                            onDismissRequest()
-                            delay(300)
-                            onExit()
-                        }
-                    },
-                    text = dismissButtonText
-                )
-            }
-
-            IconButton(
-                onClick = { onDismissRequest() },
-                modifier = modifier
-                    .align(Alignment.TopEnd)
-            ) {
-                Icon(
-                    ImageVector.vectorResource(R.drawable.ic_close_24dp),
-                    contentDescription = stringResource(
-                        id = R.string.woopos_exit_dialog_confirmation_close_content_description
-                    ),
-                    modifier = modifier
-                        .size(40.dp),
-                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                )
-            }
+            WooPosText(
+                text = title,
+                style = WooPosTypography.Heading,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+            WooPosText(
+                text = message,
+                style = WooPosTypography.BodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(WooPosSpacing.XXXLarge.value))
+            WooPosButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    scope.launch {
+                        onDismissRequest()
+                        delay(300)
+                        onExit()
+                    }
+                },
+                text = dismissButtonText
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupDialog.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
@@ -46,13 +45,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -132,6 +129,7 @@ fun WooPosScanningSetupDialog(
     WooPosDialogWrapper(
         isVisible = isVisible,
         onDismissRequest = onDismissRequestWrapper,
+        onCloseClick = onDismissRequestWrapper,
         dialogBackgroundContentDescription = stringResource(
             id = R.string.woopos_scanning_setup_dialog_content_description
         )
@@ -140,35 +138,12 @@ fun WooPosScanningSetupDialog(
 
         val state by viewModel.state.collectAsState()
         Column(
-            modifier = Modifier
-                .background(color = MaterialTheme.colorScheme.surfaceBright)
-                .padding(WooPosSpacing.XLarge.value)
-                .listenForBarcodes(
-                    { barcodeResult ->
-                        viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnBarcodeScanned(barcodeResult))
-                    }
-                )
-        ) {
-            Row {
-                Spacer(modifier = Modifier.weight(1f))
-                IconButton(
-                    onClick = onDismissRequestWrapper,
-                    modifier = Modifier
-                ) {
-                    Icon(
-                        ImageVector.vectorResource(R.drawable.ic_close_24dp),
-                        contentDescription = stringResource(
-                            id = R.string.woopos_exit_dialog_confirmation_close_content_description
-                        ),
-                        modifier = Modifier
-                            .size(40.dp),
-                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                    )
+            modifier = Modifier.listenForBarcodes(
+                { barcodeResult ->
+                    viewModel.onUiEvent(WooPosScanningSetupUiEvent.OnBarcodeScanned(barcodeResult))
                 }
-            }
-
-            Spacer(modifier = Modifier.size(WooPosSpacing.XLarge.value))
-
+            )
+        ) {
             AnimatedContent(
                 targetState = state.currentStep,
                 transitionSpec = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scanningsetup/WooPosScanningSetupDialog.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -379,7 +378,7 @@ private fun TestYourScannerScanFailedContent(
             imageVector = WooPosIcons.ErrorX,
             contentDescription = null,
             modifier = Modifier
-                .padding(WooPosSpacing.Medium.value),
+                .padding(bottom = WooPosSpacing.Medium.value),
         )
 
         Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
@@ -934,111 +933,97 @@ private fun BulletPointItem(text: String) {
     )
 }
 
+@Composable
+private fun ScanningSetupDialogPreviewWrapper(
+    content: @Composable () -> Unit
+) {
+    WooPosTheme {
+        WooPosDialogWrapper(
+            isVisible = true,
+            dialogBackgroundContentDescription = "",
+            onCloseClick = {},
+            onDismissRequest = {}
+        ) {
+            content()
+        }
+    }
+}
+
 @FontScalePreviews
 @WooPosPreview
 @Composable
 fun WooPosScanningSetupDialogPreview() {
-    WooPosTheme {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            DeviceSelectionContent(
-                step = ScanningSetupStep.DeviceSelection,
-                onDeviceSelected = {}
-            )
-        }
+    ScanningSetupDialogPreviewWrapper {
+        DeviceSelectionContent(
+            step = ScanningSetupStep.DeviceSelection,
+            onDeviceSelected = {}
+        )
     }
 }
 
 @WooPosPreview
 @Composable
 fun WooPosScanningSetupTestScannerStep() {
-    WooPosTheme {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            TestScannerContent(
-                title = "Test your scanner",
-                message = "Scan the barcode below to test your scanner.",
-                barcodeValue = "123456789012",
-                secondaryButtonText = "Skip",
-                onSecondaryClick = {},
-            )
-        }
+    ScanningSetupDialogPreviewWrapper {
+        TestScannerContent(
+            title = "Test your scanner",
+            message = "Scan the barcode below to test your scanner.",
+            barcodeValue = "123456789012",
+            secondaryButtonText = "Skip",
+            onSecondaryClick = {},
+        )
     }
 }
 
 @WooPosPreview
 @Composable
 fun WooPosScanningSetupTestScannerFailedStep() {
-    WooPosTheme {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            TestYourScannerScanFailedContent(
-                step = ScanningSetupStep.TestYourScannerScanFailed,
-                onPrimaryClick = {},
-                onSecondaryClick = {},
-            )
-        }
+    ScanningSetupDialogPreviewWrapper {
+        TestYourScannerScanFailedContent(
+            step = ScanningSetupStep.TestYourScannerScanFailed,
+            onPrimaryClick = {},
+            onSecondaryClick = {},
+        )
     }
 }
 
 @WooPosPreview
 @Composable
 fun WooPosScanningSetupTestQRContent() {
-    WooPosTheme {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            ScannerModeSetupContent(
-                onPrimaryClick = {},
-                onSecondaryClick = {},
-                primaryButtonText = "Next",
-                secondaryButtonText = "Back",
-                title = "Scanner Mode Setup",
-                message = "Follow the instructions to set up your scanner in HID mode.",
-                codeImageRes = R.drawable.ic_woopos_reader_setup_code_star_bsh_20
-            )
-        }
+    ScanningSetupDialogPreviewWrapper {
+        ScannerModeSetupContent(
+            onPrimaryClick = {},
+            onSecondaryClick = {},
+            primaryButtonText = "Next",
+            secondaryButtonText = "Back",
+            title = "Scanner Mode Setup",
+            message = "Follow the instructions to set up your scanner in HID mode.",
+            codeImageRes = R.drawable.ic_woopos_reader_setup_code_star_bsh_20
+        )
     }
 }
 
 @WooPosPreview
 @Composable
 fun WooPosScanningSetupTestBarcodeContent() {
-    WooPosTheme {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            TestScannerContent(
-                onSecondaryClick = {},
-                secondaryButtonText = "Back",
-                title = "Scanner Mode Setup",
-                message = "Follow the instructions to set up your scanner in HID mode.",
-                barcodeValue = "123456789012",
-            )
-        }
+    ScanningSetupDialogPreviewWrapper {
+        TestScannerContent(
+            onSecondaryClick = {},
+            secondaryButtonText = "Back",
+            title = "Scanner Mode Setup",
+            message = "Follow the instructions to set up your scanner in HID mode.",
+            barcodeValue = "123456789012",
+        )
     }
 }
 
 @WooPosPreview
 @Composable
 fun WooPosScanningSetupSoftwareKeyboardContent() {
-    WooPosTheme {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            SoftwareKeyboardSetupContent(
-                step = ScanningSetupStep.SoftwareKeyboardSetup,
-                onPrimaryClick = {}
-            )
-        }
+    ScanningSetupDialogPreviewWrapper {
+        SoftwareKeyboardSetupContent(
+            step = ScanningSetupStep.SoftwareKeyboardSetup,
+            onPrimaryClick = {}
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogScreen.kt
@@ -1,22 +1,17 @@
 package com.woocommerce.android.ui.woopos.settings.details.localcatalog
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -26,11 +21,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -310,78 +302,54 @@ fun WooPosSyncErrorDialog(
         dialogBackgroundContentDescription = stringResource(
             id = R.string.woopos_settings_local_catalog_sync_error_dialog_background_content_description
         ),
+        onCloseClick = onDismissRequest,
         onDismissRequest = onDismissRequest
     ) {
         Column(
             modifier = Modifier
-                .background(color = MaterialTheme.colorScheme.surfaceBright)
-                .padding(WooPosSpacing.XLarge.value)
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Row {
-                Spacer(modifier = Modifier.weight(1f))
-                IconButton(
-                    onClick = onDismissRequest,
-                    modifier = Modifier
-                ) {
-                    Icon(
-                        ImageVector.vectorResource(R.drawable.ic_close_24dp),
-                        contentDescription = stringResource(
-                            id = R.string.woopos_exit_dialog_confirmation_close_content_description
-                        ),
-                        modifier = Modifier.size(40.dp),
-                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.size(WooPosSpacing.XLarge.value))
-
-            Column(
+            Image(
+                imageVector = WooPosIcons.ErrorX,
+                contentDescription = null,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState()),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Image(
-                    imageVector = WooPosIcons.ErrorX,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .padding(WooPosSpacing.Medium.value)
-                )
+                    .padding(bottom = WooPosSpacing.Medium.value)
+            )
 
-                Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
+            Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
 
-                WooPosText(
-                    text = stringResource(R.string.woopos_settings_local_catalog_sync_error_dialog_title),
-                    style = WooPosTypography.Heading,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
+            WooPosText(
+                text = stringResource(R.string.woopos_settings_local_catalog_sync_error_dialog_title),
+                style = WooPosTypography.Heading,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
 
-                Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
-                WooPosText(
-                    text = stringResource(R.string.woopos_settings_local_catalog_sync_error_dialog_message),
-                    style = WooPosTypography.BodyLarge,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
+            WooPosText(
+                text = stringResource(R.string.woopos_settings_local_catalog_sync_error_dialog_message),
+                style = WooPosTypography.BodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
 
-                Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
+            Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
 
-                WooPosButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    onClick = onRetry,
-                    text = stringResource(R.string.woopos_settings_local_catalog_sync_error_dialog_retry_button)
-                )
+            WooPosButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onRetry,
+                text = stringResource(R.string.woopos_settings_local_catalog_sync_error_dialog_retry_button)
+            )
 
-                Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
-                WooPosOutlinedButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    onClick = onDismissRequest,
-                    text = stringResource(R.string.woopos_settings_local_catalog_sync_error_dialog_cancel_button)
-                )
-            }
+            WooPosOutlinedButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onDismissRequest,
+                text = stringResource(R.string.woopos_settings_local_catalog_sync_error_dialog_cancel_button)
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/productinfo/WooPosSettingsProductInfoDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/productinfo/WooPosSettingsProductInfoDialog.kt
@@ -52,8 +52,6 @@ fun WooPosSettingsProductInfoDialog(
     ) {
         Box(
             modifier = Modifier
-                .background(MaterialTheme.colorScheme.surfaceBright)
-                .padding(WooPosSpacing.XLarge.value)
                 .semantics(mergeDescendants = true) {
                     contentDescription = dialogContentDescription
                 },


### PR DESCRIPTION
Closes: WOOMOB-2022

### Description

This PR introduces a unified approach to close buttons and content padding in POS dialogs to ensure visual consistency across all dialog components.

**Changes:**
- Add optional `onCloseClick` parameter to `WooPosDialogWrapper` - when provided, displays a standardized close button (40dp icon with 0.6f alpha tint) at the top-right
- Add consistent XLarge padding to dialog content within the wrapper
- Update all POS dialogs to use the wrapper's close button instead of implementing their own
- Remove redundant padding from individual dialogs since the wrapper now handles it
- Refactor `WooPosScanningSetupDialog` previews to use the dialog wrapper for accurate preview rendering

This ensures all POS dialogs have the same close button appearance and spacing, making it easier to maintain consistency as new dialogs are added.

 @samiuelson I didn't touch the refund dialog as it is for some reason completely different from the rest of the dialogs, but if we still keep that in the dialog, I'd suggest strongly reconsidering and to follow the same pattern everywhere. I am fine with changing the look for all the rest of the dialogs as well, but it will still be much easier to do if we reuse the same component.

@malinajirka I will take these changes to the feature branch with the card reader connection flow so they will be applied there as well

### Test Steps

1. Open POS mode on a tablet
2. Navigate to Settings and trigger the Sync Error dialog - verify close button appears and works
3. Try to exit POS mode - verify the exit confirmation dialog has a close button
4. Go to Settings > Barcode Scanner Setup - verify the scanning setup dialog has a close button and all steps display correctly
5. Verify all dialogs have consistent padding around their content

### Images/gif
(PREVIEWS)

<img width="575" height="394" alt="image" src="https://github.com/user-attachments/assets/d68e5caa-b9ba-4867-b04d-79b1ec01606f" />
<img width="646" height="416" alt="image" src="https://github.com/user-attachments/assets/5852441f-3a46-4ccd-b0b1-747ac00124d0" />
<img width="544" height="375" alt="image" src="https://github.com/user-attachments/assets/b9c40603-739f-4cfa-9e05-fd16f58c642e" />
<img width="571" height="387" alt="image" src="https://github.com/user-attachments/assets/67e48a9a-4df1-4b00-837f-b73319b62f1b" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.