### PR TITLE
[WOOMOB-2181] Introduce booking-specific state model and event types (step 5)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -417,8 +417,7 @@ private fun WooPosLoadedBookingsList(
 
                         Spacer(Modifier.height(WooPosSpacing.XSmall.value))
 
-                        val email = item.customerEmail.orEmpty()
-                        if (email.isNotBlank()) {
+                        item.customerEmail?.let { email ->
                             WooPosText(
                                 email,
                                 style = WooPosTypography.BodySmall,
@@ -542,8 +541,8 @@ fun WooPosBookingsScreenPreview() {
             state = WooPosBookingsState.Content(
                 items = WooPosBookingsState.Content.Items.Loaded(
                     items = mapOf(
-                        item1 to WooPosBookingsState.BookingDetailsViewState.Computed(orderId = 1L, details = details1),
-                        item2 to WooPosBookingsState.BookingDetailsViewState.Computed(orderId = 2L, details = details2)
+                        item1 to details1,
+                        item2 to details2
                     )
                 ),
                 pullToRefreshState = WooPosPullToRefreshState.Enabled,
@@ -621,53 +620,40 @@ fun WooPosBookingsEmptyStatePreview() {
 private fun sampleBookingDetails(
     id: Long = 1L,
     number: String = "#014"
-) = WooPosBookingsState.BookingDetailsViewState.Computed.Details(
+) = WooPosBookingsState.BookingDetailsViewState(
     id = id,
     number = number,
-    dateTime = "Aug 28, 2025 at 10:31 AM",
-    customerEmail = "johndoe@mail.com",
-    status = WooPosBookingStatus(text = "Completed", colorKey = WooPosBookingStatusColorKey.COMPLETED),
-    lineItems = listOf(
-        WooPosBookingsState.BookingDetailsViewState.Computed.Details.LineItemRow(
-            id = 101,
-            name = "Cup",
-            attributesDescription = null,
-            qtyAndUnitPrice = "1 x $8.50",
-            lineTotal = "$15.00",
-            imageUrl = null
-        ),
-        WooPosBookingsState.BookingDetailsViewState.Computed.Details.LineItemRow(
-            id = 102,
-            name = "Coffee Container",
-            attributesDescription = "Blue, Large",
-            qtyAndUnitPrice = "1 x $10.00",
-            lineTotal = "$8.00",
-            imageUrl = null
-        ),
-        WooPosBookingsState.BookingDetailsViewState.Computed.Details.LineItemRow(
-            id = 103,
-            name = "Paper Filter",
-            attributesDescription = null,
-            qtyAndUnitPrice = "1 x $4.50",
-            lineTotal = "$8.00",
-            imageUrl = null
-        )
-    ),
-    breakdown = WooPosBookingsState.BookingDetailsViewState.Computed.Details.TotalsBreakdown(
-        products = "$23.00",
-        discount = "-$5.00",
-        discountCode = "8qew4mnq",
-        taxes = "$0.00",
-        shipping = null,
-        refunds = listOf("-$3.00", "-$2.00"),
-        netPayment = "$12.00"
-    ),
-    total = "$17.00",
-    totalPaid = "$17.00",
-    paymentMethodTitle = "WooCommerce In-Person Payments",
+    status = WooPosBookingStatus(text = "Paid", colorKey = WooPosBookingStatusColorKey.COMPLETED),
     actionsState = WooPosBookingsState.BookingActionsState.Loaded(
-        listOf(
-            WooPosBookingsState.BookingAction.EmailReceipt(id)
-        )
-    )
+        listOf(WooPosBookingsState.BookingAction.EmailReceipt(id))
+    ),
+    headerTitle = "10:30 AM - 11:30 AM",
+    headerSubtitle = "Women's Haircut \u00B7 John Doe",
+    attendanceBadge = WooPosBookingsState.AttendanceState.ATTENDED,
+    bookingName = "Women's Haircut",
+    appointmentDate = "Thursday, August 28, 2025",
+    appointmentTime = "10:30 AM - 11:30 AM",
+    duration = "1 hr",
+    teamMember = null,
+    location = null,
+    customerSection = WooPosBookingsState.CustomerSection(
+        name = "John Doe",
+        email = "johndoe@mail.com",
+        phone = "+1 555-123-4567",
+        billingAddress = null,
+        note = null,
+    ),
+    attendanceSection = WooPosBookingsState.AttendanceSection(
+        isAttendedSelected = true,
+        isUnattendedSelected = false,
+    ),
+    paymentSection = WooPosBookingsState.PaymentSection(
+        serviceAmount = "$55.00",
+        taxAmount = "$4.50",
+        discountAmount = "-",
+        totalAmount = "$59.50",
+        paidWithLabel = "WooCommerce In-Person Payments",
+        showPayButtons = false,
+    ),
+    bookingNote = null,
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -644,8 +644,7 @@ private fun sampleBookingDetails(
         note = null,
     ),
     attendanceSection = WooPosBookingsState.AttendanceSection(
-        isAttendedSelected = true,
-        isUnattendedSelected = false,
+        selection = WooPosBookingsState.AttendanceState.ATTENDED,
     ),
     paymentSection = WooPosBookingsState.PaymentSection(
         serviceAmount = "$55.00",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
@@ -1,11 +1,9 @@
 package com.woocommerce.android.ui.woopos.bookings
 
 import androidx.compose.runtime.Immutable
-import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.Status
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
-import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
 
 @Immutable
 sealed class WooPosBookingsState {
@@ -29,59 +27,56 @@ sealed class WooPosBookingsState {
     }
 
     @Immutable
-    sealed class BookingDetailsViewState {
-        abstract val orderId: Long
-
-        @Immutable
-        data class Lazy(
-            override val orderId: Long,
-            val order: Order,
-            val refundResult: RefundsFetchResult
-        ) : BookingDetailsViewState()
-
-        @Immutable
-        data class Computed(
-            override val orderId: Long,
-            val details: Details
-        ) : BookingDetailsViewState() {
-            @Immutable
-            data class Details(
-                val id: Long,
-                val number: String,
-                val dateTime: String,
-                val customerEmail: String?,
-                val status: WooPosBookingStatus,
-
-                val lineItems: List<LineItemRow>,
-                val breakdown: TotalsBreakdown,
-                val total: String,
-                val totalPaid: String,
-                val paymentMethodTitle: String?,
-                val actionsState: BookingActionsState
-            ) {
-                @Immutable
-                data class LineItemRow(
-                    val id: Long,
-                    val name: String,
-                    val attributesDescription: String?,
-                    val qtyAndUnitPrice: String,
-                    val lineTotal: String,
-                    val imageUrl: String?,
-                )
-
-                @Immutable
-                data class TotalsBreakdown(
-                    val products: String,
-                    val discount: String?,
-                    val discountCode: String?,
-                    val taxes: String,
-                    val shipping: String?,
-                    val refunds: List<String>,
-                    val netPayment: String?
-                )
-            }
-        }
+    enum class AttendanceState {
+        ATTENDED,
+        UNATTENDED,
     }
+
+    @Immutable
+    data class CustomerSection(
+        val name: String?,
+        val email: String?,
+        val phone: String?,
+        val billingAddress: String?,
+        val note: String?,
+    )
+
+    @Immutable
+    data class AttendanceSection(
+        val isAttendedSelected: Boolean,
+        val isUnattendedSelected: Boolean,
+    )
+
+    @Immutable
+    data class PaymentSection(
+        val serviceAmount: String,
+        val taxAmount: String,
+        val discountAmount: String,
+        val totalAmount: String,
+        val paidWithLabel: String?,
+        val showPayButtons: Boolean,
+    )
+
+    @Immutable
+    data class BookingDetailsViewState(
+        val id: Long,
+        val number: String,
+        val status: WooPosBookingStatus,
+        val actionsState: BookingActionsState,
+        val headerTitle: String,
+        val headerSubtitle: String,
+        val attendanceBadge: AttendanceState?,
+        val bookingName: String,
+        val appointmentDate: String,
+        val appointmentTime: String,
+        val duration: String,
+        val teamMember: String?,
+        val location: String?,
+        val customerSection: CustomerSection?,
+        val attendanceSection: AttendanceSection?,
+        val paymentSection: PaymentSection,
+        val bookingNote: String?,
+    )
 
     @Immutable
     data class BookingItemViewState(
@@ -100,7 +95,7 @@ sealed class WooPosBookingsState {
     data class Content(
         val items: Items,
         override val pullToRefreshState: WooPosPullToRefreshState,
-        val selectedDetails: BookingDetailsViewState.Computed.Details?,
+        val selectedDetails: BookingDetailsViewState?,
         val paginationState: WooPosPaginationState,
         val dialogState: DialogState
     ) : WooPosBookingsState() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
@@ -43,8 +43,7 @@ sealed class WooPosBookingsState {
 
     @Immutable
     data class AttendanceSection(
-        val isAttendedSelected: Boolean,
-        val isUnattendedSelected: Boolean,
+        val selection: AttendanceState?,
     )
 
     @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsUIEvent.kt
@@ -2,4 +2,9 @@ package com.woocommerce.android.ui.woopos.bookings
 
 sealed interface WooPosBookingsUIEvent {
     data class BookingActionClicked(val action: WooPosBookingsState.BookingAction) : WooPosBookingsUIEvent
+    data class AttendanceToggled(val attended: Boolean) : WooPosBookingsUIEvent
+    data object PayByCardClicked : WooPosBookingsUIEvent
+    data object PayByCashClicked : WooPosBookingsUIEvent
+    data object AddBookingNoteClicked : WooPosBookingsUIEvent
+    data class CopyEmailClicked(val email: String) : WooPosBookingsUIEvent
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -88,8 +88,7 @@ class WooPosBookingsViewModel @Inject constructor(
                 }
 
                 val selectedDetails = selectedBookingId?.let { id ->
-                    val details = items.entries.find { it.key.id == id }?.value
-                    (details as? WooPosBookingsState.BookingDetailsViewState.Computed)?.details
+                    items.entries.find { it.key.id == id }?.value
                 }
 
                 _state.value = WooPosBookingsState.Content(
@@ -114,7 +113,6 @@ class WooPosBookingsViewModel @Inject constructor(
         val selectedDetails = updatedItems.entries
             .find { it.key.id == bookingId }
             ?.value
-            ?.let { (it as? WooPosBookingsState.BookingDetailsViewState.Computed)?.details }
 
         _state.value = currentState.copy(
             items = WooPosBookingsState.Content.Items.Loaded(updatedItems),
@@ -229,13 +227,12 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     private fun mapToItemViewState(booking: BookingEntity): WooPosBookingsState.BookingItemViewState {
-        // TBD: create a POS-specific mapper for BookingEntity -> BookingItemViewState
         return WooPosBookingsState.BookingItemViewState(
             id = booking.id.value,
             title = booking.order.productInfo?.name ?: "#${booking.id.value}",
             date = booking.start.toString(),
             total = booking.order.paymentInfo?.total?.toPlainString() ?: "",
-            customerEmail = booking.order.customerInfo?.billingEmail,
+            customerEmail = booking.order.customerInfo?.billingEmail?.ifBlank { null },
             isSelected = booking.id.value == selectedBookingId,
             status = mapBookingStatus(booking.status),
             statusSlug = booking.status.key,
@@ -246,32 +243,33 @@ class WooPosBookingsViewModel @Inject constructor(
     private fun mapToDetailsViewState(
         booking: BookingEntity
     ): WooPosBookingsState.BookingDetailsViewState {
-        // TBD: create a POS-specific mapper for BookingEntity -> BookingDetailsViewState
-        return WooPosBookingsState.BookingDetailsViewState.Computed(
-            orderId = booking.orderId,
-            details = WooPosBookingsState.BookingDetailsViewState.Computed.Details(
-                id = booking.id.value,
-                number = "#${booking.id.value}",
-                dateTime = booking.start.toString(),
-                customerEmail = booking.order.customerInfo?.billingEmail,
-                status = mapBookingStatus(booking.status),
-                lineItems = emptyList(),
-                breakdown = WooPosBookingsState.BookingDetailsViewState.Computed.Details.TotalsBreakdown(
-                    products = booking.order.paymentInfo?.subtotal?.toPlainString() ?: "",
-                    discount = null,
-                    discountCode = null,
-                    taxes = booking.order.paymentInfo?.totalTax?.toPlainString() ?: "",
-                    shipping = null,
-                    refunds = emptyList(),
-                    netPayment = null
-                ),
-                total = booking.order.paymentInfo?.total?.toPlainString() ?: "",
-                totalPaid = booking.order.paymentInfo?.total?.toPlainString() ?: "",
-                paymentMethodTitle = booking.order.paymentInfo?.paymentMethodTitle,
-                actionsState = WooPosBookingsState.BookingActionsState.Loaded(
-                    listOf(WooPosBookingsState.BookingAction.EmailReceipt(booking.orderId))
-                )
-            )
+        return WooPosBookingsState.BookingDetailsViewState(
+            id = booking.id.value,
+            number = "#${booking.id.value}",
+            status = mapBookingStatus(booking.status),
+            actionsState = WooPosBookingsState.BookingActionsState.Loaded(
+                listOf(WooPosBookingsState.BookingAction.EmailReceipt(booking.orderId))
+            ),
+            headerTitle = "",
+            headerSubtitle = "",
+            attendanceBadge = null,
+            bookingName = booking.order.productInfo?.name ?: "#${booking.id.value}",
+            appointmentDate = "",
+            appointmentTime = "",
+            duration = "",
+            teamMember = null,
+            location = null,
+            customerSection = null,
+            attendanceSection = null,
+            paymentSection = WooPosBookingsState.PaymentSection(
+                serviceAmount = booking.order.paymentInfo?.subtotal?.toPlainString() ?: "-",
+                taxAmount = booking.order.paymentInfo?.totalTax?.toPlainString() ?: "-",
+                discountAmount = "-",
+                totalAmount = booking.order.paymentInfo?.total?.toPlainString() ?: "-",
+                paidWithLabel = booking.order.paymentInfo?.paymentMethodTitle,
+                showPayButtons = false,
+            ),
+            bookingNote = null,
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -208,6 +208,11 @@ class WooPosBookingsViewModel @Inject constructor(
     fun onUIEvent(event: WooPosBookingsUIEvent) {
         when (event) {
             is WooPosBookingsUIEvent.BookingActionClicked -> handleBookingAction(event.action)
+            is WooPosBookingsUIEvent.AttendanceToggled -> { }
+            is WooPosBookingsUIEvent.PayByCardClicked -> { }
+            is WooPosBookingsUIEvent.PayByCashClicked -> { }
+            is WooPosBookingsUIEvent.AddBookingNoteClicked -> { }
+            is WooPosBookingsUIEvent.CopyEmailClicked -> { }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -14,7 +14,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTyp
 @Suppress("UnusedParameter")
 fun WooPosBookingDetails(
     modifier: Modifier = Modifier,
-    details: WooPosBookingsState.BookingDetailsViewState.Computed.Details,
+    details: WooPosBookingsState.BookingDetailsViewState,
     onUIEvent: (WooPosBookingsUIEvent) -> Unit
 ) {
     Box(


### PR DESCRIPTION
Fixes WOOMOB-2181

### Description
Replace the order-centric `Computed`/`Lazy` state hierarchy with a flat, booking-specific state model for the POS booking details screen. This is a pure scaffolding change — the ViewModel produces dummy/minimal values and the details pane still shows the placeholder "Booking Detail #xxx" text.

This is not meant to be the final structure - but something we can iterate on.

Key changes:
- Flat `BookingDetailsViewState` data class with `CustomerSection`, `AttendanceSection` (type-safe `AttendanceState?` selection), and `PaymentSection`
- New UI event types: `AttendanceToggled`, `PayByCardClicked`, `PayByCashClicked`, `AddBookingNoteClicked`, `CopyEmailClicked`
- ViewModel wired with empty event handlers and dummy mapping

### Test Steps
1Green CI

### Images/gif
No visual changes — this is a state model refactor only.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.