### PR TITLE
[WOOMOB-2106] Fix double %% sign in battery low update dialog

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4003,7 +4003,7 @@
     <string name="woopos_card_reader_cancel_anyway_button">Cancel anyway</string>
     <string name="woopos_card_reader_update_completed_title">Software updated</string>
     <string name="woopos_card_reader_update_failed_title">Update failed</string>
-    <string name="woopos_card_reader_update_battery_low_message">The reader battery is too low to install this update. Please charge your reader to at least 50%% and try again.</string>
+    <string name="woopos_card_reader_update_battery_low_message">The reader battery is too low to install this update. Please charge your reader to at least 50% and try again.</string>
     <string name="woopos_card_reader_update_battery_low_message_with_level">The reader battery is at %d%%, which is too low to install this update. Please charge your reader to at least 50%% and try again.</string>
 
     <string name="customers_details_customer_section">Customer</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4003,7 +4003,7 @@
     <string name="woopos_card_reader_cancel_anyway_button">Cancel anyway</string>
     <string name="woopos_card_reader_update_completed_title">Software updated</string>
     <string name="woopos_card_reader_update_failed_title">Update failed</string>
-    <string name="woopos_card_reader_update_battery_low_message">The reader battery is too low to install this update. Please charge your reader to at least 50&#37; and try again.</string>
+    <string name="woopos_card_reader_update_battery_low_message" formatted="false">The reader battery is too low to install this update. Please charge your reader to at least 50% and try again.</string>
     <string name="woopos_card_reader_update_battery_low_message_with_level">The reader battery is at %d%%, which is too low to install this update. Please charge your reader to at least 50%% and try again.</string>
 
     <string name="customers_details_customer_section">Customer</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4003,7 +4003,7 @@
     <string name="woopos_card_reader_cancel_anyway_button">Cancel anyway</string>
     <string name="woopos_card_reader_update_completed_title">Software updated</string>
     <string name="woopos_card_reader_update_failed_title">Update failed</string>
-    <string name="woopos_card_reader_update_battery_low_message">The reader battery is too low to install this update. Please charge your reader to at least 50% and try again.</string>
+    <string name="woopos_card_reader_update_battery_low_message">The reader battery is too low to install this update. Please charge your reader to at least 50&#37; and try again.</string>
     <string name="woopos_card_reader_update_battery_low_message_with_level">The reader battery is at %d%%, which is too low to install this update. Please charge your reader to at least 50%% and try again.</string>
 
     <string name="customers_details_customer_section">Customer</string>


### PR DESCRIPTION
WOOMOB-2106

### Description

The battery low update dialog displayed "50%%" instead of "50%". This happened because the string resource used `%%` (the escape for `String.format()`), but Compose's `stringResource()` without format arguments doesn't go through `String.format()`, so `%%` was displayed literally.

Fixed by using a single `%` in the no-args string variant. The `_with_level` variant correctly keeps `%%` since it's called with format arguments.

### Test Steps

1. Connect a card reader with low battery
2. Trigger a software update
3. Verify the dialog shows "50%" (not "50%%")


<img width="802" height="501" alt="image" src="https://github.com/user-attachments/assets/54931654-cdee-467a-9db7-1e87af4e2d45" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.