### PR TITLE
Fix IllegalArgumentException when deserializing old NOTIFS log tag

### DIFF
--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogEntry.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogEntry.kt
@@ -62,7 +62,7 @@ class LogEntry(
             )
         }
 
-        // TODO: WOOMOB-2212 remove this migration code after a couple of releases,
+        // TODO WOOMOB-2212 remove this migration code after a couple of releases,
         //  logs are only kept for one week so the issue should fix itself by then.
         private val deprecatedTagNames = mapOf(
             "NOTIFS" to WooLog.T.NOTIFICATIONS.name

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogEntry.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogEntry.kt
@@ -62,6 +62,8 @@ class LogEntry(
             )
         }
 
+        // TODO: WOOMOB-2212 remove this migration code after a couple of releases,
+        //  logs are only kept for one week so the issue should fix itself by then.
         private val deprecatedTagNames = mapOf(
             "NOTIFS" to WooLog.T.NOTIFICATIONS.name
         )

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogEntry.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogEntry.kt
@@ -48,7 +48,8 @@ class LogEntry(
 
             val logDate = formatter.parse(parts[0] + " " + parts[1])
                 ?: Date()
-            val tag = WooLog.T.valueOf(parts[2])
+            val tagName = migrateDeprecatedTagNames(parts[2])
+            val tag = WooLog.T.valueOf(tagName)
             val level = WooLog.LogLevel.valueOf(parts[3])
 
             val text = log.substringAfter("] ").takeIf { it.isNotEmpty() }?.trim()
@@ -59,6 +60,14 @@ class LogEntry(
                 text = text,
                 logDate = logDate
             )
+        }
+
+        private val deprecatedTagNames = mapOf(
+            "NOTIFS" to WooLog.T.NOTIFICATIONS.name
+        )
+
+        private fun migrateDeprecatedTagNames(tagName: String): String {
+            return deprecatedTagNames[tagName] ?: tagName
         }
     }
 }


### PR DESCRIPTION
Closes: WOOMOB-2203

Even though this is not a crash, the consequence of this error is users not being able to share logs with support unless the clear app data, so I believe this is worth of a beta fix.

## Description

Fixes a Sentry error that recently spiked (`IllegalArgumentException: No enum constant com.woocommerce.android.util.WooLog.T.NOTIFS`) that was introduced in version 24.0 after the `WooLog.T.NOTIFS` enum value was renamed to `NOTIFICATIONS` in commit 50877ba.

### Root cause

The commit "Unify the WooLog tag for notification related logs" (50877ba) renamed the `NOTIFS` enum value to `NOTIFICATIONS` in `WooLog.T`. However, the log file on disk still contains entries serialized with the old `NOTIFS` tag name. When `LogEntry.fromString()` tries to deserialize those old entries using `WooLog.T.valueOf("NOTIFS")`, it throws an `IllegalArgumentException` because `NOTIFS` no longer exists in the enum.

This crash is triggered whenever the app attempts to read existing log entries (e.g., when uploading encrypted logs for crash reporting via `EncryptedLogsFileProvider`).

### Fix

Added a migration map in `LogEntry.fromString()` that translates deprecated tag names to their current equivalents before calling `valueOf()`. The old `NOTIFS` value is mapped to `NOTIFICATIONS`.

## Steps to reproduce

1. Install a version prior to 24.0 (where the log tag was still `NOTIFS`). You can checkout to `release/23.9` branch for example. 
2. Use the app to generate notification-related log entries (e.g., receive a push notification)
3. Update to version 24.0 or `trunk` version
4. Trigger any action that reads the log file (e.g. viewing logs in the support section)
5. Observe the error log in the logcat: `IllegalArgumentException: No enum constant com.woocommerce.android.util.WooLog.T.NOTIFS` and that app logs are empty. 

Repeat steps above but update app from version 23.9 to the one from this branch. 