### PR TITLE
Post both Prototype Build comments expanded

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1391,8 +1391,7 @@ platform :android do
         Flavor: prototype_flavor,
         'Build Type': prototype_build_type
       },
-      # Fold for Wear app, as it's modified less often
-      fold: app == WEAR_APP,
+      fold: false,
       reuse_identifier: "#{app.downcase}-prototype-build-link"
     )
 


### PR DESCRIPTION
Follow up to
https://github.com/woocommerce/woocommerce-android/pull/15197#discussion_r2775383155

I suppose folding the Wear info made sense when Prototype Builds were generated on every build and for both platforms. The Wear app was less likely to be the one people were interested in, so we were better off saving screen real estate and folding the QR code and other info.

In the new setup with optional builds, it's almost guaranteed that if a link is posted, someone needs that information. Therefore, I think it makes more sense to expand the info and make it immediately visible.

