### PR TITLE
[WOOMOB-2023] Add scanning indicator to multiple readers found dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -517,6 +517,20 @@ private fun MultipleReadersFoundContent(readers: List<WooPosCardReaderConnection
             textAlign = TextAlign.Center,
         )
 
+        Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
+
+        readers.forEachIndexed { index, reader ->
+            WooPosOutlinedButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = reader.name,
+                maxLines = 1,
+                onClick = reader.onConnectClicked,
+            )
+            if (index < readers.lastIndex) {
+                Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
+            }
+        }
+
         Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
         Row(
@@ -532,20 +546,6 @@ private fun MultipleReadersFoundContent(readers: List<WooPosCardReaderConnection
                 style = WooPosTypography.BodyLarge,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
             )
-        }
-
-        Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
-
-        readers.forEachIndexed { index, reader ->
-            WooPosOutlinedButton(
-                modifier = Modifier.fillMaxWidth(),
-                text = reader.name,
-                maxLines = 1,
-                onClick = reader.onConnectClicked,
-            )
-            if (index < readers.lastIndex) {
-                Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
-            }
         }
     }
 }
@@ -910,19 +910,25 @@ fun WooPosCardReaderConnectionDialogReaderFoundPreview() {
 @Composable
 fun WooPosCardReaderConnectionDialogMultipleReadersPreview() {
     WooPosTheme {
-        MultipleReadersFoundContent(
-            readers = listOf(
-                WooPosCardReaderConnectionState.FoundReader(
-                    id = "STRM261380012691",
-                    name = "STRM261380012691",
-                    onConnectClicked = {}
+        WooPosCardReaderConnectionDialogContent(
+            isVisible = true,
+            state = WooPosCardReaderConnectionState.MultipleReadersFound(
+                readers = listOf(
+                    WooPosCardReaderConnectionState.FoundReader(
+                        id = "STRM261380012691",
+                        name = "STRM261380012691",
+                        onConnectClicked = {}
+                    ),
+                    WooPosCardReaderConnectionState.FoundReader(
+                        id = "STRM261380012692",
+                        name = "STRM261380012692",
+                        onConnectClicked = {}
+                    )
                 ),
-                WooPosCardReaderConnectionState.FoundReader(
-                    id = "STRM261380012692",
-                    name = "STRM261380012692",
-                    onConnectClicked = {}
-                )
+                onCancelClicked = {},
             ),
+            onBackPressed = {},
+            onDismiss = {},
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -16,13 +16,16 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -50,6 +53,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderOnboardingActivity
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCircularLoadingIndicator
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
@@ -512,6 +516,23 @@ private fun MultipleReadersFoundContent(readers: List<WooPosCardReaderConnection
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
         )
+
+        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            WooPosCircularLoadingIndicator(
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
+            WooPosText(
+                text = stringResource(R.string.woopos_card_reader_multiple_found_scanning),
+                style = WooPosTypography.BodyLarge,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+            )
+        }
 
         Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -534,17 +533,12 @@ private fun MultipleReadersFoundContent(readers: List<WooPosCardReaderConnection
         Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
 
         Row(
+            modifier = Modifier.padding(bottom = WooPosSpacing.XXSmall.value),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
         ) {
             WooPosCircularLoadingIndicator(
                 modifier = Modifier.size(20.dp)
-            )
-            Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
-            WooPosText(
-                text = stringResource(R.string.woopos_card_reader_multiple_found_scanning),
-                style = WooPosTypography.BodyLarge,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -525,15 +525,12 @@ private fun MultipleReadersFoundContent(readers: List<WooPosCardReaderConnection
                 maxLines = 1,
                 onClick = reader.onConnectClicked,
             )
-            if (index < readers.lastIndex) {
-                Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
-            }
+            Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
         }
 
-        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
-
         Row(
-            modifier = Modifier.padding(bottom = WooPosSpacing.XXSmall.value),
+            modifier = Modifier
+                .height(80.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
         ) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3969,6 +3969,7 @@
     <string name="woopos_card_reader_keep_searching_button">Keep searching</string>
     <string name="woopos_card_reader_multiple_found_title">Multiple readers found</string>
     <string name="woopos_card_reader_multiple_found_description">Choose a reader</string>
+    <string name="woopos_card_reader_multiple_found_scanning">Scanning for readers</string>
     <string name="woopos_card_reader_connecting_title">Connecting</string>
     <string name="woopos_card_reader_connecting_message">Please wait while we connect to your reader</string>
     <string name="woopos_card_reader_connecting_failed_title">Connection failed</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3969,7 +3969,6 @@
     <string name="woopos_card_reader_keep_searching_button">Keep searching</string>
     <string name="woopos_card_reader_multiple_found_title">Multiple readers found</string>
     <string name="woopos_card_reader_multiple_found_description">Choose a reader</string>
-    <string name="woopos_card_reader_multiple_found_scanning">Scanning for readers</string>
     <string name="woopos_card_reader_connecting_title">Connecting</string>
     <string name="woopos_card_reader_connecting_message">Please wait while we connect to your reader</string>
     <string name="woopos_card_reader_connecting_failed_title">Connection failed</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3968,7 +3968,7 @@
     <string name="woopos_card_reader_connect_button">Connect</string>
     <string name="woopos_card_reader_keep_searching_button">Keep searching</string>
     <string name="woopos_card_reader_multiple_found_title">Multiple readers found</string>
-    <string name="woopos_card_reader_multiple_found_description">Select a reader to connect</string>
+    <string name="woopos_card_reader_multiple_found_description">Choose a reader</string>
     <string name="woopos_card_reader_connecting_title">Connecting</string>
     <string name="woopos_card_reader_connecting_message">Please wait while we connect to your reader</string>
     <string name="woopos_card_reader_connecting_failed_title">Connection failed</string>


### PR DESCRIPTION
Closes WOOMOB-2023

### Description

When multiple card readers are found, the UI now shows a scanning indicator to indicate that discovery is still ongoing. Also improves the description copy from "Select a reader to connect" to "Choose a reader".

**Changes:**
- Add spinning progress indicator below the reader list
- Update description copy to "Choose a reader"
- Update preview to use full dialog wrapper

### Test Steps

1. Go to WooPos and trigger card reader connection
2. Have multiple readers nearby and turned on (or just simulator)
3. Observe the "Multiple readers found" dialog
4. Verify the spinning indicator appears below the reader list
5. Verify the description says "Choose a reader"

### Images/gif


https://github.com/user-attachments/assets/1d40d866-09ab-466a-bf96-0531467ea917



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.