### PR TITLE
[Woo POS] Pass email directly to POS receipt endpoint for WC 10.0.0+

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepository.kt
@@ -31,7 +31,8 @@ class WooPosEmailReceiptRepository @Inject constructor(
         val sendOrderResult = orderStore.sendOrderPOSSpecificReceipt(
             selectedSite.get(),
             orderId,
-            email
+            email,
+            forceEmailUpdate = true
         )
         return if (sendOrderResult.isError) {
             Result.failure(Exception("Failed to send order receipt"))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepository.kt
@@ -16,24 +16,37 @@ class WooPosEmailReceiptRepository @Inject constructor(
     private val getWooCoreVersion: GetWooCorePluginCachedVersion
 ) {
     suspend fun sendReceiptByEmail(orderId: Long, email: String): Result<Unit> = withContext(Dispatchers.IO) {
-        val updateResult = orderStore.updateOrderBillingEmail(selectedSite.get(), orderId, email)
-        if (updateResult.isError) {
-            return@withContext Result.failure(Exception("Failed to update order with email"))
+        return@withContext if (posReceiptsAreEnabled()) {
+            sendPOSReceipt(orderId, email)
+        } else {
+            sendLegacyReceipt(orderId, email)
         }
-
-        return@withContext triggerOrderReceiptSending(orderId)
     }
 
     fun isEmailValid(email: String): Boolean = provideEmailPattern().matcher(email).matches()
 
     fun posReceiptsAreEnabled(): Boolean = isWooCoreSupportsPOSReceipts()
 
-    private suspend fun triggerOrderReceiptSending(orderId: Long): Result<Unit> {
-        val sendOrderResult = if (posReceiptsAreEnabled()) {
-            orderStore.sendOrderPOSSpecificReceipt(selectedSite.get(), orderId)
+    private suspend fun sendPOSReceipt(orderId: Long, email: String): Result<Unit> {
+        val sendOrderResult = orderStore.sendOrderPOSSpecificReceipt(
+            selectedSite.get(),
+            orderId,
+            email
+        )
+        return if (sendOrderResult.isError) {
+            Result.failure(Exception("Failed to send order receipt"))
         } else {
-            orderStore.sendOrderReceipt(selectedSite.get(), orderId)
+            Result.success(Unit)
         }
+    }
+
+    private suspend fun sendLegacyReceipt(orderId: Long, email: String): Result<Unit> {
+        val updateResult = orderStore.updateOrderBillingEmail(selectedSite.get(), orderId, email)
+        if (updateResult.isError) {
+            return Result.failure(Exception("Failed to update order with email"))
+        }
+
+        val sendOrderResult = orderStore.sendOrderReceipt(selectedSite.get(), orderId)
         return if (sendOrderResult.isError) {
             Result.failure(Exception("Failed to send order receipt"))
         } else {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepositoryTest.kt
@@ -95,14 +95,14 @@ class WooPosEmailReceiptRepositoryTest {
         val email = "test@example.com"
 
         whenever(getWooCoreVersion.invoke()).thenReturn("10.0.0")
-        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email)).thenReturn(WooPayload(Unit))
+        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email, true)).thenReturn(WooPayload(Unit))
 
         // WHEN
         val result = repository.sendReceiptByEmail(orderId, email)
 
         // THEN
         assertThat(result.isSuccess).isTrue()
-        verify(orderStore).sendOrderPOSSpecificReceipt(siteModel, orderId, email)
+        verify(orderStore).sendOrderPOSSpecificReceipt(siteModel, orderId, email, true)
         verify(orderStore, never()).updateOrderBillingEmail(siteModel, orderId, email)
     }
 
@@ -131,7 +131,7 @@ class WooPosEmailReceiptRepositoryTest {
         val email = "test@example.com"
 
         whenever(getWooCoreVersion.invoke()).thenReturn("10.0.0")
-        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email)).thenReturn(
+        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email, true)).thenReturn(
             WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.TIMEOUT))
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepositoryTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -88,32 +89,50 @@ class WooPosEmailReceiptRepositoryTest {
     }
 
     @Test
-    fun `given valid order id and email, when sendReceiptByEmail and WC version is 10 or higher, it calls for POS receipts then return success`() = runTest {
+    fun `given WC version 10 or higher, when sendReceiptByEmail, then sends POS receipt with email directly`() = runTest {
         // GIVEN
         val orderId = 1L
         val email = "test@example.com"
 
         whenever(getWooCoreVersion.invoke()).thenReturn("10.0.0")
-        whenever(orderStore.updateOrderBillingEmail(siteModel, orderId, email)).thenReturn(WooPayload(Unit))
-        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId)).thenReturn(WooPayload(Unit))
+        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email)).thenReturn(WooPayload(Unit))
 
         // WHEN
         val result = repository.sendReceiptByEmail(orderId, email)
 
         // THEN
         assertThat(result.isSuccess).isTrue()
-        verify(orderStore).updateOrderBillingEmail(siteModel, orderId, email)
-        verify(orderStore).sendOrderPOSSpecificReceipt(siteModel, orderId)
+        verify(orderStore).sendOrderPOSSpecificReceipt(siteModel, orderId, email)
+        verify(orderStore, never()).updateOrderBillingEmail(siteModel, orderId, email)
     }
 
     @Test
-    fun `given email update fails, when sendReceiptByEmail, then return failure`() = runTest {
+    fun `given legacy WC version and email update fails, when sendReceiptByEmail, then return failure`() = runTest {
         // GIVEN
         val email = "test@example.com"
         val orderId = 1L
 
+        whenever(getWooCoreVersion.invoke()).thenReturn("9.9.0")
         whenever(orderStore.updateOrderBillingEmail(siteModel, orderId, email)).thenReturn(
             WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.NETWORK_ERROR))
+        )
+
+        // WHEN
+        val result = repository.sendReceiptByEmail(orderId, email)
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+    }
+
+    @Test
+    fun `given WC 10 or higher and POS receipt fails, when sendReceiptByEmail, then return failure`() = runTest {
+        // GIVEN
+        val orderId = 1L
+        val email = "test@example.com"
+
+        whenever(getWooCoreVersion.invoke()).thenReturn("10.0.0")
+        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email)).thenReturn(
+            WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.TIMEOUT))
         )
 
         // WHEN

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -1073,13 +1073,17 @@ class OrderRestClient @Inject constructor(
     suspend fun sendOrderPOSSpecificReceipt(
         site: SiteModel,
         orderId: Long,
+        email: String,
+        forceEmailUpdate: Boolean = true
     ): WooPayload<Unit> {
         val response = wooNetwork.executePostGsonRequest(
             site = site,
             path = WOOCOMMERCE.orders.id(orderId).actions.send_email.pathV3,
             clazz = Unit::class.java,
             body = mapOf(
-                "template_id" to "customer_pos_completed_order"
+                "template_id" to "customer_pos_completed_order",
+                "email" to email,
+                "force_email_update" to forceEmailUpdate
             )
         )
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -1074,7 +1074,7 @@ class OrderRestClient @Inject constructor(
         site: SiteModel,
         orderId: Long,
         email: String,
-        forceEmailUpdate: Boolean = true
+        forceEmailUpdate: Boolean
     ): WooPayload<Unit> {
         val response = wooNetwork.executePostGsonRequest(
             site = site,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -783,7 +783,7 @@ class WCOrderStore @Inject internal constructor(
         site: SiteModel,
         orderId: Long,
         email: String,
-        forceEmailUpdate: Boolean = true
+        forceEmailUpdate: Boolean
     ) = wcOrderRestClient.sendOrderPOSSpecificReceipt(
         site,
         orderId,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -782,9 +782,13 @@ class WCOrderStore @Inject internal constructor(
     suspend fun sendOrderPOSSpecificReceipt(
         site: SiteModel,
         orderId: Long,
+        email: String,
+        forceEmailUpdate: Boolean = true
     ) = wcOrderRestClient.sendOrderPOSSpecificReceipt(
         site,
-        orderId
+        orderId,
+        email,
+        forceEmailUpdate
     )
 
     suspend fun updateOrderBillingEmail(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
@@ -308,4 +308,41 @@ class OrderRestClientTest {
 
         assertThat(bodyCaptor.firstValue).isEqualTo(expectedBody)
     }
+
+    @Test
+    fun `when sendOrderPOSSpecificReceipt is called, then email and force_email_update are sent in request body`() = runTest {
+        // Given
+        val orderId = 123L
+        val email = "test@example.com"
+        val expectedPath = WOOCOMMERCE.orders.id(orderId).actions.send_email.pathV3
+        val expectedBody = mapOf(
+            "template_id" to "customer_pos_completed_order",
+            "email" to email,
+            "force_email_update" to true
+        )
+        val mockResponse = WPAPIResponse.Success(Unit, emptyList())
+
+        whenever(
+            wooNetwork.executePostGsonRequest(
+                site = any(),
+                path = any(),
+                clazz = eq(Unit::class.java),
+                body = any()
+            )
+        ).thenReturn(mockResponse)
+
+        // When
+        orderRestClient.sendOrderPOSSpecificReceipt(testSite, orderId, email)
+
+        // Then
+        val bodyCaptor = argumentCaptor<Map<String, Any>>()
+        verify(wooNetwork).executePostGsonRequest(
+            site = eq(testSite),
+            path = eq(expectedPath),
+            clazz = eq(Unit::class.java),
+            body = bodyCaptor.capture()
+        )
+
+        assertThat(bodyCaptor.firstValue).isEqualTo(expectedBody)
+    }
 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
@@ -332,7 +332,7 @@ class OrderRestClientTest {
         ).thenReturn(mockResponse)
 
         // When
-        orderRestClient.sendOrderPOSSpecificReceipt(testSite, orderId, email)
+        orderRestClient.sendOrderPOSSpecificReceipt(testSite, orderId, email, forceEmailUpdate = true)
 
         // Then
         val bodyCaptor = argumentCaptor<Map<String, Any>>()

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -640,7 +640,7 @@ internal class WCOrderStoreTest {
             val email = "test@example.com"
 
             // WHEN
-            orderStore.sendOrderPOSSpecificReceipt(site, orderId, email)
+            orderStore.sendOrderPOSSpecificReceipt(site, orderId, email, forceEmailUpdate = true)
 
             // THEN
             verify(orderRestClient).sendOrderPOSSpecificReceipt(site, orderId, email, true)

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -637,12 +637,13 @@ internal class WCOrderStoreTest {
             val orderModel = OrderTestUtils.generateSampleOrder(42)
             val site = SiteModel().apply { id = orderModel.localSiteId.value }
             val orderId = 42L
+            val email = "test@example.com"
 
             // WHEN
-            orderStore.sendOrderPOSSpecificReceipt(site, orderId)
+            orderStore.sendOrderPOSSpecificReceipt(site, orderId, email)
 
             // THEN
-            verify(orderRestClient).sendOrderPOSSpecificReceipt(site, orderId)
+            verify(orderRestClient).sendOrderPOSSpecificReceipt(site, orderId, email, true)
         }
     }
 


### PR DESCRIPTION
WOOMOB-2044

Could be tested together https://github.com/woocommerce/woocommerce-android/pull/15256 if needed

### Description

Enhancement to the POS email receipt fix. For WooCommerce 10.0.0+, this change passes the email directly to the `send_email` endpoint with `force_email_update`, instead of separately updating the billing email first.

- Passing `email` and `force_email_update` directly to `sendOrderPOSSpecificReceipt`
- Skipping the order update step
- Matching the iOS implementation
- Legacy WC versions still use `updateOrderBillingEmail` + `sendOrderReceipt`

### Changes
- Added `email` and `forceEmailUpdate` params to `sendOrderPOSSpecificReceipt` (OrderRestClient, WCOrderStore)
- Updated `WooPosEmailReceiptRepository` to use direct email passing for WC 10.0.0+
- Added tests for the new behavior

### Test Steps

Test with both >=10.0 and <10.0:

1. Create a POS order and complete payment
2. Issue a refund for the order
3. From the orders list, select the refunded order
4. Send an email receipt
5. Verify the order status remains "Refunded" (not changed to "Completed")
6. Verify the email is received correctly

### Screenshots


#### For >=10.0

The new email is successfully sent, the order status has not changed

<img width="602" height="706" alt="image" src="https://github.com/user-attachments/assets/fae682e5-d807-4063-982b-e6ebc99d9e30" />

#### For <10.0 (Fallback)

This old email is successfully sent, the order status has not changed

<img width="604" height="672" alt="image" src="https://github.com/user-attachments/assets/c544406f-95a5-46fa-a278-e671a20e9831" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.