### PR TITLE
[CIAB] Enable WooPayments for CIAB sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
@@ -6,12 +6,14 @@ import javax.inject.Inject
 
 class CIABSiteGateKeeper @Inject constructor(private val selectedSite: SelectedSite) {
     fun isFeatureSupported(
-        @Suppress("unused")
         feature: CIABAffectedFeature
     ): Boolean {
-        // For now, all affected features are unsupported in CIAB.
-        // If there are exceptions in the future, we can handle them here.
-        return !isCurrentSiteCIAB()
+        if (!isCurrentSiteCIAB()) return true
+
+        return when (feature) {
+            CIABAffectedFeature.WooPayments -> true
+            else -> false
+        }
     }
 
     fun isFeatureUnsupported(feature: CIABAffectedFeature): Boolean {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeperTest.kt
@@ -16,13 +16,24 @@ class CIABSiteGateKeeperTest : BaseUnitTest() {
     private val ciabSiteGateKeeper = CIABSiteGateKeeper(selectedSite)
 
     @Test
-    fun `given current site is CIAB, when checking feature support, then feature is unsupported`() {
+    fun `given current site is CIAB, when checking unsupported feature, then feature is unsupported`() {
         val site = createSite(isCIAB = true)
         given(selectedSite.getOrNull()).willReturn(site)
 
-        CIABAffectedFeature.entries.forEach {
+        val unsupportedFeatures = CIABAffectedFeature.entries.filter {
+            it != CIABAffectedFeature.WooPayments
+        }
+        unsupportedFeatures.forEach {
             assertFalse(ciabSiteGateKeeper.isFeatureSupported(it))
         }
+    }
+
+    @Test
+    fun `given current site is CIAB, when checking WooPayments support, then feature is supported`() {
+        val site = createSite(isCIAB = true)
+        given(selectedSite.getOrNull()).willReturn(site)
+
+        assertTrue(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooPayments))
     }
 
     @Test


### PR DESCRIPTION
Closes WOOMOB-2169

### Description
This pull request updates the CIAB feature gating logic to make sure WooPayments (IPP and other features) are enabled for CIAB sites.

### Test Steps
1. Use a physical device (to confirm the visibility of TTP).
2. Sign in to a CIAB site.
3. Open the More Menu screen, confirm that the payments option is visible.
4. Open an order and tap on Collect Payment.
5. Confirm that card reader and TTP options are shown.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
