### PR TITLE
[CIAB: POS] Card-present booking checkout. Part-2: Card payment state, ViewModel, and navigation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -45,6 +45,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavBackStackEntry
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.bookings.details.WooPosBookingDetails
+import com.woocommerce.android.ui.woopos.cardpayment.BOOKING_CARD_PAYMENT_SUCCESS_KEY
 import com.woocommerce.android.ui.woopos.cashpayment.BOOKING_CASH_PAYMENT_SUCCESS_KEY
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
@@ -93,6 +94,17 @@ fun WooPosBookingsScreen(
         if (cashPaymentResult.value) {
             viewModel.onRefresh()
             backStackEntry.savedStateHandle[BOOKING_CASH_PAYMENT_SUCCESS_KEY] = false
+        }
+    }
+
+    val cardPaymentResult = backStackEntry.savedStateHandle
+        .getStateFlow(BOOKING_CARD_PAYMENT_SUCCESS_KEY, false)
+        .collectAsState()
+
+    LaunchedEffect(cardPaymentResult.value) {
+        if (cardPaymentResult.value) {
+            viewModel.onRefresh()
+            backStackEntry.savedStateHandle[BOOKING_CARD_PAYMENT_SUCCESS_KEY] = false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.bookings.list.BookingListHandler
 import com.woocommerce.android.ui.bookings.list.BookingListSortOption
+import com.woocommerce.android.ui.woopos.cardpayment.CardPaymentSource
 import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
@@ -215,7 +216,7 @@ class WooPosBookingsViewModel @Inject constructor(
         when (event) {
             is WooPosBookingsUIEvent.BookingActionClicked -> handleBookingAction(event.action)
             is WooPosBookingsUIEvent.AttendanceToggled -> { }
-            is WooPosBookingsUIEvent.PayByCardClicked -> { }
+            is WooPosBookingsUIEvent.PayByCardClicked -> handlePayByCard()
             is WooPosBookingsUIEvent.PayByCashClicked -> handlePayByCash()
             is WooPosBookingsUIEvent.AddBookingNoteClicked -> { }
             is WooPosBookingsUIEvent.CopyEmailClicked -> { }
@@ -227,6 +228,18 @@ class WooPosBookingsViewModel @Inject constructor(
         _state.value = currentState.copy(
             dialogState = WooPosBookingsState.Content.DialogState.Hidden
         )
+    }
+
+    private fun handlePayByCard() {
+        val details = (_state.value as? WooPosBookingsState.Content)?.selectedDetails ?: return
+        viewModelScope.launch {
+            _navigationEvent.emit(
+                WooPosNavigationEvent.OpenCardPayment(
+                    orderId = details.orderId,
+                    source = CardPaymentSource.BOOKINGS,
+                )
+            )
+        }
     }
 
     private fun handlePayByCash() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentNavigation.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.ui.woopos.cardpayment
+
+import androidx.navigation.NavController
+import com.woocommerce.android.ui.woopos.home.HOME_ROUTE
+import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
+
+const val CARD_PAYMENT_ROUTE_ORDER_ID_KEY = "orderId"
+const val CARD_PAYMENT_ROUTE_SOURCE_KEY = "source"
+const val CARD_PAYMENT_ROUTE =
+    "$HOME_ROUTE/card_payment/{$CARD_PAYMENT_ROUTE_ORDER_ID_KEY}" +
+        "?$CARD_PAYMENT_ROUTE_SOURCE_KEY={$CARD_PAYMENT_ROUTE_SOURCE_KEY}"
+
+const val BOOKING_CARD_PAYMENT_SUCCESS_KEY = "booking_card_payment_success"
+
+enum class CardPaymentSource {
+    CHECKOUT,
+    BOOKINGS,
+}
+
+fun NavController.navigateToCardPaymentScreen(
+    orderId: Long,
+    source: CardPaymentSource = CardPaymentSource.CHECKOUT,
+) {
+    navigateOnce(
+        CARD_PAYMENT_ROUTE
+            .replace("{$CARD_PAYMENT_ROUTE_ORDER_ID_KEY}", orderId.toString())
+            .replace("{$CARD_PAYMENT_ROUTE_SOURCE_KEY}", source.name)
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentNavigation.kt
@@ -1,7 +1,14 @@
 package com.woocommerce.android.ui.woopos.cardpayment
 
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.woocommerce.android.ui.woopos.home.HOME_ROUTE
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
 
 const val CARD_PAYMENT_ROUTE_ORDER_ID_KEY = "orderId"
@@ -26,4 +33,43 @@ fun NavController.navigateToCardPaymentScreen(
             .replace("{$CARD_PAYMENT_ROUTE_ORDER_ID_KEY}", orderId.toString())
             .replace("{$CARD_PAYMENT_ROUTE_SOURCE_KEY}", source.name)
     )
+}
+
+fun NavGraphBuilder.cardPaymentScreen(
+    onNavigationEvent: (WooPosNavigationEvent) -> Unit
+) {
+    composable(
+        route = CARD_PAYMENT_ROUTE,
+        arguments = listOf(
+            navArgument(CARD_PAYMENT_ROUTE_ORDER_ID_KEY) { type = NavType.LongType },
+            navArgument(CARD_PAYMENT_ROUTE_SOURCE_KEY) {
+                type = NavType.StringType
+                defaultValue = CardPaymentSource.CHECKOUT.name
+            }
+        ),
+        enterTransition = {
+            slideInHorizontally(
+                initialOffsetX = { fullWidth -> fullWidth },
+            )
+        },
+        exitTransition = {
+            slideOutHorizontally(
+                targetOffsetX = { fullWidth -> -fullWidth },
+            )
+        },
+        popEnterTransition = {
+            slideInHorizontally(
+                initialOffsetX = { fullWidth -> -fullWidth },
+            )
+        },
+        popExitTransition = {
+            slideOutHorizontally(
+                targetOffsetX = { fullWidth -> fullWidth },
+            )
+        },
+    ) {
+        WooPosCardPaymentScreen(
+            onNavigationEvent = onNavigationEvent,
+        )
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.ui.woopos.cardpayment
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+
+@Composable
+fun WooPosCardPaymentScreen(
+    onNavigationEvent: (WooPosNavigationEvent) -> Unit,
+) {
+    val viewModel: WooPosCardPaymentViewModel = hiltViewModel()
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.navigationEvent.collect { onNavigationEvent(it) }
+    }
+
+    BackHandler { viewModel.onBackClicked() }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        WooPosText(
+            text = state.toString(),
+            style = WooPosTypography.BodyLarge,
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentState.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.ui.woopos.cardpayment
+
+sealed class WooPosCardPaymentState {
+    data object Initiating : WooPosCardPaymentState()
+
+    sealed class Collecting : WooPosCardPaymentState() {
+        data class Preparing(
+            val title: String,
+            val subtitle: String,
+        ) : Collecting()
+
+        data class ReadyForPayment(
+            val title: String,
+            val subtitle: String,
+        ) : Collecting()
+
+        data class ReaderDisconnected(
+            val title: String,
+            val subtitle: String,
+            val actionButtonLabel: String,
+        ) : Collecting()
+    }
+
+    data class PaymentInProgress(
+        val title: String,
+        val subtitle: String,
+    ) : WooPosCardPaymentState()
+
+    data class PaymentFailed(
+        val title: String,
+        val subtitle: String,
+        val retryButtonLabel: String,
+        val isDismissButtonVisible: Boolean,
+    ) : WooPosCardPaymentState()
+
+    data class PaymentSuccess(
+        val orderTotalText: String,
+    ) : WooPosCardPaymentState()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnect
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.home.totals.TTPPaymentProgressDelegate
@@ -159,7 +160,12 @@ class WooPosCardPaymentViewModel @Inject constructor(
 
                     CardReaderPaymentState.ReFetchingOrder -> Unit
 
-                    else -> Unit
+                    is CardReaderPaymentOrRefundState.CardReaderInteracRefundState,
+                    is CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment,
+                    is CardReaderPaymentState.PrintingReceipt,
+                    CardReaderPaymentState.SharingReceipt -> {
+                        throw IllegalArgumentException("Payment state: $paymentState not compatible with POS")
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -1,0 +1,302 @@
+package com.woocommerce.android.ui.woopos.cardpayment
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.home.totals.WooPosCardReaderPaymentControllerFactory
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsRepository
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.util.UiStringParser
+import com.woocommerce.android.viewmodel.ResourceProvider
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WooPosCardPaymentViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    private val cardReaderPaymentControllerFactory: WooPosCardReaderPaymentControllerFactory,
+    private val cardReaderFacade: WooPosCardReaderFacade,
+    private val networkStatus: WooPosNetworkStatus,
+    private val resourceProvider: ResourceProvider,
+    private val uiStringParser: UiStringParser,
+    private val priceFormat: WooPosFormatPrice,
+    private val totalsRepository: WooPosTotalsRepository,
+) : ViewModel() {
+
+    private val orderId: Long = requireNotNull(savedState[CARD_PAYMENT_ROUTE_ORDER_ID_KEY])
+    val source: CardPaymentSource = CardPaymentSource.valueOf(
+        savedState[CARD_PAYMENT_ROUTE_SOURCE_KEY] ?: CardPaymentSource.CHECKOUT.name
+    )
+
+    private val _state = MutableStateFlow<WooPosCardPaymentState>(WooPosCardPaymentState.Initiating)
+    val state: StateFlow<WooPosCardPaymentState> = _state.asStateFlow()
+
+    private val _navigationEvent = MutableSharedFlow<WooPosNavigationEvent>()
+    val navigationEvent: SharedFlow<WooPosNavigationEvent> = _navigationEvent.asSharedFlow()
+
+    private var cardReaderPaymentController: CardReaderPaymentController? = null
+    private var paymentListenerJob: Job? = null
+    private var controllerEventJob: Job? = null
+    private var isTTPPaymentInProgress: Boolean = false
+
+    init {
+        observeCardReaderStatus()
+    }
+
+    private fun observeCardReaderStatus() {
+        viewModelScope.launch {
+            cardReaderFacade.readerStatus.collect { status ->
+                when (status) {
+                    is NotConnected, is Connecting -> {
+                        val currentState = _state.value
+                        if (currentState is WooPosCardPaymentState.PaymentSuccess ||
+                            currentState is WooPosCardPaymentState.PaymentInProgress
+                        ) {
+                            return@collect
+                        }
+                        _state.value = buildReaderDisconnectedState()
+                        cancelPayment()
+                    }
+
+                    is Connected -> {
+                        val currentState = _state.value
+                        if (currentState is WooPosCardPaymentState.PaymentSuccess ||
+                            currentState is WooPosCardPaymentState.PaymentInProgress
+                        ) {
+                            return@collect
+                        }
+                        _state.value = buildPreparingState()
+                        collectPayment()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun collectPayment() {
+        if (!networkStatus.isConnected()) {
+            _state.value = WooPosCardPaymentState.PaymentFailed(
+                title = resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title),
+                subtitle = resourceProvider.getString(R.string.woopos_no_internet_message),
+                retryButtonLabel = resourceProvider.getString(R.string.woo_pos_payment_failed_try_again),
+                isDismissButtonVisible = true
+            )
+            return
+        }
+        if (cardReaderFacade.readerStatus.value !is Connected) return
+
+        cardReaderPaymentController?.stop()
+        cardReaderPaymentController = cardReaderPaymentControllerFactory.create(
+            orderId = orderId,
+            paymentType = PaymentOrRefund.Payment.PaymentType.WOO_POS,
+            isTTPPaymentInProgress = ::isTTPPaymentInProgress,
+        )
+        cardReaderPaymentController?.start()
+        listenToPaymentState()
+        listenToControllerEvents()
+    }
+
+    private fun listenToPaymentState() {
+        paymentListenerJob?.cancel()
+        paymentListenerJob = viewModelScope.launch {
+            cardReaderPaymentController?.paymentState?.collect { paymentState ->
+                when (paymentState) {
+                    is CardReaderPaymentState.LoadingData -> {
+                        _state.value = buildPreparingState()
+                    }
+
+                    is CardReaderPaymentState.CollectingPayment -> {
+                        _state.value = WooPosCardPaymentState.Collecting.ReadyForPayment(
+                            title = resourceProvider.getString(
+                                R.string.woopos_totals_reader_ready_for_payment_title
+                            ),
+                            subtitle = resourceProvider.getString(
+                                paymentState.cardReaderHint
+                                    ?: R.string.woopos_totals_reader_ready_for_payment_subtitle
+                            )
+                        )
+                    }
+
+                    is CardReaderPaymentState.ProcessingPayment,
+                    is CardReaderPaymentState.PaymentCapturing -> {
+                        _state.value = WooPosCardPaymentState.PaymentInProgress(
+                            title = resourceProvider.getString(
+                                R.string.woopos_success_totals_payment_processing_title
+                            ),
+                            subtitle = resourceProvider.getString(
+                                R.string.woopos_success_totals_payment_processing_subtitle
+                            )
+                        )
+                    }
+
+                    is CardReaderPaymentState.PaymentSuccessful -> {
+                        handlePaymentSuccessful()
+                    }
+
+                    is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment -> {
+                        _state.value = buildPaymentFailedState(paymentState)
+                    }
+
+                    CardReaderPaymentState.ReFetchingOrder -> Unit
+
+                    else -> Unit
+                }
+            }
+        }
+    }
+
+    private fun listenToControllerEvents() {
+        controllerEventJob?.cancel()
+        controllerEventJob = viewModelScope.launch {
+            cardReaderPaymentController?.event?.collect { event ->
+                when (event) {
+                    is CardReaderPaymentEvent.ShowErrorMessage -> {
+                        _state.value = WooPosCardPaymentState.PaymentFailed(
+                            title = resourceProvider.getString(
+                                R.string.woopos_success_totals_payment_failed_title
+                            ),
+                            subtitle = resourceProvider.getString(event.message),
+                            retryButtonLabel = resourceProvider.getString(
+                                R.string.woo_pos_payment_failed_try_another_payment_method
+                            ),
+                            isDismissButtonVisible = false
+                        )
+                    }
+
+                    else -> Unit
+                }
+            }
+        }
+    }
+
+    private suspend fun handlePaymentSuccessful() {
+        val order = totalsRepository.getOrderById(orderId)
+        val orderTotalText = if (order != null) {
+            resourceProvider.getString(
+                R.string.woopos_totals_success_payment_card,
+                priceFormat(order.total)
+            )
+        } else {
+            resourceProvider.getString(R.string.woopos_payment_successful_label)
+        }
+        _state.value = WooPosCardPaymentState.PaymentSuccess(orderTotalText = orderTotalText)
+    }
+
+    private fun buildPaymentFailedState(
+        state: CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment
+    ): WooPosCardPaymentState.PaymentFailed {
+        val isRetryAvailable = state.onRetry != null
+        val retryButtonLabel = if (isRetryAvailable) {
+            resourceProvider.getString(R.string.woo_pos_payment_failed_try_again)
+        } else {
+            resourceProvider.getString(R.string.woo_pos_payment_failed_try_another_payment_method)
+        }
+        return WooPosCardPaymentState.PaymentFailed(
+            title = resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title),
+            subtitle = uiStringParser.asString(state.errorType.message),
+            retryButtonLabel = retryButtonLabel,
+            isDismissButtonVisible = isRetryAvailable
+        )
+    }
+
+    private fun buildPreparingState() = WooPosCardPaymentState.Collecting.Preparing(
+        title = resourceProvider.getString(R.string.woopos_totals_reader_getting_ready),
+        subtitle = resourceProvider.getString(R.string.woopos_totals_reader_preparing_reader_for_payment)
+    )
+
+    private fun buildReaderDisconnectedState() = WooPosCardPaymentState.Collecting.ReaderDisconnected(
+        title = resourceProvider.getString(R.string.woopos_success_totals_error_reader_not_connected_title),
+        subtitle = resourceProvider.getString(R.string.woopos_success_totals_error_reader_not_connected_subtitle),
+        actionButtonLabel = resourceProvider.getString(
+            R.string.woopos_success_totals_error_reader_not_connected_cta_button_label
+        ),
+    )
+
+    fun onRetryClicked() {
+        val paymentState = cardReaderPaymentController?.paymentState?.value
+        if (paymentState is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment &&
+            paymentState.onRetry != null
+        ) {
+            paymentState.onRetry!!()
+        } else {
+            collectPayment()
+        }
+    }
+
+    fun onBackClicked() {
+        val paymentState = cardReaderPaymentController?.paymentState?.value
+        if (paymentState is CardReaderPaymentState.ProcessingPayment ||
+            paymentState is CardReaderPaymentState.PaymentCapturing
+        ) {
+            return
+        }
+        cancelPayment()
+        viewModelScope.launch {
+            _navigationEvent.emit(WooPosNavigationEvent.GoBack)
+        }
+    }
+
+    fun onDismissClicked() {
+        cancelPayment()
+        viewModelScope.launch {
+            _navigationEvent.emit(WooPosNavigationEvent.GoBack)
+        }
+    }
+
+    fun onConnectReaderClicked() {
+        cardReaderFacade.connectToReader()
+    }
+
+    fun onDoneClicked() {
+        viewModelScope.launch {
+            if (source == CardPaymentSource.BOOKINGS) {
+                _navigationEvent.emit(
+                    WooPosNavigationEvent.GoBackWithResult(
+                        BOOKING_CARD_PAYMENT_SUCCESS_KEY,
+                        true
+                    )
+                )
+            } else {
+                _navigationEvent.emit(WooPosNavigationEvent.GoBack)
+            }
+        }
+    }
+
+    fun onEmailReceiptClicked() {
+        viewModelScope.launch {
+            _navigationEvent.emit(WooPosNavigationEvent.OpenEmailReceipt(orderId))
+        }
+    }
+
+    private fun cancelPayment() {
+        paymentListenerJob?.cancel()
+        paymentListenerJob = null
+        controllerEventJob?.cancel()
+        controllerEventJob = null
+        cardReaderPaymentController?.onBackPressed()
+        cardReaderPaymentController?.stop()
+    }
+
+    override fun onCleared() {
+        cardReaderPaymentController?.stop()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -233,10 +233,15 @@ class WooPosCardPaymentViewModel @Inject constructor(
 
     fun onRetryClicked() {
         val paymentState = cardReaderPaymentController?.paymentState?.value
-        if (paymentState is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment &&
-            paymentState.onRetry != null
-        ) {
-            paymentState.onRetry!!()
+        check(paymentState != null) {
+            "Retry clicked but payment controller is null"
+        }
+        check(paymentState is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment) {
+            "Retry clicked but payment state is not PaymentFailed"
+        }
+        val onRetry = paymentState.onRetry
+        if (onRetry != null) {
+            onRetry()
         } else {
             collectPayment()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -43,9 +43,9 @@ class WooPosCardPaymentViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val orderId: Long = requireNotNull(savedState[CARD_PAYMENT_ROUTE_ORDER_ID_KEY])
-    val source: CardPaymentSource = CardPaymentSource.valueOf(
-        savedState[CARD_PAYMENT_ROUTE_SOURCE_KEY] ?: CardPaymentSource.CHECKOUT.name
-    )
+    private val source: CardPaymentSource = (savedState[CARD_PAYMENT_ROUTE_SOURCE_KEY] as? String)
+        ?.let { runCatching { CardPaymentSource.valueOf(it) }.getOrNull() }
+        ?: CardPaymentSource.CHECKOUT
 
     private val _state = MutableStateFlow<WooPosCardPaymentState>(WooPosCardPaymentState.Initiating)
     val state: StateFlow<WooPosCardPaymentState> = _state.asStateFlow()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -309,6 +309,6 @@ class WooPosCardPaymentViewModel @Inject constructor(
     }
 
     override fun onCleared() {
-        cardReaderPaymentController?.stop()
+        cancelPayment()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardRea
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.home.totals.TTPPaymentProgressDelegate
 import com.woocommerce.android.ui.woopos.home.totals.WooPosCardReaderPaymentControllerFactory
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsRepository
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
@@ -56,7 +57,7 @@ class WooPosCardPaymentViewModel @Inject constructor(
     private var cardReaderPaymentController: CardReaderPaymentController? = null
     private var paymentListenerJob: Job? = null
     private var controllerEventJob: Job? = null
-    private var isTTPPaymentInProgress: Boolean = false
+    private var isTTPPaymentInProgress: Boolean by TTPPaymentProgressDelegate(savedState)
 
     init {
         observeCardReaderStatus()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosMainFlowGraph.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosMainFlowGraph.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.root.navigation
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.navigation
 import com.woocommerce.android.ui.woopos.bookings.bookingsScreen
+import com.woocommerce.android.ui.woopos.cardpayment.cardPaymentScreen
 import com.woocommerce.android.ui.woopos.cashpayment.cashPaymentScreen
 import com.woocommerce.android.ui.woopos.emailreceipt.emailReceiptScreen
 import com.woocommerce.android.ui.woopos.home.WooPosHomeViewModel
@@ -26,6 +27,7 @@ fun NavGraphBuilder.mainGraph(
     ) {
         splashScreen(onNavigationEvent = onNavigationEvent)
         homeScreen(homeViewModel = homeViewModel)
+        cardPaymentScreen(onNavigationEvent = onNavigationEvent)
         cashPaymentScreen(onNavigationEvent = onNavigationEvent)
         emailReceiptScreen(onNavigationEvent = onNavigationEvent)
         eligibilityScreen(onNavigationEvent = onNavigationEvent)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.root.navigation
 
+import com.woocommerce.android.ui.woopos.cardpayment.CardPaymentSource
 import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
 
@@ -11,6 +12,10 @@ sealed class WooPosNavigationEvent {
     data class OpenCashPayment(
         val orderId: Long,
         val source: CashPaymentSource = CashPaymentSource.CHECKOUT,
+    ) : WooPosNavigationEvent()
+    data class OpenCardPayment(
+        val orderId: Long,
+        val source: CardPaymentSource = CardPaymentSource.CHECKOUT,
     ) : WooPosNavigationEvent()
     data class OpenEmailReceipt(val orderId: Long) : WooPosNavigationEvent()
     data class OpenRefundReason(val orderId: Long, val initialReason: String = "") : WooPosNavigationEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.root.navigation
 import androidx.activity.ComponentActivity
 import androidx.navigation.NavHostController
 import com.woocommerce.android.ui.woopos.bookings.navigateToBookingsScreen
+import com.woocommerce.android.ui.woopos.cardpayment.navigateToCardPaymentScreen
 import com.woocommerce.android.ui.woopos.cashpayment.navigateToCashPaymentScreen
 import com.woocommerce.android.ui.woopos.emailreceipt.navigateToEmailReceipt
 import com.woocommerce.android.ui.woopos.home.navigateToEligibilityScreen
@@ -26,6 +27,9 @@ fun NavHostController.handleNavigationEvent(
 
         is WooPosNavigationEvent.OpenHomeFromSplash -> navigateToHomeScreen()
         is WooPosNavigationEvent.OpenCashPayment -> navigateToCashPaymentScreen(event.orderId, event.source)
+
+        is WooPosNavigationEvent.OpenCardPayment ->
+            navigateToCardPaymentScreen(event.orderId, event.source)
 
         is WooPosNavigationEvent.GoBackWithResult -> {
             previousBackStackEntry

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3780,6 +3780,8 @@
     <string name="woo_pos_payment_failed_try_again">Try payment again</string>
     <string name="woo_pos_payment_failed_go_back_to_checkout">Go back to checkout</string>
 
+    <string name="woopos_card_payment_done_button">Done</string>
+
     <string name="woopos_floating_toolbar_overlay_menu_content_description">Dimmed background. Tap to close the menu.</string>
     <string name="woopos_floating_toolbar_card_reader_connected_status_content_description">Card reader connected</string>
     <string name="woopos_floating_toolbar_card_reader_not_connected_status_content_description">Card reader not connected. Double tap to connect</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.bookings
 import app.cash.turbine.test
 import com.woocommerce.android.ui.bookings.list.BookingListHandler
 import com.woocommerce.android.ui.bookings.list.BookingListSortOption
+import com.woocommerce.android.ui.woopos.cardpayment.CardPaymentSource
 import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
@@ -575,6 +576,47 @@ class WooPosBookingsViewModelTest {
             viewModel.navigationEvent.test {
                 // WHEN
                 viewModel.onUIEvent(WooPosBookingsUIEvent.PayByCashClicked)
+
+                // THEN
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `given selected booking, when PayByCardClicked, then navigation event emitted with correct orderId and BOOKINGS source`() =
+        runTest {
+            // GIVEN
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.navigationEvent.test {
+                // WHEN
+                viewModel.onUIEvent(WooPosBookingsUIEvent.PayByCardClicked)
+
+                // THEN
+                val event = awaitItem()
+                assertThat(event).isInstanceOf(WooPosNavigationEvent.OpenCardPayment::class.java)
+                val cardEvent = event as WooPosNavigationEvent.OpenCardPayment
+                assertThat(cardEvent.orderId).isEqualTo(10L)
+                assertThat(cardEvent.source).isEqualTo(CardPaymentSource.BOOKINGS)
+            }
+        }
+
+    @Test
+    fun `given no selected booking, when PayByCardClicked, then no navigation event emitted`() =
+        runTest {
+            // GIVEN
+            whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
+            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+                .thenReturn(Result.failure(RuntimeException("error")))
+
+            viewModel = createViewModel()
+            advanceUntilIdle()
+            assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Error::class.java)
+
+            viewModel.navigationEvent.test {
+                // WHEN
+                viewModel.onUIEvent(WooPosBookingsUIEvent.PayByCardClicked)
 
                 // THEN
                 expectNoEvents()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -32,6 +32,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
+import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooPosCardPaymentViewModelTest {
@@ -71,10 +72,8 @@ class WooPosCardPaymentViewModelTest {
 
     @Before
     fun setUp() = runTest {
-        val mockOrder = mock<Order> {
-            on { total }.thenReturn(BigDecimal("50.00"))
-        }
-        whenever(totalsRepository.getOrderById(any())).thenReturn(mockOrder)
+        val order = Order.getEmptyOrder(Date(), Date()).copy(total = BigDecimal("50.00"))
+        whenever(totalsRepository.getOrderById(any())).thenReturn(order)
         whenever(priceFormat(any<BigDecimal>())).thenReturn("$50.00")
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -1,0 +1,323 @@
+package com.woocommerce.android.ui.woopos.cardpayment
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.woocommerce.android.cardreader.connection.CardReader
+import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.payments.cardreader.payment.PaymentFlowError
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.home.totals.WooPosCardReaderPaymentControllerFactory
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsRepository
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.util.UiStringParser
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosCardPaymentViewModelTest {
+
+    @Rule
+    @JvmField
+    val coroutineTestRule = WooPosCoroutineTestRule()
+
+    private val readerStatusFlow = MutableStateFlow<CardReaderStatus>(CardReaderStatus.Connected(mock<CardReader>()))
+    private val cardReaderFacade: WooPosCardReaderFacade = mock {
+        on { readerStatus }.thenReturn(readerStatusFlow)
+    }
+    private val controllerPaymentState =
+        MutableStateFlow<CardReaderPaymentState>(CardReaderPaymentState.LoadingData { })
+    private val controllerEventFlow = MutableSharedFlow<CardReaderPaymentEvent>()
+    private val paymentController: CardReaderPaymentController = mock {
+        on { paymentState }.thenReturn(controllerPaymentState)
+        on { event }.thenReturn(controllerEventFlow)
+    }
+    private val cardReaderPaymentControllerFactory: WooPosCardReaderPaymentControllerFactory = mock {
+        on { create(any(), any(), any()) }.thenReturn(paymentController)
+    }
+    private val networkStatus: WooPosNetworkStatus = mock {
+        on { isConnected() }.thenReturn(true)
+    }
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) }.thenReturn("test string")
+        on { getString(any(), any()) }.thenReturn("test string with arg")
+    }
+    private val uiStringParser: UiStringParser = mock {
+        on { asString(any()) }.thenReturn("parsed error")
+    }
+    private val priceFormat: WooPosFormatPrice = mock()
+    private val totalsRepository: WooPosTotalsRepository = mock()
+
+    private lateinit var viewModel: WooPosCardPaymentViewModel
+
+    @Before
+    fun setUp() = runTest {
+        val mockOrder = mock<Order> {
+            on { total }.thenReturn(BigDecimal("50.00"))
+        }
+        whenever(totalsRepository.getOrderById(any())).thenReturn(mockOrder)
+        whenever(priceFormat(any<BigDecimal>())).thenReturn("$50.00")
+    }
+
+    private fun createViewModel(
+        orderId: Long = 100L,
+        source: CardPaymentSource = CardPaymentSource.BOOKINGS,
+    ): WooPosCardPaymentViewModel {
+        val savedStateHandle = SavedStateHandle(
+            mapOf(
+                CARD_PAYMENT_ROUTE_ORDER_ID_KEY to orderId,
+                CARD_PAYMENT_ROUTE_SOURCE_KEY to source.name,
+            )
+        )
+        return WooPosCardPaymentViewModel(
+            savedState = savedStateHandle,
+            cardReaderPaymentControllerFactory = cardReaderPaymentControllerFactory,
+            cardReaderFacade = cardReaderFacade,
+            networkStatus = networkStatus,
+            resourceProvider = resourceProvider,
+            uiStringParser = uiStringParser,
+            priceFormat = priceFormat,
+            totalsRepository = totalsRepository,
+        )
+    }
+
+    @Test
+    fun `given connected reader, when init, then state is Collecting Preparing`() = runTest {
+        controllerPaymentState.value = CardReaderPaymentState.LoadingData { }
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value).isInstanceOf(WooPosCardPaymentState.Collecting.Preparing::class.java)
+    }
+
+    @Test
+    fun `given connected reader, when controller emits CollectingPayment, then state is Collecting ReadyForPayment`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.CollectingPayment
+            .ExternalReaderCollectPaymentState(
+                amountWithCurrencyLabel = "$50.00",
+                onCancel = {}
+            )
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.Collecting.ReadyForPayment::class.java)
+    }
+
+    @Test
+    fun `given connected reader, when controller emits ProcessingPayment, then state is PaymentInProgress`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.ProcessingPayment
+            .ExternalReaderProcessingPayment(
+                amountWithCurrencyLabel = "$50.00",
+                onCancel = {}
+            )
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentInProgress::class.java)
+    }
+
+    @Test
+    fun `given connected reader, when controller emits PaymentSuccessful, then state is PaymentSuccess`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.PaymentSuccessful
+            .ExternalReaderPaymentSuccessful(
+                amountWithCurrencyLabel = "$50.00",
+                onPrintReceiptClicked = {},
+                onSendReceiptClicked = {},
+                onSaveUserClicked = {}
+            )
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentSuccess::class.java)
+    }
+
+    @Test
+    fun `given connected reader, when controller emits PaymentFailed with retry, then state is PaymentFailed with isDismissButtonVisible true`() =
+        runTest {
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            controllerPaymentState.value = CardReaderPaymentState.PaymentFailed
+                .ExternalReaderFailedPayment.Cancelable(
+                    errorType = PaymentFlowError.Generic,
+                    amountWithCurrencyLabel = "$50.00",
+                    onCancel = {},
+                    onRetry = {},
+                )
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertThat(state).isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
+            assertThat((state as WooPosCardPaymentState.PaymentFailed).isDismissButtonVisible).isTrue()
+        }
+
+    @Test
+    fun `given connected reader, when controller emits PaymentFailed without retry, then state is PaymentFailed`() =
+        runTest {
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            controllerPaymentState.value = CardReaderPaymentState.PaymentFailed
+                .ExternalReaderFailedPayment.NonCancelable(
+                    errorType = PaymentFlowError.Generic,
+                    onRetry = {},
+                )
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertThat(state).isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
+        }
+
+    @Test
+    fun `given disconnected reader, when init, then state is Collecting ReaderDisconnected`() = runTest {
+        readerStatusFlow.value = CardReaderStatus.NotConnected()
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.Collecting.ReaderDisconnected::class.java)
+    }
+
+    @Test
+    fun `given disconnected reader, when onConnectReaderClicked, then connectToReader called`() = runTest {
+        readerStatusFlow.value = CardReaderStatus.NotConnected()
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onConnectReaderClicked()
+
+        verify(cardReaderFacade).connectToReader()
+    }
+
+    @Test
+    fun `given processing state, when onBackClicked, then no GoBack emitted`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.ProcessingPayment
+            .ExternalReaderProcessingPayment(
+                amountWithCurrencyLabel = "$50.00",
+                onCancel = {}
+            )
+        advanceUntilIdle()
+
+        viewModel.navigationEvent.test {
+            viewModel.onBackClicked()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `given collecting state, when onBackClicked, then GoBack emitted`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.navigationEvent.test {
+            viewModel.onBackClicked()
+
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(WooPosNavigationEvent.GoBack::class.java)
+        }
+    }
+
+    @Test
+    fun `given BOOKINGS source, when onDoneClicked, then GoBackWithResult emitted`() = runTest {
+        viewModel = createViewModel(source = CardPaymentSource.BOOKINGS)
+        advanceUntilIdle()
+
+        viewModel.navigationEvent.test {
+            viewModel.onDoneClicked()
+
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(WooPosNavigationEvent.GoBackWithResult::class.java)
+            val resultEvent = event as WooPosNavigationEvent.GoBackWithResult
+            assertThat(resultEvent.key).isEqualTo(BOOKING_CARD_PAYMENT_SUCCESS_KEY)
+            assertThat(resultEvent.value).isEqualTo(true)
+        }
+    }
+
+    @Test
+    fun `given CHECKOUT source, when onDoneClicked, then GoBack emitted`() = runTest {
+        viewModel = createViewModel(source = CardPaymentSource.CHECKOUT)
+        advanceUntilIdle()
+
+        viewModel.navigationEvent.test {
+            viewModel.onDoneClicked()
+
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(WooPosNavigationEvent.GoBack::class.java)
+        }
+    }
+
+    @Test
+    fun `when onEmailReceiptClicked, then OpenEmailReceipt emitted`() = runTest {
+        viewModel = createViewModel(orderId = 42L)
+        advanceUntilIdle()
+
+        viewModel.navigationEvent.test {
+            viewModel.onEmailReceiptClicked()
+
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(WooPosNavigationEvent.OpenEmailReceipt::class.java)
+            assertThat((event as WooPosNavigationEvent.OpenEmailReceipt).orderId).isEqualTo(42L)
+        }
+    }
+
+    @Test
+    fun `given no network, when init, then state is PaymentFailed`() = runTest {
+        whenever(networkStatus.isConnected()).thenReturn(false)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
+    }
+
+    @Test
+    fun `given controller emits ShowErrorMessage, when collecting, then state is PaymentFailed`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerEventFlow.emit(
+            CardReaderPaymentEvent.ShowErrorMessage(
+                com.woocommerce.android.R.string.card_reader_payment_order_paid_payment_cancelled
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
+    }
+}


### PR DESCRIPTION
WOOMOB-2196 Part 2

## Summary
- Adds a reusable, independent card payment flow — ViewModel, state, and navigation — that can be triggered from both checkout and bookings
- Wires up bookings to launch card payment and refresh after success
- Includes a dummy screen to show the payment state (full UI in [CIAB: POS] Card-present booking checkout. Part-3: Full screen UI and bookings integration #15329)

💡 Don't merge until parent branch is `trunk`
👉 Parent PR: [CIAB: POS] Card-present booking checkout. Part-1 #15326

## Test plan
- [ ] Run `WooPosCardPaymentViewModelTest` — all tests should pass
- [ ] Run `WooPosBookingsViewModelTest` — all tests should pass (includes PayByCard tests)
- [ ] Verify the stub screen renders the state as text when navigating to card payment
- [ ] Verify navigation to/from card payment screen works correctly
- [ ] Navigate to card payment from bookings and verify the bookings list refreshes on success

## Images/gif
https://github.com/user-attachments/assets/b1a097ef-9d34-46d8-9ad9-9f32719ca4a7

- [x]  I have considered if this change warrants release notes and have added them to RELEASE-NOTES.txt if necessary. Use the "[Internal]" label for non-user-facing changes.