### PR TITLE
POS Bookings: Add booking note support

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -45,6 +45,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavBackStackEntry
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.bookings.details.WooPosBookingDetails
+import com.woocommerce.android.ui.woopos.bookings.note.BOOKING_NOTE_RESULT_KEY
 import com.woocommerce.android.ui.woopos.cardpayment.BOOKING_CARD_PAYMENT_SUCCESS_KEY
 import com.woocommerce.android.ui.woopos.cashpayment.BOOKING_CASH_PAYMENT_SUCCESS_KEY
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
@@ -105,6 +106,17 @@ fun WooPosBookingsScreen(
         if (cardPaymentResult.value) {
             viewModel.onRefresh()
             backStackEntry.savedStateHandle[BOOKING_CARD_PAYMENT_SUCCESS_KEY] = false
+        }
+    }
+
+    val bookingNoteResult = backStackEntry.savedStateHandle
+        .getStateFlow(BOOKING_NOTE_RESULT_KEY, false)
+        .collectAsState()
+
+    LaunchedEffect(bookingNoteResult.value) {
+        if (bookingNoteResult.value) {
+            viewModel.onBookingNoteSaved()
+            backStackEntry.savedStateHandle[BOOKING_NOTE_RESULT_KEY] = false
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -218,7 +218,7 @@ class WooPosBookingsViewModel @Inject constructor(
             is WooPosBookingsUIEvent.AttendanceToggled -> { }
             is WooPosBookingsUIEvent.PayByCardClicked -> handlePayByCard()
             is WooPosBookingsUIEvent.PayByCashClicked -> handlePayByCash()
-            is WooPosBookingsUIEvent.AddBookingNoteClicked -> { }
+            is WooPosBookingsUIEvent.AddBookingNoteClicked -> handleAddBookingNote()
             is WooPosBookingsUIEvent.CopyEmailClicked -> { }
         }
     }
@@ -252,6 +252,17 @@ class WooPosBookingsViewModel @Inject constructor(
                 )
             )
         }
+    }
+
+    private fun handleAddBookingNote() {
+        val bookingId = selectedBookingId ?: return
+        viewModelScope.launch {
+            _navigationEvent.emit(WooPosNavigationEvent.OpenBookingNote(bookingId))
+        }
+    }
+
+    fun onBookingNoteSaved() {
+        onRefresh()
     }
 
     private fun handleBookingAction(action: WooPosBookingsState.BookingAction) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -448,32 +448,36 @@ private fun BookingNoteSection(
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         WooPosCard(shadowType = ShadowType.Soft) {
-            Row(
-                modifier = Modifier.padding(WooPosSpacing.Medium.value),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                WooPosText(
-                    text = stringResource(R.string.woopos_bookings_details_booking_note_title),
-                    style = WooPosTypography.BodyLarge,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.weight(1f)
-                )
-                WooPosOutlinedButtonSmall(
-                    text = stringResource(R.string.woopos_bookings_details_add_note),
-                    onClick = { onUIEvent(WooPosBookingsUIEvent.AddBookingNoteClicked) }
-                )
+            Column(modifier = Modifier.padding(WooPosSpacing.Medium.value)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    WooPosText(
+                        text = stringResource(R.string.woopos_bookings_details_booking_note_title),
+                        style = WooPosTypography.BodyLarge,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.weight(1f)
+                    )
+                    WooPosOutlinedButtonSmall(
+                        text = stringResource(
+                            if (bookingNote.isNullOrBlank()) {
+                                R.string.woopos_bookings_details_add_note
+                            } else {
+                                R.string.woopos_bookings_details_edit_note
+                            }
+                        ),
+                        onClick = { onUIEvent(WooPosBookingsUIEvent.AddBookingNoteClicked) }
+                    )
+                }
+                bookingNote?.let {
+                    Spacer(Modifier.height(WooPosSpacing.Small.value))
+                    WooPosText(
+                        text = it,
+                        style = WooPosTypography.BodyMedium,
+                    )
+                }
             }
         }
 
         Spacer(Modifier.height(WooPosSpacing.Small.value))
-
-        bookingNote?.let {
-            WooPosText(
-                text = it,
-                style = WooPosTypography.BodyMedium,
-            )
-            Spacer(Modifier.height(WooPosSpacing.Small.value))
-        }
 
         WooPosText(
             text = stringResource(R.string.woopos_bookings_details_booking_note_hint),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -467,7 +467,7 @@ private fun BookingNoteSection(
                         onClick = { onUIEvent(WooPosBookingsUIEvent.AddBookingNoteClicked) }
                     )
                 }
-                bookingNote?.let {
+                bookingNote?.takeIf { it.isNotBlank() }?.let {
                     Spacer(Modifier.height(WooPosSpacing.Small.value))
                     WooPosText(
                         text = it,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteNavigation.kt
@@ -1,0 +1,49 @@
+package com.woocommerce.android.ui.woopos.bookings.note
+
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.woocommerce.android.ui.woopos.bookings.BOOKINGS_ROUTE
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
+
+const val BOOKING_NOTE_RESULT_KEY = "booking_note_saved"
+const val BOOKING_NOTE_ROUTE_BOOKING_ID_KEY = "bookingId"
+private const val BOOKING_NOTE_ROUTE =
+    "$BOOKINGS_ROUTE/note/{$BOOKING_NOTE_ROUTE_BOOKING_ID_KEY}"
+
+fun NavController.navigateToBookingNoteScreen(bookingId: Long) {
+    navigateOnce(
+        BOOKING_NOTE_ROUTE
+            .replace("{$BOOKING_NOTE_ROUTE_BOOKING_ID_KEY}", bookingId.toString())
+    )
+}
+
+fun NavGraphBuilder.bookingNoteScreen(
+    onNavigationEvent: (WooPosNavigationEvent) -> Unit
+) {
+    composable(
+        route = BOOKING_NOTE_ROUTE,
+        arguments = listOf(
+            navArgument(BOOKING_NOTE_ROUTE_BOOKING_ID_KEY) { type = NavType.LongType }
+        ),
+        enterTransition = {
+            slideInHorizontally(
+                initialOffsetX = { fullWidth -> fullWidth },
+            )
+        },
+        exitTransition = {
+            slideOutHorizontally(
+                targetOffsetX = { fullWidth -> fullWidth },
+            )
+        },
+    ) {
+        WooPosBookingNoteScreen(
+            onNavigationEvent = onNavigationEvent,
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteScreen.kt
@@ -1,0 +1,112 @@
+package com.woocommerce.android.ui.woopos.bookings.note
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosFullScreenInputLayout
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosInputField
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+
+@Composable
+fun WooPosBookingNoteScreen(
+    onNavigationEvent: (WooPosNavigationEvent) -> Unit,
+    viewModel: WooPosBookingNoteViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    val context = LocalContext.current
+
+    LaunchedEffect(state.savedSuccessfully) {
+        if (state.savedSuccessfully) {
+            onNavigationEvent(
+                WooPosNavigationEvent.GoBackWithResult(
+                    key = BOOKING_NOTE_RESULT_KEY,
+                    value = true
+                )
+            )
+        }
+    }
+
+    LaunchedEffect(state.saveError) {
+        if (state.saveError) {
+            Toast.makeText(
+                context,
+                context.getString(R.string.woopos_bookings_note_screen_save_error),
+                Toast.LENGTH_SHORT
+            ).show()
+            viewModel.onErrorShown()
+        }
+    }
+
+    WooPosBookingNoteScreen(
+        state = state,
+        onNoteChanged = viewModel::onNoteChanged,
+        onSendClicked = viewModel::onSendClicked,
+        onBackClicked = { onNavigationEvent(WooPosNavigationEvent.GoBack) },
+    )
+}
+
+@Composable
+private fun WooPosBookingNoteScreen(
+    state: WooPosBookingNoteState,
+    onNoteChanged: (String) -> Unit,
+    onSendClicked: () -> Boolean,
+    onBackClicked: () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+        keyboardController?.show()
+    }
+
+    val buttonText = when (state.sendButtonText) {
+        SendButtonText.ADD -> stringResource(R.string.woopos_bookings_note_screen_button_add)
+        SendButtonText.SEND -> stringResource(R.string.woopos_bookings_note_screen_button_send)
+    }
+
+    WooPosFullScreenInputLayout(
+        titleText = stringResource(R.string.woopos_bookings_note_screen_title),
+        onBackClicked = onBackClicked,
+        centerContent = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                WooPosInputField(
+                    value = state.noteText,
+                    onValueChange = onNoteChanged,
+                    label = stringResource(R.string.woopos_bookings_note_screen_hint),
+                    contentAlignment = Alignment.Center,
+                    textStyle = WooPosTypography.Heading,
+                    textColor = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier
+                        .focusRequester(focusRequester)
+                        .padding(horizontal = WooPosSpacing.Medium.value)
+                )
+            }
+        },
+        buttonText = buttonText,
+        buttonState = state.sendButtonState,
+        onButtonClicked = { onSendClicked() },
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteScreen.kt
@@ -73,8 +73,14 @@ private fun WooPosBookingNoteScreen(
         keyboardController?.show()
     }
 
+    val titleText = if (state.isEditMode) {
+        stringResource(R.string.woopos_bookings_note_screen_title_edit)
+    } else {
+        stringResource(R.string.woopos_bookings_note_screen_title_add)
+    }
+
     WooPosFullScreenInputLayout(
-        titleText = stringResource(R.string.woopos_bookings_note_screen_title),
+        titleText = titleText,
         onBackClicked = onBackClicked,
         centerContent = {
             Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteScreen.kt
@@ -53,7 +53,7 @@ fun WooPosBookingNoteScreen(
     WooPosBookingNoteScreen(
         state = state,
         onNoteChanged = viewModel::onNoteChanged,
-        onSendClicked = viewModel::onSendClicked,
+        onSaveClicked = viewModel::onSaveClicked,
         onBackClicked = { onNavigationEvent(WooPosNavigationEvent.GoBack) },
     )
 }
@@ -62,7 +62,7 @@ fun WooPosBookingNoteScreen(
 private fun WooPosBookingNoteScreen(
     state: WooPosBookingNoteState,
     onNoteChanged: (String) -> Unit,
-    onSendClicked: () -> Boolean,
+    onSaveClicked: () -> Unit,
     onBackClicked: () -> Unit,
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -71,11 +71,6 @@ private fun WooPosBookingNoteScreen(
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
         keyboardController?.show()
-    }
-
-    val buttonText = when (state.sendButtonText) {
-        SendButtonText.ADD -> stringResource(R.string.woopos_bookings_note_screen_button_add)
-        SendButtonText.SEND -> stringResource(R.string.woopos_bookings_note_screen_button_send)
     }
 
     WooPosFullScreenInputLayout(
@@ -99,8 +94,8 @@ private fun WooPosBookingNoteScreen(
                 )
             }
         },
-        buttonText = buttonText,
-        buttonState = state.sendButtonState,
-        onButtonClicked = { onSendClicked() },
+        buttonText = stringResource(R.string.woopos_bookings_note_screen_button_save),
+        buttonState = state.saveButtonState,
+        onButtonClicked = { onSaveClicked() },
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteScreen.kt
@@ -34,25 +34,19 @@ fun WooPosBookingNoteScreen(
 
     val context = LocalContext.current
 
-    LaunchedEffect(state.savedSuccessfully) {
-        if (state.savedSuccessfully) {
-            onNavigationEvent(
-                WooPosNavigationEvent.GoBackWithResult(
-                    key = BOOKING_NOTE_RESULT_KEY,
-                    value = true
-                )
-            )
+    LaunchedEffect(Unit) {
+        viewModel.navigationEvent.collect { event ->
+            onNavigationEvent(event)
         }
     }
 
-    LaunchedEffect(state.saveError) {
-        if (state.saveError) {
+    LaunchedEffect(Unit) {
+        viewModel.errorEvent.collect {
             Toast.makeText(
                 context,
                 context.getString(R.string.woopos_bookings_note_screen_save_error),
                 Toast.LENGTH_SHORT
             ).show()
-            viewModel.onErrorShown()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
@@ -1,0 +1,100 @@
+package com.woocommerce.android.ui.woopos.bookings.note
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.ui.bookings.BookingsRepository
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WooPosBookingNoteViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val bookingsRepository: BookingsRepository,
+) : ViewModel() {
+
+    private val bookingId: Long = savedStateHandle[BOOKING_NOTE_ROUTE_BOOKING_ID_KEY] ?: -1L
+
+    private val _state = MutableStateFlow(WooPosBookingNoteState())
+    val state: StateFlow<WooPosBookingNoteState> = _state.asStateFlow()
+
+    init {
+        loadExistingNote()
+    }
+
+    private fun loadExistingNote() {
+        viewModelScope.launch {
+            val booking = bookingsRepository.getBooking(bookingId)
+            val existingNote = booking?.note.orEmpty()
+            _state.update {
+                it.copy(
+                    initialNote = existingNote,
+                    noteText = existingNote,
+                )
+            }
+        }
+    }
+
+    fun onNoteChanged(text: String) {
+        _state.update { it.copy(noteText = text) }
+    }
+
+    fun onSendClicked(): Boolean {
+        val currentState = _state.value
+        if (currentState.noteText.isBlank() || currentState.buttonState == WooPosButtonState.LOADING) {
+            return false
+        }
+
+        _state.update { it.copy(buttonState = WooPosButtonState.LOADING) }
+        viewModelScope.launch {
+            val result = bookingsRepository.updateNote(
+                bookingId = bookingId,
+                note = currentState.noteText.trim()
+            )
+            result.onFailure {
+                _state.update {
+                    it.copy(
+                        buttonState = WooPosButtonState.ENABLED,
+                        saveError = true,
+                    )
+                }
+            }
+            result.onSuccess {
+                _state.update { it.copy(savedSuccessfully = true) }
+            }
+        }
+        return true
+    }
+
+    fun onErrorShown() {
+        _state.update { it.copy(saveError = false) }
+    }
+}
+
+data class WooPosBookingNoteState(
+    val initialNote: String = "",
+    val noteText: String = "",
+    val buttonState: WooPosButtonState = WooPosButtonState.DISABLED,
+    val savedSuccessfully: Boolean = false,
+    val saveError: Boolean = false,
+) {
+    val sendButtonState: WooPosButtonState
+        get() = when {
+            buttonState == WooPosButtonState.LOADING -> WooPosButtonState.LOADING
+            noteText.isBlank() -> WooPosButtonState.DISABLED
+            else -> WooPosButtonState.ENABLED
+        }
+
+    val sendButtonText: SendButtonText
+        get() = if (noteText.isBlank()) SendButtonText.ADD else SendButtonText.SEND
+}
+
+enum class SendButtonText {
+    ADD, SEND
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
@@ -55,10 +55,10 @@ class WooPosBookingNoteViewModel @Inject constructor(
         _state.update { it.copy(noteText = text) }
     }
 
-    fun onSendClicked(): Boolean {
+    fun onSaveClicked() {
         val currentState = _state.value
         if (currentState.noteText.isBlank() || currentState.buttonState == WooPosButtonState.LOADING) {
-            return false
+            return
         }
 
         _state.update { it.copy(buttonState = WooPosButtonState.LOADING) }
@@ -82,9 +82,7 @@ class WooPosBookingNoteViewModel @Inject constructor(
                 )
             }
         }
-        return true
     }
-
 }
 
 data class WooPosBookingNoteState(
@@ -92,17 +90,10 @@ data class WooPosBookingNoteState(
     val noteText: String = "",
     val buttonState: WooPosButtonState = WooPosButtonState.DISABLED,
 ) {
-    val sendButtonState: WooPosButtonState
+    val saveButtonState: WooPosButtonState
         get() = when {
             buttonState == WooPosButtonState.LOADING -> WooPosButtonState.LOADING
             noteText.isBlank() -> WooPosButtonState.DISABLED
             else -> WooPosButtonState.ENABLED
         }
-
-    val sendButtonText: SendButtonText
-        get() = if (noteText.isBlank()) SendButtonText.ADD else SendButtonText.SEND
-}
-
-enum class SendButtonText {
-    ADD, SEND
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
@@ -5,9 +5,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -23,6 +27,12 @@ class WooPosBookingNoteViewModel @Inject constructor(
 
     private val _state = MutableStateFlow(WooPosBookingNoteState())
     val state: StateFlow<WooPosBookingNoteState> = _state.asStateFlow()
+
+    private val _navigationEvent = MutableSharedFlow<WooPosNavigationEvent>()
+    val navigationEvent: SharedFlow<WooPosNavigationEvent> = _navigationEvent.asSharedFlow()
+
+    private val _errorEvent = MutableSharedFlow<Unit>()
+    val errorEvent: SharedFlow<Unit> = _errorEvent.asSharedFlow()
 
     init {
         loadExistingNote()
@@ -59,30 +69,28 @@ class WooPosBookingNoteViewModel @Inject constructor(
             )
             result.onFailure {
                 _state.update {
-                    it.copy(
-                        buttonState = WooPosButtonState.ENABLED,
-                        saveError = true,
-                    )
+                    it.copy(buttonState = WooPosButtonState.ENABLED)
                 }
+                _errorEvent.emit(Unit)
             }
             result.onSuccess {
-                _state.update { it.copy(savedSuccessfully = true) }
+                _navigationEvent.emit(
+                    WooPosNavigationEvent.GoBackWithResult(
+                        key = BOOKING_NOTE_RESULT_KEY,
+                        value = true
+                    )
+                )
             }
         }
         return true
     }
 
-    fun onErrorShown() {
-        _state.update { it.copy(saveError = false) }
-    }
 }
 
 data class WooPosBookingNoteState(
     val initialNote: String = "",
     val noteText: String = "",
     val buttonState: WooPosButtonState = WooPosButtonState.DISABLED,
-    val savedSuccessfully: Boolean = false,
-    val saveError: Boolean = false,
 ) {
     val sendButtonState: WooPosButtonState
         get() = when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
@@ -96,4 +96,7 @@ data class WooPosBookingNoteState(
             initialNote.trim() != noteText.trim() -> WooPosButtonState.ENABLED
             else -> WooPosButtonState.DISABLED
         }
+
+    val isEditMode: Boolean
+        get() = initialNote.isNotBlank()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
@@ -19,7 +19,7 @@ class WooPosBookingNoteViewModel @Inject constructor(
     private val bookingsRepository: BookingsRepository,
 ) : ViewModel() {
 
-    private val bookingId: Long = savedStateHandle[BOOKING_NOTE_ROUTE_BOOKING_ID_KEY] ?: -1L
+    private val bookingId: Long = requireNotNull(savedStateHandle[BOOKING_NOTE_ROUTE_BOOKING_ID_KEY])
 
     private val _state = MutableStateFlow(WooPosBookingNoteState())
     val state: StateFlow<WooPosBookingNoteState> = _state.asStateFlow()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
@@ -57,7 +57,7 @@ class WooPosBookingNoteViewModel @Inject constructor(
 
     fun onSaveClicked() {
         val currentState = _state.value
-        if (currentState.noteText.isBlank() || currentState.buttonState == WooPosButtonState.LOADING) {
+        if (currentState.buttonState == WooPosButtonState.LOADING) {
             return
         }
 
@@ -93,7 +93,7 @@ data class WooPosBookingNoteState(
     val saveButtonState: WooPosButtonState
         get() = when {
             buttonState == WooPosButtonState.LOADING -> WooPosButtonState.LOADING
-            noteText.isBlank() -> WooPosButtonState.DISABLED
-            else -> WooPosButtonState.ENABLED
+            initialNote.trim() != noteText.trim() -> WooPosButtonState.ENABLED
+            else -> WooPosButtonState.DISABLED
         }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosMainFlowGraph.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosMainFlowGraph.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.root.navigation
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.navigation
 import com.woocommerce.android.ui.woopos.bookings.bookingsScreen
+import com.woocommerce.android.ui.woopos.bookings.note.bookingNoteScreen
 import com.woocommerce.android.ui.woopos.cardpayment.cardPaymentScreen
 import com.woocommerce.android.ui.woopos.cashpayment.cashPaymentScreen
 import com.woocommerce.android.ui.woopos.emailreceipt.emailReceiptScreen
@@ -35,5 +36,6 @@ fun NavGraphBuilder.mainGraph(
         ordersScreen(onNavigationEvent = onNavigationEvent)
         refundReasonScreen(onNavigationEvent = onNavigationEvent)
         bookingsScreen(onNavigationEvent = onNavigationEvent)
+        bookingNoteScreen(onNavigationEvent = onNavigationEvent)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
@@ -29,4 +29,5 @@ sealed class WooPosNavigationEvent {
     data object OpenSettings : WooPosNavigationEvent()
     data object OpenOrders : WooPosNavigationEvent()
     data object OpenBookings : WooPosNavigationEvent()
+    data class OpenBookingNote(val bookingId: Long) : WooPosNavigationEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.root.navigation
 import androidx.activity.ComponentActivity
 import androidx.navigation.NavHostController
 import com.woocommerce.android.ui.woopos.bookings.navigateToBookingsScreen
+import com.woocommerce.android.ui.woopos.bookings.note.navigateToBookingNoteScreen
 import com.woocommerce.android.ui.woopos.cardpayment.navigateToCardPaymentScreen
 import com.woocommerce.android.ui.woopos.cashpayment.navigateToCashPaymentScreen
 import com.woocommerce.android.ui.woopos.emailreceipt.navigateToEmailReceipt
@@ -63,5 +64,8 @@ fun NavHostController.handleNavigationEvent(
 
         is WooPosNavigationEvent.OpenBookings ->
             navigateToBookingsScreen()
+
+        is WooPosNavigationEvent.OpenBookingNote ->
+            navigateToBookingNoteScreen(event.bookingId)
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3911,7 +3911,8 @@
     <string name="woopos_bookings_details_edit_note">Edit note</string>
     <string name="woopos_bookings_details_booking_note_hint">This is a private note. It\'ll not be shared with the customer.</string>
     <string name="woopos_bookings_details_copy_email">Copy email</string>
-    <string name="woopos_bookings_note_screen_title">Add note</string>
+    <string name="woopos_bookings_note_screen_title_add">Add note</string>
+    <string name="woopos_bookings_note_screen_title_edit">Edit note</string>
     <string name="woopos_bookings_note_screen_hint">Type booking note</string>
     <string name="woopos_bookings_note_screen_button_save">Save</string>
     <string name="woopos_bookings_note_screen_save_error">Error saving booking note</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3908,8 +3908,14 @@
     <string name="woopos_bookings_details_pay_by_cash">Pay by cash</string>
     <string name="woopos_bookings_details_booking_note_title">Booking note</string>
     <string name="woopos_bookings_details_add_note">Add note</string>
+    <string name="woopos_bookings_details_edit_note">Edit note</string>
     <string name="woopos_bookings_details_booking_note_hint">This is a private note. It\'ll not be shared with the customer.</string>
     <string name="woopos_bookings_details_copy_email">Copy email</string>
+    <string name="woopos_bookings_note_screen_title">Add note</string>
+    <string name="woopos_bookings_note_screen_hint">Type booking note</string>
+    <string name="woopos_bookings_note_screen_button_add">Add</string>
+    <string name="woopos_bookings_note_screen_button_send">Send</string>
+    <string name="woopos_bookings_note_screen_save_error">Error saving booking note</string>
 
     <string name="woopos_cash_payment_title">Cash payment</string>
     <string name="woopos_complete_cash_order_button">Mark payment as complete</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3913,8 +3913,7 @@
     <string name="woopos_bookings_details_copy_email">Copy email</string>
     <string name="woopos_bookings_note_screen_title">Add note</string>
     <string name="woopos_bookings_note_screen_hint">Type booking note</string>
-    <string name="woopos_bookings_note_screen_button_add">Add</string>
-    <string name="woopos_bookings_note_screen_button_send">Send</string>
+    <string name="woopos_bookings_note_screen_button_save">Save</string>
     <string name="woopos_bookings_note_screen_save_error">Error saving booking note</string>
 
     <string name="woopos_cash_payment_title">Cash payment</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
@@ -1,0 +1,225 @@
+package com.woocommerce.android.ui.woopos.bookings.note
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.ui.bookings.BookingsRepository
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingOrderInfo
+import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import java.time.Instant
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosBookingNoteViewModelTest {
+
+    @Rule
+    @JvmField
+    val coroutineTestRule = WooPosCoroutineTestRule(StandardTestDispatcher())
+
+    private val bookingId = 42L
+
+    private val booking = BookingEntity(
+        id = RemoteId(bookingId),
+        localSiteId = LocalId(1),
+        start = Instant.now(),
+        end = Instant.now(),
+        allDay = false,
+        status = BookingEntity.Status.Confirmed,
+        cost = "100.00",
+        currency = "USD",
+        customerId = 1L,
+        productId = 1L,
+        resourceId = 1L,
+        dateCreated = Instant.now(),
+        dateModified = Instant.now(),
+        googleCalendarEventId = "",
+        orderId = 1L,
+        orderItemId = 1L,
+        parentId = 0L,
+        personCounts = listOf(1L),
+        localTimezone = "",
+        attendanceStatus = BookingEntity.AttendanceStatus.Booked,
+        note = "Existing note",
+        order = BookingOrderInfo(),
+        customerNote = ""
+    )
+
+    private val bookingsRepository = mock<BookingsRepository> {
+        onBlocking { getBooking(any()) } doReturn booking
+        onBlocking { updateNote(any(), any()) } doReturn Result.success(Unit)
+    }
+
+    private fun createSavedStateHandle() = SavedStateHandle(
+        mapOf(BOOKING_NOTE_ROUTE_BOOKING_ID_KEY to bookingId)
+    )
+
+    private fun createViewModel(
+        savedStateHandle: SavedStateHandle = createSavedStateHandle()
+    ) = WooPosBookingNoteViewModel(
+        savedStateHandle = savedStateHandle,
+        bookingsRepository = bookingsRepository,
+    )
+
+    @Test
+    fun `given booking exists, when ViewModel created, then existing note is loaded`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertThat(state.noteText).isEqualTo("Existing note")
+        assertThat(state.initialNote).isEqualTo("Existing note")
+    }
+
+    @Test
+    fun `given empty note, when ViewModel created, then button shows Add and is disabled`() = runTest {
+        whenever(bookingsRepository.getBooking(any())).thenReturn(booking.copy(note = ""))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertThat(state.sendButtonText).isEqualTo(SendButtonText.ADD)
+        assertThat(state.sendButtonState).isEqualTo(WooPosButtonState.DISABLED)
+    }
+
+    @Test
+    fun `given existing note loaded, when ViewModel created, then button shows Send and is enabled`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertThat(state.sendButtonText).isEqualTo(SendButtonText.SEND)
+        assertThat(state.sendButtonState).isEqualTo(WooPosButtonState.ENABLED)
+    }
+
+    @Test
+    fun `when note text changed to non-empty, then button shows Send and is enabled`() = runTest {
+        whenever(bookingsRepository.getBooking(any())).thenReturn(booking.copy(note = ""))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onNoteChanged("New note")
+
+        val state = viewModel.state.value
+        assertThat(state.noteText).isEqualTo("New note")
+        assertThat(state.sendButtonText).isEqualTo(SendButtonText.SEND)
+        assertThat(state.sendButtonState).isEqualTo(WooPosButtonState.ENABLED)
+    }
+
+    @Test
+    fun `when note text changed to blank, then button shows Add and is disabled`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onNoteChanged("   ")
+
+        val state = viewModel.state.value
+        assertThat(state.sendButtonText).isEqualTo(SendButtonText.ADD)
+        assertThat(state.sendButtonState).isEqualTo(WooPosButtonState.DISABLED)
+    }
+
+    @Test
+    fun `when send clicked, then note saved via repository with trimmed text`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onNoteChanged("  New note  ")
+        viewModel.onSendClicked()
+        advanceUntilIdle()
+
+        verify(bookingsRepository).updateNote(eq(bookingId), eq("New note"))
+    }
+
+    @Test
+    fun `when send clicked and succeeds, then savedSuccessfully is true`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onNoteChanged("New note")
+        viewModel.onSendClicked()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value.savedSuccessfully).isTrue()
+    }
+
+    @Test
+    fun `when send clicked and fails, then saveError is true`() = runTest {
+        whenever(bookingsRepository.updateNote(any(), any())).thenReturn(Result.failure(Exception("fail")))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onNoteChanged("New note")
+        viewModel.onSendClicked()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value.saveError).isTrue()
+        assertThat(viewModel.state.value.savedSuccessfully).isFalse()
+    }
+
+    @Test
+    fun `when save in progress, then button shows loading state`() = runTest {
+        whenever(bookingsRepository.updateNote(any(), any())).doSuspendableAnswer {
+            delay(1000)
+            Result.success(Unit)
+        }
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onNoteChanged("New note")
+        viewModel.onSendClicked()
+
+        assertThat(viewModel.state.value.sendButtonState).isEqualTo(WooPosButtonState.LOADING)
+    }
+
+    @Test
+    fun `when send clicked with blank note, then returns false and does not save`() = runTest {
+        whenever(bookingsRepository.getBooking(any())).thenReturn(booking.copy(note = ""))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val result = viewModel.onSendClicked()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `when error shown, then saveError is cleared`() = runTest {
+        whenever(bookingsRepository.updateNote(any(), any())).thenReturn(Result.failure(Exception("fail")))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onNoteChanged("New note")
+        viewModel.onSendClicked()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value.saveError).isTrue()
+
+        viewModel.onErrorShown()
+
+        assertThat(viewModel.state.value.saveError).isFalse()
+    }
+
+    @Test
+    fun `given booking not found, when ViewModel created, then state has empty note`() = runTest {
+        whenever(bookingsRepository.getBooking(any())).thenReturn(null)
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value.noteText).isEmpty()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
@@ -99,16 +99,16 @@ class WooPosBookingNoteViewModelTest {
     }
 
     @Test
-    fun `given existing note loaded, when ViewModel created, then save button is enabled`() = runTest {
+    fun `given existing note loaded, when ViewModel created, then save button is disabled`() = runTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
         val state = viewModel.state.value
-        assertThat(state.saveButtonState).isEqualTo(WooPosButtonState.ENABLED)
+        assertThat(state.saveButtonState).isEqualTo(WooPosButtonState.DISABLED)
     }
 
     @Test
-    fun `when note text changed to non-empty, then save button is enabled`() = runTest {
+    fun `when note text changed to different value, then save button is enabled`() = runTest {
         whenever(bookingsRepository.getBooking(any())).thenReturn(booking.copy(note = ""))
         val viewModel = createViewModel()
         advanceUntilIdle()
@@ -121,14 +121,34 @@ class WooPosBookingNoteViewModelTest {
     }
 
     @Test
-    fun `when note text changed to blank, then save button is disabled`() = runTest {
+    fun `given existing note, when note text cleared, then save button is enabled`() = runTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
-        viewModel.onNoteChanged("   ")
+        viewModel.onNoteChanged("")
 
         val state = viewModel.state.value
-        assertThat(state.saveButtonState).isEqualTo(WooPosButtonState.DISABLED)
+        assertThat(state.saveButtonState).isEqualTo(WooPosButtonState.ENABLED)
+    }
+
+    @Test
+    fun `given existing note, when note text unchanged, then save button is disabled`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onNoteChanged("Existing note")
+
+        assertThat(viewModel.state.value.saveButtonState).isEqualTo(WooPosButtonState.DISABLED)
+    }
+
+    @Test
+    fun `given existing note, when only whitespace differs, then save button is disabled`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onNoteChanged("Existing note  ")
+
+        assertThat(viewModel.state.value.saveButtonState).isEqualTo(WooPosButtonState.DISABLED)
     }
 
     @Test
@@ -192,12 +212,15 @@ class WooPosBookingNoteViewModelTest {
     }
 
     @Test
-    fun `when save clicked with blank note, then does not save`() = runTest {
-        whenever(bookingsRepository.getBooking(any())).thenReturn(booking.copy(note = ""))
+    fun `when save clicked with blank note, then repository called with empty trimmed text`() = runTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
+        viewModel.onNoteChanged("   ")
         viewModel.onSaveClicked()
+        advanceUntilIdle()
+
+        verify(bookingsRepository).updateNote(eq(bookingId), eq(""))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
@@ -89,28 +89,26 @@ class WooPosBookingNoteViewModelTest {
     }
 
     @Test
-    fun `given empty note, when ViewModel created, then button shows Add and is disabled`() = runTest {
+    fun `given empty note, when ViewModel created, then save button is disabled`() = runTest {
         whenever(bookingsRepository.getBooking(any())).thenReturn(booking.copy(note = ""))
         val viewModel = createViewModel()
         advanceUntilIdle()
 
         val state = viewModel.state.value
-        assertThat(state.sendButtonText).isEqualTo(SendButtonText.ADD)
-        assertThat(state.sendButtonState).isEqualTo(WooPosButtonState.DISABLED)
+        assertThat(state.saveButtonState).isEqualTo(WooPosButtonState.DISABLED)
     }
 
     @Test
-    fun `given existing note loaded, when ViewModel created, then button shows Send and is enabled`() = runTest {
+    fun `given existing note loaded, when ViewModel created, then save button is enabled`() = runTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
         val state = viewModel.state.value
-        assertThat(state.sendButtonText).isEqualTo(SendButtonText.SEND)
-        assertThat(state.sendButtonState).isEqualTo(WooPosButtonState.ENABLED)
+        assertThat(state.saveButtonState).isEqualTo(WooPosButtonState.ENABLED)
     }
 
     @Test
-    fun `when note text changed to non-empty, then button shows Send and is enabled`() = runTest {
+    fun `when note text changed to non-empty, then save button is enabled`() = runTest {
         whenever(bookingsRepository.getBooking(any())).thenReturn(booking.copy(note = ""))
         val viewModel = createViewModel()
         advanceUntilIdle()
@@ -119,42 +117,40 @@ class WooPosBookingNoteViewModelTest {
 
         val state = viewModel.state.value
         assertThat(state.noteText).isEqualTo("New note")
-        assertThat(state.sendButtonText).isEqualTo(SendButtonText.SEND)
-        assertThat(state.sendButtonState).isEqualTo(WooPosButtonState.ENABLED)
+        assertThat(state.saveButtonState).isEqualTo(WooPosButtonState.ENABLED)
     }
 
     @Test
-    fun `when note text changed to blank, then button shows Add and is disabled`() = runTest {
+    fun `when note text changed to blank, then save button is disabled`() = runTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
         viewModel.onNoteChanged("   ")
 
         val state = viewModel.state.value
-        assertThat(state.sendButtonText).isEqualTo(SendButtonText.ADD)
-        assertThat(state.sendButtonState).isEqualTo(WooPosButtonState.DISABLED)
+        assertThat(state.saveButtonState).isEqualTo(WooPosButtonState.DISABLED)
     }
 
     @Test
-    fun `when send clicked, then note saved via repository with trimmed text`() = runTest {
+    fun `when save clicked, then note saved via repository with trimmed text`() = runTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
         viewModel.onNoteChanged("  New note  ")
-        viewModel.onSendClicked()
+        viewModel.onSaveClicked()
         advanceUntilIdle()
 
         verify(bookingsRepository).updateNote(eq(bookingId), eq("New note"))
     }
 
     @Test
-    fun `when send clicked and succeeds, then navigation event emitted`() = runTest {
+    fun `when save clicked and succeeds, then navigation event emitted`() = runTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
         viewModel.navigationEvent.test {
             viewModel.onNoteChanged("New note")
-            viewModel.onSendClicked()
+            viewModel.onSaveClicked()
 
             val event = awaitItem()
             assertThat(event).isEqualTo(
@@ -167,14 +163,14 @@ class WooPosBookingNoteViewModelTest {
     }
 
     @Test
-    fun `when send clicked and fails, then error event emitted`() = runTest {
+    fun `when save clicked and fails, then error event emitted`() = runTest {
         whenever(bookingsRepository.updateNote(any(), any())).thenReturn(Result.failure(Exception("fail")))
         val viewModel = createViewModel()
         advanceUntilIdle()
 
         viewModel.errorEvent.test {
             viewModel.onNoteChanged("New note")
-            viewModel.onSendClicked()
+            viewModel.onSaveClicked()
 
             awaitItem()
         }
@@ -190,20 +186,18 @@ class WooPosBookingNoteViewModelTest {
         advanceUntilIdle()
 
         viewModel.onNoteChanged("New note")
-        viewModel.onSendClicked()
+        viewModel.onSaveClicked()
 
-        assertThat(viewModel.state.value.sendButtonState).isEqualTo(WooPosButtonState.LOADING)
+        assertThat(viewModel.state.value.saveButtonState).isEqualTo(WooPosButtonState.LOADING)
     }
 
     @Test
-    fun `when send clicked with blank note, then returns false and does not save`() = runTest {
+    fun `when save clicked with blank note, then does not save`() = runTest {
         whenever(bookingsRepository.getBooking(any())).thenReturn(booking.copy(note = ""))
         val viewModel = createViewModel()
         advanceUntilIdle()
 
-        val result = viewModel.onSendClicked()
-
-        assertThat(result).isFalse()
+        viewModel.onSaveClicked()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
@@ -222,4 +222,9 @@ class WooPosBookingNoteViewModelTest {
 
         assertThat(viewModel.state.value.noteText).isEmpty()
     }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `given missing bookingId, when ViewModel created, then throws`() {
+        createViewModel(savedStateHandle = SavedStateHandle())
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.ui.woopos.bookings.note
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
 import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -146,29 +148,36 @@ class WooPosBookingNoteViewModelTest {
     }
 
     @Test
-    fun `when send clicked and succeeds, then savedSuccessfully is true`() = runTest {
+    fun `when send clicked and succeeds, then navigation event emitted`() = runTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
-        viewModel.onNoteChanged("New note")
-        viewModel.onSendClicked()
-        advanceUntilIdle()
+        viewModel.navigationEvent.test {
+            viewModel.onNoteChanged("New note")
+            viewModel.onSendClicked()
 
-        assertThat(viewModel.state.value.savedSuccessfully).isTrue()
+            val event = awaitItem()
+            assertThat(event).isEqualTo(
+                WooPosNavigationEvent.GoBackWithResult(
+                    key = BOOKING_NOTE_RESULT_KEY,
+                    value = true
+                )
+            )
+        }
     }
 
     @Test
-    fun `when send clicked and fails, then saveError is true`() = runTest {
+    fun `when send clicked and fails, then error event emitted`() = runTest {
         whenever(bookingsRepository.updateNote(any(), any())).thenReturn(Result.failure(Exception("fail")))
         val viewModel = createViewModel()
         advanceUntilIdle()
 
-        viewModel.onNoteChanged("New note")
-        viewModel.onSendClicked()
-        advanceUntilIdle()
+        viewModel.errorEvent.test {
+            viewModel.onNoteChanged("New note")
+            viewModel.onSendClicked()
 
-        assertThat(viewModel.state.value.saveError).isTrue()
-        assertThat(viewModel.state.value.savedSuccessfully).isFalse()
+            awaitItem()
+        }
     }
 
     @Test
@@ -195,23 +204,6 @@ class WooPosBookingNoteViewModelTest {
         val result = viewModel.onSendClicked()
 
         assertThat(result).isFalse()
-    }
-
-    @Test
-    fun `when error shown, then saveError is cleared`() = runTest {
-        whenever(bookingsRepository.updateNote(any(), any())).thenReturn(Result.failure(Exception("fail")))
-        val viewModel = createViewModel()
-        advanceUntilIdle()
-
-        viewModel.onNoteChanged("New note")
-        viewModel.onSendClicked()
-        advanceUntilIdle()
-
-        assertThat(viewModel.state.value.saveError).isTrue()
-
-        viewModel.onErrorShown()
-
-        assertThat(viewModel.state.value.saveError).isFalse()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
@@ -232,6 +232,23 @@ class WooPosBookingNoteViewModelTest {
         assertThat(viewModel.state.value.noteText).isEmpty()
     }
 
+    @Test
+    fun `given existing note, when ViewModel created, then isEditMode is true`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value.isEditMode).isTrue()
+    }
+
+    @Test
+    fun `given empty note, when ViewModel created, then isEditMode is false`() = runTest {
+        whenever(bookingsRepository.getBooking(any())).thenReturn(booking.copy(note = ""))
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value.isEditMode).isFalse()
+    }
+
     @Test(expected = IllegalArgumentException::class)
     fun `given missing bookingId, when ViewModel created, then throws`() {
         createViewModel(savedStateHandle = SavedStateHandle())


### PR DESCRIPTION
WOOPRD-2293

### Description
Add the ability to add and edit booking notes from the POS bookings detail screen. When a booking is selected, the user can tap "Add note" (or "Edit note" if one already exists) to navigate to a full-screen input where they can type and save a private booking note.

Key changes:
- New `WooPosBookingNoteScreen` with full-screen input layout, auto-focused text field, and loading/error states
- New `WooPosBookingNoteViewModel` that loads existing notes, saves via `BookingsRepository.updateNote()`, and handles success/error feedback
- Navigation wiring: `OpenBookingNote` event, route registration, and `GoBackWithResult` pattern to refresh bookings list after save
- Updated booking details note section to display existing notes inside the card and toggle button text between "Add note" / "Edit note"

### Test Steps
1. Open POS and navigate to Bookings
2. Select a booking without a note — verify the button says "Add note"
3. Tap "Add note" — verify the note input screen opens with keyboard focused
4. Type a note and tap "Send" — verify it saves and returns to the bookings list
5. Select the same booking — verify the note is displayed and the button now says "Edit note"
6. Tap "Edit note" — verify the existing note is pre-filled
7. Edit the note and save — verify the updated note displays correctly
8. Verify the note is saved in wp-admin

### Images/gif
—

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.