### PR TITLE
Refactor MainSettingsPresenter to reactively update push notification UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -26,7 +26,7 @@ interface MainSettingsContract {
         fun showDeviceAppNotificationSettings()
         fun showNotificationsSettingsScreen()
         fun showLatestAnnouncementOption(announcement: FeatureAnnouncement)
-        fun showEnablePushNotificationsOption()
+        fun setEnablePushNotificationsOptionVisible(isVisible: Boolean)
         fun handleJetpackInstallOption(supportsJetpackInstallation: Boolean)
         fun handleApplicationPasswordsSettings()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -321,8 +321,8 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             .show()
     }
 
-    override fun showEnablePushNotificationsOption() {
-        binding.optionEnablePushNotifications.isVisible = true
+    override fun setEnablePushNotificationsOptionVisible(isVisible: Boolean) {
+        binding.optionEnablePushNotifications.isVisible = isVisible
         updateStoreSettingsContainerVisibility()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -13,7 +13,10 @@ import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.StringUtils
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -32,6 +35,7 @@ class MainSettingsPresenter @Inject constructor(
     private val getWooVersion: GetWooCorePluginCachedVersion,
     private val appPrefs: AppPrefsWrapper
 ) : MainSettingsContract.Presenter {
+    override val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var appSettingsFragmentView: MainSettingsContract.View? = null
 
     override val isChaChingSoundEnabled: Boolean
@@ -42,6 +46,7 @@ class MainSettingsPresenter @Inject constructor(
     }
 
     override fun dropView() {
+        coroutineScope.coroutineContext.cancelChildren()
         appSettingsFragmentView = null
     }
 
@@ -102,8 +107,8 @@ class MainSettingsPresenter @Inject constructor(
 
     override fun setupEnablePushNotificationsOption() {
         coroutineScope.launch {
-            if (shouldShowEnablePushNotificationsUi().first()) {
-                appSettingsFragmentView?.showEnablePushNotificationsOption()
+            shouldShowEnablePushNotificationsUi().collect { shouldShowOption ->
+                appSettingsFragmentView?.setEnablePushNotificationsOptionVisible(shouldShowOption)
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Test
@@ -23,6 +24,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainSettingsPresenterTest : BaseUnitTest() {
@@ -154,4 +156,20 @@ class MainSettingsPresenterTest : BaseUnitTest() {
             verify(view, times(1)).setEnablePushNotificationsOptionVisible(true)
             verify(view, times(1)).setEnablePushNotificationsOptionVisible(false)
         }
+
+    @Test
+    fun `given push notifications option setup, when view is dropped, then flow collection is cancelled`() = testBlocking {
+        val shouldShowPushNotificationOption = MutableSharedFlow<Boolean>(replay = 1)
+        setup {
+            whenever(shouldShowEnablePushNotificationsUi()).thenReturn(shouldShowPushNotificationOption)
+        }
+
+        presenter.setupEnablePushNotificationsOption()
+        advanceUntilIdle()
+        assertEquals(1, shouldShowPushNotificationOption.subscriptionCount.value)
+
+        presenter.dropView()
+        advanceUntilIdle()
+        assertEquals(0, shouldShowPushNotificationOption.subscriptionCount.value)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
@@ -14,8 +14,11 @@ import com.woocommerce.android.util.BuildConfigWrapper
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.store.AccountStore
@@ -107,4 +110,48 @@ class MainSettingsPresenterTest : BaseUnitTest() {
 
         verify(view).handleJetpackInstallOption(supportsJetpackInstallation = false)
     }
+
+    @Test
+    fun `given push notifications option should be shown, when setup is called, then show option`() = testBlocking {
+        val shouldShowPushNotificationOption = MutableStateFlow(true)
+        setup {
+            whenever(shouldShowEnablePushNotificationsUi()).thenReturn(shouldShowPushNotificationOption)
+        }
+
+        presenter.setupEnablePushNotificationsOption()
+        advanceUntilIdle()
+
+        verify(view).setEnablePushNotificationsOptionVisible(true)
+    }
+
+    @Test
+    fun `given push notifications option should be hidden, when setup is called, then hide option`() = testBlocking {
+        val shouldShowPushNotificationOption = MutableStateFlow(false)
+        setup {
+            whenever(shouldShowEnablePushNotificationsUi()).thenReturn(shouldShowPushNotificationOption)
+        }
+
+        presenter.setupEnablePushNotificationsOption()
+        advanceUntilIdle()
+
+        verify(view).setEnablePushNotificationsOptionVisible(false)
+    }
+
+    @Test
+    fun `given push notifications option visibility changes, when setup is called, then update option reactively`() =
+        testBlocking {
+            val shouldShowPushNotificationOption = MutableStateFlow(true)
+            setup {
+                whenever(shouldShowEnablePushNotificationsUi()).thenReturn(shouldShowPushNotificationOption)
+            }
+
+            presenter.setupEnablePushNotificationsOption()
+            advanceUntilIdle()
+
+            shouldShowPushNotificationOption.value = false
+            advanceUntilIdle()
+
+            verify(view, times(1)).setEnablePushNotificationsOptionVisible(true)
+            verify(view, times(1)).setEnablePushNotificationsOptionVisible(false)
+        }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-2134

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This makes the **Enable Push Notifications** row in Main Settings reactive.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
[Add_a_test_button_to_toggle_a_fake_push_token_in_settings_debug_builds.patch](https://github.com/user-attachments/files/25266207/Add_a_test_button_to_toggle_a_fake_push_token_in_settings_debug_builds.patch)
1. Apply this patch. This will add a testing-purpose button that you can use register and unregister WOO PN Server with a fake token on client.
2. Log in to a self-hosted site without support of new PN with site credentials.
3. Go to Menu → Settings
4. Verify "Enable Push Notifications" is visible.
5. Tap the "Save fake push token" button.
6. Verify "Enable Push Notifications" is hidden.
7. Tap the "Delete fake push token" button.
8. Verify "Enable Push Notifications" is visible.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
[Screen_recording_20260212_181539.webm](https://github.com/user-attachments/assets/16ccfec2-9b2f-4252-89b1-8dd2ff3b692c)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
