### PR TITLE
[Push Notifications] Move WPCom login screens to shared package

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsDialog.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -39,12 +37,8 @@ class JetpackBenefitsDialog : DialogFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         dialog?.window?.attributes?.windowAnimations = style.Woo_Animations_Dialog
 
-        return ComposeView(requireContext()).apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-
-            composeView {
-                JetpackBenefitsScreen(viewModel = viewModel)
-            }
+        return composeView {
+            JetpackBenefitsScreen(viewModel = viewModel)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptActivity.kt
@@ -26,7 +26,7 @@ import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.ContinueJetp
 import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.OpenLogin
 import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.OpenSitePicker
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherFragmentArgs
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationMagicLinkHandlerFragmentArgs
+import com.woocommerce.android.ui.login.wpcom.WPComLoginMagicLinkHandlerFragmentArgs
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -175,8 +175,8 @@ class MagicLinkInterceptActivity : AppCompatActivity() {
                 ).toBundle()
             )
             .addDestination(
-                R.id.jetpackActivationMagicLinkHandlerFragment,
-                JetpackActivationMagicLinkHandlerFragmentArgs(
+                R.id.wPComLoginMagicLinkHandlerFragment,
+                WPComLoginMagicLinkHandlerFragmentArgs(
                     jetpackStatus = event.jetpackStatus
                 ).toBundle()
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
@@ -46,7 +46,7 @@ class JetpackActivationDispatcherFragment : BaseFragment() {
     private fun navigateToWPComEmailScreen(event: StartWPComLoginForJetpackActivation) {
         findNavController().navigate(
             JetpackActivationDispatcherFragmentDirections
-                .actionJetpackActivationDispatcherFragmentToJetpackActivationWPComEmailFragment(
+                .actionJetpackActivationDispatcherFragmentToWPComLoginEmailFragment(
                     jetpackStatus = event.jetpackStatus
                 )
         )
@@ -55,7 +55,7 @@ class JetpackActivationDispatcherFragment : BaseFragment() {
     private fun navigateToWPComPasswordScreen(event: StartWPComAuthenticationForEmail) {
         findNavController().navigate(
             JetpackActivationDispatcherFragmentDirections
-                .actionJetpackActivationDispatcherFragmentToJetpackActivationWPComPasswordFragment(
+                .actionJetpackActivationDispatcherFragmentToWPComLoginPasswordFragment(
                     emailOrUsername = event.wpComEmail,
                     jetpackStatus = event.jetpackStatus
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAFragment.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -15,8 +15,8 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackActivationScreen
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackCPInstallationScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackCPInstallationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -24,11 +24,11 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class JetpackActivationWPCom2FAFragment : BaseFragment() {
+class WPComLogin2FAFragment : BaseFragment() {
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
-    private val viewModel: JetpackActivationWPCom2FAViewModel by viewModels()
+    private val viewModel: WPComLogin2FAViewModel by viewModels()
 
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
@@ -39,7 +39,7 @@ class JetpackActivationWPCom2FAFragment : BaseFragment() {
 
             setContent {
                 WooThemeWithBackground {
-                    JetpackActivationWPCom2FAScreen(viewModel = viewModel)
+                    WPComLogin2FAScreen(viewModel = viewModel)
                 }
             }
         }
@@ -62,8 +62,8 @@ class JetpackActivationWPCom2FAFragment : BaseFragment() {
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
-            JetpackActivationWPCom2FAFragmentDirections
-                .actionJetpackActivationWPCom2FAFragmentToJetpackActivationMainFragment(
+            WPComLogin2FAFragmentDirections
+                .actionWPComLogin2FAFragmentToJetpackActivationMainFragment(
                     jetpackStatus = event.jetpackStatus,
                     siteUrl = event.siteUrl
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -25,41 +25,38 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCOutlinedButton
-import com.woocommerce.android.ui.compose.component.WCPasswordField
+import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
-import com.woocommerce.android.ui.login.jetpack.components.UserInfo
 
 @Composable
-fun JetpackActivationWPComPasswordScreen(viewModel: JetpackActivationWPComPasswordViewModel) {
+fun WPComLogin2FAScreen(viewModel: WPComLogin2FAViewModel) {
     viewModel.viewState.observeAsState().value?.let {
-        JetpackActivationWPComPasswordScreen(
+        WPComLogin2FAScreen(
             viewState = it,
-            onPasswordChanged = viewModel::onPasswordChanged,
             onCloseClick = viewModel::onCloseClick,
+            onSMSLinkClick = viewModel::onSMSLinkClick,
             onContinueClick = viewModel::onContinueClick,
-            onMagicLinkClick = viewModel::onMagicLinkClick,
-            onResetPasswordClick = viewModel::onResetPasswordClick
+            onOTPChanged = viewModel::onOTPChanged
         )
     }
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun JetpackActivationWPComPasswordScreen(
-    viewState: JetpackActivationWPComPasswordViewModel.ViewState,
-    onPasswordChanged: (String) -> Unit = {},
+fun WPComLogin2FAScreen(
+    viewState: WPComLogin2FAViewModel.ViewState,
     onCloseClick: () -> Unit = {},
+    onSMSLinkClick: () -> Unit = {},
     onContinueClick: () -> Unit = {},
-    onMagicLinkClick: () -> Unit = {},
-    onResetPasswordClick: () -> Unit = {}
+    onOTPChanged: (String) -> Unit = {}
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -96,41 +93,34 @@ fun JetpackActivationWPComPasswordScreen(
                     fontWeight = FontWeight.Bold
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-                UserInfo(
-                    emailOrUsername = viewState.emailOrUsername,
-                    avatarUrl = viewState.avatarUrl,
-                    modifier = Modifier.fillMaxWidth()
-                )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
                 Text(
                     text = stringResource(
-                        id = if (viewState.isJetpackInstalled) {
-                            R.string.login_jetpack_connection_enter_wpcom_password
-                        } else {
-                            R.string.login_jetpack_installation_enter_wpcom_password
-                        }
+                        id = R.string.enter_verification_code
                     )
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-                WCPasswordField(
-                    value = viewState.password,
-                    onValueChange = onPasswordChanged,
-                    label = stringResource(id = R.string.password),
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                WCOutlinedTextField(
+                    value = viewState.otp,
+                    onValueChange = onOTPChanged,
+                    label = stringResource(id = R.string.verification_code),
                     isError = viewState.errorMessage != null,
                     helperText = viewState.errorMessage?.let { stringResource(id = it) },
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Done
+                    ),
                     keyboardActions = KeyboardActions(
                         onDone = {
-                            if (viewState.enableSubmit) {
-                                keyboardController?.hide()
-                                onContinueClick()
-                            }
+                            keyboardController?.hide()
+                            onContinueClick()
                         }
-                    )
+                    ),
+                    singleLine = true
                 )
-                WCTextButton(onClick = onResetPasswordClick) {
-                    Text(text = stringResource(id = R.string.reset_your_password))
+                WCTextButton(onClick = onSMSLinkClick) {
+                    Text(text = stringResource(id = R.string.login_text_otp))
                 }
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
             }
 
             Spacer(modifier = Modifier.weight(1f))
@@ -155,34 +145,23 @@ fun JetpackActivationWPComPasswordScreen(
                     )
                 )
             }
-            WCOutlinedButton(
-                onClick = onMagicLinkClick,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-            ) {
-                Text(
-                    text = stringResource(id = R.string.login_jetpack_installation_continue_magic_link)
-                )
-            }
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         }
     }
 
-    if (viewState.isLoadingDialogShown) {
-        ProgressDialog(title = "", subtitle = stringResource(id = R.string.logging_in))
+    viewState.loadingMessage?.let {
+        ProgressDialog(title = "", subtitle = stringResource(id = it))
     }
 }
 
 @Preview
 @Composable
-private fun JetpackActivationWPComScreenPreview() {
+private fun WPComLogin2FAScreenPreview() {
     WooThemeWithBackground {
-        JetpackActivationWPComPasswordScreen(
-            viewState = JetpackActivationWPComPasswordViewModel.ViewState(
+        WPComLogin2FAScreen(
+            viewState = WPComLogin2FAViewModel.ViewState(
                 emailOrUsername = "test@email.com",
                 password = "",
-                avatarUrl = "",
+                otp = "123456",
                 isJetpackInstalled = false
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAViewModel.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
@@ -27,21 +27,21 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType.NO
 import javax.inject.Inject
 
 @HiltViewModel
-class JetpackActivationWPCom2FAViewModel @Inject constructor(
+class WPComLogin2FAViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     selectedSite: SelectedSite,
     jetpackAccountRepository: JetpackActivationRepository,
     private val wpComLoginRepository: WPComLoginRepository,
     private val accountRepository: AccountRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
-) : JetpackActivationWPComPostLoginViewModel(
+) : WPComLoginPostLoginViewModel(
     savedStateHandle,
     selectedSite,
     jetpackAccountRepository,
     analyticsTrackerWrapper
 ) {
 
-    private val navArgs: JetpackActivationWPCom2FAFragmentArgs by savedStateHandle.navArgs()
+    private val navArgs: WPComLogin2FAFragmentArgs by savedStateHandle.navArgs()
 
     private val otp = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = "", key = "otp")
     private val loadingMessage =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailFragment.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -12,8 +12,8 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComEmailViewModel.ShowMagicLinkScreen
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComEmailViewModel.ShowPasswordScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginEmailViewModel.ShowMagicLinkScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginEmailViewModel.ShowPasswordScreen
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -21,11 +21,11 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class JetpackActivationWPComEmailFragment : BaseFragment() {
+class WPComLoginEmailFragment : BaseFragment() {
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
-    private val viewModel: JetpackActivationWPComEmailViewModel by viewModels()
+    private val viewModel: WPComLoginEmailViewModel by viewModels()
 
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
@@ -36,7 +36,7 @@ class JetpackActivationWPComEmailFragment : BaseFragment() {
 
             setContent {
                 WooThemeWithBackground {
-                    JetpackActivationWPComEmailScreen(viewModel = viewModel)
+                    WPComLoginEmailScreen(viewModel = viewModel)
                 }
             }
         }
@@ -65,8 +65,8 @@ class JetpackActivationWPComEmailFragment : BaseFragment() {
 
     private fun navigateToPasswordScreen(event: ShowPasswordScreen) {
         findNavController().navigateSafely(
-            JetpackActivationWPComEmailFragmentDirections
-                .actionJetpackActivationWPComEmailFragmentToJetpackActivationWPComPasswordFragment(
+            WPComLoginEmailFragmentDirections
+                .actionWPComLoginEmailFragmentToWPComLoginPasswordFragment(
                     jetpackStatus = event.jetpackStatus,
                     emailOrUsername = event.emailOrUsername
                 )
@@ -75,8 +75,8 @@ class JetpackActivationWPComEmailFragment : BaseFragment() {
 
     private fun navigateToMagicLinkScreen(event: ShowMagicLinkScreen) {
         findNavController().navigateSafely(
-            JetpackActivationWPComEmailFragmentDirections
-                .actionJetpackActivationWPComEmailFragmentToJetpackActivationMagicLinkRequestFragment(
+            WPComLoginEmailFragmentDirections
+                .actionWPComLoginEmailFragmentToWPComLoginMagicLinkRequestFragment(
                     emailOrUsername = event.emailOrUsername,
                     jetpackStatus = event.jetpackStatus,
                     fallbackButton = event.magicLinkFallbackButton,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailScreen.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -16,7 +16,6 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -25,38 +24,34 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
-import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.components.JetpackConsent
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 
 @Composable
-fun JetpackActivationWPCom2FAScreen(viewModel: JetpackActivationWPCom2FAViewModel) {
+fun WPComLoginEmailScreen(viewModel: WPComLoginEmailViewModel) {
     viewModel.viewState.observeAsState().value?.let {
-        JetpackActivationWPCom2FAScreen(
+        WPComLoginEmailScreen(
             viewState = it,
+            onEmailChanged = viewModel::onEmailOrUsernameChanged,
             onCloseClick = viewModel::onCloseClick,
-            onSMSLinkClick = viewModel::onSMSLinkClick,
-            onContinueClick = viewModel::onContinueClick,
-            onOTPChanged = viewModel::onOTPChanged
+            onContinueClick = viewModel::onContinueClick
         )
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun JetpackActivationWPCom2FAScreen(
-    viewState: JetpackActivationWPCom2FAViewModel.ViewState,
+fun WPComLoginEmailScreen(
+    viewState: WPComLoginEmailViewModel.ViewState,
+    onEmailChanged: (String) -> Unit = {},
     onCloseClick: () -> Unit = {},
-    onSMSLinkClick: () -> Unit = {},
-    onContinueClick: () -> Unit = {},
-    onOTPChanged: (String) -> Unit = {}
+    onContinueClick: () -> Unit = {}
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -73,7 +68,7 @@ fun JetpackActivationWPCom2FAScreen(
                 .background(MaterialTheme.colors.surface)
                 .padding(paddingValues)
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState()),
+                .verticalScroll(rememberScrollState())
         ) {
             Column(
                 modifier = Modifier
@@ -92,35 +87,45 @@ fun JetpackActivationWPCom2FAScreen(
                     style = MaterialTheme.typography.h4,
                     fontWeight = FontWeight.Bold
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
                 Text(
                     text = stringResource(
-                        id = R.string.enter_verification_code
+                        id = if (viewState.isJetpackInstalled) {
+                            R.string.login_jetpack_connection_enter_wpcom_email
+                        } else {
+                            R.string.login_jetpack_installation_enter_wpcom_email
+                        }
                     )
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+
                 WCOutlinedTextField(
-                    value = viewState.otp,
-                    onValueChange = onOTPChanged,
-                    label = stringResource(id = R.string.verification_code),
+                    value = viewState.emailOrUsername,
+                    onValueChange = onEmailChanged,
+                    label = if (viewState.usernameOnly) {
+                        stringResource(R.string.username)
+                    } else {
+                        stringResource(id = R.string.email_or_username)
+                    },
                     isError = viewState.errorMessage != null,
                     helperText = viewState.errorMessage?.let { stringResource(id = it) },
-                    keyboardOptions = KeyboardOptions(
-                        keyboardType = KeyboardType.Number,
-                        imeAction = ImeAction.Done
-                    ),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(
                         onDone = {
                             keyboardController?.hide()
                             onContinueClick()
                         }
-                    ),
-                    singleLine = true
+                    )
                 )
-                WCTextButton(onClick = onSMSLinkClick) {
-                    Text(text = stringResource(id = R.string.login_text_otp))
-                }
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+
+                if (!viewState.usernameOnly) {
+                    Text(
+                        style = MaterialTheme.typography.body2,
+                        text = stringResource(id = R.string.login_jetpack_connection_create_account)
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.weight(1f))
@@ -145,23 +150,28 @@ fun JetpackActivationWPCom2FAScreen(
                     )
                 )
             }
+            JetpackConsent(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         }
     }
 
-    viewState.loadingMessage?.let {
-        ProgressDialog(title = "", subtitle = stringResource(id = it))
+    if (viewState.isLoadingDialogShown) {
+        ProgressDialog(title = "", subtitle = stringResource(id = R.string.checking_email))
     }
 }
 
-@Preview
+@Preview(heightDp = 130)
 @Composable
-private fun JetpackActivationWPCom2FAScreenPreview() {
+private fun JetpackActivationWPComScreenPreview() {
     WooThemeWithBackground {
-        JetpackActivationWPCom2FAScreen(
-            viewState = JetpackActivationWPCom2FAViewModel.ViewState(
-                emailOrUsername = "test@email.com",
-                password = "",
-                otp = "123456",
+        WPComLoginEmailScreen(
+            viewState = WPComLoginEmailViewModel.ViewState(
+                usernameOnly = false,
+                emailOrUsername = "",
                 isJetpackInstalled = false
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailViewModel.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
@@ -27,13 +27,13 @@ import org.wordpress.android.login.MagicLinkFallbackButton
 import javax.inject.Inject
 
 @HiltViewModel
-class JetpackActivationWPComEmailViewModel @Inject constructor(
+class WPComLoginEmailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val wpComLoginRepository: WPComLoginRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val stringUtils: StringUtils,
 ) : ScopedViewModel(savedStateHandle) {
-    private val navArgs: JetpackActivationWPComEmailFragmentArgs by savedStateHandle.navArgs()
+    private val navArgs: WPComLoginEmailFragmentArgs by savedStateHandle.navArgs()
 
     private val emailOrUsername = savedStateHandle.getStateFlow(
         scope = viewModelScope,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerFragment.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import android.content.Intent
 import android.os.Bundle
@@ -17,8 +17,8 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.GoToStore
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackActivationScreen
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackCPInstallationScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackCPInstallationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -27,11 +27,11 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class JetpackActivationMagicLinkHandlerFragment : BaseFragment() {
+class WPComLoginMagicLinkHandlerFragment : BaseFragment() {
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
-    private val viewModel: JetpackActivationMagicLinkHandlerViewModel by viewModels()
+    private val viewModel: WPComLoginMagicLinkHandlerViewModel by viewModels()
 
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
@@ -42,7 +42,7 @@ class JetpackActivationMagicLinkHandlerFragment : BaseFragment() {
 
             setContent {
                 WooThemeWithBackground {
-                    JetpackActivationMagicLinkHandlerScreen(viewModel)
+                    WPComLoginMagicLinkHandlerScreen(viewModel)
                 }
             }
         }
@@ -62,8 +62,8 @@ class JetpackActivationMagicLinkHandlerFragment : BaseFragment() {
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
-            JetpackActivationMagicLinkHandlerFragmentDirections
-                .actionJetpackActivationMagicLinkHandlerFragmentToJetpackActivationMainFragment(
+            WPComLoginMagicLinkHandlerFragmentDirections
+                .actionWPComLoginMagicLinkHandlerFragmentToJetpackActivationMainFragment(
                     jetpackStatus = event.jetpackStatus,
                     siteUrl = event.siteUrl
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerScreen.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
@@ -27,9 +27,9 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
-fun JetpackActivationMagicLinkHandlerScreen(viewModel: JetpackActivationMagicLinkHandlerViewModel) {
+fun WPComLoginMagicLinkHandlerScreen(viewModel: WPComLoginMagicLinkHandlerViewModel) {
     viewModel.viewState.observeAsState().value?.let {
-        JetpackActivationMagicLinkHandlerScreen(
+        WPComLoginMagicLinkHandlerScreen(
             viewState = it,
             onRetryClick = viewModel::continueLogin,
             onCloseClick = viewModel::onCloseClick
@@ -38,15 +38,15 @@ fun JetpackActivationMagicLinkHandlerScreen(viewModel: JetpackActivationMagicLin
 }
 
 @Composable
-fun JetpackActivationMagicLinkHandlerScreen(
-    viewState: JetpackActivationMagicLinkHandlerViewModel.ViewState,
+fun WPComLoginMagicLinkHandlerScreen(
+    viewState: WPComLoginMagicLinkHandlerViewModel.ViewState,
     onRetryClick: () -> Unit = {},
     onCloseClick: () -> Unit = {}
 ) {
     BackHandler(onBack = onCloseClick)
 
     when (viewState) {
-        JetpackActivationMagicLinkHandlerViewModel.ViewState.Loading -> Box(
+        WPComLoginMagicLinkHandlerViewModel.ViewState.Loading -> Box(
             modifier = Modifier
                 .background(MaterialTheme.colors.surface)
                 .fillMaxSize()
@@ -54,7 +54,7 @@ fun JetpackActivationMagicLinkHandlerScreen(
             CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
         }
 
-        JetpackActivationMagicLinkHandlerViewModel.ViewState.Error ->
+        WPComLoginMagicLinkHandlerViewModel.ViewState.Error ->
             Scaffold(
                 topBar = {
                     Toolbar(
@@ -90,8 +90,8 @@ fun JetpackActivationMagicLinkHandlerScreen(
 @Composable
 private fun ErrorPreview() {
     WooThemeWithBackground {
-        JetpackActivationMagicLinkHandlerScreen(
-            viewState = JetpackActivationMagicLinkHandlerViewModel.ViewState.Error
+        WPComLoginMagicLinkHandlerScreen(
+            viewState = WPComLoginMagicLinkHandlerViewModel.ViewState.Error
         )
     }
 }
@@ -100,8 +100,8 @@ private fun ErrorPreview() {
 @Composable
 private fun LoadingPreview() {
     WooThemeWithBackground {
-        JetpackActivationMagicLinkHandlerScreen(
-            viewState = JetpackActivationMagicLinkHandlerViewModel.ViewState.Loading
+        WPComLoginMagicLinkHandlerScreen(
+            viewState = WPComLoginMagicLinkHandlerViewModel.ViewState.Loading
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerViewModel.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
@@ -15,18 +15,18 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class JetpackActivationMagicLinkHandlerViewModel @Inject constructor(
+class WPComLoginMagicLinkHandlerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     selectedSite: SelectedSite,
     jetpackActivationRepository: JetpackActivationRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
-) : JetpackActivationWPComPostLoginViewModel(
+) : WPComLoginPostLoginViewModel(
     savedStateHandle,
     selectedSite,
     jetpackActivationRepository,
     analyticsTrackerWrapper
 ) {
-    private val navArgs: JetpackActivationMagicLinkHandlerFragmentArgs by savedStateHandle.navArgs()
+    private val navArgs: WPComLoginMagicLinkHandlerFragmentArgs by savedStateHandle.navArgs()
 
     private val _viewState = MutableStateFlow(ViewState.Loading)
     val viewState = _viewState.asLiveData()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestFragment.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -12,7 +12,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationMagicLinkRequestViewModel.OpenEmailClient
+import com.woocommerce.android.ui.login.wpcom.WPComLoginMagicLinkRequestViewModel.OpenEmailClient
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -21,8 +21,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class JetpackActivationMagicLinkRequestFragment : BaseFragment() {
-    private val viewModel: JetpackActivationMagicLinkRequestViewModel by viewModels()
+class WPComLoginMagicLinkRequestFragment : BaseFragment() {
+    private val viewModel: WPComLoginMagicLinkRequestViewModel by viewModels()
 
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
@@ -36,7 +36,7 @@ class JetpackActivationMagicLinkRequestFragment : BaseFragment() {
 
             setContent {
                 WooThemeWithBackground {
-                    JetpackActivationMagicLinkRequestScreen(viewModel = viewModel)
+                    WPComLoginMagicLinkRequestScreen(viewModel = viewModel)
                 }
             }
         }
@@ -50,8 +50,8 @@ class JetpackActivationMagicLinkRequestFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is OpenEmailClient -> openEmailClient()
-                is JetpackActivationMagicLinkRequestViewModel.ShowPasswordScreen -> openPasswordScreen(event)
-                is JetpackActivationMagicLinkRequestViewModel.ShowUsernameScreen -> openUsernameScreen(event)
+                is WPComLoginMagicLinkRequestViewModel.ShowPasswordScreen -> openPasswordScreen(event)
+                is WPComLoginMagicLinkRequestViewModel.ShowUsernameScreen -> openUsernameScreen(event)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is Exit -> findNavController().navigateUp()
             }
@@ -66,20 +66,20 @@ class JetpackActivationMagicLinkRequestFragment : BaseFragment() {
         }
     }
 
-    private fun openPasswordScreen(event: JetpackActivationMagicLinkRequestViewModel.ShowPasswordScreen) {
+    private fun openPasswordScreen(event: WPComLoginMagicLinkRequestViewModel.ShowPasswordScreen) {
         findNavController().navigate(
-            JetpackActivationMagicLinkRequestFragmentDirections
-                .actionJetpackActivationMagicLinkRequestFragmentToJetpackActivationWPComPasswordFragment(
+            WPComLoginMagicLinkRequestFragmentDirections
+                .actionWPComLoginMagicLinkRequestFragmentToWPComLoginPasswordFragment(
                     emailOrUsername = event.emailOrUsername,
                     jetpackStatus = event.jetpackStatus
                 )
         )
     }
 
-    private fun openUsernameScreen(event: JetpackActivationMagicLinkRequestViewModel.ShowUsernameScreen) {
+    private fun openUsernameScreen(event: WPComLoginMagicLinkRequestViewModel.ShowUsernameScreen) {
         findNavController().navigate(
-            JetpackActivationMagicLinkRequestFragmentDirections
-                .actionJetpackActivationMagicLinkRequestFragmentToJetpackActivationWPComEmailFragment(
+            WPComLoginMagicLinkRequestFragmentDirections
+                .actionWPComLoginMagicLinkRequestFragmentToWPComLoginEmailFragment(
                     usernameOnly = true,
                     jetpackStatus = event.jetpackStatus
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -30,13 +30,13 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
-import com.woocommerce.android.ui.login.jetpack.components.UserInfo
+import com.woocommerce.android.ui.login.wpcom.components.UserInfo
 import org.wordpress.android.login.MagicLinkFallbackButton
 
 @Composable
-fun JetpackActivationMagicLinkRequestScreen(viewModel: JetpackActivationMagicLinkRequestViewModel) {
+fun WPComLoginMagicLinkRequestScreen(viewModel: WPComLoginMagicLinkRequestViewModel) {
     viewModel.viewState.observeAsState().value?.let {
-        JetpackActivationMagicLinkRequestScreen(
+        WPComLoginMagicLinkRequestScreen(
             viewState = it,
             onCloseClick = viewModel::onCloseClick,
             onRequestMagicLinkClick = viewModel::onRequestMagicLinkClick,
@@ -47,8 +47,8 @@ fun JetpackActivationMagicLinkRequestScreen(viewModel: JetpackActivationMagicLin
 }
 
 @Composable
-fun JetpackActivationMagicLinkRequestScreen(
-    viewState: JetpackActivationMagicLinkRequestViewModel.ViewState,
+fun WPComLoginMagicLinkRequestScreen(
+    viewState: WPComLoginMagicLinkRequestViewModel.ViewState,
     onCloseClick: () -> Unit = {},
     onRequestMagicLinkClick: () -> Unit = {},
     onOpenEmailClientClick: () -> Unit = {},
@@ -84,11 +84,11 @@ fun JetpackActivationMagicLinkRequestScreen(
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
 
             when (viewState) {
-                is JetpackActivationMagicLinkRequestViewModel.ViewState.MagicLinkRequestState -> {
+                is WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkRequestState -> {
                     MagicLinkRequestContent(viewState, onRequestMagicLinkClick, Modifier.weight(1f))
                 }
 
-                is JetpackActivationMagicLinkRequestViewModel.ViewState.MagicLinkSentState -> {
+                is WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkSentState -> {
                     MagicLinkSentContent(viewState, onOpenEmailClientClick, Modifier.weight(1f))
                 }
             }
@@ -112,7 +112,7 @@ fun JetpackActivationMagicLinkRequestScreen(
 
 @Composable
 private fun MagicLinkRequestContent(
-    viewState: JetpackActivationMagicLinkRequestViewModel.ViewState.MagicLinkRequestState,
+    viewState: WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkRequestState,
     onRequestMagicLinkClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -144,7 +144,7 @@ private fun MagicLinkRequestContent(
 
 @Composable
 private fun MagicLinkSentContent(
-    viewState: JetpackActivationMagicLinkRequestViewModel.ViewState.MagicLinkSentState,
+    viewState: WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkSentState,
     onOpenEmailClientClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -216,8 +216,8 @@ private fun MagicLinkSentContent(
 @Composable
 private fun MagicLinkRequestPreview() {
     WooThemeWithBackground {
-        JetpackActivationMagicLinkRequestScreen(
-            viewState = JetpackActivationMagicLinkRequestViewModel.ViewState.MagicLinkRequestState(
+        WPComLoginMagicLinkRequestScreen(
+            viewState = WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkRequestState(
                 emailOrUsername = "test@email.com",
                 avatarUrl = "avatar",
                 isJetpackInstalled = false,
@@ -232,8 +232,8 @@ private fun MagicLinkRequestPreview() {
 @Composable
 private fun MagicLinkSentPreview() {
     WooThemeWithBackground {
-        JetpackActivationMagicLinkRequestScreen(
-            viewState = JetpackActivationMagicLinkRequestViewModel.ViewState.MagicLinkSentState(
+        WPComLoginMagicLinkRequestScreen(
+            viewState = WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkSentState(
                 email = null,
                 isJetpackInstalled = false,
                 magicLinkFallbackButton = MagicLinkFallbackButton.Password,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModel.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import android.os.Parcelable
 import androidx.core.util.PatternsCompat
@@ -31,14 +31,14 @@ import org.wordpress.android.login.MagicLinkFallbackButton
 import javax.inject.Inject
 
 @HiltViewModel
-class JetpackActivationMagicLinkRequestViewModel @Inject constructor(
+class WPComLoginMagicLinkRequestViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val resourceProvider: ResourceProvider,
     private val wpComLoginRepository: WPComLoginRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
 
-    private val navArgs: JetpackActivationMagicLinkRequestFragmentArgs by savedStateHandle.navArgs()
+    private val navArgs: WPComLoginMagicLinkRequestFragmentArgs by savedStateHandle.navArgs()
 
     private val _viewState = savedStateHandle.getStateFlow<ViewState>(
         scope = viewModelScope,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import android.content.Intent
 import android.os.Bundle
@@ -17,10 +17,10 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.GoToStore
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPasswordViewModel.Show2FAScreen
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPasswordViewModel.ShowMagicLinkScreen
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackActivationScreen
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPostLoginViewModel.ShowJetpackCPInstallationScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordViewModel.Show2FAScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordViewModel.ShowMagicLinkScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackCPInstallationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -32,11 +32,11 @@ import org.wordpress.android.login.MagicLinkFallbackButton
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class JetpackActivationWPComPasswordFragment : BaseFragment() {
+class WPComLoginPasswordFragment : BaseFragment() {
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
-    private val viewModel: JetpackActivationWPComPasswordViewModel by viewModels()
+    private val viewModel: WPComLoginPasswordViewModel by viewModels()
 
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
@@ -47,7 +47,7 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
 
             setContent {
                 WooThemeWithBackground {
-                    JetpackActivationWPComPasswordScreen(viewModel = viewModel)
+                    WPComLoginPasswordScreen(viewModel = viewModel)
                 }
             }
         }
@@ -74,8 +74,8 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
 
     private fun navigateTo2FAScreen(event: Show2FAScreen) {
         findNavController().navigateSafely(
-            JetpackActivationWPComPasswordFragmentDirections
-                .actionJetpackActivationWPComPasswordFragmentToJetpackActivationWPCom2FAFragment(
+            WPComLoginPasswordFragmentDirections
+                .actionWPComLoginPasswordFragmentToWPComLogin2FAFragment(
                     jetpackStatus = event.jetpackStatus,
                     emailOrUsername = event.emailOrUsername,
                     password = event.password
@@ -85,8 +85,8 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
-            JetpackActivationWPComPasswordFragmentDirections
-                .actionJetpackActivationWPComPasswordFragmentToJetpackActivationMainFragment(
+            WPComLoginPasswordFragmentDirections
+                .actionWPComLoginPasswordFragmentToJetpackActivationMainFragment(
                     jetpackStatus = event.jetpackStatus,
                     siteUrl = event.siteUrl
                 )
@@ -95,8 +95,8 @@ class JetpackActivationWPComPasswordFragment : BaseFragment() {
 
     private fun navigateToMagicLinkScreen(event: ShowMagicLinkScreen) {
         findNavController().navigateSafely(
-            JetpackActivationWPComPasswordFragmentDirections
-                .actionJetpackActivationWPComPasswordFragmentToJetpackActivationMagicLinkRequestFragment(
+            WPComLoginPasswordFragmentDirections
+                .actionWPComLoginPasswordFragmentToWPComLoginMagicLinkRequestFragment(
                     emailOrUsername = event.emailOrUsername,
                     jetpackStatus = event.jetpackStatus,
                     fallbackButton = MagicLinkFallbackButton.Password,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -16,6 +16,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -29,29 +30,36 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.component.WCPasswordField
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.login.jetpack.components.JetpackConsent
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
+import com.woocommerce.android.ui.login.wpcom.components.UserInfo
 
 @Composable
-fun JetpackActivationWPComEmailScreen(viewModel: JetpackActivationWPComEmailViewModel) {
+fun WPComLoginPasswordScreen(viewModel: WPComLoginPasswordViewModel) {
     viewModel.viewState.observeAsState().value?.let {
-        JetpackActivationWPComEmailScreen(
+        WPComLoginPasswordScreen(
             viewState = it,
-            onEmailChanged = viewModel::onEmailOrUsernameChanged,
+            onPasswordChanged = viewModel::onPasswordChanged,
             onCloseClick = viewModel::onCloseClick,
-            onContinueClick = viewModel::onContinueClick
+            onContinueClick = viewModel::onContinueClick,
+            onMagicLinkClick = viewModel::onMagicLinkClick,
+            onResetPasswordClick = viewModel::onResetPasswordClick
         )
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun JetpackActivationWPComEmailScreen(
-    viewState: JetpackActivationWPComEmailViewModel.ViewState,
-    onEmailChanged: (String) -> Unit = {},
+fun WPComLoginPasswordScreen(
+    viewState: WPComLoginPasswordViewModel.ViewState,
+    onPasswordChanged: (String) -> Unit = {},
     onCloseClick: () -> Unit = {},
-    onContinueClick: () -> Unit = {}
+    onContinueClick: () -> Unit = {},
+    onMagicLinkClick: () -> Unit = {},
+    onResetPasswordClick: () -> Unit = {}
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -68,7 +76,7 @@ fun JetpackActivationWPComEmailScreen(
                 .background(MaterialTheme.colors.surface)
                 .padding(paddingValues)
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(rememberScrollState()),
         ) {
             Column(
                 modifier = Modifier
@@ -87,44 +95,41 @@ fun JetpackActivationWPComEmailScreen(
                     style = MaterialTheme.typography.h4,
                     fontWeight = FontWeight.Bold
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                UserInfo(
+                    emailOrUsername = viewState.emailOrUsername,
+                    avatarUrl = viewState.avatarUrl,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
                 Text(
                     text = stringResource(
                         id = if (viewState.isJetpackInstalled) {
-                            R.string.login_jetpack_connection_enter_wpcom_email
+                            R.string.login_jetpack_connection_enter_wpcom_password
                         } else {
-                            R.string.login_jetpack_installation_enter_wpcom_email
+                            R.string.login_jetpack_installation_enter_wpcom_password
                         }
                     )
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-
-                WCOutlinedTextField(
-                    value = viewState.emailOrUsername,
-                    onValueChange = onEmailChanged,
-                    label = if (viewState.usernameOnly) {
-                        stringResource(R.string.username)
-                    } else {
-                        stringResource(id = R.string.email_or_username)
-                    },
+                WCPasswordField(
+                    value = viewState.password,
+                    onValueChange = onPasswordChanged,
+                    label = stringResource(id = R.string.password),
                     isError = viewState.errorMessage != null,
                     helperText = viewState.errorMessage?.let { stringResource(id = it) },
-                    singleLine = true,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(
                         onDone = {
-                            keyboardController?.hide()
-                            onContinueClick()
+                            if (viewState.enableSubmit) {
+                                keyboardController?.hide()
+                                onContinueClick()
+                            }
                         }
                     )
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-
-                if (!viewState.usernameOnly) {
-                    Text(
-                        style = MaterialTheme.typography.body2,
-                        text = stringResource(id = R.string.login_jetpack_connection_create_account)
-                    )
+                WCTextButton(onClick = onResetPasswordClick) {
+                    Text(text = stringResource(id = R.string.reset_your_password))
                 }
             }
 
@@ -150,28 +155,34 @@ fun JetpackActivationWPComEmailScreen(
                     )
                 )
             }
-            JetpackConsent(
+            WCOutlinedButton(
+                onClick = onMagicLinkClick,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))
-            )
+            ) {
+                Text(
+                    text = stringResource(id = R.string.login_jetpack_installation_continue_magic_link)
+                )
+            }
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
         }
     }
 
     if (viewState.isLoadingDialogShown) {
-        ProgressDialog(title = "", subtitle = stringResource(id = R.string.checking_email))
+        ProgressDialog(title = "", subtitle = stringResource(id = R.string.logging_in))
     }
 }
 
-@Preview(heightDp = 130)
+@Preview
 @Composable
 private fun JetpackActivationWPComScreenPreview() {
     WooThemeWithBackground {
-        JetpackActivationWPComEmailScreen(
-            viewState = JetpackActivationWPComEmailViewModel.ViewState(
-                usernameOnly = false,
-                emailOrUsername = "",
+        WPComLoginPasswordScreen(
+            viewState = WPComLoginPasswordViewModel.ViewState(
+                emailOrUsername = "test@email.com",
+                password = "",
+                avatarUrl = "",
                 isJetpackInstalled = false
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
@@ -34,7 +34,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType
 import javax.inject.Inject
 
 @HiltViewModel
-class JetpackActivationWPComPasswordViewModel @Inject constructor(
+class WPComLoginPasswordViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     selectedSite: SelectedSite,
     jetpackAccountRepository: JetpackActivationRepository,
@@ -42,7 +42,7 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
     private val accountRepository: AccountRepository,
     private val resourceProvider: ResourceProvider,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
-) : JetpackActivationWPComPostLoginViewModel(
+) : WPComLoginPostLoginViewModel(
     savedStateHandle,
     selectedSite,
     jetpackAccountRepository,
@@ -52,7 +52,7 @@ class JetpackActivationWPComPasswordViewModel @Inject constructor(
         private const val RESET_PASSWORD_URL = "https://wordpress.com/wp-login.php?action=lostpassword"
     }
 
-    private val navArgs: JetpackActivationWPComPasswordFragmentArgs by savedStateHandle.navArgs()
+    private val navArgs: WPComLoginPasswordFragmentArgs by savedStateHandle.navArgs()
 
     private val password = savedStateHandle.getStateFlow(scope = viewModelScope, initialValue = "", key = "password")
     private val errorMessage =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModel.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
@@ -12,7 +12,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 
-open class JetpackActivationWPComPostLoginViewModel(
+open class WPComLoginPostLoginViewModel(
     savedStateHandle: SavedStateHandle,
     private val selectedSite: SelectedSite,
     private val jetpackActivationRepository: JetpackActivationRepository,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/components/UserInfo.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/components/UserInfo.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.components
+package com.woocommerce.android.ui.login.wpcom.components
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionDialog.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -33,16 +31,12 @@ class WooPushNotificationsIntroductionDialog : DialogFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         dialog?.window?.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
 
-        return ComposeView(requireContext()).apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-
-            composeView {
-                WooPushNotificationsIntroductionScreen(
-                    onContinueClick = viewModel::onContinueClick,
-                    onNotNowClick = viewModel::onNotNowClick,
-                    onWhatIsWPComClick = viewModel::onWhatIsWPComClick
-                )
-            }
+        return composeView {
+            WooPushNotificationsIntroductionScreen(
+                onContinueClick = viewModel::onContinueClick,
+                onNotNowClick = viewModel::onNotNowClick,
+                onWhatIsWPComClick = viewModel::onWhatIsWPComClick
+            )
         }
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -20,18 +20,18 @@
             app:popUpTo="@id/jetpackActivationDispatcherFragment"
             app:popUpToInclusive="true" />
         <action
-            android:id="@+id/action_jetpackActivationDispatcherFragment_to_jetpackActivationWPComEmailFragment"
-            app:destination="@id/jetpackActivationWPComEmailFragment"
+            android:id="@+id/action_jetpackActivationDispatcherFragment_to_wPComLoginEmailFragment"
+            app:destination="@id/wPComLoginEmailFragment"
             app:popUpTo="@id/jetpackActivationDispatcherFragment"
             app:popUpToInclusive="true" />
         <action
-            android:id="@+id/action_jetpackActivationDispatcherFragment_to_jetpackActivationWPComPasswordFragment"
-            app:destination="@id/jetpackActivationWPComPasswordFragment"
+            android:id="@+id/action_jetpackActivationDispatcherFragment_to_wPComLoginPasswordFragment"
+            app:destination="@id/wPComLoginPasswordFragment"
             app:popUpTo="@id/jetpackActivationDispatcherFragment"
             app:popUpToInclusive="true" />
         <action
-            android:id="@+id/action_jetpackActivationDispatcherFragment_to_jetpackActivationMagicLinkHandlerFragment"
-            app:destination="@id/jetpackActivationMagicLinkHandlerFragment"
+            android:id="@+id/action_jetpackActivationDispatcherFragment_to_wPComLoginMagicLinkHandlerFragment"
+            app:destination="@id/wPComLoginMagicLinkHandlerFragment"
             app:popUpTo="@id/jetpackActivationDispatcherFragment"
             app:popUpToInclusive="true" />
     </fragment>
@@ -83,27 +83,27 @@
             app:destination="@id/jetpackActivationWebViewFragment" />
     </fragment>
     <fragment
-        android:id="@+id/jetpackActivationWPComEmailFragment"
-        android:name="com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComEmailFragment"
-        android:label="JetpackActivationWPComEmailFragment">
+        android:id="@+id/wPComLoginEmailFragment"
+        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginEmailFragment"
+        android:label="WPComLoginEmailFragment">
         <argument
             android:name="jetpackStatus"
             app:argType="com.woocommerce.android.model.JetpackStatus" />
         <action
-            android:id="@+id/action_jetpackActivationWPComEmailFragment_to_jetpackActivationWPComPasswordFragment"
-            app:destination="@id/jetpackActivationWPComPasswordFragment" />
+            android:id="@+id/action_wPComLoginEmailFragment_to_wPComLoginPasswordFragment"
+            app:destination="@id/wPComLoginPasswordFragment" />
         <action
-            android:id="@+id/action_jetpackActivationWPComEmailFragment_to_jetpackActivationMagicLinkRequestFragment"
-            app:destination="@id/jetpackActivationMagicLinkRequestFragment" />
+            android:id="@+id/action_wPComLoginEmailFragment_to_wPComLoginMagicLinkRequestFragment"
+            app:destination="@id/wPComLoginMagicLinkRequestFragment" />
         <argument
             android:name="usernameOnly"
             app:argType="boolean"
             android:defaultValue="false" />
     </fragment>
     <fragment
-        android:id="@+id/jetpackActivationWPComPasswordFragment"
-        android:name="com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComPasswordFragment"
-        android:label="JetpackActivationWPComPasswordFragment">
+        android:id="@+id/wPComLoginPasswordFragment"
+        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordFragment"
+        android:label="WPComLoginPasswordFragment">
         <argument
             android:name="jetpackStatus"
             app:argType="com.woocommerce.android.model.JetpackStatus" />
@@ -111,19 +111,19 @@
             android:name="emailOrUsername"
             app:argType="string" />
         <action
-            android:id="@+id/action_jetpackActivationWPComPasswordFragment_to_jetpackActivationMainFragment"
+            android:id="@+id/action_wPComLoginPasswordFragment_to_jetpackActivationMainFragment"
             app:destination="@id/jetpackActivationMainFragment" />
         <action
-            android:id="@+id/action_jetpackActivationWPComPasswordFragment_to_jetpackActivationWPCom2FAFragment"
-            app:destination="@id/jetpackActivationWPCom2FAFragment" />
+            android:id="@+id/action_wPComLoginPasswordFragment_to_wPComLogin2FAFragment"
+            app:destination="@id/wPComLogin2FAFragment" />
         <action
-            android:id="@+id/action_jetpackActivationWPComPasswordFragment_to_jetpackActivationMagicLinkRequestFragment"
-            app:destination="@id/jetpackActivationMagicLinkRequestFragment" />
+            android:id="@+id/action_wPComLoginPasswordFragment_to_wPComLoginMagicLinkRequestFragment"
+            app:destination="@id/wPComLoginMagicLinkRequestFragment" />
     </fragment>
     <fragment
-        android:id="@+id/jetpackActivationWPCom2FAFragment"
-        android:name="com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPCom2FAFragment"
-        android:label="JetpackActivationWPCom2FAFragment">
+        android:id="@+id/wPComLogin2FAFragment"
+        android:name="com.woocommerce.android.ui.login.wpcom.WPComLogin2FAFragment"
+        android:label="WPComLogin2FAFragment">
         <argument
             android:name="jetpackStatus"
             app:argType="com.woocommerce.android.model.JetpackStatus" />
@@ -134,13 +134,13 @@
             android:name="password"
             app:argType="string" />
         <action
-            android:id="@+id/action_jetpackActivationWPCom2FAFragment_to_jetpackActivationMainFragment"
+            android:id="@+id/action_wPComLogin2FAFragment_to_jetpackActivationMainFragment"
             app:destination="@id/jetpackActivationMainFragment" />
     </fragment>
     <fragment
-        android:id="@+id/jetpackActivationMagicLinkRequestFragment"
-        android:name="com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationMagicLinkRequestFragment"
-        android:label="JetpackActivationMagicLinkRequestFragment">
+        android:id="@+id/wPComLoginMagicLinkRequestFragment"
+        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginMagicLinkRequestFragment"
+        android:label="WPComLoginMagicLinkRequestFragment">
         <argument
             android:name="jetpackStatus"
             app:argType="com.woocommerce.android.model.JetpackStatus" />
@@ -157,27 +157,27 @@
             android:name="isNewWpComAccount"
             app:argType="boolean" />
         <action
-            android:id="@+id/action_jetpackActivationMagicLinkRequestFragment_to_jetpackActivationWPComPasswordFragment"
-            app:destination="@id/jetpackActivationWPComPasswordFragment"
+            android:id="@+id/action_wPComLoginMagicLinkRequestFragment_to_wPComLoginPasswordFragment"
+            app:destination="@id/wPComLoginPasswordFragment"
             app:launchSingleTop="true"
-            app:popUpTo="@id/jetpackActivationMagicLinkRequestFragment"
+            app:popUpTo="@id/wPComLoginMagicLinkRequestFragment"
             app:popUpToInclusive="true" />
         <action
-            android:id="@+id/action_jetpackActivationMagicLinkRequestFragment_to_jetpackActivationWPComEmailFragment"
-            app:destination="@id/jetpackActivationWPComEmailFragment"
+            android:id="@+id/action_wPComLoginMagicLinkRequestFragment_to_wPComLoginEmailFragment"
+            app:destination="@id/wPComLoginEmailFragment"
             app:launchSingleTop="true"
-            app:popUpTo="@id/jetpackActivationMagicLinkRequestFragment"
+            app:popUpTo="@id/wPComLoginMagicLinkRequestFragment"
             app:popUpToInclusive="true" />
     </fragment>
     <fragment
-        android:id="@+id/jetpackActivationMagicLinkHandlerFragment"
-        android:name="com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationMagicLinkHandlerFragment"
-        android:label="JetpackActivationMagicLinkHandlerFragment">
+        android:id="@+id/wPComLoginMagicLinkHandlerFragment"
+        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginMagicLinkHandlerFragment"
+        android:label="WPComLoginMagicLinkHandlerFragment">
         <argument
             android:name="jetpackStatus"
             app:argType="com.woocommerce.android.model.JetpackStatus" />
         <action
-            android:id="@+id/action_jetpackActivationMagicLinkHandlerFragment_to_jetpackActivationMainFragment"
+            android:id="@+id/action_wPComLoginMagicLinkHandlerFragment_to_jetpackActivationMainFragment"
             app:destination="@id/jetpackActivationMainFragment"
             app:popUpTo="@id/jetpackActivationDispatcherFragment"
             app:popUpToInclusive="true" />

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailViewModelTest.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.R
@@ -7,8 +7,8 @@ import com.woocommerce.android.model.JetpackConnectionStatus
 import com.woocommerce.android.model.JetpackSiteRegistrationStatus
 import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.ui.login.WPComLoginRepository
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComEmailViewModel.ShowMagicLinkScreen
-import com.woocommerce.android.ui.login.jetpack.wpcom.JetpackActivationWPComEmailViewModel.ShowPasswordScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginEmailViewModel.ShowMagicLinkScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginEmailViewModel.ShowPasswordScreen
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -26,7 +26,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class JetpackActivationWPComEmailViewModelTest : BaseUnitTest() {
+class WPComLoginEmailViewModelTest : BaseUnitTest() {
     companion object {
         const val WPCOM_EMAIL = "wpcomUser@gmail.com"
         const val UNKNOWN_EMAIL = "newUser@example.com"
@@ -40,17 +40,17 @@ class JetpackActivationWPComEmailViewModelTest : BaseUnitTest() {
         )
     }
 
-    private val saveStateHandle = JetpackActivationWPComEmailFragmentArgs(
+    private val saveStateHandle = WPComLoginEmailFragmentArgs(
         jetpackStatus = JETPACK_STATUS,
     ).toSavedStateHandle()
     private val wpComLoginRepository: WPComLoginRepository = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val stringUtils: StringUtils = mock()
-    private lateinit var viewModel: JetpackActivationWPComEmailViewModel
+    private lateinit var viewModel: WPComLoginEmailViewModel
 
     fun setup(wpComEmail: String) {
         saveStateHandle["email"] = wpComEmail
-        viewModel = JetpackActivationWPComEmailViewModel(
+        viewModel = WPComLoginEmailViewModel(
             savedStateHandle = saveStateHandle,
             wpComLoginRepository = wpComLoginRepository,
             analyticsTrackerWrapper = analyticsTrackerWrapper,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModelTest.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.login.jetpack.wpcom
+package com.woocommerce.android.ui.login.wpcom
 
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.JetpackConnectionStatus
@@ -18,7 +18,7 @@ import org.mockito.kotlin.verify
 import org.wordpress.android.login.MagicLinkFallbackButton
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class JetpackActivationMagicLinkRequestViewModelTest : BaseUnitTest() {
+class WPComLoginMagicLinkRequestViewModelTest : BaseUnitTest() {
     companion object {
         private const val EMAIL = "email@example.com"
         private val JetpackStatus = JetpackStatus(
@@ -34,14 +34,14 @@ class JetpackActivationMagicLinkRequestViewModelTest : BaseUnitTest() {
     private val wpComLoginRepository: WPComLoginRepository = mock()
     private val resourceProvider: ResourceProvider = mock()
 
-    private lateinit var viewModel: JetpackActivationMagicLinkRequestViewModel
+    private lateinit var viewModel: WPComLoginMagicLinkRequestViewModel
 
     fun setup(
         fallbackButton: MagicLinkFallbackButton,
         requestEmailAtStart: Boolean = true
     ) {
-        viewModel = JetpackActivationMagicLinkRequestViewModel(
-            JetpackActivationMagicLinkRequestFragmentArgs(
+        viewModel = WPComLoginMagicLinkRequestViewModel(
+            WPComLoginMagicLinkRequestFragmentArgs(
                 jetpackStatus = JetpackStatus,
                 emailOrUsername = EMAIL,
                 fallbackButton = fallbackButton,
@@ -100,7 +100,7 @@ class JetpackActivationMagicLinkRequestViewModelTest : BaseUnitTest() {
             viewModel.onOpenEmailClientClick()
         }.last()
 
-        assertThat(event).isEqualTo(JetpackActivationMagicLinkRequestViewModel.OpenEmailClient)
+        assertThat(event).isEqualTo(WPComLoginMagicLinkRequestViewModel.OpenEmailClient)
     }
 
     @Test
@@ -112,7 +112,7 @@ class JetpackActivationMagicLinkRequestViewModelTest : BaseUnitTest() {
         }.last()
 
         assertThat(event).isEqualTo(
-            JetpackActivationMagicLinkRequestViewModel.ShowPasswordScreen(
+            WPComLoginMagicLinkRequestViewModel.ShowPasswordScreen(
                 emailOrUsername = EMAIL,
                 jetpackStatus = JetpackStatus
             )
@@ -128,7 +128,7 @@ class JetpackActivationMagicLinkRequestViewModelTest : BaseUnitTest() {
         }.last()
 
         assertThat(event).isEqualTo(
-            JetpackActivationMagicLinkRequestViewModel.ShowUsernameScreen(
+            WPComLoginMagicLinkRequestViewModel.ShowUsernameScreen(
                 jetpackStatus = JetpackStatus
             )
         )


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-1925

### Description
This is the first PR for the attached task, it moves the login related files to a common package. Key changes:

- Move WPCom login files from `ui/login/jetpack/wpcom/` to `ui/login/wpcom/` and rename classes to drop the `JetpackActivation` prefix (e.g. `JetpackActivationWPComEmailFragment` → `WPComLoginEmailFragment`)
- Update nav graph fragment IDs, action IDs, and `android:name` references to point to new locations
- Update callers (`JetpackActivationDispatcherFragment`, `MagicLinkInterceptActivity`) and move test files accordingly

This is a structural move with no behavior changes, preparing for configurable branding in follow-up PRs.

Note: the last commit fixes an accidental change(f6f39a0597db5a39e235f72c90f26f375628d63e) that broke the Jetpack Benefits dialog.

### Test Steps
1. Sign in using site credentials to a site that's not connected to Jetpack
2. Start Jetpack setup.
3. Confirm WordPress.com login works without issues.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
