### PR TITLE
[Woo POS][Refunds] Fix dialog state handling in WooPosOrdersScreen 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -608,7 +608,8 @@ fun WooPosOrdersScreenPreview() {
                 pullToRefreshState = WooPosPullToRefreshState.Enabled,
                 searchInputState = WooPosSearchInputState.Closed,
                 selectedDetails = details1,
-                paginationState = WooPosPaginationState.None
+                paginationState = WooPosPaginationState.None,
+                dialogState = WooPosOrdersState.Content.DialogState.Hidden
             ),
             scrollToTopEvent = MutableSharedFlow(),
             onBackClicked = {},
@@ -644,7 +645,8 @@ fun WooPosOrdersSearchErrorStatePreview() {
                     isLoading = false
                 ),
                 selectedDetails = details,
-                paginationState = WooPosPaginationState.None
+                paginationState = WooPosPaginationState.None,
+                dialogState = WooPosOrdersState.Content.DialogState.Hidden
             ),
             scrollToTopEvent = MutableSharedFlow(),
             onBackClicked = {},
@@ -680,7 +682,8 @@ fun WooPosOrdersNothingFoundStatePreview() {
                     isLoading = false
                 ),
                 selectedDetails = details,
-                paginationState = WooPosPaginationState.None
+                paginationState = WooPosPaginationState.None,
+                dialogState = WooPosOrdersState.Content.DialogState.Hidden
             ),
             scrollToTopEvent = MutableSharedFlow(),
             onBackClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -107,7 +107,7 @@ sealed class WooPosOrdersState {
         override val searchInputState: WooPosSearchInputState,
         val selectedDetails: OrderDetailsViewState.Computed.Details?,
         val paginationState: WooPosPaginationState,
-        val dialogState: DialogState = DialogState.Hidden
+        val dialogState: DialogState
     ) : WooPosOrdersState() {
         sealed class Items {
             data class Loaded(val items: Map<OrderItemViewState, OrderDetailsViewState>) : Items()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -484,7 +484,8 @@ class WooPosOrdersViewModel @Inject constructor(
                     pullToRefreshState = WooPosPullToRefreshState.Disabled,
                     searchInputState = _state.value.searchInputState,
                     selectedDetails = currentSelectedDetails,
-                    paginationState = WooPosPaginationState.None
+                    paginationState = WooPosPaginationState.None,
+                    dialogState = WooPosOrdersState.Content.DialogState.Hidden
                 )
             }
 
@@ -502,7 +503,8 @@ class WooPosOrdersViewModel @Inject constructor(
                         pullToRefreshState = WooPosPullToRefreshState.Enabled,
                         searchInputState = _state.value.searchInputState,
                         selectedDetails = null,
-                        paginationState = WooPosPaginationState.None
+                        paginationState = WooPosPaginationState.None,
+                        dialogState = WooPosOrdersState.Content.DialogState.Hidden
                     )
                 }
 
@@ -516,7 +518,8 @@ class WooPosOrdersViewModel @Inject constructor(
                             pullToRefreshState = WooPosPullToRefreshState.Enabled,
                             searchInputState = _state.value.searchInputState,
                             selectedDetails = null,
-                            paginationState = WooPosPaginationState.None
+                            paginationState = WooPosPaginationState.None,
+                            dialogState = WooPosOrdersState.Content.DialogState.Hidden
                         )
                     } else {
                         replaceOrders(result.ordersWithRefunds)
@@ -573,6 +576,7 @@ class WooPosOrdersViewModel @Inject constructor(
         searchJob?.cancel()
         loadingJob?.cancel()
         loadingMoreOrdersJob?.cancel()
+        sideLoadActionsJob?.cancel()
     }
 
     private suspend fun getOrComputeDetails(orderId: Long): WooPosOrdersState.OrderDetailsViewState.Computed.Details {
@@ -650,7 +654,9 @@ class WooPosOrdersViewModel @Inject constructor(
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
             selectedDetails = selectedDetails,
             paginationState = paginationState,
-            searchInputState = _state.value.searchInputState
+            searchInputState = _state.value.searchInputState,
+            dialogState = (currentState as? WooPosOrdersState.Content)?.dialogState
+                ?: WooPosOrdersState.Content.DialogState.Hidden
         )
 
         if (currentFirstOrderId != null && currentFirstOrderId != newFirstOrderId) {
@@ -675,7 +681,8 @@ class WooPosOrdersViewModel @Inject constructor(
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
             selectedDetails = current.selectedDetails,
             paginationState = paginationState,
-            searchInputState = _state.value.searchInputState
+            searchInputState = _state.value.searchInputState,
+            dialogState = current.dialogState
         )
     }
 


### PR DESCRIPTION
WOOMOB-2079

<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes dialog state handling in the WooPos Orders screen by ensuring the dialog state  is properly preserved during state transitions in WooPosOrdersViewModel.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Steps to reproduce bug on `trunk`:

1. Open POS Orders and click Issue refund on the first selected order
2. Wait for refundable items list to apprea in dialog
3. Go back to POS Home
4. Go to Orders again and tap Issue refund button again (immediately)
5. Notice the dialog shows loading state and then gets dismissed before showing refundable items

This was happening because WooPosOrdersViewModel fetches orders in background and when receives the result, updates UI state resulting in refund flow being set to Hidden.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
—

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
