### PR TITLE
Allow displaying PN for non WP users

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore.FetchNotificationPayload
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -39,6 +40,7 @@ class NotificationMessageHandler @Inject constructor(
     private val wooLog: WooLog,
     private val dispatcher: Dispatcher,
     private val resourceProvider: ResourceProvider,
+    private val siteStore: SiteStore,
     private val selectedSite: SelectedSite,
     private val workManagerScheduler: WorkManagerScheduler
 ) {
@@ -94,6 +96,10 @@ class NotificationMessageHandler @Inject constructor(
         if (isRegisteredForWooPush) {
             if (notification.remoteNoteId > 0L) {
                 wooLog.d(NOTIFICATIONS, "Skipping WPCOM notification, already registered with Woo Core")
+                return
+            }
+            if (siteStore.visibleSites.none { it.siteId == notification.remoteSiteId }) {
+                wooLog.w(NOTIFICATIONS, "Skipping notification, site ${notification.remoteSiteId} is not visible")
                 return
             }
         } else if (!accountStore.hasAccessToken()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -67,11 +67,6 @@ class NotificationMessageHandler @Inject constructor(
 
     @Suppress("ReturnCount", "ComplexMethod")
     fun onNewMessageReceived(messageData: Map<String, String>) {
-        if (!accountStore.hasAccessToken()) {
-            wooLog.e(NOTIFICATIONS, "User is not logged in!")
-            return
-        }
-
         if (!selectedSite.exists()) {
             wooLog.e(NOTIFICATIONS, "User has no site selected!")
             return
@@ -101,6 +96,9 @@ class NotificationMessageHandler @Inject constructor(
                 wooLog.d(NOTIFICATIONS, "Skipping WPCOM notification, already registered with Woo Core")
                 return
             }
+        } else if (!accountStore.hasAccessToken()) {
+            wooLog.e(NOTIFICATIONS, "User is not logged in!")
+            return
         } else if (notification.remoteNoteId == 0L) {
             // At this point 'note_id' is always available in the notification bundle.
             wooLog.e(NOTIFICATIONS, "Push notification received without a valid note_id in the payload!")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -40,8 +40,10 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore.FetchNotificationPayload
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -70,6 +72,7 @@ class NotificationMessageHandlerTest {
         }
     }
     private val notificationsParser: NotificationsParser = NotificationsParser(jvmBase64Decoder)
+    private val siteStore: SiteStore = mock()
     private val selectedSite: SelectedSite = mock {
         on { exists() }.thenReturn(true)
     }
@@ -100,6 +103,7 @@ class NotificationMessageHandlerTest {
             wooLog = wooLog,
             dispatcher = dispatcher,
             resourceProvider = resourceProvider,
+            siteStore = siteStore,
             selectedSite = selectedSite,
             workManagerScheduler = workManagerScheduler,
         )
@@ -108,15 +112,25 @@ class NotificationMessageHandlerTest {
         doReturn(accountModel).whenever(accountStore).account
         doReturn(true).whenever(notificationBuilder).isNotificationsEnabled()
         doReturn(emptyList<ActiveNotificationData>()).whenever(notificationBuilder).getActiveNotifications()
+
+        // Mock visibleSites to include both order and review notification site IDs
+        val visibleSite = mock<SiteModel> {
+            on { siteId } doReturn orderNotification.remoteSiteId
+        }
+        val visibleSite2 = mock<SiteModel> {
+            on { siteId } doReturn reviewNotification.remoteSiteId
+        }
+        doReturn(listOf(visibleSite, visibleSite2)).whenever(siteStore).visibleSites
     }
 
     @Test
-    fun `when the user is not logged in, then do not process the incoming notification`() {
+    fun `when the user is not logged in, then do not process the incoming notification`() = runTest {
+        whenever(registrationStatus.invoke(any())).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
         doReturn(false).whenever(accountStore).hasAccessToken()
 
-        notificationMessageHandler.onNewMessageReceived(emptyMap())
-        verify(accountStore, atLeastOnce()).hasAccessToken()
-        verify(wooLog, only()).e(eq(WooLog.T.NOTIFICATIONS), eq("User is not logged in!"))
+        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
+
+        verify(wooLog).e(eq(WooLog.T.NOTIFICATIONS), eq("User is not logged in!"))
     }
 
     @Test
@@ -132,8 +146,8 @@ class NotificationMessageHandlerTest {
     @Test
     fun `when the notification payload data is empty, then do not process the notification`() {
         notificationMessageHandler.onNewMessageReceived(emptyMap())
-        verify(accountStore, atLeastOnce()).hasAccessToken()
-        verify(wooLog, only()).e(
+
+        verify(wooLog).e(
             eq(WooLog.T.NOTIFICATIONS),
             eq("Push notification received without a valid Bundle!")
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the Woo Push Notifications project, we allow users who are using self-hosted sites without a WP.com login to receive push notifications. Previously, we had a check that prevented displaying notifications if users were not logged in. Now, for Woo-driven notifications, we skip this check and instead verify that the notification's site is still visible before displaying it.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Testing isn’t currently possible because the Woo push server isn’t active yet.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
