### PR TITLE
[WOOMOB-2094] Fix battery level discrepancy between main app and WooPOS

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderFacade.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderFacade.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.cardreader
 
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,6 +15,7 @@ class WooPosCardReaderFacade @Inject constructor(
 ) {
     val readerStatus: StateFlow<CardReaderStatus> = cardReaderManager.readerStatus
     val softwareUpdateAvailability: Flow<SoftwareUpdateAvailability> = cardReaderManager.softwareUpdateAvailability
+    val batteryStatus: Flow<CardReaderBatteryStatus> = cardReaderManager.batteryStatus
 
     fun cancelReconnection() {
         cardReaderManager.cancelReconnection()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
@@ -51,12 +51,11 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
     val openUrl = _openUrl.asSharedFlow()
 
     private lateinit var softwareUpdateAvailabilityJob: Job
-    private lateinit var batteryStatusJob: Job
+    private var batteryStatusJob: Job? = null
     private var currentSoftwareUpdateAvailable = false
 
     init {
         listenForSoftwareUpdateAvailability()
-        listenForBatteryStatus()
         observeCardReaderStatus()
     }
 
@@ -113,6 +112,7 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
     }
 
     private fun listenForBatteryStatus() {
+        if (batteryStatusJob?.isActive == true) return
         batteryStatusJob = viewModelScope.launch {
             cardReaderFacade.batteryStatus.collect { status ->
                 if (status is CardReaderBatteryStatus.StatusChanged) {
@@ -132,6 +132,7 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
             cardReaderFacade.readerStatus.collect { status ->
                 _uiState.value = when (status) {
                     is CardReaderStatus.Connected -> {
+                        listenForBatteryStatus()
                         WooPosSettingsHardwareCardReaderUiState.Connected(
                             readerName = status.cardReader.id ?: resourceProvider.getString(
                                 R.string.woopos_settings_card_reader_unknown_reader
@@ -144,6 +145,7 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
 
                     is CardReaderStatus.Connecting,
                     is CardReaderStatus.NotConnected -> {
+                        cancelBatteryStatusJob()
                         currentSoftwareUpdateAvailable = false
                         WooPosSettingsHardwareCardReaderUiState.Disconnected
                     }
@@ -155,5 +157,10 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun cancelBatteryStatusJob() {
+        batteryStatusJob?.cancel()
+        batteryStatusJob = null
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType.STRIPE_EXTENSION_GATEWAY
@@ -50,10 +51,12 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
     val openUrl = _openUrl.asSharedFlow()
 
     private lateinit var softwareUpdateAvailabilityJob: Job
+    private lateinit var batteryStatusJob: Job
     private var currentSoftwareUpdateAvailable = false
 
     init {
         listenForSoftwareUpdateAvailability()
+        listenForBatteryStatus()
         observeCardReaderStatus()
     }
 
@@ -106,6 +109,21 @@ class WooPosSettingsHardwareCardReaderViewModel @Inject constructor(
             _uiState.value = currentState.copy(
                 isSoftwareUpdateAvailable = currentSoftwareUpdateAvailable
             )
+        }
+    }
+
+    private fun listenForBatteryStatus() {
+        batteryStatusJob = viewModelScope.launch {
+            cardReaderFacade.batteryStatus.collect { status ->
+                if (status is CardReaderBatteryStatus.StatusChanged) {
+                    val currentState = _uiState.value
+                    if (currentState is WooPosSettingsHardwareCardReaderUiState.Connected) {
+                        _uiState.value = currentState.copy(
+                            batteryLevel = status.batteryLevel
+                        )
+                    }
+                }
+            }
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/hardware/cardreader/WooPosSettingsHardwareCardReaderViewModelTest.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.woopos.settings.details.hardware.cardreader
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.cardreader.connection.event.BatteryStatus
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
@@ -47,12 +49,16 @@ class WooPosSettingsHardwareCardReaderViewModelTest {
     private val softwareUpdateFlow = MutableStateFlow<SoftwareUpdateAvailability>(
         SoftwareUpdateAvailability.NotAvailable
     )
+    private val batteryStatusFlow = MutableStateFlow<CardReaderBatteryStatus>(
+        CardReaderBatteryStatus.Unknown
+    )
 
     @Test
     fun `given disconnected reader, when init, then shows disconnected state`() = runTest {
         // GIVEN
         whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
         whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
+        whenever(cardReaderFacade.batteryStatus).thenReturn(batteryStatusFlow)
         readerStatusFlow.value = CardReaderStatus.NotConnected()
 
         // WHEN
@@ -75,6 +81,7 @@ class WooPosSettingsHardwareCardReaderViewModelTest {
         }
         whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
         whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
+        whenever(cardReaderFacade.batteryStatus).thenReturn(batteryStatusFlow)
         // WHEN
         val viewModel = createViewModel()
         readerStatusFlow.value = CardReaderStatus.Connected(mockReader)
@@ -94,6 +101,7 @@ class WooPosSettingsHardwareCardReaderViewModelTest {
         // GIVEN
         whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
         whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
+        whenever(cardReaderFacade.batteryStatus).thenReturn(batteryStatusFlow)
         val viewModel = createViewModel()
 
         // WHEN
@@ -111,6 +119,7 @@ class WooPosSettingsHardwareCardReaderViewModelTest {
         // GIVEN
         whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
         whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
+        whenever(cardReaderFacade.batteryStatus).thenReturn(batteryStatusFlow)
         val viewModel = createViewModel()
 
         // WHEN
@@ -133,6 +142,7 @@ class WooPosSettingsHardwareCardReaderViewModelTest {
         }
         whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
         whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
+        whenever(cardReaderFacade.batteryStatus).thenReturn(batteryStatusFlow)
 
         // WHEN
         val viewModel = createViewModel()
@@ -157,6 +167,7 @@ class WooPosSettingsHardwareCardReaderViewModelTest {
         }
         whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
         whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
+        whenever(cardReaderFacade.batteryStatus).thenReturn(batteryStatusFlow)
 
         // WHEN
         val viewModel = createViewModel()
@@ -169,6 +180,37 @@ class WooPosSettingsHardwareCardReaderViewModelTest {
         assertThat(uiState).isInstanceOf(WooPosSettingsHardwareCardReaderUiState.Connected::class.java)
         val connectedState = uiState as WooPosSettingsHardwareCardReaderUiState.Connected
         assertThat(connectedState.isSoftwareUpdateAvailable).isFalse()
+    }
+
+    @Test
+    fun `given connected reader, when battery status changes, then updates battery level`() = runTest {
+        // GIVEN
+        val mockReader = mock<CardReader> {
+            whenever(it.id).thenReturn("Test Reader")
+            whenever(it.currentBatteryLevel).thenReturn(0.75f)
+            whenever(it.firmwareVersion).thenReturn("1.2.3")
+        }
+        whenever(cardReaderFacade.readerStatus).thenReturn(readerStatusFlow)
+        whenever(cardReaderFacade.softwareUpdateAvailability).thenReturn(softwareUpdateFlow)
+        whenever(cardReaderFacade.batteryStatus).thenReturn(batteryStatusFlow)
+
+        val viewModel = createViewModel()
+        readerStatusFlow.value = CardReaderStatus.Connected(mockReader)
+        advanceUntilIdle()
+
+        // WHEN
+        batteryStatusFlow.value = CardReaderBatteryStatus.StatusChanged(
+            batteryLevel = 0.15f,
+            batteryStatus = BatteryStatus.LOW,
+            isCharging = false
+        )
+        advanceUntilIdle()
+
+        // THEN
+        val uiState = viewModel.uiState.value
+        assertThat(uiState).isInstanceOf(WooPosSettingsHardwareCardReaderUiState.Connected::class.java)
+        val connectedState = uiState as WooPosSettingsHardwareCardReaderUiState.Connected
+        assertThat(connectedState.batteryLevel).isEqualTo(0.15f)
     }
 
     private fun createViewModel() = WooPosSettingsHardwareCardReaderViewModel(


### PR DESCRIPTION
WOOMOB-2094

### Description

The WooPOS settings screen was showing different battery levels compared to the main app for the same card reader. This happened because WooPOS only read the battery level from the CardReader object captured at connection time and never updated it afterward.

The main app subscribes to the `batteryStatus` flow which receives live battery updates from the Stripe Terminal SDK. This PR adds the same subscription pattern to WooPOS so both screens show consistent battery levels.

### Test Steps

1. Enable Developer Options > Simulated Card Reader
2. Set "Simulated reader update" to "Low battery, succeed connect"
3. Connect to the simulated reader in WooPOS
4. Go to WooPOS Settings > Hardware > Card Reader
5. Verify the battery level is 15% (not 80 as used to be)
6. Compare with the main app's card reader details - both should show the same battery level

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.