### PR TITLE
Add card payment ViewModel and navigation for bookings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
@@ -9,9 +9,10 @@ class CIABSiteGateKeeper @Inject constructor(private val selectedSite: SelectedS
         @Suppress("unused")
         feature: CIABAffectedFeature
     ): Boolean {
-        // For now, all affected features are unsupported in CIAB.
-        // If there are exceptions in the future, we can handle them here.
-        return !isCurrentSiteCIAB()
+        return when (feature) {
+            CIABAffectedFeature.WooPayments -> true
+            else -> !isCurrentSiteCIAB()
+        }
     }
 
     fun isFeatureUnsupported(feature: CIABAffectedFeature): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentNavigation.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.ui.woopos.cardpayment
+
+import androidx.navigation.NavController
+import com.woocommerce.android.ui.woopos.home.HOME_ROUTE
+import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
+
+const val CARD_PAYMENT_ROUTE_ORDER_ID_KEY = "orderId"
+const val CARD_PAYMENT_ROUTE_SOURCE_KEY = "source"
+const val CARD_PAYMENT_ROUTE =
+    "$HOME_ROUTE/card_payment/{$CARD_PAYMENT_ROUTE_ORDER_ID_KEY}" +
+        "?$CARD_PAYMENT_ROUTE_SOURCE_KEY={$CARD_PAYMENT_ROUTE_SOURCE_KEY}"
+
+const val BOOKING_CARD_PAYMENT_SUCCESS_KEY = "booking_card_payment_success"
+
+enum class CardPaymentSource {
+    CHECKOUT,
+    BOOKINGS,
+}
+
+fun NavController.navigateToCardPaymentScreen(
+    orderId: Long,
+    source: CardPaymentSource = CardPaymentSource.CHECKOUT,
+) {
+    navigateOnce(
+        CARD_PAYMENT_ROUTE
+            .replace("{$CARD_PAYMENT_ROUTE_ORDER_ID_KEY}", orderId.toString())
+            .replace("{$CARD_PAYMENT_ROUTE_SOURCE_KEY}", source.name)
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentState.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.ui.woopos.cardpayment
+
+sealed class WooPosCardPaymentState {
+    data object Initiating : WooPosCardPaymentState()
+
+    sealed class Collecting : WooPosCardPaymentState() {
+        data class Preparing(
+            val title: String,
+            val subtitle: String,
+        ) : Collecting()
+
+        data class ReadyForPayment(
+            val title: String,
+            val subtitle: String,
+        ) : Collecting()
+
+        data class ReaderDisconnected(
+            val title: String,
+            val subtitle: String,
+            val actionButtonLabel: String,
+        ) : Collecting()
+    }
+
+    data class PaymentInProgress(
+        val title: String,
+        val subtitle: String,
+    ) : WooPosCardPaymentState()
+
+    data class PaymentFailed(
+        val title: String,
+        val subtitle: String,
+        val retryButtonLabel: String,
+        val isDismissButtonVisible: Boolean,
+    ) : WooPosCardPaymentState()
+
+    data class PaymentSuccess(
+        val orderTotalText: String,
+    ) : WooPosCardPaymentState()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -1,0 +1,302 @@
+package com.woocommerce.android.ui.woopos.cardpayment
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.home.totals.WooPosCardReaderPaymentControllerFactory
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsRepository
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.util.UiStringParser
+import com.woocommerce.android.viewmodel.ResourceProvider
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WooPosCardPaymentViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    private val cardReaderPaymentControllerFactory: WooPosCardReaderPaymentControllerFactory,
+    private val cardReaderFacade: WooPosCardReaderFacade,
+    private val networkStatus: WooPosNetworkStatus,
+    private val resourceProvider: ResourceProvider,
+    private val uiStringParser: UiStringParser,
+    private val priceFormat: WooPosFormatPrice,
+    private val totalsRepository: WooPosTotalsRepository,
+) : ViewModel() {
+
+    private val orderId: Long = requireNotNull(savedState[CARD_PAYMENT_ROUTE_ORDER_ID_KEY])
+    val source: CardPaymentSource = CardPaymentSource.valueOf(
+        savedState[CARD_PAYMENT_ROUTE_SOURCE_KEY] ?: CardPaymentSource.CHECKOUT.name
+    )
+
+    private val _state = MutableStateFlow<WooPosCardPaymentState>(WooPosCardPaymentState.Initiating)
+    val state: StateFlow<WooPosCardPaymentState> = _state.asStateFlow()
+
+    private val _navigationEvent = MutableSharedFlow<WooPosNavigationEvent>()
+    val navigationEvent: SharedFlow<WooPosNavigationEvent> = _navigationEvent.asSharedFlow()
+
+    private var cardReaderPaymentController: CardReaderPaymentController? = null
+    private var paymentListenerJob: Job? = null
+    private var controllerEventJob: Job? = null
+    private var isTTPPaymentInProgress: Boolean = false
+
+    init {
+        observeCardReaderStatus()
+    }
+
+    private fun observeCardReaderStatus() {
+        viewModelScope.launch {
+            cardReaderFacade.readerStatus.collect { status ->
+                when (status) {
+                    is NotConnected, is Connecting -> {
+                        val currentState = _state.value
+                        if (currentState is WooPosCardPaymentState.PaymentSuccess ||
+                            currentState is WooPosCardPaymentState.PaymentInProgress
+                        ) {
+                            return@collect
+                        }
+                        _state.value = buildReaderDisconnectedState()
+                        cancelPayment()
+                    }
+
+                    is Connected -> {
+                        val currentState = _state.value
+                        if (currentState is WooPosCardPaymentState.PaymentSuccess ||
+                            currentState is WooPosCardPaymentState.PaymentInProgress
+                        ) {
+                            return@collect
+                        }
+                        _state.value = buildPreparingState()
+                        collectPayment()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun collectPayment() {
+        if (!networkStatus.isConnected()) {
+            _state.value = WooPosCardPaymentState.PaymentFailed(
+                title = resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title),
+                subtitle = resourceProvider.getString(R.string.woopos_no_internet_message),
+                retryButtonLabel = resourceProvider.getString(R.string.woo_pos_payment_failed_try_again),
+                isDismissButtonVisible = true
+            )
+            return
+        }
+        if (cardReaderFacade.readerStatus.value !is Connected) return
+
+        cardReaderPaymentController?.stop()
+        cardReaderPaymentController = cardReaderPaymentControllerFactory.create(
+            orderId = orderId,
+            paymentType = PaymentOrRefund.Payment.PaymentType.WOO_POS,
+            isTTPPaymentInProgress = ::isTTPPaymentInProgress,
+        )
+        cardReaderPaymentController?.start()
+        listenToPaymentState()
+        listenToControllerEvents()
+    }
+
+    private fun listenToPaymentState() {
+        paymentListenerJob?.cancel()
+        paymentListenerJob = viewModelScope.launch {
+            cardReaderPaymentController?.paymentState?.collect { paymentState ->
+                when (paymentState) {
+                    is CardReaderPaymentState.LoadingData -> {
+                        _state.value = buildPreparingState()
+                    }
+
+                    is CardReaderPaymentState.CollectingPayment -> {
+                        _state.value = WooPosCardPaymentState.Collecting.ReadyForPayment(
+                            title = resourceProvider.getString(
+                                R.string.woopos_totals_reader_ready_for_payment_title
+                            ),
+                            subtitle = resourceProvider.getString(
+                                paymentState.cardReaderHint
+                                    ?: R.string.woopos_totals_reader_ready_for_payment_subtitle
+                            )
+                        )
+                    }
+
+                    is CardReaderPaymentState.ProcessingPayment,
+                    is CardReaderPaymentState.PaymentCapturing -> {
+                        _state.value = WooPosCardPaymentState.PaymentInProgress(
+                            title = resourceProvider.getString(
+                                R.string.woopos_success_totals_payment_processing_title
+                            ),
+                            subtitle = resourceProvider.getString(
+                                R.string.woopos_success_totals_payment_processing_subtitle
+                            )
+                        )
+                    }
+
+                    is CardReaderPaymentState.PaymentSuccessful -> {
+                        handlePaymentSuccessful()
+                    }
+
+                    is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment -> {
+                        _state.value = buildPaymentFailedState(paymentState)
+                    }
+
+                    CardReaderPaymentState.ReFetchingOrder -> Unit
+
+                    else -> Unit
+                }
+            }
+        }
+    }
+
+    private fun listenToControllerEvents() {
+        controllerEventJob?.cancel()
+        controllerEventJob = viewModelScope.launch {
+            cardReaderPaymentController?.event?.collect { event ->
+                when (event) {
+                    is CardReaderPaymentEvent.ShowErrorMessage -> {
+                        _state.value = WooPosCardPaymentState.PaymentFailed(
+                            title = resourceProvider.getString(
+                                R.string.woopos_success_totals_payment_failed_title
+                            ),
+                            subtitle = resourceProvider.getString(event.message),
+                            retryButtonLabel = resourceProvider.getString(
+                                R.string.woo_pos_payment_failed_try_another_payment_method
+                            ),
+                            isDismissButtonVisible = false
+                        )
+                    }
+
+                    else -> Unit
+                }
+            }
+        }
+    }
+
+    private suspend fun handlePaymentSuccessful() {
+        val order = totalsRepository.getOrderById(orderId)
+        val orderTotalText = if (order != null) {
+            resourceProvider.getString(
+                R.string.woopos_totals_success_payment_card,
+                priceFormat(order.total)
+            )
+        } else {
+            resourceProvider.getString(R.string.woopos_payment_successful_label)
+        }
+        _state.value = WooPosCardPaymentState.PaymentSuccess(orderTotalText = orderTotalText)
+    }
+
+    private fun buildPaymentFailedState(
+        state: CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment
+    ): WooPosCardPaymentState.PaymentFailed {
+        val isRetryAvailable = state.onRetry != null
+        val retryButtonLabel = if (isRetryAvailable) {
+            resourceProvider.getString(R.string.woo_pos_payment_failed_try_again)
+        } else {
+            resourceProvider.getString(R.string.woo_pos_payment_failed_try_another_payment_method)
+        }
+        return WooPosCardPaymentState.PaymentFailed(
+            title = resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title),
+            subtitle = uiStringParser.asString(state.errorType.message),
+            retryButtonLabel = retryButtonLabel,
+            isDismissButtonVisible = isRetryAvailable
+        )
+    }
+
+    private fun buildPreparingState() = WooPosCardPaymentState.Collecting.Preparing(
+        title = resourceProvider.getString(R.string.woopos_totals_reader_getting_ready),
+        subtitle = resourceProvider.getString(R.string.woopos_totals_reader_preparing_reader_for_payment)
+    )
+
+    private fun buildReaderDisconnectedState() = WooPosCardPaymentState.Collecting.ReaderDisconnected(
+        title = resourceProvider.getString(R.string.woopos_success_totals_error_reader_not_connected_title),
+        subtitle = resourceProvider.getString(R.string.woopos_success_totals_error_reader_not_connected_subtitle),
+        actionButtonLabel = resourceProvider.getString(
+            R.string.woopos_success_totals_error_reader_not_connected_cta_button_label
+        ),
+    )
+
+    fun onRetryClicked() {
+        val paymentState = cardReaderPaymentController?.paymentState?.value
+        if (paymentState is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment &&
+            paymentState.onRetry != null
+        ) {
+            paymentState.onRetry!!()
+        } else {
+            collectPayment()
+        }
+    }
+
+    fun onBackClicked() {
+        val paymentState = cardReaderPaymentController?.paymentState?.value
+        if (paymentState is CardReaderPaymentState.ProcessingPayment ||
+            paymentState is CardReaderPaymentState.PaymentCapturing
+        ) {
+            return
+        }
+        cancelPayment()
+        viewModelScope.launch {
+            _navigationEvent.emit(WooPosNavigationEvent.GoBack)
+        }
+    }
+
+    fun onDismissClicked() {
+        cancelPayment()
+        viewModelScope.launch {
+            _navigationEvent.emit(WooPosNavigationEvent.GoBack)
+        }
+    }
+
+    fun onConnectReaderClicked() {
+        cardReaderFacade.connectToReader()
+    }
+
+    fun onDoneClicked() {
+        viewModelScope.launch {
+            if (source == CardPaymentSource.BOOKINGS) {
+                _navigationEvent.emit(
+                    WooPosNavigationEvent.GoBackWithResult(
+                        BOOKING_CARD_PAYMENT_SUCCESS_KEY,
+                        true
+                    )
+                )
+            } else {
+                _navigationEvent.emit(WooPosNavigationEvent.GoBack)
+            }
+        }
+    }
+
+    fun onEmailReceiptClicked() {
+        viewModelScope.launch {
+            _navigationEvent.emit(WooPosNavigationEvent.OpenEmailReceipt(orderId))
+        }
+    }
+
+    private fun cancelPayment() {
+        paymentListenerJob?.cancel()
+        paymentListenerJob = null
+        controllerEventJob?.cancel()
+        controllerEventJob = null
+        cardReaderPaymentController?.onBackPressed()
+        cardReaderPaymentController?.stop()
+    }
+
+    override fun onCleared() {
+        cardReaderPaymentController?.stop()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.root.navigation
 
+import com.woocommerce.android.ui.woopos.cardpayment.CardPaymentSource
 import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 
@@ -11,6 +12,10 @@ sealed class WooPosNavigationEvent {
     data class OpenCashPayment(
         val orderId: Long,
         val source: CashPaymentSource = CashPaymentSource.CHECKOUT,
+    ) : WooPosNavigationEvent()
+    data class OpenCardPayment(
+        val orderId: Long,
+        val source: CardPaymentSource = CardPaymentSource.CHECKOUT,
     ) : WooPosNavigationEvent()
     data class OpenEmailReceipt(val orderId: Long) : WooPosNavigationEvent()
     data class OpenRefundReason(val orderId: Long, val initialReason: String = "") : WooPosNavigationEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.root.navigation
 import androidx.activity.ComponentActivity
 import androidx.navigation.NavHostController
 import com.woocommerce.android.ui.woopos.bookings.navigateToBookingsScreen
+import com.woocommerce.android.ui.woopos.cardpayment.navigateToCardPaymentScreen
 import com.woocommerce.android.ui.woopos.cashpayment.navigateToCashPaymentScreen
 import com.woocommerce.android.ui.woopos.emailreceipt.navigateToEmailReceipt
 import com.woocommerce.android.ui.woopos.home.navigateToEligibilityScreen
@@ -26,6 +27,9 @@ fun NavHostController.handleNavigationEvent(
 
         is WooPosNavigationEvent.OpenHomeFromSplash -> navigateToHomeScreen()
         is WooPosNavigationEvent.OpenCashPayment -> navigateToCashPaymentScreen(event.orderId, event.source)
+
+        is WooPosNavigationEvent.OpenCardPayment ->
+            navigateToCardPaymentScreen(event.orderId, event.source)
 
         is WooPosNavigationEvent.GoBackWithResult -> {
             previousBackStackEntry

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3780,6 +3780,8 @@
     <string name="woo_pos_payment_failed_try_again">Try payment again</string>
     <string name="woo_pos_payment_failed_go_back_to_checkout">Go back to checkout</string>
 
+    <string name="woopos_card_payment_done_button">Done</string>
+
     <string name="woopos_floating_toolbar_overlay_menu_content_description">Dimmed background. Tap to close the menu.</string>
     <string name="woopos_floating_toolbar_card_reader_connected_status_content_description">Card reader connected</string>
     <string name="woopos_floating_toolbar_card_reader_not_connected_status_content_description">Card reader not connected. Double tap to connect</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -1,0 +1,323 @@
+package com.woocommerce.android.ui.woopos.cardpayment
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.woocommerce.android.cardreader.connection.CardReader
+import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.payments.cardreader.payment.PaymentFlowError
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.home.totals.WooPosCardReaderPaymentControllerFactory
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsRepository
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.util.UiStringParser
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosCardPaymentViewModelTest {
+
+    @Rule
+    @JvmField
+    val coroutineTestRule = WooPosCoroutineTestRule()
+
+    private val readerStatusFlow = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connected(mock<CardReader>()))
+    private val cardReaderFacade: WooPosCardReaderFacade = mock {
+        on { readerStatus }.thenReturn(readerStatusFlow)
+    }
+    private val controllerPaymentState =
+        MutableStateFlow<CardReaderPaymentState>(CardReaderPaymentState.LoadingData { })
+    private val controllerEventFlow = MutableSharedFlow<CardReaderPaymentEvent>()
+    private val paymentController: CardReaderPaymentController = mock {
+        on { paymentState }.thenReturn(controllerPaymentState)
+        on { event }.thenReturn(controllerEventFlow)
+    }
+    private val cardReaderPaymentControllerFactory: WooPosCardReaderPaymentControllerFactory = mock {
+        on { create(any(), any(), any()) }.thenReturn(paymentController)
+    }
+    private val networkStatus: WooPosNetworkStatus = mock {
+        on { isConnected() }.thenReturn(true)
+    }
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) }.thenReturn("test string")
+        on { getString(any(), any()) }.thenReturn("test string with arg")
+    }
+    private val uiStringParser: UiStringParser = mock {
+        on { asString(any()) }.thenReturn("parsed error")
+    }
+    private val priceFormat: WooPosFormatPrice = mock()
+    private val totalsRepository: WooPosTotalsRepository = mock()
+
+    private lateinit var viewModel: WooPosCardPaymentViewModel
+
+    @Before
+    fun setUp() = runTest {
+        val mockOrder = mock<Order> {
+            on { total }.thenReturn(BigDecimal("50.00"))
+        }
+        whenever(totalsRepository.getOrderById(any())).thenReturn(mockOrder)
+        whenever(priceFormat(any<BigDecimal>())).thenReturn("$50.00")
+    }
+
+    private fun createViewModel(
+        orderId: Long = 100L,
+        source: CardPaymentSource = CardPaymentSource.BOOKINGS,
+    ): WooPosCardPaymentViewModel {
+        val savedStateHandle = SavedStateHandle(
+            mapOf(
+                CARD_PAYMENT_ROUTE_ORDER_ID_KEY to orderId,
+                CARD_PAYMENT_ROUTE_SOURCE_KEY to source.name,
+            )
+        )
+        return WooPosCardPaymentViewModel(
+            savedState = savedStateHandle,
+            cardReaderPaymentControllerFactory = cardReaderPaymentControllerFactory,
+            cardReaderFacade = cardReaderFacade,
+            networkStatus = networkStatus,
+            resourceProvider = resourceProvider,
+            uiStringParser = uiStringParser,
+            priceFormat = priceFormat,
+            totalsRepository = totalsRepository,
+        )
+    }
+
+    @Test
+    fun `given connected reader, when init, then state is Collecting Preparing`() = runTest {
+        controllerPaymentState.value = CardReaderPaymentState.LoadingData { }
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value).isInstanceOf(WooPosCardPaymentState.Collecting.Preparing::class.java)
+    }
+
+    @Test
+    fun `given connected reader, when controller emits CollectingPayment, then state is Collecting ReadyForPayment`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.CollectingPayment
+            .ExternalReaderCollectPaymentState(
+                amountWithCurrencyLabel = "$50.00",
+                onCancel = {}
+            )
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.Collecting.ReadyForPayment::class.java)
+    }
+
+    @Test
+    fun `given connected reader, when controller emits ProcessingPayment, then state is PaymentInProgress`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.ProcessingPayment
+            .ExternalReaderProcessingPayment(
+                amountWithCurrencyLabel = "$50.00",
+                onCancel = {}
+            )
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentInProgress::class.java)
+    }
+
+    @Test
+    fun `given connected reader, when controller emits PaymentSuccessful, then state is PaymentSuccess`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.PaymentSuccessful
+            .ExternalReaderPaymentSuccessful(
+                amountWithCurrencyLabel = "$50.00",
+                onPrintReceiptClicked = {},
+                onSendReceiptClicked = {},
+                onSaveUserClicked = {}
+            )
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentSuccess::class.java)
+    }
+
+    @Test
+    fun `given connected reader, when controller emits PaymentFailed with retry, then state is PaymentFailed with isDismissButtonVisible true`() =
+        runTest {
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            controllerPaymentState.value = CardReaderPaymentState.PaymentFailed
+                .ExternalReaderFailedPayment.Cancelable(
+                    errorType = PaymentFlowError.Generic,
+                    amountWithCurrencyLabel = "$50.00",
+                    onCancel = {},
+                    onRetry = {},
+                )
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertThat(state).isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
+            assertThat((state as WooPosCardPaymentState.PaymentFailed).isDismissButtonVisible).isTrue()
+        }
+
+    @Test
+    fun `given connected reader, when controller emits PaymentFailed without retry, then state is PaymentFailed`() =
+        runTest {
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            controllerPaymentState.value = CardReaderPaymentState.PaymentFailed
+                .ExternalReaderFailedPayment.NonCancelable(
+                    errorType = PaymentFlowError.Generic,
+                    onRetry = {},
+                )
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertThat(state).isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
+        }
+
+    @Test
+    fun `given disconnected reader, when init, then state is Collecting ReaderDisconnected`() = runTest {
+        readerStatusFlow.value = CardReaderStatus.NotConnected()
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.Collecting.ReaderDisconnected::class.java)
+    }
+
+    @Test
+    fun `given disconnected reader, when onConnectReaderClicked, then connectToReader called`() = runTest {
+        readerStatusFlow.value = CardReaderStatus.NotConnected()
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onConnectReaderClicked()
+
+        verify(cardReaderFacade).connectToReader()
+    }
+
+    @Test
+    fun `given processing state, when onBackClicked, then no GoBack emitted`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.ProcessingPayment
+            .ExternalReaderProcessingPayment(
+                amountWithCurrencyLabel = "$50.00",
+                onCancel = {}
+            )
+        advanceUntilIdle()
+
+        viewModel.navigationEvent.test {
+            viewModel.onBackClicked()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `given collecting state, when onBackClicked, then GoBack emitted`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.navigationEvent.test {
+            viewModel.onBackClicked()
+
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(WooPosNavigationEvent.GoBack::class.java)
+        }
+    }
+
+    @Test
+    fun `given BOOKINGS source, when onDoneClicked, then GoBackWithResult emitted`() = runTest {
+        viewModel = createViewModel(source = CardPaymentSource.BOOKINGS)
+        advanceUntilIdle()
+
+        viewModel.navigationEvent.test {
+            viewModel.onDoneClicked()
+
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(WooPosNavigationEvent.GoBackWithResult::class.java)
+            val resultEvent = event as WooPosNavigationEvent.GoBackWithResult
+            assertThat(resultEvent.key).isEqualTo(BOOKING_CARD_PAYMENT_SUCCESS_KEY)
+            assertThat(resultEvent.value).isEqualTo(true)
+        }
+    }
+
+    @Test
+    fun `given CHECKOUT source, when onDoneClicked, then GoBack emitted`() = runTest {
+        viewModel = createViewModel(source = CardPaymentSource.CHECKOUT)
+        advanceUntilIdle()
+
+        viewModel.navigationEvent.test {
+            viewModel.onDoneClicked()
+
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(WooPosNavigationEvent.GoBack::class.java)
+        }
+    }
+
+    @Test
+    fun `when onEmailReceiptClicked, then OpenEmailReceipt emitted`() = runTest {
+        viewModel = createViewModel(orderId = 42L)
+        advanceUntilIdle()
+
+        viewModel.navigationEvent.test {
+            viewModel.onEmailReceiptClicked()
+
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(WooPosNavigationEvent.OpenEmailReceipt::class.java)
+            assertThat((event as WooPosNavigationEvent.OpenEmailReceipt).orderId).isEqualTo(42L)
+        }
+    }
+
+    @Test
+    fun `given no network, when init, then state is PaymentFailed`() = runTest {
+        whenever(networkStatus.isConnected()).thenReturn(false)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
+    }
+
+    @Test
+    fun `given controller emits ShowErrorMessage, when collecting, then state is PaymentFailed`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerEventFlow.emit(
+            CardReaderPaymentEvent.ShowErrorMessage(
+                com.woocommerce.android.R.string.card_reader_payment_order_paid_payment_cancelled
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `WooPosCardPaymentViewModel` with card reader payment controller integration
- Add `WooPosCardPaymentState` sealed class for payment UI states (Initiating, Collecting, PaymentInProgress, PaymentFailed, PaymentSuccess)
- Add card payment navigation constants, source enum, and navigate function
- Add `OpenCardPayment` navigation event and handler
- Allow WooPayments feature in CIAB site gatekeeper

## Test plan
- [ ] 15 unit tests for `WooPosCardPaymentViewModel`
- [ ] Verify build compiles successfully
- [ ] Detekt passes

> **Note:** This is part 1 of 2. The card payment screen composable and bookings wiring follow in the next PR.