### PR TITLE
Dependency submission only main modules

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,9 +1,6 @@
 name: Submit dependencies to GitHub Dependency Graph
 on:
   push:
-    branches:
-      - trunk
-      - release/*
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,9 @@
 name: Submit dependencies to GitHub Dependency Graph
 on:
   push:
+    branches:
+      - trunk
+      - release/*
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,4 +16,4 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/actions/dependency-submission@v3
+        uses: gradle/actions/dependency-submission@v5

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,3 +16,4 @@ jobs:
         uses: gradle/actions/dependency-submission@v5
         with:
           dependency-graph-include-projects: '^:(WooCommerce|WooCommerce-Wear)$'
+          dependency-graph-include-configurations: 'vanillaReleaseRuntimeClasspath'

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,3 +14,5 @@ jobs:
           java-version: '17'
       - name: Setup Gradle to generate and submit dependency graphs
         uses: gradle/actions/dependency-submission@v5
+        with:
+          dependency-graph-include-projects: '^:(WooCommerce|WooCommerce-Wear)$'


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Fixes: [AINFRA-1690: Send dependencies for analysis for main app modules only](https://linear.app/a8c/issue/AINFRA-1690/send-dependencies-for-analysis-for-main-app-modules-only)

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR closes, partially, a problem of false reports from GitHub's Dependabot security alerts.

### Problem to address

#### Declarations in different modules

3d210c9fd840bd9f877b0d04eec3ce18aa710056

See context in the attached Linear issue. TLDR; currently, we **resolve and send dependencies for each project separately**. So if `:libs:cardreader` declares `depA:1.2.3` and `:WooCommerce` declares `depB:3.4.5`, we send **both** versions to Dependabot. This causes confusing and false positive alerts as actually during the build, Gradle resolves dependencies to the newest declared: so it'll always be `depB:3.4.5`.

Solution is to send dependencies of main modules only (they will of course contain transitevely dependencies of sub-projects). More info: [Selecting Gradle projects that will contribute to the dependency graph](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#selecting-gradle-projects-that-will-contribute-to-the-dependency-graph).

#### Unused configurations

cf6655818082b40f9449bd187709aec055fc3680

By default, [github-dependency-graph-gradle-plugin](https://github.com/gradle/github-dependency-graph-gradle-plugin) sends dependencies for all possible configurations. This causes, again, false positives, as there are configurations like `implementationDependenciesMetadata` which is some kind of a helper for IDE, that's not even displayed in Gradle Scans. These metadata configurations might contain duplicates with different versions (as they're not subject for the standard dependency resolution) causing, again, false-positive reports. 

In case of Woo, it happened with `okhttp`: release runtime resolved to `okhttp:5.3.2` but `implementationDependenciesMetadata` had `okhttp:4.12.0`, so we had a false report that app uses `okhttp:4.12.0` too.

Solution is to send **runtime release** dependencies as this code specifically is sent to our users.


#### Diff between old report and new one

| Header | old | new |
|--------|--------|--------|
| file | [old.json](https://github.com/user-attachments/files/24934707/old.json) | [new.json](https://github.com/user-attachments/files/24934704/new.json) |
| size | 605KB | 236KB | 

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

See that in `old.json` you can find both (look for exactly this string to find the top-level dependencies)
- `"com.squareup.okhttp3:okhttp:4.12.0" :`
- `"com.squareup.okhttp3:okhttp:5.3.2" :` 

And in `new.json` there's only 
- `"com.squareup.okhttp3:okhttp:5.3.2" :` 

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
