### PR TITLE
[Woo POS] Fix POS email receipt changing refunded order status to completed

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepository.kt
@@ -2,11 +2,7 @@ package com.woocommerce.android.ui.woopos.emailreceipt
 
 import android.util.Patterns
 import com.woocommerce.android.extensions.semverCompareTo
-import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
-import com.woocommerce.android.ui.orders.creation.OrderCreationSource
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -16,18 +12,12 @@ import javax.inject.Inject
 class WooPosEmailReceiptRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val orderStore: WCOrderStore,
-    private val orderCreateEditRepository: OrderCreateEditRepository,
-    private val orderMapper: OrderMapper,
     private val provideEmailPattern: WooPosProvideEmailPattern,
     private val getWooCoreVersion: GetWooCorePluginCachedVersion
 ) {
     suspend fun sendReceiptByEmail(orderId: Long, email: String): Result<Unit> = withContext(Dispatchers.IO) {
-        val order = getOrderById(orderId) ?: fetchOrderById(orderId)
-        if (order == null) {
-            return@withContext Result.failure(Exception("Failed to get order"))
-        }
-
-        if (updateOrderWithEmail(order, email).isFailure) {
+        val updateResult = orderStore.updateOrderBillingEmail(selectedSite.get(), orderId, email)
+        if (updateResult.isError) {
             return@withContext Result.failure(Exception("Failed to update order with email"))
         }
 
@@ -48,33 +38,6 @@ class WooPosEmailReceiptRepository @Inject constructor(
             Result.failure(Exception("Failed to send order receipt"))
         } else {
             Result.success(Unit)
-        }
-    }
-
-    private suspend fun updateOrderWithEmail(order: Order, email: String): Result<Order> {
-        val updatedBillingAddress = order.billingAddress.copy(email = email)
-        val updatedCustomer = order.customer?.copy(billingAddress = updatedBillingAddress)
-        return orderCreateEditRepository.createOrUpdateOrder(
-            order = order.copy(customer = updatedCustomer),
-            source = OrderCreationSource.POINT_OF_SALE
-        )
-    }
-
-    private suspend fun getOrderById(orderId: Long) =
-        orderStore.getOrderByIdAndSite(orderId, selectedSite.get())?.let {
-            orderMapper.toAppModel(it)
-        }
-
-    private suspend fun fetchOrderById(orderId: Long): Order? {
-        val result = orderStore.fetchSingleOrder(
-            selectedSite.get(),
-            orderId
-        )
-
-        return if (!result.isError) {
-            getOrderById(orderId)
-        } else {
-            null
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepositoryTest.kt
@@ -1,28 +1,18 @@
 package com.woocommerce.android.ui.woopos.emailreceipt
 
-import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.OrderMapper
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.orders.OrderTestUtils
-import com.woocommerce.android.ui.orders.creation.OrderCreateEditRepository
-import com.woocommerce.android.ui.orders.creation.OrderCreationSource
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
-import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
 import java.util.regex.Pattern
 
@@ -32,8 +22,6 @@ class WooPosEmailReceiptRepositoryTest {
         on { get() }.thenReturn(siteModel)
     }
     private val orderStore: WCOrderStore = mock()
-    private val orderCreateEditRepository: OrderCreateEditRepository = mock()
-    private val orderMapper: OrderMapper = mock()
     private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock()
     private val provideEmailPattern: WooPosEmailReceiptRepository.WooPosProvideEmailPattern = mock {
         on { invoke() }.thenReturn(
@@ -52,8 +40,6 @@ class WooPosEmailReceiptRepositoryTest {
     private val repository = WooPosEmailReceiptRepository(
         selectedSite,
         orderStore,
-        orderCreateEditRepository,
-        orderMapper,
         provideEmailPattern,
         getWooCoreVersion
     )
@@ -87,26 +73,18 @@ class WooPosEmailReceiptRepositoryTest {
         // GIVEN
         val orderId = 1L
         val email = "test@example.com"
-        val mockOrder: Order = OrderTestUtils.generateTestOrder()
 
         whenever(getWooCoreVersion.invoke()).thenReturn("9.9.0")
-        whenever(orderStore.getOrderByIdAndSite(orderId, siteModel)).thenReturn(mock())
-        whenever(orderMapper.toAppModel(any())).thenReturn(mockOrder)
-        whenever(
-            orderCreateEditRepository.createOrUpdateOrder(
-                any(),
-                eq(OrderCreationSource.POINT_OF_SALE),
-                eq("")
-            )
-        ).thenReturn(Result.success(mockOrder))
-        val sendOrderReceiptResult = WooPayload<Unit>(Unit)
-        whenever(orderStore.sendOrderReceipt(siteModel, orderId)).thenReturn(sendOrderReceiptResult)
+        whenever(orderStore.updateOrderBillingEmail(siteModel, orderId, email)).thenReturn(WooPayload(Unit))
+        whenever(orderStore.sendOrderReceipt(siteModel, orderId)).thenReturn(WooPayload(Unit))
 
         // WHEN
         val result = repository.sendReceiptByEmail(orderId, email)
 
         // THEN
         assertThat(result.isSuccess).isTrue()
+        verify(orderStore).updateOrderBillingEmail(siteModel, orderId, email)
+        verify(orderStore).sendOrderReceipt(siteModel, orderId)
     }
 
     @Test
@@ -114,46 +92,18 @@ class WooPosEmailReceiptRepositoryTest {
         // GIVEN
         val orderId = 1L
         val email = "test@example.com"
-        val mockOrder: Order = OrderTestUtils.generateTestOrder()
 
         whenever(getWooCoreVersion.invoke()).thenReturn("10.0.0")
-        whenever(orderStore.getOrderByIdAndSite(orderId, siteModel)).thenReturn(mock())
-        whenever(orderMapper.toAppModel(any())).thenReturn(mockOrder)
-        whenever(
-            orderCreateEditRepository.createOrUpdateOrder(
-                any(),
-                eq(OrderCreationSource.POINT_OF_SALE),
-                eq("")
-            )
-        ).thenReturn(Result.success(mockOrder))
-        val sendOrderReceiptResult = WooPayload<Unit>(Unit)
-        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId)).thenReturn(sendOrderReceiptResult)
+        whenever(orderStore.updateOrderBillingEmail(siteModel, orderId, email)).thenReturn(WooPayload(Unit))
+        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId)).thenReturn(WooPayload(Unit))
 
         // WHEN
         val result = repository.sendReceiptByEmail(orderId, email)
 
         // THEN
         assertThat(result.isSuccess).isTrue()
-    }
-
-    @Test
-    fun `given invalid order id, when sendReceiptByEmail, then return failure`() = runTest {
-        // GIVEN
-        val orderId = 999L
-        val email = "test@example.com"
-        whenever(selectedSite.get()).thenReturn(siteModel)
-        whenever(orderStore.getOrderByIdAndSite(orderId, siteModel)).thenReturn(null)
-
-        val onOrderChangedError = WCOrderStore.OnOrderChanged(
-            orderError = WCOrderStore.OrderError()
-        )
-        whenever(orderStore.fetchSingleOrder(siteModel, orderId)).thenReturn(onOrderChangedError)
-
-        // WHEN
-        val result = repository.sendReceiptByEmail(orderId, email)
-
-        // THEN
-        assertThat(result.isFailure).isTrue()
+        verify(orderStore).updateOrderBillingEmail(siteModel, orderId, email)
+        verify(orderStore).sendOrderPOSSpecificReceipt(siteModel, orderId)
     }
 
     @Test
@@ -161,19 +111,9 @@ class WooPosEmailReceiptRepositoryTest {
         // GIVEN
         val email = "test@example.com"
         val orderId = 1L
-        val mockOrder: Order = OrderTestUtils.generateTestOrder()
 
-        whenever(selectedSite.get()).thenReturn(siteModel)
-        whenever(orderStore.getOrderByIdAndSite(orderId, siteModel)).thenReturn(mock())
-        whenever(orderMapper.toAppModel(any())).thenReturn(mockOrder)
-        whenever(
-            orderCreateEditRepository.createOrUpdateOrder(
-                anyOrNull(),
-                eq(OrderCreationSource.POINT_OF_SALE),
-                eq("")
-            )
-        ).thenReturn(
-            Result.failure(Exception("Update failed"))
+        whenever(orderStore.updateOrderBillingEmail(siteModel, orderId, email)).thenReturn(
+            WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.NETWORK_ERROR))
         )
 
         // WHEN
@@ -188,77 +128,17 @@ class WooPosEmailReceiptRepositoryTest {
         // GIVEN
         val orderId = 1L
         val email = "test@example.com"
-        val mockOrder: Order = OrderTestUtils.generateTestOrder()
-        whenever(selectedSite.get()).thenReturn(siteModel)
-        whenever(orderStore.getOrderByIdAndSite(orderId, siteModel)).thenReturn(mock())
-        whenever(orderMapper.toAppModel(any())).thenReturn(mockOrder)
-        whenever(
-            orderCreateEditRepository.createOrUpdateOrder(
-                any(),
-                eq(OrderCreationSource.POINT_OF_SALE),
-                eq("")
-            )
-        ).thenReturn(
-            Result.success(mockOrder)
+
+        whenever(getWooCoreVersion.invoke()).thenReturn("9.9.0")
+        whenever(orderStore.updateOrderBillingEmail(siteModel, orderId, email)).thenReturn(WooPayload(Unit))
+        whenever(orderStore.sendOrderReceipt(siteModel, orderId)).thenReturn(
+            WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.TIMEOUT))
         )
-        val sendOrderReceiptResult = WooPayload<Unit>(
-            WooError(
-                WooErrorType.GENERIC_ERROR,
-                GenericErrorType.TIMEOUT,
-            )
-        )
-        whenever(orderStore.sendOrderReceipt(siteModel, orderId)).thenReturn(sendOrderReceiptResult)
 
         // WHEN
         val result = repository.sendReceiptByEmail(orderId, email)
 
         // THEN
         assertThat(result.isFailure).isTrue()
-    }
-
-    @Test
-    fun `given order not in DB, when sendReceiptByEmail, then fetches remotely and succeeds`() = runTest {
-        // GIVEN
-        val orderId = 123L
-        val email = "test@example.com"
-
-        val mockOrder: Order = OrderTestUtils.generateTestOrder()
-
-        whenever(selectedSite.get()).thenReturn(siteModel)
-
-        val dbEntity = OrderEntity(LocalOrRemoteId.LocalId(1), orderId = orderId)
-        whenever(orderStore.getOrderByIdAndSite(orderId, siteModel))
-            .thenReturn(null, dbEntity)
-
-        val onOrderChangedSuccess = WCOrderStore.OnOrderChanged()
-
-        whenever(orderStore.fetchSingleOrder(siteModel, orderId)).thenReturn(onOrderChangedSuccess)
-
-        whenever(orderMapper.toAppModel(dbEntity)).thenReturn(mockOrder)
-
-        whenever(
-            orderCreateEditRepository.createOrUpdateOrder(
-                any(),
-                eq(OrderCreationSource.POINT_OF_SALE),
-                eq("")
-            )
-        ).thenReturn(
-            Result.success(mockOrder)
-        )
-
-        whenever(getWooCoreVersion.invoke()).thenReturn("9.9.0")
-
-        val sendOrderReceiptResult = WooPayload<Unit>(Unit)
-        whenever(orderStore.sendOrderReceipt(siteModel, orderId)).thenReturn(sendOrderReceiptResult)
-
-        // WHEN
-        val result = repository.sendReceiptByEmail(orderId, email)
-
-        // THEN
-        assertThat(result.isSuccess).isTrue()
-
-        verify(orderStore).fetchSingleOrder(siteModel, orderId)
-        verify(orderStore, org.mockito.kotlin.times(2)).getOrderByIdAndSite(orderId, siteModel)
-        verify(orderStore).sendOrderReceipt(siteModel, orderId)
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -1086,6 +1086,28 @@ class OrderRestClient @Inject constructor(
         return response.toWooPayload { it }
     }
 
+    suspend fun updateOrderBillingEmail(
+        site: SiteModel,
+        orderId: Long,
+        email: String
+    ): WooPayload<Unit> {
+        val url = WOOCOMMERCE.orders.id(orderId).pathV3
+        val body = mapOf(
+            "billing" to mapOf(
+                "email" to email
+            )
+        )
+
+        val response = wooNetwork.executePutGsonRequest(
+            site = site,
+            path = url,
+            clazz = Unit::class.java,
+            body = body
+        )
+
+        return response.toWooPayload { it }
+    }
+
     private suspend fun doFetchOrderCount(site: SiteModel, filterByStatus: String?): FetchOrdersCountResponsePayload {
         val url = WOOCOMMERCE.reports.orders.totals.pathV3
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -787,6 +787,16 @@ class WCOrderStore @Inject internal constructor(
         orderId
     )
 
+    suspend fun updateOrderBillingEmail(
+        site: SiteModel,
+        orderId: Long,
+        email: String
+    ) = wcOrderRestClient.updateOrderBillingEmail(
+        site,
+        orderId,
+        email
+    )
+
     private suspend fun optimisticallyUpdateOrder(
         orderId: Long,
         localSiteId: LocalId,

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
@@ -271,4 +271,41 @@ class OrderRestClientTest {
         )
         assertThat(paramsCaptor.firstValue["created_via"]).isEqualTo(expectedCreatedVia)
     }
+
+    @Test
+    fun `when updateOrderBillingEmail is called, then only billing email is sent in request body`() = runTest {
+        // Given
+        val orderId = 123L
+        val email = "test@example.com"
+        val expectedPath = WOOCOMMERCE.orders.id(orderId).pathV3
+        val expectedBody = mapOf(
+            "billing" to mapOf(
+                "email" to email
+            )
+        )
+        val mockResponse = WPAPIResponse.Success(Unit, emptyList())
+
+        whenever(
+            wooNetwork.executePutGsonRequest(
+                site = any(),
+                path = any(),
+                clazz = eq(Unit::class.java),
+                body = any()
+            )
+        ).thenReturn(mockResponse)
+
+        // When
+        orderRestClient.updateOrderBillingEmail(testSite, orderId, email)
+
+        // Then
+        val bodyCaptor = argumentCaptor<Map<String, Any>>()
+        verify(wooNetwork).executePutGsonRequest(
+            site = eq(testSite),
+            path = eq(expectedPath),
+            clazz = eq(Unit::class.java),
+            body = bodyCaptor.capture()
+        )
+
+        assertThat(bodyCaptor.firstValue).isEqualTo(expectedBody)
+    }
 }


### PR DESCRIPTION
WOOMOB-2044

### Description

Fixes an issue where sending an email receipt for a refunded POS order would change the order status from "Refunded" to "Completed".

**Root Cause:**
The previous implementation used `createOrUpdateOrder` to update the billing email, which sent the entire order object to the server. After refund, an order in a database was oudated and still had a "Completed" order status. When we sent it to the backend, it was overwritten from "Refunded" back to "Completed". 

**Solution:**
Added a new `updateOrderBillingEmail` method that only updates the billing email field without sending the entire order. This matches the iOS implementation and prevents unintended status changes.

### Changes
- Added `updateOrderBillingEmail` to `OrderRestClient` and `WCOrderStore`
- Updated `WooPosEmailReceiptRepository` to use the new method
- Removed unused dependencies (`OrderCreateEditRepository`, `OrderMapper`)

### Test Steps

1. Create a POS order and complete payment
2. Issue a refund for the order
3. From the orders list, select the refunded order
4. Send an email receipt
5. Verify the order status remains "Refunded" (not changed to "Completed")


https://github.com/user-attachments/assets/67385d55-feba-4536-b758-1ed0b15757fb

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.