### PR TITLE
[Analysis] Update `Aligned16KB` Lint Check Severity to Error

### DIFF
--- a/WooCommerce-Wear/lint.xml
+++ b/WooCommerce-Wear/lint.xml
@@ -3,6 +3,7 @@
     <!-- WARNING -->
 
     <!-- ERROR -->
+    <issue id="Aligned16KB" severity="error" />
     <issue id="InconsistentArrays" severity="error" />
     <issue id="HardcodedText" severity="error" />
     <issue id="IconDuplicates" severity="error" />

--- a/WooCommerce/lint.xml
+++ b/WooCommerce/lint.xml
@@ -3,6 +3,7 @@
     <!-- WARNING -->
 
     <!-- ERROR -->
+    <issue id="Aligned16KB" severity="error" />
     <issue id="InconsistentArrays" severity="error" />
     <issue id="HardcodedText" severity="error" />
     <issue id="IconDuplicates" severity="error" />


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

Closes: [AINFRA-1814](https://linear.app/a8c/issue/AINFRA-1814)
Reason: pdt0Fp-4dX-p2 + pdt0Fp-4dX-p2#comment-1740

---

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Add `Aligned16KB` lint check with error severity to both `WooCommerce` and `WooCommerce-Wear` `lint.xml` files to ensure 16KB page alignment compliance is enforced at build time.

FYI: Starting with Android 15 (API 35), devices may use 16KB memory page sizes. Apps with native code or dependencies using native libraries must be 16KB aligned to run on these devices. By elevating this lint check to error severity, we catch alignment issues during the build process rather than at runtime.

---

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Run lint on both modules:
    ```
    ./gradlew lintJalapenoDebug
    ```
2. Verify no `Aligned16KB` errors are reported.
3. (Optional) To verify the lint check catches non-aligned libraries:
    - Temporarily add the [MockK](https://github.com/mockk/mockk) library of version [1.14.2](https://github.com/mockk/mockk/releases/tag/1.14.2) (see patch).
        - FYI: This version includes native libraries compiled before 16KB page alignment was required.
    - Run lint again:
        ```
        ./gradlew lintJalapenoDebug
        ```
    - Verify lint fails with an `Aligned16KB` error for the [MockK](https://github.com/mockk/mockk) library.

<details>
    <summary>patch</summary>

```diff
Subject: [PATCH] [Analysis] Update `Aligned16KB` Lint Check Severity to Error
---
Index: gradle/libs.versions.toml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
--- a/gradle/libs.versions.toml	(revision 4f442702fb839bb8409f334a75365b560e53c30c)
+++ b/gradle/libs.versions.toml	(date 1769503355298)
@@ -90,6 +90,7 @@
 kotlinx-coroutines = '1.10.2'
 ksp = '2.3.4'
 mockito-kotlin = '6.1.0'
+mockk = '1.14.2'
 mpandroidchart = 'v3.1.0'
 photoview = '2.3.0'
 robolectric = "4.16.1"
@@ -252,6 +253,7 @@
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockito-kotlin" }
+mockk = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 mpandroidchart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "mpandroidchart" }
 photoview = { group = "com.github.chrisbanes", name = "PhotoView", version.ref = "photoview" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
Index: WooCommerce/build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/build.gradle b/WooCommerce/build.gradle
--- a/WooCommerce/build.gradle	(revision 4f442702fb839bb8409f334a75365b560e53c30c)
+++ b/WooCommerce/build.gradle	(date 1769503355300)
@@ -334,6 +334,7 @@
     // Dependencies for local unit tests
     testImplementation(libs.junit)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.mockk)
     testImplementation(libs.kotlin.test.junit)
     testImplementation(libs.assertj.core)
     testImplementation(libs.androidx.arch.core.testing) {
```

</details>

---

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->