### PR TITLE
Use `getOrNull()` to safely access the selected site and avoid crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 24.1
 -----
+- [Internal] Fixes crash in app Dashboard when no site is selected [https://github.com/woocommerce/woocommerce-android/pull/15287]
 
 
 24.0

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -150,9 +150,9 @@ class DashboardViewModel @Inject constructor(
 
     private fun updateShareStoreButtonVisibility() {
         _appbarState.value = AppbarState(
-            showShareStoreButton = selectedSite.get().let {
+            showShareStoreButton = selectedSite.getOrNull()?.let {
                 it.isSitePublic && it.url != null
-            }
+            } ?: false
         )
     }
 
@@ -182,9 +182,9 @@ class DashboardViewModel @Inject constructor(
 
     fun onShareStoreClicked() {
         AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_SHARE_YOUR_STORE_BUTTON_TAPPED)
-        triggerEvent(
-            DashboardEvent.ShareStore(storeUrl = selectedSite.get().url)
-        )
+        selectedSite.getOrNull()?.url?.let { url ->
+            triggerEvent(DashboardEvent.ShareStore(storeUrl = url))
+        }
     }
 
     fun onEditWidgetsClicked() {
@@ -238,9 +238,11 @@ class DashboardViewModel @Inject constructor(
         // We add the other cards even if they should not be visible, so that the addition/deletion
         // of the cards is animated properly
 
+        val site = selectedSite.getOrNull()
         val shouldShowShareCard = !widgets.first { it.type == DashboardWidget.Type.STATS }.isAvailable &&
-            selectedSite.get().isSitePublic &&
-            selectedSite.get().url != null
+            site != null &&
+            site.isSitePublic &&
+            site.url != null
         add(DashboardWidgetUiModel.ShareStoreWidget(shouldShowShareCard, ::onShareStoreClicked))
 
         add(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -35,7 +35,7 @@ class DashboardViewModelTest : BaseUnitTest() {
         val site = SiteModel().apply {
             url = "https://example.com"
         }
-        on { get() } doReturn site
+        on { getOrNull() } doReturn site
         on { getIfExists() } doReturn site
     }
     private val appPrefsWrapper: AppPrefsWrapper = mock()


### PR DESCRIPTION
Fixes WOOMOB-2114

### Description
I think back when we attempted to fix this issue: https://github.com/woocommerce/woocommerce-android/pull/15138 what we really did is move the crash elsewhere. 

`DashboardViewModel.kt` has multiple unsafe calls to `selectedSite.get()` which throws `SelectedSiteResetException` when:

- `state.value` is null
-  Site cannot be restored from persistence
- `wasReset` flag is true (set by `reset()` method)

The `reset()` method is called when user logs out, switches sites, or is removed from a site. 

Now the trick was to figure out when could this race condition happen, as navigating to site picker and switch site is simply not possible while dashboard is loading. Checking a few of the encrypted logs for users experiencing the crash was key:

App Password Revoked (likely the most frequent cause)
```
[Feb-04 09:58:40:867 WP w] MAIN Authentication failure using application password, maybe revoked? Delete the saved one then retry
[Feb-04 09:58:40:889 GOOGLE_ADS e] Failed to fetch Google Ads campaigns: Site password is missing. The application password was probably authorized using the Web flow
[Feb-04 09:58:40:891 LOGIN w] Use is unauthorized to generate a new application password
[Feb-04 09:58:40:891 UTILS i] 🔵 Tracked: woocommerceandroid_application_passwords_generation_failed, Properties: {"cause":"authorization_failed","scenario":"regeneration","error_context":"WPAPINetworkError","error_description":"Site password is missing. The application password was probably authorized using the Web flow","error_type":"NOT_AUTHENTICATED","blog_id":0,"is_wpcom_store":false,"was_ecommerce_trial":null,"plan_product_slug":null,"store_id":"68e9fcf4-0822-4620-aaaf-1c3cf58b68bc","is_debug":false,"site_url":"https:\/\/dzbrico.com","cached_woo_core_version":"10.3.7"}
[Feb-04 09:58:40:894 WP d] API SiteStore: Delete Application Password
[Feb-04 09:58:40:895 LOGIN i] Application password deleted
[Feb-04 09:58:40:896 UTILS i] 🔵 Tracked: woocommerceandroid_account_logout, Properties: {"is_debug":false,"site_url":"https:\/\/dzbrico.com","cached_woo_core_version":"10.3.7"}
```

WooCommerce uninstalled
```
[Jan-31 10:49:54:442 LOGIN w] Selected site no longer has WooCommerce
```

Those represent the most common causes for the crash. However, despite repducing those situations manually I was unable to reproduce the crash. Anyway I'm fairly confident the applied changes should fix the issue so that the app is able to complete a logout without crashing. 

### Test Steps

As mentioned I wasn't able to reproduce the crash but attem
- Log into the app using app passwords login
- Let Dashboard load
- Revoke app paswords from `wc-admin` or uninstall WooCommerce from the site
- Kill and restart the app
- Check the app doesn't crash. User should be logged out, but I think there's some caching the keeps the application password active for a while before revoking takes effect. 

- [X] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
