### PR TITLE
[WOOMOB-2093] Show low battery warning in floating toolbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbar.kt
@@ -351,14 +351,16 @@ private fun CardReaderStatusButton(
             ) {
                 Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
                 Circle(size = 14.dp, color = illustrationColor)
-                if (state is WooPosCardReaderStatus.Connected) {
-                    BatteryWarningIcon(batteryState = state.batteryState)
-                }
                 Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
                 ReaderStatusText(
                     modifier = Modifier.animateContentSize(),
                     title = title,
                 )
+
+                if (state is WooPosCardReaderStatus.Connected) {
+                    BatteryWarningIcon(batteryState = state.batteryState)
+                }
+
                 Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
             }
         }
@@ -395,21 +397,19 @@ private fun BatteryWarningIcon(batteryState: WooPosHomeFloatingToolbarState.Batt
     when (batteryState) {
         WooPosHomeFloatingToolbarState.BatteryState.NOMINAL -> { }
         WooPosHomeFloatingToolbarState.BatteryState.LOW -> {
-            Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
             Icon(
                 imageVector = ImageVector.vectorResource(R.drawable.ic_woo_pos_battery_low),
                 contentDescription = stringResource(R.string.woopos_battery_low),
                 tint = WooPosTheme.colors.alert,
-                modifier = Modifier.size(16.dp)
+                modifier = Modifier.size(20.dp)
             )
         }
         WooPosHomeFloatingToolbarState.BatteryState.CRITICAL -> {
-            Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
             Icon(
                 imageVector = ImageVector.vectorResource(R.drawable.ic_woo_pos_battery_critical),
                 contentDescription = stringResource(R.string.woopos_battery_critical),
                 tint = MaterialTheme.colorScheme.error,
-                modifier = Modifier.size(16.dp)
+                modifier = Modifier.size(20.dp)
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbar.kt
@@ -305,7 +305,7 @@ private fun CardReaderStatusButton(
         label = "IllustrationColorTransition"
     ) { status ->
         when (status) {
-            WooPosCardReaderStatus.Connected -> WooPosTheme.colors.success
+            is WooPosCardReaderStatus.Connected -> WooPosTheme.colors.success
             WooPosCardReaderStatus.NotConnected -> WooPosTheme.colors.alert
             WooPosCardReaderStatus.Reconnecting -> WooPosTheme.colors.alert
         }
@@ -318,7 +318,7 @@ private fun CardReaderStatusButton(
         label = "BorderColorTransition"
     ) { status ->
         when (status) {
-            WooPosCardReaderStatus.Connected -> Color.Transparent
+            is WooPosCardReaderStatus.Connected -> Color.Transparent
             WooPosCardReaderStatus.NotConnected -> MaterialTheme.colorScheme.primary
             WooPosCardReaderStatus.Reconnecting -> WooPosTheme.colors.alert
         }
@@ -351,6 +351,9 @@ private fun CardReaderStatusButton(
             ) {
                 Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
                 Circle(size = 14.dp, color = illustrationColor)
+                if (state is WooPosCardReaderStatus.Connected) {
+                    BatteryWarningIcon(batteryState = state.batteryState)
+                }
                 Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
                 ReaderStatusText(
                     modifier = Modifier.animateContentSize(),
@@ -388,6 +391,31 @@ private fun Circle(
 }
 
 @Composable
+private fun BatteryWarningIcon(batteryState: WooPosHomeFloatingToolbarState.BatteryState) {
+    when (batteryState) {
+        WooPosHomeFloatingToolbarState.BatteryState.NOMINAL -> { }
+        WooPosHomeFloatingToolbarState.BatteryState.LOW -> {
+            Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_woo_pos_battery_low),
+                contentDescription = stringResource(R.string.woopos_battery_low),
+                tint = WooPosTheme.colors.alert,
+                modifier = Modifier.size(16.dp)
+            )
+        }
+        WooPosHomeFloatingToolbarState.BatteryState.CRITICAL -> {
+            Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_woo_pos_battery_critical),
+                contentDescription = stringResource(R.string.woopos_battery_critical),
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(16.dp)
+            )
+        }
+    }
+}
+
+@Composable
 private fun getToolbarAccessibilityLabels(
     cardReaderStatus: WooPosCardReaderStatus,
     menuCardDisabled: Boolean
@@ -397,7 +425,7 @@ private fun getToolbarAccessibilityLabels(
     )
 
     val cardReaderStatusContentDescription = when (cardReaderStatus) {
-        WooPosCardReaderStatus.Connected -> stringResource(
+        is WooPosCardReaderStatus.Connected -> stringResource(
             id = R.string.woopos_floating_toolbar_card_reader_connected_status_content_description
         )
 
@@ -475,7 +503,7 @@ fun PreviewWooPosFloatingToolbarStatusConnectedWithMenu() {
     val state = remember {
         mutableStateOf(
             WooPosHomeFloatingToolbarState(
-                cardReaderStatus = WooPosCardReaderStatus.Connected,
+                cardReaderStatus = WooPosCardReaderStatus.Connected(),
                 menu = Menu.Visible(
                     listOf(
                         Menu.MenuItem(
@@ -492,6 +520,38 @@ fun PreviewWooPosFloatingToolbarStatusConnectedWithMenu() {
                         ),
                     )
                 ),
+            )
+        )
+    }
+    Preview(state)
+}
+
+@WooPosPreview
+@Composable
+fun PreviewWooPosFloatingToolbarStatusConnectedBatteryLow() {
+    val state = remember {
+        mutableStateOf(
+            WooPosHomeFloatingToolbarState(
+                cardReaderStatus = WooPosCardReaderStatus.Connected(
+                    batteryState = WooPosHomeFloatingToolbarState.BatteryState.LOW
+                ),
+                menu = Menu.Hidden
+            )
+        )
+    }
+    Preview(state)
+}
+
+@WooPosPreview
+@Composable
+fun PreviewWooPosFloatingToolbarStatusConnectedBatteryCritical() {
+    val state = remember {
+        mutableStateOf(
+            WooPosHomeFloatingToolbarState(
+                cardReaderStatus = WooPosCardReaderStatus.Connected(
+                    batteryState = WooPosHomeFloatingToolbarState.BatteryState.CRITICAL
+                ),
+                menu = Menu.Hidden
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarState.kt
@@ -10,8 +10,16 @@ data class WooPosHomeFloatingToolbarState(
 ) {
     sealed class WooPosCardReaderStatus(@StringRes val title: Int) {
         data object NotConnected : WooPosCardReaderStatus(title = R.string.woopos_reader_disconnected)
-        data object Connected : WooPosCardReaderStatus(title = R.string.woopos_reader_connected)
+        data class Connected(
+            val batteryState: BatteryState = BatteryState.NOMINAL
+        ) : WooPosCardReaderStatus(title = R.string.woopos_reader_connected)
         data object Reconnecting : WooPosCardReaderStatus(title = R.string.woopos_reader_reconnecting)
+    }
+
+    enum class BatteryState {
+        NOMINAL,
+        LOW,
+        CRITICAL
     }
 
     sealed class Menu {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
@@ -8,6 +8,8 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Reconnecting
+import com.woocommerce.android.cardreader.connection.event.BatteryStatus
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionController
@@ -27,6 +29,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -55,10 +58,13 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            cardReaderFacade.readerStatus.collect {
-                _state.value = _state.value.copy(
-                    cardReaderStatus = mapCardReaderStatusToUiState(it)
-                )
+            combine(
+                cardReaderFacade.readerStatus,
+                cardReaderFacade.batteryStatus
+            ) { readerStatus, batteryStatus ->
+                mapCardReaderStatusToUiState(readerStatus, batteryStatus)
+            }.collect { cardReaderStatus ->
+                _state.value = _state.value.copy(cardReaderStatus = cardReaderStatus)
             }
         }
     }
@@ -125,7 +131,7 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
 
     private fun handleOnCardReaderStatusClicked() {
         when (_state.value.cardReaderStatus) {
-            WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected -> {
+            is WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected -> {
                 viewModelScope.launch {
                     controller.disconnect()
                 }
@@ -153,10 +159,27 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
         }
     }
 
-    private fun mapCardReaderStatusToUiState(status: CardReaderStatus) = when (status) {
-        is Connected -> WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected
+    private fun mapCardReaderStatusToUiState(
+        status: CardReaderStatus,
+        batteryStatus: CardReaderBatteryStatus
+    ): WooPosHomeFloatingToolbarState.WooPosCardReaderStatus = when (status) {
+        is Connected -> WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected(
+            batteryState = mapBatteryState(batteryStatus)
+        )
         is NotConnected, Connecting -> WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.NotConnected
         Reconnecting -> WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Reconnecting
+    }
+
+    private fun mapBatteryState(status: CardReaderBatteryStatus): WooPosHomeFloatingToolbarState.BatteryState {
+        return when (status) {
+            is CardReaderBatteryStatus.StatusChanged -> when (status.batteryStatus) {
+                BatteryStatus.CRITICAL -> WooPosHomeFloatingToolbarState.BatteryState.CRITICAL
+                BatteryStatus.LOW -> WooPosHomeFloatingToolbarState.BatteryState.LOW
+                BatteryStatus.NOMINAL, BatteryStatus.UNKNOWN -> WooPosHomeFloatingToolbarState.BatteryState.NOMINAL
+            }
+            CardReaderBatteryStatus.Warning -> WooPosHomeFloatingToolbarState.BatteryState.LOW
+            CardReaderBatteryStatus.Unknown -> WooPosHomeFloatingToolbarState.BatteryState.NOMINAL
+        }
     }
 
     private val toolbarMenuItems by lazy {

--- a/WooCommerce/src/main/res/drawable/ic_woo_pos_battery_critical.xml
+++ b/WooCommerce/src/main/res/drawable/ic_woo_pos_battery_critical.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportWidth="960"
+    android:viewportHeight="960">
     <path
-        android:pathData="M17,5v16c0,0.55 -0.45,1 -1,1H8c-0.55,0 -1,-0.45 -1,-1V5c0,-0.55 0.45,-1 1,-1h2V2h4v2h2C16.55,4 17,4.45 17,5zM15,6H9v14h6V6z"
-        android:fillColor="#000000"/>
+        android:fillColor="@android:color/white"
+        android:pathData="M440,560L520,560L520,320L440,320L440,560ZM480,720Q497,720 508.5,708.5Q520,697 520,680Q520,663 508.5,651.5Q497,640 480,640Q463,640 451.5,651.5Q440,663 440,680Q440,697 451.5,708.5Q463,720 480,720ZM320,880Q303,880 291.5,868.5Q280,857 280,840L280,200Q280,183 291.5,171.5Q303,160 320,160L400,160L400,80L560,80L560,160L640,160Q657,160 668.5,171.5Q680,183 680,200L680,840Q680,857 668.5,868.5Q657,880 640,880L320,880ZM360,800L600,800L600,240L360,240L360,800ZM360,800L360,800L600,800L600,800L360,800Z" />
 </vector>

--- a/WooCommerce/src/main/res/drawable/ic_woo_pos_battery_critical.xml
+++ b/WooCommerce/src/main/res/drawable/ic_woo_pos_battery_critical.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M17,5v16c0,0.55 -0.45,1 -1,1H8c-0.55,0 -1,-0.45 -1,-1V5c0,-0.55 0.45,-1 1,-1h2V2h4v2h2C16.55,4 17,4.45 17,5zM15,6H9v14h6V6z"
+        android:fillColor="#000000"/>
+</vector>

--- a/WooCommerce/src/main/res/drawable/ic_woo_pos_battery_low.xml
+++ b/WooCommerce/src/main/res/drawable/ic_woo_pos_battery_low.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M15.67,4H14V2h-4v2H8.33C7.6,4 7,4.6 7,5.33v15.33C7,21.4 7.6,22 8.33,22h7.33c0.74,0 1.34,-0.6 1.34,-1.33V5.33C17,4.6 16.4,4 15.67,4zM13,18h-2v-2h2v2zm0,-4h-2V9h2v5z"
+        android:fillColor="#000000"/>
+</vector>

--- a/WooCommerce/src/main/res/drawable/ic_woo_pos_battery_low.xml
+++ b/WooCommerce/src/main/res/drawable/ic_woo_pos_battery_low.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportWidth="960"
+    android:viewportHeight="960">
     <path
-        android:pathData="M15.67,4H14V2h-4v2H8.33C7.6,4 7,4.6 7,5.33v15.33C7,21.4 7.6,22 8.33,22h7.33c0.74,0 1.34,-0.6 1.34,-1.33V5.33C17,4.6 16.4,4 15.67,4zM13,18h-2v-2h2v2zm0,-4h-2V9h2v5z"
-        android:fillColor="#000000"/>
+        android:fillColor="@android:color/white"
+        android:pathData="M320,880Q303,880 291.5,868.5Q280,857 280,840L280,200Q280,183 291.5,171.5Q303,160 320,160L400,160L400,80L560,80L560,160L640,160Q657,160 668.5,171.5Q680,183 680,200L680,840Q680,857 668.5,868.5Q657,880 640,880L320,880ZM360,720L600,720L600,240L360,240L360,720Z" />
 </vector>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3646,6 +3646,8 @@
     <string name="woopos_reader_connected">Reader connected</string>
     <string name="woopos_reader_disconnected">Connect your reader</string>
     <string name="woopos_reader_reconnecting">Reconnecting…</string>
+    <string name="woopos_battery_low">Card reader battery low</string>
+    <string name="woopos_battery_critical">Card reader battery critical</string>
     <string name="woopos_checkout_button">Check out</string>
     <string name="woopos_remove_item_button_from_cart_content_description">Remove %s from cart</string>
     <string name="woopos_product_item_content_description">Product %s, Price %s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -2,12 +2,15 @@ package com.woocommerce.android.ui.woopos.home.toolbar
 
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.cardreader.connection.event.BatteryStatus
+import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionController
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionControllerFactory
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
+import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarState.BatteryState
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ExitTapped
@@ -15,6 +18,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
@@ -33,6 +37,7 @@ class WooPosHomeFloatingToolbarViewModelTest {
 
     private val cardReaderFacade: WooPosCardReaderFacade = mock {
         onBlocking { readerStatus }.thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+        onBlocking { batteryStatus }.thenReturn(flowOf(CardReaderBatteryStatus.Unknown))
     }
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val networkStatus: WooPosNetworkStatus = mock()
@@ -65,7 +70,7 @@ class WooPosHomeFloatingToolbarViewModelTest {
 
         // THEN
         assertThat(viewModel.state.value.cardReaderStatus)
-            .isEqualTo(WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected)
+            .isInstanceOf(WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected::class.java)
     }
 
     @Test
@@ -313,6 +318,92 @@ class WooPosHomeFloatingToolbarViewModelTest {
         assertThat(menu).isInstanceOf(WooPosHomeFloatingToolbarState.Menu.Visible::class.java)
         val items = (menu as WooPosHomeFloatingToolbarState.Menu.Visible).items
         assertThat(items.any { it.title == R.string.woopos_bookings_title }).isFalse
+    }
+
+    @Test
+    fun `given connected with nominal battery, when initialized, then battery state should be NOMINAL`() = runTest {
+        // GIVEN
+        whenever(cardReaderFacade.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connected(mock())))
+        whenever(cardReaderFacade.batteryStatus).thenReturn(
+            flowOf(CardReaderBatteryStatus.StatusChanged(0.8f, BatteryStatus.NOMINAL, false))
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val status = viewModel.state.value.cardReaderStatus
+        assertThat(status).isInstanceOf(WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected::class.java)
+        assertThat((status as WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected).batteryState)
+            .isEqualTo(BatteryState.NOMINAL)
+    }
+
+    @Test
+    fun `given connected with low battery, when initialized, then battery state should be LOW`() = runTest {
+        // GIVEN
+        whenever(cardReaderFacade.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connected(mock())))
+        whenever(cardReaderFacade.batteryStatus).thenReturn(
+            flowOf(CardReaderBatteryStatus.StatusChanged(0.2f, BatteryStatus.LOW, false))
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val status = viewModel.state.value.cardReaderStatus
+        assertThat(status).isInstanceOf(WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected::class.java)
+        assertThat((status as WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected).batteryState)
+            .isEqualTo(BatteryState.LOW)
+    }
+
+    @Test
+    fun `given connected with critical battery, when initialized, then battery state should be CRITICAL`() = runTest {
+        // GIVEN
+        whenever(cardReaderFacade.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connected(mock())))
+        whenever(cardReaderFacade.batteryStatus).thenReturn(
+            flowOf(CardReaderBatteryStatus.StatusChanged(0.05f, BatteryStatus.CRITICAL, false))
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val status = viewModel.state.value.cardReaderStatus
+        assertThat(status).isInstanceOf(WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected::class.java)
+        assertThat((status as WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected).batteryState)
+            .isEqualTo(BatteryState.CRITICAL)
+    }
+
+    @Test
+    fun `given connected with battery warning, when initialized, then battery state should be LOW`() = runTest {
+        // GIVEN
+        whenever(cardReaderFacade.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connected(mock())))
+        whenever(cardReaderFacade.batteryStatus).thenReturn(flowOf(CardReaderBatteryStatus.Warning))
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val status = viewModel.state.value.cardReaderStatus
+        assertThat(status).isInstanceOf(WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected::class.java)
+        assertThat((status as WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected).batteryState)
+            .isEqualTo(BatteryState.LOW)
+    }
+
+    @Test
+    fun `given connected with unknown battery, when initialized, then battery state should be NOMINAL`() = runTest {
+        // GIVEN
+        whenever(cardReaderFacade.readerStatus).thenReturn(MutableStateFlow(CardReaderStatus.Connected(mock())))
+        whenever(cardReaderFacade.batteryStatus).thenReturn(flowOf(CardReaderBatteryStatus.Unknown))
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val status = viewModel.state.value.cardReaderStatus
+        assertThat(status).isInstanceOf(WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected::class.java)
+        assertThat((status as WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected).batteryState)
+            .isEqualTo(BatteryState.NOMINAL)
     }
 
     private fun createViewModel() = WooPosHomeFloatingToolbarViewModel(


### PR DESCRIPTION
Closes: WOOMOB-2093

### Description

Display a battery warning icon in the floating toolbar when the connected card reader has low or critical battery. This provides a non-intrusive way to inform merchants that the reader needs charging without interrupting the payment flow.

- Added `BatteryState` enum (NOMINAL, LOW, CRITICAL) to toolbar state
- Combined `readerStatus` and `batteryStatus` flows in ViewModel to map battery state
- Display orange battery alert icon for LOW battery
- Display red empty battery icon for CRITICAL battery
- No icon shown for NOMINAL battery

@joshheald @malinajirka 👋

I’m not sure about this change. I appreciate that it’s not intrusive and the change is minor code-wise. Also, I don’t like showing Toast/Snack bars during the connection flow - that usually feels like an afterthought and especially doesn't look good on tablets. On the other hand, this icon can be missed. iOS doesn't have anything, from what I can tell regarding notifying about battery levels. 

Maybe displaying the battery level in % or with icons all the time to make it more clear where to look?

What are your thoughts?

### Test Steps

1. Connect a card reader with low battery
2. Verify the orange battery icon appears next to "Reader connected" text in the floating toolbar
3. Connect a card reader with critical battery
4. Verify the red battery icon appears
5. Connect a card reader with normal battery
6. Verify no battery icon is shown

### Images/gif

<img width="1053" height="663" alt="image" src="https://github.com/user-attachments/assets/605d9563-14eb-4f3d-9d45-6664d6281b9c" />
<img width="1053" height="661" alt="image" src="https://github.com/user-attachments/assets/b7b9c034-4ada-48b2-a789-c0be0c818a45" />



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.