### PR TITLE
[CIAB MVP] Rearrange bookings and POS entry points

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -483,6 +483,7 @@ class AnalyticsTracker private constructor(
 
         // -- More Menu (aka Hub Menu) option values
         const val VALUE_MORE_MENU_VIEW_STORE = "view_store"
+        const val VALUE_MORE_MENU_BOOKINGS = "bookings"
         const val VALUE_MORE_MENU_ADMIN_MENU = "admin_menu"
         const val VALUE_MORE_MENU_REVIEWS = "reviews"
         const val VALUE_MORE_MENU_INBOX = "inbox"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
@@ -6,12 +6,14 @@ import javax.inject.Inject
 
 class CIABSiteGateKeeper @Inject constructor(private val selectedSite: SelectedSite) {
     fun isFeatureSupported(
-        @Suppress("unused")
         feature: CIABAffectedFeature
     ): Boolean {
-        // For now, all affected features are unsupported in CIAB.
-        // If there are exceptions in the future, we can handle them here.
-        return !isCurrentSiteCIAB()
+        if (!isCurrentSiteCIAB()) return true
+
+        return when (feature) {
+            CIABAffectedFeature.POS -> true
+            else -> false
+        }
     }
 
     fun isFeatureUnsupported(feature: CIABAffectedFeature): Boolean {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/base/TopLevelFragment.kt
@@ -19,6 +19,9 @@ abstract class TopLevelFragment : BaseFragment, TopLevelFragmentView {
             hasShadow = false,
         )
 
+    open val shouldShowBottomNavigation: Boolean
+        get() = true
+
     /**
      * Called when the fragment shows or hides a search view so we can properly disable the collapsing
      * toolbar when a search is active

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -56,13 +56,13 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
             ).toBundle()
         )
     override val activityAppBarStatus: AppBarStatus
-        get() = if (navArgs.launchedFromMoreMenu) {
-            AppBarStatus.Visible(hasShadow = false, hasDivider = true)
-        } else {
+        get() = if (navArgs.showBottomNavigation) {
             AppBarStatus.Hidden
+        } else {
+            AppBarStatus.Visible(hasShadow = false, hasDivider = true)
         }
     override val shouldShowBottomNavigation: Boolean
-        get() = !navArgs.launchedFromMoreMenu
+        get() = navArgs.showBottomNavigation
 
     private val viewModel: BookingListViewModel by viewModels()
     private val navArgs: BookingsArgs by navArgs()
@@ -155,7 +155,7 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
 
     private fun handleBottomNavigationVisibility() {
         viewModel.bottomNavigationVisible.observe(viewLifecycleOwner) { isVisible ->
-            if (navArgs.launchedFromMoreMenu || !isVisible) {
+            if (!navArgs.showBottomNavigation || !isVisible) {
                 (activity as? MainActivity)?.hideBottomNav()
             } else {
                 (activity as? MainActivity)?.showBottomNav()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -10,6 +10,8 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.woocommerce.android.BookingsArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentBookingListBinding
 import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
@@ -54,9 +56,16 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
             ).toBundle()
         )
     override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Hidden
+        get() = if (navArgs.launchedFromMoreMenu) {
+            AppBarStatus.Visible(hasShadow = false, hasDivider = true)
+        } else {
+            AppBarStatus.Hidden
+        }
+    override val shouldShowBottomNavigation: Boolean
+        get() = !navArgs.launchedFromMoreMenu
 
     private val viewModel: BookingListViewModel by viewModels()
+    private val navArgs: BookingsArgs by navArgs()
     private val bookingsCommunicationViewModel: BookingsCommunicationViewModel by activityViewModels()
 
     @Inject
@@ -146,7 +155,7 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
 
     private fun handleBottomNavigationVisibility() {
         viewModel.bottomNavigationVisible.observe(viewLifecycleOwner) { isVisible ->
-            if (!isVisible) {
+            if (navArgs.launchedFromMoreMenu || !isVisible) {
                 (activity as? MainActivity)?.hideBottomNav()
             } else {
                 (activity as? MainActivity)?.showBottomNav()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/BookingsTabController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/BookingsTabController.kt
@@ -2,14 +2,15 @@ package com.woocommerce.android.ui.bookings.tab
 
 import androidx.lifecycle.lifecycleScope
 import com.woocommerce.android.databinding.ActivityMainBinding
-import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.ui.main.BottomNavigationPosition
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.ui.woopos.tab.WooPosTabShouldBeVisible
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class BookingsTabController @Inject constructor(
-    private val observeBookingsVisibility: ObserveBookingsVisibility
+    private val observeBookingsVisibility: ObserveBookingsVisibility,
+    private val shouldPosTabBeVisible: WooPosTabShouldBeVisible
 ) {
     private lateinit var activity: MainActivity
     private lateinit var binding: ActivityMainBinding
@@ -27,15 +28,12 @@ class BookingsTabController @Inject constructor(
     }
 
     private fun checkBookingsTabVisibility() {
-        // On large screens, Bookings is accessible from the More Menu instead of a bottom tab.
-        if (activity.isTwoPanesShouldBeUsed) {
-            return
-        }
-
         activity.lifecycleScope.launch {
+            val isPosVisible = shouldPosTabBeVisible().getOrDefault(false)
             observeBookingsVisibility()
                 .collect { isVisible ->
-                    binding.bottomNav.menu.findItem(BottomNavigationPosition.BOOKINGS.id)?.isVisible = isVisible
+                    binding.bottomNav.menu.findItem(BottomNavigationPosition.BOOKINGS.id)?.isVisible =
+                        isVisible && !isPosVisible
                 }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/BookingsTabController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/BookingsTabController.kt
@@ -2,13 +2,14 @@ package com.woocommerce.android.ui.bookings.tab
 
 import androidx.lifecycle.lifecycleScope
 import com.woocommerce.android.databinding.ActivityMainBinding
+import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.ui.main.BottomNavigationPosition
 import com.woocommerce.android.ui.main.MainActivity
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class BookingsTabController @Inject constructor(
-    private val observeBookingsTabVisibility: ObserveBookingsTabVisibility
+    private val observeBookingsVisibility: ObserveBookingsVisibility
 ) {
     private lateinit var activity: MainActivity
     private lateinit var binding: ActivityMainBinding
@@ -19,12 +20,20 @@ class BookingsTabController @Inject constructor(
     ) {
         this.activity = activity
         this.binding = binding
+
+        binding.bottomNav.menu.findItem(BottomNavigationPosition.BOOKINGS.id)?.isVisible = false
+
         checkBookingsTabVisibility()
     }
 
     private fun checkBookingsTabVisibility() {
+        // On large screens, Bookings is accessible from the More Menu instead of a bottom tab.
+        if (activity.isTwoPanesShouldBeUsed) {
+            return
+        }
+
         activity.lifecycleScope.launch {
-            observeBookingsTabVisibility()
+            observeBookingsVisibility()
                 .collect { isVisible ->
                     binding.bottomNav.menu.findItem(BottomNavigationPosition.BOOKINGS.id)?.isVisible = isVisible
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibility.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibility.kt
@@ -27,7 +27,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsOrderO
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import javax.inject.Inject
 
-class ObserveBookingsTabVisibility @Inject constructor(
+class ObserveBookingsVisibility @Inject constructor(
     private val productListRepository: ProductListRepository,
     private val bookingsRepository: BookingsRepository,
     private val selectedSite: SelectedSite,
@@ -39,10 +39,10 @@ class ObserveBookingsTabVisibility @Inject constructor(
         selectedSite.observe()
             .filterNotNull()
             .flatMapLatest { siteModel ->
-                observeBookingTabVisibility(siteModel)
+                observeBookingsVisibilityForSite(siteModel)
             }
 
-    private fun observeBookingTabVisibility(siteModel: SiteModel): Flow<Boolean> = flow {
+    private fun observeBookingsVisibilityForSite(siteModel: SiteModel): Flow<Boolean> = flow {
         val isCIABSite = FeatureFlag.BOOKINGS_MVP.isEnabled() && siteModel.isCIABSite()
         if (!isCIABSite) {
             emit(false)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -253,13 +253,14 @@ class MainActivity :
         private fun updateAppBarAndBottomNav(f: Fragment) {
             if (f is DialogFragment) return
             lastFragment = WeakReference(f)
+            val shouldShowBottomNavigation = (f as? TopLevelFragment)?.shouldShowBottomNavigation ?: false
 
             when (val appBarStatus = (f as? BaseFragment)?.activityAppBarStatus ?: AppBarStatus.Visible()) {
                 is AppBarStatus.Visible -> {
                     showToolbar()
                     // re-expand the AppBar when returning to top level fragment,
                     // collapse it when entering a child fragment
-                    if (f is TopLevelFragment) {
+                    if (f is TopLevelFragment && shouldShowBottomNavigation) {
                         // Post this to the view handler to make sure shouldExpandToolbar returns the correct value
                         f.view?.post {
                             if (f.view != null) {
@@ -289,7 +290,7 @@ class MainActivity :
                 }
             }
 
-            if (f is TopLevelFragment) {
+            if (shouldShowBottomNavigation) {
                 showBottomNav()
             } else {
                 hideBottomNav()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainBottomNavigationView.kt
@@ -116,7 +116,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
      */
     fun restoreSelectedItemState(itemId: Int) {
         assignNavigationListeners(false)
-        selectedItemId = itemId
+        selectedItemId = if (menu.findItem(itemId) != null) itemId else BottomNavigationPosition.MY_STORE.id
         assignNavigationListeners(true)
     }
 
@@ -162,9 +162,7 @@ class MainBottomNavigationView @JvmOverloads constructor(
      * adding or removing tabs based on the user's site type/configuration. However, there shouldn't be any
      * scenario where we end up displaying more than 5 tabs at once.
      */
-    override fun getMaxItemCount(): Int {
-        return OVERRIDEN_MAX_ITEM_COUNT
-    }
+    override fun getMaxItemCount(): Int = OVERRIDDEN_MAX_ITEM_COUNT
 
     private fun assignNavigationListeners(assign: Boolean) {
         setOnItemSelectedListener(if (assign) this else null)
@@ -176,6 +174,6 @@ class MainBottomNavigationView @JvmOverloads constructor(
 
     companion object {
         private const val MAX_CHARACTERS_IN_BADGE = 4
-        private const val OVERRIDEN_MAX_ITEM_COUNT = 6
+        private const val OVERRIDDEN_MAX_ITEM_COUNT = 6
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -12,6 +12,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleNotice
+import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.TopLevelFragment
@@ -92,6 +93,7 @@ class MoreMenuFragment : TopLevelFragment() {
     override fun onResume() {
         super.onResume()
 
+        viewModel.onWindowClassChanged(requireContext().isTwoPanesShouldBeUsed)
         viewModel.onViewResumed()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -28,6 +28,7 @@ import com.woocommerce.android.ui.moremenu.MoreMenuEvent.NavigateToSubscriptions
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.OpenBlazeCampaignCreationEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.OpenBlazeCampaignListEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.StartSitePickerEvent
+import com.woocommerce.android.ui.moremenu.MoreMenuEvent.ViewBookingsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.ViewCouponsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.ViewCustomersEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.ViewGoogleForWooEvent
@@ -99,6 +100,7 @@ class MoreMenuFragment : TopLevelFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is NavigateToSettingsEvent -> navigateToSettings()
+                is ViewBookingsEvent -> navigateToBookings()
                 is NavigateToSubscriptionsEvent -> navigateToSubscriptions()
                 is StartSitePickerEvent -> startSitePicker()
                 is ViewGoogleForWooEvent -> openGoogleAdsWebview(event.url, event.isCreationFlow)
@@ -183,6 +185,12 @@ class MoreMenuFragment : TopLevelFragment() {
     private fun navigateToCustomers() {
         findNavController().navigateSafely(
             MoreMenuFragmentDirections.actionMoreMenuToCustomerListFragment()
+        )
+    }
+
+    private fun navigateToBookings() {
+        findNavController().navigateSafely(
+            MoreMenuFragmentDirections.actionMoreMenuToBookings()
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuState.kt
@@ -18,6 +18,7 @@ data class MoreMenuViewState(
 
 sealed class MoreMenuEvent : MultiLiveEvent.Event() {
     data object NavigateToSettingsEvent : MoreMenuEvent()
+    data object ViewBookingsEvent : MoreMenuEvent()
     data object NavigateToSubscriptionsEvent : MoreMenuEvent()
     data object StartSitePickerEvent : MoreMenuEvent()
     data object ViewPayments : MoreMenuEvent()
@@ -51,7 +52,7 @@ data class MoreMenuItemButton(
     }
 
     enum class Type {
-        Blaze, GoogleForWoo, Inbox, Settings, Payments
+        Blaze, GoogleForWoo, Inbox, Settings, Payments, Bookings
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -38,15 +38,17 @@ import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.taptopay.isAvailable
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
-import com.woocommerce.android.util.IsWindowClassLargeThanCompact
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -77,16 +79,19 @@ class MoreMenuViewModel @Inject constructor(
     private val isGoogleForWooEnabled: IsGoogleForWooEnabled,
     private val hasGoogleAdsCampaigns: HasGoogleAdsCampaigns,
     observeBookingsVisibility: ObserveBookingsVisibility,
-    isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val ciabSiteGateKeeper: CIABSiteGateKeeper,
 ) : ScopedViewModel(savedState) {
     private var storeHasGoogleAdsCampaigns = false
-    private val shouldShowBookingsInMenu = isWindowClassLargeThanCompact()
-    private val bookingsVisibilityFlow = if (shouldShowBookingsInMenu) {
-        observeBookingsVisibility()
-    } else {
-        flowOf(false)
+    private val shouldShowBookingsInMenu = MutableStateFlow(false)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val bookingsVisibilityFlow = shouldShowBookingsInMenu.flatMapLatest { shouldShow ->
+        if (shouldShow) {
+            observeBookingsVisibility()
+        } else {
+            flowOf(false)
+        }
     }
 
     val moreMenuViewState =
@@ -147,6 +152,10 @@ class MoreMenuViewModel @Inject constructor(
             trackBlazeDisplayed()
             trackGoogleAdsDisplayed()
         }
+    }
+
+    fun onWindowClassChanged(isLargeThanCompact: Boolean) {
+        shouldShowBookingsInMenu.value = isLargeThanCompact
     }
 
     @Suppress("LongMethod")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_DISPLA
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_OPTION
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_ADMIN_MENU
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_BOOKINGS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_COUPONS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_CUSTOMERS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_INBOX
@@ -29,6 +30,7 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.blaze.BlazeUrlsHelper.BlazeFlowSource
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
+import com.woocommerce.android.ui.bookings.tab.ObserveBookingsVisibility
 import com.woocommerce.android.ui.google.HasGoogleAdsCampaigns
 import com.woocommerce.android.ui.google.IsGoogleForWooEnabled
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
@@ -36,6 +38,7 @@ import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.taptopay.isAvailable
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
+import com.woocommerce.android.util.IsWindowClassLargeThanCompact
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -45,6 +48,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
@@ -72,10 +76,18 @@ class MoreMenuViewModel @Inject constructor(
     private val isBlazeEnabled: IsBlazeEnabled,
     private val isGoogleForWooEnabled: IsGoogleForWooEnabled,
     private val hasGoogleAdsCampaigns: HasGoogleAdsCampaigns,
+    observeBookingsVisibility: ObserveBookingsVisibility,
+    isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val ciabSiteGateKeeper: CIABSiteGateKeeper,
 ) : ScopedViewModel(savedState) {
     private var storeHasGoogleAdsCampaigns = false
+    private val shouldShowBookingsInMenu = isWindowClassLargeThanCompact()
+    private val bookingsVisibilityFlow = if (shouldShowBookingsInMenu) {
+        observeBookingsVisibility()
+    } else {
+        flowOf(false)
+    }
 
     val moreMenuViewState =
         combine(
@@ -89,7 +101,7 @@ class MoreMenuViewModel @Inject constructor(
                 menuSections = generateAllSections(
                     moreMenuButtonStatus,
                     count,
-                    paymentsFeatureWasClicked
+                    paymentsFeatureWasClicked,
                 ).map { section ->
                     section.copy(
                         items = section.items.filter { it.state != MoreMenuItemButton.State.Hidden }
@@ -124,7 +136,8 @@ class MoreMenuViewModel @Inject constructor(
             googleForWooState = buttonsStates[MoreMenuItemButton.Type.GoogleForWoo]!!,
             blazeState = buttonsStates[MoreMenuItemButton.Type.Blaze]!!,
             inboxState = buttonsStates[MoreMenuItemButton.Type.Inbox]!!,
-            paymentsState = buttonsStates[MoreMenuItemButton.Type.Payments]!!
+            paymentsState = buttonsStates[MoreMenuItemButton.Type.Payments]!!,
+            bookingsButtonState = buttonsStates[MoreMenuItemButton.Type.Bookings]!!,
         )
     )
 
@@ -143,7 +156,8 @@ class MoreMenuViewModel @Inject constructor(
         googleForWooState: MoreMenuItemButton.State,
         blazeState: MoreMenuItemButton.State,
         inboxState: MoreMenuItemButton.State,
-        paymentsState: MoreMenuItemButton.State
+        paymentsState: MoreMenuItemButton.State,
+        bookingsButtonState: MoreMenuItemButton.State,
     ) = MoreMenuItemSection(
         title = R.string.more_menu_general_section_title,
         items = listOf(
@@ -154,6 +168,13 @@ class MoreMenuViewModel @Inject constructor(
                 badgeState = buildPaymentsBadgeState(paymentsFeatureWasClicked),
                 onClick = ::onPaymentsButtonClick,
                 state = paymentsState
+            ),
+            MoreMenuItemButton(
+                title = R.string.bookings_tab_title,
+                description = R.string.more_menu_button_bookings_description,
+                icon = R.drawable.ic_bookings_tab,
+                onClick = ::onBookingsButtonClick,
+                state = bookingsButtonState,
             ),
             MoreMenuItemButton(
                 title = R.string.more_menu_button_google,
@@ -310,6 +331,11 @@ class MoreMenuViewModel @Inject constructor(
         triggerEvent(MoreMenuEvent.ViewPayments)
     }
 
+    private fun onBookingsButtonClick() {
+        trackMoreMenuOptionSelected(VALUE_MORE_MENU_BOOKINGS)
+        triggerEvent(MoreMenuEvent.ViewBookingsEvent)
+    }
+
     private fun onPromoteProductsWithGoogle() {
         launch {
             val urlToOpen = determineUrlToOpen()
@@ -459,6 +485,13 @@ class MoreMenuViewModel @Inject constructor(
         }.toMutableMap()
 
         return listOf(
+            bookingsVisibilityFlow.map { isVisible ->
+                MoreMenuItemButton.Type.Bookings to if (isVisible) {
+                    MoreMenuItemButton.State.Visible
+                } else {
+                    MoreMenuItemButton.State.Hidden
+                }
+            },
             doCheckAvailability(MoreMenuItemButton.Type.Blaze) { isBlazeEnabled() },
             doCheckAvailability(MoreMenuItemButton.Type.GoogleForWoo) { isGoogleForWooEnabled() },
             doCheckAvailability(MoreMenuItemButton.Type.Inbox) { moreMenuRepository.isInboxEnabled() },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -482,7 +482,9 @@ class MoreMenuViewModel @Inject constructor(
     private fun checkFeaturesAvailability(): Flow<Map<MoreMenuItemButton.Type, MoreMenuItemButton.State>> {
         val initialState = MoreMenuItemButton.Type.entries.associateWith {
             MoreMenuItemButton.State.Loading
-        }.toMutableMap()
+        }.toMutableMap().apply {
+            this[MoreMenuItemButton.Type.Bookings] = MoreMenuItemButton.State.Hidden
+        }
 
         return listOf(
             bookingsVisibilityFlow.map { isVisible ->

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
@@ -3,6 +3,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/bookings"
     app:startDestination="@id/bookingListFragment">
+    <argument
+        android:name="launchedFromMoreMenu"
+        android:defaultValue="false"
+        app:argType="boolean" />
 
     <include app:graph="@navigation/nav_graph_bookings_details" />
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings.xml
@@ -4,8 +4,8 @@
     android:id="@+id/bookings"
     app:startDestination="@id/bookingListFragment">
     <argument
-        android:name="launchedFromMoreMenu"
-        android:defaultValue="false"
+        android:name="showBottomNavigation"
+        android:defaultValue="true"
         app:argType="boolean" />
 
     <include app:graph="@navigation/nav_graph_bookings_details" />

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -325,6 +325,14 @@
         <action
             android:id="@+id/action_moreMenu_to_customerListFragment"
             app:destination="@id/menuCustomerListFragment" />
+        <action
+            android:id="@+id/action_moreMenu_to_bookings"
+            app:destination="@id/bookings">
+            <argument
+                android:name="launchedFromMoreMenu"
+                android:defaultValue="true"
+                app:argType="boolean" />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/feedbackSurveyFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -329,8 +329,8 @@
             android:id="@+id/action_moreMenu_to_bookings"
             app:destination="@id/bookings">
             <argument
-                android:name="launchedFromMoreMenu"
-                android:defaultValue="true"
+                android:name="showBottomNavigation"
+                android:defaultValue="false"
                 app:argType="boolean" />
         </action>
     </fragment>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3146,6 +3146,8 @@
     <string name="more_menu_button_payments">Payments</string>
     <string name="more_menu_button_payments_description">Take payments on the go</string>
 
+    <string name="more_menu_button_bookings_description">Manage your client appointments</string>
+
     <string name="more_menu_button_google">Google for WooCommerce</string>
     <string name="more_menu_button_google_description">Drive sales and generate more traffic with Google Ads</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeperTest.kt
@@ -16,13 +16,23 @@ class CIABSiteGateKeeperTest : BaseUnitTest() {
     private val ciabSiteGateKeeper = CIABSiteGateKeeper(selectedSite)
 
     @Test
-    fun `given current site is CIAB, when checking feature support, then feature is unsupported`() {
+    fun `given current site is CIAB, when checking POS support, then feature is supported`() {
         val site = createSite(isCIAB = true)
         given(selectedSite.getOrNull()).willReturn(site)
 
-        CIABAffectedFeature.entries.forEach {
-            assertFalse(ciabSiteGateKeeper.isFeatureSupported(it))
-        }
+        assertTrue(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.POS))
+    }
+
+    @Test
+    fun `given current site is CIAB, when checking non POS feature support, then feature is unsupported`() {
+        val site = createSite(isCIAB = true)
+        given(selectedSite.getOrNull()).willReturn(site)
+
+        CIABAffectedFeature.entries
+            .filterNot { it == CIABAffectedFeature.POS }
+            .forEach {
+                assertFalse(ciabSiteGateKeeper.isFeatureSupported(it))
+            }
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibilityTest.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class ObserveBookingsTabVisibilityTest : BaseUnitTest() {
+class ObserveBookingsVisibilityTest : BaseUnitTest() {
     private val testScope = TestScope(coroutinesTestRule.testDispatcher)
     private val selectedSite: SelectedSite = mock()
     private val selectedSiteFlow = MutableStateFlow<SiteModel?>(null)
@@ -49,12 +49,12 @@ class ObserveBookingsTabVisibilityTest : BaseUnitTest() {
         }.thenReturn(bookingsCountFlow)
     }
 
-    private lateinit var sut: ObserveBookingsTabVisibility
+    private lateinit var sut: ObserveBookingsVisibility
 
     suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
         prepareMocks()
         whenever(selectedSite.observe()).thenReturn(selectedSiteFlow)
-        sut = ObserveBookingsTabVisibility(
+        sut = ObserveBookingsVisibility(
             productListRepository = productListRepository,
             bookingsRepository = bookingsRepository,
             selectedSite = selectedSite,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -457,14 +457,18 @@ class MoreMenuViewModelTests : BaseUnitTest() {
     }
 
     @Test
-    fun `given bookings is visible and not on tablet, when building state, then bookings button is not displayed`() =
+    fun `given bookings is visible, when switching to non tablet, then bookings button is not displayed`() =
         testBlocking {
             // GIVEN
-            setup()
-            viewModel.onWindowClassChanged(false)
+            setup {
+                whenever(observeBookingsVisibility.invoke()).thenReturn(flowOf(true))
+            }
+            viewModel.onWindowClassChanged(true)
 
             // WHEN
             val states = viewModel.moreMenuViewState.captureValues()
+            advanceUntilIdle()
+            viewModel.onWindowClassChanged(false)
             advanceUntilIdle()
 
             // THEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -15,7 +15,6 @@ import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
-import com.woocommerce.android.util.IsWindowClassLargeThanCompact
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -91,10 +90,6 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         on { invoke() } doReturn flowOf(false)
     }
 
-    private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact = mock {
-        on { invoke() } doReturn false
-    }
-
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
 
     private val blazeCampaignsStore: BlazeCampaignsStore = mock()
@@ -123,7 +118,6 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             isGoogleForWooEnabled = isGoogleForWooEnabled,
             hasGoogleAdsCampaigns = hasGoogleAdsCampaigns,
             observeBookingsVisibility = observeBookingsVisibility,
-            isWindowClassLargeThanCompact = isWindowClassLargeThanCompact,
             analyticsTrackerWrapper = analyticsTrackerWrapper,
             ciabSiteGateKeeper = ciabSiteGateKeeper
         )
@@ -449,8 +443,8 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         // GIVEN
         setup {
             whenever(observeBookingsVisibility.invoke()).thenReturn(flowOf(true))
-            whenever(isWindowClassLargeThanCompact.invoke()).thenReturn(true)
         }
+        viewModel.onWindowClassChanged(true)
 
         // WHEN
         val states = viewModel.moreMenuViewState.captureValues()
@@ -466,9 +460,8 @@ class MoreMenuViewModelTests : BaseUnitTest() {
     fun `given bookings is visible and not on tablet, when building state, then bookings button is not displayed`() =
         testBlocking {
             // GIVEN
-            setup {
-                whenever(isWindowClassLargeThanCompact.invoke()).thenReturn(false)
-            }
+            setup()
+            viewModel.onWindowClassChanged(false)
 
             // WHEN
             val states = viewModel.moreMenuViewState.captureValues()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -8,12 +8,14 @@ import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.blaze.IsBlazeEnabled
+import com.woocommerce.android.ui.bookings.tab.ObserveBookingsVisibility
 import com.woocommerce.android.ui.google.HasGoogleAdsCampaigns
 import com.woocommerce.android.ui.google.IsGoogleForWooEnabled
 import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
+import com.woocommerce.android.util.IsWindowClassLargeThanCompact
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -23,6 +25,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -84,6 +87,14 @@ class MoreMenuViewModelTests : BaseUnitTest() {
 
     private val hasGoogleAdsCampaigns: HasGoogleAdsCampaigns = mock()
 
+    private val observeBookingsVisibility: ObserveBookingsVisibility = mock {
+        on { invoke() } doReturn flowOf(false)
+    }
+
+    private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact = mock {
+        on { invoke() } doReturn false
+    }
+
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
 
     private val blazeCampaignsStore: BlazeCampaignsStore = mock()
@@ -111,6 +122,8 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             isBlazeEnabled = isBlazeEnabled,
             isGoogleForWooEnabled = isGoogleForWooEnabled,
             hasGoogleAdsCampaigns = hasGoogleAdsCampaigns,
+            observeBookingsVisibility = observeBookingsVisibility,
+            isWindowClassLargeThanCompact = isWindowClassLargeThanCompact,
             analyticsTrackerWrapper = analyticsTrackerWrapper,
             ciabSiteGateKeeper = ciabSiteGateKeeper
         )
@@ -430,6 +443,42 @@ class MoreMenuViewModelTests : BaseUnitTest() {
 
         assertThat(event).isEqualTo(MoreMenuEvent.OpenBlazeCampaignListEvent)
     }
+
+    @Test
+    fun `given bookings is visible and on tablet, when building state, then bookings button is displayed`() = testBlocking {
+        // GIVEN
+        setup {
+            whenever(observeBookingsVisibility.invoke()).thenReturn(flowOf(true))
+            whenever(isWindowClassLargeThanCompact.invoke()).thenReturn(true)
+        }
+
+        // WHEN
+        val states = viewModel.moreMenuViewState.captureValues()
+        advanceUntilIdle()
+
+        // THEN
+        val bookingsButton =
+            states.last().menuSections.flatMap { it.items }.first { it.title == R.string.bookings_tab_title }
+        assertThat(bookingsButton.description).isEqualTo(R.string.more_menu_button_bookings_description)
+    }
+
+    @Test
+    fun `given bookings is visible and not on tablet, when building state, then bookings button is not displayed`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(isWindowClassLargeThanCompact.invoke()).thenReturn(false)
+            }
+
+            // WHEN
+            val states = viewModel.moreMenuViewState.captureValues()
+            advanceUntilIdle()
+
+            // THEN
+            assertThat(
+                states.last().menuSections.flatMap { it.items }.none { it.title == R.string.bookings_tab_title }
+            ).isTrue()
+        }
 
     @Test
     fun `when building state, then all optional buttons start with loading state`() = testBlocking {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
WOOMOB-2164

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates how Bookings is exposed in navigation for large-screen layouts.
- Shows Bookings as a **More menu item** on tablet/large-window layouts.
- Keeps Bookings as a **bottom tab** on phone/compact layouts.
- When opened from More menu, Bookings shows top app bar and hides bottom navigation.
- Uses the existing More menu analytics flow by tracking Bookings with option value `bookings`.
- Sets Bookings button initial state to `Hidden` to avoid loading/flicker behavior.
- Renames `ObserveBookingsTabVisibility` to `ObserveBookingsVisibility`.
- Updates CIAB gatekeeper behavior so POS remains supported while other CIAB-affected features stay gated.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

### CIAB site + Tablet
- Login to CIAB site on a tablet
- Make sure the POS is displayed in tab bar
- Make sure there is no "Bookings" tab in tab bar
- Navigate to "More" menu
- Make sure the "Bookings" entry is presented in menu
- Tap on "Bookings" entry. Make sure the bookings screen is presented.

### CIAB site + phone
- Login to CIAB site on iPhone
- Make sure the is no POS is displayed in tab bar
- Make sure there is the "Bookings" tab in tab bar
- Navigate to "More" menu
- Make sure no "Bookings" entry is presented in menu
- Tap on "Bookings" entry. Make sure the bookings screen is presented.

### NON-CIAB site + Tablet
- Login to non-CIAB site on iPad
- Make sure the POS is displayed in tab bar
- Make sure there is no "Bookings" tab in tab bar
- Navigate to "More" menu
- Make sure there is no "Bookings" entry is presented in menu

### NON-CIAB site + phone
- Login to non-CIAB site on iPhone
- Make sure the is no POS is displayed in tab bar
- Make sure there is no "Bookings" tab in tab bar
- Navigate to "More" menu
- Make sure no "Bookings" entry is not presented in menu

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="600" alt="Screenshot_20260211_205142" src="https://github.com/user-attachments/assets/c7575079-26e4-4a0f-9760-af57958909c6" />
<img width="600" alt="Screenshot_20260211_205137" src="https://github.com/user-attachments/assets/101013e9-ca69-47c3-9ac2-deecd635cac2" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
