### PR TITLE
[WOOMOB-2133] Copy-paste and rename Orders ViewModel and mappers to Bookings equivalents

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingActionsProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingActionsProvider.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.woopos.bookings
+
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
+import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosGetRefundableItems
+import com.woocommerce.android.util.FeatureFlag
+import javax.inject.Inject
+
+class WooPosBookingActionsProvider @Inject constructor(
+    private val getRefundableItems: WooPosGetRefundableItems,
+) {
+    internal var isPosRefundsEnabled: () -> Boolean = { FeatureFlag.POS_REFUNDS.isEnabled() }
+
+    fun getAvailableActions(
+        order: Order,
+        refundResult: RefundsFetchResult
+    ): List<WooPosBookingsState.BookingAction> {
+        return buildList {
+            if (isPosRefundsEnabled() && hasRefundableItems(order, refundResult)) {
+                add(WooPosBookingsState.BookingAction.IssueRefund(order.id))
+            }
+            add(WooPosBookingsState.BookingAction.EmailReceipt(order.id))
+        }
+    }
+
+    private fun hasRefundableItems(order: Order, refundResult: RefundsFetchResult): Boolean {
+        val refunds = when (refundResult) {
+            is RefundsFetchResult.Success -> refundResult.refunds
+            is RefundsFetchResult.Error -> emptyList()
+        }
+        return getRefundableItems(order, refunds).isNotEmpty()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
@@ -16,6 +16,9 @@ sealed class WooPosBookingsState {
         val orderId: Long
 
         @Immutable
+        data class IssueRefund(override val orderId: Long) : BookingAction
+
+        @Immutable
         data class EmailReceipt(override val orderId: Long) : BookingAction
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -18,7 +18,6 @@ import com.woocommerce.android.ui.woopos.orders.SearchOrdersResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
-import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersUIEvent
 import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderDetailsMapper
 import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderItemMapper
@@ -54,12 +53,10 @@ class WooPosBookingsViewModel @Inject constructor(
     private val orderActionsProvider: WooPosOrderActionsProvider,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow<WooPosOrdersState>(
-        WooPosOrdersState.Loading(
-            searchInputState = WooPosSearchInputState.Closed
-        )
+    private val _state = MutableStateFlow<WooPosBookingsState>(
+        WooPosBookingsState.Loading
     )
-    val state: StateFlow<WooPosOrdersState> = _state.asStateFlow()
+    val state: StateFlow<WooPosBookingsState> = _state.asStateFlow()
 
     private val _openUrlEvent = MutableSharedFlow<String>()
     val openUrlEvent: SharedFlow<String> = _openUrlEvent.asSharedFlow()
@@ -93,16 +90,16 @@ class WooPosBookingsViewModel @Inject constructor(
         }
     }
 
-    private fun handleActionClicked(action: WooPosOrdersState.OrderAction) {
+    private fun handleActionClicked(action: WooPosBookingsState.OrderAction) {
         when (action) {
-            is WooPosOrdersState.OrderAction.EmailReceipt -> onEmailReceiptButtonClicked(action.orderId)
-            is WooPosOrdersState.OrderAction.IssueRefund -> onIssueRefundButtonClicked(action.orderId)
+            is WooPosBookingsState.OrderAction.EmailReceipt -> onEmailReceiptButtonClicked(action.orderId)
+            is WooPosBookingsState.OrderAction.IssueRefund -> onIssueRefundButtonClicked(action.orderId)
         }
     }
 
     fun onOrderSelected(orderId: Long) {
-        val current = _state.value as? WooPosOrdersState.Content ?: return
-        val loadedItems = current.items as? WooPosOrdersState.Content.Items.Loaded ?: return
+        val current = _state.value as? WooPosBookingsState.Content ?: return
+        val loadedItems = current.items as? WooPosBookingsState.Content.Items.Loaded ?: return
 
         if (isAlreadySelectedWithActions(current, orderId)) return
 
@@ -114,7 +111,7 @@ class WooPosBookingsViewModel @Inject constructor(
             val updatedItems = updateItemsSelection(loadedItems, orderId, details)
 
             _state.value = current.copy(
-                items = WooPosOrdersState.Content.Items.Loaded(items = updatedItems),
+                items = WooPosBookingsState.Content.Items.Loaded(items = updatedItems),
                 selectedDetails = details
             )
 
@@ -122,13 +119,13 @@ class WooPosBookingsViewModel @Inject constructor(
         }
     }
 
-    private fun isAlreadySelectedWithActions(current: WooPosOrdersState.Content, orderId: Long): Boolean {
+    private fun isAlreadySelectedWithActions(current: WooPosBookingsState.Content, orderId: Long): Boolean {
         return current.selectedDetails?.id == orderId &&
-            current.selectedDetails.actionsState is WooPosOrdersState.OrderActionsState.Loaded
+            current.selectedDetails.actionsState is WooPosBookingsState.OrderActionsState.Loaded
     }
 
     private fun trackOrderSelectionAnalytics(
-        loadedItems: WooPosOrdersState.Content.Items.Loaded,
+        loadedItems: WooPosBookingsState.Content.Items.Loaded,
         orderId: Long
     ) {
         val keys = loadedItems.items.keys.toList()
@@ -152,9 +149,9 @@ class WooPosBookingsViewModel @Inject constructor(
 
     private suspend fun computeOrderDetails(
         orderId: Long,
-        orderDetailsViewState: WooPosOrdersState.OrderDetailsViewState?
-    ): WooPosOrdersState.OrderDetailsViewState.Computed.Details {
-        return if (orderDetailsViewState is WooPosOrdersState.OrderDetailsViewState.Lazy) {
+        orderDetailsViewState: WooPosBookingsState.OrderDetailsViewState?
+    ): WooPosBookingsState.OrderDetailsViewState.Computed.Details {
+        return if (orderDetailsViewState is WooPosBookingsState.OrderDetailsViewState.Lazy) {
             getOrComputeDetailsWithoutActions(orderId)
         } else {
             getOrComputeDetails(orderId)
@@ -162,15 +159,15 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     private fun updateItemsSelection(
-        loadedItems: WooPosOrdersState.Content.Items.Loaded,
+        loadedItems: WooPosBookingsState.Content.Items.Loaded,
         orderId: Long,
-        details: WooPosOrdersState.OrderDetailsViewState.Computed.Details
-    ): Map<WooPosOrdersState.OrderItemViewState, WooPosOrdersState.OrderDetailsViewState> {
+        details: WooPosBookingsState.OrderDetailsViewState.Computed.Details
+    ): Map<WooPosBookingsState.OrderItemViewState, WooPosBookingsState.OrderDetailsViewState> {
         return loadedItems.items.mapKeys { (item, _) ->
             item.copy(isSelected = item.id == orderId)
         }.mapValues { (item, orderDetails) ->
-            if (item.id == orderId && orderDetails is WooPosOrdersState.OrderDetailsViewState.Lazy) {
-                WooPosOrdersState.OrderDetailsViewState.Computed(orderId = orderId, details = details)
+            if (item.id == orderId && orderDetails is WooPosBookingsState.OrderDetailsViewState.Lazy) {
+                WooPosBookingsState.OrderDetailsViewState.Computed(orderId = orderId, details = details)
             } else {
                 orderDetails
             }
@@ -179,11 +176,11 @@ class WooPosBookingsViewModel @Inject constructor(
 
     private suspend fun startSideLoadActionsIfNeeded(
         orderId: Long,
-        details: WooPosOrdersState.OrderDetailsViewState.Computed.Details,
-        orderDetailsViewState: WooPosOrdersState.OrderDetailsViewState?,
-        loadedItems: WooPosOrdersState.Content.Items.Loaded
+        details: WooPosBookingsState.OrderDetailsViewState.Computed.Details,
+        orderDetailsViewState: WooPosBookingsState.OrderDetailsViewState?,
+        loadedItems: WooPosBookingsState.Content.Items.Loaded
     ) {
-        if (details.actionsState !is WooPosOrdersState.OrderActionsState.Loading) return
+        if (details.actionsState !is WooPosBookingsState.OrderActionsState.Loading) return
 
         val order = getOrderForSideLoading(orderId, orderDetailsViewState, loadedItems) ?: return
         sideLoadActions(orderId, order)
@@ -191,12 +188,12 @@ class WooPosBookingsViewModel @Inject constructor(
 
     private suspend fun getOrderForSideLoading(
         orderId: Long,
-        orderDetailsViewState: WooPosOrdersState.OrderDetailsViewState?,
-        loadedItems: WooPosOrdersState.Content.Items.Loaded
+        orderDetailsViewState: WooPosBookingsState.OrderDetailsViewState?,
+        loadedItems: WooPosBookingsState.Content.Items.Loaded
     ): Order? {
         return when (orderDetailsViewState) {
-            is WooPosOrdersState.OrderDetailsViewState.Lazy -> orderDetailsViewState.order
-            is WooPosOrdersState.OrderDetailsViewState.Computed -> {
+            is WooPosBookingsState.OrderDetailsViewState.Lazy -> orderDetailsViewState.order
+            is WooPosBookingsState.OrderDetailsViewState.Computed -> {
                 loadedItems.items.keys.firstOrNull { it.id == orderId }?.let { item ->
                     ordersDataSource.getOrderById(item.id).getOrNull()
                 }
@@ -214,7 +211,7 @@ class WooPosBookingsViewModel @Inject constructor(
                 onFailure = { RefundsFetchResult.Error }
             )
 
-            val stateAfterRefundsFetch = _state.value as? WooPosOrdersState.Content
+            val stateAfterRefundsFetch = _state.value as? WooPosBookingsState.Content
             if (stateAfterRefundsFetch?.selectedDetails?.id != orderId) {
                 return@launch
             }
@@ -223,20 +220,20 @@ class WooPosBookingsViewModel @Inject constructor(
             val refundInfo = refundInfoBuilder.buildRefundInfo(order, refundsResult)
             val updatedBreakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
 
-            val updatedState = _state.value as? WooPosOrdersState.Content ?: return@launch
+            val updatedState = _state.value as? WooPosBookingsState.Content ?: return@launch
             val updatedSelectedDetails = updatedState.selectedDetails
 
             if (updatedSelectedDetails?.id == orderId &&
-                updatedSelectedDetails.actionsState is WooPosOrdersState.OrderActionsState.Loading
+                updatedSelectedDetails.actionsState is WooPosBookingsState.OrderActionsState.Loading
             ) {
-                val loadedItems = updatedState.items as? WooPosOrdersState.Content.Items.Loaded
+                val loadedItems = updatedState.items as? WooPosBookingsState.Content.Items.Loaded
                 val updatedItems = loadedItems?.items?.map { (item, details) ->
                     val updatedDetails =
-                        if (item.id == orderId && details is WooPosOrdersState.OrderDetailsViewState.Computed) {
-                            WooPosOrdersState.OrderDetailsViewState.Computed(
+                        if (item.id == orderId && details is WooPosBookingsState.OrderDetailsViewState.Computed) {
+                            WooPosBookingsState.OrderDetailsViewState.Computed(
                                 orderId = orderId,
                                 details = details.details.copy(
-                                    actionsState = WooPosOrdersState.OrderActionsState.Loaded(actions),
+                                    actionsState = WooPosBookingsState.OrderActionsState.Loaded(actions),
                                     breakdown = updatedBreakdown
                                 )
                             )
@@ -248,12 +245,12 @@ class WooPosBookingsViewModel @Inject constructor(
 
                 _state.value = updatedState.copy(
                     items = if (updatedItems != null) {
-                        WooPosOrdersState.Content.Items.Loaded(updatedItems)
+                        WooPosBookingsState.Content.Items.Loaded(updatedItems)
                     } else {
                         updatedState.items
                     },
                     selectedDetails = updatedSelectedDetails.copy(
-                        actionsState = WooPosOrdersState.OrderActionsState.Loaded(actions),
+                        actionsState = WooPosBookingsState.OrderActionsState.Loaded(actions),
                         breakdown = updatedBreakdown
                     )
                 )
@@ -268,16 +265,16 @@ class WooPosBookingsViewModel @Inject constructor(
 
         val currentState = _state.value
         _state.value = when (currentState) {
-            is WooPosOrdersState.Content -> currentState.copy(
+            is WooPosBookingsState.Content -> currentState.copy(
                 pullToRefreshState = WooPosPullToRefreshState.Refreshing
             )
 
-            is WooPosOrdersState.Empty -> currentState.copy(
+            is WooPosBookingsState.Empty -> currentState.copy(
                 pullToRefreshState = WooPosPullToRefreshState.Refreshing
             )
 
-            is WooPosOrdersState.Error -> currentState
-            is WooPosOrdersState.Loading -> currentState
+            is WooPosBookingsState.Error -> currentState
+            is WooPosBookingsState.Loading -> currentState
         }
 
         ordersDataSource.clearCache()
@@ -292,7 +289,7 @@ class WooPosBookingsViewModel @Inject constructor(
 
     fun onEndOfOrdersListReached() {
         val currentState = _state.value
-        if (currentState !is WooPosOrdersState.Content ||
+        if (currentState !is WooPosBookingsState.Content ||
             currentState.paginationState != WooPosPaginationState.None ||
             currentState.pullToRefreshState == WooPosPullToRefreshState.Refreshing
         ) {
@@ -316,18 +313,18 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     fun onIssueRefundButtonClicked(orderId: Long) {
-        val currentState = _state.value as? WooPosOrdersState.Content ?: return
+        val currentState = _state.value as? WooPosBookingsState.Content ?: return
         _state.value = currentState.copy(
-            dialogState = WooPosOrdersState.Content.DialogState.IssueRefund(
+            dialogState = WooPosBookingsState.Content.DialogState.IssueRefund(
                 orderId = orderId
             )
         )
     }
 
     fun onIssueRefundDialogDismissed() {
-        val currentState = _state.value as? WooPosOrdersState.Content ?: return
+        val currentState = _state.value as? WooPosBookingsState.Content ?: return
         _state.value = currentState.copy(
-            dialogState = WooPosOrdersState.Content.DialogState.Hidden
+            dialogState = WooPosBookingsState.Content.DialogState.Hidden
         )
         refreshSelectedOrder()
     }
@@ -339,7 +336,7 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     fun onOrdersLoadingErrorRetryButtonClicked() {
-        _state.value = WooPosOrdersState.Loading(
+        _state.value = WooPosBookingsState.Loading(
             searchInputState = WooPosSearchInputState.Closed
         )
         loadOrders()
@@ -358,7 +355,7 @@ class WooPosBookingsViewModel @Inject constructor(
 
         val currentState = _state.value
         val newState = when (currentState) {
-            is WooPosOrdersState.Content -> currentState.copy(paginationState = WooPosPaginationState.Loading)
+            is WooPosBookingsState.Content -> currentState.copy(paginationState = WooPosPaginationState.Loading)
             else -> return
         }
         _state.value = newState
@@ -438,7 +435,7 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     private fun refreshSelectedOrder() {
-        val current = _state.value as? WooPosOrdersState.Content ?: return
+        val current = _state.value as? WooPosBookingsState.Content ?: return
         val selectedOrderId = current.selectedDetails?.id ?: return
 
         sideLoadActionsJob?.cancel()
@@ -449,8 +446,8 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     private suspend fun applyOrderUpdate(updated: Order) {
-        val current = _state.value as? WooPosOrdersState.Content ?: return
-        val loaded = current.items as? WooPosOrdersState.Content.Items.Loaded ?: return
+        val current = _state.value as? WooPosBookingsState.Content ?: return
+        val loaded = current.items as? WooPosBookingsState.Content.Items.Loaded ?: return
 
         val historicalRefundsResult = retrieveOrderRefunds(updated, forceRefresh = true).fold(
             onSuccess = { refunds -> RefundsFetchResult.Success(refunds) },
@@ -460,7 +457,7 @@ class WooPosBookingsViewModel @Inject constructor(
         val selectedId = loaded.items.keys.firstOrNull { it.isSelected }?.id
         val newItem = orderItemMapper.mapOrderItem(updated, selectedId)
         val newDetailsViewState = orderDetailsMapper.mapOrderDetails(updated, historicalRefundsResult)
-        val newDetails = WooPosOrdersState.OrderDetailsViewState.Computed(
+        val newDetails = WooPosBookingsState.OrderDetailsViewState.Computed(
             orderId = updated.id,
             details = newDetailsViewState
         )
@@ -470,34 +467,34 @@ class WooPosBookingsViewModel @Inject constructor(
         }
 
         _state.value = current.copy(
-            items = WooPosOrdersState.Content.Items.Loaded(newMap),
+            items = WooPosBookingsState.Content.Items.Loaded(newMap),
             selectedDetails = if (selectedId == updated.id) newDetailsViewState else current.selectedDetails
         )
     }
 
     private fun updateSearchState(searchState: WooPosSearchInputState) {
         _state.value = when (val currentState = _state.value) {
-            is WooPosOrdersState.Content -> currentState.copy(searchInputState = searchState)
-            is WooPosOrdersState.Empty -> currentState.copy(searchInputState = searchState)
-            is WooPosOrdersState.Error -> currentState.copy(searchInputState = searchState)
-            is WooPosOrdersState.Loading -> currentState.copy(searchInputState = searchState)
+            is WooPosBookingsState.Content -> currentState.copy(searchInputState = searchState)
+            is WooPosBookingsState.Empty -> currentState.copy(searchInputState = searchState)
+            is WooPosBookingsState.Error -> currentState.copy(searchInputState = searchState)
+            is WooPosBookingsState.Loading -> currentState.copy(searchInputState = searchState)
         }
     }
 
     private fun performSearch(query: String, isRefreshing: Boolean = false) {
         cancelJobs()
 
-        val currentSelectedDetails = (_state.value as? WooPosOrdersState.Content)?.selectedDetails
+        val currentSelectedDetails = (_state.value as? WooPosBookingsState.Content)?.selectedDetails
         searchJob = viewModelScope.launch {
             delay(SEARCH_DEBOUNCE_DELAY_MS)
             if (!isRefreshing) {
-                _state.value = WooPosOrdersState.Content(
-                    items = WooPosOrdersState.Content.Items.Searching,
+                _state.value = WooPosBookingsState.Content(
+                    items = WooPosBookingsState.Content.Items.Searching,
                     pullToRefreshState = WooPosPullToRefreshState.Disabled,
                     searchInputState = _state.value.searchInputState,
                     selectedDetails = currentSelectedDetails,
                     paginationState = WooPosPaginationState.None,
-                    dialogState = WooPosOrdersState.Content.DialogState.Hidden
+                    dialogState = WooPosBookingsState.Content.DialogState.Hidden
                 )
             }
 
@@ -507,8 +504,8 @@ class WooPosBookingsViewModel @Inject constructor(
             ordersAnalyticsTracker.trackOrdersListSearchResultsFetched(elapsedMs)
             when (result) {
                 is SearchOrdersResult.Error -> {
-                    _state.value = WooPosOrdersState.Content(
-                        items = WooPosOrdersState.Content.Items.Error(
+                    _state.value = WooPosBookingsState.Content(
+                        items = WooPosBookingsState.Content.Items.Error(
                             title = resourceProvider.getString(R.string.woopos_search_orders_error_title),
                             message = resourceProvider.getString(R.string.woopos_search_orders_error_description)
                         ),
@@ -516,14 +513,14 @@ class WooPosBookingsViewModel @Inject constructor(
                         searchInputState = _state.value.searchInputState,
                         selectedDetails = null,
                         paginationState = WooPosPaginationState.None,
-                        dialogState = WooPosOrdersState.Content.DialogState.Hidden
+                        dialogState = WooPosBookingsState.Content.DialogState.Hidden
                     )
                 }
 
                 is SearchOrdersResult.Success -> {
                     if (result.ordersWithRefunds.isEmpty()) {
-                        _state.value = WooPosOrdersState.Content(
-                            items = WooPosOrdersState.Content.Items.NothingFound(
+                        _state.value = WooPosBookingsState.Content(
+                            items = WooPosBookingsState.Content.Items.NothingFound(
                                 title = resourceProvider.getString(R.string.woopos_search_orders_empty_title),
                                 message = resourceProvider.getString(R.string.woopos_search_orders_empty_description)
                             ),
@@ -531,7 +528,7 @@ class WooPosBookingsViewModel @Inject constructor(
                             searchInputState = _state.value.searchInputState,
                             selectedDetails = null,
                             paginationState = WooPosPaginationState.None,
-                            dialogState = WooPosOrdersState.Content.DialogState.Hidden
+                            dialogState = WooPosBookingsState.Content.DialogState.Hidden
                         )
                     } else {
                         replaceOrders(result.ordersWithRefunds)
@@ -551,7 +548,7 @@ class WooPosBookingsViewModel @Inject constructor(
                         val elapsedMs = mark.elapsedNow().inWholeMilliseconds
                         ordersAnalyticsTracker.trackOrdersListFetched(elapsedMs)
 
-                        _state.value = WooPosOrdersState.Error(
+                        _state.value = WooPosBookingsState.Error(
                             message = result.message,
                             searchInputState = WooPosSearchInputState.Closed
                         )
@@ -559,7 +556,7 @@ class WooPosBookingsViewModel @Inject constructor(
 
                     is LoadOrdersResult.SuccessCache -> {
                         if (result.ordersWithRefunds.isEmpty()) {
-                            _state.value = WooPosOrdersState.Loading(
+                            _state.value = WooPosBookingsState.Loading(
                                 searchInputState = WooPosSearchInputState.Closed
                             )
                         } else {
@@ -572,7 +569,7 @@ class WooPosBookingsViewModel @Inject constructor(
                         ordersAnalyticsTracker.trackOrdersListFetched(elapsedMs)
 
                         if (result.ordersWithRefunds.isEmpty()) {
-                            _state.value = WooPosOrdersState.Empty(
+                            _state.value = WooPosBookingsState.Empty(
                                 searchInputState = WooPosSearchInputState.Closed
                             )
                         } else {
@@ -591,43 +588,43 @@ class WooPosBookingsViewModel @Inject constructor(
         sideLoadActionsJob?.cancel()
     }
 
-    private suspend fun getOrComputeDetails(orderId: Long): WooPosOrdersState.OrderDetailsViewState.Computed.Details {
-        val current = _state.value as? WooPosOrdersState.Content ?: error("State is not Content")
-        val loadedItems = current.items as? WooPosOrdersState.Content.Items.Loaded ?: error("Items not loaded")
+    private suspend fun getOrComputeDetails(orderId: Long): WooPosBookingsState.OrderDetailsViewState.Computed.Details {
+        val current = _state.value as? WooPosBookingsState.Content ?: error("State is not Content")
+        val loadedItems = current.items as? WooPosBookingsState.Content.Items.Loaded ?: error("Items not loaded")
 
         val orderDetails = loadedItems.items.values.firstOrNull { it.orderId == orderId }
             ?: error("Order $orderId not found in state")
 
         return orderDetailsMapper.mapOrderDetails(
             when (orderDetails) {
-                is WooPosOrdersState.OrderDetailsViewState.Lazy -> orderDetails.order
-                is WooPosOrdersState.OrderDetailsViewState.Computed -> {
+                is WooPosBookingsState.OrderDetailsViewState.Lazy -> orderDetails.order
+                is WooPosBookingsState.OrderDetailsViewState.Computed -> {
                     loadedItems.items.keys.firstOrNull { it.id == orderId }?.let {
                         ordersDataSource.getOrderById(it.id).getOrNull()
                     } ?: error("Order $orderId not found")
                 }
             },
             when (orderDetails) {
-                is WooPosOrdersState.OrderDetailsViewState.Lazy -> orderDetails.refundResult
-                is WooPosOrdersState.OrderDetailsViewState.Computed -> RefundsFetchResult.Error
+                is WooPosBookingsState.OrderDetailsViewState.Lazy -> orderDetails.refundResult
+                is WooPosBookingsState.OrderDetailsViewState.Computed -> RefundsFetchResult.Error
             }
         )
     }
 
     private suspend fun getOrComputeDetailsWithoutActions(
         orderId: Long
-    ): WooPosOrdersState.OrderDetailsViewState.Computed.Details {
-        val current = _state.value as? WooPosOrdersState.Content ?: error("State is not Content")
-        val loadedItems = current.items as? WooPosOrdersState.Content.Items.Loaded ?: error("Items not loaded")
+    ): WooPosBookingsState.OrderDetailsViewState.Computed.Details {
+        val current = _state.value as? WooPosBookingsState.Content ?: error("State is not Content")
+        val loadedItems = current.items as? WooPosBookingsState.Content.Items.Loaded ?: error("Items not loaded")
 
         val orderDetails = loadedItems.items.values.firstOrNull { it.orderId == orderId }
             ?: error("Order $orderId not found in state")
 
         return when (orderDetails) {
-            is WooPosOrdersState.OrderDetailsViewState.Lazy ->
+            is WooPosBookingsState.OrderDetailsViewState.Lazy ->
                 orderDetailsMapper.mapOrderDetailsWithoutActions(orderDetails.order)
 
-            is WooPosOrdersState.OrderDetailsViewState.Computed -> {
+            is WooPosBookingsState.OrderDetailsViewState.Computed -> {
                 orderDetails.details
             }
         }
@@ -638,14 +635,14 @@ class WooPosBookingsViewModel @Inject constructor(
         paginationState: WooPosPaginationState = WooPosPaginationState.None
     ) {
         val currentState = _state.value
-        val currentFirstOrderId = (currentState as? WooPosOrdersState.Content)
-            ?.let { it.items as? WooPosOrdersState.Content.Items.Loaded }
+        val currentFirstOrderId = (currentState as? WooPosBookingsState.Content)
+            ?.let { it.items as? WooPosBookingsState.Content.Items.Loaded }
             ?.items?.keys?.firstOrNull()?.id
 
         val orders = ordersWithRefunds.keys.toList()
         val newFirstOrderId = orders.firstOrNull()?.id
 
-        val currentSelectedId = (currentState as? WooPosOrdersState.Content)?.selectedDetails?.id
+        val currentSelectedId = (currentState as? WooPosBookingsState.Content)?.selectedDetails?.id
         val isSelectedOrderStillInList = currentSelectedId != null && orders.any { it.id == currentSelectedId }
         val newSelectedId =
             if (isSelectedOrderStillInList) {
@@ -656,20 +653,20 @@ class WooPosBookingsViewModel @Inject constructor(
         val items = buildItemsMap(ordersWithRefunds, newSelectedId)
         val selectedEntry = items.entries.first { (item, _) -> item.isSelected }
         val selectedDetails = when (val details = selectedEntry.value) {
-            is WooPosOrdersState.OrderDetailsViewState.Computed -> details.details
-            is WooPosOrdersState.OrderDetailsViewState.Lazy -> error("Selected order should have computed details")
+            is WooPosBookingsState.OrderDetailsViewState.Computed -> details.details
+            is WooPosBookingsState.OrderDetailsViewState.Lazy -> error("Selected order should have computed details")
         }
 
-        _state.value = WooPosOrdersState.Content(
-            items = WooPosOrdersState.Content.Items.Loaded(
+        _state.value = WooPosBookingsState.Content(
+            items = WooPosBookingsState.Content.Items.Loaded(
                 items = items
             ),
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
             selectedDetails = selectedDetails,
             paginationState = paginationState,
             searchInputState = _state.value.searchInputState,
-            dialogState = (currentState as? WooPosOrdersState.Content)?.dialogState
-                ?: WooPosOrdersState.Content.DialogState.Hidden
+            dialogState = (currentState as? WooPosBookingsState.Content)?.dialogState
+                ?: WooPosBookingsState.Content.DialogState.Hidden
         )
 
         if (currentFirstOrderId != null && currentFirstOrderId != newFirstOrderId) {
@@ -681,14 +678,14 @@ class WooPosBookingsViewModel @Inject constructor(
         ordersWithRefunds: Map<Order, RefundsFetchResult>,
         paginationState: WooPosPaginationState = WooPosPaginationState.None
     ) {
-        val current = _state.value as WooPosOrdersState.Content
-        val loadedItems = current.items as WooPosOrdersState.Content.Items.Loaded
+        val current = _state.value as WooPosBookingsState.Content
+        val loadedItems = current.items as WooPosBookingsState.Content.Items.Loaded
         val currentSelectedId = loadedItems.items.entries.firstOrNull { it.key.isSelected }?.key?.id
         val newItems = buildItemsMap(ordersWithRefunds, currentSelectedId)
         val items = loadedItems.items + newItems
 
-        _state.value = WooPosOrdersState.Content(
-            items = WooPosOrdersState.Content.Items.Loaded(
+        _state.value = WooPosBookingsState.Content(
+            items = WooPosBookingsState.Content.Items.Loaded(
                 items = items
             ),
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
@@ -702,15 +699,15 @@ class WooPosBookingsViewModel @Inject constructor(
     private suspend fun buildItemsMap(
         ordersWithRefunds: Map<Order, RefundsFetchResult>,
         selectedId: Long?
-    ): Map<WooPosOrdersState.OrderItemViewState, WooPosOrdersState.OrderDetailsViewState> = coroutineScope {
+    ): Map<WooPosBookingsState.OrderItemViewState, WooPosBookingsState.OrderDetailsViewState> = coroutineScope {
         ordersWithRefunds.map { (order, refundResult) ->
             async {
                 val item = orderItemMapper.mapOrderItem(order, selectedId)
-                val details: WooPosOrdersState.OrderDetailsViewState = if (order.id == selectedId) {
+                val details: WooPosBookingsState.OrderDetailsViewState = if (order.id == selectedId) {
                     val fullDetails = orderDetailsMapper.mapOrderDetails(order, refundResult)
-                    WooPosOrdersState.OrderDetailsViewState.Computed(orderId = order.id, details = fullDetails)
+                    WooPosBookingsState.OrderDetailsViewState.Computed(orderId = order.id, details = fullDetails)
                 } else {
-                    WooPosOrdersState.OrderDetailsViewState.Lazy(
+                    WooPosBookingsState.OrderDetailsViewState.Lazy(
                         orderId = order.id,
                         order = order,
                         refundResult = refundResult

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.ui.woopos.orders.LoadOrdersResult
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
-import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -40,8 +39,7 @@ class WooPosBookingsViewModel @Inject constructor(
     private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker,
     private val bookingItemMapper: WooPosBookingItemMapper,
     private val bookingDetailsMapper: WooPosBookingDetailsMapper,
-    private val refundInfoBuilder: WooPosRefundInfoBuilder,
-    private val orderActionsProvider: WooPosBookingActionsProvider,
+    private val bookingActionsProvider: WooPosBookingActionsProvider,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<WooPosBookingsState>(
@@ -56,11 +54,11 @@ class WooPosBookingsViewModel @Inject constructor(
     val scrollToTopEvent: SharedFlow<Unit> = _scrollToTopEvent.asSharedFlow()
 
     private var loadingJob: Job? = null
-    private var loadingMoreOrdersJob: Job? = null
+    private var loadingMoreBookingsJob: Job? = null
     private var sideLoadActionsJob: Job? = null
 
     init {
-        loadOrders()
+        loadBookings()
     }
 
     fun onUIEvent(event: WooPosBookingsUIEvent) {
@@ -82,11 +80,11 @@ class WooPosBookingsViewModel @Inject constructor(
 
         if (isAlreadySelectedWithActions(current, orderId)) return
 
-        trackOrderSelectionAnalytics(loadedItems, orderId)
+        trackBookingSelectionAnalytics(loadedItems, orderId)
 
         viewModelScope.launch {
             val orderDetailsViewState = loadedItems.items.values.firstOrNull { it.orderId == orderId }
-            val details = computeOrderDetails(orderId, orderDetailsViewState)
+            val details = computeBookingDetails(orderId, orderDetailsViewState)
             val updatedItems = updateItemsSelection(loadedItems, orderId, details)
 
             _state.value = current.copy(
@@ -103,7 +101,7 @@ class WooPosBookingsViewModel @Inject constructor(
             current.selectedDetails.actionsState is WooPosBookingsState.BookingActionsState.Loaded
     }
 
-    private fun trackOrderSelectionAnalytics(
+    private fun trackBookingSelectionAnalytics(
         loadedItems: WooPosBookingsState.Content.Items.Loaded,
         orderId: Long
     ) {
@@ -126,7 +124,7 @@ class WooPosBookingsViewModel @Inject constructor(
         }
     }
 
-    private suspend fun computeOrderDetails(
+    private suspend fun computeBookingDetails(
         orderId: Long,
         orderDetailsViewState: WooPosBookingsState.BookingDetailsViewState?
     ): WooPosBookingsState.BookingDetailsViewState.Computed.Details {
@@ -156,22 +154,22 @@ class WooPosBookingsViewModel @Inject constructor(
     private suspend fun startSideLoadActionsIfNeeded(
         orderId: Long,
         details: WooPosBookingsState.BookingDetailsViewState.Computed.Details,
-        orderDetailsViewState: WooPosBookingsState.BookingDetailsViewState?,
+        bookingDetailsViewState: WooPosBookingsState.BookingDetailsViewState?,
         loadedItems: WooPosBookingsState.Content.Items.Loaded
     ) {
         if (details.actionsState !is WooPosBookingsState.BookingActionsState.Loading) return
 
-        val order = getOrderForSideLoading(orderId, orderDetailsViewState, loadedItems) ?: return
+        val order = getBookingForSideLoading(orderId, bookingDetailsViewState, loadedItems) ?: return
         sideLoadActions(orderId, order)
     }
 
-    private suspend fun getOrderForSideLoading(
+    private suspend fun getBookingForSideLoading(
         orderId: Long,
-        orderDetailsViewState: WooPosBookingsState.BookingDetailsViewState?,
+        bookingDetailsViewState: WooPosBookingsState.BookingDetailsViewState?,
         loadedItems: WooPosBookingsState.Content.Items.Loaded
     ): Order? {
-        return when (orderDetailsViewState) {
-            is WooPosBookingsState.BookingDetailsViewState.Lazy -> orderDetailsViewState.order
+        return when (bookingDetailsViewState) {
+            is WooPosBookingsState.BookingDetailsViewState.Lazy -> bookingDetailsViewState.order
             is WooPosBookingsState.BookingDetailsViewState.Computed -> {
                 loadedItems.items.keys.firstOrNull { it.id == orderId }?.let { item ->
                     ordersDataSource.getOrderById(item.id).getOrNull()
@@ -195,7 +193,7 @@ class WooPosBookingsViewModel @Inject constructor(
                 return@launch
             }
 
-            val actions = orderActionsProvider.getAvailableActions(order, refundsResult)
+            val actions = bookingActionsProvider.getAvailableActions(order, refundsResult)
 //            val refundInfo = refundInfoBuilder.buildRefundInfo(order, refundsResult)
 //            val updatedBreakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
             val updatedBreakdown = WooPosBookingsState.BookingDetailsViewState.Computed.Details.TotalsBreakdown(
@@ -267,7 +265,7 @@ class WooPosBookingsViewModel @Inject constructor(
 
         ordersDataSource.clearCache()
 
-        loadOrders(isRefreshing = true)
+        loadBookings(isRefreshing = true)
     }
 
     fun onEndOfBookingsListReached() {
@@ -309,7 +307,7 @@ class WooPosBookingsViewModel @Inject constructor(
         _state.value = currentState.copy(
             dialogState = WooPosBookingsState.Content.DialogState.Hidden
         )
-        refreshSelectedOrder()
+        refreshSelectedBooking()
     }
 
     fun onBookingsEmptyActionClicked() {
@@ -320,11 +318,11 @@ class WooPosBookingsViewModel @Inject constructor(
 
     fun onBookingsLoadingErrorRetryButtonClicked() {
         _state.value = WooPosBookingsState.Loading
-        loadOrders()
+        loadBookings()
     }
 
     fun loadMoreIfPossible() {
-        if (loadingJob?.isActive == true || loadingMoreOrdersJob?.isActive == true) return
+        if (loadingJob?.isActive == true || loadingMoreBookingsJob?.isActive == true) return
         if (!ordersDataSource.hasMorePages) return
 
         val currentState = _state.value
@@ -334,13 +332,13 @@ class WooPosBookingsViewModel @Inject constructor(
         }
         _state.value = newState
 
-        loadingMoreOrdersJob?.cancel()
-        loadingMoreOrdersJob = viewModelScope.launch {
+        loadingMoreBookingsJob?.cancel()
+        loadingMoreBookingsJob = viewModelScope.launch {
             val result = ordersDataSource.loadMore()
 
             if (result.isSuccess) {
                 ordersAnalyticsTracker.trackOrdersListNextPageLoaded()
-                appendOrders(result.getOrThrow())
+                appendBookings(result.getOrThrow())
             } else {
                 _state.value = newState.copy(paginationState = WooPosPaginationState.Error)
             }
@@ -348,21 +346,21 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     fun onBackFromSuccessfullySendingEmailReceipt() {
-        refreshSelectedOrder()
+        refreshSelectedBooking()
     }
 
-    private fun refreshSelectedOrder() {
+    private fun refreshSelectedBooking() {
         val current = _state.value as? WooPosBookingsState.Content ?: return
         val selectedOrderId = current.selectedDetails?.id ?: return
 
         sideLoadActionsJob?.cancel()
         viewModelScope.launch {
             ordersDataSource.refreshOrderById(selectedOrderId)
-                .onSuccess { applyOrderUpdate(it) }
+                .onSuccess { applyBookingUpdate(it) }
         }
     }
 
-    private suspend fun applyOrderUpdate(updated: Order) {
+    private suspend fun applyBookingUpdate(updated: Order) {
         val current = _state.value as? WooPosBookingsState.Content ?: return
         val loaded = current.items as? WooPosBookingsState.Content.Items.Loaded ?: return
 
@@ -372,7 +370,7 @@ class WooPosBookingsViewModel @Inject constructor(
         )
 
         val selectedId = loaded.items.keys.firstOrNull { it.isSelected }?.id
-        val newItem = bookingItemMapper.mapOrderItem(updated, selectedId)
+        val newItem = bookingItemMapper.mapBookingItem(updated, selectedId)
         val newDetailsViewState = bookingDetailsMapper.mapBookingDetails(updated, historicalRefundsResult)
         val newDetails = WooPosBookingsState.BookingDetailsViewState.Computed(
             orderId = updated.id,
@@ -389,7 +387,7 @@ class WooPosBookingsViewModel @Inject constructor(
         )
     }
 
-    private fun loadOrders(isRefreshing: Boolean = false) {
+    private fun loadBookings(isRefreshing: Boolean = false) {
         cancelJobs()
         val mark = Monotonic.markNow()
         loadingJob = viewModelScope.launch {
@@ -408,7 +406,7 @@ class WooPosBookingsViewModel @Inject constructor(
                         if (result.ordersWithRefunds.isEmpty()) {
                             _state.value = WooPosBookingsState.Loading
                         } else {
-                            replaceOrders(result.ordersWithRefunds)
+                            replaceBookings(result.ordersWithRefunds)
                         }
                     }
 
@@ -419,7 +417,7 @@ class WooPosBookingsViewModel @Inject constructor(
                         if (result.ordersWithRefunds.isEmpty()) {
                             _state.value = WooPosBookingsState.Empty()
                         } else {
-                            replaceOrders(result.ordersWithRefunds)
+                            replaceBookings(result.ordersWithRefunds)
                         }
                     }
                 }
@@ -429,7 +427,7 @@ class WooPosBookingsViewModel @Inject constructor(
 
     private fun cancelJobs() {
         loadingJob?.cancel()
-        loadingMoreOrdersJob?.cancel()
+        loadingMoreBookingsJob?.cancel()
         sideLoadActionsJob?.cancel()
     }
 
@@ -477,7 +475,7 @@ class WooPosBookingsViewModel @Inject constructor(
         }
     }
 
-    private suspend fun replaceOrders(
+    private suspend fun replaceBookings(
         ordersWithRefunds: Map<Order, RefundsFetchResult>,
         paginationState: WooPosPaginationState = WooPosPaginationState.None
     ) {
@@ -520,7 +518,7 @@ class WooPosBookingsViewModel @Inject constructor(
         }
     }
 
-    private suspend fun appendOrders(
+    private suspend fun appendBookings(
         ordersWithRefunds: Map<Order, RefundsFetchResult>,
         paginationState: WooPosPaginationState = WooPosPaginationState.None
     ) {
@@ -547,7 +545,7 @@ class WooPosBookingsViewModel @Inject constructor(
     ): Map<WooPosBookingsState.BookingItemViewState, WooPosBookingsState.BookingDetailsViewState> = coroutineScope {
         ordersWithRefunds.map { (order, refundResult) ->
             async {
-                val item = bookingItemMapper.mapOrderItem(order, selectedId)
+                val item = bookingItemMapper.mapBookingItem(order, selectedId)
                 val details: WooPosBookingsState.BookingDetailsViewState = if (order.id == selectedId) {
                     val fullDetails = bookingDetailsMapper.mapBookingDetails(order, refundResult)
                     WooPosBookingsState.BookingDetailsViewState.Computed(orderId = order.id, details = fullDetails)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -78,7 +78,7 @@ class WooPosBookingsViewModel @Inject constructor(
         }
     }
 
-    fun onOrderSelected(orderId: Long) {
+    fun onBookingSelected(orderId: Long) {
         val current = _state.value as? WooPosBookingsState.Content ?: return
         val loadedItems = current.items as? WooPosBookingsState.Content.Items.Loaded ?: return
 
@@ -272,7 +272,7 @@ class WooPosBookingsViewModel @Inject constructor(
         loadOrders(isRefreshing = true)
     }
 
-    fun onEndOfOrdersListReached() {
+    fun onEndOfBookingsListReached() {
         val currentState = _state.value
         if (currentState !is WooPosBookingsState.Content ||
             currentState.paginationState != WooPosPaginationState.None ||
@@ -314,13 +314,13 @@ class WooPosBookingsViewModel @Inject constructor(
         refreshSelectedOrder()
     }
 
-    fun onOrdersEmptyActionClicked() {
+    fun onBookingsEmptyActionClicked() {
         viewModelScope.launch {
             _openUrlEvent.emit(AppUrls.URL_LEARN_MORE_ORDERS)
         }
     }
 
-    fun onOrdersLoadingErrorRetryButtonClicked() {
+    fun onBookingsLoadingErrorRetryButtonClicked() {
         _state.value = WooPosBookingsState.Loading
         loadOrders()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -11,7 +11,7 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.orders.LoadOrdersResult
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
-import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
+import com.woocommerce.android.ui.woopos.orders.WooPosBookingActionsProvider
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersUIEvent
@@ -45,7 +45,7 @@ class WooPosBookingsViewModel @Inject constructor(
     private val orderItemMapper: WooPosOrderItemMapper,
     private val orderDetailsMapper: WooPosOrderDetailsMapper,
     private val refundInfoBuilder: WooPosRefundInfoBuilder,
-    private val orderActionsProvider: WooPosOrderActionsProvider,
+    private val orderActionsProvider: WooPosBookingActionsProvider,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<WooPosBookingsState>(
@@ -69,14 +69,14 @@ class WooPosBookingsViewModel @Inject constructor(
 
     fun onUIEvent(event: WooPosOrdersUIEvent) {
         when (event) {
-            is WooPosOrdersUIEvent.OrderActionClicked -> handleActionClicked(event.action)
+            is WooPosOrdersUIEvent.BookingActionClicked -> handleActionClicked(event.action)
         }
     }
 
-    private fun handleActionClicked(action: WooPosBookingsState.OrderAction) {
+    private fun handleActionClicked(action: WooPosBookingsState.BookingAction) {
         when (action) {
-            is WooPosBookingsState.OrderAction.EmailReceipt -> onEmailReceiptButtonClicked(action.orderId)
-            is WooPosBookingsState.OrderAction.IssueRefund -> onIssueRefundButtonClicked(action.orderId)
+            is WooPosBookingsState.BookingAction.EmailReceipt -> onEmailReceiptButtonClicked(action.orderId)
+            is WooPosBookingsState.BookingAction.IssueRefund -> onIssueRefundButtonClicked(action.orderId)
         }
     }
 
@@ -104,7 +104,7 @@ class WooPosBookingsViewModel @Inject constructor(
 
     private fun isAlreadySelectedWithActions(current: WooPosBookingsState.Content, orderId: Long): Boolean {
         return current.selectedDetails?.id == orderId &&
-            current.selectedDetails.actionsState is WooPosBookingsState.OrderActionsState.Loaded
+            current.selectedDetails.actionsState is WooPosBookingsState.BookingActionsState.Loaded
     }
 
     private fun trackOrderSelectionAnalytics(
@@ -132,9 +132,9 @@ class WooPosBookingsViewModel @Inject constructor(
 
     private suspend fun computeOrderDetails(
         orderId: Long,
-        orderDetailsViewState: WooPosBookingsState.OrderDetailsViewState?
-    ): WooPosBookingsState.OrderDetailsViewState.Computed.Details {
-        return if (orderDetailsViewState is WooPosBookingsState.OrderDetailsViewState.Lazy) {
+        orderDetailsViewState: WooPosBookingsState.BookingDetailsViewState?
+    ): WooPosBookingsState.BookingDetailsViewState.Computed.Details {
+        return if (orderDetailsViewState is WooPosBookingsState.BookingDetailsViewState.Lazy) {
             getOrComputeDetailsWithoutActions(orderId)
         } else {
             getOrComputeDetails(orderId)
@@ -144,13 +144,13 @@ class WooPosBookingsViewModel @Inject constructor(
     private fun updateItemsSelection(
         loadedItems: WooPosBookingsState.Content.Items.Loaded,
         orderId: Long,
-        details: WooPosBookingsState.OrderDetailsViewState.Computed.Details
-    ): Map<WooPosBookingsState.OrderItemViewState, WooPosBookingsState.OrderDetailsViewState> {
+        details: WooPosBookingsState.BookingDetailsViewState.Computed.Details
+    ): Map<WooPosBookingsState.BookingItemViewState, WooPosBookingsState.BookingDetailsViewState> {
         return loadedItems.items.mapKeys { (item, _) ->
             item.copy(isSelected = item.id == orderId)
         }.mapValues { (item, orderDetails) ->
-            if (item.id == orderId && orderDetails is WooPosBookingsState.OrderDetailsViewState.Lazy) {
-                WooPosBookingsState.OrderDetailsViewState.Computed(orderId = orderId, details = details)
+            if (item.id == orderId && orderDetails is WooPosBookingsState.BookingDetailsViewState.Lazy) {
+                WooPosBookingsState.BookingDetailsViewState.Computed(orderId = orderId, details = details)
             } else {
                 orderDetails
             }
@@ -159,11 +159,11 @@ class WooPosBookingsViewModel @Inject constructor(
 
     private suspend fun startSideLoadActionsIfNeeded(
         orderId: Long,
-        details: WooPosBookingsState.OrderDetailsViewState.Computed.Details,
-        orderDetailsViewState: WooPosBookingsState.OrderDetailsViewState?,
+        details: WooPosBookingsState.BookingDetailsViewState.Computed.Details,
+        orderDetailsViewState: WooPosBookingsState.BookingDetailsViewState?,
         loadedItems: WooPosBookingsState.Content.Items.Loaded
     ) {
-        if (details.actionsState !is WooPosBookingsState.OrderActionsState.Loading) return
+        if (details.actionsState !is WooPosBookingsState.BookingActionsState.Loading) return
 
         val order = getOrderForSideLoading(orderId, orderDetailsViewState, loadedItems) ?: return
         sideLoadActions(orderId, order)
@@ -171,12 +171,12 @@ class WooPosBookingsViewModel @Inject constructor(
 
     private suspend fun getOrderForSideLoading(
         orderId: Long,
-        orderDetailsViewState: WooPosBookingsState.OrderDetailsViewState?,
+        orderDetailsViewState: WooPosBookingsState.BookingDetailsViewState?,
         loadedItems: WooPosBookingsState.Content.Items.Loaded
     ): Order? {
         return when (orderDetailsViewState) {
-            is WooPosBookingsState.OrderDetailsViewState.Lazy -> orderDetailsViewState.order
-            is WooPosBookingsState.OrderDetailsViewState.Computed -> {
+            is WooPosBookingsState.BookingDetailsViewState.Lazy -> orderDetailsViewState.order
+            is WooPosBookingsState.BookingDetailsViewState.Computed -> {
                 loadedItems.items.keys.firstOrNull { it.id == orderId }?.let { item ->
                     ordersDataSource.getOrderById(item.id).getOrNull()
                 }
@@ -207,16 +207,16 @@ class WooPosBookingsViewModel @Inject constructor(
             val updatedSelectedDetails = updatedState.selectedDetails
 
             if (updatedSelectedDetails?.id == orderId &&
-                updatedSelectedDetails.actionsState is WooPosBookingsState.OrderActionsState.Loading
+                updatedSelectedDetails.actionsState is WooPosBookingsState.BookingActionsState.Loading
             ) {
                 val loadedItems = updatedState.items as? WooPosBookingsState.Content.Items.Loaded
                 val updatedItems = loadedItems?.items?.map { (item, details) ->
                     val updatedDetails =
-                        if (item.id == orderId && details is WooPosBookingsState.OrderDetailsViewState.Computed) {
-                            WooPosBookingsState.OrderDetailsViewState.Computed(
+                        if (item.id == orderId && details is WooPosBookingsState.BookingDetailsViewState.Computed) {
+                            WooPosBookingsState.BookingDetailsViewState.Computed(
                                 orderId = orderId,
                                 details = details.details.copy(
-                                    actionsState = WooPosBookingsState.OrderActionsState.Loaded(actions),
+                                    actionsState = WooPosBookingsState.BookingActionsState.Loaded(actions),
                                     breakdown = updatedBreakdown
                                 )
                             )
@@ -233,7 +233,7 @@ class WooPosBookingsViewModel @Inject constructor(
                         updatedState.items
                     },
                     selectedDetails = updatedSelectedDetails.copy(
-                        actionsState = WooPosBookingsState.OrderActionsState.Loaded(actions),
+                        actionsState = WooPosBookingsState.BookingActionsState.Loaded(actions),
                         breakdown = updatedBreakdown
                     )
                 )
@@ -369,7 +369,7 @@ class WooPosBookingsViewModel @Inject constructor(
         val selectedId = loaded.items.keys.firstOrNull { it.isSelected }?.id
         val newItem = orderItemMapper.mapOrderItem(updated, selectedId)
         val newDetailsViewState = orderDetailsMapper.mapOrderDetails(updated, historicalRefundsResult)
-        val newDetails = WooPosBookingsState.OrderDetailsViewState.Computed(
+        val newDetails = WooPosBookingsState.BookingDetailsViewState.Computed(
             orderId = updated.id,
             details = newDetailsViewState
         )
@@ -428,7 +428,7 @@ class WooPosBookingsViewModel @Inject constructor(
         sideLoadActionsJob?.cancel()
     }
 
-    private suspend fun getOrComputeDetails(orderId: Long): WooPosBookingsState.OrderDetailsViewState.Computed.Details {
+    private suspend fun getOrComputeDetails(orderId: Long): WooPosBookingsState.BookingDetailsViewState.Computed.Details {
         val current = _state.value as? WooPosBookingsState.Content ?: error("State is not Content")
         val loadedItems = current.items as? WooPosBookingsState.Content.Items.Loaded ?: error("Items not loaded")
 
@@ -437,23 +437,23 @@ class WooPosBookingsViewModel @Inject constructor(
 
         return orderDetailsMapper.mapOrderDetails(
             when (orderDetails) {
-                is WooPosBookingsState.OrderDetailsViewState.Lazy -> orderDetails.order
-                is WooPosBookingsState.OrderDetailsViewState.Computed -> {
+                is WooPosBookingsState.BookingDetailsViewState.Lazy -> orderDetails.order
+                is WooPosBookingsState.BookingDetailsViewState.Computed -> {
                     loadedItems.items.keys.firstOrNull { it.id == orderId }?.let {
                         ordersDataSource.getOrderById(it.id).getOrNull()
                     } ?: error("Order $orderId not found")
                 }
             },
             when (orderDetails) {
-                is WooPosBookingsState.OrderDetailsViewState.Lazy -> orderDetails.refundResult
-                is WooPosBookingsState.OrderDetailsViewState.Computed -> RefundsFetchResult.Error
+                is WooPosBookingsState.BookingDetailsViewState.Lazy -> orderDetails.refundResult
+                is WooPosBookingsState.BookingDetailsViewState.Computed -> RefundsFetchResult.Error
             }
         )
     }
 
     private suspend fun getOrComputeDetailsWithoutActions(
         orderId: Long
-    ): WooPosBookingsState.OrderDetailsViewState.Computed.Details {
+    ): WooPosBookingsState.BookingDetailsViewState.Computed.Details {
         val current = _state.value as? WooPosBookingsState.Content ?: error("State is not Content")
         val loadedItems = current.items as? WooPosBookingsState.Content.Items.Loaded ?: error("Items not loaded")
 
@@ -461,10 +461,10 @@ class WooPosBookingsViewModel @Inject constructor(
             ?: error("Order $orderId not found in state")
 
         return when (orderDetails) {
-            is WooPosBookingsState.OrderDetailsViewState.Lazy ->
+            is WooPosBookingsState.BookingDetailsViewState.Lazy ->
                 orderDetailsMapper.mapOrderDetailsWithoutActions(orderDetails.order)
 
-            is WooPosBookingsState.OrderDetailsViewState.Computed -> {
+            is WooPosBookingsState.BookingDetailsViewState.Computed -> {
                 orderDetails.details
             }
         }
@@ -493,8 +493,8 @@ class WooPosBookingsViewModel @Inject constructor(
         val items = buildItemsMap(ordersWithRefunds, newSelectedId)
         val selectedEntry = items.entries.first { (item, _) -> item.isSelected }
         val selectedDetails = when (val details = selectedEntry.value) {
-            is WooPosBookingsState.OrderDetailsViewState.Computed -> details.details
-            is WooPosBookingsState.OrderDetailsViewState.Lazy -> error("Selected order should have computed details")
+            is WooPosBookingsState.BookingDetailsViewState.Computed -> details.details
+            is WooPosBookingsState.BookingDetailsViewState.Lazy -> error("Selected order should have computed details")
         }
 
         _state.value = WooPosBookingsState.Content(
@@ -537,15 +537,15 @@ class WooPosBookingsViewModel @Inject constructor(
     private suspend fun buildItemsMap(
         ordersWithRefunds: Map<Order, RefundsFetchResult>,
         selectedId: Long?
-    ): Map<WooPosBookingsState.OrderItemViewState, WooPosBookingsState.OrderDetailsViewState> = coroutineScope {
+    ): Map<WooPosBookingsState.BookingItemViewState, WooPosBookingsState.BookingDetailsViewState> = coroutineScope {
         ordersWithRefunds.map { (order, refundResult) ->
             async {
                 val item = orderItemMapper.mapOrderItem(order, selectedId)
-                val details: WooPosBookingsState.OrderDetailsViewState = if (order.id == selectedId) {
+                val details: WooPosBookingsState.BookingDetailsViewState = if (order.id == selectedId) {
                     val fullDetails = orderDetailsMapper.mapOrderDetails(order, refundResult)
-                    WooPosBookingsState.OrderDetailsViewState.Computed(orderId = order.id, details = fullDetails)
+                    WooPosBookingsState.BookingDetailsViewState.Computed(orderId = order.id, details = fullDetails)
                 } else {
-                    WooPosBookingsState.OrderDetailsViewState.Lazy(
+                    WooPosBookingsState.BookingDetailsViewState.Lazy(
                         orderId = order.id,
                         order = order,
                         refundResult = refundResult

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -2,9 +2,33 @@ package com.woocommerce.android.ui.woopos.bookings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppUrls
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
+import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToEmailReceipt
+import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
+import com.woocommerce.android.ui.woopos.orders.LoadOrdersResult
+import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
+import com.woocommerce.android.ui.woopos.orders.SearchOrdersResult
+import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersUIEvent
+import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderDetailsMapper
+import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderItemMapper
+import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
+import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,145 +38,687 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.time.TimeSource.Monotonic
 
 @Suppress("LargeClass", "MagicNumber")
 @HiltViewModel
-class WooPosBookingsViewModel @Inject constructor() : ViewModel() {
+class WooPosBookingsViewModel @Inject constructor(
+    private val ordersDataSource: WooPosOrdersDataSource,
+    private val resourceProvider: ResourceProvider,
+    private val childrenToParentEventSender: WooPosChildrenToParentEventSender,
+    private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds,
+    private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker,
+    private val orderItemMapper: WooPosOrderItemMapper,
+    private val orderDetailsMapper: WooPosOrderDetailsMapper,
+    private val refundInfoBuilder: WooPosRefundInfoBuilder,
+    private val orderActionsProvider: WooPosOrderActionsProvider,
+) : ViewModel() {
 
-    private val _state = MutableStateFlow<WooPosBookingsState>(WooPosBookingsState.Loading)
-    val state: StateFlow<WooPosBookingsState> = _state.asStateFlow()
+    private val _state = MutableStateFlow<WooPosOrdersState>(
+        WooPosOrdersState.Loading(
+            searchInputState = WooPosSearchInputState.Closed
+        )
+    )
+    val state: StateFlow<WooPosOrdersState> = _state.asStateFlow()
+
+    private val _openUrlEvent = MutableSharedFlow<String>()
+    val openUrlEvent: SharedFlow<String> = _openUrlEvent.asSharedFlow()
 
     private val _scrollToTopEvent = MutableSharedFlow<Unit>()
     val scrollToTopEvent: SharedFlow<Unit> = _scrollToTopEvent.asSharedFlow()
 
-    init {
-        loadBookings()
+    private var searchJob: Job? = null
+    private var loadingJob: Job? = null
+    private var loadingMoreOrdersJob: Job? = null
+    private var sideLoadActionsJob: Job? = null
+
+    private val currentSearchQuery: String?
+        get() = (
+            (
+                _state.value.searchInputState as? WooPosSearchInputState.Open
+                )?.input as? WooPosSearchInputState.Open.Input.Query
+            )?.query
+
+    companion object {
+        private const val SEARCH_DEBOUNCE_DELAY_MS = 300L
     }
 
-    private fun loadBookings() {
-        viewModelScope.launch {
-            delay(3000L)
-            _state.value = createDummyContentState()
+    init {
+        loadOrders()
+    }
+
+    fun onUIEvent(event: WooPosOrdersUIEvent) {
+        when (event) {
+            is WooPosOrdersUIEvent.OrderActionClicked -> handleActionClicked(event.action)
         }
     }
 
-    private fun createDummyContentState(): WooPosBookingsState.Content {
-        val details1 = createDummyDetails(1L, "#001")
-        val details2 = createDummyDetails(2L, "#002")
-
-        val item1 = WooPosBookingsState.BookingItemViewState(
-            id = 1L,
-            title = "#001",
-            date = "Feb 5, 2026 at 10:00 AM",
-            total = "$50.00",
-            customerEmail = "john@example.com",
-            isSelected = true,
-            status = PosBookingStatus("Completed", BookingStatusColorKey.COMPLETED),
-            statusSlug = "completed",
-            createdAtMillis = System.currentTimeMillis()
-        )
-
-        val item2 = WooPosBookingsState.BookingItemViewState(
-            id = 2L,
-            title = "#002",
-            date = "Feb 4, 2026 at 2:30 PM",
-            total = "$75.00",
-            customerEmail = "jane@example.com",
-            isSelected = false,
-            status = PosBookingStatus("Processing", BookingStatusColorKey.PROCESSING),
-            statusSlug = "processing",
-            createdAtMillis = System.currentTimeMillis() - 86400000
-        )
-
-        return WooPosBookingsState.Content(
-            items = WooPosBookingsState.Content.Items.Loaded(
-                items = mapOf(
-                    item1 to WooPosBookingsState.BookingDetailsViewState.Computed(orderId = 1L, details = details1),
-                    item2 to WooPosBookingsState.BookingDetailsViewState.Computed(orderId = 2L, details = details2)
-                )
-            ),
-            pullToRefreshState = WooPosPullToRefreshState.Enabled,
-            selectedDetails = details1,
-            paginationState = WooPosPaginationState.None,
-            dialogState = WooPosBookingsState.Content.DialogState.Hidden
-        )
+    private fun handleActionClicked(action: WooPosOrdersState.OrderAction) {
+        when (action) {
+            is WooPosOrdersState.OrderAction.EmailReceipt -> onEmailReceiptButtonClicked(action.orderId)
+            is WooPosOrdersState.OrderAction.IssueRefund -> onIssueRefundButtonClicked(action.orderId)
+        }
     }
 
-    private fun createDummyDetails(
-        id: Long,
-        number: String
-    ) = WooPosBookingsState.BookingDetailsViewState.Computed.Details(
-        id = id,
-        number = number,
-        dateTime = "Feb 5, 2026 at 10:00 AM",
-        customerEmail = "customer@example.com",
-        status = PosBookingStatus("Completed", BookingStatusColorKey.COMPLETED),
-        lineItems = listOf(
-            WooPosBookingsState.BookingDetailsViewState.Computed.Details.LineItemRow(
-                id = 1L,
-                name = "Haircut",
-                attributesDescription = "30 min",
-                qtyAndUnitPrice = "1 x $30.00",
-                lineTotal = "$30.00",
-                imageUrl = null
-            ),
-            WooPosBookingsState.BookingDetailsViewState.Computed.Details.LineItemRow(
-                id = 2L,
-                name = "Beard Trim",
-                attributesDescription = "15 min",
-                qtyAndUnitPrice = "1 x $20.00",
-                lineTotal = "$20.00",
-                imageUrl = null
+    fun onOrderSelected(orderId: Long) {
+        val current = _state.value as? WooPosOrdersState.Content ?: return
+        val loadedItems = current.items as? WooPosOrdersState.Content.Items.Loaded ?: return
+
+        if (isAlreadySelectedWithActions(current, orderId)) return
+
+        trackOrderSelectionAnalytics(loadedItems, orderId)
+
+        viewModelScope.launch {
+            val orderDetailsViewState = loadedItems.items.values.firstOrNull { it.orderId == orderId }
+            val details = computeOrderDetails(orderId, orderDetailsViewState)
+            val updatedItems = updateItemsSelection(loadedItems, orderId, details)
+
+            _state.value = current.copy(
+                items = WooPosOrdersState.Content.Items.Loaded(items = updatedItems),
+                selectedDetails = details
             )
-        ),
-        breakdown = WooPosBookingsState.BookingDetailsViewState.Computed.Details.TotalsBreakdown(
-            products = "$50.00",
-            discount = null,
-            discountCode = null,
-            taxes = "$0.00",
-            shipping = null,
-            refunds = emptyList(),
-            netPayment = null
-        ),
-        total = "$50.00",
-        totalPaid = "$50.00",
-        paymentMethodTitle = "Cash",
-        actionsState = WooPosBookingsState.BookingActionsState.Loaded(
-            listOf(WooPosBookingsState.BookingAction.EmailReceipt(id))
-        )
-    )
+
+            startSideLoadActionsIfNeeded(orderId, details, orderDetailsViewState, loadedItems)
+        }
+    }
+
+    private fun isAlreadySelectedWithActions(current: WooPosOrdersState.Content, orderId: Long): Boolean {
+        return current.selectedDetails?.id == orderId &&
+            current.selectedDetails.actionsState is WooPosOrdersState.OrderActionsState.Loaded
+    }
+
+    private fun trackOrderSelectionAnalytics(
+        loadedItems: WooPosOrdersState.Content.Items.Loaded,
+        orderId: Long
+    ) {
+        val keys = loadedItems.items.keys.toList()
+        val position = keys.indexOfFirst { it.id == orderId }.coerceAtLeast(0)
+        val selectedItem = keys.firstOrNull { it.id == orderId } ?: return
+
+        viewModelScope.launch {
+            ordersAnalyticsTracker.trackOrdersListRowTapped(
+                orderId = selectedItem.id,
+                orderStatus = selectedItem.statusSlug,
+                listPosition = position,
+                createdAtMillis = selectedItem.createdAtMillis
+            )
+            ordersAnalyticsTracker.trackOrderDetailsLoaded(
+                orderId = selectedItem.id,
+                orderStatus = selectedItem.statusSlug,
+                createdAtMillis = selectedItem.createdAtMillis
+            )
+        }
+    }
+
+    private suspend fun computeOrderDetails(
+        orderId: Long,
+        orderDetailsViewState: WooPosOrdersState.OrderDetailsViewState?
+    ): WooPosOrdersState.OrderDetailsViewState.Computed.Details {
+        return if (orderDetailsViewState is WooPosOrdersState.OrderDetailsViewState.Lazy) {
+            getOrComputeDetailsWithoutActions(orderId)
+        } else {
+            getOrComputeDetails(orderId)
+        }
+    }
+
+    private fun updateItemsSelection(
+        loadedItems: WooPosOrdersState.Content.Items.Loaded,
+        orderId: Long,
+        details: WooPosOrdersState.OrderDetailsViewState.Computed.Details
+    ): Map<WooPosOrdersState.OrderItemViewState, WooPosOrdersState.OrderDetailsViewState> {
+        return loadedItems.items.mapKeys { (item, _) ->
+            item.copy(isSelected = item.id == orderId)
+        }.mapValues { (item, orderDetails) ->
+            if (item.id == orderId && orderDetails is WooPosOrdersState.OrderDetailsViewState.Lazy) {
+                WooPosOrdersState.OrderDetailsViewState.Computed(orderId = orderId, details = details)
+            } else {
+                orderDetails
+            }
+        }
+    }
+
+    private suspend fun startSideLoadActionsIfNeeded(
+        orderId: Long,
+        details: WooPosOrdersState.OrderDetailsViewState.Computed.Details,
+        orderDetailsViewState: WooPosOrdersState.OrderDetailsViewState?,
+        loadedItems: WooPosOrdersState.Content.Items.Loaded
+    ) {
+        if (details.actionsState !is WooPosOrdersState.OrderActionsState.Loading) return
+
+        val order = getOrderForSideLoading(orderId, orderDetailsViewState, loadedItems) ?: return
+        sideLoadActions(orderId, order)
+    }
+
+    private suspend fun getOrderForSideLoading(
+        orderId: Long,
+        orderDetailsViewState: WooPosOrdersState.OrderDetailsViewState?,
+        loadedItems: WooPosOrdersState.Content.Items.Loaded
+    ): Order? {
+        return when (orderDetailsViewState) {
+            is WooPosOrdersState.OrderDetailsViewState.Lazy -> orderDetailsViewState.order
+            is WooPosOrdersState.OrderDetailsViewState.Computed -> {
+                loadedItems.items.keys.firstOrNull { it.id == orderId }?.let { item ->
+                    ordersDataSource.getOrderById(item.id).getOrNull()
+                }
+            }
+
+            else -> null
+        }
+    }
+
+    private fun sideLoadActions(orderId: Long, order: Order) {
+        sideLoadActionsJob?.cancel()
+        sideLoadActionsJob = viewModelScope.launch {
+            val refundsResult = retrieveOrderRefunds(order = order, forceRefresh = true).fold(
+                onSuccess = { refunds -> RefundsFetchResult.Success(refunds) },
+                onFailure = { RefundsFetchResult.Error }
+            )
+
+            val stateAfterRefundsFetch = _state.value as? WooPosOrdersState.Content
+            if (stateAfterRefundsFetch?.selectedDetails?.id != orderId) {
+                return@launch
+            }
+
+            val actions = orderActionsProvider.getAvailableActions(order, refundsResult)
+            val refundInfo = refundInfoBuilder.buildRefundInfo(order, refundsResult)
+            val updatedBreakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
+
+            val updatedState = _state.value as? WooPosOrdersState.Content ?: return@launch
+            val updatedSelectedDetails = updatedState.selectedDetails
+
+            if (updatedSelectedDetails?.id == orderId &&
+                updatedSelectedDetails.actionsState is WooPosOrdersState.OrderActionsState.Loading
+            ) {
+                val loadedItems = updatedState.items as? WooPosOrdersState.Content.Items.Loaded
+                val updatedItems = loadedItems?.items?.map { (item, details) ->
+                    val updatedDetails =
+                        if (item.id == orderId && details is WooPosOrdersState.OrderDetailsViewState.Computed) {
+                            WooPosOrdersState.OrderDetailsViewState.Computed(
+                                orderId = orderId,
+                                details = details.details.copy(
+                                    actionsState = WooPosOrdersState.OrderActionsState.Loaded(actions),
+                                    breakdown = updatedBreakdown
+                                )
+                            )
+                        } else {
+                            details
+                        }
+                    item to updatedDetails
+                }?.toMap()
+
+                _state.value = updatedState.copy(
+                    items = if (updatedItems != null) {
+                        WooPosOrdersState.Content.Items.Loaded(updatedItems)
+                    } else {
+                        updatedState.items
+                    },
+                    selectedDetails = updatedSelectedDetails.copy(
+                        actionsState = WooPosOrdersState.OrderActionsState.Loaded(actions),
+                        breakdown = updatedBreakdown
+                    )
+                )
+            }
+        }
+    }
 
     fun onRefresh() {
-        return Unit
+        viewModelScope.launch {
+            ordersAnalyticsTracker.trackOrdersListPullToRefreshTriggered()
+        }
+
+        val currentState = _state.value
+        _state.value = when (currentState) {
+            is WooPosOrdersState.Content -> currentState.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Refreshing
+            )
+
+            is WooPosOrdersState.Empty -> currentState.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Refreshing
+            )
+
+            is WooPosOrdersState.Error -> currentState
+            is WooPosOrdersState.Loading -> currentState
+        }
+
+        ordersDataSource.clearCache()
+
+        val query = currentSearchQuery
+        if (query.isNullOrEmpty()) {
+            loadOrders(isRefreshing = true)
+        } else {
+            performSearch(query, isRefreshing = true)
+        }
     }
 
-    @Suppress("UnusedParameter")
-    fun onBookingSelected(bookingId: Long) {
-        return Unit
-    }
+    fun onEndOfOrdersListReached() {
+        val currentState = _state.value
+        if (currentState !is WooPosOrdersState.Content ||
+            currentState.paginationState != WooPosPaginationState.None ||
+            currentState.pullToRefreshState == WooPosPullToRefreshState.Refreshing
+        ) {
+            return
+        }
 
-    fun onEndOfBookingsListReached() {
-        return Unit
+        loadMoreIfPossible()
     }
 
     fun onPaginationErrorTryAgain() {
-        return Unit
+        loadMoreIfPossible()
     }
 
-    fun onBookingsEmptyActionClicked() {
-        return Unit
+    fun onEmailReceiptButtonClicked(orderId: Long) {
+        viewModelScope.launch {
+            ordersAnalyticsTracker.trackOrderDetailsEmailReceiptTapped()
+            childrenToParentEventSender.sendToParent(
+                ToEmailReceipt(orderId)
+            )
+        }
     }
 
-    fun onBookingsLoadingErrorRetryButtonClicked() {
-        return Unit
-    }
-
-    @Suppress("UnusedParameter")
-    fun onUIEvent(event: WooPosBookingsUIEvent) {
-        return Unit
+    fun onIssueRefundButtonClicked(orderId: Long) {
+        val currentState = _state.value as? WooPosOrdersState.Content ?: return
+        _state.value = currentState.copy(
+            dialogState = WooPosOrdersState.Content.DialogState.IssueRefund(
+                orderId = orderId
+            )
+        )
     }
 
     fun onIssueRefundDialogDismissed() {
-        return Unit
+        val currentState = _state.value as? WooPosOrdersState.Content ?: return
+        _state.value = currentState.copy(
+            dialogState = WooPosOrdersState.Content.DialogState.Hidden
+        )
+        refreshSelectedOrder()
+    }
+
+    fun onOrdersEmptyActionClicked() {
+        viewModelScope.launch {
+            _openUrlEvent.emit(AppUrls.URL_LEARN_MORE_ORDERS)
+        }
+    }
+
+    fun onOrdersLoadingErrorRetryButtonClicked() {
+        _state.value = WooPosOrdersState.Loading(
+            searchInputState = WooPosSearchInputState.Closed
+        )
+        loadOrders()
+    }
+
+    fun onSearchErrorRetry() {
+        val query = currentSearchQuery
+        if (!query.isNullOrEmpty()) {
+            performSearch(query)
+        }
+    }
+
+    fun loadMoreIfPossible() {
+        if (loadingJob?.isActive == true || loadingMoreOrdersJob?.isActive == true) return
+        if (!ordersDataSource.hasMorePages) return
+
+        val currentState = _state.value
+        val newState = when (currentState) {
+            is WooPosOrdersState.Content -> currentState.copy(paginationState = WooPosPaginationState.Loading)
+            else -> return
+        }
+        _state.value = newState
+
+        loadingMoreOrdersJob?.cancel()
+        loadingMoreOrdersJob = viewModelScope.launch {
+            val normalizedQuery = currentSearchQuery.takeUnless { it.isNullOrEmpty() }
+            val result = ordersDataSource.loadMore(normalizedQuery)
+
+            if (result.isSuccess) {
+                ordersAnalyticsTracker.trackOrdersListNextPageLoaded()
+                appendOrders(result.getOrThrow())
+            } else {
+                _state.value = newState.copy(paginationState = WooPosPaginationState.Error)
+            }
+        }
+    }
+
+    fun onSearchEvent(event: WooPosSearchUIEvent) {
+        when (event) {
+            is WooPosSearchUIEvent.SearchIconClicked -> {
+                viewModelScope.launch {
+                    ordersAnalyticsTracker.trackOrdersListSearchButtonTapped()
+                }
+
+                updateSearchState(
+                    WooPosSearchInputState.Open(
+                        input = WooPosSearchInputState.Open.Input.Hint(
+                            resourceProvider.getString(R.string.woopos_search_orders)
+                        ),
+                        isLoading = false,
+                        requestFocus = true
+                    )
+                )
+            }
+
+            is WooPosSearchUIEvent.Search -> {
+                updateSearchState(
+                    WooPosSearchInputState.Open(
+                        input = WooPosSearchInputState.Open.Input.Query(
+                            event.query,
+                            event.cursorPosition
+                        ),
+                        isLoading = false,
+                    )
+                )
+
+                if (event.query.isEmpty()) {
+                    loadOrders()
+                } else {
+                    performSearch(event.query)
+                }
+            }
+
+            is WooPosSearchUIEvent.Clear -> {
+                updateSearchState(
+                    WooPosSearchInputState.Open(
+                        input = WooPosSearchInputState.Open.Input.Hint(
+                            resourceProvider.getString(R.string.woopos_search_orders)
+                        ),
+                        isLoading = false,
+                        requestFocus = true
+                    )
+                )
+                loadOrders()
+            }
+
+            is WooPosSearchUIEvent.Close -> {
+                updateSearchState(WooPosSearchInputState.Closed)
+                loadOrders()
+            }
+        }
+    }
+
+    fun onBackFromSuccessfullySendingEmailReceipt() {
+        refreshSelectedOrder()
+    }
+
+    private fun refreshSelectedOrder() {
+        val current = _state.value as? WooPosOrdersState.Content ?: return
+        val selectedOrderId = current.selectedDetails?.id ?: return
+
+        sideLoadActionsJob?.cancel()
+        viewModelScope.launch {
+            ordersDataSource.refreshOrderById(selectedOrderId)
+                .onSuccess { applyOrderUpdate(it) }
+        }
+    }
+
+    private suspend fun applyOrderUpdate(updated: Order) {
+        val current = _state.value as? WooPosOrdersState.Content ?: return
+        val loaded = current.items as? WooPosOrdersState.Content.Items.Loaded ?: return
+
+        val historicalRefundsResult = retrieveOrderRefunds(updated, forceRefresh = true).fold(
+            onSuccess = { refunds -> RefundsFetchResult.Success(refunds) },
+            onFailure = { RefundsFetchResult.Error }
+        )
+
+        val selectedId = loaded.items.keys.firstOrNull { it.isSelected }?.id
+        val newItem = orderItemMapper.mapOrderItem(updated, selectedId)
+        val newDetailsViewState = orderDetailsMapper.mapOrderDetails(updated, historicalRefundsResult)
+        val newDetails = WooPosOrdersState.OrderDetailsViewState.Computed(
+            orderId = updated.id,
+            details = newDetailsViewState
+        )
+
+        val newMap = loaded.items.entries.associate { (item, details) ->
+            if (item.id == updated.id) newItem to newDetails else item to details
+        }
+
+        _state.value = current.copy(
+            items = WooPosOrdersState.Content.Items.Loaded(newMap),
+            selectedDetails = if (selectedId == updated.id) newDetailsViewState else current.selectedDetails
+        )
+    }
+
+    private fun updateSearchState(searchState: WooPosSearchInputState) {
+        _state.value = when (val currentState = _state.value) {
+            is WooPosOrdersState.Content -> currentState.copy(searchInputState = searchState)
+            is WooPosOrdersState.Empty -> currentState.copy(searchInputState = searchState)
+            is WooPosOrdersState.Error -> currentState.copy(searchInputState = searchState)
+            is WooPosOrdersState.Loading -> currentState.copy(searchInputState = searchState)
+        }
+    }
+
+    private fun performSearch(query: String, isRefreshing: Boolean = false) {
+        cancelJobs()
+
+        val currentSelectedDetails = (_state.value as? WooPosOrdersState.Content)?.selectedDetails
+        searchJob = viewModelScope.launch {
+            delay(SEARCH_DEBOUNCE_DELAY_MS)
+            if (!isRefreshing) {
+                _state.value = WooPosOrdersState.Content(
+                    items = WooPosOrdersState.Content.Items.Searching,
+                    pullToRefreshState = WooPosPullToRefreshState.Disabled,
+                    searchInputState = _state.value.searchInputState,
+                    selectedDetails = currentSelectedDetails,
+                    paginationState = WooPosPaginationState.None,
+                    dialogState = WooPosOrdersState.Content.DialogState.Hidden
+                )
+            }
+
+            val mark = Monotonic.markNow()
+            val result = ordersDataSource.searchOrders(query, forceRefreshRefunds = isRefreshing)
+            val elapsedMs = mark.elapsedNow().inWholeMilliseconds
+            ordersAnalyticsTracker.trackOrdersListSearchResultsFetched(elapsedMs)
+            when (result) {
+                is SearchOrdersResult.Error -> {
+                    _state.value = WooPosOrdersState.Content(
+                        items = WooPosOrdersState.Content.Items.Error(
+                            title = resourceProvider.getString(R.string.woopos_search_orders_error_title),
+                            message = resourceProvider.getString(R.string.woopos_search_orders_error_description)
+                        ),
+                        pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                        searchInputState = _state.value.searchInputState,
+                        selectedDetails = null,
+                        paginationState = WooPosPaginationState.None,
+                        dialogState = WooPosOrdersState.Content.DialogState.Hidden
+                    )
+                }
+
+                is SearchOrdersResult.Success -> {
+                    if (result.ordersWithRefunds.isEmpty()) {
+                        _state.value = WooPosOrdersState.Content(
+                            items = WooPosOrdersState.Content.Items.NothingFound(
+                                title = resourceProvider.getString(R.string.woopos_search_orders_empty_title),
+                                message = resourceProvider.getString(R.string.woopos_search_orders_empty_description)
+                            ),
+                            pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                            searchInputState = _state.value.searchInputState,
+                            selectedDetails = null,
+                            paginationState = WooPosPaginationState.None,
+                            dialogState = WooPosOrdersState.Content.DialogState.Hidden
+                        )
+                    } else {
+                        replaceOrders(result.ordersWithRefunds)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun loadOrders(isRefreshing: Boolean = false) {
+        cancelJobs()
+        val mark = Monotonic.markNow()
+        loadingJob = viewModelScope.launch {
+            ordersDataSource.loadOrders(forceRefreshRefunds = isRefreshing).collect { result ->
+                when (result) {
+                    is LoadOrdersResult.Error -> {
+                        val elapsedMs = mark.elapsedNow().inWholeMilliseconds
+                        ordersAnalyticsTracker.trackOrdersListFetched(elapsedMs)
+
+                        _state.value = WooPosOrdersState.Error(
+                            message = result.message,
+                            searchInputState = WooPosSearchInputState.Closed
+                        )
+                    }
+
+                    is LoadOrdersResult.SuccessCache -> {
+                        if (result.ordersWithRefunds.isEmpty()) {
+                            _state.value = WooPosOrdersState.Loading(
+                                searchInputState = WooPosSearchInputState.Closed
+                            )
+                        } else {
+                            replaceOrders(result.ordersWithRefunds)
+                        }
+                    }
+
+                    is LoadOrdersResult.SuccessRemote -> {
+                        val elapsedMs = mark.elapsedNow().inWholeMilliseconds
+                        ordersAnalyticsTracker.trackOrdersListFetched(elapsedMs)
+
+                        if (result.ordersWithRefunds.isEmpty()) {
+                            _state.value = WooPosOrdersState.Empty(
+                                searchInputState = WooPosSearchInputState.Closed
+                            )
+                        } else {
+                            replaceOrders(result.ordersWithRefunds)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun cancelJobs() {
+        searchJob?.cancel()
+        loadingJob?.cancel()
+        loadingMoreOrdersJob?.cancel()
+        sideLoadActionsJob?.cancel()
+    }
+
+    private suspend fun getOrComputeDetails(orderId: Long): WooPosOrdersState.OrderDetailsViewState.Computed.Details {
+        val current = _state.value as? WooPosOrdersState.Content ?: error("State is not Content")
+        val loadedItems = current.items as? WooPosOrdersState.Content.Items.Loaded ?: error("Items not loaded")
+
+        val orderDetails = loadedItems.items.values.firstOrNull { it.orderId == orderId }
+            ?: error("Order $orderId not found in state")
+
+        return orderDetailsMapper.mapOrderDetails(
+            when (orderDetails) {
+                is WooPosOrdersState.OrderDetailsViewState.Lazy -> orderDetails.order
+                is WooPosOrdersState.OrderDetailsViewState.Computed -> {
+                    loadedItems.items.keys.firstOrNull { it.id == orderId }?.let {
+                        ordersDataSource.getOrderById(it.id).getOrNull()
+                    } ?: error("Order $orderId not found")
+                }
+            },
+            when (orderDetails) {
+                is WooPosOrdersState.OrderDetailsViewState.Lazy -> orderDetails.refundResult
+                is WooPosOrdersState.OrderDetailsViewState.Computed -> RefundsFetchResult.Error
+            }
+        )
+    }
+
+    private suspend fun getOrComputeDetailsWithoutActions(
+        orderId: Long
+    ): WooPosOrdersState.OrderDetailsViewState.Computed.Details {
+        val current = _state.value as? WooPosOrdersState.Content ?: error("State is not Content")
+        val loadedItems = current.items as? WooPosOrdersState.Content.Items.Loaded ?: error("Items not loaded")
+
+        val orderDetails = loadedItems.items.values.firstOrNull { it.orderId == orderId }
+            ?: error("Order $orderId not found in state")
+
+        return when (orderDetails) {
+            is WooPosOrdersState.OrderDetailsViewState.Lazy ->
+                orderDetailsMapper.mapOrderDetailsWithoutActions(orderDetails.order)
+
+            is WooPosOrdersState.OrderDetailsViewState.Computed -> {
+                orderDetails.details
+            }
+        }
+    }
+
+    private suspend fun replaceOrders(
+        ordersWithRefunds: Map<Order, RefundsFetchResult>,
+        paginationState: WooPosPaginationState = WooPosPaginationState.None
+    ) {
+        val currentState = _state.value
+        val currentFirstOrderId = (currentState as? WooPosOrdersState.Content)
+            ?.let { it.items as? WooPosOrdersState.Content.Items.Loaded }
+            ?.items?.keys?.firstOrNull()?.id
+
+        val orders = ordersWithRefunds.keys.toList()
+        val newFirstOrderId = orders.firstOrNull()?.id
+
+        val currentSelectedId = (currentState as? WooPosOrdersState.Content)?.selectedDetails?.id
+        val isSelectedOrderStillInList = currentSelectedId != null && orders.any { it.id == currentSelectedId }
+        val newSelectedId =
+            if (isSelectedOrderStillInList) {
+                currentSelectedId
+            } else {
+                requireNotNull(newFirstOrderId) { "Content requires at least one order" }
+            }
+        val items = buildItemsMap(ordersWithRefunds, newSelectedId)
+        val selectedEntry = items.entries.first { (item, _) -> item.isSelected }
+        val selectedDetails = when (val details = selectedEntry.value) {
+            is WooPosOrdersState.OrderDetailsViewState.Computed -> details.details
+            is WooPosOrdersState.OrderDetailsViewState.Lazy -> error("Selected order should have computed details")
+        }
+
+        _state.value = WooPosOrdersState.Content(
+            items = WooPosOrdersState.Content.Items.Loaded(
+                items = items
+            ),
+            pullToRefreshState = WooPosPullToRefreshState.Enabled,
+            selectedDetails = selectedDetails,
+            paginationState = paginationState,
+            searchInputState = _state.value.searchInputState,
+            dialogState = (currentState as? WooPosOrdersState.Content)?.dialogState
+                ?: WooPosOrdersState.Content.DialogState.Hidden
+        )
+
+        if (currentFirstOrderId != null && currentFirstOrderId != newFirstOrderId) {
+            _scrollToTopEvent.emit(Unit)
+        }
+    }
+
+    private suspend fun appendOrders(
+        ordersWithRefunds: Map<Order, RefundsFetchResult>,
+        paginationState: WooPosPaginationState = WooPosPaginationState.None
+    ) {
+        val current = _state.value as WooPosOrdersState.Content
+        val loadedItems = current.items as WooPosOrdersState.Content.Items.Loaded
+        val currentSelectedId = loadedItems.items.entries.firstOrNull { it.key.isSelected }?.key?.id
+        val newItems = buildItemsMap(ordersWithRefunds, currentSelectedId)
+        val items = loadedItems.items + newItems
+
+        _state.value = WooPosOrdersState.Content(
+            items = WooPosOrdersState.Content.Items.Loaded(
+                items = items
+            ),
+            pullToRefreshState = WooPosPullToRefreshState.Enabled,
+            selectedDetails = current.selectedDetails,
+            paginationState = paginationState,
+            searchInputState = _state.value.searchInputState,
+            dialogState = current.dialogState
+        )
+    }
+
+    private suspend fun buildItemsMap(
+        ordersWithRefunds: Map<Order, RefundsFetchResult>,
+        selectedId: Long?
+    ): Map<WooPosOrdersState.OrderItemViewState, WooPosOrdersState.OrderDetailsViewState> = coroutineScope {
+        ordersWithRefunds.map { (order, refundResult) ->
+            async {
+                val item = orderItemMapper.mapOrderItem(order, selectedId)
+                val details: WooPosOrdersState.OrderDetailsViewState = if (order.id == selectedId) {
+                    val fullDetails = orderDetailsMapper.mapOrderDetails(order, refundResult)
+                    WooPosOrdersState.OrderDetailsViewState.Computed(orderId = order.id, details = fullDetails)
+                } else {
+                    WooPosOrdersState.OrderDetailsViewState.Lazy(
+                        orderId = order.id,
+                        order = order,
+                        refundResult = refundResult
+                    )
+                }
+
+                item to details
+            }
+        }.awaitAll().toMap()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
 import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
-import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -36,7 +35,6 @@ import kotlin.time.TimeSource.Monotonic
 @HiltViewModel
 class WooPosBookingsViewModel @Inject constructor(
     private val ordersDataSource: WooPosOrdersDataSource,
-    private val resourceProvider: ResourceProvider,
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender,
     private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds,
     private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker,
@@ -198,9 +196,9 @@ class WooPosBookingsViewModel @Inject constructor(
             }
 
             val actions = orderActionsProvider.getAvailableActions(order, refundsResult)
-            val refundInfo = refundInfoBuilder.buildRefundInfo(order, refundsResult)
+//            val refundInfo = refundInfoBuilder.buildRefundInfo(order, refundsResult)
 //            val updatedBreakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
-            val updatedBreakdown =  WooPosBookingsState.BookingDetailsViewState.Computed.Details.TotalsBreakdown(
+            val updatedBreakdown = WooPosBookingsState.BookingDetailsViewState.Computed.Details.TotalsBreakdown(
                 products = "9999999",
                 shipping = "9999999",
                 discount = "9999999",
@@ -435,7 +433,9 @@ class WooPosBookingsViewModel @Inject constructor(
         sideLoadActionsJob?.cancel()
     }
 
-    private suspend fun getOrComputeDetails(orderId: Long): WooPosBookingsState.BookingDetailsViewState.Computed.Details {
+    private suspend fun getOrComputeDetails(
+        orderId: Long
+    ): WooPosBookingsState.BookingDetailsViewState.Computed.Details {
         val current = _state.value as? WooPosBookingsState.Content ?: error("State is not Content")
         val loadedItems = current.items as? WooPosBookingsState.Content.Items.Loaded ?: error("Items not loaded")
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.woopos.bookings.details.WooPosBookingDetailsMapper
 import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToEmailReceipt
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
@@ -11,11 +12,9 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.orders.LoadOrdersResult
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
-import com.woocommerce.android.ui.woopos.orders.WooPosBookingActionsProvider
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersUIEvent
-import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderDetailsMapper
 import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderItemMapper
 import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -43,7 +42,7 @@ class WooPosBookingsViewModel @Inject constructor(
     private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds,
     private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker,
     private val orderItemMapper: WooPosOrderItemMapper,
-    private val orderDetailsMapper: WooPosOrderDetailsMapper,
+    private val bookingDetailsMapper: WooPosBookingDetailsMapper,
     private val refundInfoBuilder: WooPosRefundInfoBuilder,
     private val orderActionsProvider: WooPosBookingActionsProvider,
 ) : ViewModel() {
@@ -368,7 +367,7 @@ class WooPosBookingsViewModel @Inject constructor(
 
         val selectedId = loaded.items.keys.firstOrNull { it.isSelected }?.id
         val newItem = orderItemMapper.mapOrderItem(updated, selectedId)
-        val newDetailsViewState = orderDetailsMapper.mapOrderDetails(updated, historicalRefundsResult)
+        val newDetailsViewState = bookingDetailsMapper.mapBookingDetails(updated, historicalRefundsResult)
         val newDetails = WooPosBookingsState.BookingDetailsViewState.Computed(
             orderId = updated.id,
             details = newDetailsViewState
@@ -435,7 +434,7 @@ class WooPosBookingsViewModel @Inject constructor(
         val orderDetails = loadedItems.items.values.firstOrNull { it.orderId == orderId }
             ?: error("Order $orderId not found in state")
 
-        return orderDetailsMapper.mapOrderDetails(
+        return bookingDetailsMapper.mapBookingDetails(
             when (orderDetails) {
                 is WooPosBookingsState.BookingDetailsViewState.Lazy -> orderDetails.order
                 is WooPosBookingsState.BookingDetailsViewState.Computed -> {
@@ -462,7 +461,7 @@ class WooPosBookingsViewModel @Inject constructor(
 
         return when (orderDetails) {
             is WooPosBookingsState.BookingDetailsViewState.Lazy ->
-                orderDetailsMapper.mapOrderDetailsWithoutActions(orderDetails.order)
+                bookingDetailsMapper.mapBookingDetailsWithoutActions(orderDetails.order)
 
             is WooPosBookingsState.BookingDetailsViewState.Computed -> {
                 orderDetails.details
@@ -542,7 +541,7 @@ class WooPosBookingsViewModel @Inject constructor(
             async {
                 val item = orderItemMapper.mapOrderItem(order, selectedId)
                 val details: WooPosBookingsState.BookingDetailsViewState = if (order.id == selectedId) {
-                    val fullDetails = orderDetailsMapper.mapOrderDetails(order, refundResult)
+                    val fullDetails = bookingDetailsMapper.mapBookingDetails(order, refundResult)
                     WooPosBookingsState.BookingDetailsViewState.Computed(orderId = order.id, details = fullDetails)
                 } else {
                     WooPosBookingsState.BookingDetailsViewState.Lazy(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -3,10 +3,7 @@ package com.woocommerce.android.ui.woopos.bookings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppUrls
-import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
 import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToEmailReceipt
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
@@ -14,7 +11,6 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.orders.LoadOrdersResult
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
-import com.woocommerce.android.ui.woopos.orders.SearchOrdersResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
@@ -28,7 +24,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -64,21 +59,9 @@ class WooPosBookingsViewModel @Inject constructor(
     private val _scrollToTopEvent = MutableSharedFlow<Unit>()
     val scrollToTopEvent: SharedFlow<Unit> = _scrollToTopEvent.asSharedFlow()
 
-    private var searchJob: Job? = null
     private var loadingJob: Job? = null
     private var loadingMoreOrdersJob: Job? = null
     private var sideLoadActionsJob: Job? = null
-
-    private val currentSearchQuery: String?
-        get() = (
-            (
-                _state.value.searchInputState as? WooPosSearchInputState.Open
-                )?.input as? WooPosSearchInputState.Open.Input.Query
-            )?.query
-
-    companion object {
-        private const val SEARCH_DEBOUNCE_DELAY_MS = 300L
-    }
 
     init {
         loadOrders()
@@ -279,12 +262,7 @@ class WooPosBookingsViewModel @Inject constructor(
 
         ordersDataSource.clearCache()
 
-        val query = currentSearchQuery
-        if (query.isNullOrEmpty()) {
-            loadOrders(isRefreshing = true)
-        } else {
-            performSearch(query, isRefreshing = true)
-        }
+        loadOrders(isRefreshing = true)
     }
 
     fun onEndOfOrdersListReached() {
@@ -336,17 +314,8 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     fun onOrdersLoadingErrorRetryButtonClicked() {
-        _state.value = WooPosBookingsState.Loading(
-            searchInputState = WooPosSearchInputState.Closed
-        )
+        _state.value = WooPosBookingsState.Loading
         loadOrders()
-    }
-
-    fun onSearchErrorRetry() {
-        val query = currentSearchQuery
-        if (!query.isNullOrEmpty()) {
-            performSearch(query)
-        }
     }
 
     fun loadMoreIfPossible() {
@@ -362,70 +331,13 @@ class WooPosBookingsViewModel @Inject constructor(
 
         loadingMoreOrdersJob?.cancel()
         loadingMoreOrdersJob = viewModelScope.launch {
-            val normalizedQuery = currentSearchQuery.takeUnless { it.isNullOrEmpty() }
-            val result = ordersDataSource.loadMore(normalizedQuery)
+            val result = ordersDataSource.loadMore()
 
             if (result.isSuccess) {
                 ordersAnalyticsTracker.trackOrdersListNextPageLoaded()
                 appendOrders(result.getOrThrow())
             } else {
                 _state.value = newState.copy(paginationState = WooPosPaginationState.Error)
-            }
-        }
-    }
-
-    fun onSearchEvent(event: WooPosSearchUIEvent) {
-        when (event) {
-            is WooPosSearchUIEvent.SearchIconClicked -> {
-                viewModelScope.launch {
-                    ordersAnalyticsTracker.trackOrdersListSearchButtonTapped()
-                }
-
-                updateSearchState(
-                    WooPosSearchInputState.Open(
-                        input = WooPosSearchInputState.Open.Input.Hint(
-                            resourceProvider.getString(R.string.woopos_search_orders)
-                        ),
-                        isLoading = false,
-                        requestFocus = true
-                    )
-                )
-            }
-
-            is WooPosSearchUIEvent.Search -> {
-                updateSearchState(
-                    WooPosSearchInputState.Open(
-                        input = WooPosSearchInputState.Open.Input.Query(
-                            event.query,
-                            event.cursorPosition
-                        ),
-                        isLoading = false,
-                    )
-                )
-
-                if (event.query.isEmpty()) {
-                    loadOrders()
-                } else {
-                    performSearch(event.query)
-                }
-            }
-
-            is WooPosSearchUIEvent.Clear -> {
-                updateSearchState(
-                    WooPosSearchInputState.Open(
-                        input = WooPosSearchInputState.Open.Input.Hint(
-                            resourceProvider.getString(R.string.woopos_search_orders)
-                        ),
-                        isLoading = false,
-                        requestFocus = true
-                    )
-                )
-                loadOrders()
-            }
-
-            is WooPosSearchUIEvent.Close -> {
-                updateSearchState(WooPosSearchInputState.Closed)
-                loadOrders()
             }
         }
     }
@@ -472,72 +384,6 @@ class WooPosBookingsViewModel @Inject constructor(
         )
     }
 
-    private fun updateSearchState(searchState: WooPosSearchInputState) {
-        _state.value = when (val currentState = _state.value) {
-            is WooPosBookingsState.Content -> currentState.copy(searchInputState = searchState)
-            is WooPosBookingsState.Empty -> currentState.copy(searchInputState = searchState)
-            is WooPosBookingsState.Error -> currentState.copy(searchInputState = searchState)
-            is WooPosBookingsState.Loading -> currentState.copy(searchInputState = searchState)
-        }
-    }
-
-    private fun performSearch(query: String, isRefreshing: Boolean = false) {
-        cancelJobs()
-
-        val currentSelectedDetails = (_state.value as? WooPosBookingsState.Content)?.selectedDetails
-        searchJob = viewModelScope.launch {
-            delay(SEARCH_DEBOUNCE_DELAY_MS)
-            if (!isRefreshing) {
-                _state.value = WooPosBookingsState.Content(
-                    items = WooPosBookingsState.Content.Items.Searching,
-                    pullToRefreshState = WooPosPullToRefreshState.Disabled,
-                    searchInputState = _state.value.searchInputState,
-                    selectedDetails = currentSelectedDetails,
-                    paginationState = WooPosPaginationState.None,
-                    dialogState = WooPosBookingsState.Content.DialogState.Hidden
-                )
-            }
-
-            val mark = Monotonic.markNow()
-            val result = ordersDataSource.searchOrders(query, forceRefreshRefunds = isRefreshing)
-            val elapsedMs = mark.elapsedNow().inWholeMilliseconds
-            ordersAnalyticsTracker.trackOrdersListSearchResultsFetched(elapsedMs)
-            when (result) {
-                is SearchOrdersResult.Error -> {
-                    _state.value = WooPosBookingsState.Content(
-                        items = WooPosBookingsState.Content.Items.Error(
-                            title = resourceProvider.getString(R.string.woopos_search_orders_error_title),
-                            message = resourceProvider.getString(R.string.woopos_search_orders_error_description)
-                        ),
-                        pullToRefreshState = WooPosPullToRefreshState.Enabled,
-                        searchInputState = _state.value.searchInputState,
-                        selectedDetails = null,
-                        paginationState = WooPosPaginationState.None,
-                        dialogState = WooPosBookingsState.Content.DialogState.Hidden
-                    )
-                }
-
-                is SearchOrdersResult.Success -> {
-                    if (result.ordersWithRefunds.isEmpty()) {
-                        _state.value = WooPosBookingsState.Content(
-                            items = WooPosBookingsState.Content.Items.NothingFound(
-                                title = resourceProvider.getString(R.string.woopos_search_orders_empty_title),
-                                message = resourceProvider.getString(R.string.woopos_search_orders_empty_description)
-                            ),
-                            pullToRefreshState = WooPosPullToRefreshState.Enabled,
-                            searchInputState = _state.value.searchInputState,
-                            selectedDetails = null,
-                            paginationState = WooPosPaginationState.None,
-                            dialogState = WooPosBookingsState.Content.DialogState.Hidden
-                        )
-                    } else {
-                        replaceOrders(result.ordersWithRefunds)
-                    }
-                }
-            }
-        }
-    }
-
     private fun loadOrders(isRefreshing: Boolean = false) {
         cancelJobs()
         val mark = Monotonic.markNow()
@@ -550,15 +396,12 @@ class WooPosBookingsViewModel @Inject constructor(
 
                         _state.value = WooPosBookingsState.Error(
                             message = result.message,
-                            searchInputState = WooPosSearchInputState.Closed
                         )
                     }
 
                     is LoadOrdersResult.SuccessCache -> {
                         if (result.ordersWithRefunds.isEmpty()) {
-                            _state.value = WooPosBookingsState.Loading(
-                                searchInputState = WooPosSearchInputState.Closed
-                            )
+                            _state.value = WooPosBookingsState.Loading
                         } else {
                             replaceOrders(result.ordersWithRefunds)
                         }
@@ -569,9 +412,7 @@ class WooPosBookingsViewModel @Inject constructor(
                         ordersAnalyticsTracker.trackOrdersListFetched(elapsedMs)
 
                         if (result.ordersWithRefunds.isEmpty()) {
-                            _state.value = WooPosBookingsState.Empty(
-                                searchInputState = WooPosSearchInputState.Closed
-                            )
+                            _state.value = WooPosBookingsState.Empty()
                         } else {
                             replaceOrders(result.ordersWithRefunds)
                         }
@@ -582,7 +423,6 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     private fun cancelJobs() {
-        searchJob?.cancel()
         loadingJob?.cancel()
         loadingMoreOrdersJob?.cancel()
         sideLoadActionsJob?.cancel()
@@ -664,7 +504,6 @@ class WooPosBookingsViewModel @Inject constructor(
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
             selectedDetails = selectedDetails,
             paginationState = paginationState,
-            searchInputState = _state.value.searchInputState,
             dialogState = (currentState as? WooPosBookingsState.Content)?.dialogState
                 ?: WooPosBookingsState.Content.DialogState.Hidden
         )
@@ -691,7 +530,6 @@ class WooPosBookingsViewModel @Inject constructor(
             pullToRefreshState = WooPosPullToRefreshState.Enabled,
             selectedDetails = current.selectedDetails,
             paginationState = paginationState,
-            searchInputState = _state.value.searchInputState,
             dialogState = current.dialogState
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.bookings.details.WooPosBookingDetailsMapper
+import com.woocommerce.android.ui.woopos.bookings.details.WooPosBookingItemMapper
 import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToEmailReceipt
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
@@ -14,8 +15,6 @@ import com.woocommerce.android.ui.woopos.orders.LoadOrdersResult
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
-import com.woocommerce.android.ui.woopos.orders.WooPosOrdersUIEvent
-import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderItemMapper
 import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -41,7 +40,7 @@ class WooPosBookingsViewModel @Inject constructor(
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender,
     private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds,
     private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker,
-    private val orderItemMapper: WooPosOrderItemMapper,
+    private val bookingItemMapper: WooPosBookingItemMapper,
     private val bookingDetailsMapper: WooPosBookingDetailsMapper,
     private val refundInfoBuilder: WooPosRefundInfoBuilder,
     private val orderActionsProvider: WooPosBookingActionsProvider,
@@ -66,9 +65,9 @@ class WooPosBookingsViewModel @Inject constructor(
         loadOrders()
     }
 
-    fun onUIEvent(event: WooPosOrdersUIEvent) {
+    fun onUIEvent(event: WooPosBookingsUIEvent) {
         when (event) {
-            is WooPosOrdersUIEvent.BookingActionClicked -> handleActionClicked(event.action)
+            is WooPosBookingsUIEvent.BookingActionClicked -> handleActionClicked(event.action)
         }
     }
 
@@ -200,7 +199,16 @@ class WooPosBookingsViewModel @Inject constructor(
 
             val actions = orderActionsProvider.getAvailableActions(order, refundsResult)
             val refundInfo = refundInfoBuilder.buildRefundInfo(order, refundsResult)
-            val updatedBreakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
+//            val updatedBreakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
+            val updatedBreakdown =  WooPosBookingsState.BookingDetailsViewState.Computed.Details.TotalsBreakdown(
+                products = "9999999",
+                shipping = "9999999",
+                discount = "9999999",
+                taxes = "9999999",
+                refunds = listOf("9999999"),
+                discountCode = "9999999",
+                netPayment = "9999999"
+            )
 
             val updatedState = _state.value as? WooPosBookingsState.Content ?: return@launch
             val updatedSelectedDetails = updatedState.selectedDetails
@@ -366,7 +374,7 @@ class WooPosBookingsViewModel @Inject constructor(
         )
 
         val selectedId = loaded.items.keys.firstOrNull { it.isSelected }?.id
-        val newItem = orderItemMapper.mapOrderItem(updated, selectedId)
+        val newItem = bookingItemMapper.mapOrderItem(updated, selectedId)
         val newDetailsViewState = bookingDetailsMapper.mapBookingDetails(updated, historicalRefundsResult)
         val newDetails = WooPosBookingsState.BookingDetailsViewState.Computed(
             orderId = updated.id,
@@ -539,7 +547,7 @@ class WooPosBookingsViewModel @Inject constructor(
     ): Map<WooPosBookingsState.BookingItemViewState, WooPosBookingsState.BookingDetailsViewState> = coroutineScope {
         ordersWithRefunds.map { (order, refundResult) ->
             async {
-                val item = orderItemMapper.mapOrderItem(order, selectedId)
+                val item = bookingItemMapper.mapOrderItem(order, selectedId)
                 val details: WooPosBookingsState.BookingDetailsViewState = if (order.id == selectedId) {
                     val fullDetails = bookingDetailsMapper.mapBookingDetails(order, refundResult)
                     WooPosBookingsState.BookingDetailsViewState.Computed(orderId = order.id, details = fullDetails)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -22,7 +22,7 @@ fun WooPosBookingDetails(
         contentAlignment = Alignment.Center
     ) {
         WooPosText(
-            text = "Booking Detail",
+            text = "Booking Detail ${details.id}",
             style = WooPosTypography.Heading
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetailsMapper.kt
@@ -6,14 +6,12 @@ import com.woocommerce.android.ui.woopos.bookings.WooPosBookingActionsProvider
 import com.woocommerce.android.ui.woopos.bookings.WooPosBookingsState
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
-import com.woocommerce.android.ui.woopos.orders.details.refund.RefundInfo
 import com.woocommerce.android.ui.woopos.util.ext.formatToMMMddYYYYAtHHmm
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import java.math.BigDecimal
 import javax.inject.Inject
 
 class WooPosBookingDetailsMapper @Inject constructor(
@@ -31,7 +29,6 @@ class WooPosBookingDetailsMapper @Inject constructor(
         val lineItems = buildLineItems(order)
 
         // val refundInfo = refundInfoBuilder.buildRefundInfo(order, historicalRefundsResult)
-        val refundInfo = RefundInfo(listOf("99999"), BigDecimal(999999))
         // val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
         val breakdown = WooPosBookingsState.BookingDetailsViewState.Computed.Details.TotalsBreakdown(
             products = "$999999",
@@ -67,7 +64,7 @@ class WooPosBookingDetailsMapper @Inject constructor(
     ): WooPosBookingsState.BookingDetailsViewState.Computed.Details = coroutineScope {
         val status = bookingStatusMapper.mapBookingStatus(order.status)
         val lineItems = buildLineItems(order)
-        val refundInfo = RefundInfo(emptyList(), BigDecimal.ZERO)
+//        val refundInfo = RefundInfo(emptyList(), BigDecimal.ZERO)
 //        val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
         val breakdown = WooPosBookingsState.BookingDetailsViewState.Computed.Details.TotalsBreakdown(
             products = "$999999",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetailsMapper.kt
@@ -2,12 +2,11 @@ package com.woocommerce.android.ui.woopos.bookings.details
 
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.woopos.bookings.WooPosBookingActionsProvider
 import com.woocommerce.android.ui.woopos.bookings.WooPosBookingsState
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
-import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
 import com.woocommerce.android.ui.woopos.orders.details.refund.RefundInfo
-import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
 import com.woocommerce.android.ui.woopos.util.ext.formatToMMMddYYYYAtHHmm
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -22,8 +21,7 @@ class WooPosBookingDetailsMapper @Inject constructor(
     private val getProductById: WooPosGetProductById,
     private val formatPrice: WooPosFormatPrice,
     private val bookingStatusMapper: WooPosBookingStatusMapper,
-    private val refundInfoBuilder: WooPosRefundInfoBuilder,
-    private val orderActionsProvider: WooPosOrderActionsProvider,
+    private val bookingActionsProvider: WooPosBookingActionsProvider,
 ) {
     suspend fun mapBookingDetails(
         order: Order,
@@ -31,9 +29,21 @@ class WooPosBookingDetailsMapper @Inject constructor(
     ): WooPosBookingsState.BookingDetailsViewState.Computed.Details = coroutineScope {
         val status = bookingStatusMapper.mapBookingStatus(order.status)
         val lineItems = buildLineItems(order)
-        val refundInfo = refundInfoBuilder.buildRefundInfo(order, historicalRefundsResult)
-        val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
-        val actions = orderActionsProvider.getAvailableActions(order, historicalRefundsResult)
+
+        // val refundInfo = refundInfoBuilder.buildRefundInfo(order, historicalRefundsResult)
+        val refundInfo = RefundInfo(listOf("99999"), BigDecimal(999999))
+        // val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
+        val breakdown = WooPosBookingsState.BookingDetailsViewState.Computed.Details.TotalsBreakdown(
+            products = "$999999",
+            discount = "-$999999",
+            taxes = "999999",
+            shipping = null,
+            refunds = listOf("-$999999"),
+            netPayment = "$999999",
+            discountCode = null
+        )
+
+        val actions = bookingActionsProvider.getAvailableActions(order, historicalRefundsResult)
 
         WooPosBookingsState.BookingDetailsViewState.Computed.Details(
             id = order.id,
@@ -58,7 +68,16 @@ class WooPosBookingDetailsMapper @Inject constructor(
         val status = bookingStatusMapper.mapBookingStatus(order.status)
         val lineItems = buildLineItems(order)
         val refundInfo = RefundInfo(emptyList(), BigDecimal.ZERO)
-        val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
+//        val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
+        val breakdown = WooPosBookingsState.BookingDetailsViewState.Computed.Details.TotalsBreakdown(
+            products = "$999999",
+            discount = "-$999999",
+            taxes = "999999",
+            shipping = null,
+            refunds = listOf("-$999999"),
+            netPayment = "$999999",
+            discountCode = null
+        )
 
         WooPosBookingsState.BookingDetailsViewState.Computed.Details(
             id = order.id,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetailsMapper.kt
@@ -1,0 +1,103 @@
+package com.woocommerce.android.ui.woopos.bookings.details
+
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.woopos.bookings.WooPosBookingsState
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
+import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
+import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
+import com.woocommerce.android.ui.woopos.orders.details.refund.RefundInfo
+import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
+import com.woocommerce.android.ui.woopos.util.ext.formatToMMMddYYYYAtHHmm
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import java.math.BigDecimal
+import javax.inject.Inject
+
+class WooPosBookingDetailsMapper @Inject constructor(
+    private val resourceProvider: ResourceProvider,
+    private val getProductById: WooPosGetProductById,
+    private val formatPrice: WooPosFormatPrice,
+    private val bookingStatusMapper: WooPosBookingStatusMapper,
+    private val refundInfoBuilder: WooPosRefundInfoBuilder,
+    private val orderActionsProvider: WooPosOrderActionsProvider,
+) {
+    suspend fun mapBookingDetails(
+        order: Order,
+        historicalRefundsResult: RefundsFetchResult
+    ): WooPosBookingsState.BookingDetailsViewState.Computed.Details = coroutineScope {
+        val status = bookingStatusMapper.mapBookingStatus(order.status)
+        val lineItems = buildLineItems(order)
+        val refundInfo = refundInfoBuilder.buildRefundInfo(order, historicalRefundsResult)
+        val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
+        val actions = orderActionsProvider.getAvailableActions(order, historicalRefundsResult)
+
+        WooPosBookingsState.BookingDetailsViewState.Computed.Details(
+            id = order.id,
+            number = "#${order.number}",
+            dateTime = order.dateCreated.formatToMMMddYYYYAtHHmm(
+                atWord = resourceProvider.getString(R.string.date_time_connector)
+            ),
+            customerEmail = order.customer?.email ?: order.billingAddress.email,
+            status = status,
+            lineItems = lineItems,
+            breakdown = breakdown,
+            total = formatPrice(order.total, order.currency),
+            totalPaid = formatPrice(order.total, order.currency),
+            paymentMethodTitle = order.paymentMethodTitle.takeIf { it.isNotBlank() },
+            actionsState = WooPosBookingsState.BookingActionsState.Loaded(actions)
+        )
+    }
+
+    suspend fun mapBookingDetailsWithoutActions(
+        order: Order
+    ): WooPosBookingsState.BookingDetailsViewState.Computed.Details = coroutineScope {
+        val status = bookingStatusMapper.mapBookingStatus(order.status)
+        val lineItems = buildLineItems(order)
+        val refundInfo = RefundInfo(emptyList(), BigDecimal.ZERO)
+        val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
+
+        WooPosBookingsState.BookingDetailsViewState.Computed.Details(
+            id = order.id,
+            number = "#${order.number}",
+            dateTime = order.dateCreated.formatToMMMddYYYYAtHHmm(
+                atWord = resourceProvider.getString(R.string.date_time_connector)
+            ),
+            customerEmail = order.customer?.email ?: order.billingAddress.email,
+            status = status,
+            lineItems = lineItems,
+            breakdown = breakdown,
+            total = formatPrice(order.total),
+            totalPaid = formatPrice(order.total),
+            paymentMethodTitle = order.paymentMethodTitle.takeIf { it.isNotBlank() },
+            actionsState = WooPosBookingsState.BookingActionsState.Loading
+        )
+    }
+
+    private suspend fun buildLineItems(
+        order: Order
+    ): List<WooPosBookingsState.BookingDetailsViewState.Computed.Details.LineItemRow> = coroutineScope {
+        order.items.map { item ->
+            async {
+                val unitPrice =
+                    if (item.quantity == 0f) {
+                        item.total
+                    } else {
+                        item.total / item.quantity.toBigDecimal()
+                    }
+                val product = getProductById(item.productId)
+                WooPosBookingsState.BookingDetailsViewState.Computed.Details.LineItemRow(
+                    id = item.itemId,
+                    name = item.name,
+                    attributesDescription = item.attributesDescription.takeIf { it.isNotEmpty() },
+                    qtyAndUnitPrice = "${item.quantity.toInt()} x ${formatPrice(unitPrice)}",
+                    lineTotal = formatPrice(item.total, order.currency),
+                    imageUrl = product?.firstImageUrl
+                )
+            }
+        }.awaitAll()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingItemMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingItemMapper.kt
@@ -13,7 +13,7 @@ class WooPosBookingItemMapper @Inject constructor(
     private val formatPrice: WooPosFormatPrice,
     private val bookingStatusMapper: WooPosBookingStatusMapper,
 ) {
-    fun mapOrderItem(order: Order, selectedId: Long?): WooPosBookingsState.BookingItemViewState {
+    fun mapBookingItem(order: Order, selectedId: Long?): WooPosBookingsState.BookingItemViewState {
         val status = bookingStatusMapper.mapBookingStatus(order.status)
 
         return WooPosBookingsState.BookingItemViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingItemMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingItemMapper.kt
@@ -1,15 +1,14 @@
-package com.woocommerce.android.ui.woopos.orders.details
+package com.woocommerce.android.ui.woopos.bookings.details
 
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.bookings.WooPosBookingsState
-import com.woocommerce.android.ui.woopos.bookings.details.WooPosBookingStatusMapper
 import com.woocommerce.android.ui.woopos.util.ext.formatToMMMddYYYYAtHHmm
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
-class WooPosOrderItemMapper @Inject constructor(
+class WooPosBookingItemMapper @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val formatPrice: WooPosFormatPrice,
     private val bookingStatusMapper: WooPosBookingStatusMapper,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingStatusMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingStatusMapper.kt
@@ -1,0 +1,36 @@
+package com.woocommerce.android.ui.woopos.bookings.details
+
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.woopos.bookings.BookingStatusColorKey
+import com.woocommerce.android.ui.woopos.bookings.PosBookingStatus
+import com.woocommerce.android.viewmodel.ResourceProvider
+import java.util.Locale
+import javax.inject.Inject
+
+class WooPosBookingStatusMapper @Inject constructor(
+    private val resourceProvider: ResourceProvider,
+    private val locale: Locale,
+) {
+    fun mapOrderStatus(status: Order.Status): PosBookingStatus {
+        val statusText = localizedLabel(status)
+        return PosBookingStatus(
+            text = statusText,
+            colorKey = BookingStatusColorKey.fromStatus(status)
+        )
+    }
+
+    private fun localizedLabel(status: Order.Status): String {
+        return when (status) {
+            Order.Status.Cancelled -> resourceProvider.getString(R.string.woopos_orders_status_cancelled)
+            Order.Status.Completed -> resourceProvider.getString(R.string.woopos_orders_status_completed)
+            is Order.Status.Custom ->
+                status.value.replaceFirstChar { it.titlecase(locale) }.replace("-", " ")
+            Order.Status.Failed -> resourceProvider.getString(R.string.woopos_orders_status_failed)
+            Order.Status.OnHold -> resourceProvider.getString(R.string.woopos_orders_status_on_hold)
+            Order.Status.Pending -> resourceProvider.getString(R.string.woopos_orders_status_pending)
+            Order.Status.Processing -> resourceProvider.getString(R.string.woopos_orders_status_processing)
+            Order.Status.Refunded -> resourceProvider.getString(R.string.woopos_orders_status_refunded)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingStatusMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingStatusMapper.kt
@@ -12,7 +12,7 @@ class WooPosBookingStatusMapper @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val locale: Locale,
 ) {
-    fun mapOrderStatus(status: Order.Status): PosBookingStatus {
+    fun mapBookingStatus(status: Order.Status): PosBookingStatus {
         val statusText = localizedLabel(status)
         return PosBookingStatus(
             text = statusText,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderItemMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderItemMapper.kt
@@ -2,8 +2,7 @@ package com.woocommerce.android.ui.woopos.orders.details
 
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.ui.woopos.bookings.WooPosBookingsState
-import com.woocommerce.android.ui.woopos.bookings.details.WooPosBookingStatusMapper
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState
 import com.woocommerce.android.ui.woopos.util.ext.formatToMMMddYYYYAtHHmm
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -12,12 +11,12 @@ import javax.inject.Inject
 class WooPosOrderItemMapper @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val formatPrice: WooPosFormatPrice,
-    private val bookingStatusMapper: WooPosBookingStatusMapper,
+    private val orderStatusMapper: WooPosOrderStatusMapper,
 ) {
-    fun mapOrderItem(order: Order, selectedId: Long?): WooPosBookingsState.BookingItemViewState {
-        val status = bookingStatusMapper.mapBookingStatus(order.status)
+    fun mapOrderItem(order: Order, selectedId: Long?): WooPosOrdersState.OrderItemViewState {
+        val status = orderStatusMapper.mapOrderStatus(order.status)
 
-        return WooPosBookingsState.BookingItemViewState(
+        return WooPosOrdersState.OrderItemViewState(
             id = order.id,
             title = "#${order.number}",
             date = order.dateCreated.formatToMMMddYYYYAtHHmm(


### PR DESCRIPTION
**_### NOTE - I'm thinking about throwing aways this PR and implement the VM based on Kiwi's booking feature._**

Fixes WOOMOB-2133

Do not merge label - https://github.com/woocommerce/woocommerce-android/pull/15297 needs to be merged first.

**Note - this PR exceeds the limit of 300 lines of code. However, since vast majority of the code is copy-pasted => I believe the only review necessary is whether it makes sense from a conceptual point of view.**

### Description
This step copies the Orders ViewModel and its supporting mappers/providers into the Bookings package, renaming all `Order` references to `Booking` equivalents. Specifically:

- Copies `WooPosOrdersViewModel` → `WooPosBookingsViewModel`, replacing order-related types and logic with booking equivalents and removing search functionality
- Copies `WooPosOrderDetailsMapper` → `WooPosBookingDetailsMapper`
- Copies `WooPosOrderItemMapper` → `WooPosBookingItemMapper`
- Copies `WooPosOrderStatusMapper` → `WooPosBookingStatusMapper`
- Copies `WooPosOrderActionsProvider` → `WooPosBookingActionsProvider`
- Replaces `WooPosOrdersState` usage with `WooPosBookingsState`

### Test Steps
1. Open POS
2. Tap on more menu
3. Tap on Bookings
4. Notice a list of orders is loaded and selecting an order works

Next step - replace order model with booking model + replace data source

### Images/gif

<img width="1310" height="822" alt="Screenshot 2026-02-06 at 8 31 41" src="https://github.com/user-attachments/assets/01d7b8cf-2efd-475b-8de6-841c018ad4e7" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.