### PR TITLE
[CIAB: POS] Single collect payment button

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.bookings
 
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.DateFormatter
 import com.woocommerce.android.util.normalizeDuration
 import com.woocommerce.android.util.toHumanReadableFormat
@@ -16,9 +17,10 @@ import javax.inject.Inject
 class WooPosBookingViewStateMapper @Inject constructor(
     private val dateFormatter: DateFormatter,
     private val resourceProvider: ResourceProvider,
+    private val priceFormat: WooPosFormatPrice,
 ) {
 
-    fun mapToItemViewState(
+    suspend fun mapToItemViewState(
         booking: BookingEntity,
         selectedBookingId: Long?,
     ): WooPosBookingsState.BookingItemViewState {
@@ -26,7 +28,7 @@ class WooPosBookingViewStateMapper @Inject constructor(
             id = booking.id.value,
             title = booking.order.productInfo?.name ?: "#${booking.id.value}",
             date = dateFormatter.formatDateTime(booking.start),
-            total = booking.order.paymentInfo?.total?.toPlainString() ?: "",
+            total = priceFormat(booking.order.paymentInfo?.total),
             customerEmail = booking.order.customerInfo?.billingEmail?.ifBlank { null },
             isSelected = booking.id.value == selectedBookingId,
             status = mapBookingStatus(booking.status),
@@ -35,7 +37,7 @@ class WooPosBookingViewStateMapper @Inject constructor(
         )
     }
 
-    fun mapToDetailsViewState(
+    suspend fun mapToDetailsViewState(
         booking: BookingEntity,
     ): WooPosBookingsState.BookingDetailsViewState {
         val detailsDateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
@@ -97,27 +99,29 @@ class WooPosBookingViewStateMapper @Inject constructor(
         return WooPosBookingsState.AttendanceSection(selection = selection)
     }
 
-    private fun buildPaymentSection(
+    private suspend fun buildPaymentSection(
         booking: BookingEntity
     ): WooPosBookingsState.PaymentSection {
         val paymentInfo = booking.order.paymentInfo
         val isPaid = booking.status == BookingEntity.Status.Paid ||
             booking.status == BookingEntity.Status.Complete
 
+        val totalAmount = paymentInfo?.let { priceFormat(it.total + it.totalTax) } ?: "-"
+
         return WooPosBookingsState.PaymentSection(
-            serviceAmount = paymentInfo?.subtotal?.toPlainString() ?: "-",
-            taxAmount = paymentInfo?.totalTax?.toPlainString() ?: "-",
+            serviceAmount = paymentInfo?.subtotal?.let { priceFormat(it) } ?: "-",
+            taxAmount = paymentInfo?.totalTax?.let { priceFormat(it) } ?: "-",
             discountAmount = paymentInfo?.let {
                 val discount = it.total - it.subtotal
                 if (discount.compareTo(java.math.BigDecimal.ZERO) != 0) {
-                    "-${discount.abs().toPlainString()}"
+                    "-${priceFormat(discount.abs())}"
                 } else {
                     "-"
                 }
             } ?: "-",
-            totalAmount = paymentInfo?.let { (it.total + it.totalTax).toPlainString() } ?: "-",
+            totalAmount = totalAmount,
             paidWithLabel = if (isPaid) paymentInfo?.paymentMethodTitle else null,
-            showPayButtons = !isPaid,
+            collectPaymentLabel = if (!isPaid) totalAmount else null,
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -683,7 +683,7 @@ private fun sampleBookingDetails(
         discountAmount = "-",
         totalAmount = "$59.50",
         paidWithLabel = "WooCommerce In-Person Payments",
-        showPayButtons = false,
+        collectPaymentLabel = null,
     ),
     bookingNote = null,
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
@@ -53,7 +53,7 @@ sealed class WooPosBookingsState {
         val discountAmount: String,
         val totalAmount: String,
         val paidWithLabel: String?,
-        val showPayButtons: Boolean,
+        val collectPaymentLabel: String?,
     )
 
     @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsUIEvent.kt
@@ -3,8 +3,7 @@ package com.woocommerce.android.ui.woopos.bookings
 sealed interface WooPosBookingsUIEvent {
     data class BookingActionClicked(val action: WooPosBookingsState.BookingAction) : WooPosBookingsUIEvent
     data class AttendanceToggled(val attended: Boolean) : WooPosBookingsUIEvent
-    data object PayByCardClicked : WooPosBookingsUIEvent
-    data object PayByCashClicked : WooPosBookingsUIEvent
+    data object CollectPaymentClicked : WooPosBookingsUIEvent
     data object AddBookingNoteClicked : WooPosBookingsUIEvent
     data class CopyEmailClicked(val email: String) : WooPosBookingsUIEvent
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -235,6 +235,7 @@ class WooPosBookingsViewModel @Inject constructor(
                 WooPosNavigationEvent.OpenCardPayment(
                     orderId = details.orderId,
                     source = CardPaymentSource.BOOKINGS,
+                    showPayByCashButton = true,
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.bookings.list.BookingListHandler
 import com.woocommerce.android.ui.bookings.list.BookingListSortOption
 import com.woocommerce.android.ui.woopos.cardpayment.CardPaymentSource
-import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.localcatalog.DateTimeProvider
@@ -216,8 +215,7 @@ class WooPosBookingsViewModel @Inject constructor(
         when (event) {
             is WooPosBookingsUIEvent.BookingActionClicked -> handleBookingAction(event.action)
             is WooPosBookingsUIEvent.AttendanceToggled -> { }
-            is WooPosBookingsUIEvent.PayByCardClicked -> handlePayByCard()
-            is WooPosBookingsUIEvent.PayByCashClicked -> handlePayByCash()
+            is WooPosBookingsUIEvent.CollectPaymentClicked -> handleCollectPayment()
             is WooPosBookingsUIEvent.AddBookingNoteClicked -> { }
             is WooPosBookingsUIEvent.CopyEmailClicked -> { }
         }
@@ -230,25 +228,13 @@ class WooPosBookingsViewModel @Inject constructor(
         )
     }
 
-    private fun handlePayByCard() {
+    private fun handleCollectPayment() {
         val details = (_state.value as? WooPosBookingsState.Content)?.selectedDetails ?: return
         viewModelScope.launch {
             _navigationEvent.emit(
                 WooPosNavigationEvent.OpenCardPayment(
                     orderId = details.orderId,
                     source = CardPaymentSource.BOOKINGS,
-                )
-            )
-        }
-    }
-
-    private fun handlePayByCash() {
-        val details = (_state.value as? WooPosBookingsState.Content)?.selectedDetails ?: return
-        viewModelScope.launch {
-            _navigationEvent.emit(
-                WooPosNavigationEvent.OpenCashPayment(
-                    orderId = details.orderId,
-                    source = CashPaymentSource.BOOKINGS,
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -48,7 +48,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButtonSmall
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
@@ -95,9 +94,13 @@ fun WooPosBookingDetails(
 
         BookingPaymentCard(paymentSection = details.paymentSection)
 
-        if (details.paymentSection.showPayButtons) {
+        details.paymentSection.collectPaymentLabel?.let { label ->
             Spacer(Modifier.height(WooPosSpacing.Large.value))
-            BookingPayButtons(onUIEvent = onUIEvent)
+            WooPosButton(
+                text = stringResource(R.string.woopos_bookings_details_collect_payment, label),
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onUIEvent(WooPosBookingsUIEvent.CollectPaymentClicked) }
+            )
         }
 
         Spacer(Modifier.height(WooPosSpacing.Large.value))
@@ -423,25 +426,6 @@ private fun BookingPaymentCard(
 }
 
 @Composable
-private fun BookingPayButtons(onUIEvent: (WooPosBookingsUIEvent) -> Unit) {
-    Column(modifier = Modifier.fillMaxWidth()) {
-        WooPosButton(
-            text = stringResource(R.string.woopos_bookings_details_pay_by_card),
-            modifier = Modifier.fillMaxWidth(),
-            onClick = { onUIEvent(WooPosBookingsUIEvent.PayByCardClicked) }
-        )
-
-        Spacer(Modifier.height(WooPosSpacing.Medium.value))
-
-        WooPosOutlinedButton(
-            text = stringResource(R.string.woopos_bookings_details_pay_by_cash),
-            modifier = Modifier.fillMaxWidth(),
-            onClick = { onUIEvent(WooPosBookingsUIEvent.PayByCashClicked) }
-        )
-    }
-}
-
-@Composable
 private fun BookingNoteSection(
     bookingNote: String?,
     onUIEvent: (WooPosBookingsUIEvent) -> Unit
@@ -609,7 +593,7 @@ fun WooPosBookingDetailsPreview() {
             discountAmount = "-",
             totalAmount = "$55.00",
             paidWithLabel = null,
-            showPayButtons = true,
+            collectPaymentLabel = "$55.00",
         ),
         bookingNote = null,
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentNavigation.kt
@@ -13,9 +13,11 @@ import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
 
 const val CARD_PAYMENT_ROUTE_ORDER_ID_KEY = "orderId"
 const val CARD_PAYMENT_ROUTE_SOURCE_KEY = "source"
+const val CARD_PAYMENT_ROUTE_SHOW_PAY_BY_CASH_KEY = "showPayByCash"
 const val CARD_PAYMENT_ROUTE =
     "$HOME_ROUTE/card_payment/{$CARD_PAYMENT_ROUTE_ORDER_ID_KEY}" +
-        "?$CARD_PAYMENT_ROUTE_SOURCE_KEY={$CARD_PAYMENT_ROUTE_SOURCE_KEY}"
+        "?$CARD_PAYMENT_ROUTE_SOURCE_KEY={$CARD_PAYMENT_ROUTE_SOURCE_KEY}" +
+        "&$CARD_PAYMENT_ROUTE_SHOW_PAY_BY_CASH_KEY={$CARD_PAYMENT_ROUTE_SHOW_PAY_BY_CASH_KEY}"
 
 const val BOOKING_CARD_PAYMENT_SUCCESS_KEY = "booking_card_payment_success"
 
@@ -27,11 +29,13 @@ enum class CardPaymentSource {
 fun NavController.navigateToCardPaymentScreen(
     orderId: Long,
     source: CardPaymentSource = CardPaymentSource.CHECKOUT,
+    showPayByCashButton: Boolean = false,
 ) {
     navigateOnce(
         CARD_PAYMENT_ROUTE
             .replace("{$CARD_PAYMENT_ROUTE_ORDER_ID_KEY}", orderId.toString())
             .replace("{$CARD_PAYMENT_ROUTE_SOURCE_KEY}", source.name)
+            .replace("{$CARD_PAYMENT_ROUTE_SHOW_PAY_BY_CASH_KEY}", showPayByCashButton.toString())
     )
 }
 
@@ -45,6 +49,10 @@ fun NavGraphBuilder.cardPaymentScreen(
             navArgument(CARD_PAYMENT_ROUTE_SOURCE_KEY) {
                 type = NavType.StringType
                 defaultValue = CardPaymentSource.CHECKOUT.name
+            },
+            navArgument(CARD_PAYMENT_ROUTE_SHOW_PAY_BY_CASH_KEY) {
+                type = NavType.BoolType
+                defaultValue = false
             }
         ),
         enterTransition = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -67,24 +68,28 @@ fun WooPosCardPaymentScreen(
 
     WooPosCardPaymentScreenContent(
         state = state,
+        showCashPaymentButton = viewModel.showCashPaymentButton,
         onRetryClicked = viewModel::onRetryClicked,
         onDismissClicked = viewModel::onDismissClicked,
         onConnectReaderClicked = viewModel::onConnectReaderClicked,
         onDoneClicked = viewModel::onDoneClicked,
         onEmailReceiptClicked = viewModel::onEmailReceiptClicked,
         onBackClicked = viewModel::onBackClicked,
+        onCashPaymentClicked = viewModel::onCashPaymentClicked,
     )
 }
 
 @Composable
 private fun WooPosCardPaymentScreenContent(
     state: WooPosCardPaymentState,
+    showCashPaymentButton: Boolean,
     onRetryClicked: () -> Unit,
     onDismissClicked: () -> Unit,
     onConnectReaderClicked: () -> Unit,
     onDoneClicked: () -> Unit,
     onEmailReceiptClicked: () -> Unit,
     onBackClicked: () -> Unit,
+    onCashPaymentClicked: () -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         StateChangeAnimated(visible = state is WooPosCardPaymentState.Initiating) {
@@ -93,13 +98,21 @@ private fun WooPosCardPaymentScreenContent(
 
         StateChangeAnimated(visible = state is WooPosCardPaymentState.Collecting.Preparing) {
             if (state is WooPosCardPaymentState.Collecting.Preparing) {
-                CardPaymentPreparingReader(state)
+                CardPaymentPreparingReader(
+                    state = state,
+                    showCashPaymentButton = showCashPaymentButton,
+                    onCashPaymentClicked = onCashPaymentClicked,
+                )
             }
         }
 
         StateChangeAnimated(visible = state is WooPosCardPaymentState.Collecting.ReadyForPayment) {
             if (state is WooPosCardPaymentState.Collecting.ReadyForPayment) {
-                CardPaymentReadyForPayment(state)
+                CardPaymentReadyForPayment(
+                    state = state,
+                    showCashPaymentButton = showCashPaymentButton,
+                    onCashPaymentClicked = onCashPaymentClicked,
+                )
             }
         }
 
@@ -165,7 +178,11 @@ private fun CardPaymentInitiating() {
 }
 
 @Composable
-private fun CardPaymentPreparingReader(state: WooPosCardPaymentState.Collecting.Preparing) {
+private fun CardPaymentPreparingReader(
+    state: WooPosCardPaymentState.Collecting.Preparing,
+    showCashPaymentButton: Boolean,
+    onCashPaymentClicked: () -> Unit,
+) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -190,11 +207,19 @@ private fun CardPaymentPreparingReader(state: WooPosCardPaymentState.Collecting.
                 fontWeight = FontWeight.Bold
             )
         }
+        CashPaymentButton(
+            showCashPaymentButton = showCashPaymentButton,
+            onCashPaymentClicked = onCashPaymentClicked,
+        )
     }
 }
 
 @Composable
-private fun CardPaymentReadyForPayment(state: WooPosCardPaymentState.Collecting.ReadyForPayment) {
+private fun CardPaymentReadyForPayment(
+    state: WooPosCardPaymentState.Collecting.ReadyForPayment,
+    showCashPaymentButton: Boolean,
+    onCashPaymentClicked: () -> Unit,
+) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -229,6 +254,28 @@ private fun CardPaymentReadyForPayment(state: WooPosCardPaymentState.Collecting.
                 modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
             )
         }
+        CashPaymentButton(
+            showCashPaymentButton = showCashPaymentButton,
+            onCashPaymentClicked = onCashPaymentClicked,
+        )
+    }
+}
+
+@Composable
+private fun BoxScope.CashPaymentButton(
+    showCashPaymentButton: Boolean,
+    onCashPaymentClicked: () -> Unit,
+) {
+    if (showCashPaymentButton) {
+        WooPosOutlinedButton(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = WooPosSpacing.Huge.value)
+                .height(80.dp)
+                .width(604.dp),
+            text = stringResource(R.string.woopos_cash_payment_title),
+            onClick = onCashPaymentClicked,
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -53,6 +53,8 @@ class WooPosCardPaymentViewModel @Inject constructor(
     private val _state = MutableStateFlow<WooPosCardPaymentState>(WooPosCardPaymentState.Initiating)
     val state: StateFlow<WooPosCardPaymentState> = _state.asStateFlow()
 
+    val showCashPaymentButton: Boolean = savedState[CARD_PAYMENT_ROUTE_SHOW_PAY_BY_CASH_KEY] ?: false
+
     private val _navigationEvent = MutableSharedFlow<WooPosNavigationEvent>()
     val navigationEvent: SharedFlow<WooPosNavigationEvent> = _navigationEvent.asSharedFlow()
 
@@ -303,6 +305,13 @@ class WooPosCardPaymentViewModel @Inject constructor(
         viewModelScope.launch {
             analyticsTracker.trackEmailReceiptTapped()
             _navigationEvent.emit(WooPosNavigationEvent.OpenEmailReceipt(orderId))
+        }
+    }
+
+    fun onCashPaymentClicked() {
+        cancelPayment()
+        viewModelScope.launch {
+            _navigationEvent.emit(WooPosNavigationEvent.SwitchToCashPayment(orderId))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
@@ -16,6 +16,7 @@ sealed class WooPosNavigationEvent {
     data class OpenCardPayment(
         val orderId: Long,
         val source: CardPaymentSource = CardPaymentSource.CHECKOUT,
+        val showPayByCashButton: Boolean = false,
     ) : WooPosNavigationEvent()
     data class OpenEmailReceipt(val orderId: Long) : WooPosNavigationEvent()
     data class OpenRefundReason(val orderId: Long, val initialReason: String = "") : WooPosNavigationEvent()
@@ -29,4 +30,5 @@ sealed class WooPosNavigationEvent {
     data object OpenSettings : WooPosNavigationEvent()
     data object OpenOrders : WooPosNavigationEvent()
     data object OpenBookings : WooPosNavigationEvent()
+    data class SwitchToCashPayment(val orderId: Long) : WooPosNavigationEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
@@ -4,6 +4,7 @@ import androidx.activity.ComponentActivity
 import androidx.navigation.NavHostController
 import com.woocommerce.android.ui.woopos.bookings.navigateToBookingsScreen
 import com.woocommerce.android.ui.woopos.cardpayment.navigateToCardPaymentScreen
+import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
 import com.woocommerce.android.ui.woopos.cashpayment.navigateToCashPaymentScreen
 import com.woocommerce.android.ui.woopos.emailreceipt.navigateToEmailReceipt
 import com.woocommerce.android.ui.woopos.home.navigateToEligibilityScreen
@@ -29,7 +30,7 @@ fun NavHostController.handleNavigationEvent(
         is WooPosNavigationEvent.OpenCashPayment -> navigateToCashPaymentScreen(event.orderId, event.source)
 
         is WooPosNavigationEvent.OpenCardPayment ->
-            navigateToCardPaymentScreen(event.orderId, event.source)
+            navigateToCardPaymentScreen(event.orderId, event.source, event.showPayByCashButton)
 
         is WooPosNavigationEvent.GoBackWithResult -> {
             previousBackStackEntry
@@ -63,5 +64,10 @@ fun NavHostController.handleNavigationEvent(
 
         is WooPosNavigationEvent.OpenBookings ->
             navigateToBookingsScreen()
+
+        is WooPosNavigationEvent.SwitchToCashPayment -> {
+            popBackStack()
+            navigateToCashPaymentScreen(event.orderId, CashPaymentSource.BOOKINGS)
+        }
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3904,8 +3904,7 @@
     <string name="woopos_bookings_details_tax_label">Taxes</string>
     <string name="woopos_bookings_details_discount_label">Discount</string>
     <string name="woopos_bookings_details_total_label">Total</string>
-    <string name="woopos_bookings_details_pay_by_card">Pay by card</string>
-    <string name="woopos_bookings_details_pay_by_cash">Pay by cash</string>
+    <string name="woopos_bookings_details_collect_payment">Collect payment · %s</string>
     <string name="woopos_bookings_details_booking_note_title">Booking note</string>
     <string name="woopos_bookings_details_add_note">Add note</string>
     <string name="woopos_bookings_details_booking_note_hint">This is a private note. It\'ll not be shared with the customer.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.ui.woopos.bookings
 
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.DateFormatter
 import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -33,6 +35,7 @@ class WooPosBookingViewStateMapperTest {
     }
 
     private val dateFormatter: DateFormatter = mock()
+    private val priceFormat: WooPosFormatPrice = mock()
     private val resourceProvider: ResourceProvider = mock {
         on { getQuantityString(any(), any(), anyOrNull(), anyOrNull()) } doAnswer { invocation ->
             val quantity = invocation.arguments[0] as Int
@@ -60,14 +63,18 @@ class WooPosBookingViewStateMapperTest {
     private lateinit var mapper: WooPosBookingViewStateMapper
 
     @Before
-    fun setup() {
+    fun setup() = runTest {
         whenever(dateFormatter.formatDateTime(any<Instant>())).thenReturn(FORMATTED_DATE_TIME)
         whenever(dateFormatter.formatTime(any<Instant>())).thenReturn(FORMATTED_TIME)
-        mapper = WooPosBookingViewStateMapper(dateFormatter, resourceProvider)
+        whenever(priceFormat(anyOrNull())).doAnswer { invocation ->
+            val amount = invocation.arguments[0] as? BigDecimal
+            amount?.let { "$${it.toPlainString()}" } ?: "$0.00"
+        }
+        mapper = WooPosBookingViewStateMapper(dateFormatter, resourceProvider, priceFormat)
     }
 
     @Test
-    fun `given booking, when mapped to item view state, then formats date and maps fields correctly`() {
+    fun `given booking, when mapped to item view state, then formats date and maps fields correctly`() = runTest {
         val booking = sampleBooking()
 
         val result = mapper.mapToItemViewState(booking, selectedBookingId = null)
@@ -75,13 +82,13 @@ class WooPosBookingViewStateMapperTest {
         assertThat(result.id).isEqualTo(1L)
         assertThat(result.title).isEqualTo("Women's Haircut")
         assertThat(result.date).isEqualTo(FORMATTED_DATE_TIME)
-        assertThat(result.total).isEqualTo("55")
+        assertThat(result.total).isEqualTo("$55")
         assertThat(result.customerEmail).isEqualTo("margarita@example.com")
         assertThat(result.isSelected).isFalse()
     }
 
     @Test
-    fun `given booking, when mapped to details view state, then formats date time and duration correctly`() {
+    fun `given booking, when mapped to details view state, then formats date time and duration correctly`() = runTest {
         val start = Instant.parse("2025-07-05T11:00:00Z")
         val end = start.plus(Duration.ofMinutes(90))
         val booking = sampleBooking(start = start, end = end)
@@ -97,7 +104,7 @@ class WooPosBookingViewStateMapperTest {
     }
 
     @Test
-    fun `given booking with null paymentInfo, when mapped to details, then payment section shows dashes`() {
+    fun `given booking with null paymentInfo, when mapped to details, then payment section shows dashes`() = runTest {
         val booking = sampleBooking(paymentInfo = null)
 
         val result = mapper.mapToDetailsViewState(booking)
@@ -109,7 +116,7 @@ class WooPosBookingViewStateMapperTest {
     }
 
     @Test
-    fun `given booking with discount, when mapped to details, then discount is negative formatted`() {
+    fun `given booking with discount, when mapped to details, then discount is negative formatted`() = runTest {
         val paymentInfo = BookingPaymentInfo(
             paymentMethodId = "cod",
             paymentMethodTitle = "Cash on Delivery",
@@ -122,12 +129,12 @@ class WooPosBookingViewStateMapperTest {
 
         val result = mapper.mapToDetailsViewState(booking)
 
-        assertThat(result.paymentSection.discountAmount).isEqualTo("-10")
-        assertThat(result.paymentSection.totalAmount).isEqualTo("99")
+        assertThat(result.paymentSection.discountAmount).isEqualTo("-$10")
+        assertThat(result.paymentSection.totalAmount).isEqualTo("$99")
     }
 
     @Test
-    fun `given booking with editable attendance status CheckedIn, when mapped, then attendance section shows ATTENDED`() {
+    fun `given booking with editable attendance status CheckedIn, when mapped, then attendance section shows ATTENDED`() = runTest {
         val booking = sampleBooking(
             status = BookingEntity.Status.Confirmed,
             attendanceStatus = BookingEntity.AttendanceStatus.CheckedIn,
@@ -140,7 +147,7 @@ class WooPosBookingViewStateMapperTest {
     }
 
     @Test
-    fun `given booking with non-editable attendance, when mapped, then attendance section is null`() {
+    fun `given booking with non-editable attendance, when mapped, then attendance section is null`() = runTest {
         val booking = sampleBooking(
             status = BookingEntity.Status.Cancelled,
             attendanceStatus = BookingEntity.AttendanceStatus.Booked,
@@ -152,7 +159,7 @@ class WooPosBookingViewStateMapperTest {
     }
 
     @Test
-    fun `given booking with null customerInfo, when mapped, then customer section is null`() {
+    fun `given booking with null customerInfo, when mapped, then customer section is null`() = runTest {
         val booking = sampleBooking(customerInfo = null, customerNote = null)
 
         val result = mapper.mapToDetailsViewState(booking)
@@ -161,7 +168,7 @@ class WooPosBookingViewStateMapperTest {
     }
 
     @Test
-    fun `given booking with blank fields, when mapped, then fields resolve to null`() {
+    fun `given booking with blank fields, when mapped, then fields resolve to null`() = runTest {
         val customerInfo = BookingCustomerInfo(
             billingFirstName = "",
             billingLastName = "",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -595,6 +595,7 @@ class WooPosBookingsViewModelTest {
                 val cardEvent = event as WooPosNavigationEvent.OpenCardPayment
                 assertThat(cardEvent.orderId).isEqualTo(10L)
                 assertThat(cardEvent.source).isEqualTo(CardPaymentSource.BOOKINGS)
+                assertThat(cardEvent.showPayByCashButton).isTrue()
             }
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -5,12 +5,12 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.list.BookingListHandler
 import com.woocommerce.android.ui.bookings.list.BookingListSortOption
 import com.woocommerce.android.ui.woopos.cardpayment.CardPaymentSource
-import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.localcatalog.DateTimeProvider
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.DateFormatter
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -50,6 +50,7 @@ class WooPosBookingsViewModelTest {
     private val bookingListHandler: BookingListHandler = mock()
     private val dateTimeProvider: DateTimeProvider = mock()
     private val dateFormatter: DateFormatter = mock()
+    private val priceFormat: WooPosFormatPrice = mock()
     private val resourceProvider: ResourceProvider = mock {
         on { getQuantityString(any(), any(), anyOrNull(), anyOrNull()) } doAnswer { invocation ->
             val quantity = invocation.arguments[0] as Int
@@ -107,12 +108,16 @@ class WooPosBookingsViewModelTest {
         return WooPosBookingsViewModel(
             bookingListHandler = bookingListHandler,
             dateTimeProvider = dateTimeProvider,
-            mapper = WooPosBookingViewStateMapper(dateFormatter, resourceProvider),
+            mapper = WooPosBookingViewStateMapper(dateFormatter, resourceProvider, priceFormat),
         )
     }
 
     @Before
     fun setUp() = runTest {
+        whenever(priceFormat(anyOrNull())).doAnswer { invocation ->
+            val amount = invocation.arguments[0] as? java.math.BigDecimal
+            amount?.let { "$${it.toPlainString()}" } ?: "$0.00"
+        }
         whenever(dateFormatter.formatDateTime(any<Instant>())).thenReturn("Nov 14, 2023, 10:13 AM")
         whenever(dateFormatter.formatTime(any<Instant>())).thenReturn("10:13 AM")
         whenever(bookingListHandler.bookingsFlow).thenReturn(
@@ -574,7 +579,7 @@ class WooPosBookingsViewModelTest {
         }
 
     @Test
-    fun `given selected booking, when PayByCashClicked, then navigation event emitted with correct orderId and BOOKINGS source`() =
+    fun `given selected booking, when CollectPaymentClicked, then navigation event emitted with correct orderId and BOOKINGS source`() =
         runTest {
             // GIVEN
             viewModel = createViewModel()
@@ -582,48 +587,7 @@ class WooPosBookingsViewModelTest {
 
             viewModel.navigationEvent.test {
                 // WHEN
-                viewModel.onUIEvent(WooPosBookingsUIEvent.PayByCashClicked)
-
-                // THEN
-                val event = awaitItem()
-                assertThat(event).isInstanceOf(WooPosNavigationEvent.OpenCashPayment::class.java)
-                val cashEvent = event as WooPosNavigationEvent.OpenCashPayment
-                assertThat(cashEvent.orderId).isEqualTo(10L)
-                assertThat(cashEvent.source).isEqualTo(CashPaymentSource.BOOKINGS)
-            }
-        }
-
-    @Test
-    fun `given no selected booking, when PayByCashClicked, then no navigation event emitted`() =
-        runTest {
-            // GIVEN
-            whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
-            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
-                .thenReturn(Result.failure(RuntimeException("error")))
-
-            viewModel = createViewModel()
-            advanceUntilIdle()
-            assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Error::class.java)
-
-            viewModel.navigationEvent.test {
-                // WHEN
-                viewModel.onUIEvent(WooPosBookingsUIEvent.PayByCashClicked)
-
-                // THEN
-                expectNoEvents()
-            }
-        }
-
-    @Test
-    fun `given selected booking, when PayByCardClicked, then navigation event emitted with correct orderId and BOOKINGS source`() =
-        runTest {
-            // GIVEN
-            viewModel = createViewModel()
-            advanceUntilIdle()
-
-            viewModel.navigationEvent.test {
-                // WHEN
-                viewModel.onUIEvent(WooPosBookingsUIEvent.PayByCardClicked)
+                viewModel.onUIEvent(WooPosBookingsUIEvent.CollectPaymentClicked)
 
                 // THEN
                 val event = awaitItem()
@@ -635,7 +599,7 @@ class WooPosBookingsViewModelTest {
         }
 
     @Test
-    fun `given no selected booking, when PayByCardClicked, then no navigation event emitted`() =
+    fun `given no selected booking, when CollectPaymentClicked, then no navigation event emitted`() =
         runTest {
             // GIVEN
             whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
@@ -648,7 +612,7 @@ class WooPosBookingsViewModelTest {
 
             viewModel.navigationEvent.test {
                 // WHEN
-                viewModel.onUIEvent(WooPosBookingsUIEvent.PayByCardClicked)
+                viewModel.onUIEvent(WooPosBookingsUIEvent.CollectPaymentClicked)
 
                 // THEN
                 expectNoEvents()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -81,11 +81,13 @@ class WooPosCardPaymentViewModelTest {
     private fun createViewModel(
         orderId: Long = 100L,
         source: CardPaymentSource = CardPaymentSource.BOOKINGS,
+        showPayByCashButton: Boolean = false,
     ): WooPosCardPaymentViewModel {
         val savedStateHandle = SavedStateHandle(
             mapOf(
                 CARD_PAYMENT_ROUTE_ORDER_ID_KEY to orderId,
                 CARD_PAYMENT_ROUTE_SOURCE_KEY to source.name,
+                CARD_PAYMENT_ROUTE_SHOW_PAY_BY_CASH_KEY to showPayByCashButton,
             )
         )
         return WooPosCardPaymentViewModel(
@@ -339,5 +341,71 @@ class WooPosCardPaymentViewModelTest {
         advanceUntilIdle()
 
         verify(analyticsTracker).trackEmailReceiptTapped()
+    }
+
+    @Test
+    fun `given showPayByCashButton is true, when created, then showCashPaymentButton is true`() = runTest {
+        viewModel = createViewModel(showPayByCashButton = true)
+        advanceUntilIdle()
+
+        assertThat(viewModel.showCashPaymentButton).isTrue()
+    }
+
+    @Test
+    fun `given showPayByCashButton is false, when created, then showCashPaymentButton is false`() = runTest {
+        viewModel = createViewModel(showPayByCashButton = false)
+        advanceUntilIdle()
+
+        assertThat(viewModel.showCashPaymentButton).isFalse()
+    }
+
+    @Test
+    fun `given showPayByCashButton not provided, when created, then showCashPaymentButton is false`() = runTest {
+        val savedStateHandle = SavedStateHandle(
+            mapOf(
+                CARD_PAYMENT_ROUTE_ORDER_ID_KEY to 100L,
+                CARD_PAYMENT_ROUTE_SOURCE_KEY to CardPaymentSource.CHECKOUT.name,
+            )
+        )
+        viewModel = WooPosCardPaymentViewModel(
+            savedState = savedStateHandle,
+            cardReaderPaymentControllerFactory = cardReaderPaymentControllerFactory,
+            cardReaderFacade = cardReaderFacade,
+            networkStatus = networkStatus,
+            resourceProvider = resourceProvider,
+            uiStringParser = uiStringParser,
+            priceFormat = priceFormat,
+            totalsRepository = totalsRepository,
+            analyticsTracker = analyticsTracker,
+        )
+        advanceUntilIdle()
+
+        assertThat(viewModel.showCashPaymentButton).isFalse()
+    }
+
+    @Test
+    fun `given BOOKINGS source, when onCashPaymentClicked, then SwitchToCashPayment emitted`() = runTest {
+        viewModel = createViewModel(orderId = 42L, source = CardPaymentSource.BOOKINGS)
+        advanceUntilIdle()
+
+        viewModel.navigationEvent.test {
+            viewModel.onCashPaymentClicked()
+
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(WooPosNavigationEvent.SwitchToCashPayment::class.java)
+            assertThat((event as WooPosNavigationEvent.SwitchToCashPayment).orderId).isEqualTo(42L)
+        }
+    }
+
+    @Test
+    fun `given BOOKINGS source, when onCashPaymentClicked, then payment is cancelled`() = runTest {
+        viewModel = createViewModel(source = CardPaymentSource.BOOKINGS)
+        advanceUntilIdle()
+
+        viewModel.onCashPaymentClicked()
+        advanceUntilIdle()
+
+        verify(paymentController).onBackPressed()
+        verify(paymentController).stop()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
WOOMOB-2215
<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates WooPOS bookings payment UX by replacing separate “Pay by card” / “Pay by cash” actions with a single “Collect payment” CTA that routes into the card payment flow, with an optional switch to cash payment from within the card payment screen.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
Go to POS / Bookings / Booking details screen, and:
1. Verify you can collect card payment for the booking
2. Verify you can collect cash payment fo the booking

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
