### PR TITLE
[WOOMOB-2133] Add pay by card button to booking details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsUIEvent.kt
@@ -2,4 +2,5 @@ package com.woocommerce.android.ui.woopos.bookings
 
 sealed interface WooPosBookingsUIEvent {
     data class BookingActionClicked(val action: WooPosBookingsState.BookingAction) : WooPosBookingsUIEvent
+    data object PayByCardClicked : WooPosBookingsUIEvent
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.woopos.bookings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,7 +19,9 @@ import javax.inject.Inject
 
 @Suppress("LargeClass", "MagicNumber")
 @HiltViewModel
-class WooPosBookingsViewModel @Inject constructor() : ViewModel() {
+class WooPosBookingsViewModel @Inject constructor(
+    private val cardReaderFacade: WooPosCardReaderFacade
+) : ViewModel() {
 
     private val _state = MutableStateFlow<WooPosBookingsState>(WooPosBookingsState.Loading)
     val state: StateFlow<WooPosBookingsState> = _state.asStateFlow()
@@ -147,12 +151,20 @@ class WooPosBookingsViewModel @Inject constructor() : ViewModel() {
         return Unit
     }
 
-    @Suppress("UnusedParameter")
     fun onUIEvent(event: WooPosBookingsUIEvent) {
-        return Unit
+        when (event) {
+            is WooPosBookingsUIEvent.BookingActionClicked -> Unit
+            is WooPosBookingsUIEvent.PayByCardClicked -> onPayByCardClicked()
+        }
     }
 
-    fun onIssueRefundDialogDismissed() {
-        return Unit
+    private fun onPayByCardClicked() {
+        when (cardReaderFacade.readerStatus.value) {
+            is CardReaderStatus.Connected -> TODO()
+            is CardReaderStatus.Connecting -> {
+                // no-op
+            }
+            is CardReaderStatus.NotConnected -> cardReaderFacade.connectToReader()
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -1,13 +1,20 @@
 package com.woocommerce.android.ui.woopos.bookings.details
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.bookings.WooPosBookingsState
 import com.woocommerce.android.ui.woopos.bookings.WooPosBookingsUIEvent
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 
 @Composable
@@ -17,13 +24,19 @@ fun WooPosBookingDetails(
     details: WooPosBookingsState.BookingDetailsViewState.Computed.Details,
     onUIEvent: (WooPosBookingsUIEvent) -> Unit
 ) {
-    Box(
+    Column(
         modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
         WooPosText(
             text = "Booking Detail",
             style = WooPosTypography.Heading
+        )
+        Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
+        WooPosButton(
+            text = stringResource(R.string.woopos_bookings_pay_by_card),
+            onClick = { onUIEvent(WooPosBookingsUIEvent.PayByCardClicked) }
         )
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3864,6 +3864,7 @@
     <string name="woopos_orders_status_refunded">Refunded</string>
 
     <string name="woopos_bookings_title">Bookings</string>
+    <string name="woopos_bookings_pay_by_card">Pay by card</string>
 
     <string name="woopos_cash_payment_title">Cash payment</string>
     <string name="woopos_complete_cash_order_button">Mark payment as complete</string>


### PR DESCRIPTION
### Description

Adds a "Pay by card" button to the POS booking details screen. When tapped, it checks the card reader connection status and starts the connection flow if the reader is not connected. The payment flow is not part of this PR

### Test Steps

1. Open POS, go to Bookings, select a booking
2. Tap "Pay by card" button
3. Verify the card reader connection flow starts if no reader is connected


https://github.com/user-attachments/assets/50dbe85b-6a99-46e8-9faa-bfda6a14b265



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.