### PR TITLE
[WOOMOB-2022] Improve card reader connection dialog width and spacing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -474,6 +474,7 @@ private fun ScanningContent() {
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
         )
+        Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
     }
 }
 
@@ -562,6 +563,7 @@ private fun ConnectingContent() {
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
         )
+        Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
     }
 }
 
@@ -578,6 +580,7 @@ private fun ConnectedContent(readerName: String) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+        Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -18,16 +18,12 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -39,7 +35,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -257,156 +252,137 @@ fun WooPosCardReaderConnectionDialogContent(
             R.string.woopos_card_reader_connection_dialog_background_content_description
         ),
         widthFraction = 0.6f,
+        onCloseClick = if (state.showCloseButton) onDismiss else null,
         onDismissRequest = onBackPressed,
     ) {
-        Column(
-            modifier = Modifier.padding(WooPosSpacing.XLarge.value)
-        ) {
-            if (state.showCloseButton) {
-                Box(modifier = Modifier.fillMaxWidth()) {
-                    IconButton(
-                        onClick = onDismiss,
-                        modifier = Modifier.align(Alignment.TopEnd)
-                    ) {
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.ic_close_24dp),
-                            contentDescription = stringResource(R.string.woopos_card_reader_close_content_description),
-                            modifier = Modifier.size(40.dp),
-                            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                        )
-                    }
+        AnimatedContent(
+            targetState = state,
+            transitionSpec = {
+                fadeIn(animationSpec = tween(300)) togetherWith
+                    fadeOut(animationSpec = tween(300)) using
+                    SizeTransform(clip = false)
+            },
+            contentKey = { it::class },
+            label = "CardReaderConnectionStateTransition",
+            modifier = Modifier.fillMaxWidth()
+        ) { currentState ->
+            when (currentState) {
+                is WooPosCardReaderConnectionState.Scanning -> {
+                    ScanningContent()
                 }
-            }
-
-            AnimatedContent(
-                targetState = state,
-                transitionSpec = {
-                    fadeIn(animationSpec = tween(300)) togetherWith
-                        fadeOut(animationSpec = tween(300)) using
-                        SizeTransform(clip = false)
-                },
-                contentKey = { it::class },
-                label = "CardReaderConnectionStateTransition",
-                modifier = Modifier.fillMaxWidth()
-            ) { currentState ->
-                when (currentState) {
-                    is WooPosCardReaderConnectionState.Scanning -> {
-                        ScanningContent()
-                    }
-                    is WooPosCardReaderConnectionState.ReaderFound -> {
-                        ReaderFoundContent(
-                            readerName = currentState.reader.name,
-                            onConnectClicked = currentState.reader.onConnectClicked,
-                            onKeepSearchingClicked = currentState.onKeepSearchingClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.MultipleReadersFound -> {
-                        MultipleReadersFoundContent(
-                            readers = currentState.readers,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.Connecting -> {
-                        ConnectingContent()
-                    }
-                    is WooPosCardReaderConnectionState.Connected -> {
-                        ConnectedContent(readerName = currentState.readerName)
-                    }
-                    is WooPosCardReaderConnectionState.ScanningFailed -> {
-                        ErrorContent(
-                            title = stringResource(R.string.woopos_card_reader_scanning_failed_title),
-                            message = currentState.errorMessage,
-                            onRetryClicked = currentState.onRetryClicked,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.ConnectingFailed -> {
-                        ErrorContent(
-                            title = stringResource(R.string.woopos_card_reader_connecting_failed_title),
-                            message = currentState.errorMessage,
-                            onRetryClicked = currentState.onRetryClicked,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.ConnectingFailedBatteryLow -> {
-                        BatteryLowErrorContent(
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.BluetoothDisabled -> {
-                        BluetoothDisabledContent(
-                            onEnableBluetoothClicked = currentState.onEnableBluetoothClicked,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.LocationDisabled -> {
-                        LocationDisabledContent(
-                            onEnableLocationClicked = currentState.onEnableLocationClicked,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.MissingLocationPermission -> {
-                        MissingPermissionContent(
-                            title = stringResource(R.string.woopos_card_reader_location_permission_title),
-                            message = stringResource(R.string.woopos_card_reader_location_permission_message),
-                            onRequestPermissionClicked = currentState.onRequestPermissionClicked,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.MissingBluetoothPermission -> {
-                        MissingPermissionContent(
-                            title = stringResource(R.string.woopos_card_reader_bluetooth_permission_title),
-                            message = stringResource(R.string.woopos_card_reader_bluetooth_permission_message),
-                            onRequestPermissionClicked = currentState.onRequestPermissionClicked,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.InvalidMerchantAddress -> {
-                        ErrorContent(
-                            title = stringResource(R.string.woopos_card_reader_invalid_address_title),
-                            message = stringResource(R.string.woopos_card_reader_invalid_address_message),
-                            onRetryClicked = null,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.InvalidPostalCode -> {
-                        ErrorContent(
-                            title = stringResource(R.string.woopos_card_reader_invalid_postal_code_title),
-                            message = stringResource(R.string.woopos_card_reader_invalid_postal_code_message),
-                            onRetryClicked = null,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.UpdateRequired -> {
-                        UpdateRequiredContent(
-                            progress = currentState.progress,
-                            showCancelWarning = currentState.showCancelWarning,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.UpdateAvailable -> {
-                        UpdateOptionalContent(
-                            progress = currentState.progress,
-                            showCancelWarning = currentState.showCancelWarning,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.UpdateCompleted -> {
-                        UpdateCompletedContent()
-                    }
-                    is WooPosCardReaderConnectionState.UpdateFailed -> {
-                        ErrorContent(
-                            title = stringResource(R.string.woopos_card_reader_update_failed_title),
-                            message = currentState.errorMessage,
-                            onRetryClicked = currentState.onRetryClicked,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
-                    is WooPosCardReaderConnectionState.UpdateFailedBatteryLow -> {
-                        UpdateBatteryLowErrorContent(
-                            currentBatteryLevel = currentState.currentBatteryLevel,
-                            onCancelClicked = currentState.onCancelClicked,
-                        )
-                    }
+                is WooPosCardReaderConnectionState.ReaderFound -> {
+                    ReaderFoundContent(
+                        readerName = currentState.reader.name,
+                        onConnectClicked = currentState.reader.onConnectClicked,
+                        onKeepSearchingClicked = currentState.onKeepSearchingClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.MultipleReadersFound -> {
+                    MultipleReadersFoundContent(
+                        readers = currentState.readers,
+                    )
+                }
+                is WooPosCardReaderConnectionState.Connecting -> {
+                    ConnectingContent()
+                }
+                is WooPosCardReaderConnectionState.Connected -> {
+                    ConnectedContent(readerName = currentState.readerName)
+                }
+                is WooPosCardReaderConnectionState.ScanningFailed -> {
+                    ErrorContent(
+                        title = stringResource(R.string.woopos_card_reader_scanning_failed_title),
+                        message = currentState.errorMessage,
+                        onRetryClicked = currentState.onRetryClicked,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.ConnectingFailed -> {
+                    ErrorContent(
+                        title = stringResource(R.string.woopos_card_reader_connecting_failed_title),
+                        message = currentState.errorMessage,
+                        onRetryClicked = currentState.onRetryClicked,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.ConnectingFailedBatteryLow -> {
+                    BatteryLowErrorContent(
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.BluetoothDisabled -> {
+                    BluetoothDisabledContent(
+                        onEnableBluetoothClicked = currentState.onEnableBluetoothClicked,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.LocationDisabled -> {
+                    LocationDisabledContent(
+                        onEnableLocationClicked = currentState.onEnableLocationClicked,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.MissingLocationPermission -> {
+                    MissingPermissionContent(
+                        title = stringResource(R.string.woopos_card_reader_location_permission_title),
+                        message = stringResource(R.string.woopos_card_reader_location_permission_message),
+                        onRequestPermissionClicked = currentState.onRequestPermissionClicked,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.MissingBluetoothPermission -> {
+                    MissingPermissionContent(
+                        title = stringResource(R.string.woopos_card_reader_bluetooth_permission_title),
+                        message = stringResource(R.string.woopos_card_reader_bluetooth_permission_message),
+                        onRequestPermissionClicked = currentState.onRequestPermissionClicked,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.InvalidMerchantAddress -> {
+                    ErrorContent(
+                        title = stringResource(R.string.woopos_card_reader_invalid_address_title),
+                        message = stringResource(R.string.woopos_card_reader_invalid_address_message),
+                        onRetryClicked = null,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.InvalidPostalCode -> {
+                    ErrorContent(
+                        title = stringResource(R.string.woopos_card_reader_invalid_postal_code_title),
+                        message = stringResource(R.string.woopos_card_reader_invalid_postal_code_message),
+                        onRetryClicked = null,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.UpdateRequired -> {
+                    UpdateRequiredContent(
+                        progress = currentState.progress,
+                        showCancelWarning = currentState.showCancelWarning,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.UpdateAvailable -> {
+                    UpdateOptionalContent(
+                        progress = currentState.progress,
+                        showCancelWarning = currentState.showCancelWarning,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.UpdateCompleted -> {
+                    UpdateCompletedContent()
+                }
+                is WooPosCardReaderConnectionState.UpdateFailed -> {
+                    ErrorContent(
+                        title = stringResource(R.string.woopos_card_reader_update_failed_title),
+                        message = currentState.errorMessage,
+                        onRetryClicked = currentState.onRetryClicked,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
+                }
+                is WooPosCardReaderConnectionState.UpdateFailedBatteryLow -> {
+                    UpdateBatteryLowErrorContent(
+                        currentBatteryLevel = currentState.currentBatteryLevel,
+                        onCancelClicked = currentState.onCancelClicked,
+                    )
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -256,7 +256,7 @@ fun WooPosCardReaderConnectionDialogContent(
         dialogBackgroundContentDescription = stringResource(
             R.string.woopos_card_reader_connection_dialog_background_content_description
         ),
-        widthFraction = 0.5f,
+        widthFraction = 0.6f,
         onDismissRequest = onBackPressed,
     ) {
         Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -251,7 +251,7 @@ fun WooPosCardReaderConnectionDialogContent(
         dialogBackgroundContentDescription = stringResource(
             R.string.woopos_card_reader_connection_dialog_background_content_description
         ),
-        widthFraction = 0.6f,
+        widthFraction = 0.55f,
         onCloseClick = if (state.showCloseButton) onDismiss else null,
         onDismissRequest = onBackPressed,
     ) {
@@ -746,8 +746,10 @@ private fun UpdateRequiredContent(
             color = MaterialTheme.colorScheme.onSurface,
         )
 
+        Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
+
         if (showCancelWarning) {
-            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+            Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
 
             WooPosText(
                 text = stringResource(R.string.woopos_card_reader_update_required_message),


### PR DESCRIPTION
Closes: WOOMOB-2022

### Description

Improves UI consistency in the card reader connection dialog:
- Increases dialog width a bit
- Adds bottom spacing to text-only dialog states (scanning, connecting, connected)
- Reuses `WooPosDialogWrapper` padding and close button instead of custom implementation

### Test Steps

1. Go to WooPos and open the card reader connection dialog
2. Verify the dialog appears slightly wider than before
3. Check scanning, connecting, and connected states have balanced spacing
4. Verify the close button appears and works correctly on states that support it

### Images/gif


https://github.com/user-attachments/assets/aa0b4a45-e599-4850-bdcd-51bbdcd2f93d


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.