### PR TITLE
Fix the broken Most Recent Orders card in the dashboard

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -191,7 +191,7 @@ class OrderRestClient @Inject constructor(
             "status" to statusFilter,
             "created_via" to createdVia,
             "search" to searchQuery,
-            "dp" to decimalPoints.toString(),
+            "dp" to decimalPoints?.toString(),
         )
 
         val response = wooNetwork.executeGetGsonRequest(
@@ -491,7 +491,7 @@ class OrderRestClient @Inject constructor(
     ): RemoteOrderPayload.Fetching {
         val url = WOOCOMMERCE.orders.id(orderId).pathV3
         val params = mutableMapOf("_fields" to ORDER_FIELDS)
-            .putIfNotEmpty("dp" to decimalPoints.toString())
+            .putIfNotEmpty("dp" to decimalPoints?.toString())
 
         val response = wooNetwork.executeGetGsonRequest(
             site = site,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
This PR fixes the issue identified in the last release 24.0: the Most Recent Orders card is broken because of a change to the API call after adding the `dp` argument.
This PR fixes the logic to ensure the argument is not added to the API request when it's `null`.

### Test Steps
1. Sign in.
2. Open the dashboard.
3. Enabled the `Most Recent Orders` card in the dashboard.
4. Confirm it works as expected.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
