### PR TITLE
[WOOMOB-2064] Add feature flag for Products Full-Text Search

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/featureflags/IsPosProductsFtsEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/featureflags/IsPosProductsFtsEnabled.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.ui.woopos.featureflags
+
+import com.woocommerce.android.util.FeatureFlag
+import javax.inject.Inject
+
+class IsPosProductsFtsEnabled @Inject constructor() {
+    operator fun invoke(): Boolean = FeatureFlag.POS_PRODUCTS_FTS.isEnabled()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -30,12 +30,11 @@ enum class FeatureFlag {
             BOOKINGS_MVP,
             POS_PRODUCTS_FTS,
             POS_REFUNDS,
+            WOO_POS_CLIENT_SIDE_BANNER,
             AGE_ELIGIBILITY_CHECKS -> PackageUtils.isDebugBuild()
 
             WOO_POS_LOCAL_CATALOG_FILE_APPROACH,
             WOO_PUSH_NOTIFICATIONS_SYSTEM -> false
-
-            WOO_POS_CLIENT_SIDE_BANNER -> true
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -12,6 +12,7 @@ enum class FeatureFlag {
     ORDER_CREATION_AUTO_TAX_RATE,
     BOOKINGS_MVP,
     POS_REFUNDS,
+    POS_PRODUCTS_FTS,
     WOO_POS_LOCAL_CATALOG_FILE_APPROACH,
     WOO_PUSH_NOTIFICATIONS_SYSTEM,
     WOO_POS_CLIENT_SIDE_BANNER,
@@ -27,8 +28,9 @@ enum class FeatureFlag {
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
             BOOKINGS_MVP,
+            POS_PRODUCTS_FTS,
             POS_REFUNDS,
-            AGE_ELIGIBILITY_CHECKS -> PackageUtils.isDebugBuild()
+            AGE_ELIGIBILITY_CHECKS-> PackageUtils.isDebugBuild()
 
             WOO_POS_LOCAL_CATALOG_FILE_APPROACH,
             WOO_PUSH_NOTIFICATIONS_SYSTEM -> false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -30,7 +30,7 @@ enum class FeatureFlag {
             BOOKINGS_MVP,
             POS_PRODUCTS_FTS,
             POS_REFUNDS,
-            AGE_ELIGIBILITY_CHECKS-> PackageUtils.isDebugBuild()
+            AGE_ELIGIBILITY_CHECKS -> PackageUtils.isDebugBuild()
 
             WOO_POS_LOCAL_CATALOG_FILE_APPROACH,
             WOO_PUSH_NOTIFICATIONS_SYSTEM -> false


### PR DESCRIPTION
Closes WOOMOB-2064

### Description

Adds a new `POS_PRODUCTS_FTS` feature flag to control the rollout of FTS-based product search in POS. The flag is enabled in debug builds only. Also adds an `IsPosProductsFtsEnabled` wrapper class for dependency injection and testing.

### Test Steps

1. Verify the app builds successfully in debug and release configurations
2. Confirm `POS_PRODUCTS_FTS` is enabled in debug builds
3. Confirm `POS_PRODUCTS_FTS` is disabled in release builds

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.