### PR TITLE
[Tooling] Add fastlane lane for AI-generated translation context

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'rubocop', '~> 1.65'
 ### Fastlane Plugins
 
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 13.8'
+gem 'txcontext', git: 'https://github.com/iangmaia/txcontext'
 # gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: ''
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/iangmaia/txcontext
+  revision: c19f9620e6e1e37eb8d8cec5e1d37d639d816f99
+  specs:
+    txcontext (0.1.0)
+      concurrent-ruby (~> 1.2)
+      dotstrings (~> 0.6)
+      httpx (~> 1.0)
+      oj (~> 3.16)
+      rexml (~> 3.2)
+      thor (~> 1.3)
+      tty-progressbar (~> 0.18)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -90,6 +103,7 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
+    dotstrings (0.6.0)
     drb (2.2.3)
     emoji_regex (3.2.3)
     excon (0.112.0)
@@ -236,10 +250,13 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
+    http-2 (1.1.1)
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
+    httpx (1.7.2)
+      http-2 (>= 1.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     java-properties (0.3.0)
@@ -270,10 +287,14 @@ GEM
     octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
+    oj (3.16.13)
+      bigdecimal (>= 3.0)
+      ostruct (>= 0.2)
     open4 (1.3.4)
     options (2.3.2)
     optparse (0.8.1)
     os (1.1.4)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.0)
       ast (~> 2.4.1)
@@ -330,12 +351,19 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
+    strings-ansi (0.2.0)
     sysrandom (1.0.5)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    thor (1.5.0)
     trailblazer-option (0.1.2)
     tty-cursor (0.7.1)
+    tty-progressbar (0.18.3)
+      strings-ansi (~> 0.2)
+      tty-cursor (~> 0.7)
+      tty-screen (~> 0.8)
+      unicode-display_width (>= 1.6, < 3.0)
     tty-screen (0.8.2)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
@@ -368,6 +396,7 @@ DEPENDENCIES
   nokogiri
   rmagick (~> 4.1)
   rubocop (~> 1.65)
+  txcontext!
 
 BUNDLED WITH
    2.5.20

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="set_up_now">Set up now</string>
     <string name="offline_message">Offline \u2014 using cached data</string>
     <string name="offline_error">Your network is unavailable. Check your data or wifi connection.</string>
+    <!-- Error message displayed as a toast notification in WooCommerce POS when pull-to-refresh fails due to network connectivity issues while syncing product data or search results. -->
     <string name="woo_pos_ptr_offline_error">No internet connection. Please check your network and try again.</string>
     <string name="product">Product</string>
     <string name="today">Today</string>
@@ -2316,6 +2317,7 @@
     <string name="settings_about_recommend_app_subject">WooCommerce</string>
     <string name="settings_about_recommend_app_message">Hey! Here is a link to download the WooCommerce app. I\'m really enjoying it and thought you might too. %1$s</string>
     <string name="dev_options">Developer Options</string>
+    <!-- This text appears as the title in the top navigation bar of a developer options screen that allows developers to toggle various feature flags on/off, and also as a menu item label in the main developer options list that navigates to this feature flags screen. -->
     <string name="dev_feature_flags">Feature Flags</string>
     <string name="restart">Restart</string>
     <string name="settings_account">Account Settings</string>
@@ -3820,9 +3822,12 @@
     </plurals>
     <string name="woopos_orders_refund_total">Refund total</string>
     <string name="woopos_orders_refund_reason">Refund reason</string>
+    <!-- This text appears as a label for an input field on the WooPos refund reason screen, where users enter the reason for refunding an order. It serves as the field label to guide users on what information to provide in the text input area. -->
     <string name="woopos_orders_refund_reason_placeholder">Reason for refunding order</string>
     <string name="woopos_orders_edit_reason">Edit reason</string>
+    <!-- This text appears as a button label on the WooPos refund reason screen when the input field is empty, allowing users to add a refund reason for an order. -->
     <string name="woopos_orders_refund_reason_add">Add</string>
+    <!-- Button text that appears on the refund reason entry screen in the WooPos (Point of Sale) system. The button displays 'Save' when the user has entered a refund reason and allows them to save and proceed with the refund process. -->
     <string name="woopos_orders_refund_reason_save">Save</string>
     <string name="woopos_orders_edit_refund">Edit refund</string>
     <string name="woopos_orders_confirm_refund_title">Refund %1$s</string>
@@ -4359,11 +4364,14 @@
     <string name="about_automattic_logo_description">Automattic logo</string>
     <string name="about_automattic_back_icon_description">Back icon</string>
     <string name="about_automattic_app_icon_description">App icon</string>
+    <!-- This text appears as the title of a dialog box that is displayed when a user's account access is restricted due to age eligibility requirements. The dialog is shown as part of the WooCommerce app's age verification system to inform users that their account has limited access. -->
     <string name="age_restriction_dialog_title">Account Access Restricted</string>
+    <!-- This message appears in a dialog box shown to users whose Google Account indicates they need parental permission to use the WooCommerce app, explaining how a parent or guardian can grant access through their Google account. -->
     <string name="age_restriction_supervised_user_account_dialog_message">Your Google Account settings indicate that you need a parent or guardian\'s permission to continue. They can grant access using their Google account to get you back online.</string>
+    <!-- This message appears in a dialog that blocks app access when the user's Google Account indicates they are under 13 years old, explaining they don't meet the minimum age requirement for WooCommerce's terms of service. -->
     <string name="age_restriction_user_below_tos_minimum_age_dialog_message">Your Google Account indicates that you are under 13 years old, which is below the minimum age allowed to use the WooCommerce platform under its terms of service.</string>
 
-    <!-- Woo POS Promo Carousel -->
+    <!-- This text appears as the main title in a promotional screen that introduces WooCommerce's Point of Sale feature to users. It's displayed prominently at the top of a carousel-style promotional interface that showcases the POS functionality. -->
     <string name="woo_pos_promo_title">Point of Sale from WooCommerce</string>
     <string name="woo_pos_promo_page1_description">Take payments in person and connect everything back to your store — all through the WooCommerce mobile app.</string>
     <string name="woo_pos_promo_page2_description">Real-time syncing for inventory, customer, and order data between online and in-person channels.</string>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1696,7 +1696,7 @@ platform :android do
   def fetch_release_tags
     Actions.sh('git', 'fetch', '--tags', '--force')
     tags = Actions.sh('git', 'tag', '--list', '--sort=-v:refname').split("\n")
-    tags.select { |tag| tag.match?(/^\d+\.\d+(\.\d+)?$/) }
+    tags.grep(/^\d+\.\d+(\.\d+)?$/)
   end
 
   # Returns true if the tag version is numerically less than the comparison parts.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1684,26 +1684,26 @@ platform :android do
   # the most recent one that is numerically less than the current release version.
   #
   def previous_release_tag
-    current_version = release_version_current
-    current_parts = current_version.split('.').map(&:to_i)
+    current_parts = release_version_current.split('.').map(&:to_i)
+    release_tags = fetch_release_tags
 
-    # Fetch tags from remote to ensure we have the latest
+    release_tags.find { |tag| version_less_than?(tag, current_parts) }
+  end
+
+  # Fetches all release tags from the remote, sorted by version descending.
+  # Release tags are in format X.Y or X.Y.Z (no -rc suffix, no wear tags).
+  #
+  def fetch_release_tags
     Actions.sh('git', 'fetch', '--tags', '--force')
-
-    # Get all tags sorted by version (descending), filtering for release-like tags
-    # Release tags are in format X.Y or X.Y.Z (no -rc suffix)
     tags = Actions.sh('git', 'tag', '--list', '--sort=-v:refname').split("\n")
+    tags.select { |tag| tag.match?(/^\d+\.\d+(\.\d+)?$/) }
+  end
 
-    # Filter for release tags (X.Y or X.Y.Z format, excluding RCs and wear tags)
-    release_tags = tags.select do |tag|
-      tag.match?(/^\d+\.\d+(\.\d+)?$/) && !tag.include?('-') && !tag.include?('w')
-    end
-
-    # Find the first tag that's numerically less than the current version
-    release_tags.find do |tag|
-      tag_parts = tag.split('.').map(&:to_i)
-      (tag_parts <=> current_parts) < 0
-    end
+  # Returns true if the tag version is numerically less than the comparison parts.
+  #
+  def version_less_than?(tag, comparison_parts)
+    tag_parts = tag.split('.').map(&:to_i)
+    (tag_parts <=> comparison_parts).negative?
   end
 
   # Returns the next beta version in the format `1.2-rc-2` (increments the build number)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,7 @@
 
 default_platform(:android)
 fastlane_require 'dotenv'
+fastlane_require 'txcontext'
 
 UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Helper.bundler?
 
@@ -246,6 +247,7 @@ platform :android do
 
     update_play_store_strings
     localize_libs
+    add_translation_context
     freeze_strings_for_translation
 
     push_to_git_remote(tags: false)
@@ -1481,6 +1483,55 @@ platform :android do
   # The reason for the WPCOM job to import the file from `FROZEN_STRINGS_PATH` and not `MAIN_STRINGS_PATH` is so
   # that it picks the file's content as it was at the time of code freeze, and does not risk picking up changes
   # that could be made to the `MAIN_STRINGS_PATH` file on `trunk` _after_ code freeze, by devs working on features.
+
+  # Adds AI-generated translation context to new/changed strings.
+  #
+  # Uses the txcontext gem to analyze source code usage and generate helpful descriptions
+  # for translators. Context is written back to the strings.xml file as XML comments.
+  #
+  # @param [String] diff_base (default: auto-detected previous release tag) Git ref to compare against for finding changed strings
+  # @param [Boolean] skip_commit (default: false) If true, does not commit the changes made to the `strings.xml` file
+  #
+  # @example Running the lane
+  #          bundle exec fastlane add_translation_context
+  #          bundle exec fastlane add_translation_context diff_base:9.5
+  #
+  lane :add_translation_context do |diff_base: previous_release_tag, skip_commit: false|
+    UI.user_error!('Could not determine previous release tag. Please specify diff_base parameter.') if diff_base.nil?
+    UI.user_error!('ANTHROPIC_API_KEY environment variable is required.') if ENV['ANTHROPIC_API_KEY'].nil?
+
+    source_paths = [
+      File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'src', 'main', 'java'),
+      File.join(PROJECT_ROOT_FOLDER, 'WooCommerce', 'src', 'main', 'kotlin')
+    ]
+
+    UI.message("Adding translation context for strings changed since #{diff_base}...")
+
+    # Use txcontext Ruby API directly
+    config = Txcontext::Config.new(
+      translations: [MAIN_STRINGS_PATH],
+      source_paths: source_paths,
+      diff_base: diff_base,
+      write_back: true,
+      context_prefix: '',
+      context_mode: 'replace'
+    )
+
+    extractor = Txcontext::ContextExtractor.new(config)
+    extractor.run
+
+    unless skip_commit
+      git_add(path: MAIN_STRINGS_PATH, shell_escape: false)
+      git_commit(
+        path: MAIN_STRINGS_PATH,
+        message: 'Add AI-generated translation context for new strings',
+        allow_nothing_to_commit: true
+      )
+    end
+
+    UI.success('Translation context added successfully!')
+  end
+
   #
   # A WPCOM job is responsible to import the `FROZEN_STRINGS_PATH` file into GlotPress (as opposed to e.g. us sending them via API).
   # Note: If you decide to change the path to `FROZEN_STRINGS_PATH` at some point, ensure you also update it in the WPCOM job:
@@ -1624,6 +1675,35 @@ platform :android do
     release_version_next = VERSION_CALCULATOR.next_release_version(version: current_version)
     # Return the formatted release version
     VERSION_FORMATTER.release_version(release_version_next)
+  end
+
+  # Returns the most recent release tag before the current version.
+  # Used for comparing changes between releases (e.g., for translation context).
+  #
+  # Looks for tags matching the release version pattern (X.Y or X.Y.Z) and returns
+  # the most recent one that is numerically less than the current release version.
+  #
+  def previous_release_tag
+    current_version = release_version_current
+    current_parts = current_version.split('.').map(&:to_i)
+
+    # Fetch tags from remote to ensure we have the latest
+    Actions.sh('git', 'fetch', '--tags', '--force')
+
+    # Get all tags sorted by version (descending), filtering for release-like tags
+    # Release tags are in format X.Y or X.Y.Z (no -rc suffix)
+    tags = Actions.sh('git', 'tag', '--list', '--sort=-v:refname').split("\n")
+
+    # Filter for release tags (X.Y or X.Y.Z format, excluding RCs and wear tags)
+    release_tags = tags.select do |tag|
+      tag.match?(/^\d+\.\d+(\.\d+)?$/) && !tag.include?('-') && !tag.include?('w')
+    end
+
+    # Find the first tag that's numerically less than the current version
+    release_tags.find do |tag|
+      tag_parts = tag.split('.').map(&:to_i)
+      (tag_parts <=> current_parts) < 0
+    end
   end
 
   # Returns the next beta version in the format `1.2-rc-2` (increments the build number)


### PR DESCRIPTION
Fixes AINFRA-1870

See paaHJt-9BZ-p2

## Summary

This PR uses the gem https://github.com/iangmaia/txcontext (name and location are temporary to validate the general idea) within the release process, specifically in the Code Freeze, to include now a step to enhance the context of translation strings using a LLM.

## Changes

- Adds a new `add_translation_context` fastlane lane that uses the `txcontext` gem to generate AI-powered translation context comments for new/changed strings
- Integrates the lane into the code freeze process (`complete_code_freeze` lane)
- Adds `previous_release_tag` helper to automatically detect the comparison base
- Includes example context comments for recently added strings

## Test plan

- [ ] Run `bundle exec fastlane add_translation_context diff_base:<tag>` with `ANTHROPIC_API_KEY` set
- [ ] Verify context comments are added to strings.xml