### PR TITLE
[Tooling] Test add context to localized strings

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1,433 +1,803 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- The application name displayed in the device's app launcher, settings, and as the default subject prefix when sharing system reports or logs from within the app. -->
     <string name="app_name">Woo</string>
 
-    <!-- Android O notification channels, these show in the Android app settings -->
+    <!-- This is the title for a general notification channel that handles miscellaneous push notifications in the Android system settings. Users will see this text when managing notification preferences for the WooCommerce app, specifically for notifications that don't fall into specific categories like orders or reviews. -->
     <string name="notification_channel_general_title">General</string>
+    <!-- This is an internal identifier string used by the Android system to create a notification channel for general/miscellaneous push notifications in the WooCommerce app. It's not displayed to users but serves as a unique ID for the notification system to categorize and manage general notifications. -->
     <string name="notification_channel_general_id" content_override="true" translatable="false">wooandroid_notification_channel_general_id</string>
+    <!-- This text appears as the title/name of a notification channel in Android system settings, where users can configure how they receive alerts about new orders in the WooCommerce app. -->
     <string name="notification_channel_order_title">New order alerts</string>
+    <!-- This string serves as a unique identifier for the notification channel that handles new order notifications in the Android system. It is used internally by the notification system to categorize and manage push notifications for new orders, but is not displayed to users in the app interface. -->
     <string name="notification_channel_order_id" content_override="true" translatable="false">wooandroid_notification_channel_order_id</string>
+    <!-- This is the title/name of an Android notification channel that groups product review-related push notifications, displayed in the device's notification settings where users can configure alert preferences. -->
     <string name="notification_channel_review_title">Product review alerts</string>
+    <!-- This is an internal identifier used by the Android system to categorize review-related push notifications in the notification settings. It is not displayed to users but is used as a unique channel ID for managing notification preferences. -->
     <string name="notification_channel_review_id" content_override="true" translatable="false">wooandroid_notification_channel_review_id</string>
     <!-- Required by the login library - overwrites the placeholder value with a real channel -->
     <string name="login_notification_channel_id" content_override="true" translatable="false">@string/notification_channel_general_id</string>
     <!--
         General Strings
     -->
+    <!-- This text appears as a filter option in the product reviews section, allowing users to view all reviews regardless of their status (approved, unapproved, spam, or trash). -->
     <string name="all">All</string>
+    <!-- This text appears as a subtitle in a progress dialog during the Jetpack activation login process, shown when the user is authenticating with their WordPress.com credentials or site credentials. -->
     <string name="logging_in">Logging in</string>
+    <!-- Progress dialog message shown when the app is fetching and loading store information after a user account downgrade. This text appears in a loading dialog while the app retrieves the updated list of available stores. -->
     <string name="loading_stores">Loading stores</string>
+    <!-- This text appears as a clickable link within a username display on the login screen and as a confirmation button in a logout dialog. It allows users to sign out of their account either during the login flow or from the app settings. -->
     <string name="signout">Log out</string>
+    <!-- This text appears as the main navigation title/header for the store dashboard screen and as a fallback title for the stats widget when no store name is available. -->
     <string name="my_store">My store</string>
+    <!-- This text appears as the toolbar title on the orders list screen where users can view and manage their WooCommerce orders. It serves as the main heading identifying the current section of the app focused on order management. -->
     <string name="orders">Orders</string>
+    <!-- This text appears as a placeholder hint in the email input field on the login screen, guiding users to enter their email address to sign in to their WordPress.com account. -->
     <string name="email_address">Email address</string>
+    <!-- A field label that appears next to an email input field in the simple payments feature and as a placeholder hint in the domain registration form, identifying where users should enter an email address. -->
     <string name="email">Email</string>
+    <!-- A label that appears on payment and order screens to indicate the final total amount of an order or payment transaction. It's displayed as bold text in a horizontal layout alongside the actual monetary amount. -->
     <string name="order_total">Order total</string>
+    <!-- This text appears as a title or label in shipping-related screens within the WooCommerce app, specifically in contexts related to shipping label creation and address editing functionality. -->
     <string name="shipping">Shipping</string>
     <string name="multiple_shipping">multiple shipping lines</string>
+    <!-- Button text that appears in product editing screens to modify linked products (upsells and cross-sells) when products have already been added, and as an edit button in shipping label creation steps. -->
     <string name="edit">Edit</string>
+    <!-- This text appears as the title in the toolbar/navigation bar for the payments hub section of the WooCommerce app, where users can manage payment-related settings and card readers. -->
     <string name="payment">Payment</string>
+    <!-- A label that appears in order payment summaries and refund screens to display the tax amount charged on items or fees. It shows as a line item in financial breakdowns alongside subtotals and totals. -->
     <string name="taxes">Taxes</string>
+    <!-- A label displayed in the booking payment section that identifies the tax amount row, shown alongside other payment details like service cost, discount, and total. -->
     <string name="tax">Tax</string>
+    <!-- A label displayed in payment summary sections to show the final total amount, appearing in booking payment details and shipping cost breakdowns where it's typically emphasized with bold formatting. -->
     <string name="total">Total</string>
+    <!-- Label displayed in payment and refund screens to show the subtotal amount before taxes and additional fees are applied. Appears in shipping cost breakdowns, simple payment forms, and refund by items sections as part of financial calculations. -->
     <string name="subtotal">Subtotal</string>
+    <!-- This text appears as a label in the order details payment information section, displaying the subtotal amount for all products in the order before taxes and discounts are applied. -->
     <string name="products_total">Products total</string>
+    <!-- This text appears in multiple contexts related to e-commerce order and booking management: as a label in payment breakdown sections showing discount amounts, as a screen title when editing product discounts, and as a button label for applying/editing discounts on products. -->
     <string name="discount">Discount</string>
+    <!-- A generic section header label used in address forms and product variation details screens to indicate a section containing detailed information. This text appears as a header above form fields or detail sections to group related content. -->
     <string name="details">Details</string>
+    <!-- Button label that toggles the visibility of additional attribution information in order details. When clicked, it expands/collapses extra details and switches between 'Show Details' and 'Hide Details' text. -->
     <string name="show_details">Show Details</string>
+    <!-- Button label that appears on the order details screen to collapse expanded attribution information. When clicked, it hides additional details that were previously shown to the user. -->
     <string name="hide_details">Hide Details</string>
+    <!-- Button text that appears in snackbar messages (temporary notification bars) throughout the WooCommerce app, allowing users to retry failed operations like network requests or data loading. -->
     <string name="retry">Retry</string>
+    <!-- Text for an 'Undo' button that appears in snackbar notifications throughout the WooCommerce app, allowing users to reverse actions like deleting custom fields or other operations. -->
     <string name="undo">Undo</string>
+    <!-- Button text that appears on snackbar notifications related to app updates and WC Shipping plugin installation, allowing users to proceed with or restart after an installation process. -->
     <string name="install">Install</string>
+    <!-- This text appears in a success snackbar notification that displays when the WooCommerce app has successfully downloaded an update, informing users they can manually restart the app to apply it. -->
     <string name="update_downloaded">Woo has downloaded an update</string>
+    <!-- Error message displayed in a snackbar when an in-app update of the WooCommerce app fails, with a retry action button for users to attempt the update again. -->
     <string name="update_failed">Woo update has failed</string>
+    <!-- Button label used on the Account Mismatch Error Screen during the login process, where users encounter account mismatches and can continue with the login flow. This appears as multiple button variants (primary, secondary, and inline buttons) that allow users to proceed despite the account mismatch warning. -->
     <string name="continue_button">Continue</string>
+    <!-- This text appears as a secondary button label in the card reader onboarding screens for WooCommerce payments setup. Users tap this button to refresh the connection status or retry the setup process when there are issues with payment configuration. -->
     <string name="refresh_button">Refresh</string>
+    <!-- Fallback text displayed when a product name or product category name is empty in WooCommerce product lists and category selection screens. -->
     <string name="untitled">Untitled</string>
+    <!-- Text displayed on the positive action button in dialog boxes throughout the WooCommerce app, including error dialogs for invalid ad images, informational alerts about visitor stats, and confirmation dialogs for store setup actions. -->
     <string name="dialog_ok">OK</string>
+    <!-- A button label that appears in dialogs throughout the WooCommerce app, allowing users to dismiss or close dialog windows without saving changes. Used in contexts like support identity input forms and campaign creation workflows. -->
     <string name="cancel">Cancel</string>
+    <!-- This text appears as a status indicator in the shipping label hazmat section, showing 'Yes' when a hazardous material category has been selected for a package. -->
     <string name="yes">Yes</string>
+    <!-- Appears as a text label in the shipping hazmat section to indicate 'No' when no hazardous materials category is selected, displayed alongside 'Yes' as a binary status indicator. -->
     <string name="no">No</string>
+    <!-- Button label that appears during card reader firmware updates, allowing users to cancel the update process even when cancellation might not be recommended or safe. -->
     <string name="cancel_anyway">Cancel anyway</string>
+    <!-- Button text in confirmation dialogs that appears when users try to discard changes while editing products or product images. Clicking this button dismisses the dialog and returns the user to the editing interface to continue making changes. -->
     <string name="keep_editing">Keep editing</string>
+    <!-- Button text in a discard changes confirmation dialog that appears when users try to exit filter screens (bookings, orders, products) with unsaved changes. Selecting this option dismisses the dialog and keeps the user on the current screen to preserve their filter modifications. -->
     <string name="keep_changes">Keep changes</string>
+    <!-- Button label that appears in multiple screens to allow users to access additional information - including an empty custom fields view, payment setup onboarding screen, and order totals tax information section. -->
     <string name="learn_more">Learn more</string>
+    <!-- This text appears as the primary action button label in promotional banners that encourage users to configure or activate features in the WooCommerce app. When tapped, it initiates the setup process for the promoted feature or service. -->
     <string name="set_up_now">Set up now</string>
+    <!-- This text appears in a status bar at the top of screens to inform users when the app is offline and displaying cached data instead of live information. It's shown as a persistent notification banner with an offline icon to indicate reduced functionality. -->
     <string name="offline_message">Offline \u2014 using cached data</string>
+    <!-- Error message displayed as a snackbar notification when users try to perform network-dependent actions (like fetching booking details, updating attendance status, or generating system status reports) while offline. The message appears temporarily at the bottom of the screen to inform users they need to check their internet connection. -->
     <string name="offline_error">Your network is unavailable. Check your data or wifi connection.</string>
     <string name="woo_pos_ptr_offline_error">No internet connection. Please check your network and try again.</string>
     <string name="product">Product</string>
+    <!-- This text appears as a label for an app widget that displays today's store statistics on the device home screen, and as a date range selection option in the dashboard analytics section. -->
     <string name="today">Today</string>
+    <!-- This text appears as a selectable time period option in the WooCommerce dashboard's date range selector, allowing users to filter data for the current week. It's also used as a header label in order lists to indicate orders from the current week period. -->
     <string name="this_week">This Week</string>
+    <!-- This text appears as a selectable tab or filter option in the dashboard date range selector, allowing users to view data for the current month-to-date period. -->
     <string name="this_month">This Month</string>
+    <!-- This text appears as a selectable tab or filter option in the dashboard date range selector, allowing users to view analytics data for the current year to date. -->
     <string name="this_year">This Year</string>
+    <!-- A button label that appears in confirmation dialogs when users have unsaved changes in booking filters or product details, allowing them to abandon their changes and exit without saving. -->
     <string name="discard">Discard</string>
-    <!-- Booking note discard changes dialog -->
+    <!-- This text appears as the main message in a confirmation dialog that displays when a user tries to navigate away from editing a booking note after making changes. The dialog asks the user to confirm whether they want to lose their unsaved edits. -->
     <string name="booking_note_discard_changes_message">Are you sure you want to discard these changes?</string>
+    <!-- This text appears as a button label in a confirmation dialog that shows when a user tries to leave the booking note editing screen after making unsaved changes. When tapped, it discards the user's edits and exits the screen without saving. -->
     <string name="booking_note_discard_changes_discard">Discard changes</string>
+    <!-- This text appears as a section header or title in multiple areas of the WooCommerce app, including the shipping label creation screen, product list toolbar, and order creation form, identifying sections that contain product information. -->
     <string name="products">Products</string>
+    <!-- This text appears as a bottom navigation tab label and as an option in the sales channel filter for orders, allowing users to access point-of-sale functionality and filter orders by POS transactions. -->
     <string name="point_of_sale">Point of Sale</string>
+    <!-- A label that appears in order totals sections and custom amount cards to identify fees or custom charges added to an order. It's displayed as a descriptive text label alongside the monetary amount in the order creation and editing interface. -->
     <string name="custom_amounts">Custom Amounts</string>
+    <!-- This text serves as an accessibility content description for the refunds information section on the order details screen, helping screen readers announce this section to users with visual impairments. -->
     <string name="refunds">Refunds</string>
+    <!-- This text appears as an error message in the domain registration contact form when a required field is left empty, displayed as part of a validation error that includes the field name. -->
     <string name="domain">Domain</string>
+    <!-- This text appears as the title in the navigation toolbar of the domain dashboard screen in the WooCommerce app, where users can manage their website domains and search for new ones. -->
     <string name="domains">Domains</string>
+    <!-- Generic error message displayed as a toast notification when operations fail in the payments hub (enabling/disabling cash on delivery) or when refreshing products in the WooPos interface, shown when no specific error message is available from the server. -->
     <string name="something_went_wrong_try_again">Something went wrong, Please try again later.</string>
+    <!-- Generic loading text displayed as the title of progress dialogs and loading states throughout the WooCommerce shipping features when the app is fetching data or processing requests. -->
     <string name="loading">Loading…</string>
+    <!-- Used as accessibility content description for UI elements related to shipping labels functionality, including an informational image and a shipping labels list view on order detail screens. -->
     <string name="shipping_labels">Shipping Labels</string>
+    <!-- This text appears as a navigation title in the toolbar when viewing or managing product variations in a WooCommerce store. It's displayed at the top of screens where users can view, add, or edit product variants (like different sizes or colors of a product). -->
     <string name="product_variations">Variations</string>
+    <!-- This text appears as a property format in the product details screen for variable products, showing attribute names with the count of available options in parentheses (e.g., 'Color (3 options)', 'Size (5 options)'). -->
     <string name="product_variation_options">%1$s (%2$s options)</string>
+    <!-- This text appears as a clickable property label in the product details screen showing the number of variations available for a variable product (e.g., '5 variations'). It uses string formatting where %1$s is replaced with the actual number, and tapping it navigates users to view all product variations. -->
     <string name="product_variation_multiple_count">%1$s variations</string>
+    <!-- This text appears as a label in the product details screen to indicate that a variable product has exactly one variation available. It's displayed as part of a clickable property row that shows product variation information. -->
     <string name="product_variation_single_count">1 variation</string>
+    <!-- This text appears as the toolbar title on the product variation attributes screen, where users can view and manage attributes for product variations in a WooCommerce store. -->
     <string name="product_variation_attributes">Attributes</string>
+    <!-- This text appears as both a button label in the product attributes screen and as a toolbar title in the Add Attribute fragment. Users tap the button to add new product attributes, and the title appears when they're in the process of adding an attribute to a product. -->
     <string name="product_add_attribute">Add attribute</string>
+    <!-- This text appears as a hint/placeholder text in a text input field where users can enter the name for a new product attribute they are creating. -->
     <string name="product_new_attribute_name">New attribute name</string>
+    <!-- This text appears as the title in the toolbar/navigation bar of a screen where users can rename product attributes. It displays at the top of the rename attribute interface when users are editing product variation attributes. -->
     <string name="product_rename_attribute">Rename attribute</string>
+    <!-- This helper text appears below an input field in the product attribute renaming screen, providing guidance to users about what type of attribute variation they should enter (such as 'size' or 'color'). -->
     <string name="product_rename_attribute_helper">Type of variation, eg. size or color</string>
+    <!-- Helper text displayed on the product attribute creation screen that explains to users they need to define product attributes (like Color or Size) before they can create product variations. -->
     <string name="product_create_attribute_helper">To create a variation, you\'ll need to set its attributes (ie \"Color\", \"Size\") first</string>
+    <!-- This text appears as a hint label on the product attribute creation screen, instructing users that they can tap to select from existing product attributes instead of creating a new one. It's displayed above a list of selectable attributes in the WooCommerce mobile app. -->
     <string name="product_select_attribute">Or tap to select an existing attribute</string>
+    <!-- This text appears as a placeholder hint in a text input field where users enter the name of a new product attribute option/term (such as color names like 'Red', 'Blue' or size options like 'Small', 'Large'). -->
     <string name="product_new_attribute_term_name">Option name</string>
+    <!-- This text appears as an instructional label on the product attribute configuration screen, guiding users to tap and select from a list of existing attribute options below the text. -->
     <string name="product_select_attribute_term">Or tap to select an existing option</string>
+    <!-- This text appears as helper text below an input field where users can add option names for product attributes, instructing them to enter each option and press enter to confirm. -->
     <string name="product_enter_attribute_term">Add each option name and press enter</string>
+    <!-- Error message displayed as a snackbar notification when a user tries to add a new product attribute or rename an existing attribute with a name that already exists for that product. -->
     <string name="product_attribute_name_already_exists">An attribute with this name already exists</string>
+    <!-- This text appears as a placeholder or default value in product variation attribute displays when no specific attribute option is selected, indicating that any variant of that attribute is acceptable. It's used in product configuration screens and variation detail views within the WooCommerce Android app. -->
     <string name="product_any_attribute_hint">Any</string>
+    <!-- Error message displayed as a snackbar notification when a user tries to add a product attribute term that already exists with the same name. This appears in the product editing screen when managing product attributes and variants. -->
     <string name="product_term_name_already_exists">An option with this name already exists</string>
+    <!-- Error message displayed as a snackbar notification when the system fails to rename a product attribute due to technical issues, appearing on the product details editing screen. -->
     <string name="product_attribute_error_renaming">Error while renaming your attribute</string>
+    <!-- Error message displayed in a snackbar notification when the app fails to save product attribute changes to the backend server. This appears on the product details screen after a user attempts to save modifications to product attributes. -->
     <string name="product_attributes_error_saving">Error while saving your attributes</string>
+    <!-- This text appears as a confirmation dialog message when a user attempts to remove a product attribute. It's displayed in a modal dialog with Remove and Cancel buttons to confirm the destructive action. -->
     <string name="product_attribute_remove">Remove this attribute?</string>
+    <!-- This text appears as the title of a dialog box that allows users to bulk update the regular price for multiple selected products in the product list. The dialog contains a price input field where users can enter a new regular price to apply to all selected products. -->
     <string name="product_bulk_update_regular_price">Update regular price</string>
+    <!-- A success confirmation message that appears as a snackbar/toast notification after the user successfully bulk updates prices for multiple products in the product list screen. -->
     <string name="product_bulk_update_price_updated">Price updated!</string>
+    <!-- This text appears as the title of a dialog box that allows users to bulk update the status (published, draft, private, etc.) of multiple selected products in the product list screen. -->
     <string name="product_bulk_update_status">Update status</string>
+    <!-- Success message displayed to the user after they have successfully updated the status (such as draft, published, private) of multiple products at once in the product list screen. -->
     <string name="product_bulk_update_status_updated">Status updated!</string>
+    <!-- This text appears as the title of a screen that displays a list of product reviews for store owners to manage. It serves as the navigation bar title for the reviews section where users can view, filter, and mark reviews as read. -->
     <string name="review_notifications">Reviews</string>
+    <!-- Displays the app version number in the Help screen, shown as a text label that users can view for support or troubleshooting purposes. The %s parameter is replaced with the actual version number (e.g., 'Version 1.2.3'). -->
     <string name="version_with_name_param">Version %s</string>
+    <!-- Button text that appears on the dashboard and empty state screens, allowing users to share their WooCommerce store with others as part of a promotional feature. -->
     <string name="share_store_button">Share your store</string>
+    <!-- This text appears as the title of a share dialog when users choose to share their WooCommerce store's URL with others through Android's native sharing interface. -->
     <string name="share_store_dialog_title">Share your store\'s URL</string>
+    <!-- An em dash character (—) used as a placeholder in the dashboard statistics display when numeric values are unavailable or being cleared, shown in place of visitor count, revenue, orders, and conversion rate statistics. -->
     <string name="emdash" translatable="false">\u2014</string>
+    <!-- Text displayed in the Android system share dialog when users share system status reports or app logs from the support section. This appears as the title of the share chooser that shows available apps to share with. -->
     <string name="share">Share</string>
+    <!-- This text appears as the content description for search icon buttons and as a menu item title in the WooCommerce Android app. It's used for accessibility purposes to describe search functionality to screen readers and as a visible menu label in the order list screen. -->
     <string name="search">Search</string>
+    <!-- This text appears as a content description for barcode scanner buttons in the product inventory screen and as a menu item title in the order list screen. It describes the action of scanning a barcode to automatically populate product information like SKU or GTIN fields. -->
     <string name="scan_barcode">Scan Barcode</string>
+    <!-- Button label and accessibility text that allows users to clear/reset date and time filters in the bookings section, and also serves as content description for a close/clear icon in text input fields. -->
     <string name="clear">Clear</string>
+    <!-- Button label that appears in the top-right corner of editing screens (text editor and custom fields editor) to save changes and return to the previous screen, and as a confirmation button in the WooPayments setup celebration dialog. -->
     <string name="done">Done</string>
+    <!-- Content description for back navigation icons used in toolbars and search interfaces throughout the app. This accessibility text is read by screen readers when users interact with back buttons or icons to return to the previous screen. -->
     <string name="back">Back</string>
+    <!-- Text displayed as the content description for close buttons and as button text for dismissing dialogs or overlays. Used in campaign creation screens, feedback dialogs, and custom field viewers to allow users to close or dismiss the current interface. -->
     <string name="close">Close</string>
     <string name="button_update_instructions">Update instructions</string>
+    <!-- Button text that allows users to close or hide UI elements like expandable banner notifications, permission request bars, and modal web views without taking any additional action. -->
     <string name="dismiss">Dismiss</string>
+    <!-- This text appears as a button label in a notifications permission request dialog/banner that prompts users to allow the app to send notifications. When tapped, it grants notification permissions to the WooCommerce app. -->
     <string name="allow">Allow</string>
+    <!-- Button label used in order management screens to confirm and apply changes to order status selections. Appears on confirmation dialogs when selecting a new status for an order and on gift card editing screens to apply gift card codes. -->
     <string name="apply">Apply</string>
+    <!-- A toast message that appears to confirm successful copy operations, shown when users copy custom field content or text selections to their device clipboard. -->
     <string name="copied_to_clipboard">Copied to clipboard</string>
+    <!-- Error message displayed as a toast notification when copying an order's shipment tracking number to the device clipboard fails due to a technical error. -->
     <string name="error_copy_to_clipboard">Error copying to clipboard</string>
+    <!-- Button text that appears in the inbox notification screen to expand truncated notification descriptions. When tapped, it reveals the full text content of notifications that were initially shown with a 2-line limit. -->
     <string name="read_more">Read more</string>
+    <!-- This text appears as a toast message (temporary popup notification) shown to developers in debug builds when the app's database version has been downgraded and needs to be recreated. It's a technical notification that briefly appears at the bottom of the screen to inform developers about database maintenance happening in the background. -->
     <string name="database_downgraded">Database downgraded, recreating tables and loading stores</string>
+    <!-- Button text that appears in dialogs to confirm removal of product images, and as content description for swipe-to-delete functionality for shipping packages. This action word confirms destructive operations throughout the app. -->
     <string name="remove">Remove</string>
+    <!-- This text appears as a menu item in the attribute terms management screen, allowing users to rename product attribute terms (like color or size values) in their WooCommerce store. -->
     <string name="rename">Rename</string>
+    <!-- This text appears as a placeholder hint in an input field where users can enter or edit the name/type of a product attribute when renaming attributes in the WooCommerce app. -->
     <string name="type">Type</string>
+    <!-- Button text that appears on error screens to allow users to retry a failed action, specifically used in Blaze campaign payment processing, Jetpack connection setup, and login flows when operations fail. -->
     <string name="try_again">Try again</string>
+    <!-- Button label that appears in menu bars on product download details and product variation screens, allowing users to save their changes and update the product information. -->
     <string name="update">Update</string>
+    <!-- Text displayed on save buttons in the Blaze campaign creation flow, including ad destination configuration and campaign objective selection screens. Users tap this button to confirm and save their campaign settings. -->
     <string name="save">Save</string>
+    <!-- Button label that allows users to bypass or dismiss optional onboarding steps in the card reader setup process and modal dialogs. Appears as a secondary action button that lets users proceed without completing the current step. -->
     <string name="skip">Skip</string>
+    <!-- Confirmation dialog message displayed when users attempt to close or exit a screen with unsaved changes, asking if they want to discard their edits. Appears in booking filters and product editing screens with accompanying 'Discard' and 'Keep Editing' buttons. -->
     <string name="discard_message">Do you want to discard your changes?</string>
+    <!-- A confirmation dialog message that appears when users try to exit product or variation editing screens while product images are still uploading, warning them that their changes will be lost. -->
     <string name="discard_images_message">Product images are still uploading. Do you want to discard your changes?</string>
+    <!-- A section header that appears in the product settings screen, introducing a group of additional configuration options below the main product settings. This text acts as a category label to organize less commonly used product configuration switches and fields. -->
     <string name="more_options">More options</string>
+    <!-- Displayed as placeholder text in product settings fields when a value has not been configured, such as when the product slug, purchase note, or menu order fields are empty or set to default values. -->
     <string name="value_not_set">Not set</string>
     <string name="selection_count">%d selected</string>
+    <!-- This text appears as a subtitle in progress dialogs that display while the app is performing background operations like saving custom fields or fetching Jetpack installation status. It's shown below a main title to indicate the user should wait for the operation to complete. -->
     <string name="please_wait">Please wait…</string>
+    <!-- This text appears as a shipping method option in the order creation flow, allowing users to select 'Other' when the desired shipping method is not available in the predefined list. -->
     <string name="other">Other</string>
+    <!-- This text appears as a placeholder hint in a dropdown field for selecting shipping methods during order creation, displayed when no shipping method has been selected yet. -->
     <string name="na">N/A</string>
+    <!-- Displays as a label for shipping rates or fees when the cost is zero/no additional charge in the shipping label creation flow and WooCommerce shipping rates selection. -->
     <string name="free">free</string>
+    <!-- This error message appears when users leave required form fields empty during validation, specifically shown in shipping label address forms and other input validation contexts throughout the WooCommerce app. -->
     <string name="error_required_field">Required field</string>
+    <!-- This text appears as section titles or filter labels in the Google Ads analytics dashboard, specifically used to label different metric categories like total sales, spend, clicks, and impressions when displaying advertising campaign performance data. -->
     <string name="analytics">Analytics</string>
+    <!-- This text appears as the title in the top navigation bar of the Analytics Hub settings screen, where users can customize which analytics cards are displayed and their order. -->
     <string name="customize_analytics">Customize Analytics</string>
+    <!-- This is an accessibility content description for a drag handle icon that allows users to reorder items in a drag-and-drop list. The text is used by screen readers to describe the interactive grip icon that users can press and drag to rearrange list items. -->
     <string name="drag_handle">Drag handle</string>
+    <!-- This text appears in a cash payment calculator screen where users can input the amount of cash received from customers and calculate change due. The term 'Cash' is used as a label or identifier for cash payment functionality within the payment processing flow. -->
     <string name="cash">Cash</string>
+    <!-- This text appears as a menu item label in the order creation screen toolbar. When tapped, it triggers the creation of a new order from the current draft. -->
     <string name="create">Create</string>
+    <!-- This text appears as a placeholder hint in currency input fields when creating or editing fees and shipping charges for orders, prompting users to enter a monetary amount. -->
     <string name="amount">Amount</string>
+    <!-- Label text for copy buttons that allow users to copy AI-generated content (product descriptions and thank you notes) to their clipboard, and for a copy action in the log viewer screen toolbar. -->
     <string name="copy" tools:override="true">Copy</string>
+    <!-- This text appears as a toolbar title in the variations bulk update screen when users are updating sale prices for multiple product variations in a WooCommerce store. -->
     <string name="variations_bulk_update_sale_price">Update Sale Price</string>
+    <!-- This text appears as the toolbar title when users are bulk updating the regular prices of product variations in WooCommerce. It's displayed at the top of the screen to indicate the current editing mode when managing multiple product variant prices. -->
     <string name="variations_bulk_update_regular_price">Update Regular Price</string>
+    <!-- This text appears as a badge label on promotional banners in the WooCommerce app, likely indicating that the banner contains helpful advice or suggestions for users. -->
     <string name="tip">Tip</string>
+    <!-- Content description for the hide password visibility toggle icon button in password input fields. This accessibility text is used by screen readers when the password is currently visible and the user can tap to hide it. -->
     <string name="hide_password_content_description">Hide password</string>
+    <!-- This is the content description (accessibility text) for an icon button that toggles password visibility in password input fields. When the password is hidden, this text describes what the button will do when tapped - make the password visible to the user. -->
     <string name="show_password_content_description">Show password</string>
+    <!-- A status label that displays when data was last refreshed in analytics and dashboard sections, showing timestamps like 'Last update: 2 hours ago' or 'Last update: Dec 15, 3:30 PM'. -->
     <string name="last_update">Last update: %s</string>
+    <!-- This text appears as a label in the analytics hub date range selector card, showing when the analytics data was last updated along with information about the automatic update frequency. The %s placeholder is replaced with a formatted timestamp indicating when the data was last refreshed. -->
     <string name="last_update_with_frequency">Last update %s (Updates every 30 minutes)</string>
+    <!-- Error message displayed to users when the app fails to load a receipt for an order, appearing both in order details and during card reader payment flows when receipt fetching fails. -->
     <string name="receipt_fetching_error">Sorry, we couldn\'t load a receipt for this order</string>
+    <!-- Default fallback text displayed as the store name in the dashboard header when no custom store name has been set by the user. Also used to check if the store naming onboarding task has been completed. -->
     <string name="store_name_default">Store name</string>
+    <!-- This text serves as an accessibility content description for dropdown arrow icons in shipping-related screens, specifically for paper size selection and shipping rate sorting options. The %s placeholder is replaced with the currently selected option (e.g. 'Sorted by Price' or 'Sorted by A4'), helping screen readers announce what the dropdown is currently sorted or filtered by. -->
     <string name="sorted_by">Sorted by 1%s</string>
+    <!-- This appears to be a generic template string used for button labels and titles throughout the app where '%s' is replaced with the specific item being added (e.g., 'Add Note', 'Add Products'). Based on the code context, it's used in scenarios like adding order notes and product relationships. -->
     <string name="add">Add %s</string>
+    <!-- Accessibility content description for an EAN13 barcode image displayed in the WooCommerce app, used by screen readers to describe the barcode to visually impaired users. -->
     <string name="barcode_ean13_content_description">Barcode EAN13</string>
     <!--
         Date/Time Labels
     -->
+    <!-- Section header label used in the reviews list to group reviews that are scheduled or dated in the future. Appears as a divider header above reviews in chronological groupings within the WooCommerce app's review management interface. -->
     <string name="date_timeframe_future">Upcoming</string>
+    <!-- This text appears as an option in the analytics date range selector, allowing users to choose a custom date range instead of predefined timeframes like 'Today', 'Last Week', or 'Last Month'. -->
     <string name="date_timeframe_custom">Custom</string>
+    <!-- A section header label used to group items (like reviews or analytics data) that occurred on the current day. This appears in list views to organize content by time periods, helping users quickly identify today's activity. -->
     <string name="date_timeframe_today">Today</string>
+    <!-- This text appears as a section header in lists (such as reviews) to group items that were created or occurred yesterday, and as a selectable time range option in analytics date filtering. -->
     <string name="date_timeframe_yesterday">Yesterday</string>
+    <!-- This text appears as a selectable option in the analytics date range picker for WooCommerce store statistics, allowing users to view data from the previous week (Monday to Sunday). -->
     <string name="date_timeframe_last_week">Last Week</string>
+    <!-- This text appears as a selectable option in the analytics date range picker, allowing users to view statistics for the previous calendar month. It's displayed in a dropdown or list alongside other time period options like 'Today', 'Yesterday', and 'Last Week'. -->
     <string name="date_timeframe_last_month">Last Month</string>
+    <!-- This text appears as a selectable option in the analytics date range picker for the WooCommerce app, allowing users to filter their store statistics by the previous quarter (3-month period). -->
     <string name="date_timeframe_last_quarter">Last Quarter</string>
+    <!-- This text appears as a selectable option in the analytics/statistics time range picker, allowing users to filter data to show results from the previous calendar year. -->
     <string name="date_timeframe_last_year">Last Year</string>
+    <!-- This text appears as a selectable option in the analytics time range picker, allowing users to filter store statistics from the beginning of the current week up to today. It's displayed alongside other time period options like 'Month to Date' and 'Year to Date' in a dropdown or selection menu. -->
     <string name="date_timeframe_week_to_date">Week to Date</string>
+    <!-- This text appears as a selectable time range option in the analytics/statistics section of the WooCommerce app, allowing users to filter data from the beginning of the current month up to today's date. -->
     <string name="date_timeframe_month_to_date">Month to Date</string>
+    <!-- This text appears as a selectable option in the analytics time range selection menu, allowing users to filter store statistics and reports from the beginning of the current quarter to the present date. -->
     <string name="date_timeframe_quarter_to_date">Quarter to Date</string>
+    <!-- This text appears as a selectable time range option in the analytics/statistics section of the WooCommerce app, allowing users to view data from January 1st of the current year up to the current date. -->
     <string name="date_timeframe_year_to_date">Year to Date</string>
+    <!-- A section header label used in review lists to group reviews that were posted more than 2 days ago but less than a week ago. This text appears as a header separating different time periods in chronologically organized review listings. -->
     <string name="date_timeframe_older_two_days">Older than 2 days</string>
+    <!-- This text appears as a section header in the reviews list to group reviews that were created more than a week ago but less than a month ago. It helps organize reviews chronologically in the WooCommerce app's review management interface. -->
     <string name="date_timeframe_older_week">Older than a week</string>
+    <!-- This text appears as a section header in lists (such as product reviews) to group items that are older than one month from the current date. It helps organize chronological content by creating time-based categories for easier browsing. -->
     <string name="date_timeframe_older_month">Older than a month</string>
+    <!-- This text appears in the analytics date range selector screen as a label that introduces the comparison period. It precedes the previous date range text to show what time period the current analytics data is being compared against. -->
     <string name="date_compared_to">Compared to</string>
+    <!-- A connector word used in date and time formatting within the WooCommerce POS orders interface, appearing between the date and time portions (e.g., 'Mar 15, 2024 at 2:30 PM') when displaying order creation timestamps. -->
     <string name="date_time_connector">at</string>
+    <!-- This text appears as a warning notice on the product detail screen when product images cannot be displayed because the WooCommerce site is set to private mode. It's displayed in a centered warning banner with an info icon to inform users why images are unavailable and how to resolve the issue. -->
     <string name="images_unavailable_notice">The images are unavailable because your site is marked Private. You can change this by switching to Coming Soon mode.\n<a href="">Tap to learn more.</a></string>
     <!--
         Error Strings
     -->
+    <!-- Error message displayed as a toast notification when the app fails to open external links or URLs due to missing browser apps or system restrictions. -->
     <string name="error_cant_open_url">Unable to open the link</string>
+    <!-- This text appears as the title of an app chooser dialog when the default browser fails to open a URL due to security restrictions. It prompts the user to select an alternative browser or app from a list of available options. -->
     <string name="error_please_choose_browser">Error opening the default web browser. Please choose another app:</string>
+    <!-- Error message displayed in a toast notification when the user tries to make a phone call but no phone/dialer app is installed on their device. This appears when users attempt to call customers from order details or booking contact options. -->
     <string name="error_no_phone_app">No phone app was found</string>
+    <!-- Error message displayed as a toast notification when the user tries to view a shipping address in Google Maps but the Google Maps app is not installed on their device. This appears in the shipping label address editing screen when the maps integration fails. -->
     <string name="error_no_gmaps_app">Google Maps app was found</string>
+    <!-- Error message displayed as a toast notification when the user attempts to email a customer from an order but no email application is installed on their device. -->
     <string name="error_no_email_app">No e-mail app was found</string>
+    <!-- Error message displayed as a toast notification when the user attempts to send an SMS to a customer but no SMS messaging app is installed on their device. -->
     <string name="error_no_sms_app">No SMS app was found</string>
     <!--
         Payment methods
     -->
+    <!-- This text appears as a label for American Express payment method cards in the shipping label payment methods selection screen, displayed alongside card details like card number digits and expiration date. -->
     <string name="payment_method_american_express">American Express</string>
+    <!-- This text appears as a payment method label in the shipping label payment methods selection screen, specifically identifying Discover credit cards when users choose how to pay for shipping labels. -->
     <string name="payment_method_discover">Discover</string>
+    <!-- This text appears as a label for MasterCard payment method options in the shipping label payment methods selection screen, displayed alongside card type and last four digits to help users identify their payment method. -->
     <string name="payment_method_mastercard">MasterCard</string>
+    <!-- This text displays as a label for Visa credit cards in the shipping label payment method selection screen, where users can choose which payment method to use for purchasing shipping labels. -->
     <string name="payment_method_visa">VISA</string>
+    <!-- This text appears as a payment method option label in the shipping label payment methods selection screen, displayed alongside other payment options like credit cards when users need to choose how to pay for shipping labels. -->
     <string name="payment_method_paypal">Paypal</string>
     <!--
         Login Library Overrides
     -->
+    <!-- This text appears as an instructional label on the site discovery screen where users enter their WooCommerce store URL to connect their store to the app. It displays above an input field to guide users on what information they need to provide. -->
     <string name="enter_site_address" content_override="true">Enter the address of the WooCommerce store you\'d like to connect.</string>
     <!--
         Login View
     -->
+    <!-- This text appears as a toast notification (temporary popup message) shown when a user attempts to add a WordPress.com site that belongs to a different account while already logged into their current WordPress.com account. -->
     <string name="already_logged_in_wpcom">You\'re already logged in a WordPress.com account, you can\'t add a WordPress.com site bound to another account.</string>
+    <!-- This text appears on the login screen when a user is signed in but Jetpack is not available, showing their username with an @ symbol and providing a clickable logout option. The second parameter (%2$s) becomes a clickable link that allows users to sign out and switch to a different account. -->
     <string name="login_no_jetpack_username">Signed in as \@%1$s\nWrong account? %2$s</string>
+    <!-- This text appears on a button in the login prologue screen of the WooCommerce Android app, allowing users to sign in using their WordPress.com account credentials as an alternative to entering a store address directly. -->
     <string name="login_wpcom">Continue with WordPress.com</string>
+    <!-- This is the text displayed on the main login button in the WooCommerce app's login prologue screen that allows users to log in with their existing store credentials. The button appears prominently on the welcome screen and initiates the store login flow when tapped. -->
     <string name="login_store_address">Log In</string>
+    <!-- This text appears as a clickable button label in a login error dialog that displays when Application Passwords are disabled on a WooCommerce site. When tapped, it opens a help guide in a browser to explain what Application Passwords are. -->
     <string name="login_application_passwords_help">What are Application Passwords?</string>
+    <!-- This text appears as a title in the login prologue screen, which is part of an onboarding carousel that introduces users to key WooCommerce app features before they log in. It serves as a headline describing the analytics capabilities of the app. -->
     <string name="login_prologue_label_analytics">Track sales and high performing products</string>
+    <!-- This text appears as a title or heading in the login prologue screens, specifically for the orders section that introduces new users to the app's order management capabilities before they sign in. -->
     <string name="login_prologue_label_orders">Manage and edit orders on the go</string>
+    <!-- This text appears as a title in the login prologue carousel, describing the products management feature to users before they log in. It's displayed alongside an illustration as part of an onboarding flow that highlights key app capabilities. -->
     <string name="login_prologue_label_products">Edit and add new products from anywhere</string>
+    <!-- This subtitle text appears on the third page of the login onboarding flow, specifically under the analytics section that introduces users to the app's analytics features before they log in. -->
     <string name="login_prologue_label_analytics_subtitle">We know it\'s essential to your business.</string>
+    <!-- This text appears as a subtitle in the login prologue screen, specifically for the orders management section. It's displayed below the orders title to explain that users can manage their orders quickly and easily through the app. -->
     <string name="login_prologue_label_orders_subtitle">You can manage them quickly and easily.</string>
+    <!-- This text appears as a subtitle in the login prologue screen's product management section, explaining the benefit of using the app to handle products. It's displayed as part of an onboarding carousel that introduces key app features to new users before they log in. -->
     <string name="login_prologue_label_products_subtitle">We enable you to process them effortlessly.</string>
 
 
+    <!-- This text appears as a button label on the login prologue screen that allows users to start creating a new WooCommerce store. The button is styled as a text button and is positioned below the main store login option, providing an alternative path for users who don't have an existing store. -->
     <string name="login_prologue_start_new_store">Starting a new store?</string>
 
+    <!-- This text appears as a section header label on the site picker screen during the login flow, instructing users to select a store from the list of available WooCommerce sites to connect to their account. -->
     <string name="login_pick_store">Select store to connect</string>
+    <!-- A section header label that appears on the site picker screen during login, displayed above a list of non-WooCommerce sites when the user has multiple sites but some don't have WooCommerce installed. -->
     <string name="login_non_woo_stores_label">Other sites</string>
+    <!-- Loading message displayed in a progress dialog during the site verification process when users are logging into their WooCommerce store. This text appears in a modal dialog that cannot be dismissed while the app checks if the entered site URL is valid and has the required Jetpack plugin. -->
     <string name="login_verifying_site">Verifying site…</string>
+    <!-- Error message displayed in a snackbar when the app fails to connect to a WooCommerce site during the site verification process. The %s placeholder is replaced with the site name. -->
     <string name="login_verifying_site_error">Cannot connect to %s</string>
+    <!-- Title text displayed in a dialog box that appears when there's a connection timeout error while verifying a site's Jetpack connection during the login/site selection process. The dialog includes options to contact support or cancel, helping users understand and resolve the connection issue. -->
     <string name="login_verifying_site_jetpack_timeout_error_title">Connection Error</string>
+    <!-- This message appears in an error dialog shown to users when the app fails to connect to their WooCommerce site due to a timeout during the Jetpack verification process in the site picker screen. The dialog includes contact support and cancel buttons to help users resolve the connection issue. -->
     <string name="login_verifying_site_jetpack_timeout_error_description">We were unable to connect to your site. Please contact support to troubleshoot the problem.</string>
+    <!-- This text appears as the title of an alert dialog that prompts users to update their WooCommerce store to version 3.5 or higher when the current version is incompatible with the mobile app. -->
     <string name="login_update_required_title">Update Store to WooCommerce 3.5</string>
+    <!-- This text appears as the body message in an alert dialog that is shown when a user tries to connect to a WooCommerce store that has an incompatible version. The dialog explains why the store cannot be used with the app and prompts the user to upgrade their WooCommerce installation. -->
     <string name="login_update_required_desc">This store uses an older version of WooCommerce. Please upgrade your store to WooCommerce 3.5 or greater to use it with this app.</string>
+    <!-- Accessibility text for screen readers describing a user's profile photo/avatar image that appears on login-related screens, specifically when there's an account mismatch error during the login process. -->
     <string name="login_avatar_content_description">Your profile photo</string>
+    <!-- This text appears as a header/title in the login flow when a user has successfully logged in but has no WooCommerce stores connected to their account. It's displayed prominently on a screen that encourages the user to create their first store to proceed with using the app. -->
     <string name="login_no_stores_header">Create your first store</string>
+    <!-- This subtitle text appears on a 'no stores found' screen during the login flow, displayed below the main header to encourage users to create their first online store. It serves as supportive messaging when a user has successfully logged in but has no WooCommerce stores associated with their account. -->
     <string name="login_no_stores_subtitle">Quickly get up and selling with a beautiful online store.</string>
+    <!-- Error message displayed on the account mismatch error screen when a user tries to connect to a WordPress.com store that is already linked to a different WordPress.com account. The %1$s placeholder is replaced with the store URL or name to specify which store has the account conflict. -->
     <string name="login_wpcom_account_mismatch">It looks like %1$s is connected to a different WordPress.com account.</string>
+    <!-- Error message displayed on the account mismatch screen when a user's account is not connected to Jetpack for their WooCommerce site. The %1$s placeholder is replaced with the site URL to show which specific site has the connection issue. -->
     <string name="login_jetpack_not_connected">It looks like your account is not connected to %1$s\'s Jetpack</string>
+    <!-- Secondary button text that appears on error screens when users encounter account eligibility issues or account mismatches, allowing them to log out of the current account and try logging in with a different one. -->
     <string name="login_try_another_account">Log in with another account</string>
+    <!-- Button text that appears in error dialogs when a user tries to log into a site that isn't a WordPress/WooCommerce store, allowing them to go back and enter a different store URL. -->
     <string name="login_try_another_store">Try another store</string>
+    <!-- Error message displayed when a user tries to log into a site that doesn't have WooCommerce installed, shown in a dialog during the login process and on the site picker screen. -->
     <string name="login_not_woo_store">It looks like %1$s is not a WooCommerce site.</string>
+    <!-- This text appears as a button label on the site picker screen when a connected site doesn't have WooCommerce installed, allowing users to install the WooCommerce plugin. It also serves as the title for the web view that opens during the installation process. -->
     <string name="login_install_woo">Install WooCommerce</string>
+    <!-- This text appears as a button label in an error dialog that is shown when a user tries to log into a site that doesn't have WooCommerce installed. The button opens a web page where users can install the WooCommerce plugin. -->
     <string name="login_open_installation_page">Open installation page</string>
+    <!-- Error message displayed on the login screen when a user successfully authenticates with WordPress.com but their site doesn't have the required Jetpack plugin installed or connected. The message appears as explanatory text above action buttons that allow the user to install Jetpack or try again. -->
     <string name="login_no_jetpack">To use this app for %1$s you\'ll need to have the Jetpack plugin setup and connected to a WordPress.com account</string>
+    <!-- This error message appears in a dialog and error screen when the user enters a website address that is not a WordPress site during the login/site setup process. It provides explanation to help users understand why their site address was rejected and guides them to verify their WordPress installation. -->
     <string name="login_not_wordpress_site_v2">We were not able to detect a WordPress site at the address you entered. Please make sure WordPress is installed and that you are running the latest available version.</string>
+    <!-- This text appears as a button label in the site picker screen during the login flow, allowing users to navigate to view their existing connected WooCommerce stores when the current site is not a WooCommerce store or is a simple WordPress.com site. -->
     <string name="login_view_connected_stores">View connected stores</string>
+    <!-- This text appears as a title/heading on an informational screen that explains what Jetpack is to users, and also as a button label that opens this explanation screen when users need more information about Jetpack during login. -->
     <string name="login_jetpack_what_is">What is Jetpack?</string>
+    <!-- This is explanatory text displayed on the 'What is Jetpack?' screen during the login flow, providing users with a detailed description of what Jetpack is and its benefits for mobile WooCommerce users. -->
     <string name="login_jetpack_what_is_description">Jetpack is a free WordPress plugin that connects your store with the tools needed to give you the best mobile experience, including push notifications and stats</string>
+    <!-- Error message displayed in a snackbar notification when the Jetpack plugin is not found during the login process for a WooCommerce site. This appears after the user attempts to connect to their site but the required Jetpack plugin is missing or unavailable. -->
     <string name="login_jetpack_not_found">Jetpack not found. Please try again</string>
+    <!-- Button text and screen title that appears during the Jetpack setup flow when Jetpack is not yet installed on the user's WooCommerce site. The text is used both as a primary action button label and as a heading to guide users through the Jetpack installation process. -->
     <string name="login_jetpack_install">Install Jetpack</string>
+    <!-- This text appears as an inline button/link in login error screens, specifically when users encounter account mismatch issues or when no WordPress.com account is found. It provides users with an option to get help locating the correct email address needed for login. -->
     <string name="login_need_help_finding_email">Need help finding the required email?</string>
+    <!-- This text appears as the title of a help dialog that opens when users need assistance finding the correct email address to use for signing into their WooCommerce account. The dialog provides guidance to users who are unsure which email they should enter during the login process. -->
     <string name="login_email_help_title">What email do I use to sign in?</string>
+    <!-- This text appears as the main message content in a help dialog that assists users in finding their WordPress.com connected email address during the login process. The message contains HTML formatting with bold text for 'Jetpack Dashboard' and 'Connections > Account connection' to highlight important navigation paths. -->
     <string name="login_email_help_desc">In your site admin you can find the email you used to connect to WordPress.com from the %1$sJetpack Dashboard%2$s under %3$sConnections &gt; Account connection%4$s</string>
+    <!-- This text appears as a headline title on the login discovery error screen, displayed when the app encounters connection issues while trying to discover or connect to a WooCommerce store during the login process. -->
     <string name="login_discovery_error_title">Connection error</string>
+    <!-- This text appears as an introductory message on the login discovery error screen, displayed above a list of alternative options that users can try when they encounter login connection issues. -->
     <string name="login_discovery_error_options">Here are a few other things you can try:</string>
+    <!-- This text appears as a clickable option in a login error dialog when application passwords are disabled but Jetpack is connected, allowing users to switch to WordPress.com authentication instead of retrying the current login method. -->
     <string name="login_with_wordpress">Sign in with WordPress.com</string>
+    <!-- This text appears as a clickable option in the login error screen when site discovery fails, allowing users to access troubleshooting help documentation. It's displayed as one of several recovery options alongside 'Login with WordPress' and 'Try again'. -->
     <string name="login_troubleshooting_tips">Read our troubleshooting tips</string>
+    <!-- Error message displayed in a dialog when a user attempts to log in with an email address that is not associated with a WordPress.com account. This appears as the main text in an error dialog fragment with an illustration and action buttons. -->
     <string name="login_no_wpcom_account_found">Your email isn\'t used with a WordPress.com account.</string>
+    <!-- This error message is displayed on a user eligibility screen when the app cannot determine the user's roles due to null/missing role data. It appears as the main error text explaining why access is restricted and instructs the user to contact support for assistance. -->
     <string name="user_role_access_error_user_roles_null">This app supports only Administrator and Shop Manager user roles. We were unable to fetch user roles for your account. Please contact support.</string>
+    <!-- Error message displayed on a user eligibility error screen when a user's account doesn't have the required permissions to use the WooCommerce app. The message appears below an error illustration and explains that only Administrator and Shop Manager roles are supported, instructing the user to contact their store owner for a role upgrade. -->
     <string name="user_role_access_error_msg">This app supports only Administrator and Shop Manager user roles. Please contact your store owner to upgrade your role.</string>
+    <!-- This text appears as a clickable button or link on an error screen that displays when a user doesn't have sufficient role permissions to access certain features in the WooCommerce app. The button provides users with additional information about user roles and permissions to help them understand the access restriction. -->
     <string name="user_role_access_error_link">Learn more about roles and permissions</string>
+    <!-- This error message appears as a snackbar notification when a user retries an action but still doesn't have the required permissions or user role to access a feature in the WooCommerce app. -->
     <string name="user_role_access_error_retry">You don\'t have the correct user role</string>
+    <!-- This text appears in a progress dialog that displays while the app is verifying a user's access permissions or role. It shows as a loading message during the authentication/authorization process. -->
     <string name="user_access_verifying">Verifying role…</string>
+    <!-- This error message appears in the site picker screen when a user selects a WordPress.com site that has a basic plan which doesn't support plugin installation, explaining why WooCommerce cannot be installed and suggesting a plan upgrade. -->
     <string name="login_simple_wpcom_site">The site %1$s is currently on a WordPress.com plan that does not support plugin installation. Please upgrade your plan to use WooCommerce.</string>
+    <!-- This text appears as a button label on an account mismatch error screen in the login flow, allowing users to connect Jetpack to their account when there's a connection issue. -->
     <string name="login_account_mismatch_connect_jetpack">Connect Jetpack to your account</string>
+    <!-- This text appears as a primary button label on an account mismatch error screen in the login flow, specifically when the user needs to connect their WordPress.com site after a connection issue. -->
     <string name="login_account_mismatch_connect_wpcom">Connect to the site</string>
+    <!-- Title text for a dialog that appears when connecting to a WordPress.com site during the login account mismatch flow. This dialog is shown when the user attempts to connect a WooCommerce site that requires WordPress.com authentication. -->
     <string name="login_account_mismatch_connect_wpcom_dialog_title">Connecting to a WordPress.com site</string>
+    <!-- This message appears in a dialog box shown when there's an account mismatch during login, informing users they need proper permissions (shop manager or administrator) to access the WooCommerce app and should contact the site owner for an invitation. -->
     <string name="login_account_mismatch_connect_wpcom_dialog_message">Please contact the site owner for an invitation to the site as a shop manager or administrator to use the app.</string>
+    <!-- This text appears as a consent disclaimer below the Connect Jetpack button on the account mismatch error screen and other Jetpack connection flows. It contains clickable links to the Terms of Service and sync policy that open in a browser when tapped. -->
     <string name="login_jetpack_connection_consent">By tapping the Connect Jetpack button, you agree to our &lt;a href=\'terms\'&gt;Terms of Service&lt;/a&gt; and to &lt;a href=\'sync\'&gt;share details&lt;/a&gt; with WordPress.com.</string>
+    <!-- This text appears as the title in the top navigation bar/toolbar of the Jetpack activation start screen, where users begin the process of connecting their WooCommerce store to Jetpack services. -->
     <string name="login_jetpack_installation_screen_title">Connect store</string>
+    <!-- This explanatory text appears on the Jetpack activation screen when the Jetpack plugin is not yet installed, informing users they need to install the free plugin to access their WooCommerce store through the mobile app. -->
     <string name="login_jetpack_installation_explanation">Please install the free Jetpack plugin to access your store on this app.</string>
+    <!-- This explanatory text appears on the Jetpack activation screen when Jetpack is already installed but not connected, instructing users to connect their WooCommerce store to Jetpack to access it in the mobile app. -->
     <string name="login_jetpack_connection_explanation">Please connect your store to Jetpack to access it on this app.</string>
+    <!-- This text appears as a hint message on the Jetpack activation screen, instructing users to prepare their store login credentials before proceeding with the installation or connection process. -->
     <string name="login_jetpack_installation_credentials_hint">Have your store credentials ready.</string>
+    <!-- Button text that appears on the Jetpack activation screen when Jetpack is already installed on the user's WooCommerce site. The button initiates the connection process between the existing Jetpack plugin and the WooCommerce mobile app. -->
     <string name="login_jetpack_connect">Connect Jetpack</string>
+    <!-- Instructional text displayed on the Jetpack activation screen that explains to users they need to log in with their store credentials to install the Jetpack plugin. The text appears above username and password input fields and includes the site URL as a parameter formatted in bold. -->
     <string name="login_jetpack_installation_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to install Jetpack.</string>
+    <!-- This instructional text appears on the Jetpack activation screen where users need to enter their WordPress site login credentials. It displays as explanatory text above the username and password input fields, with the site URL dynamically inserted and formatted in bold. -->
     <string name="login_jetpack_connection_enter_site_credentials">Log in to &lt;b&gt;%1$s&lt;/b&gt; with your store credentials to connect Jetpack.</string>
+    <!-- This text appears as the title of a dialog box that is shown during the Jetpack login process when the user's account is already connected to WordPress.com. The dialog appears on the site credentials screen and requires the user to choose whether to proceed with the connected account or cancel the operation. -->
     <string name="login_jetpack_user_already_connected_dialog_title">Account already connected</string>
+    <!-- This text appears as the main message in a dialog box that warns users during Jetpack login when their WordPress admin account is already linked to a different WordPress.com account, explaining the consequences of proceeding with the login. -->
     <string name="login_jetpack_user_already_connected_dialog_message">This WordPress admin account is already connected to a different WordPress.com account.\nContinuing with that account will log you out of your current account.</string>
+    <!-- This is a button label in a dialog that appears during Jetpack activation when a WordPress.com account is already connected. When tapped, it allows the user to proceed with signing in using the existing connected account. -->
     <string name="login_jetpack_user_already_connected_dialog_proceed_button">Proceed</string>
+    <!-- This text appears as the cancel button in a dialog that shows when a user is already connected to a Jetpack account during the login process. When tapped, it dismisses the dialog and clears the entered username and password fields. -->
     <string name="login_jetpack_user_already_connected_dialog_cancel_button">Cancel</string>
+    <!-- This text appears as a step label in the Jetpack activation progress screen during the login flow, specifically showing the current status when the Jetpack plugin is being installed on the user's WooCommerce site. -->
     <string name="login_jetpack_steps_installing">Installing Jetpack</string>
+    <!-- This text appears as a step title in the Jetpack activation progress screen during the WooCommerce login flow, specifically when the app is in the process of activating the Jetpack plugin after installation. -->
     <string name="login_jetpack_steps_activating">Activating</string>
+    <!-- This text appears as a step title in the Jetpack activation progress screen, specifically for the connection/authorization step when setting up Jetpack for a WooCommerce store during the login process. -->
     <string name="login_jetpack_steps_authorizing">Connect store to Jetpack</string>
+    <!-- A status label that appears during the Jetpack connection process in WooCommerce, specifically shown when the app is validating the authorization connection. This text is displayed as a hint below the connection step to inform users that the validation process is currently in progress. -->
     <string name="login_jetpack_steps_authorizing_validation">Validating</string>
+    <!-- A status label that appears during Jetpack connection setup, displayed in green text to indicate successful completion of the authorization/connection process. -->
     <string name="login_jetpack_steps_authorizing_done">Connected</string>
+    <!-- This text appears as a step title in the Jetpack activation process during login, specifically when all setup steps (installation, activation, and connection) have been completed successfully. -->
     <string name="login_jetpack_steps_done">All done</string>
+    <!-- Screen title displayed at the top of the Jetpack installation progress screen during the login/setup flow, shown when the app is in the process of installing the Jetpack plugin for WooCommerce. -->
     <string name="login_jetpack_installation_steps_screen_title">Installing Jetpack</string>
+    <!-- This text appears as a screen title during the Jetpack connection process in the WooCommerce app, specifically when Jetpack is already installed and the app is establishing the connection to the user's site. -->
     <string name="login_jetpack_connection_steps_screen_title">Connecting Jetpack</string>
+    <!-- This text appears as a screen title on the Jetpack activation progress screen when the Jetpack connection process has been successfully completed. It's displayed prominently at the top of the screen to indicate the final state of the connection workflow. -->
     <string name="login_jetpack_connection_steps_screen_title_done">Connected Jetpack</string>
+    <!-- This text appears as a screen title on the Jetpack activation screen when the Jetpack plugin installation process has been completed successfully. It's displayed as a bold heading at the top of the screen to indicate the current status of the installation workflow. -->
     <string name="login_jetpack_installation_steps_screen_title_done">Installed Jetpack</string>
+    <!-- This subtitle text appears on the Jetpack activation screen during the store connection process, displayed below the main title to inform users that their WooCommerce store is being connected to Jetpack services. The %1$s placeholder is replaced with the actual store URL/name. -->
     <string name="login_jetpack_steps_screen_subtitle">Please wait while we connect your store &lt;b&gt;%1$s&lt;/b&gt; with Jetpack.</string>
+    <!-- This subtitle text appears on the Jetpack activation screen when the store connection process has been successfully completed. It displays below the main title to confirm that the user's WooCommerce store is now connected to Jetpack, with the store URL displayed in bold formatting. -->
     <string name="login_jetpack_steps_screen_subtitle_done">Your store &lt;b&gt;%1$s&lt;/b&gt; is now connected to Jetpack.</string>
+    <!-- Error code display text that appears on the Jetpack activation screen when installation fails, showing a specific error code number to help with troubleshooting. It's displayed as a small caption below the main error message to provide technical details for support purposes. -->
     <string name="login_jetpack_installation_error_code_template">Error code %1$s</string>
+    <!-- Error message displayed below a step title in the Jetpack activation process when the step encounters an error state. This text appears in red color with caption styling to indicate that something went wrong during the Jetpack installation or activation process. -->
     <string name="login_jetpack_installation_error">Error</string>
+    <!-- This text appears as a button label on the Jetpack activation screen in a WooCommerce app. The button becomes visible after the Jetpack installation process is complete and allows users to navigate to their store. -->
     <string name="login_jetpack_installation_go_to_store_button">Go to store</string>
+    <!-- This text appears as the title in the top navigation toolbar of a web view screen where users complete the Jetpack connection process for their WooCommerce store. -->
     <string name="login_jetpack_installation_approve_connection">Connect Jetpack</string>
+    <!-- Error title displayed on the Jetpack activation screen when the installation step fails. This appears as a prominent heading in an error state view that also includes retry and help options. -->
     <string name="login_jetpack_installation_error_installing">Error installing Jetpack</string>
+    <!-- Error title displayed on the Jetpack activation screen when the activation step fails during the login/setup process. This appears as a heading in an error state view where users can retry the activation or get help. -->
     <string name="login_jetpack_installation_error_activating">Error activating Jetpack</string>
+    <!-- Error title displayed on the Jetpack installation screen when the connection authorization step fails during the Jetpack setup process. -->
     <string name="login_jetpack_installation_error_authorizing">Error authorising connection to Jetpack</string>
+    <!-- An error message displayed during the Jetpack plugin installation/activation process when the user lacks sufficient permissions to manage plugins on their WooCommerce store. This appears as explanatory text in an error screen when a forbidden (403) error occurs during plugin operations. -->
     <string name="login_jetpack_installation_error_plugin_permission_message">You don’t have permission to manage plugins on this store</string>
+    <!-- Error message displayed on the Jetpack activation screen when there's a communication failure while trying to connect to the user's WooCommerce site. This appears as subtitle text below the main error title to explain the connection issue to the user. -->
     <string name="login_jetpack_installation_error_connection_message">There was an error communicating with your site.</string>
+    <!-- This text appears as a suggestion message on the Jetpack activation screen when there's a connection error during the login process. It's displayed below the main error message to guide users on how to resolve the Jetpack connection issue. -->
     <string name="login_jetpack_installation_error_connection_suggestion">Please connect Jetpack through your admin page on a browser or contact support.</string>
+    <!-- Error message displayed on the Jetpack activation screen when a generic communication error occurs between the app and the user's WooCommerce site during the login/setup process. -->
     <string name="login_jetpack_installation_error_generic_message">There was an error communicating with your site.</string>
+    <!-- This text appears as a suggestion message on the Jetpack installation/activation error screen when a generic error occurs that doesn't match specific error types. It displays below the main error message to guide users on next steps when Jetpack setup fails. -->
     <string name="login_jetpack_installation_error_generic_suggestion">Please try again and contact support if this error continues.</string>
+    <!-- This text appears as a button label on the Jetpack activation screen, allowing users to get help or support when encountering installation, activation, or connection issues. The button is displayed alongside a help icon and triggers a support action when tapped. -->
     <string name="login_jetpack_installation_get_support">Get support</string>
+    <!-- Button label displayed on the Jetpack activation screen when the installation step fails, allowing users to retry the Jetpack plugin installation process. -->
     <string name="login_jetpack_installation_retry_installing">Try installing again</string>
+    <!-- This is a retry button label that appears during the Jetpack activation step in the login/setup flow. The button allows users to attempt the Jetpack plugin activation process again if it failed previously. -->
     <string name="login_jetpack_installation_retry_activating">Try activating again</string>
+    <!-- This text appears as a button label on the Jetpack activation screen when the authorization (connection) step fails, allowing users to retry the authorization process. -->
     <string name="login_jetpack_installation_retry_authorizing">Try authorising again</string>
+    <!-- Button label that appears on the Jetpack activation screen during the WordPress.com login flow, allowing users to cancel the Jetpack plugin installation process and return to the previous screen. -->
     <string name="login_jetpack_installation_cancel">Cancel installation</string>
+    <!-- A suggestion message displayed to users on the Jetpack activation screen when they encounter a 403 Forbidden error during plugin installation or connection setup, advising them to contact their site administrator for assistance. -->
     <string name="login_jetpack_installation_error_forbidden_suggestion">Please contact your administrator for help.</string>
+    <!-- Error message displayed during WooCommerce store setup when the user lacks permission to connect Jetpack to their store. This appears as explanatory text in an error dialog or screen after a failed Jetpack connection attempt. -->
     <string name="login_jetpack_installation_error_connection_permission_message">You don’t have permission to connect to Jetpack on this store</string>
+    <!-- A status message displayed on the Jetpack activation screen when Jetpack plugin is installed on the user's WooCommerce site but the connection was dismissed or not completed. This appears as a heading text to inform users about the current connection state before they can proceed with setup. -->
     <string name="login_jetpack_installation_connection_dismissed">Jetpack is installed, but not connected.</string>
+    <!-- This explanatory text appears below the main heading on the Jetpack connection dismissed screen, providing guidance to users when their Jetpack connection attempt has been dismissed or failed. It encourages the user to retry the connection process to access their WooCommerce store. -->
     <string name="login_jetpack_installation_connection_dismissed_explanation">Try connecting again to access your store.</string>
+    <!-- This text appears on a button in the Jetpack activation screen when the user has previously dismissed the connection process and needs to continue with connecting their WooCommerce store to Jetpack. -->
     <string name="login_jetpack_installation_continue_connection">Continue connection</string>
+    <!-- This text appears as a button label on the Jetpack activation screen that allows users to exit the login flow without establishing a Jetpack connection to their WooCommerce site. The button is displayed when the connection process has been dismissed, giving users an option to skip the Jetpack setup entirely. -->
     <string name="login_jetpack_installation_exit_without_connection">Exit Without Connecting</string>
+    <!-- Error message displayed in a dialog when users try to log into the WooCommerce app but their WordPress site has Application Passwords disabled. The message includes the site URL as a parameter and appears with help and retry buttons to guide users through enabling this required feature. -->
     <string name="login_application_passwords_unavailable">It looks like Application Passwords feature is disabled in your site %1$s.\n Please enable it to use the WooCommerce app.</string>
+    <!-- This text appears as an instructional message on the Jetpack connection screen in WooCommerce Android app, displayed above the email/username input field when Jetpack is already installed but needs to be connected to a WordPress.com account. -->
     <string name="login_jetpack_connection_enter_wpcom_email">Log in with your WordPress.com account to connect Jetpack</string>
+    <!-- This text appears as instructional text on the Jetpack activation screen when Jetpack is not yet installed, guiding users to log in with their WordPress.com credentials to proceed with the installation process. -->
     <string name="login_jetpack_installation_enter_wpcom_email">Log in with your WordPress.com account to install Jetpack</string>
+    <!-- This instructional text appears on the Jetpack connection screen in the WooCommerce app, displayed above a password input field to guide users when they need to enter their WordPress.com account password to connect Jetpack services. -->
     <string name="login_jetpack_connection_enter_wpcom_password">Enter the password of your WordPress.com account to connect to Jetpack</string>
+    <!-- This text appears as instructional text on the Jetpack activation screen when Jetpack is not yet installed, guiding users to enter their WordPress.com password to proceed with the installation process. -->
     <string name="login_jetpack_installation_enter_wpcom_password">Enter the password of your WordPress.com account to install Jetpack</string>
+    <!-- This text appears as a button label on the Jetpack activation screen, offering users an alternative login method to continue the Jetpack installation/connection process using a magic link instead of entering their password. -->
     <string name="login_jetpack_installation_continue_magic_link">Or continue using Magic Link</string>
+    <!-- Error message displayed on the Jetpack activation screen when the app fails to fetch website information during the magic link authentication process. The message appears centered on the screen above a retry button, prompting the user to attempt the operation again. -->
     <string name="login_jetpack_installation_magic_link_failure">An error occurred while fetching your website, please retry!</string>
+    <!-- This error message appears when login fails due to an unexpected response from the user's WooCommerce site during the authentication process. It displays as an error message to inform users that the login attempt was unsuccessful due to a server communication issue. -->
     <string name="login_site_credentials_invalid_response">Login failed with an unexpected response from your site.</string>
+    <!-- This is an error message displayed to users when the app cannot determine the correct login URL for their WooCommerce store during the authentication process. It appears when there's a CUSTOM_LOGIN_URL error type, indicating the store has a non-standard login configuration that prevents automatic login. -->
     <string name="login_site_credentials_custom_login_url">Unable to login because we cannot identify your store\'s login URL</string>
+    <!-- Error message displayed to users when they cannot log into their WooCommerce store because the app is unable to identify or access the store's admin URL during the authentication process. -->
     <string name="login_site_credentials_custom_admin_url">Unable to login because we cannot identify your store\'s admin URL</string>
+    <!-- Error message displayed when login authentication fails due to a network/server error, showing the specific HTTP status code to help users understand the technical reason for the failure. -->
     <string name="login_site_credentials_http_error">Login failed with status code %1$s</string>
+    <!-- This text appears as a button label in an error dialog on the login credentials screen, offering users an alternative authentication method when their site credentials fail. The button triggers web-based authorization through the WordPress Admin page as a fallback option. -->
     <string name="login_site_credentials_use_web_authorization">Try again with WP Admin page</string>
+    <!-- Error message displayed during site login when the WooCommerce site has Basic Authentication enabled, explaining that this authentication method is not supported by the mobile app and providing guidance to disable it or contact support. -->
     <string name="login_site_credentials_http_basic_auth_error">Basic Authentication is enabled on your site. Basic Authentication is unsupported in the WooCommerce mobile app. Please disable it, or contact support for troubleshooting.</string>
+    <!-- Error message displayed to the user when the app fails to fetch or connect to their website during the login process on the site credentials screen. -->
     <string name="login_site_credentials_fetching_site_failed">An error occurred while fetching your website</string>
+    <!-- Loading message displayed during the site credential login process when the app is retrieving site information from a WooCommerce store URL. -->
     <string name="login_site_credentials_fetching_site">Fetching site…</string>
+    <!-- Error message displayed as a snackbar notification when the user attempts to login but the application password authorization is rejected during the web authentication process. -->
     <string name="login_site_credentials_web_authorization_connection_rejected">Unable to login because application password creation is not approved.</string>
+    <!-- Error message displayed as a toast notification when the app cannot process a malformed login link, typically when a user clicks on an invalid or corrupted app login URL. -->
     <string name="login_app_login_malformed_link">We couldn\'t process your app login request</string>
+    <!-- This is explanatory helper text that appears below an email input field on the Jetpack activation screen, informing users that if they don't already have a WordPress.com account, one will be created automatically using the email address they entered. -->
     <string name="login_jetpack_connection_create_account">If you don\'t have an account, we\'ll use this email to create one.</string>
 
     <!--
         Site picker
     -->
+    <!-- A header text displayed in the store selection screen when some WooCommerce stores are hidden from view, showing the total number of hidden stores in parentheses. This appears as a section header above the list of visible stores that users can connect to. -->
     <string name="site_picker_select_store_list_header_with_hidden_sites">Select store to connect (%d hidden)</string>
+    <!-- This text appears as the screen title in the top navigation toolbar when users need to manually enter a website address during the site selection process in the WooCommerce app setup flow. -->
     <string name="login_site_picker_enter_site_address">Enter a site address</string>
+    <!-- Button text that appears in the site picker screen during login, allowing users to connect an additional WooCommerce store to their account. The button is displayed both when users have existing stores and want to add more, and when users have no connected stores yet. -->
     <string name="login_site_picker_add_a_store">Connect another store</string>
+    <!-- This text appears as a clickable button option in a bottom sheet dialog that allows users to add a store to their WooCommerce app. When tapped, it initiates the process for creating a brand new store rather than connecting an existing one. -->
     <string name="site_picker_create_new_store">Create a new store</string>
+    <!-- This text appears as a clickable button label in a bottom sheet dialog that allows users to add a store to their WooCommerce app. The button gives users the option to connect an existing store as an alternative to creating a new one. -->
     <string name="site_picker_connect_existing_store">Connect an existing store</string>
+    <!-- This text appears as a menu item title in the site picker screen, allowing users to edit their list of WooCommerce stores. It's used both as a menu option and as labels within the store visibility management interface. -->
     <string name="site_picker_edit_store_list">Edit Stores</string>
+    <!-- This text appears as the title in the top navigation bar of a screen where users can manage which WooCommerce stores are visible in their store list. It's displayed in a TopAppBar component with close and save actions available. -->
     <string name="site_picker_edit_store_list_title">Visible Stores</string>
+    <!-- This text appears as explanatory text in the store visibility settings screen, displayed below a header and above a list of stores that can be selected/unselected. It informs users about the consequences of unselecting stores - they won't appear in the site picker and won't receive push notifications. -->
     <string name="site_picker_edit_store_list_footer">Unselected stores won\'t be shown in the app site\'s picker and won\'t receive push notifications for new orders or product reviews.</string>
+    <!-- This text appears as a section header in the store visibility/site picker screen, displayed above the current store information to label which store is currently selected. -->
     <string name="site_picker_edit_store_current_site_header">Current Store</string>
+    <!-- Instructional text that appears in the site visibility settings screen, displayed below a header and above the current store item to explain that users must switch to a different store before they can hide the currently active one. -->
     <string name="site_picker_edit_store_current_site_footer">Please switch to another store if you want to hide this one.</string>
+    <!-- This text appears as a section header in the store visibility settings screen, displayed above a list of additional WooCommerce stores that users can show or hide from their site picker. -->
     <string name="site_picker_edit_store_list_header">Other Stores</string>
+    <!-- This is an error dialog title that appears when the app fails to update notification settings while editing the store list in the site picker. It's displayed as the title of an error dialog with retry and cancel options. -->
     <string name="site_picker_edit_store_list_error_title">There was an error when updating notification settings. Please try again</string>
 
     <!--
         My Store View
     -->
+    <!-- Content description for accessibility readers describing a button that opens a dropdown menu to change the date range on the dashboard statistics screen. This text is not visible to users but helps screen readers identify the purpose of the calendar icon button. -->
     <string name="dashboard_stats_edit_granularity_content_description">Change date range button</string>
+    <!-- Accessibility label for an icon button that opens a dropdown menu for filtering content on the dashboard and AI product creation screens. This text is read by screen readers when users focus on the filter button but is not visible on screen. -->
     <string name="dashboard_filter_menu_content_description">Open filter dropdown</string>
 
+    <!-- Label text that appears below visitor count numbers in the WooCommerce dashboard statistics section and stats widgets, identifying the metric being displayed to users. -->
     <string name="dashboard_stats_visitors">Visitors</string>
+    <!-- A label that appears in the dashboard statistics section to identify the number of orders, displayed below a numerical value showing the order count. -->
     <string name="dashboard_stats_orders">Orders</string>
+    <!-- A label that appears below the total revenue amount on the dashboard statistics screen and in stats widgets, identifying the revenue metric being displayed to users. -->
     <string name="dashboard_stats_revenue">Revenue</string>
+    <!-- This text appears as a label underneath a conversion rate percentage value in the dashboard statistics section, identifying what the numerical metric represents to users viewing their store's performance data. -->
     <string name="dashboard_stats_conversion">Conversion</string>
+    <!-- This text appears as a placeholder message on a chart in the dashboard stats view when there is no revenue data available for the selected time period. -->
     <string name="dashboard_state_no_data">No revenue this period</string>
+    <!-- Error message displayed in a snackbar notification when data loading fails or address validation encounters an error during the shipping label creation process. -->
     <string name="dashboard_stats_error">Error fetching data</string>
+    <!-- Accessibility content description for an error state image that appears in the center of the dashboard stats chart area when statistics fail to load. -->
     <string name="dashboard_stats_error_content_description">Error image</string>
 
+    <!-- This text appears as a column header in the dashboard's top performers widget, displaying above the quantity values showing how many items were sold for each top-performing product. -->
     <string name="dashboard_top_performers_items_sold">Items Sold</string>
+    <!-- This text appears as an empty state message in the Top Performers widget on the dashboard when there is no sales or product activity data available for the selected time period. It displays centered below a 'not found' icon to inform users that no performance metrics can be shown. -->
     <string name="dashboard_top_performers_empty">No activity this period</string>
+    <!-- This text appears as a data label in the top performers section of the dashboard, displaying the net sales amount for each top-performing product. The %s placeholder is replaced with a formatted currency value showing how much revenue each product generated. -->
     <string name="dashboard_top_performers_net_sales">Net sales: %s</string>
+    <!-- Error message title displayed in the top performers widget on the dashboard when WooCommerce Analytics is inactive and performance data cannot be loaded. -->
     <string name="dashboard_top_performers_wcanalytics_inactive_title">Unable to load the top performers</string>
 
+    <!-- This text appears as a button label in the dashboard orders widget that allows users to navigate from the dashboard to view their complete orders list. It's displayed as an action button below the orders summary card on the main dashboard screen. -->
     <string name="dashboard_action_view_all_orders">View all orders</string>
 
+    <!-- This text appears as a button label in the WooCommerce dashboard inbox widget that allows users to navigate to view all their inbox messages, displayed when there are more messages than can be shown in the dashboard widget preview. -->
     <string name="dashboard_action_view_all_messages">View all messages</string>
 
+    <!-- This is an error message title displayed when the WooCommerce Analytics plugin is inactive and the app cannot show store analytics data. It appears as a heading in an error view on the dashboard stats screen when analytics functionality is unavailable. -->
     <string name="my_store_stats_plugin_inactive_title">We can\'t display your\n store\'s analytics</string>
+    <!-- This is an accessibility content description for an ImageButton with a calendar icon that allows users to add custom date range statistics in the store analytics screen. The text is read by screen readers when users focus on the button but is not visible on screen. -->
     <string name="my_store_custom_range_content_description">Add custom date range stats</string>
+    <!-- This text appears as a label in the dashboard statistics view to describe the time interval for chart data, where %s is replaced with specific time units like 'day', 'week', 'month', etc. It's displayed as part of the chart or statistics interface to help users understand the granularity of the data they're viewing. -->
     <string name="my_store_custom_range_granularity_label">%s interval</string>
+    <!-- This text appears as a granularity option label in the store dashboard statistics view, used to indicate hourly time intervals when viewing revenue and sales data charts. -->
     <string name="my_store_custom_range_granularity_hour">Hourly</string>
+    <!-- This text appears as a label in the WooCommerce store dashboard's statistics view to indicate daily granularity when viewing revenue stats and analytics data over time. -->
     <string name="my_store_custom_range_granularity_day">Daily</string>
+    <!-- This text appears as a label option in the dashboard statistics view when users can select different time granularities for viewing their store data. It's used to indicate weekly time intervals in a custom date range selector for analytics charts. -->
     <string name="my_store_custom_range_granularity_week">Weekly</string>
+    <!-- This text appears as a label option in the store dashboard statistics view, specifically used to indicate monthly granularity when viewing revenue stats and analytics data over custom date ranges. -->
     <string name="my_store_custom_range_granularity_month">Monthly</string>
+    <!-- This text appears as a granularity option label in the WooCommerce store dashboard statistics view, used to indicate yearly time periods when viewing revenue and sales data charts. -->
     <string name="my_store_custom_range_granularity_year">Yearly</string>
+    <!-- This is the title of an alert dialog that appears in the store dashboard when users click on an info icon indicating that visitor and conversion statistics are not available for custom date ranges. -->
     <string name="my_store_custom_range_visitors_stats_unavailable_title">Visitors and conversion data not available</string>
+    <!-- This message appears in an alert dialog on the dashboard/stats screen when users try to view visitor and conversion statistics for custom date ranges, explaining why the data isn't available and suggesting an alternative way to view the information by tapping graph values. -->
     <string name="my_store_custom_range_visitors_stats_unavailable_message">The stats feature does not support the display of visitors and conversions data for arbitrary date ranges.\n\nHowever, you can tap a value on the graph to see visitors and conversions for that specific range.</string>
+    <!-- This text appears as the title of a screen that allows users to customize their dashboard widgets, and also as a menu item label that opens this customization screen. It's used in the context of editing and rearranging dashboard elements in a WooCommerce store management app. -->
     <string name="my_store_edit_screen_widgets">Customize</string>
 
+    <!-- This is the title for a dashboard widget that helps users set up their WooCommerce store. It appears as a widget title on the main dashboard screen, guiding users through initial store configuration steps. -->
     <string name="my_store_widget_onboarding_title">Store setup</string>
+    <!-- This is the title for a dashboard widget that displays store performance statistics and analytics data on the main store screen. -->
     <string name="my_store_widget_stats_title">Performance</string>
+    <!-- Title for a dashboard widget on the store's main screen that displays the best-performing products based on sales or other metrics. -->
     <string name="my_store_widget_top_products_title">Top performers</string>
+    <!-- This text appears as the title for a dashboard widget in the store management section that displays Blaze marketing campaigns. It serves as a header label to identify the Blaze campaigns widget among other dashboard widgets like stats, reviews, and orders. -->
     <string name="my_store_widget_blaze_title">Blaze campaigns</string>
+    <!-- This text appears as the title of a dashboard widget in the store management section that displays the merchant's most recent orders. It serves as a section header to help users quickly identify and access their latest order information. -->
     <string name="my_store_widget_orders_title">Most recent orders</string>
+    <!-- This text appears as the title of a reviews widget on the store dashboard screen, displayed above a section showing the most recent customer reviews for the store's products. -->
     <string name="my_store_widget_reviews_title">Most recent reviews</string>
+    <!-- This text appears as the title of a dashboard widget on the store management screen that displays the most frequently used or currently active coupon codes. It serves as a section header to help store owners quickly identify and manage their most relevant promotional offers. -->
     <string name="my_store_widget_coupons_title">Most active coupons</string>
+    <!-- This text appears as the title for a stock/inventory widget on the store dashboard screen, allowing merchants to monitor their product stock levels at a glance. -->
     <string name="my_store_widget_product_stock_title">Stock</string>
+    <!-- This text appears as the title for a Google Ads widget on the store dashboard screen, helping merchants identify and access their Google Ads campaign management features. -->
     <string name="my_store_widget_google_ads_title">Google Ads campaigns</string>
 
+    <!-- This text appears as a badge or status indicator on dashboard widgets (like orders and stock widgets) when those features are not available or have no data to display in the store dashboard. -->
     <string name="my_store_widget_unavailable">Unavailable</string>
+    <!-- This text appears as a status message or label in the dashboard indicating that the store onboarding process has been completed. It's used to mark the onboarding widget as unavailable when all setup tasks are finished. -->
     <string name="my_store_widget_onboarding_completed">Completed</string>
 
+    <!-- Menu item text that appears in a context menu for dashboard widgets, allowing users to hide specific widgets from their dashboard. The %s placeholder is replaced with the name of the widget being hidden. -->
     <string name="dynamic_dashboard_widget_menu_item_hide">Hide %s</string>
+    <!-- This text appears as the main error title in a dashboard widget when data fails to load, displayed prominently above an error description and retry button in a centered error state screen. -->
     <string name="dynamic_dashboard_widget_error_title">Unable to load data</string>
+    <!-- This error message appears in a dashboard widget when it fails to load data, displayed in the center of an error state screen with an image and retry button. The text includes a clickable link to contact support if reloading doesn't resolve the issue. -->
     <string name="dynamic_dashboard_widget_error_description"><![CDATA[Try reloading this card. If the issue persists, please <a href="support">contact support</a>.]]></string>
 
+    <!-- Header title displayed at the top of dashboard cards for both orders and reviews sections, where users can filter items by different status options (like order status or review status). -->
     <string name="dashboard_reviews_card_header_title">Status</string>
+    <!-- Title text displayed on the dashboard reviews card when no reviews match the currently selected filter criteria. This appears as a centered heading above an empty state illustration when users have applied filters but no reviews exist for those filter conditions. -->
     <string name="dashboard_reviews_card_empty_title_filtered">No reviews found</string>
+    <!-- This message appears in the dashboard reviews card when no product reviews match the currently applied filter, prompting the user to adjust their filter settings to see results. -->
     <string name="dashboard_reviews_card_empty_message_filtered">No reviews match the selected filter, please try changing the filter</string>
+    <!-- This text appears as a button label on the Reviews dashboard widget card in the WooCommerce app. When tapped, it navigates the user to a full list of all product reviews for their store. -->
     <string name="dashboard_reviews_card_view_all_button">View all reviews</string>
 
+    <!-- Column header label in a dashboard coupons card that displays as part of a table showing coupon data, positioned alongside a 'Uses' column header to organize coupon information. -->
     <string name="dashboard_coupons_card_header_coupons">Coupons</string>
+    <!-- This text appears as a column header in the dashboard coupons card, specifically labeling the right column that displays usage statistics for each coupon. -->
     <string name="dashboard_coupons_card_header_uses">Uses</string>
+    <!-- This text appears as a button label on the dashboard coupons widget card that allows users to navigate to a full list view of all available coupons when clicked. -->
     <string name="dashboard_coupons_view_all_button">View all coupons</string>
+    <!-- This message appears as an empty state text in the coupons section of the dashboard, displayed to users when no coupon usage data is available for the selected time period. It's shown in the center of an empty view along with an illustration to inform users why no coupon data is displayed. -->
     <string name="dashboard_coupons_card_empty_view_message">No coupon usage during this period</string>
+    <!-- Error message title displayed in the dashboard coupons section when the WooCommerce Analytics plugin is inactive and coupon usage data cannot be loaded. -->
     <string name="dashboard_coupons_wcanalytics_inactive_title">Unable to load coupon usage report</string>
 
+    <!-- This text appears as a description message in an error view on the dashboard when WooCommerce Analytics is not enabled or available, explaining to users what they need to do to resolve the issue. -->
     <string name="dashboard_wcanalytics_inactive_description">Make sure you are running the latest version of WooCommerce on your site and that you have WooCommerce Analytics activated.</string>
+    <!-- This text appears as a button label on the WooCommerce Analytics error screen when the analytics feature is inactive or unavailable. The button allows users to contact support for help with enabling analytics functionality. -->
     <string name="dashboard_wcanalytics_inactive_contact_us">Still need help? Contact us</string>
 
+    <!-- This text appears as the main title/header for the product stock status dashboard card in the WooCommerce app. It labels a filterable section where users can view and filter products by their inventory status (in stock, out of stock, etc.). -->
     <string name="dashboard_product_stock_status_header_title">Status</string>
+    <!-- This text appears as a column header in a dashboard table showing product stock information, displayed alongside a 'Products' column to create a two-column layout for viewing inventory levels. -->
     <string name="dashboard_product_stock_levels">Stock levels</string>
+    <!-- A column header label that appears in the dashboard stock management card, displayed above a list of products to indicate the 'Products' column in a two-column layout alongside stock levels. -->
     <string name="dashboard_product_stock_products">Products</string>
+    <!-- This text appears on the dashboard product stock card to show how many items of a specific product were sold in the past 30 days. It displays as informational text below the product name and stock quantity when the product has recorded sales. -->
     <string name="dashboard_product_stock_sales_last_30_days">%d items sold in last 30 days</string>
+    <!-- This text appears as a label in the dashboard product stock card when a product has no sales in the last 30 days. It displays below the product name and stock quantity to inform merchants about the product's recent sales performance. -->
     <string name="dashboard_product_stock_no_sales_last_30_days">No items sold in the last 30 days</string>
+    <!-- Error message title displayed on the dashboard when product stock reports cannot be loaded due to WooCommerce Analytics being inactive or unavailable. This appears as a title in an error view that also includes a contact support option. -->
     <string name="dashboard_product_stock_wcanalytics_inactive_title">Unable to load product stock reports</string>
+    <!-- This text appears as a centered message in the product stock dashboard when no products match the currently selected stock status filter (e.g., out of stock, low stock). It displays below an empty state illustration to inform users that their filter criteria returned no results. -->
     <string name="dashboard_product_stock_empty_products">No products found for the selected stock status</string>
 
+    <!-- This is a heading text that appears on a dashboard card promoting Google Ads integration when the user has no active campaigns. It's displayed prominently on the card alongside the Google logo to encourage users to start using Google Ads for their WooCommerce store. -->
     <string name="dashboard_google_ads_card_no_campaign_heading">Drive sales and generate more traffic with Google Ads</string>
+    <!-- This text appears as a description in a Google Ads card on the dashboard when no advertising campaigns exist, explaining the benefits of promoting products across Google's platforms. It's displayed below a heading and above a 'Create Campaign' button to encourage users to start advertising. -->
     <string name="dashboard_google_ads_card_no_campaign_description">Promote your products across Google Search, Shopping, Youtube, Gmail, and more.</string>
+    <!-- This text appears as a clickable heading in a Google Ads performance card on the dashboard, displaying campaign performance metrics like impressions. It serves as both a section title and a clickable element that allows users to navigate to more detailed campaign performance information. -->
     <string name="dashboard_google_ads_card_has_campaign_heading">Paid campaign performance</string>
+    <!-- A label that appears above an impressions metric in the Google Ads performance section of the dashboard, displayed alongside a corresponding clicks metric in a two-column layout. -->
     <string name="dashboard_google_ads_card_has_campaign_impressions">Impressions</string>
+    <!-- A label displayed in the Google Ads dashboard card that appears above the number of clicks metric, shown alongside impressions data to summarize ad campaign performance. -->
     <string name="dashboard_google_ads_card_has_campaign_clicks">Clicks</string>
+    <!-- Button label on the dashboard Google Ads card that allows users to create a new advertising campaign. This is a prominent call-to-action button that spans the full width of the card. -->
     <string name="dashboard_google_ads_card_create_campaign_button">Create Campaign</string>
+    <!-- A button label that appears on the Google Ads dashboard widget when campaigns exist, allowing users to navigate to view all their advertising campaigns. -->
     <string name="dashboard_google_ads_card_view_all_campaigns_button">View all campaigns</string>
 
+    <!-- This is the main title text displayed on a promotional card in the WooCommerce dashboard that encourages users to explore additional analytics widgets. The title appears above a description and action button in a bordered card layout. -->
     <string name="dashboard_new_widgets_card_title">Looking for more insights?</string>
+    <!-- This text appears as a descriptive label in a promotional card on the dashboard that encourages users to add new customizable sections to their store management interface. It's displayed below the card title and above an action button, explaining the benefit of the feature being promoted. -->
     <string name="dashboard_new_widgets_card_description">Add new sections to customize your store management experience</string>
+    <!-- Button label that appears on the dashboard screen within a card promoting new dashboard functionality. When tapped, it opens a screen or dialog where users can browse and add new sections/widgets to customize their dashboard. -->
     <string name="dashboard_new_widgets_card_button">Add new Sections</string>
 
     <!--
         Analytics View
     -->
+    <!-- This is a button label that appears on dashboard widget cards for analytics sections (store stats and top performers). When tapped, it opens a detailed analytics view showing comprehensive store performance data. -->
     <string name="analytics_section_see_all">View all store analytics</string>
     <string-array name="analytics_date_range_selectors">
         <item translatable="false">@string/date_timeframe_custom</item>
@@ -442,147 +812,272 @@
         <item translatable="false">@string/date_timeframe_quarter_to_date</item>
         <item translatable="false">@string/date_timeframe_year_to_date</item>
     </string-array>
+    <!-- This text appears as the title of a Revenue analytics card in the WooCommerce app's Analytics Hub dashboard, displaying financial performance data including total sales and net sales metrics. -->
     <string name="analytics_revenue_card_title">Revenue</string>
+    <!-- This text appears as an error message in the analytics section when revenue data fails to load or is unavailable for the selected time period. It's displayed in a card-style layout within the analytics dashboard to inform users that no revenue information can be shown. -->
     <string name="analytics_revenue_no_data">No revenue this period</string>
+    <!-- Error message displayed in the analytics hub when order data cannot be loaded or is unavailable for the selected time period. This text appears as a fallback message in the orders analytics card when there's an error fetching order statistics. -->
     <string name="analytics_orders_no_data">No orders this period</string>
+    <!-- Error message displayed in the analytics dashboard when there are no product sales or data available for the selected time period. Also used for product bundles when no bundle data is available. -->
     <string name="analytics_products_no_data">No products this period</string>
+    <!-- This message appears in the analytics section when no gift card data is available for the selected time period, displayed as an error state message to inform users that there are no gift card statistics to show. -->
     <string name="analytics_gift_cards_no_data">No gift cards this period</string>
+    <!-- Error message displayed in the Google Ads analytics card on the analytics hub screen when there's an error loading Google Ads campaign data for the selected time period. -->
     <string name="analytics_google_ads_no_data">No Programs this period</string>
+    <!-- Error message displayed on the analytics hub screen when session data cannot be loaded or is unavailable for the selected time period. Appears as the main message in a 'No Data' state card replacing the session analytics content. -->
     <string name="analytics_session_no_data">No sessions this period</string>
+    <!-- This text appears as an error message in the Analytics section when session data is not supported or available for the store, displayed in a card view alongside a longer description to inform users why session analytics cannot be shown. -->
     <string name="analytics_session_no_available">Session data unavailable</string>
+    <!-- This text serves as the accessibility description for a filter button in the analytics section of the WooCommerce mobile app. It helps screen readers announce the purpose of the filter icon button that allows users to customize their analytics data selection. -->
     <string name="analytics_custom_list_selection_button_description">Filter selection</string>
+    <!-- This is a detailed explanation message that appears on the analytics screen when session data is not available for custom date ranges, providing users with technical context about why the session analytics card cannot display data. -->
     <string name="analytics_session_no_available_description">Session analytics rely on unique visitor counts not available for custom date ranges</string>
+    <!-- Label that appears in the analytics revenue section of the WooCommerce app, displaying as a title above the total sales monetary value and percentage change data. -->
     <string name="analytics_total_sales_title">Total sales</string>
+    <!-- This text appears as a secondary label in Google Ads analytics campaign lists, showing the advertising spend amount below the main statistic (sales, clicks, impressions, or conversions) for each campaign. -->
     <string name="analytics_spend_subtitle_value">Spend: %1$s</string>
+    <!-- This text appears as a secondary statistic label in the Google Ads analytics section, showing total sales amounts when the main focus is on advertising spend metrics. It displays below campaign names to provide additional context about sales performance relative to ad spend. -->
     <string name="analytics_total_sales_subtitle_value">Total Sales: %1$s</string>
+    <!-- This text appears as a section title in the analytics dashboard for gift card statistics, specifically labeling the left section that displays how many gift cards have been used during the selected time period. -->
     <string name="analytics_used_title">Used</string>
+    <!-- A section title displayed in the analytics dashboard that labels the net sales metric, appearing in both the Revenue card and Gift Cards analytics sections to show net sales values with percentage changes and trend data. -->
     <string name="analytics_net_sales_title">Net sales</string>
+    <!-- This string formats a percentage change indicator that appears as a tag/badge in analytics cards, showing the delta (change) with a sign (+ or -) and percentage value. It's displayed in analytics dashboard cards to show performance changes compared to previous periods. -->
     <string name="analytics_information_card_delta" translatable="false">%1$s%2$d%%</string>
+    <!-- This is the title displayed on an analytics card in the app's analytics dashboard/hub screen that shows order-related statistics and metrics for the store. -->
     <string name="analytics_orders_card_title">Orders</string>
+    <!-- This text appears as a section label in the analytics dashboard, specifically labeling the left section of the Orders analytics card that displays the total number of orders. -->
     <string name="analytics_total_orders_title">Total Orders</string>
+    <!-- This text appears as a section title in the analytics dashboard showing order statistics, specifically labeling the metric that displays the average monetary value of customer orders. -->
     <string name="analytics_avg_orders_title">Average Order Value</string>
+    <!-- This text appears as a subtitle label in the Products analytics card on the analytics hub screen, describing the metric being displayed (total number of items sold). -->
     <string name="analytics_products_list_items_sold">Items sold</string>
+    <!-- This text appears as a subtitle label in the analytics bundles card on the analytics hub screen, displaying the total number of product bundles that have been sold during the selected time period. -->
     <string name="analytics_bundles_list_items_sold">Bundles sold</string>
+    <!-- This text appears as the title of an analytics card in the WooCommerce analytics dashboard that displays product performance metrics and statistics. -->
     <string name="analytics_products_card_title">Products</string>
+    <!-- This text appears as a column header in the analytics products section, labeling the left column of a list that displays product names and their sales performance data. -->
     <string name="analytics_products_list_header_title">Products</string>
+    <!-- This text appears as a column header in the analytics bundles list view, displayed above the list of product bundles to identify what type of items are being shown in the left column. -->
     <string name="analytics_bundles_list_header_title">Bundles</string>
+    <!-- This text appears as a column header on the right side of a products analytics list, indicating the metric being displayed for each product row (items sold quantities). -->
     <string name="analytics_products_list_header_subtitle">Items sold</string>
+    <!-- This text appears as a column header in the analytics bundles report list, specifically as the right column header that likely indicates quantity or sales data for product bundles. -->
     <string name="analytics_bundles_list_header_subtitle">Bundles sold</string>
+    <!-- This text appears as a description label for individual product and bundle items in analytics lists, showing the net sales amount with currency formatting. It displays beneath each product/bundle name in the analytics dashboard to provide sales performance data. -->
     <string name="analytics_products_list_item_description">Net sales: %1$s</string>
+    <!-- Title text for the Sessions analytics card in the WooCommerce analytics dashboard, which displays visitor and conversion rate statistics for the selected time period. -->
     <string name="analytics_session_card_title">Sessions</string>
+    <!-- This is the title for an analytics card that displays bundle product statistics in the WooCommerce app's analytics dashboard. It appears as a card title in the analytics hub where users can view performance metrics for product bundles sold through their store. -->
     <string name="analytics_bundles_card_title">Bundles</string>
+    <!-- Title text displayed on an analytics card in the WooCommerce analytics dashboard that shows gift card statistics and metrics. -->
     <string name="analytics_gift_cards_card_title">Gift Cards</string>
+    <!-- This text appears as the title of an analytics card in the WooCommerce app's analytics dashboard that displays Google advertising campaign performance data and statistics. -->
     <string name="analytics_google_ads_card_title">Google Campaigns</string>
+    <!-- This text appears as a filter title in the Google Ads analytics section, likely labeling a dropdown or selection control that allows users to choose which metric to display (e.g., total sales, clicks, impressions). -->
     <string name="analytics_google_ads_metric_card_title">Metric</string>
+    <!-- This text appears as a filter option label in the Google Ads analytics section, allowing users to view total sales data from their advertising campaigns. It serves as both a selectable filter button and a column/section title when displaying the corresponding sales statistics. -->
     <string name="analytics_google_ads_filter_total_sales">Total Sales</string>
+    <!-- This text appears as a filter option and column title in the Google Ads analytics screen, allowing users to view advertising spend data for their campaigns. -->
     <string name="analytics_google_ads_filter_spend">Spend</string>
+    <!-- This text appears as a filter option and column header in the Google Ads analytics screen, allowing users to view conversion statistics for their advertising campaigns. -->
     <string name="analytics_google_ads_filter_conversion">Conversion</string>
+    <!-- This text appears as a filter option label in the Google Ads analytics section, allowing users to view impression statistics for their advertising campaigns. It's used both as a selectable filter option and as a title when impressions data is being displayed. -->
     <string name="analytics_google_ads_filter_impressions">Impressions</string>
+    <!-- This text appears as a filter option in Google Ads analytics, allowing users to view click statistics for their advertising campaigns. It serves as both a selectable filter option and as the title displayed when clicks data is being shown. -->
     <string name="analytics_google_ads_filter_clicks">Clicks</string>
+    <!-- This text appears as a column header in the Google Ads analytics section, specifically labeling the left column that displays a list of advertising programs or campaigns in a data table. -->
     <string name="analytics_google_ads_programs_card_title">Programs</string>
+    <!-- This text appears as a subtitle label in the analytics dashboard's session card, specifically labeling the conversion rate metric displayed in the right section of the card. -->
     <string name="analytics_conversion_subtitle">Conversion Rate</string>
+    <!-- This text appears as a subtitle label in the analytics section of a WooCommerce store dashboard, specifically labeling the visitor count metric within the session analytics card. -->
     <string name="analytics_visitors_subtitle">Visitors</string>
+    <!-- Used in accessibility descriptions for analytics list items showing product sales data. This is the singular form used when displaying '1 item' in content descriptions for screen readers in the analytics dashboard. -->
     <string name="analytics_item">item</string>
+    <!-- This text appears as part of accessibility content descriptions in the analytics hub to indicate the plural form of 'items' when describing product sales data. It's used alongside quantity values to help screen readers announce product statistics properly. -->
     <string name="analytics_items">items</string>
+    <!-- Content description for screen readers in the analytics section, describing products sold data with four parameters: title, description, value, and item count. This accessibility text helps visually impaired users understand analytics list items showing product sales information. -->
     <string name="analytics_list_item_products_sold">%1$s, %2$s, %3$s, %4$s sold</string>
+    <!-- This is the title text displayed in a call-to-action (CTA) card on the analytics screen that promotes Google Ads campaigns functionality when it's not yet set up or available. -->
     <string name="analytics_google_ads_cta_title">Google Campaigns</string>
+    <!-- This text appears as a description in a call-to-action (CTA) card for Google Ads in the analytics section, encouraging users to use Google Ads for their business by explaining its benefits. -->
     <string name="analytics_google_ads_cta_description">Drive sales and generate more traffic with Google Ads.</string>
+    <!-- This is the text displayed on a call-to-action button in the Analytics Hub screen that appears when Google Ads integration is available but no campaigns are set up. When tapped, it guides users to start creating their first paid advertising campaign. -->
     <string name="analytics_google_ads_cta_action">Add paid campaign</string>
+    <!-- This text appears as the title of a web view that opens when users tap a Google Ads call-to-action button in the Analytics Hub. It displays in the navigation bar or header of the web view that loads the Google for WooCommerce campaign creation interface. -->
     <string name="analytics_google_ads_cta_web_view_title">Google for WooCommerce</string>
 
 
+    <!-- This text appears as the title of a feedback banner displayed at the top of the analytics screen, asking users if they are enjoying the analytics feature before potentially prompting for feedback. -->
     <string name="analytics_banner_title">Enjoying analytics?</string>
+    <!-- This text appears as the message content in a feedback banner displayed at the top of the analytics screen, prompting users to rate their experience with the analytics features. -->
     <string name="analytics_banner_message">Please rate your analytics experience</string>
     <!--
         Order List View
     -->
+    <!-- Error message displayed in a snackbar notification when the app fails to load the orders list due to a generic network or server error. This appears on the orders screen when data fetching encounters an unexpected error that doesn't fall into specific error categories like timeout or parsing errors. -->
     <string name="orderlist_error_fetch_generic">Error fetching orders</string>
+    <!-- A confirmation message that appears as a snackbar notification when a customer filter has been successfully applied to the order list, informing users that the order list is now filtered to show orders from a specific customer. -->
     <string name="order_list_customer_filter_applied">Customer filter applied</string>
+    <!-- Placeholder text that appears in the search input field on the orders list screen when no filters are active, prompting users to search through their orders. -->
     <string name="orderlist_search_hint">Search orders</string>
+    <!-- This text appears as a search hint/placeholder in the order list screen when filters are currently active, guiding users to search within their already filtered results. -->
     <string name="orderlist_search_hint_active_filters">Search filtered orders</string>
+    <!-- A loading message displayed as the title in an empty view while the app is fetching the user's order list from the server. This appears on the orders screen when the app is actively retrieving order data. -->
     <string name="orderlist_loading">Looking up your orders…</string>
+    <!-- This text appears as a card title in the orders section when no filters are currently applied to the order list, indicating that all orders are being displayed. -->
     <string name="orderlist_no_filters_title">All Orders</string>
+    <!-- This is a technical identifier used internally for Android view transitions when navigating from an order card in the order list to the order details screen. It's not displayed to users but helps create smooth animations between screens. -->
     <string name="order_card_transition_name">order_card_%1$s</string>
+    <!-- This is an internal transition name identifier used for shared element animations when navigating from the order list to order detail screen. It is not displayed to users but serves as a technical reference for smooth visual transitions between screens. -->
     <string name="order_card_detail_transition_name">order_card_detail</string>
+    <!-- This text appears as a swipe action label in the orders list, displayed when the user swipes left on an order item to mark it as completed. The text is rendered with white text over a colored background as part of the swipe-to-complete gesture interface. -->
     <string name="orderlist_mark_completed">Mark\ncompleted</string>
+    <!-- Success message displayed in an undo snackbar notification when an order is successfully marked as completed through a swipe gesture on the order list screen. The message includes the order number and allows users to undo the status change. -->
     <string name="orderlist_mark_completed_success">Order #%1$d marked as completed</string>
+    <!-- Error message displayed in a snackbar when updating an order's status fails in the order list screen. The message includes the specific order ID number and appears with a retry action button. -->
     <string name="orderlist_updating_order_error">Error updating Order #%1$d</string>
+    <!-- This is the title text displayed in an error troubleshooting card on the orders list screen when the app fails to parse or process order data from the server. -->
     <string name="orderlist_parsing_error_title">We couldn\'t load your data.</string>
+    <!-- Error message displayed in a troubleshooting card on the orders list screen when there's an error parsing order data, suggesting the issue may be plugin-related and offering user assistance options. -->
     <string name="orderlist_parsing_error_message">This could be related to a conflict with a plugin. Please try again later or reach out to us and we\'ll be happy to assist you!</string>
+    <!-- This text appears as a button label on an expandable error card in the orders list screen. When users encounter errors loading orders, they can tap this button to access troubleshooting options or guidance. -->
     <string name="error_troubleshooting">Troubleshooting</string>
+    <!-- This text appears as the title of an error troubleshooting card displayed on the orders list screen when the app experiences a timeout while trying to load order data from the user's WooCommerce site. -->
     <string name="orderlist_timeout_error_title">Your site is taking a long time to respond</string>
+    <!-- An error message displayed in a troubleshooting card on the orders list screen when there's a timeout error loading orders. The message appears as part of an error banner that provides options for users to contact support or access troubleshooting tools. -->
     <string name="orderlist_timeout_error_message">Please try again later or reach out to us and we\'ll be happy to assist you</string>
+    <!-- This text appears as the main heading/title on a connectivity troubleshooting screen in the WooCommerce Android app, specifically used when users encounter issues with order synchronization or connection problems. -->
     <string name="orderlist_connectivity_tool_title">Troubleshoot Connection</string>
+    <!-- This is a subtitle text that appears on the Order Connectivity Tool screen, displayed below the main title to inform users that the app is currently running diagnostic checks to identify connection problems with their store orders. -->
     <string name="orderlist_connectivity_tool_subtitle">Please wait while we attempt to identify your connection issue.</string>
+    <!-- This text appears as a title for an internet connectivity check card in the orders section's connectivity troubleshooting tool. It labels a diagnostic check that verifies whether the device has a working internet connection. -->
     <string name="orderlist_connectivity_tool_internet_check_title">Internet connection</string>
+    <!-- This text appears as a suggestion message in the connectivity troubleshooting tool within the orders section, specifically for internet connectivity checks. It provides guidance to users when their device appears to be offline, helping them resolve connection issues to access their orders. -->
     <string name="orderlist_connectivity_tool_internet_check_suggestion">It looks like you\'re not connected to the internet.\n\nEnsure your Wi-Fi is turned on. If you\'re using mobile data, make sure it\'s enabled in your device settings.</string>
+    <!-- This text appears as a title in a connectivity diagnostic tool within the order list feature, specifically for the step that checks connection to WordPress.com servers. It's displayed as part of a connectivity troubleshooting card that helps users diagnose connection issues when loading orders. -->
     <string name="orderlist_connectivity_tool_wordpress_check_title">Connecting to WordPress.com servers</string>
+    <!-- This text appears as a suggestion message in the WordPress connectivity check card within the orders list connectivity troubleshooting tool, displayed when the app cannot connect to WordPress.com servers. -->
     <string name="orderlist_connectivity_tool_wordpress_check_suggestion">We can\'t connect to WordPress.com right now.\n\nTry again in a few minutes, or contact our support team and we will happily assist you.</string>
+    <!-- This text appears as a title on a connectivity check card in the order list screen, shown when the app is testing the connection to the user's WooCommerce store. It's displayed as part of a diagnostic tool that helps users troubleshoot connection issues with their store. -->
     <string name="orderlist_connectivity_tool_store_check_title">Connecting to your site</string>
+    <!-- This text appears as a title in a connectivity diagnostic tool within the orders section, displayed while the app is in the process of fetching/retrieving orders from the user's WooCommerce store to test connectivity. -->
     <string name="orderlist_connectivity_tool_store_orders_check_title">Fetching your site orders</string>
+    <!-- This text appears as a button label on the Order Connectivity Tool screen, which helps diagnose connection issues with orders. The button allows users to contact customer support when they experience connectivity problems, and is only enabled when appropriate based on the connectivity check results. -->
     <string name="orderlist_connectivity_tool_contact_support_action">Contact Support</string>
+    <!-- A button label in the order connectivity troubleshooting tool that allows users to access additional information or documentation about connection issues. This button appears conditionally alongside a retry button when there are connectivity problems with loading orders. -->
     <string name="orderlist_connectivity_tool_read_more_action">Read More</string>
+    <!-- Button label that appears on the order connectivity tool screen when a connection check fails, allowing users to attempt reconnecting to the WooCommerce store. -->
     <string name="orderlist_connectivity_tool_retry_action">Retry connection</string>
+    <!-- This text appears as the label for a button on the Order Connectivity Tool screen that allows users to navigate back to the previous screen. The button includes a back arrow icon and is displayed in a connectivity diagnostic interface for troubleshooting order-related network issues. -->
     <string name="orderlist_connectivity_tool_return_action">Return to the previous screen</string>
+    <!-- Error message displayed in a connectivity tool when the user's WooCommerce site fails to respond within the expected time limit, providing troubleshooting guidance to contact their hosting provider. -->
     <string name="orderlist_connectivity_tool_timeout_error_suggestion">Your site seems to be taking too long to respond.\n\nContact your hosting provider for further assistance.</string>
+    <!-- This error message appears in the connectivity tool when the app fails to parse the response from the user's WooCommerce site while checking order synchronization. It's displayed as a suggestion message to reassure users and guide them to contact support for assistance. -->
     <string name="orderlist_connectivity_tool_parsing_error_suggestion">It seems we can\'t work properly with your site\'s response.\n\nBut don\'t worry, our support team is here to help. Contact us and we will happily assist you.</string>
+    <!-- Error message displayed in the orders list connectivity tool when there's a problem with the Jetpack connection, offering reassurance and encouraging users to contact support for assistance. -->
     <string name="orderlist_connectivity_tool_jetpack_error_suggestion">There seems to be a problem with your jetpack connection.\n\nBut don\'t worry, our support team is here to help. Contact us and we will happily assist you.</string>
+    <!-- Error message displayed as a suggestion in connectivity check cards when diagnosing connection issues in the order list screen. This generic error text appears when store connectivity or store orders connectivity checks fail with no specific error type identified. -->
     <string name="orderlist_connectivity_tool_generic_error_suggestion">There seems to be a problem with your site.\n\nContact your hosting provider for further assistance.</string>
+    <!-- This text appears as a title in the connectivity tool summary section on the order list screen, displayed when connection tests show no issues with the store connection. -->
     <string name="orderlist_connectivity_tool_summary_title">No connection issues</string>
+    <!-- This text appears as a suggestion message in the Order Connectivity Tool summary section, displayed when there are data loading issues with orders. It follows the main title and provides users with guidance to contact support if troubleshooting steps haven't resolved their connectivity problems. -->
     <string name="orderlist_connectivity_tool_summary_suggestion">If your data still isn\'t loading, contact our support team for assistance.</string>
+    <!-- This text appears in an undo snackbar message that shows when a user trashes/deletes an order from the order list, giving them a chance to undo the action before it's permanently deleted. -->
     <string name="orderlist_order_trashed">Order trashed</string>
+    <!-- Error message displayed in a snackbar notification when the system fails to move an order to the trash in the order list screen. This appears when the trash operation encounters a technical problem after the user has attempted to delete an order. -->
     <string name="orderlist_order_trashed_error">Error trashing order</string>
+    <!-- This text appears as the title in an action mode toolbar when multiple orders are selected in the order list screen, showing the count of currently selected orders (e.g., '5 orders selected'). -->
     <string name="orderlist_selection_count">%d orders selected</string>
+    <!-- This text appears as the action bar title when exactly one order is selected in the order list screen, typically during bulk operations where users can select multiple orders for batch updates. -->
     <string name="orderlist_selection_count_single">%d order selected</string>
+    <!-- This text appears as a menu item in the orders list screen that allows users to update the status of selected orders. It's displayed in an action mode menu that becomes available when users select one or more orders from the list. -->
     <string name="orderlist_selection_menu_update_status">Update status</string>
+    <!-- Success message displayed in a snackbar notification when a bulk status update operation on multiple orders completes successfully in the order list screen. -->
     <string name="orderlist_bulk_update_status_updated">Status updated!</string>
+    <!-- Error message displayed as a snackbar notification when users try to select more than the maximum allowed number of orders for bulk update operations in the order list screen. -->
     <string name="orderlist_bulk_update_maximum_reached">Maximum selection count (%d) is reached.</string>
+    <!-- Error message displayed as a snackbar notification when a bulk update operation on orders fails because no orders were actually updated, prompting the user to retry the action. -->
     <string name="orderlist_bulk_update_result_no_orders_updated">No orders updated. Please try again.</string>
+    <!-- Error message displayed in a snackbar when all selected orders fail to update during a bulk update operation in the orders list screen. -->
     <string name="orderlist_bulk_update_result_all_failed">Failed to update orders. Please try again.</string>
+    <!-- This message appears as a snackbar notification on the order list screen when a bulk order update operation partially succeeds, informing users how many orders were successfully updated and how many failed. -->
     <string name="orderlist_bulk_update_result_partial_success">%d order(s) updated, and %d order(s) failed to update. Please try again.</string>
+    <!-- A badge/tag label that appears next to order information to indicate that an order was created through a Point of Sale (POS) system. It displays in order lists and order detail screens to help users identify the sales channel origin of orders. -->
     <string name="pos_badge" translatable="false">POS</string>
 
     <!--
          Simple Payments
     -->
+    <!-- This text appears as the screen title/header for the Simple Payments feature, which allows merchants to create and process one-off payments outside of regular order flow. -->
     <string name="simple_payments_title">Simple payment</string>
+    <!-- Error message displayed as a snackbar notification when updating a simple payment order fails in the payments flow. This appears at the bottom of the screen to inform users that their payment order changes could not be saved. -->
     <string name="simple_payments_update_error">Unable to update simple payment order</string>
+    <!-- This is a placeholder hint text that appears inside an email input field on the Simple Payments screen, guiding users to enter an email address for payment processing. -->
     <string name="simple_payments_edit_email_hint">Enter email</string>
+    <!-- A label displayed in the Simple Payments screen that identifies the custom amount field where users can enter or view a monetary value for a payment transaction. -->
     <string name="simple_payments_custom_amount">Custom amount</string>
+    <!-- This text appears as the label for a toggle switch in the Simple Payments feature that allows merchants to enable or disable tax charging on payments. It's displayed as part of a payment form where users can configure whether taxes should be applied to their simple payment transactions. -->
     <string name="simple_payments_charge_taxes">Charge taxes</string>
+    <!-- This text appears as both a toolbar title and button label in the WooCommerce payment flow, displaying the total amount to be charged when taking a payment for a simple payment order. -->
     <string name="simple_payments_take_payment_button">Take payment (%s)</string>
+    <!-- An informational message that appears below the tax calculation section in the Simple Payments screen, explaining to users how taxes are automatically determined for their payment transactions. -->
     <string name="simple_payments_tax_message">Taxes are automatically calculated based on your store address</string>
+    <!-- This text appears as a section title/header on the payment method selection screen, displayed in all caps to guide users in choosing how they want to pay for their purchase. -->
     <string name="simple_payments_choose_method">Choose your payment method</string>
+    <!-- This text appears as a clickable row option in the payment method selection screen, allowing users to share a payment link for an order when one is available. -->
     <string name="simple_payments_share_payment_link">Share Payment Link</string>
+    <!-- This text appears as the title of a share dialog when users share a payment URL, where %s is replaced with the store name (e.g., 'Checkout - My Store'). It's used both as the dialog title and as the subject line when sharing the payment link via email or messaging apps. -->
     <string name="simple_payments_share_payment_dialog_title">Checkout - %s</string>
 
     <!--
      Cash Payments
     -->
+    <!-- This text appears as a screen title in the cash payment flow, showing the total amount due that needs to be collected from the customer. The %s placeholder is replaced with a formatted currency amount (e.g., 'Take payment ($25.99)'). -->
     <string name="cash_payments_take_payment_title">Take payment (%s)</string>
+    <!-- This text appears as a label for a currency input field in the change due calculator screen, where users enter the amount of cash they received from a customer during a transaction. -->
     <string name="cash_payments_cash_received">Cash received</string>
+    <!-- A label that appears above the calculated change amount in the cash payment change due calculator screen, helping users understand what the displayed monetary value represents. -->
     <string name="cash_payments_change_due">Change due</string>
+    <!-- This text appears as a label next to a toggle switch in a cash payment calculator screen, allowing users to choose whether transaction details should be recorded in the order notes. -->
     <string name="cash_payments_record_transaction_details">Record transaction details in order note</string>
+    <!-- This text appears as a button label in the cash payments change due calculator screen, allowing users to finalize an order after calculating payment amounts and change. -->
     <string name="cash_payments_mark_order_as_complete">Mark Order as Complete</string>
+    <!-- This text appears as an order note that is automatically added to cash payment orders when the merchant chooses to record transaction details, documenting the amount paid by the customer and any change given back. -->
     <string name="cash_payments_order_note_text">The order was paid by cash. Customer paid %s. The change due was %s.</string>
+    <!-- Error message displayed in a snackbar notification when the app fails to add an order note during cash payment processing. This appears when the user completes an order with transaction details recording enabled but the system cannot save the payment note to the order. -->
     <string name="cash_payments_order_note_adding_error">Error adding order note</string>
 
     <!--
          Custom Amounts
     -->
+    <!-- Label text that appears in a custom amounts dialog, specifically for a caption field that guides users when entering an amount value. This text is used as a descriptive label in the WooCommerce Android app's custom amounts input interface. -->
     <string name="custom_amounts_enter_amount">Amount</string>
+    <!-- This is a field label that appears in a custom amounts dialog, positioned above a text input field where users can enter a custom name for their custom amount item. -->
     <string name="custom_amounts_name">Name</string>
+    <!-- This text appears as the label on a primary action button in a custom amounts dialog/screen, specifically when creating a new custom amount (as opposed to editing an existing one). The button is used to confirm and add the custom amount that the user has configured. -->
     <string name="custom_amounts_add_custom_amount">Add Custom Amount</string>
+    <!-- This text appears on a delete button in a dialog for managing custom amounts, allowing users to remove a previously created custom amount entry. The button uses red styling to indicate a destructive action and is only visible when editing an existing custom amount. -->
     <string name="custom_amounts_delete_custom_amount">Delete Custom Amount</string>
+    <!-- This text appears as placeholder text in an input field where users can enter a custom name when creating or editing custom amounts in a WooCommerce dialog. The hint text guides users on what information to provide in the text field. -->
     <string name="custom_amounts_add_custom_name_hint">Enter Custom name</string>
+    <!-- A label for a tax configuration option in the custom amounts feature, likely displayed as a checkbox or toggle label that allows users to enable or disable tax charges on custom payment amounts. -->
     <string name="custom_amounts_tax_label">Charge Taxes</string>
+    <!-- A label that appears in the custom amounts dialog for adding fees or charges to an order, explaining that the percentage will be calculated based on the order total amount. The %1$s placeholder is replaced with the actual order total value to show users what amount the percentage will be calculated from. -->
     <string name="custom_amounts_percentage_label">Percentage of order total (%1$s)</string>
+    <!-- This text appears as a heading in a bottom sheet modal that allows users to choose how to add a custom amount to an order, with options for fixed amount or percentage. -->
     <string name="custom_amounts_bottom_sheet_heading">How do you want to add your custom amount?</string>
+    <!-- This text appears as a selectable option in a bottom sheet dialog where users can choose between different custom amount types for orders, specifically representing the option to enter a fixed monetary amount (as opposed to a percentage). -->
     <string name="custom_amounts_bottom_sheet_fixed_amount_option">A fixed amount</string>
+    <!-- This text appears as a label for a selectable option in a bottom sheet dialog that allows users to choose how to calculate custom amounts for orders. It's displayed alongside a percentage symbol (%) and when tapped, allows users to enter amounts as a percentage of the total order value. -->
     <string name="custom_amounts_bottom_sheet_percentage_amount_option">A percentage of the order total</string>
+    <!-- Placeholder text that appears in a percentage input field within a custom amounts dialog, indicating the default or expected format for percentage values (showing '0' as the starting value). -->
     <string name="custom_amounts_percentage_hint">0</string>
+    <!-- A percentage symbol (%) displayed next to a percentage input field in a custom amounts dialog, positioned between the percentage value and the calculated amount. -->
     <string name="custom_amounts_percentage_symbol">%</string>
+    <!-- Error message displayed below a percentage input field when the user enters an invalid percentage value (non-numeric characters) in the custom amounts dialog for payment processing. -->
     <string name="custom_amounts_percentage_invalid_value">Invalid value</string>
+    <!-- Button text that appears in the custom amounts dialog when editing an existing custom amount, allowing users to save their modifications to the amount configuration. -->
     <string name="custom_amounts_save_changes">Save Changes</string>
 
     <!--
@@ -592,539 +1087,1031 @@
     <!--
          Order Creation
     -->
+    <!-- This text appears as the label for an app shortcut and as the accessibility description for a floating action button on the order list screen that allows users to create a new order. -->
     <string name="orderlist_create_order_button_description">Create order</string>
+    <!-- Error message displayed to users when barcode scanning fails in the order list screen. This message appears when the camera fails to scan a product barcode and includes a retry action. -->
     <string name="order_list_barcode_scanning_scanning_failed">Scanning failed. Please try again later</string>
+    <!-- This text appears as the title in the navigation bar or header when users are creating a new order in the WooCommerce app. It distinguishes the 'create new order' screen from the 'edit existing order' screen mode. -->
     <string name="order_creation_fragment_title">New order</string>
+    <!-- This text appears as the main toolbar title in tablet mode when creating or editing orders, displayed in the left pane of a two-pane layout interface. -->
     <string name="order_creation_tablet_mode_fragment_title">Order Summary</string>
+    <!-- A label that appears in the order creation screen when a product has a discount applied, indicating the final price after the discount has been deducted. It's displayed below the discount amount to show the calculated discounted price for the product. -->
     <string name="order_creation_price_after_discount">Price after discount</string>
+    <!-- Label text that appears on the order creation screen next to quantity controls, allowing users to see and adjust the number of items for a product being added to an order. -->
     <string name="order_creation_products_order_count">Order count</string>
+    <!-- This text appears as a section label or heading in the order creation/editing interface, identifying the customer information section where users can view, add, or edit customer details for an order. -->
     <string name="order_creation_customer">Customer</string>
+    <!-- This text serves as a content description for an edit button in the customer section of the order creation screen, used for accessibility purposes to help screen readers describe the button's function to visually impaired users. -->
     <string name="order_creation_customer_edit_content_description">Edit customer details</string>
+    <!-- This text appears as a dialog title when viewing customer notes in the order creation/editing screen, displayed in an expandable read-more dialog. -->
     <string name="order_creation_customer_note">Customer note</string>
+    <!-- Content description for accessibility on an edit button in the notes section of the order creation/editing screen. This text is read by screen readers when users focus on the button that allows editing customer notes for an order. -->
     <string name="order_creation_customer_note_edit_content_description">Edit customer note</string>
+    <!-- Button text that appears in the order creation/editing screen's customer section, allowing users to add customer information to a new or existing order. -->
     <string name="order_creation_add_customer">Add customer details</string>
+    <!-- Content description for an accessibility-enabled floating action button with a plus icon that allows users to add a new customer during order creation. This text is read by screen readers to help visually impaired users understand the button's purpose. -->
     <string name="order_creation_add_customer_content_description">add customer</string>
+    <!-- Button text that appears in order creation and simple payments screens, allowing users to add a note for the customer. The button is displayed in a notes section and triggers a flow to input customer-facing notes when tapped. -->
     <string name="order_creation_add_customer_note">Add note</string>
+    <!-- Button label that appears in the order creation/editing screen when no products have been added yet. When tapped, it opens a product selection interface to add items to the order. -->
     <string name="order_creation_add_products">Add products</string>
+    <!-- This text appears as a button label in the order creation/editing screen that allows users to add custom amounts (like fees, discounts, or other line items) to an order. The button is displayed in different UI states depending on whether products have been added and the device layout configuration. -->
     <string name="order_creation_add_custom_amounts">Add custom amount</string>
+    <!-- This text appears as a button label in the order creation screen that allows users to add products to an order by scanning their barcodes. The button is displayed as an icon button on single-pane layouts and triggers the barcode scanning functionality when tapped. -->
     <string name="order_creation_add_product_via_barcode_scanning">Add products via scanner</string>
+    <!-- Button text that appears in the order creation screen, allowing users to scan product barcodes to add items to an order. This button is displayed specifically in two-pane layout mode (likely tablet view) as an alternative to the regular 'Add products' button. -->
     <string name="order_creation_scan_products">Scan products</string>
+    <!-- Button label that appears in the order creation/editing screen when no tax rate is currently active, allowing users to set a new tax rate for the order. -->
     <string name="order_creation_set_tax_rate">Set New Tax Rate</string>
+    <!-- This text appears as a button label in the order creation screen when automatic tax rate calculation is already active, allowing users to modify the current tax rate settings. -->
     <string name="order_creation_edit_tax_rate">Edit Tax Rate Setting</string>
+    <!-- This text appears as the screen title/header when users are adding a fee to an order in the WooCommerce app. It's displayed in the navigation bar or fragment title area of the fee creation screen. -->
     <string name="order_creation_add_fee">Add fee</string>
+    <!-- Button text that allows users to add discount coupons when creating or editing an order. Also used as accessibility content description for an add icon in the coupons section. -->
     <string name="order_creation_add_coupon">Add coupon</string>
+    <!-- This text appears as both a button label in the order creation screen and as the screen title when adding gift cards to an order. The button has an add icon and allows users to navigate to the gift card addition screen. -->
     <string name="order_creation_add_gift_card">Add gift card</string>
+    <!-- This text appears as the screen title/header for a coupon selection screen in the WooCommerce app, specifically when creating an order and needing to choose a coupon to apply. -->
     <string name="order_creation_select_coupon">Select a coupon</string>
+    <!-- Displays the discount amount for applied coupons in the order totals section during order creation, showing as a negative value (e.g., '-$10.00'). This appears as a value label next to the coupon section in the order summary. -->
     <string name="order_creation_coupon_discount_value">-%1$s</string>
+    <!-- This text appears as a label in the order totals section when creating or editing an order, specifically showing the coupon discount line item with the discount amount. -->
     <string name="order_creation_coupon_button">Coupons</string>
+    <!-- This text appears as a navigation bar title on the screen that displays a list of coupons applied to an order, and also as a label in the order totals section showing the coupon discount amount. -->
     <string name="order_creation_coupons_title">Coupons applied</string>
+    <!-- This text serves as an accessibility content description for a plus/add icon button that increases the quantity of a product when creating an order. It appears in the order creation screen where users can adjust product quantities, and is specifically used by screen readers to describe the button's function. -->
     <string name="order_creation_increase_item_amount_content_description">Increase product quantity</string>
+    <!-- Content description for accessibility on a decrease/remove button in the order creation screen that reduces product quantity or deletes the item when quantity is 1. -->
     <string name="order_creation_decrease_item_amount_content_description">Decrease product quantity</string>
+    <!-- A button label that appears on the coupon selector screen when no coupons are available, taking users to the main coupons management section where they can create or manage their coupons. -->
     <string name="coupon_selector_empty_list_button">Go to Coupons</string>
+    <!-- This message appears in the center of the coupon selector screen when no coupons have been created yet, displayed below an empty state image and above a create button to guide users toward creating their first coupon. -->
     <string name="coupon_selector_empty_list_message">You haven\'t created any coupons yet. Create a coupon to apply it to this order.</string>
+    <!-- This is the main heading displayed on the coupon selector screen when no coupons are available, shown above an empty state illustration to encourage users that deals are worth creating or finding. -->
     <string name="coupon_selector_empty_list_title">Everyone loves a deal</string>
+    <!-- This text appears as an accessibility label for a delete icon in the order creation screen, allowing users to remove applied coupons from their order. It also serves as the label for a remove button in the coupon editing interface. -->
     <string name="order_creation_remove_coupon">Remove coupon from order</string>
+    <!-- This text appears as the title/header of a screen where users can edit or remove a coupon that was previously applied to an order during the order creation process. -->
     <string name="order_creation_remove_this_coupon">Remove coupon</string>
+    <!-- This text appears as the screen title/header for the customer details section during order creation, where users can view and edit customer information including billing and shipping addresses. -->
     <string name="order_creation_customer_details">Customer details</string>
+    <!-- This text appears as a fallback customer name in booking cancellation dialogs and customer detail screens when no actual customer name is available (i.e., for anonymous/guest purchases). It serves as a placeholder label to indicate that the customer made their purchase without creating an account. -->
     <string name="customer_detail_guest_customer">Guest</string>
+    <!-- This text appears as a switch/toggle label in the order creation flow, allowing users to enable the option to add a different shipping address from the billing address for new customers. -->
     <string name="order_creation_new_customer_add_different_shipping_address">Add a different shipping address</string>
+    <!-- Button label that appears on product cards during order creation, allowing users to add a discount to individual products. The button is displayed when no discount has been applied yet and includes an add icon alongside the text. -->
     <string name="order_creation_add_discount">Add discount</string>
+    <!-- This text appears as a label in the order creation discount screen when applying a percentage discount to a product, displaying next to the calculated monetary amount after the discount is applied. -->
     <string name="order_creation_discount_amount_label">Calculated Amount</string>
+    <!-- This is a label that appears on the order creation/discount screen when applying a fixed amount discount to a product. It displays next to the calculated percentage value showing what percentage the fixed discount amount represents. -->
     <string name="order_creation_discount_percentage_label">Calculated Percentage</string>
+    <!-- A label that appears in the order creation product discount screen, displayed in a row alongside the calculated price value after a discount has been applied to show users the final discounted price. -->
     <string name="order_creation_price_after_discount_label">Price after discount</string>
+    <!-- This text appears as a button label on the discount editing screen during order creation, allowing users to completely remove an applied discount from a product. The button is displayed when a discount has been applied and provides a way to delete it entirely. -->
     <string name="order_creation_remove_discount">Remove discount</string>
+    <!-- Error message displayed when a user tries to apply a discount amount that exceeds the total price of a product during order creation. This validation error appears to prevent users from setting invalid discount values that would result in negative totals. -->
     <string name="order_creation_discount_too_big_error">Discount cannot be greater than the price</string>
+    <!-- This is a field label for a text input where users enter a discount amount when creating or editing orders. The %1$s placeholder is replaced with the currency symbol (like $ or €) to show 'Amount ($)' or similar. -->
     <string name="order_creation_discount_amount_with_currency">Amount (%1$s)</string>
+    <!-- A label that appears in the order creation/editing screen's totals section, displaying the text 'Discounts Total' when there are discounts applied to the order. -->
     <string name="order_creation_discounts_total">Discounts Total</string>
+    <!-- This text displays the discount amount value in the order creation/editing totals section, formatted as a negative currency amount (e.g., '- $10.00'). It appears as a line item value showing how much discount is being applied to the order total. -->
     <string name="order_creation_discounts_total_value">- %1$s</string>
+    <!-- Text displayed on a button within an expandable product card during order creation that allows users to remove a product from the order they are building. -->
     <string name="order_creation_remove_product">Remove product from order</string>
+    <!-- A label that appears in the order creation/editing totals section showing the subtotal amount for all products in the order. It's displayed as a line item in the order summary breakdown before shipping, taxes, and final total. -->
     <string name="order_creation_payment_products">Products</string>
+    <!-- Label text that appears in the order creation/editing screen to identify the final total amount for an order, displayed prominently in both expanded and minimized views of the order totals section. -->
     <string name="order_creation_payment_order_total">Order Total</string>
+    <!-- This text appears as the title of a loading dialog that displays when the user is creating a new order, informing them that the order creation process is in progress. -->
     <string name="order_creation_loading_dialog_title">Creating your order</string>
+    <!-- Message displayed in a loading dialog when creating an order, asking the user to wait while the order creation process is in progress. -->
     <string name="order_creation_loading_dialog_message">Please wait…</string>
+    <!-- This text appears in a snackbar notification that displays when an order creation process fails in the WooCommerce store management feature. It's shown as a brief error message to inform the user that their attempt to create a new order was unsuccessful. -->
     <string name="order_creation_failure_snackbar">Order creation failed</string>
+    <!-- A success message displayed in a snackbar (temporary notification overlay) when an order is successfully created in the order management screen. This appears briefly at the bottom of the screen to confirm the action was completed successfully. -->
     <string name="order_creation_success_snackbar">Order created</string>
+    <!-- Label displayed in the order creation/editing screen that appears above the total tax amount and breakdown of individual tax rates (e.g., Government Sales Tax, State Tax) when creating or editing an order. -->
     <string name="order_creation_payment_tax_label">Taxes</string>
+    <!-- This text appears as a placeholder hint in a text input field within the order creation shipping section, prompting the user to enter a name for the shipping method or service. -->
     <string name="order_creation_shipping_name">Name</string>
+    <!-- This text appears as the screen title when users are adding shipping information to a new order, displayed in the navigation bar or header area of the shipping configuration screen. -->
     <string name="order_creation_shipping_title_add">Add Shipping</string>
+    <!-- This text appears as the navigation title/header when users are editing shipping information for an order during the order creation process. It's displayed at the top of the shipping configuration screen to indicate the user is in edit mode rather than adding new shipping details. -->
     <string name="order_creation_shipping_title_edit">Edit Shipping</string>
+    <!-- This text appears as the screen title/header for the shipping methods selection screen during order creation, where users can choose from available shipping options. -->
     <string name="order_creation_shipping_methods_title">Method</string>
+    <!-- Error message displayed on the order creation screen when the app fails to load available shipping methods, shown with a retry button to allow users to attempt loading the shipping options again. -->
     <string name="order_creation_shipping_methods_error">Error while fetching your shipping methods. Please try again</string>
+    <!-- This text appears as a button label on the order creation shipping screen when adding new shipping information to an order. The button is enabled/disabled based on form validation and triggers saving the shipping details when tapped. -->
     <string name="order_creation_shipping_add">Add Shipping</string>
+    <!-- This text appears as a button label on the order shipping screen when editing existing shipping information. The button allows users to save changes to shipping details during order creation/modification. -->
     <string name="order_creation_shipping_edit">Edit Shipping</string>
+    <!-- Button text that allows users to add shipping information when creating or editing an order. Also used as accessibility text for an add icon in the shipping section and as a default name hint for shipping entries. -->
     <string name="order_creation_add_shipping">Add shipping</string>
+    <!-- This text appears as a field label on the order shipping configuration screen, specifically labeling the section where users can select a shipping method when creating or editing an order. -->
     <string name="order_creation_add_shipping_method">Method</string>
+    <!-- A field label that appears above a currency input field on the order creation shipping screen, where users enter the shipping cost amount for a new order. -->
     <string name="order_creation_add_shipping_amount">Amount</string>
+    <!-- A field label that appears above a text input field on the order shipping configuration screen, where users can enter a custom name for the shipping method being added to an order. -->
     <string name="order_creation_add_shipping_name">Name</string>
+    <!-- This text appears as a placeholder hint in a text input field on the order creation shipping screen, and also serves as the default name for shipping when no custom name is entered by the user. -->
     <string name="order_creation_add_shipping_name_hint">Shipping</string>
+    <!-- This text appears as a button label on the order shipping configuration screen, allowing users to remove shipping charges from an order they are creating or editing. The button is styled with error colors (red) to indicate it's a destructive action that will remove the shipping information from the order. -->
     <string name="order_creation_remove_shipping">Remove shipping from order</string>
+    <!-- This text appears as a button label in the order creation/editing screen that allows users to remove a fee from an order. The button is likely displayed when editing fee details and provides a clear action to delete the fee entirely. -->
     <string name="order_creation_add_fee_removal_hint">Remove fee from order</string>
+    <!-- This is a placeholder text that appears in an input field where users enter a percentage value for fees when creating or editing orders. The text guides users to input a numerical percentage value in the fee calculation section. -->
     <string name="order_creation_fee_percentage_hint">Percentage (%)</string>
+    <!-- This text appears as the label for a toggle switch in the order creation fee screen, allowing users to switch between calculating fees as a fixed amount or as a percentage of the order total. -->
     <string name="order_creation_fee_percentage_toggle_text">Calculate as percentage</string>
+    <!-- This text appears as a label in the order fee creation screen, displaying the calculated monetary amount when a percentage-based fee is entered. The %s placeholder is replaced with a formatted currency amount that appears in bold styling. -->
     <string name="order_creation_fee_percentage_calculated_amount">Calculated amount: %s</string>
+    <!-- Empty state message displayed in the customer search screen when no customers match the search query, shown with an empty search illustration and optional action buttons to add customer details manually. -->
     <string name="order_creation_customer_search_empty">No customers found</string>
+    <!-- This text appears as an empty state message on the customer search screen when using an older version of WooCommerce that doesn't support advanced search features. It's displayed with a search suggestion image and typically followed by a button to add customer details manually. -->
     <string name="order_creation_customer_search_empty_on_old_version_wcpay">Search for an existing customer or</string>
+    <!-- Placeholder text that appears in the search field on the customer list screen during order creation, guiding users to search for existing customers to add to their order. -->
     <string name="order_creation_customer_search_hint">Search for customers</string>
+    <!-- This is a search hint/placeholder text that appears in the search field on the customer list screen when creating orders on older WooCommerce versions that don't support advanced search. It provides guidance to users about what they can search for in the customer database. -->
     <string name="order_creation_customer_search_old_wc_hint">Search for customers by</string>
+    <!-- Label for an email search filter option in the customer search interface during order creation. Users can tap this to switch the search mode to search customers by their email addresses. -->
     <string name="order_creation_customer_search_email">Email</string>
+    <!-- Label for a search filter option in the customer list screen during order creation, allowing users to search for customers by their name rather than username or email. -->
     <string name="order_creation_customer_search_name">Name</string>
+    <!-- Label for a search filter option that allows users to search for customers by their username when creating orders. This appears as a selectable search mode alongside other options like name and email in the customer search interface. -->
     <string name="order_creation_customer_search_username">Username</string>
+    <!-- This text appears as a placeholder in the customer list when creating an order, displayed when a customer record has no name information available. It helps users identify customers who lack name data during the order creation process. -->
     <string name="order_creation_customer_search_empty_name">No name</string>
+    <!-- Placeholder text displayed in the customer search results when a customer record has no email address associated with it, shown during order creation when searching for existing customers. -->
     <string name="order_creation_customer_search_empty_email">No email address</string>
+    <!-- A button label that appears on the customer search screen when no customers are found, allowing users to manually add customer details instead of searching for existing customers during order creation. -->
     <string name="order_creation_customer_search_empty_add_details_manually">Add details manually</string>
+    <!-- Button label that appears when searching for customers during order creation returns no results and the search query is a valid email address. When tapped, it allows the user to manually create a new customer using the entered email address. -->
     <string name="order_creation_customer_search_empty_add_details_manually_with_email">Add details manually using email</string>
+    <!-- Error message displayed when barcode scanning fails to find a product with the scanned SKU during order creation. The message includes the specific SKU that wasn't found and explains that the product cannot be added to the order. -->
     <string name="order_creation_barcode_scanning_unable_to_add_product">Product with SKU %s not found. Unable to add to the order</string>
+    <!-- Error message displayed as a snackbar notification when barcode scanning fails in the order creation screen or product inventory screen. This message appears when the camera-based barcode scanner encounters a technical failure or cannot complete the scanning process. -->
     <string name="order_creation_barcode_scanning_scanning_failed">Scanning failed. Please try again later</string>
+    <!-- Error message displayed when scanning a barcode for a variable product during order creation, informing the user they cannot add the parent product and must select a specific variation instead. -->
     <string name="order_creation_barcode_scanning_unable_to_add_variable_product">You cannot add variable product directly. Please select a specific variation</string>
+    <!-- Error message displayed when a user scans a barcode to add a product to an order, but the scanned product is in draft status (not published). This message appears as a failure notification during the barcode scanning workflow in the order creation screen. -->
     <string name="order_creation_barcode_scanning_unable_to_add_draft_product">You cannot add products that are not published</string>
+    <!-- Error message displayed to users when they attempt to scan a barcode to add a product to an order, but the scanned product has no price configured. This message appears as a failure notification during the barcode scanning workflow in order creation. -->
     <string name="order_creation_barcode_scanning_unable_to_add_product_with_invalid_price">You cannot add products with no price specified</string>
+    <!-- This text appears as a label in the order creation/editing screen to indicate that tax calculations are based on the store's address. It's displayed as part of tax configuration settings when merchants are creating or editing orders. -->
     <string name="order_creation_tax_based_on_store_address">Calculated on store address</string>
+    <!-- This text appears as a label in the tax section of the order creation/editing screen, indicating that tax calculations are based on the customer's billing address. It's displayed as informational text alongside tax details to explain how taxes are being calculated for the order. -->
     <string name="order_creation_tax_based_on_billing_address">Calculated on billing address</string>
+    <!-- This text appears as a label in the order creation/editing screen to indicate that tax calculations are based on the customer's shipping address. It's displayed as part of tax configuration options when creating or editing an order. -->
     <string name="order_creation_tax_based_on_shipping_address">Calculated on shipping address</string>
+    <!-- Content description for screen readers for a chevron icon button that allows users to expand or collapse product cards during order creation. The button shows additional product details when expanded and hides them when collapsed. -->
     <string name="order_creation_collapse_expand_product_card_content_description">Collapse/expand product card</string>
+    <!-- This text appears as a label/hint for a text input field on the gift card editing screen during order creation, prompting users to enter their gift card code. -->
     <string name="order_creation_gift_card_text_field_hint">Enter code</string>
+    <!-- Error message displayed as a text field label when the user enters an invalid gift card code format in the order creation gift card screen. The message appears in place of the normal field hint when the gift card code validation fails. -->
     <string name="order_creation_gift_card_text_error">The code should be in XXXX-XXXX-XXXX-XXXX format</string>
+    <!-- This text appears on a button in the order creation screen that allows users to proceed with collecting payment for a new order they are creating. -->
     <string name="order_creation_collect_payment_button">Collect Payment</string>
+    <!-- Button label that appears in the order creation/editing screen when totals need to be recalculated due to changes in products, taxes, or discounts. The button triggers a recalculation of the order totals and is displayed in two-pane layouts when recalculation is needed. -->
     <string name="order_creation_recalculate_button">Recalculate</string>
+    <!-- This is accessibility text (content description) for an expand/collapse arrow icon that toggles the visibility of order total details in the order creation screen and shipment details view. -->
     <string name="order_creation_expand_collapse_order_totals">Expand collapse order totals</string>
+    <!-- A label displayed in the order creation/editing screen's totals section that shows the tax amount specifically applied to shipping costs, appearing as a line item when shipping tax is greater than zero. -->
     <string name="order_creation_payment_shipping_tax_label">Shipping Tax</string>
+    <!-- Error message displayed in a dialog when a user tries to select a guest customer during order creation, but the app is configured to only allow registered customers for order filtering purposes. -->
     <string name="customer_picker_guest_customer_not_allowed_message">This user is a guest, and guests can\'t be used for filtering orders.</string>
 
+    <!-- This text appears as the title of a feedback dialog that is shown to users after they successfully add shipping information while creating or editing an order. It's displayed as a confirmation message in a dialog box to indicate the shipping was successfully added. -->
     <string name="order_creation_shipping_feedback_title">Shipping added!</string>
+    <!-- This text appears as the main message in a feedback dialog that asks users about their experience with WooCommerce's shipping functionality during order creation. It's displayed in a modal dialog alongside a title and action button to collect user feedback. -->
     <string name="order_creation_shipping_feedback_message">Does Woo make shipping easy?</string>
+    <!-- This text appears as an action button label in a feedback dialog that prompts users to share feedback about shipping functionality during order creation. The button triggers the feedback submission process when tapped. -->
     <string name="order_creation_feedback_action">Share your feedback</string>
 
     <!--
          Barcode Scanning
     -->
+    <!-- This text appears as the screen title/header for the barcode scanning functionality in a WooCommerce Android app, displayed when users access the camera-based barcode scanner feature. -->
     <string name="barcode_scanning_title">Scan Barcode</string>
+    <!-- This is the title text displayed in alert dialogs that appear when the barcode scanner feature needs camera permission from the user. The dialog is shown both when permission is denied once (asking user to grant permission) and when permission is permanently denied (directing user to app settings). -->
     <string name="barcode_scanning_alert_dialog_title">Grant Camera Permission</string>
+    <!-- This message appears in an alert dialog when the app needs camera permission to scan barcodes, explaining why the permission is required before prompting the user to grant access. -->
     <string name="barcode_scanning_alert_dialog_rationale_message">Camera permission is required in order to scan the barcode</string>
+    <!-- This text appears as the message in an alert dialog shown to users when they have permanently denied camera permission for barcode scanning functionality. The dialog explains why camera access is needed and instructs users to manually enable the permission through the app's system settings. -->
     <string name="barcode_scanning_alert_dialog_permanently_denied_message">You have permanently denied Camera permission. It is required in order to scan the barcode. Please enable it from the app settings</string>
+    <!-- This is the label for the primary action button in an alert dialog that appears when the user has previously denied camera permission for barcode scanning, asking them to grant the permission to proceed with scanning. -->
     <string name="barcode_scanning_alert_dialog_rationale_cta_label">Grant</string>
+    <!-- This is the dismiss button label that appears in alert dialogs within the barcode scanner feature, specifically when requesting camera permissions. Users tap this button to cancel the permission request and exit the barcode scanning screen. -->
     <string name="barcode_scanning_alert_dialog_dismiss_label">Cancel</string>
+    <!-- This is a button label in an alert dialog that appears when camera permission has been permanently denied for barcode scanning. The button allows users to navigate to the app's system settings where they can manually enable camera permissions. -->
     <string name="barcode_scanning_alert_dialog_permanently_denied_cta_label">Go to settings</string>
+    <!-- This text appears as an instructional label in the barcode scanner overlay screen, positioned below the scanning viewfinder to guide users on what action to perform. It serves as a static instruction that tells users to scan a product's barcode using their device's camera. -->
     <string name="barcode_scanning_scan_product_barcode_label">Scan Product Barcode</string>
 
     <!--
         Domains
     -->
+    <!-- This text appears as a section label on the domain dashboard screen, displayed above the user's free WordPress.com store address to identify it as their complimentary domain option. -->
     <string name="domains_your_free_store_address">Your free store address</string>
+    <!-- This text appears as a bold title in a banner section on the domain dashboard screen, encouraging users to claim a free domain for their WooCommerce store. It's displayed prominently at the top of a promotional banner that includes an accompanying image and additional description text. -->
     <string name="domains_claim_your_free_domain_title">Claim your free domain</string>
+    <!-- This text appears as a descriptive message on the Domain Dashboard screen, explaining to users that their current plan includes a complimentary one-year domain registration benefit. -->
     <string name="domains_claim_your_free_domain_description">You have a free one-year domain registration included with your plan.</string>
+    <!-- This text appears as the label on a button in the Domain Dashboard screen that allows users to claim a free domain for their WooCommerce store. The same text is also used as the content description for an accompanying image that illustrates the domain claiming feature. -->
     <string name="domains_claim_your_free_domain_link">Claim Domain</string>
+    <!-- An informational notice displayed on the domain dashboard screen that explains what happens when a user purchases a domain. It appears as a caption-style text below the domain claiming section to inform users about the redirect functionality. -->
     <string name="domains_purchase_redirect_notice">The domain purchased will redirect users to your primary address.</string>
+    <!-- This text appears as the label on a prominent button in the domain dashboard screen that allows users to search for and find available domains for their WooCommerce store. The button is displayed when the user has no paid domains and serves as the primary call-to-action for domain discovery. -->
     <string name="domains_search_for_domain_button_title">Search for a domain</string>
+    <!-- This text appears as a clickable link in the Domain Dashboard screen, providing users with additional information about domains and domain-related actions. It includes HTML formatting for an underlined hyperlink and is displayed alongside an info icon. -->
     <string name="domains_learn_more">&lt;a href=\'\'&gt;&lt;u&gt;Learn more&lt;/u&gt;&lt;/a&gt; about domains and how to take domain-related actions.</string>
+    <!-- A label tag that appears on the domain dashboard screen to identify which domain is the primary/main site address for the user's WooCommerce store. -->
     <string name="domains_primary_address">Primary site address</string>
     <string name="domains_your_domains">Your site domains</string>
+    <!-- Button text that appears on the domain dashboard screen in a list of user domains, allowing users to add a new domain to their WooCommerce store. -->
     <string name="domains_add_domain_button_title">Add a domain</string>
+    <!-- This text appears as a button label in the domain picker screen where users can search for and select a domain for their WooCommerce store. The button is used to confirm the selection of a chosen domain from the list of suggestions. -->
     <string name="domains_select_domain">Select domain</string>
+    <!-- This text appears as a section header on the domain picker screen, displayed when the user has a free URL and is searching for additional domain options for their WooCommerce store. -->
     <string name="domains_search_domains">Search domains</string>
+    <!-- This text appears in the domain picker screen as informational text that explains to users that their purchased domain will redirect to another URL. The text is followed by the actual URL in bold formatting to complete the sentence. -->
     <string name="domains_redirect_notice">The domain purchased will redirect users to</string>
+    <!-- Error message title displayed on the Domain Dashboard screen when the app fails to load site domains due to a generic/unknown error. This appears as the main heading in an error state view with a centered layout. -->
     <string name="domains_generic_error_title">Unable to load site domains</string>
+    <!-- Error message title displayed on the domain settings screen when a user without administrator privileges attempts to access domain configuration options. This appears as the main heading of an error screen with a generic error illustration. -->
     <string name="domains_access_error_title">Only store administrators can access domain settings</string>
+    <!-- This text appears as a green-colored label in the domain picker screen, displayed next to a crossed-out price to indicate that a premium domain is free for the first year when the user has available credits. -->
     <string name="domains_free_with_credits">Free for the first year</string>
+    <!-- This text appears as a heading on the purchase success screen that displays after a user successfully buys a domain, shown prominently below a celebratory image and above the purchased domain name. -->
     <string name="domains_purchase_successful_heading">Congratulations on your purchase</string>
+    <!-- This text appears as an informational notice on the domain purchase success screen, displayed below the purchased domain name to inform users that their domain setup is in progress and may take up to 30 minutes to become functional. -->
     <string name="domains_purchase_successful_delay_notice">Your site address is being set up. It may take up 30 minutes for your domain to start working.</string>
+    <!-- This informational text appears on a purchase success screen after a user successfully buys a domain, providing guidance on where to find domain management options in the app's settings menu. -->
     <string name="domains_purchase_successful_settings_notice">You can find the domain settings in Settings -&gt; Domains</string>
+    <!-- This text appears as a section heading on the domain registration screen, introducing privacy protection options for domain purchases. It's displayed as a prominent headline above the privacy protection description and radio button selection options. -->
     <string name="domain_registration_privacy_protection_title">Privacy Protection</string>
     <string name="domain_registration_privacy_protection_description">Domain owners have to share contact information in a public database of all domains.
         With Privacy Protection, we publish our own information instead of yours and privately forward any communication to you.</string>
+    <!-- This text appears as a clickable terms and conditions notice on the domain registration screen, displayed below the privacy protection options. The text contains an HTML link that users can tap to view the full terms and conditions. -->
     <string name="domain_registration_privacy_protection_tos">By registering this domain you agree to our &lt;a href=\'\'&gt;terms and conditions&lt;/a&gt;</string>
+    <!-- Error message displayed below input fields in the domain registration contact form when a field is left empty or contains invalid data. The %s placeholder is replaced with the field's label (e.g., 'first name', 'email address') to create messages like 'Please enter a valid email address'. -->
     <string name="domain_registration_contact_form_input_error">Please enter a valid %s</string>
+    <!-- This text appears as a radio button option in the domain registration screen, allowing users to choose privacy protection when registering a domain. It's part of a radio button group where users select between enabling or disabling domain privacy protection. -->
     <string name="domain_privacy_option_on_title">Register privately with Privacy Protection</string>
+    <!-- This text appears as a radio button option in the domain registration screen, allowing users to choose whether to register their domain publicly (without privacy protection). It's part of a toggle selection where users can choose between private and public domain registration. -->
     <string name="domain_privacy_option_off_title">Register publicly</string>
+    <!-- This text appears as a section heading in the free domain registration screen, introducing a form where users need to enter their contact details for domain registration. -->
     <string name="domain_contact_information_title">Domain contact information</string>
     <string name="domain_contact_information_description">For your convenience, we have pre-filled your WordPress.com
         contact information. Please review to be sure it’s the correct information you want to use for this domain.</string>
+    <!-- Placeholder text for an optional organization name input field in a domain registration contact information form, displayed between last name and email fields. -->
     <string name="domain_contact_information_organization_hint">Organization (optional)</string>
+    <!-- This text appears as a placeholder hint in a phone number input field within the domain registration contact information form, guiding users on what type of information to enter. -->
     <string name="domain_contact_information_phone_number_hint">Phone</string>
+    <!-- This text appears as a placeholder hint in a country code input field within the domain registration form, guiding users to enter their phone number's country code (e.g., 44 for UK). -->
     <string name="domain_contact_information_country_code_hint">Country code</string>
+    <!-- This text appears as a placeholder hint in a country selection input field within the free domain registration form, helping users understand they need to select their country for contact information. -->
     <string name="domain_contact_information_country_hint">Country</string>
+    <!-- This text appears as a placeholder hint in the first address line input field within the domain registration contact information form, guiding users to enter their street address. -->
     <string name="domain_contact_information_address_hint">Address</string>
+    <!-- This text appears as a placeholder hint in the second address line input field on the domain registration contact information form, helping users understand they can enter additional address details like apartment or suite numbers. -->
     <string name="domain_contact_information_address_hint_two">Address 2</string>
+    <!-- A placeholder text that appears in a city input field within the domain registration contact information form, guiding users to enter their city name as part of their address details. -->
     <string name="domain_contact_information_city_hint">City</string>
+    <!-- Hint text displayed in a state/province input field on the domain registration contact information form. This placeholder text appears when the state field is enabled and available for user input. -->
     <string name="domain_contact_information_state_hint">State</string>
+    <!-- This text appears as a placeholder hint in a state/province input field on the domain registration form when state options are not available or cannot be loaded for the selected country. -->
     <string name="domain_contact_information_state_not_available_hint">State (Not Available)</string>
+    <!-- This text appears as a placeholder hint inside a postal code input field on the domain registration screen, guiding users on what information to enter in this required address field. -->
     <string name="domain_contact_information_postal_code_hint">Postal code</string>
+    <!-- Button label for the primary action button that allows users to complete domain registration after entering their contact information on the free domain registration screen. -->
     <string name="domain_contact_information_register_domain_button">Register domain</string>
+    <!-- This text appears as a message in a progress dialog that displays while a domain name is being registered in the WooCommerce app's free domain registration feature. The message shows to inform users that the registration process is in progress and cannot be cancelled. -->
     <string name="domain_registration_registering_domain_name_progress_dialog_message">Registering domain name…</string>
+    <!-- This text appears as the title of a dialog box that displays a list of countries for users to select from during domain registration. The dialog is shown when users need to specify their country as part of the free domain registration process in WooCommerce. -->
     <string name="domain_registration_country_picker_dialog_title">Select Country</string>
+    <!-- This text appears as the title of a dialog box that allows users to select their state/province during the domain registration process in WooCommerce. The dialog displays a list of available states for the user to choose from. -->
     <string name="domain_registration_state_picker_dialog_title">Select State</string>
+    <!-- Error message displayed to users when domain registration fails and no specific error message is available from the server. This appears as a fallback error message in the WooCommerce domain registration flow when either shopping cart creation or site update operations encounter problems. -->
     <string name="domain_registration_generic_error">An error occurred during domain registration</string>
+    <!-- This text appears as a main heading (H5 typography style) on the domain picker screen in WooCommerce Android app, displayed when users need to select a domain for their store. -->
     <string name="domain_picker_title">Choose a domain</string>
+    <!-- This subtitle text appears on the domain picker screen below the main title, providing explanatory information to help users understand what a domain is for and reassuring them that they can modify their choice later. -->
     <string name="domain_picker_subtitle">This is where people will find you on the Internet. Don\'t worry, you can change it later.</string>
+    <!-- This text appears as placeholder text in a search field on the domain picker screen, prompting users to enter a domain name they want to search for or register. -->
     <string name="domain_picker_hint">Type a domain</string>
+    <!-- A section header label that appears on the domain picker screen, displayed above a list of domain name suggestions when users are searching for or selecting a domain for their WooCommerce store. -->
     <string name="domain_picker_suggestions_title">Suggestions</string>
+    <!-- This message is displayed in the center of the domain picker screen when a user searches for domains but no domain suggestions are available for their search query. -->
     <string name="domain_picker_empty_suggestions">No available domains for this search</string>
+    <!-- Error message displayed as a snackbar notification when the app fails to load domain name suggestions during domain search in the domain picker feature. -->
     <string name="domain_picker_suggestions_error">Unable to load domain suggestions</string>
 
     <!--
         Order Editing
     -->
+    <!-- This text appears as the title of an expandable warning message displayed on the order editing screen when certain parts of an order cannot be modified. It serves as a header above a more detailed explanation message to inform users about editing limitations. -->
     <string name="order_editing_non_editable_title">Parts of this order are not currently editable</string>
+    <!-- This message appears in an expandable message view on the order editing screen, explaining to users why certain fields cannot be modified and providing instructions on how to enable editing by changing the order status. -->
     <string name="order_editing_non_editable_message">To edit Products or Payment Details, change the status to Pending Payment.</string>
+    <!-- Content description for lock icons that appear next to disabled 'Add Shipping', 'Add Coupon', and 'Add Gift Card' buttons in the order creation screen, providing accessibility information that these features are currently locked/unavailable. -->
     <string name="order_editing_locked_content_description">locked</string>
+    <!-- This is an accessibility content description for a barcode icon button that appears in the order creation/editing screen, allowing users to scan product barcodes to add items to an order. -->
     <string name="order_editing_barcode_content_description">Scan barcode</string>
+    <!-- This is the accessibility content description for an add icon button in the order creation/editing screen that allows users to add products to an order. It provides screen reader users with context about what the plus icon button does when tapped. -->
     <string name="order_editing_add_content_description">Add product</string>
+    <!-- Error message displayed in a snackbar when saving changes to an order fails in the order creation/editing screen. The snackbar includes a retry button and cannot be dismissed by swiping. -->
     <string name="order_sync_failed">Unable to save changes</string>
+    <!-- This error message appears when a coupon that was previously applied to an order cannot be validated during synchronization and gets automatically removed from the order. It's displayed as a notification or alert to inform the user that their discount is no longer applied. -->
     <string name="order_sync_coupon_removed">Coupon could not be applied and was removed from the order</string>
     <!--
         Order Filters
     -->
+    <!-- Button label in the order filters screen that applies the selected filter criteria and displays the filtered list of orders to the user. -->
     <string name="orderfilters_show_orders_button">Show Orders</string>
+    <!-- This text appears as the default filter option in the WooCommerce order management system, displayed when no specific order status filter is selected. It shows in filter dropdowns and category displays to indicate that all orders (regardless of status) are being shown. -->
     <string name="orderfilters_default_filter_value">All</string>
+    <!-- This text appears as the display name for the order status filter category in the orders filtering interface, allowing users to filter orders by their current status (e.g., completed, pending, processing). -->
     <string name="orderfilters_order_status_filter">Order Status</string>
+    <!-- This text appears as a filter category label in the orders filtering interface, allowing users to filter their orders by a specific date range. -->
     <string name="orderfilters_date_range_filter">Date Range</string>
+    <!-- Label for the product filter category in the order filtering interface. This appears as a filter category name that users can select to filter orders by specific products. -->
     <string name="orderfilters_product_filter">Product</string>
+    <!-- This text appears as a filter category label in the orders screen, allowing users to filter their order list by customer. It's displayed as one of several filter options alongside order status, date range, and product filters. -->
     <string name="orderfilters_customer_filter">Customer</string>
+    <!-- This text appears as the category label for the sales channel filter in the order filtering interface, allowing users to filter orders by different sales channels like POS, web checkout, or WordPress admin. -->
     <string name="orderfilters_sales_channel_filter">Sales Channel</string>
+    <!-- A fallback display text shown in order filters when the app cannot retrieve the proper name for a customer or product, displaying only their ID number instead. This appears in the order filtering interface when customer names or product names are unavailable from the database. -->
     <string name="orderfilters_selected_filter_fallback_display_value">Id: %d</string>
+    <!-- Accessibility label for a checkmark icon that appears next to filter options in the order filters screen when that option is currently selected. This text is read by screen readers to help visually impaired users understand which filter options are active. -->
     <string name="orderfilters_filter_option_item_selected">Selected filter option</string>
+    <!-- This text appears as a section title in the order filters screen, labeling the group of filter options related to order status (such as pending, processing, completed, etc.). It helps users identify which category of filters they are configuring when customizing their order list view. -->
     <string name="orderfilters_filter_order_status_options_title">Order Status</string>
+    <!-- This text appears as a section title or header in the order filters screen, specifically for the date range filtering options where users can select different time periods to filter their orders. -->
     <string name="orderfilters_filter_date_range_options_title">Date Range</string>
+    <!-- This text appears as a title in the order filters card when no filters are applied, indicating that all orders are currently being displayed. It's displayed in a filter interface where users can view and manage order filtering options. -->
     <string name="orderfilters_filter_card_title_all_orders">All orders</string>
+    <!-- This text appears as a card title in the orders screen when the user has applied one or more filters to the order list, indicating that the displayed orders have been filtered according to their selected criteria. -->
     <string name="orderfilters_filter_card_title_filtered_orders">Filtered orders</string>
+    <!-- This text appears as the default title in the order filters screen toolbar, displayed when no filters are currently selected. When filters are selected, the title changes to show a count, but this default 'Filters' title is shown initially and when all filters are cleared. -->
     <string name="orderfilters_filters_default_title">Filters</string>
+    <!-- This text appears as a screen title in the order filters section, showing the number of currently active filters applied (e.g., 'Filters (3)'). It dynamically updates to display the count of selected filter options when users have applied one or more filters to their order list. -->
     <string name="orderfilters_filters_count_title">Filters (%d)</string>
+    <!-- This text appears in the order filters screen as a filter option label that displays an order status name with its count in parentheses (e.g., 'Pending (5)'). It's used when showing available order status filters with the number of orders matching each status. -->
     <string name="orderfilters_order_status_with_count_filter_option">%1$s (%2$d)</string>
+    <!-- This text appears as a selectable filter option in the order filtering interface, allowing users to filter orders to show only those placed today. It displays as the label for one of the predefined date range options in the order filters screen. -->
     <string name="orderfilters_date_range_filter_today">Today</string>
+    <!-- This text appears as a selectable option in the order filters screen, allowing users to filter their WooCommerce orders to show only those from the last 2 days. It's displayed as the label for a filter option that users can select to narrow down their order list by date range. -->
     <string name="orderfilters_date_range_filter_last_two_days">Last 2 Days</string>
+    <!-- This text appears as a selectable filter option in the order filtering interface, allowing users to filter their WooCommerce orders to show only those from the last 7 days. It displays as the name of a predefined date range filter that users can choose from a list of time period options. -->
     <string name="orderfilters_date_range_filter_last_7_days">Last 7 days</string>
+    <!-- This text appears as a selectable filter option in the order filters screen, allowing users to filter their WooCommerce orders to show only those from the past 30 days. -->
     <string name="orderfilters_date_range_filter_last_30_days">Last 30 days</string>
+    <!-- This text appears as a selectable filter option in the order filtering screen, allowing users to filter orders by sales channel to show only orders placed through web checkout. -->
     <string name="orderfilters_sales_channel_filter_web_checkout">Web checkout</string>
+    <!-- This text appears as a selectable filter option in the order filtering screen, representing orders that were created through the WordPress admin dashboard. Users can select this option to filter their order list to show only orders placed via the WP-admin interface. -->
     <string name="orderfilters_sales_channel_filter_wp_admin">WP-admin</string>
+    <!-- This text appears as a label option in the order filters screen when users can select from predefined date ranges (Today, Last 7 Days, etc.) or choose a custom date range. It represents the option that allows users to manually specify their own start and end dates for filtering orders. -->
     <string name="orderfilters_date_range_filter_custom_range">Custom Range</string>
+    <!-- This text appears as the title of a date range picker dialog in the WooCommerce Android app, specifically used for filtering orders by date range. It's displayed at the top of a calendar interface where users can select start and end dates. -->
     <string name="orderfilters_date_range_picker_title">Select dates</string>
 
     <!--
         Order Detail Views
     -->
+    <!-- Header text that appears at the top of a customer information card section on an order details screen, introducing customer-related data such as notes and contact information. -->
     <string name="orderdetail_customer_header">CUSTOMER</string>
+    <!-- This text displays a customer note on the order details screen, showing the actual note content surrounded by quotation marks. It appears in a expandable text section that can be clicked to edit the note when not in read-only mode. -->
     <string name="orderdetail_customer_note">\u0022%1$s\u0022</string>
+    <!-- Default text displayed when a customer's name is not available or empty in order details, booking summaries, and the dashboard orders list. This fallback label appears in place of the actual customer name across various order-related screens. -->
     <string name="orderdetail_customer_name_default">Guest</string>
+    <!-- This text appears as a screen title in the navigation bar when viewing or editing order details, displaying the order number (e.g., 'Order #12345'). It's used across multiple order-related screens including order detail view, order editing, and order note creation to help users identify which specific order they're working with. -->
     <string name="orderdetail_orderstatus_ordernum">Order #%s</string>
+    <!-- A section label in the order details screen that introduces the shipping method information for a customer's order. This appears as a heading above the actual shipping method details in the customer information section. -->
     <string name="orderdetail_shipping_method">Shipping method</string>
+    <!-- A section header label that appears on the order details screen, specifically labeling the customer's shipping address information section within the customer info area. -->
     <string name="orderdetail_shipping_details">Shipping details</string>
+    <!-- A section header label that appears on the order details screen, specifically labeling the billing information section within the customer info area. This text introduces the customer's billing address and payment details for a particular order. -->
     <string name="orderdetail_billing_details">Billing details</string>
+    <!-- Accessibility content description for an email button on the order details screen that allows users to send an email to the customer. This text is read by screen readers when users focus on the email icon button next to the customer's email address. -->
     <string name="orderdetail_email_contentdesc">email customer</string>
+    <!-- This text appears as a button label on the order details screen in the customer information section, allowing users to view all orders placed by that specific customer. -->
     <string name="orderdetail_view_customer_orders">View customer orders</string>
+    <!-- This text serves as accessibility content description for an image button in the order details customer information section that allows store managers to call or message the customer associated with the order. -->
     <string name="orderdetail_call_or_message_contentdesc">Call or message customer</string>
+    <!-- This text appears as a menu item and button label in the order details screen that allows store managers to initiate a phone call to the customer. It's part of the contact options available when viewing order information. -->
     <string name="orderdetail_call_customer">Call</string>
+    <!-- This text appears as a menu item label in the order details screen, allowing users to send an SMS message to the customer. It's part of a contact options menu that includes calling, messaging via SMS, WhatsApp, and Telegram. -->
     <string name="orderdetail_message_customer">Message</string>
+    <!-- This text appears as a menu item option in the order details screen that allows store owners to contact a customer via WhatsApp when viewing customer information for a specific order. -->
     <string name="orderdetail_message_customer_using_whatsapp">Contact using WhatsApp</string>
+    <!-- Menu item label that appears in a popup menu when viewing order details, allowing the store owner to contact a customer via Telegram messaging app using their phone number. -->
     <string name="orderdetail_message_customer_using_telegram">Contact using Telegram</string>
+    <!-- This text displays product line item information in order details, showing product attributes, quantity, and unit price in a formatted string (e.g., 'Color: Red • 2 x $15.99'). It appears as descriptive text below the product name in order detail views. -->
     <string name="orderdetail_product_lineitem_attributes">%1$s%2$s x %3$s</string>
+    <!-- A label that displays the SKU (Stock Keeping Unit) code for a product in order details and product cards. It appears when viewing order information and expandable product cards, showing the product's unique identifier in the format 'SKU: [code]'. -->
     <string name="orderdetail_product_lineitem_sku_value">SKU: %1$s</string>
+    <!-- A clickable text label that appears in order details and refund details screens, allowing users to view additional product add-ons or customizations associated with a line item. -->
     <string name="orderdetail_product_lineitem_view_addons_action">View Add-ons</string>
+    <!-- Accessibility content description for product images displayed in order details screens. This text is read aloud by screen readers when users navigate to product thumbnail images, but is not visible to sighted users. -->
     <string name="orderdetail_product_image_contentdesc">Product Image</string>
+    <!-- This text appears as a singular form label when displaying refund information in order details, specifically when exactly one product is being refunded. It's used in conjunction with quantity information to show what items were refunded. -->
     <string name="orderdetail_product">Product</string>
+    <!-- This text appears in order refund details to label multiple products when displaying the quantity and type of items being refunded (e.g., '3 Products'). It's used as part of a summary line that shows what was included in a refund alongside shipping and fees. -->
     <string name="orderdetail_product_multiple">Products</string>
+    <!-- Label text displayed in the order details screen when there is exactly one product in the order. This is part of a quantity-aware string system that shows either 'PRODUCT' (singular) or 'PRODUCTS' (plural) depending on the number of items. -->
     <string name="orderdetail_product_uppercase">PRODUCT</string>
+    <!-- A section header label that appears on the order details screen when displaying multiple products in an order, shown above the list of products. -->
     <string name="orderdetail_product_multiple_uppercase">PRODUCTS</string>
+    <!-- This appears as a column header label in the refund details screen, positioned above a list of products to indicate the quantity column for items being refunded. -->
     <string name="orderdetail_product_qty">QTY</string>
+    <!-- This text appears in the order details payment summary section when an order has been paid, displaying the payment date and payment method used (e.g., 'March 15, 2024 via Credit Card'). -->
     <string name="orderdetail_payment_summary_completed">%1$s via %2$s</string>
+    <!-- Displays as a status message in the order details payment section when an order has not yet been paid, showing which payment method the customer is expected to use. The %s placeholder is replaced with the specific payment method name (e.g., 'Credit Card', 'PayPal'). -->
     <string name="orderdetail_payment_summary_onhold">Awaiting payment via %s</string>
+    <!-- This text appears as a status message in the payment information section of an order details screen when no payment method is specified and the order payment is still pending. -->
     <string name="orderdetail_payment_summary_onhold_plain">Awaiting payment</string>
+    <!-- This text appears as a label in the order details payment information section, identifying the amount that has been paid by the customer. It's displayed alongside the actual payment amount in a horizontal layout within the payment information card. -->
     <string name="orderdetail_payment_paid_by_customer">Paid</string>
+    <!-- This text appears as a label in the order payment information section to indicate the refunded amount for an order. It's displayed alongside the refund total amount in the order details screen. -->
     <string name="orderdetail_refunded">Refunded</string>
+    <!-- This label appears in the order details screen to identify refunded items in a list format. It displays information about what was refunded, with the %1$s placeholder being replaced with specific refund details built by the system. -->
     <string name="orderdetail_refunded_line_with_info">Refunded: %1$s</string>
+    <!-- This text appears as a screen title when viewing a list of refunded products from an order in the WooCommerce app. It's displayed at the top of the screen to indicate the user is viewing products that have been refunded from a specific order. -->
     <string name="orderdetail_refunded_products">Refunded products</string>
+    <!-- This text appears in the order details screen showing refund information, displaying the refund date and payment method in a formatted string (e.g., 'Jan 15, 2024 via Credit Card'). -->
     <string name="orderdetail_refund_detail">%1$s via %2$s</string>
+    <!-- Label displayed in the order details payment information section that shows the net payment amount after any refunds have been deducted from the original order total. -->
     <string name="orderdetail_net">Net Payment</string>
+    <!-- This text wraps discount codes and gift card codes in parentheses on the order details payment information screen, displaying the specific codes used for discounts or gift cards applied to the order. -->
     <string name="orderdetail_discount_items">(%1$s)</string>
+    <!-- This text displays the refunded amount on the order details screen, shown as a negative value (with minus sign) next to each refund entry in the refunds list. -->
     <string name="orderdetail_refund_amount" translatable="false">-%1$s</string>
+    <!-- A label that appears in the order details payment information section, displayed next to the fees amount to identify additional charges like processing or handling fees for the order. -->
     <string name="orderdetail_payment_fees">Fees</string>
+    <!-- This text appears as the toolbar title in screens where users can edit customer notes for orders and simple payments. It serves as a header to identify the purpose of the editing screen. -->
     <string name="orderdetail_customer_provided_note">Customer provided note</string>
+    <!-- This text appears as placeholder text in a multi-line text input field where users can compose notes about an order. It's displayed in the add order note screen to guide users on what to enter in the text editor. -->
     <string name="orderdetail_note_hint">Compose an order note</string>
+    <!-- This text appears as a label in the order details screen to categorize order notes that are only visible to store administrators/staff and not to customers. It's displayed in parentheses next to the timestamp and author information in the note header. -->
     <string name="orderdetail_note_private">Private</string>
+    <!-- This text appears as a label in the order details screen to indicate that a note is visible to the customer. It's displayed in parentheses next to the timestamp and author information in the note header. -->
     <string name="orderdetail_note_public">To customer</string>
+    <!-- This text appears as a label in the order details screen to categorize notes that were automatically generated by the system (as opposed to notes written by customers or staff). It displays in parentheses next to the timestamp in the note header to help users identify the source of the note. -->
     <string name="orderdetail_note_system">System</string>
+    <!-- This text appears as a section header/title in the order details screen, specifically labeling the section that displays notes related to a customer's order. It uses uppercase styling to make it stand out as a card title within the order information layout. -->
     <string name="orderdetail_order_notes_uppercase">ORDER NOTES</string>
+    <!-- This text appears as placeholder text (hint) in a multi-line text input field where users can enter or edit notes that will be visible to customers on their order details. -->
     <string name="orderdetail_customer_note_hint">Edit a customer order note</string>
+    <!-- This is the label for an expandable button in the order details customer information section that reveals billing address details when tapped. The text toggles between 'Show Billing' when collapsed and 'Hide Billing' when expanded. -->
     <string name="orderdetail_show_billing">Show Billing</string>
+    <!-- Button text that appears in the order details screen to hide expanded billing address information. This is a toggle button that changes from 'Show Billing' to 'Hide Billing' when the customer billing information panel is expanded. -->
     <string name="orderdetail_hide_billing">Hide Billing</string>
+    <!-- This text appears as a clickable button label in the order details screen that allows users to add a note to an existing order. The button is positioned above a list of existing notes and includes an add icon alongside the text. -->
     <string name="orderdetail_add_note">Add a note</string>
+    <!-- This text serves as an accessibility content description for UI elements that allow users to add notes to orders. It appears on both an icon in the add note form and a clickable container in the order notes list that opens the add note functionality. -->
     <string name="orderdetail_addnote_contentdesc">Add an order note</string>
+    <!-- This text appears as a menu item in an overflow menu on the order details screen, allowing users to track a shipment by opening the tracking link in a browser or external app. -->
     <string name="orderdetail_track_shipment">Track shipment</string>
+    <!-- This text appears as a menu item in an overflow menu for order shipment tracking details, allowing users to copy a tracking number to their clipboard. It's used in the order details screen when viewing shipping information for WooCommerce orders. -->
     <string name="orderdetail_copy_tracking_number">Copy tracking number</string>
+    <!-- This text serves as the accessibility label for a delete button in order shipment tracking details, and also appears as a menu item title for deleting tracking information. It helps users understand they can remove tracking data from an order. -->
     <string name="orderdetail_delete_tracking">Delete tracking</string>
+    <!-- A warning notice that appears on the order details screen to inform users when shipping calculations are using extensions and the displayed shipping methods may not be complete. This text is displayed alongside a notice icon in a card-style warning container. -->
     <string name="orderdetail_shipping_notice">This order is using extensions to calculate shipping. The shipping methods shown might be incomplete.</string>
+    <!-- Button label that appears in order details screens to initiate a refund process for a customer's order. The text appears on both small action buttons and dropdown menu items in the WooCommerce Point of Sale interface. -->
     <string name="orderdetail_issue_refund_button">Issue refund</string>
+    <!-- This text appears as a button label in the order details payment section that allows merchants to collect card present payments from customers. The button is displayed alongside other payment actions like issuing refunds and viewing receipts. -->
     <string name="orderdetail_collect_payment_button">Collect Payment</string>
+    <!-- This text appears as a button label in the order details payment information section that allows users to view or download a receipt for their order. -->
     <string name="orderdetail_see_receipt_button">See receipt</string>
+    <!-- This text appears as a clickable informational link in the order details payment section that helps users learn how to print receipts using their mobile device. It's displayed with an info icon and provides access to printing instructions or documentation. -->
     <string name="orderdetail_printing_instructions_button">Learn more about printing receipts with your device</string>
+    <!-- This text appears as both a menu item label and accessibility description for a menu button in the order details screen's product list section. When tapped, it allows users to create a new shipping label for the order's products. -->
     <string name="orderdetail_products_recreate_shipping_label_menu">Create new shipping label</string>
+    <!-- A header label that appears on the order details screen for each shipping package, displaying a sequential package number (Package 1, Package 2, etc.) to help users identify and distinguish between multiple packages in an order. -->
     <string name="orderdetail_shipping_label_item_header">Package %d</string>
+    <!-- This text serves as the accessibility content description for a menu button in the order details screen's shipping label section, specifically describing the action to refund a shipping label. -->
     <string name="orderdetail_shipping_label_item_menu">Refund shipping label</string>
+    <!-- A label that appears on shipping label address screens to identify the origin address field, used when creating or editing shipping labels to distinguish the 'ship from' address from the 'ship to' address. -->
     <string name="orderdetail_shipping_label_item_shipfrom">Ship from</string>
+    <!-- This text appears as a section label in the shipping label creation flow, specifically identifying the destination address section where packages will be delivered. It's displayed as a header label above the destination address details on the shipping address configuration screen. -->
     <string name="orderdetail_shipping_label_item_shipto">Ship to</string>
+    <!-- This text appears as a section label in the shipping label details screen, identifying the package information section that displays details like package type and name. It also serves as the toolbar title when editing shipping label packages. -->
     <string name="orderdetail_shipping_label_item_package_info">Package details</string>
+    <!-- This text appears as a section label in the shipping label creation flow and order details screen, identifying the step or section where users select shipping carriers and view associated shipping rates for their packages. -->
     <string name="orderdetail_shipping_label_item_carrier">Shipping carriers and rates</string>
+    <!-- This text appears as both a screen title and step label in the shipping label creation flow, specifically for the payment method selection step where users choose how to pay for shipping labels. -->
     <string name="orderdetail_shipping_label_item_payment">Payment method</string>
+    <!-- This text appears as a label value in the shipping label details section of an order, specifically showing the payment method used to purchase the shipping label (displayed next to a money icon). -->
     <string name="orderdetail_shipping_label_item_payment_type">Credit card</string>
+    <!-- This text appears as a clickable row item in the order details screen that allows users to view a shipping label they have already purchased for an order shipment. -->
     <string name="orderdetail_shipping_label_item_view_purchased_shipping_label">View purchased shipping label</string>
+    <!-- Button text that allows users to expand and view detailed shipping information for a shipping label in the order details screen. The text toggles between 'Show' and 'Hide' states as users expand/collapse the shipping details panel. -->
     <string name="orderdetail_shipping_label_item_show_shipping">Show shipment details</string>
+    <!-- Button text that appears on an expandable shipping label details section in the order details screen. When the shipping details are expanded, this text replaces 'Show shipment details' to allow users to collapse the expanded information. -->
     <string name="orderdetail_shipping_label_item_hide_shipping">Hide shipment details</string>
+    <!-- A label displaying shipping carrier information on the order details screen, showing the shipping service name and cost formatted as two separate lines. -->
     <string name="orderdetail_shipping_label_carrier_info">%1$s\n%2$s</string>
+    <!-- This text appears as a title/label in the order details screen when displaying information about a shipping label that has had a refund requested. The %1$s placeholder is replaced with the shipping service name (like 'USPS Priority Mail label refund requested'). -->
     <string name="orderdetail_shipping_label_refund_title">%1$s label refund requested</string>
+    <!-- This text appears as a subtitle in the order details screen when displaying refunded shipping labels, showing the refund amount and date in a formatted string with a bullet separator. -->
     <string name="orderdetail_shipping_label_refund_subtitle">%1$s \u2022 %2$s</string>
+    <!-- This text appears as both a menu option in an overflow menu for purchased shipping labels and as the title of the refund request screen. It allows users to initiate a refund process for a shipping label they have purchased. -->
     <string name="orderdetail_shipping_label_request_refund">Request a refund</string>
+    <!-- This text appears as a menu item in the shipping label section of order details, allowing users to print customs documentation required for international shipments. -->
     <string name="orderdetail_shipping_label_print_customs_form">Print customs form</string>
+    <!-- This label appears as a header in the order details shipping section to identify products that have not been assigned to any shipping package or label yet. -->
     <string name="orderdetail_shipping_label_unpackaged_products_header">Remaining products</string>
+    <!-- This text appears as a button label in the order details screen that allows users to print a shipping label for a specific package. The button is displayed within a shipping label item view alongside package tracking information. -->
     <string name="orderdetail_shipping_label_print">Print shipping label</string>
+    <!-- Button text that appears on the order details screen when a shipping label has not yet been purchased for a shipment, allowing the user to initiate the shipping label creation process. -->
     <string name="orderdetail_shipping_label_create_shipping_label">Create shipping label</string>
+    <!-- This text appears as an informational notice on the order details screen, displayed below shipping-related buttons to guide users about creating shipping labels on mobile devices. It includes an info icon and is clickable, likely leading to help documentation or tutorials. -->
     <string name="orderdetail_shipping_label_notice">Learn more about creating labels with your mobile device</string>
+    <!-- This text appears as a header label in the order details screen showing shipping information, displaying the current shipment number out of total shipments (e.g., 'Shipment 1/3'). It helps users identify which specific shipment they are viewing when an order has multiple shipments. -->
     <string name="orderdetail_shipping_label_shipment_header">Shipment %1$s</string>
+    <!-- This text appears as a clickable label in the order details screen for WooCommerce shipping shipments, showing the count when exactly one item is being shipped. The label is used both in a row display and as a dialog title when users tap to view shipment item details. -->
     <string name="orderdetail_shipping_label_shipment_items_one">%1$d item</string>
+    <!-- This text appears as a clickable label in the order details shipping section, showing the count of items in a shipment (e.g., "5 items"). It's used both as a row label that users can tap to view shipment details and as a dialog title when the detailed item list is displayed. -->
     <string name="orderdetail_shipping_label_shipment_items_multiple">%1$d items</string>
+    <!-- This text appears as an informational message in the order details screen when a shipping label refund has been successfully requested. It displays in a highlighted box below the shipping information to confirm the refund status and inform the user they can purchase a replacement label. -->
     <string name="orderdetail_shipping_label_refunded">You have successfully submitted a request for refund. You can purchase a new label.</string>
+    <!-- This text appears as a button label on an order details screen that allows users to view or edit custom fields associated with a specific order. The button is displayed within a card layout and includes a pencil icon, indicating it's an interactive element for accessing custom field functionality. -->
     <string name="orderdetail_custom_fields">Custom fields</string>
+    <!-- This is a button label that appears on the order detail screen, allowing users to generate an AI-powered thank-you note for a customer order. The button includes a sparkle emoji (✨) to indicate AI functionality and triggers the creation process when tapped. -->
     <string name="orderdetail_ai_create_thank_you_note_button">✨Create thank-you note</string>
+    <!-- This text appears as the title in the toolbar/navigation bar of a receipt preview screen where users can view a generated receipt before printing or sharing it. -->
     <string name="receipt_preview_toolbar_title">Receipt Preview</string>
+    <!-- This text appears as a menu item in the receipt preview screen that allows users to print a receipt. It's displayed in the app's action menu (likely in the top toolbar) when viewing a receipt. -->
     <string name="receipt_preview_print_menu_item">Print</string>
+    <!-- This text appears as a menu item label in the receipt preview screen, allowing users to send the receipt (likely via email, messaging, or other sharing options). -->
     <string name="receipt_preview_send_menu_item">Send</string>
+    <!-- Button text that appears on order fulfillment and order detail screens, allowing users to mark an order as complete when all items have been processed or shipped. -->
     <string name="order_mark_complete">Mark order complete</string>
+    <!-- This text appears in a snackbar message that displays when an order fulfillment is completed from the fulfill screen, providing confirmation feedback to the user with an undo option. -->
     <string name="order_fulfill_completed">🎉 Order completed!</string>
+    <!-- This text appears in a snackbar message (temporary notification) that confirms when an order's status has been successfully changed in the order details screen. The message includes an undo action allowing users to revert the status change. -->
     <string name="order_status_updated">Order status updated</string>
+    <!-- Error message displayed as a snackbar notification when the app fails to fetch order notes from the server in the order details screen. -->
     <string name="order_error_fetch_notes_generic">Error fetching notes</string>
+    <!-- Error message displayed as a snackbar/toast notification when updating an order fails, such as when changing order status or editing order details encounters a server error. -->
     <string name="order_error_update_general">Error changing order</string>
+    <!-- Error message displayed to users when they attempt to update an order's address information but the email field is empty, suggesting they update their WooCommerce version to resolve the issue. -->
     <string name="order_error_update_empty_mail">Unable to update address with empty email. Make sure you are running the latest version of WooCommerce.</string>
+    <!-- Error message displayed as a snackbar notification when the app fails to fetch or load order details from the server. This appears in the order details screen and during card payment processing flows when order data cannot be retrieved. -->
     <string name="order_error_fetch_generic">Error fetching order</string>
+    <!-- This text appears as a label for tracking number sections in order shipment details, specifically used when displaying shipping label information to identify the tracking number field. -->
     <string name="order_shipment_tracking">Tracking</string>
+    <!-- A label that appears above tracking numbers in the order shipment details screen, identifying the tracking number field when displaying shipping information to users. -->
     <string name="order_shipment_tracking_number">Tracking Number</string>
+    <!-- This text appears in a toast notification that confirms to the user that a shipment tracking number has been successfully copied to their device's clipboard when they tap a copy action in the order details screen. -->
     <string name="order_shipment_tracking_number_clipboard">Tracking number copied to the clipboard</string>
+    <!-- Accessibility content description for image buttons that allow users to track shipments or view tracking options in order details and shipping label views. This text is read by screen readers when users focus on the tracking button but is not visible on screen. -->
     <string name="order_detail_shipment_tracking_button_contentdesc">Track or delete shipment tracking</string>
+    <!-- Accessibility content description for the shipment tracking section that appears on order detail and order fulfillment screens, helping screen readers identify this section when users navigate through order information. -->
     <string name="order_shipment_tracking_section_cd">Shipment tracking</string>
+    <!-- This text serves as an accessibility description for a clickable area containing shipment tracking information in the order details screen. When users tap on the tracking information section, it copies the tracking number to their device's clipboard. -->
     <string name="order_shipment_tracking_copy_to_clipboard">Copy tracking number to clipboard</string>
+    <!-- Button label that appears in the order details screen's shipment tracking section, allowing users to add new tracking information for an order shipment. -->
     <string name="order_shipment_tracking_add_button">Add tracking</string>
+    <!-- A confirmation message displayed in a snackbar (temporary notification) after a user deletes shipment tracking information from an order, with an option to undo the deletion. -->
     <string name="order_shipment_tracking_delete_snackbar_msg">Deleted shipment tracking</string>
+    <!-- Error message displayed as a snackbar notification when the user attempts to delete a shipment tracking entry for an order but the deletion fails due to a network or server error. -->
     <string name="order_shipment_tracking_delete_error">Error deleting tracking</string>
+    <!-- Success message displayed in a snackbar (temporary notification) when a user successfully deletes shipment tracking information from an order in the WooCommerce app. -->
     <string name="order_shipment_tracking_delete_success">Tracking deleted</string>
+    <!-- Error message displayed when barcode scanning fails while trying to scan a tracking number for order shipment tracking. This message appears to inform the user that the barcode scan was unsuccessful and they should retry the operation. -->
     <string name="order_shipment_tracking_barcode_scanning_failed">Scanning failed. Please try again later</string>
+    <!-- This informational notice appears below a list of add-ons in an order details screen, warning users that renamed add-ons from their web dashboard won't display correctly in previous mobile app orders. -->
     <string name="ordered_add_ons_details_info_notice">If renaming an add-on in your web dashboard, please note that previous orders will no longer show that add-on within the app.</string>
+    <!-- This text appears as the title of a work-in-progress notification card shown on the ordered add-ons screen, informing users they can view product add-ons from their device while the feature is still being developed. -->
     <string name="ordered_add_ons_wip_title">View add-ons from your device!</string>
+    <!-- This text appears as a message in a WIP (Work in Progress) notification card on the ordered add-ons screen, explaining to users that product add-on functionality is still being developed and directing them to use the web dashboard for editing. -->
     <string name="ordered_add_ons_wip_message">We are working on making it easier for you to see product add-ons from your device! For now, you’ll be able to see the add-ons for your orders. You can create and edit these add-ons in your web dashboard.</string>
+    <!-- This text appears as the title of an error dialog that is displayed when the app fails to load add-on products for an order. The dialog appears in the product add-ons section and includes an OK button that navigates the user back to the previous screen. -->
     <string name="ordered_add_ons_loading_failed_dialog_title">Something went wrong</string>
+    <!-- This text appears as the message body in an error dialog that displays when the app fails to load order add-ons data. The dialog includes this message along with a title and an OK button that navigates the user back to the previous screen. -->
     <string name="ordered_add_ons_loading_failed_dialog_message">Sorry, we couldn\'t load the Order Add-ons right now</string>
+    <!-- This text appears as the positive action button in an error dialog that displays when the app fails to load add-ons for a product order. When tapped, this button dismisses the dialog and navigates the user back to the previous screen. -->
     <string name="ordered_add_ons_loading_failed_dialog_ok_action">OK</string>
+    <!-- This text appears as a placeholder hint in first name input fields within forms, specifically in the domain registration contact information form and address editing form. It guides users to enter their first name in the text input field. -->
     <string name="order_detail_edit_address_details_first_name">First name</string>
+    <!-- This text appears as a placeholder hint in a text input field for entering a person's last name/surname, used in address forms and contact information screens within the WooCommerce mobile app. -->
     <string name="order_detail_edit_address_details_last_name">Last name</string>
+    <!-- This text appears as a hint/placeholder in an email input field within the address form on the order detail editing screen. It guides users to enter their email address as part of their billing or shipping address information. -->
     <string name="order_detail_edit_address_details_email">Email</string>
+    <!-- This text appears as a placeholder/hint text in a phone number input field within an address form, likely shown when editing billing or shipping address details for an order. -->
     <string name="order_detail_edit_address_details_phone">Phone</string>
+    <!-- Appears as a hint/placeholder text in a company name input field within an address editing form, likely on an order details screen where users can modify shipping or billing addresses. -->
     <string name="order_detail_edit_address_company">Company</string>
+    <!-- This text appears as a placeholder/hint in the first address input field within an address editing form, typically used when editing shipping or billing addresses for orders. It helps users understand they should enter the primary street address line in this field. -->
     <string name="order_detail_edit_address_line1">Address 1</string>
+    <!-- This is a placeholder text that appears in the second address line input field of an address form, typically used when editing shipping or billing addresses in order details. It helps users understand this field is for additional address information like apartment numbers, suite numbers, or building names. -->
     <string name="order_detail_edit_address_line2">Address 2</string>
+    <!-- This text appears as a placeholder hint in a city input field within an address form, likely used when editing shipping or billing addresses for orders in the WooCommerce app. -->
     <string name="order_detail_edit_address_city">City</string>
+    <!-- This text appears as a hint/placeholder text in a postal code input field within an address form, likely displayed when editing order delivery or billing addresses. -->
     <string name="order_detail_edit_address_zip">Postal Code</string>
+    <!-- Section header label that appears in an address form within order details, used to identify the address input section of the form. -->
     <string name="order_detail_address_section">Address</string>
+    <!-- This text appears as a section header and form title on shipping address editing screens in the WooCommerce order management interface. It's displayed in the toolbar title, section headers, and accessibility labels when users are viewing or editing shipping address information for orders. -->
     <string name="order_detail_shipping_address_section">Shipping Address</string>
+    <!-- This text appears as a section header and form title in the order management feature when editing billing address information. It's used in multiple contexts including as an accessibility header for address forms, a toolbar title, and section header when merchants edit billing addresses for customer orders. -->
     <string name="order_detail_billing_address_section">Billing Address</string>
+    <!-- This text appears as a clickable label in the customer information section of an order details screen, displayed when there is no customer note yet. It prompts the user to add a customer note and is shown with an add icon. -->
     <string name="order_detail_add_customer_note">Add customer note</string>
+    <!-- Placeholder text displayed in the shipping address field on the order details screen when no shipping address has been provided for the order. It prompts the user to add a shipping address by tapping on the field. -->
     <string name="order_detail_add_shipping_address">Add shipping address</string>
+    <!-- This text appears as a clickable prompt in the order details customer information section when no billing address is present, allowing users to add a billing address to the order. -->
     <string name="order_detail_add_billing_address">Add billing address</string>
+    <!-- Text displayed in the order details customer information section when billing address information is missing but other billing details (like email or phone) are present in read-only view mode. -->
     <string name="orderdetail_empty_address">No address specified</string>
+    <!-- This text appears as a label for a switch/toggle control on the shipping address editing screen that allows users to copy the shipping address to use as the billing address for the order. -->
     <string name="order_detail_use_as_billing_address">Use as Billing Address</string>
+    <!-- This text appears as a switch/toggle label on the billing address editing screen, allowing users to copy their billing address to use as their shipping address for the order. -->
     <string name="order_detail_use_as_shipping_address">Use as Shipping Address</string>
+    <!-- This text appears as a section header in the order details screen, displayed above the payment totals breakdown that shows subtotals, shipping, taxes, and final total amounts for a WooCommerce order. -->
     <string name="order_detail_payment_header">PAYMENT TOTALS</string>
+    <!-- Section header displayed above custom fee line items on the order details screen in a WooCommerce store management app. This label categorizes and introduces additional charges or services that were added to an order beyond the standard product costs. -->
     <string name="order_detail_custom_amounts_header">CUSTOM AMOUNTS</string>
+    <!-- A section header that appears above shipping information on the order details screen in a WooCommerce mobile app. It labels the shipping section that displays shipping line items with their methods and costs. -->
     <string name="order_detail_shipping_header">SHIPPING</string>
     <string name="order_detail_attribution_header">Order attribution</string>
+    <!-- A label displayed in the order details screen that identifies the origin or source where the customer's order came from (e.g., website, mobile app, social media). This appears as a field title in an expandable attribution information section that shows order tracking details. -->
     <string name="order_detail_attribution_origin">Origin</string>
+    <!-- This text appears as a label in the order details screen to show the attribution origin when an order came through organic traffic, with %1$s being replaced by the specific organic source name (or 'Unknown' if not available). -->
     <string name="order_detail_attribution_organic_origin">Organic: %1$s</string>
+    <!-- This text appears as a label in the order details screen to show the referral source that led to an order, where %1$s is replaced with the actual referral source name (or 'Unknown' if not available). -->
     <string name="order_detail_attribution_referral_origin">Referral: %1$s</string>
+    <!-- This text appears as a label in the order details screen showing the UTM source attribution for how a customer found the store. It displays in an attribution information section with the %1$s placeholder being replaced by the actual source name (e.g., 'Source: Google' or 'Source: Facebook'). -->
     <string name="order_detail_attribution_utm_origin">Source: %1$s</string>
+    <!-- This text appears as a label in the order details screen to indicate that a customer found the store through direct traffic (typing URL directly, bookmarks, etc.) rather than through referrals or search engines. It's displayed as part of the order attribution information showing how the customer originally discovered the store. -->
     <string name="order_detail_attribution_direct_origin">Direct</string>
+    <!-- A label that appears in the order details screen to indicate that an order was created through the web admin interface. This text identifies the origin/source of the order as part of order attribution information displayed to store managers. -->
     <string name="order_detail_attribution_admin_origin">Web admin</string>
+    <!-- This text appears as a label in the order details screen to indicate that an order originated from a mobile app, helping merchants understand the source channel of their orders. -->
     <string name="order_detail_attribution_mobile_origin">Mobile App</string>
+    <!-- This text appears in the order details screen when the source of an order attribution (how the customer found the store) cannot be determined. It displays as a fallback label when UTM, referral, or organic traffic source information is missing or unavailable. -->
     <string name="order_detail_attribution_unknown_origin">Unknown</string>
+    <!-- This text appears as a field label in the order details screen under the attribution information section, specifically labeling the source type data that describes how the customer found the store (e.g., organic search, paid advertising, direct visit). -->
     <string name="order_detail_attribution_source_type">Source type</string>
+    <!-- This text appears as a field label in the order details screen, specifically in the attribution information section that shows marketing data about how the customer found the store. It labels the specific source value (like a website URL or referrer) that led to the order. -->
     <string name="order_detail_attribution_source">Source</string>
+    <!-- This text appears as a field label in the order details screen, specifically in the attribution information section that shows how a customer found the store (e.g., through social media, email, search, etc.). -->
     <string name="order_detail_attribution_medium">Medium</string>
+    <!-- This text appears as a field label in the order details screen, specifically in an expandable attribution information section that shows marketing campaign data for how the customer found the store. -->
     <string name="order_detail_attribution_campaign">Medium</string>
+    <!-- This text appears as a label in the order details screen within an attribution information section, specifically identifying the device type field where a customer's device information (like mobile, tablet, or desktop) is displayed. -->
     <string name="order_detail_attribution_device_type">Device type</string>
+    <!-- This text appears as a label in the order details screen within the attribution information section, displayed alongside the number of pages viewed during the customer's session before placing the order. -->
     <string name="order_detail_attribution_session_page_views">Session page views</string>
+    <!-- This text appears as a button label in the order details screen that allows users to move an order to trash/delete it. It appears both as a standalone button on the order detail view and as the positive action button in a confirmation dialog when the user attempts to delete an order. -->
     <string name="order_detail_move_to_trash">Move to trash</string>
+    <!-- This message appears in a confirmation dialog when a user attempts to delete an order, asking them to confirm before moving the order to trash. It's displayed in the order details screen when the user taps a trash/delete action. -->
     <string name="order_detail_trash_order_dialog_message">Do you want to move this order to the trash?</string>
 
     <!--
         Shipping label Refunds
     -->
+    <!-- This text appears as an informational message on the shipping label refund screen, explaining to users the conditions and timeline for requesting a refund of unused shipping labels. -->
     <string name="shipping_label_refund_message">You can request a refund for a shipping label that has not been used to ship a package. It will take at least 14 days to process.</string>
+    <!-- A section header label that appears on the shipping label refund screen, displayed above the actual purchase date value to identify when the shipping label was originally purchased. -->
     <string name="shipping_label_refund_purchase_date_title">Purchase date</string>
+    <!-- This text appears as a section title on the shipping label refund screen, labeling the refund amount field that shows how much money the user can get back when requesting a refund for a shipping label. -->
     <string name="shipping_label_refund_amount_title">Amount eligible for refund</string>
+    <!-- This is the label for a button that initiates a shipping label refund process, displaying the refundable amount in parentheses with a minus sign (e.g., 'Refund label (-$7.50)'). The button appears on shipping label refund screens where users can request refunds for purchased shipping labels. -->
     <string name="shipping_label_refund_button">Refund label (-%1$s)</string>
+    <!-- This text appears as a snackbar notification message shown to the user after they successfully submit a refund request for a shipping label in the orders section. It confirms that the refund request has been processed and submitted successfully. -->
     <string name="shipping_label_refund_success">Refund request was successfully submitted</string>
+    <!-- A progress message displayed in a snackbar (temporary notification) when a user initiates a shipping label refund, informing them that the refund request is being processed and they should wait. -->
     <string name="shipping_label_refund_progress_message">Your refund is being processed. Please wait…</string>
+    <!-- This text appears as a warning banner message in the shipping label refund screen to inform users that shipping labels cannot be refunded after 30 days have passed since purchase. -->
     <string name="shipping_label_refund_expired">Labels older than 30 days cannot be refunded</string>
     <!--
         Fulfill order
     -->
+    <!-- This text appears as the toolbar/navigation title at the top of the order fulfillment screen where users review order details before fulfilling them. -->
     <string name="order_fulfill_title">Review order</string>
+    <!-- This informational text appears on the order fulfillment screen below shipment tracking details, explaining to merchants that customers will receive a confirmation email when an order is marked as complete (if email notifications are enabled in settings). -->
     <string name="order_fulfill_email_info">If you’ve enabled this setting, the customer will receive a confirmation email once the order is completed</string>
 
     <!--
         Print shipping labels
     -->
+    <!-- This error message appears on the shipping label print screen when there was a printing issue, explaining to users that they can reprint the label if needed. It displays as instructional text above a disclaimer section to help users understand their reprint options. -->
     <string name="shipping_label_print_error_message">If there was a printing error when you purchased the label, you can print it again.</string>
+    <!-- A disclaimer text that appears below an info icon in the shipping label print screen, warning users about the terms of service violation when reusing already-used shipping labels. -->
     <string name="shipping_label_print_disclaimer">If you already used the label on a package, printing and using it again is a violation of our terms of service.</string>
+    <!-- This text appears as a hint/label for a dropdown selector on the shipping label printing screen, where users can choose the paper size (Legal, Letter, or Label) for printing their shipping labels. -->
     <string name="shipping_label_paper_size">Paper size</string>
+    <!-- This text appears as the title of a dialog box that allows users to select paper size options when creating shipping labels for orders. The dialog presents radio button choices for different paper sizes (Legal, Letter, Label) that users can select from. -->
     <string name="shipping_label_paper_size_options_title">Choose paper size</string>
+    <!-- Button label that appears on shipping label screens in a WooCommerce app, allowing users to print a single shipping label after purchase. The button is displayed prominently below paper size selection options and triggers the actual printing process when tapped. -->
     <string name="shipping_label_print_button">Print shipping label</string>
+    <!-- Button label that appears in the shipping label printing screen when multiple shipping labels are selected for printing. This button triggers the action to print all selected shipping labels at once. -->
     <string name="shipping_label_print_multiple_button">Print shipping labels</string>
+    <!-- This text appears as both a clickable label and accessibility description for an icon in the shipping label printing screen, allowing users to access paper size and layout configuration options. -->
     <string name="shipping_label_paper_size_options_info">See label layout and paper size options</string>
+    <!-- This text appears on the shipping label print screen as informational text next to an info icon, offering help to users who may be unsure about printing from their mobile device. -->
     <string name="shipping_label_print_info">Don\'t know how to print with your mobile device?</string>
+    <!-- A success message displayed on the print shipping label screen after a single shipping label has been successfully purchased, appearing above a confirmation image and print options. -->
     <string name="shipping_label_print_purchase_success">Shipping label purchased!</string>
+    <!-- A success message displayed on the print shipping label screen when multiple shipping labels have been successfully purchased, informing the user they can now proceed to print them. -->
     <string name="shipping_label_print_multiple_purchase_success">Shipping labels purchased!</string>
+    <!-- This text appears on a button in the shipping label printing screens that allows users to postpone printing shipping labels or customs forms. It's displayed as a secondary action button below the main print button, giving users the option to save their progress and return to complete the printing process later. -->
     <string name="shipping_label_print_save_for_later">Save for later</string>
+    <!-- This is a screen title that appears at the top of the print shipping label screen when there is a single shipping label to print (as opposed to multiple labels). It displays in the navigation bar or header area of the screen where users can print previously purchased shipping labels. -->
     <string name="shipping_label_print_screen_title">Print shipping label</string>
+    <!-- This text appears as the screen title when users are printing multiple shipping labels at once, displayed in the navigation bar or header area of the print shipping labels screen. -->
     <string name="shipping_label_print_multiple_screen_title">Print shipping labels</string>
+    <!-- Error message displayed as a snackbar notification when the app fails to preview a shipping label PDF file, either due to network issues during label generation or file system problems when saving the preview. -->
     <string name="shipping_label_preview_error">Error previewing shipping label</string>
+    <!-- Error message displayed as a toast notification when a user tries to preview a shipping label PDF but no PDF viewer app is installed on their device. This appears in the shipping/order management section when the system cannot find an appropriate app to open the PDF file. -->
     <string name="shipping_label_preview_pdf_app_missing">Unable to preview shipping label. Please install a PDF viewer app and try again.</string>
+    <!-- This text appears as an option for selecting Legal paper size (8.5 x 14 inches) when printing shipping labels, displayed in both a paper size selector dialog and as a label for format options in the shipping label interface. -->
     <string name="shipping_label_paper_size_legal">Legal (8.5 x 14 in)</string>
+    <!-- This text appears as a selectable option in the WooCommerce shipping label paper size selection interface, representing the A4 paper format with its dimensions in millimeters. -->
     <string name="shipping_label_paper_size_a4">A4 (210 x 297mm)</string>
+    <!-- This text appears as a selectable option in shipping label paper size selection dialogs and format option screens, representing the Letter paper size with its dimensions in inches. It's displayed as a choice that users can select when configuring shipping label printing preferences. -->
     <string name="shipping_label_paper_size_letter">Letter (8.5 x 11 in)</string>
+    <!-- This text appears as a selectable option in a dialog for choosing shipping label paper size, specifically representing a 4x6 inch label format. It's used both in the paper size selector dialog and on the label format options screen where users can view and select different paper size options for printing shipping labels. -->
     <string name="shipping_label_paper_size_label">Label (4 x 6 in)</string>
+    <!-- This is the step number displayed inside a circular button in the printing instructions screen, indicating the first step of a multi-step process for printing receipts or labels. -->
     <string name="print_receipt_label_info_step_count_1" translatable="false">1</string>
+    <!-- This is a step number displayed inside a circular button in the printing instructions screen, indicating step 2 of a multi-step process for receipt/label printing setup. -->
     <string name="print_receipt_label_info_step_count_2" translatable="false">2</string>
+    <!-- This text appears as the number label inside a circular button for step 3 in the printing instructions screen, which shows users a numbered sequence of steps for printing receipts or labels. -->
     <string name="print_receipt_label_info_step_count_3" translatable="false">3</string>
+    <!-- This is the number '4' displayed inside a circular button that serves as a step counter in the printing instructions screen. It appears as part of a numbered sequence guiding users through the process of printing receipts or labels. -->
     <string name="print_receipt_label_info_step_count_4" translatable="false">4</string>
+    <!-- This text appears as the number label inside a circular button for step 5 of the receipt/label printing instructions screen. It serves as a visual step indicator in a sequential instruction flow. -->
     <string name="print_receipt_label_info_step_count_5" translatable="false">5</string>
+    <!-- This is the step number '6' displayed in a circular button as part of a numbered sequence in the printing instructions screen. It appears as a visual step indicator alongside the corresponding instruction text for step 6. -->
     <string name="print_receipt_label_info_step_count_6" translatable="false">6</string>
+    <!-- This is the step number displayed in a circular button for step 7 of the printing instructions screen, which guides users through the process of printing receipts and labels. -->
     <string name="print_receipt_label_info_step_count_7" translatable="false">7</string>
+    <!-- This text appears as the first step instruction in a printing setup guide screen, displayed next to a numbered step indicator. It's part of a multi-step tutorial that helps users configure their printer for receipt/label printing in the WooCommerce app. -->
     <string name="print_receipt_label_info_step_1">Make sure the Print Service Plugin for your printer is installed.</string>
+    <!-- This text appears as step 2 in a printer setup instructions screen within a WooCommerce mobile app, displayed as instructional text next to a numbered step indicator to guide users through the receipt/label printing setup process. -->
     <string name="print_receipt_label_info_step_2">Enable bluetooth or Wifi connection on your printer.</string>
+    <!-- This text appears as step 3 in a printer setup instructions screen, guiding users through the process of configuring receipt printing by explaining how to find and select printers in the system print dialog. -->
     <string name="print_receipt_label_info_step_3">When selecting "Print receipt" after accepting payment, replace "Save as PDF" with "All printers", and search for new printer.</string>
+    <!-- This text appears as step 4 in a printer setup instructions screen within the WooCommerce mobile app, guiding users through the process of connecting a receipt/label printer to their mobile device. -->
     <string name="print_receipt_label_info_step_4">Pair and connect the printer to your mobile when prompted.</string>
+    <!-- This text appears as step 5 in a printing instructions screen that guides users through the process of printing receipts or labels. It's displayed as instructional text alongside a numbered step indicator, advising users to adjust paper size settings before completing the print action. -->
     <string name="print_receipt_label_info_step_5">Adjust paper size as needed, and select "Print" when ready to print the receipt.</string>
+    <!-- This text appears as step 6 in a printing instructions screen, providing users with an alternative method to print receipts when direct printing is unavailable. It's displayed as informational text in a step-by-step guide for receipt printing functionality. -->
     <string name="print_receipt_label_info_step_6">If printing is not available, you can always save your receipt as PDF and send it by email to print it from another device.</string>
+    <!-- This text appears as step 7 in a printing instructions screen that guides users through setting up receipt and label printing. It serves as troubleshooting advice displayed alongside a numbered step indicator when users need help resolving printer connectivity issues. -->
     <string name="print_receipt_label_info_step_7">If you are experiencing issues printing from your device, contact customer support for your printer.</string>
+    <!-- This text appears as the toolbar title on a screen that provides instructions for printing shipping labels directly from the user's mobile device. It serves as the main heading for an informational page that guides users through the printing process. -->
     <string name="print_shipping_label_info_title">Print with your device</string>
+    <!-- This text appears as the title in the toolbar/navigation bar of a screen where users can configure options for printing shipping label formats. It serves as the main heading that identifies the current screen's purpose within the shipping label workflow. -->
     <string name="print_shipping_label_format_options_title">Label format options</string>
+    <!-- This text appears as a step number inside a circular button on the shipping label printing instructions screen, specifically marking the first step in a multi-step process guide. -->
     <string name="print_shipping_label_info_step_count_1" translatable="false">1</string>
+    <!-- This text appears as the number label on a circular step indicator button in the shipping label printing instructions screen, specifically marking step 2 of a multi-step process. -->
     <string name="print_shipping_label_info_step_count_2" translatable="false">2</string>
+    <!-- This text appears as the number label inside a circular button for step 3 in the shipping label printing instruction flow, displayed as part of a numbered step sequence on the print shipping label info screen. -->
     <string name="print_shipping_label_info_step_count_3" translatable="false">3</string>
+    <!-- This text appears as the number displayed inside a circular button representing step 4 in the print shipping label information screen. It's part of a step-by-step guide showing the shipping label printing process. -->
     <string name="print_shipping_label_info_step_count_4" translatable="false">4</string>
+    <!-- This text appears as the number '5' inside a circular button that serves as a step indicator in the shipping label printing instructions screen. It's the fifth step marker in a multi-step process guide that shows users how to print shipping labels. -->
     <string name="print_shipping_label_info_step_count_5" translatable="false">5</string>
+    <!-- This text appears as an instructional step in a shipping label printing tutorial screen, specifically as step 1 in a multi-step guide that explains how to print shipping labels from the WooCommerce app. It's displayed as formatted text with HTML bold tags around 'same WiFi networks' to emphasize this important requirement. -->
     <string name="print_shipping_label_info_step_1">Make sure your printer and your device are connected to the &lt;b&gt;same WiFi networks&lt;/b&gt;</string>
+    <!-- This text appears as step 2 in a multi-step instructional guide explaining how to print shipping labels, displayed in an information screen that users can reference before attempting to print labels for their orders. -->
     <string name="print_shipping_label_info_step_2">After selecting &lt;b&gt;\"Print shipping label\"&lt;/b&gt;, you may have to select and add a printer if you haven\'t printed from this device before.</string>
+    <!-- This text appears as step 3 in a multi-step instructional guide on the shipping label printing information screen, explaining printer service options to users. The text contains HTML bold formatting for emphasis on key terms and is displayed as informational content in a tutorial-style interface. -->
     <string name="print_shipping_label_info_step_3">You can select your device\'s &lt;b&gt;default print service&lt;/b&gt; or install your &lt;b&gt;printer\'s brand app&lt;/b&gt; (this should appear as a recommended option)</string>
+    <!-- This text appears as step 4 in a multi-step instruction guide on the shipping label printing information screen, providing technical guidance about configuring WiFi printing on the printer device itself. -->
     <string name="print_shipping_label_info_step_4">You might have to &lt;b&gt;configure WiFi printing directly on the printer itself.&lt;/b&gt; Make sure the printer firmware is updated and see your printer documentation for instructions.</string>
+    <!-- This text appears as step 5 in a shipping label printing troubleshooting guide, providing an alternative solution when users can't print directly from their mobile device. It's displayed as instructional text with HTML formatting to emphasize the 'save as PDF' option. -->
     <string name="print_shipping_label_info_step_5">If you are still experiencing issues printing from your device, you can &lt;b&gt;save your label as PDF&lt;/b&gt; and send it by email to print it from another device.</string>
+    <!-- This message appears in a warning banner on the shipping label reprint screen to inform users that label images older than 180 days have been automatically deleted for security reasons. It explains why older shipping labels cannot be reprinted and provides context about the data retention policy. -->
     <string name="shipping_label_reprint_expired_message">Label images older than 180 days are deleted by our technology partners for general security and data privacy concerns.</string>
 
     <!--
         Create shipping labels
     -->
+    <!-- This text appears as the screen title when users navigate to an informational screen about creating shipping labels, accessed from the shipping label creation flow in the WooCommerce app. -->
     <string name="shipping_label_more_information_title">WooCommerce Shipping</string>
+    <!-- This is a heading displayed on an informational screen about WooCommerce Shipping labels, appearing prominently at the top of the screen to introduce users to the benefits of using the shipping service. The text is displayed in a bold, headline style and serves as the main promotional message before additional details and images about the feature. -->
     <string name="shipping_label_more_information_heading">Save time and money by fulfilling with WooCommerce Shipping</string>
+    <!-- This text appears as a message on an informational screen about shipping labels, explaining the benefits of printing shipping labels at home using the mobile device. It's displayed in the center of the screen below an image of a phone, as part of an educational flow about shipping label functionality. -->
     <string name="shipping_label_more_information_message">Cut the post office line by printing shipping labels at home with your mobile device at discounted rates!</string>
+    <!-- This text appears as a clickable button link on an information screen about shipping labels, allowing users to learn more about the shipping label feature when creating or managing shipping labels for orders. -->
     <string name="shipping_label_more_information_link">Learn more</string>
+    <!-- This text appears as the toolbar title on the shipping label creation screen in a WooCommerce Android app, displayed at the top of the screen when users are creating new shipping labels for orders. -->
     <string name="shipping_label_create_title">Create shipping label</string>
+    <!-- This text appears as a step caption/title in the shipping label creation workflow, specifically labeling the packaging configuration step where users set up package details like weight and dimensions. -->
     <string name="shipping_label_create_packaging_details">Packaging details</string>
+    <!-- This text appears as a description in the packaging step of the shipping label creation flow, instructing users to select the type of packaging for their items. It displays as descriptive text within a step view component on the create shipping label screen. -->
     <string name="shipping_label_create_packaging_details_description">Select the type of packaging you\’d like to ship your items in</string>
+    <!-- This text appears as the screen title/header for the customs information form when creating shipping labels for international orders. It's displayed in the navigation bar at the top of the screen where users enter customs details for their packages. -->
     <string name="shipping_label_create_customs">Customs</string>
+    <!-- This text appears as a description/instruction label in the customs step of the shipping label creation flow, telling users what they need to do when the customs form is not yet completed. -->
     <string name="shipping_label_create_customs_description">Fill out customs form</string>
+    <!-- Status description text that appears in the shipping label creation flow when the customs form step has been completed. This text is displayed to indicate progress in a multi-step process for creating shipping labels for orders. -->
     <string name="shipping_label_create_customs_done">Customs form completed</string>
+    <!-- This text appears as a description or instruction in the shipping label creation workflow, specifically for the carrier selection step where users choose their preferred shipping carrier and view available shipping rates. -->
     <string name="shipping_label_create_carrier_description">Select your shipping carrier and rates</string>
+    <!-- This text appears as a description or detail text in the payment step of the shipping label creation flow, indicating to users that they need to add a new credit card for payment when no payment method is currently selected. -->
     <string name="shipping_label_create_payment_description">Add a new credit card</string>
+    <!-- A section title that appears on the shipping label creation screen, displayed as a header above order summary information to organize the content for users creating shipping labels. -->
     <string name="shipping_label_create_order_summary">Shipping label order summary</string>
+    <!-- A label that appears in the shipping label creation order summary view, displayed next to the subtotal amount before taxes and fees are added. This is part of a price breakdown section that shows individual package costs and the calculated subtotal. -->
     <string name="shipping_label_create_price_subtotal">Subtotal</string>
+    <!-- This text appears as a label in the shipping label creation order summary screen, identifying a discount applied through WooCommerce Services. It's displayed alongside pricing information with an info button that provides additional details about the discount. -->
     <string name="shipping_label_create_price_woo_discount">WooCommerce Services discount</string>
+    <!-- This text serves as accessibility content description for an info button that appears next to a WooCommerce Services discount line item in the shipping label price breakdown, allowing users to learn more details about the discount. -->
     <string name="shipping_label_create_price_woo_discount_content_description">Learn more about WooCommerce Services discount</string>
+    <!-- This text appears as a label in the shipping label creation flow's order summary section, displaying next to the final total price amount after any discounts have been applied. -->
     <string name="shipping_label_create_price_total">Order total</string>
+    <!-- This text appears as a checkbox label in the shipping label creation flow, allowing users to automatically mark an order as complete and send a notification to the customer when purchasing a shipping label. -->
     <string name="shipping_label_create_mark_order_complete">Mark this order as complete and notify the customer</string>
+    <!-- This text appears as the label on a primary action button in the shipping label order summary screen, allowing users to complete the purchase of a shipping label after reviewing order details and costs. -->
     <string name="shipping_label_create_purchase">Purchase shipping label</string>
+    <!-- This text appears as the title of a progress dialog shown to users while the app is processing the purchase of a shipping label for an order. It's displayed during the brief loading period between when the user initiates the label purchase and when the transaction completes. -->
     <string name="shipping_label_create_purchase_progress_title">Purchasing label</string>
+    <!-- This message appears in a progress dialog during the shipping label purchase process in the orders section. It's shown while the app is processing the label purchase request, indicating to users they should wait for the operation to complete. -->
     <string name="shipping_label_create_purchase_progress_message">Please wait…</string>
+    <!-- This error message appears as a snackbar notification when there's a failure during the purchase of shipping labels in the order fulfillment process. It's displayed to inform the user that the shipping label purchase could not be completed. -->
     <string name="shipping_label_create_purchase_error">Error purchasing the labels</string>
+    <!-- Error message displayed in a snackbar notification when the app fails to automatically mark an order as complete after successfully creating a shipping label. This appears during the shipping label creation flow when the optional order fulfillment step encounters an error. -->
     <string name="shipping_label_create_purchase_fulfill_error">Couldn\'t mark the order as complete</string>
+    <!-- This text appears as a descriptive label in the shipping label creation flow, showing the selected payment method after a credit card has been chosen. It displays in a step summary section to confirm which card will be charged, with the last 4 digits of the card number replacing the %1$s placeholder. -->
     <string name="shipping_label_selected_payment_description">Credit card ending in %1$s</string>
+    <!-- This text appears as a placeholder/hint text in a text input field on the shipping label address editing screen, prompting users to enter the recipient's name for the shipping address. -->
     <string name="shipping_label_edit_address_name">Name</string>
+    <!-- This text appears as a hint/placeholder text in a company name input field on the shipping label address editing screen, positioned between the name and phone number fields in the address form. -->
     <string name="shipping_label_edit_address_company">Company</string>
+    <!-- This text appears as a placeholder hint in a phone number input field within the shipping label address editing screen, guiding users to enter a phone number for the shipping address. -->
     <string name="shipping_label_edit_address_phone">Phone</string>
+    <!-- This text appears as a placeholder hint in the first address input field when editing shipping label addresses, guiding users to enter the primary street address information (street number, street name, etc.). -->
     <string name="shipping_label_edit_address_line1">Address line 1</string>
+    <!-- This text appears as a placeholder hint in the second address line input field when editing shipping label addresses. It helps users understand they can enter additional address information like apartment numbers, suite numbers, or building details in this optional field. -->
     <string name="shipping_label_edit_address_line2">Address line 2</string>
+    <!-- This text appears as a placeholder hint in a city input field on the shipping label address editing screen, guiding users to enter the city portion of a shipping address. -->
     <string name="shipping_label_edit_address_city">City</string>
+    <!-- Title text displayed at the top of a search screen where users can select a state/province when editing customer addresses during order creation or order detail editing. -->
     <string name="shipping_label_edit_address_state">State</string>
+    <!-- Placeholder text that appears in a search field when users are selecting a state/province while editing shipping or billing addresses in order management. This hint text guides users to type and filter through available states in a dropdown search interface. -->
     <string name="shipping_label_edit_address_state_search_hint">Filter state</string>
+    <!-- This text appears as a hint/placeholder text in a zip/postal code input field on the shipping label address editing screen in a WooCommerce mobile app. It guides users to enter their zip or postal code when creating or editing shipping addresses. -->
     <string name="shipping_label_edit_address_zip">Zip / Postal Code</string>
+    <!-- This text appears as the title of a search screen that allows users to select a country when editing shipping or billing addresses during order creation and editing. It's displayed in the navigation bar or header of the country selection interface. -->
     <string name="shipping_label_edit_address_country">Country</string>
+    <!-- This text appears as a search field placeholder hint when users are selecting a country while editing shipping addresses in order management and shipping label creation screens. -->
     <string name="shipping_label_edit_address_country_search_hint">Filter countries</string>
+    <!-- This text appears as a button label on the shipping label address editing screen, allowing users to proceed with the address exactly as they entered it without making corrections. The button provides an option to bypass address validation or suggestions. -->
     <string name="shipping_label_edit_address_use_address_as_is">Use address as entered</string>
+    <!-- Title text displayed in a progress dialog that appears when the app is validating address information during the shipping label creation process. This dialog shows while the system checks if the entered origin or destination address is valid and properly formatted. -->
     <string name="shipping_label_edit_address_validation_progress_title">Address validation in progress</string>
+    <!-- This text appears as the title of a progress dialog that displays while the app is loading address data in the shipping label address editing screen. The dialog shows this title along with a progress indicator to inform users that address information is being retrieved. -->
     <string name="shipping_label_edit_address_loading_progress_title">Loading address data</string>
+    <!-- This text appears as a message in a progress dialog that displays while the app is validating or loading shipping addresses during the shipping label creation process. The dialog shows this generic waiting message to inform users that an address validation operation is in progress. -->
     <string name="shipping_label_edit_address_progress_message">Please wait…</string>
+    <!-- Error message displayed as a snackbar notification when address validation fails during shipping label creation, and also used as accessibility text for an error banner icon in the address editing screen. -->
     <string name="shipping_label_edit_address_validation_error">Address validation failed</string>
+    <!-- This error message appears as a banner warning on the shipping label address editing screen when the system cannot automatically validate the origin address entered by the user. The message includes a suggestion to use Google Maps to verify the address accuracy. -->
     <string name="shipping_label_edit_origin_address_error_warning">We were unable to automatically verify the origin address. View it on Google Maps to make sure the address is correct.</string>
+    <!-- Warning message displayed in a banner on the shipping label address edit screen when the app cannot automatically verify the entered shipping address, informing users they can view the address on maps or contact the customer to confirm accuracy. -->
     <string name="shipping_label_edit_address_error_warning">We were unable to automatically verify the shipping address. View it on Google Maps or try contacting the customer to make sure the address is correct.</string>
+    <!-- Error message displayed when address validation fails during shipping label creation because the entered address cannot be found or verified by the shipping service. -->
     <string name="shipping_label_error_address_not_found">Address was not found</string>
+    <!-- Error message displayed when validating shipping label addresses and the house number field is missing or empty. This appears as part of address validation feedback in the shipping label creation flow. -->
     <string name="shipping_label_error_address_house_number_missing">House number missing</string>
+    <!-- Error message displayed when validating a shipping address during shipping label creation, specifically when the street address field contains invalid information that prevents the address from being processed. -->
     <string name="shipping_label_error_address_invalid_street">Invalid street</string>
+    <!-- Error message displayed as a banner in the shipping label address editing screen when the app cannot automatically verify the entered shipping address. The %s placeholder is replaced with specific details about the validation error. -->
     <string name="shipping_label_validation_error_template">We were unable to automatically verify the shipping address: %s</string>
+    <!-- This text appears as a button label in the shipping label address editing screen, displayed when there's an address validation error. The button allows users to contact the customer to resolve address issues before creating the shipping label. -->
     <string name="shipping_label_validation_contact_customer">Contact Customer</string>
+    <!-- This text appears as a button label in the shipping label address editing screen, displayed when there's an address validation error. Users can tap this button to open a map view to help locate or verify the correct shipping address. -->
     <string name="shipping_label_validation_view_map">Find on Map</string>
+    <!-- This text appears as a button label in the shipping label address suggestion screen, allowing users to confirm and use the currently selected address from available address options. -->
     <string name="shipping_label_address_suggestion_use_selected_address">Use selected address</string>
+    <!-- This text appears as a button label on the shipping label address suggestion screen, allowing users to edit the currently selected address option instead of using it as-is. -->
     <string name="shipping_label_address_suggestion_edit_selected_address">Edit selected address</string>
+    <!-- This text appears in a warning banner on the shipping label address entry screen when the system has automatically corrected or modified the address the user entered. The banner message encourages users to accept the suggested address correction to ensure proper package delivery. -->
     <string name="shipping_label_address_suggestion_banner">We have slightly modified the address entered. If correct, please use the suggested address to ensure accurate delivery.</string>
+    <!-- This text appears as a radio button label in the shipping label address suggestion screen, allowing users to choose between their originally entered address and a suggested corrected address. -->
     <string name="shipping_label_address_suggestion_entered_address">Entered address</string>
+    <!-- This text appears as a label for a radio button option in the shipping label address suggestion screen, where users can choose between a suggested corrected address and their original address entry. -->
     <string name="shipping_label_address_suggestion_suggested_address">Suggested address</string>
     <string name="shipping_label_address_phone_required">A phone number is required</string>
+    <!-- Error message displayed in the shipping label creation form when the user enters an invalid phone number for the origin address and customs forms are required. This validation error appears below the phone number input field to inform the user that a specific 10-digit format is needed for customs documentation. -->
     <string name="shipping_label_origin_address_phone_invalid">Customs forms require a 10-digit phone number</string>
+    <!-- Error message displayed when the user enters an invalid phone number in the destination address field while creating shipping labels for orders. This validation error appears below the phone input field to guide the user to enter a properly formatted phone number. -->
     <string name="shipping_label_destination_address_phone_invalid">Please enter a valid phone number</string>
+    <!-- Error message displayed in a snackbar (temporary popup notification) when users try to save or validate a shipping address but some required fields are empty or invalid in the shipping label creation flow. -->
     <string name="shipping_label_address_data_invalid_snackbar_message">Certain required fields are blank.</string>
+    <!-- This text appears as a section header in the shipping label package details screen, displayed above a list of items that need to be fulfilled for the shipment. -->
     <string name="shipping_label_package_details_items_section_title">Items to fulfill</string>
+    <!-- A button label in the shipping label package details screen that allows users to move an item from one package to another during the shipping label creation process. -->
     <string name="shipping_label_package_details_move_item">Move</string>
+    <!-- This text appears as a section header in the shipping label creation flow, specifically above the package configuration options where users can select package types and enter package dimensions. -->
     <string name="shipping_label_package_details_section_title">Package details</string>
+    <!-- This text appears as a hint/placeholder text in a dropdown spinner on the shipping label package details screen, prompting the user to select a package type for their shipment. -->
     <string name="shipping_label_package_details_selected_package_hint">Package selected</string>
+    <!-- This text appears as a hint/placeholder in an input field where users enter the total weight of a shipping package, with the weight unit (like 'kg' or 'lbs') dynamically inserted. It's part of the shipping label creation flow in a WooCommerce store management app. -->
     <string name="shipping_label_package_details_weight_hint">Total package weight (%1$s)</string>
+    <!-- This text appears as helper text below a weight input field in the shipping label package details screen, informing users that the weight they enter should include the package weight itself. -->
     <string name="shipping_label_package_details_weight_info">Includes package weight</string>
+    <!-- Error message displayed as a snackbar notification when the app fails to load shipping package definitions during the shipping label creation process. This appears when there's a network or server error preventing the retrieval of available shipping packages for an order. -->
     <string name="shipping_label_packages_loading_error">Unable to load package definitions</string>
+    <!-- Displays the count of items in a shipping package when there is exactly one item. Appears in shipping label management screens as part of a collapsible package details section that shows item counts and package information. -->
     <string name="shipping_label_package_details_items_count_one">%d item</string>
+    <!-- This text appears as a collapsible button label in shipping label package details, showing the count of items in a package (e.g., '5 items'). It's used in both order details and shipping label creation flows to display how many products are contained within each shipping package. -->
     <string name="shipping_label_package_details_items_count_many">%d items</string>
+    <!-- A subtitle label that appears in the shipping label package details screen to describe an item that will be shipped individually rather than grouped with other items in a package. -->
     <string name="shipping_label_package_details_individual_package_subtitle">Individually Shipped Item</string>
+    <!-- This is a section label that appears on the shipping label package details screen, displayed above the actual dimensions of an individual package (e.g., '10cm x 10cm x 10cm'). -->
     <string name="shipping_label_package_details_individual_package_dimensions">Item Dimensions</string>
+    <!-- This text appears as a section title in the shipping label package details screen, specifically labeling the section where users can configure individual package settings when using original product packaging instead of predefined shipping boxes. -->
     <string name="shipping_label_package_details_individual_package_title">Original packaging</string>
+    <!-- Error message displayed in the shipping label package details screen when package dimensions are zero or invalid, appearing below the dimensions display with an error icon to guide users to update their product dimensions. -->
     <string name="shipping_label_package_details_individual_package_dimensions_error">Package dimensions must be greater than zero. Please update your item’s dimensions in the Shipping section of your product page to continue.</string>
+    <!-- This text appears as the label for a toggle switch (checkbox) on the shipping label package details screen, allowing users to indicate whether their package contains hazardous materials. -->
     <string name="shipping_label_package_details_hazmat_content_checkbox_title">Contains Hazardous Materials</string>
+    <!-- This text appears as an informational description in the shipping label package details screen, explaining what items are considered hazardous materials and that they require separate packaging. -->
     <string name="shipping_label_package_details_hazmat_content_description">Potentially hazardous material includes items such as batteries, dry ice, flammable liquids, aerosols, ammunition, fireworks, nail polish, perfume, paint, solvents, and more. Hazardous items must ship in separate packages.</string>
+    <!-- This text appears as instructional content on the shipping labels creation screen when users toggle on hazardous materials (HAZMAT) options for USPS shipping. It contains a clickable link that directs users to USPS hazmat packaging instructions. -->
     <string name="shipping_label_usps_hazmat_instructions">Learn how to securely package, label, and ship HAZMAT through USPS® at %1$s</string>
+    <!-- This text appears as a clickable link within hazardous materials instructions on the shipping label creation screen. When tapped, it opens the USPS hazmat instructions website to help users understand shipping requirements for dangerous goods. -->
     <string name="shipping_label_usps_instructions_link_text">www.usps.com/hazmat.</string>
+    <!-- This text appears as instructional content in the shipping label creation screen for hazardous materials (hazmat) packages, specifically directing users to a USPS search tool to check if their product can be mailed. The %1$s placeholder is replaced with clickable link text that opens the USPS hazmat search tool. -->
     <string name="shipping_label_usps_search_tool">Determine your product\'s mailability using the %1$s</string>
+    <!-- This text appears as a clickable link within the shipping labels hazmat instructions section, directing users to the USPS HAZMAT Search Tool website to help them determine hazmat classifications for their products. -->
     <string name="shipping_label_usps_search_tool_link_text">USPS HAZMAT Search Tool.</string>
+    <!-- This text appears as clickable instructional content in the shipping label creation screen, specifically informing users that WooCommerce Shipping doesn't support hazardous materials (HAZMAT) shipments through DHL Express. The %1$s placeholder is replaced with a clickable link that leads to DHL's hazmat instructions. -->
     <string name="shipping_label_hazmat_content_dhl_instructions">WooCommerce Shipping does not currently support HAZMAT shipments through %1$s</string>
+    <!-- This text appears as clickable link text within hazardous materials shipping instructions on the shipping label creation screen. When tapped, it opens DHL Express hazmat guidelines to help users understand shipping restrictions for dangerous goods. -->
     <string name="shipping_label_hazmat_content_dhl_instructions_link_text">DHL Express.</string>
+    <!-- This text appears as a section title in the shipping label package details screen, specifically labeling the hazardous material category selection area where users can choose the appropriate hazmat classification for their package. -->
     <string name="shipping_label_package_details_hazmat_selection_title">Hazardous material category</string>
+    <!-- This text appears as the default/placeholder text in a hazmat category selection field within the shipping label package details screen, and also serves as the title for the hazmat category picker dialog that opens when the user taps to select a category. -->
     <string name="shipping_label_package_details_hazmat_select_category_action">Select a category</string>
+    <!-- This text appears as a placeholder label for a button that shows the count of items in a shipping label on the order details screen. The button is expandable and likely displays the actual number of items when populated with real data. -->
     <string name="shipping_label_items_count_placeholder">Items count</string>
+    <!-- Title displayed for individual shipping packages in the WooCommerce app, where %1$d is replaced with the package number (e.g., 'Package 1', 'Package 2'). This appears in shipping label creation and customs form screens to help users identify and manage multiple packages in an order. -->
     <string name="shipping_label_package_details_title_template">Package %1$d</string>
+    <!-- This text appears as the title in the toolbar/navigation bar of a screen where users select shipping packages for creating shipping labels in WooCommerce orders. -->
     <string name="shipping_label_package_selector_title">Selected Package</string>
+    <!-- Error message displayed below a weight input field when creating shipping labels for orders, shown when the user enters an invalid weight value (zero or negative numbers). -->
     <string name="shipping_label_package_details_weight_error">Invalid weight</string>
+    <!-- Error message displayed as a snackbar notification when the app fails to fetch product information while creating shipping labels for an order. This appears when there's a network or server error preventing the retrieval of product details needed for package configuration. -->
     <string name="shipping_label_package_details_fetch_products_error">Can\'t fetch products</string>
+    <!-- This is a section header displayed in the shipping packages selection screen within the shipping label creation flow. It categorizes and labels a group of custom package options that users can choose from when creating shipping labels for orders. -->
     <string name="shipping_label_packages_custom_section_title">Custom packages</string>
+    <!-- This text appears as a descriptive label on the shipping label creation screen when packaging a single item, showing the total weight of the package with its unit of measurement (e.g., 'Total package weight: 2.5 lbs'). -->
     <string name="shipping_label_single_package_total_weight">Total package weight: %1$s %2$s</string>
+    <!-- This text appears as a descriptive label in the shipping label creation flow when multiple packages are being processed, showing the total number of items distributed across multiple packages (e.g., '15 items in 3 packages'). -->
     <string name="shipping_label_multi_packages_items_count">%1$d items in %2$d packages</string>
+    <!-- This text appears as a descriptive label in the shipping label creation flow when multiple packages are being shipped, showing the combined weight of all packages with the appropriate unit (e.g., 'Total packages weight: 2.5 kg'). It's displayed as part of the packaging step summary information. -->
     <string name="shipping_label_multi_packages_total_weight">Total packages weight: %1$s %2$s</string>
+    <!-- Button text that appears in the shipping packages selector screen, allowing users to create a new package for shipping labels. The button is displayed with a plus icon and positioned at the bottom of the package selection interface. -->
     <string name="shipping_label_create_new_package_button">Create new package</string>
+    <!-- This text appears as a selectable option in a dropdown or list when creating shipping labels for hazardous materials, specifically for packages containing ethanol-based products like fragrances and hand sanitizers that are eligible for air transport. -->
     <string name="shipping_label_hazmat_option_air_eligible_ethanol">Air Eligible Ethanol Package - (authorized fragrance and hand sanitizer shipments)</string>
+    <!-- This text appears as a selectable option in a hazmat category selection list when creating shipping labels for orders that contain hazardous materials classified as Class 1 explosives (toy propellants/safety fuses). -->
     <string name="shipping_label_hazmat_option_class_1">Class 1 – Toy Propellant/Safety Fuse Package</string>
+    <!-- This text appears as a selectable option in a hazardous materials classification list when creating shipping labels, helping users identify Class 3 dangerous goods (flammable liquids) with specific product examples. -->
     <string name="shipping_label_hazmat_option_class_3">Class 3 - Package (Hand sanitizer, rubbing alcohol, ethanol base products, flammable liquids etc.)</string>
+    <!-- This text appears as a selectable option in a hazmat category dropdown or list when creating shipping labels, specifically representing the Class 4 hazardous materials classification for flammable solids that need special shipping handling. -->
     <string name="shipping_label_hazmat_option_class_4">Class 4 - Package (Flammable solids)</string>
+    <!-- This text appears as a selectable option in a dropdown or list when creating shipping labels for hazardous materials, specifically identifying packages containing oxidizing substances under Class 5 hazmat regulations. -->
     <string name="shipping_label_hazmat_option_class_5">Class 5 - Package (Oxidizers)</string>
+    <!-- This text appears as a selectable option in a hazardous materials classification dropdown or list when creating shipping labels, specifically identifying packages containing poisonous materials under Class 6 regulations. -->
     <string name="shipping_label_hazmat_option_class_6">Class 6 - Package (Poisonous materials)</string>
+    <!-- This text appears as a selectable option in a dropdown or list when creating shipping labels for hazardous materials, specifically for packages containing radioactive materials like smoke detectors or minerals. -->
     <string name="shipping_label_hazmat_option_class_7">Class 7 – Radioactive Materials Package (e.g., smoke detectors, minerals, gun sights, etc.)</string>
+    <!-- This text appears as a selectable option in the hazardous materials classification menu when creating shipping labels, specifically for Class 8 corrosive materials that are eligible for air transport. Users select this option to properly classify packages containing corrosive substances like certain cleaning products or herbicides/pesticides. -->
     <string name="shipping_label_hazmat_option_class_8_corrosive">Class 8 – Corrosive Materials Package - Air Eligible Corrosive Materials (certain cleaning or tree/weed killing compounds, etc.)</string>
+    <!-- This text appears as a selectable option in the hazardous materials classification dropdown when creating shipping labels for orders containing sealed lead acid batteries. It helps users properly classify their shipment according to shipping regulations for Class 8 nonspillable wet battery packages. -->
     <string name="shipping_label_hazmat_option_class_8_wet_battery">Class 8 – Nonspillable Wet Battery Package - Sealed lead acid batteries</string>
+    <!-- This text appears as a selectable option in a hazardous materials classification list when creating shipping labels, specifically for new individual or spare lithium batteries that are ground-only shipments. It's one of multiple hazmat categories users can choose from to properly classify their package contents for shipping compliance. -->
     <string name="shipping_label_hazmat_option_class_9_new_lithium_individual">Class 9 - Lithium Battery Marked – Ground Only Package - New Individual or spare lithium batteries (marked UN3480 or UN3090)</string>
+    <!-- This text appears as a selectable option in a dropdown or list when creating shipping labels for hazardous materials, specifically for packages containing used electronic devices with lithium batteries that are being returned. -->
     <string name="shipping_label_hazmat_option_class_9_used_lithium">Class 9 - Lithium Battery – Returns Package - Used electronic devices containing or packaged with lithium batteries (markings required)</string>
+    <!-- This text appears as a selectable option in the hazardous materials classification dropdown when creating shipping labels for WooCommerce orders, specifically for new electronic devices that contain lithium batteries with proper UN markings. -->
     <string name="shipping_label_hazmat_option_class_9_new_lithium_device">Class 9 - Lithium batteries, marked package - New electronic devices packaged with lithium batteries (marked UN3481 or UN3091)</string>
+    <!-- This text appears as a selectable option in a hazardous materials classification list when creating shipping labels, specifically for packages containing dry ice with air shipping weight restrictions. -->
     <string name="shipping_label_hazmat_option_class_9_dry_ice">Class 9 – Dry Ice Package (limited to 5 lbs. if shipped via Air)</string>
+    <!-- This text appears as a selectable option in a hazmat classification dropdown or list when creating shipping labels, specifically for lithium battery packages that don't require hazmat markings. Users select this option to properly classify their shipment containing electronic devices with lithium batteries. -->
     <string name="shipping_label_hazmat_option_class_9_unmarked_lithium">Class 9 – Lithium batteries, unmarked package - New electronic devices installed or packaged with lithium batteries (no marking)</string>
+    <!-- This text appears as a selectable option in a dropdown or list when creating shipping labels for packages that contain magnetized materials, allowing users to classify their hazardous materials according to shipping regulations. -->
     <string name="shipping_label_hazmat_option_class_9_magnetized">Class 9 – Magnetized Materials Package</string>
+    <!-- This text appears as a selectable option in a hazardous materials category dropdown or list when creating shipping labels, specifically for Division 4.1 hazmat classification covering flammable solids and safety matches. -->
     <string name="shipping_label_hazmat_option_division_4_1">Division 4.1 – Mailable flammable solids and Safety Matches Package - Safety/strike on box matches, book matches, mailable flammable solids</string>
+    <!-- This text appears as a selectable option in a dropdown or list when users are creating shipping labels for hazardous materials, specifically for packages containing hydrogen peroxide with 8-20% concentration that fall under Division 5.1 oxidizers classification. -->
     <string name="shipping_label_hazmat_option_division_5_1">Division 5.1 – Oxidizers Package - Hydrogen peroxide (8 to 20%% concentration)</string>
+    <!-- This text appears as a selectable option in a dropdown or list when creating shipping labels for packages containing hazardous materials, specifically identifying organic peroxides under Division 5.2 classification. -->
     <string name="shipping_label_hazmat_option_division_5_2">Division 5.2 – Organic Peroxides Package</string>
+    <!-- This text appears as a selectable option in a hazardous materials classification dropdown or list when creating shipping labels, specifically for Division 6.1 toxic materials with detailed technical specifications and examples. -->
     <string name="shipping_label_hazmat_option_division_6_1">Division 6.1 – Toxic Materials Package (with an LD50 of 50 mg/kg or less) - (pesticides, herbicides, etc.)</string>
     <string name="shipping_label_hazmat_option_division_6_2">Division 6.2 - Hazardous Materials - Biological Materials (e.g., lab test kits, authorized COVID test kit returns)</string>
     <string name="shipping_label_hazmat_option_excepted_quantity_provision">Excepted Quantity Provision Package (e.g., small volumes of flammable liquids, corrosive, toxic or environmentally hazardous materials - marking required)</string>


### PR DESCRIPTION
Fixes AINFRA-1870

See paaHJt-9BZ-p2 and https://github.com/woocommerce/woocommerce-android/pull/15271

### Description
This PR is the result of exploring ideas on extracting context for localization strings based on the codebase.
For this, I've been using a gem that I've _vibe-built_, https://github.com/iangmaia/txcontext. The idea is to add (or enhance) context to all strings and then have a process where they're continuously added in an automated way.
Then, once we have better detailed context, we will have better quality automated (or human) translations.

**Note**: we can tweak a few configuration parameters such as the size of the code context for each string to fine tune what yields better context quality.

**The idea of this PR is just to review the context that has been added so far, the quality, and to validate if the idea makes sense in general.**