### PR TITLE
Register device after logging in with site credentials

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
+import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
@@ -58,7 +59,8 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val appPrefs: AppPrefsWrapper,
     private val resourceProvider: ResourceProvider,
-    private val applicationPasswordsConfiguration: ApplicationPasswordsConfiguration
+    private val applicationPasswordsConfiguration: ApplicationPasswordsConfiguration,
+    private val registerDevice: RegisterDevice
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         const val SITE_ADDRESS_KEY = "site-address"
@@ -337,6 +339,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 }
                 appPrefs.removeLoginSiteAddress()
                 selectedSite.set(site)
+                registerDevice(RegisterDevice.Mode.IF_NEEDED)
                 triggerEvent(LoggedIn(selectedSite.getSelectedSiteId()))
             },
             onFailure = { exception ->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordGenerationException
 import com.woocommerce.android.applicationpasswords.ApplicationPasswordsNotifier
 import com.woocommerce.android.model.UiString.UiStringText
+import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
@@ -77,6 +78,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }
     }
+    private val registerDevice: RegisterDevice = mock()
 
     private lateinit var viewModel: LoginSiteCredentialsViewModel
 
@@ -100,7 +102,8 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
                 override val applicationName: String = clientId
                 override suspend fun isEnabledForJetpackAccess(): Boolean = true
             },
-            resourceProvider = resourceProvider
+            resourceProvider = resourceProvider,
+            registerDevice = registerDevice
         )
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-2100

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, `registerDevice()` was only invoked when the user logged in via WordPress.com. For users who logged in with site credentials, `registerDevice()` was never called.

Now that we support push notifications for site credentials login (via the WOO self-serve PN system), we need to trigger device registration for this flow as well.

This PR adds `registerDevice()` call to the site credentials login flow.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. To enable `WOO_PUSH_NOTIFICATIONS_SYSTEM` feature flag, apply this patch: 
[Enable_WOO_PUSH_NOTIFICATIONS_SYSTEM_feature_flag_for_debug_builds.patch](https://github.com/user-attachments/files/25020347/Enable_WOO_PUSH_NOTIFICATIONS_SYSTEM_feature_flag_for_debug_builds.patch)
2. Log in to a site with support of new PN with site credentials.
3. Expected logs:
```
Registering FCM token in Woo Core instance: cRUfXyhgQnuOZAXUT9UrRC:APA91bHz...
```

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
