### PR TITLE
Fix SQLiteDiskIOException crash from disk storage exhaustion

### DIFF
--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
@@ -20,7 +20,12 @@ class LogFileWriter(
     private val logsDirectory: File,
     private val maxLogFiles: Int,
     private val dispatchers: CoroutineDispatchers,
-    private val availableDiskBytes: () -> Long = defaultAvailableDiskBytes(logsDirectory)
+    private val availableDiskBytes: () -> Long = {
+        if (!logsDirectory.exists()) {
+            logsDirectory.mkdirs()
+        }
+        runCatching { StatFs(logsDirectory.absolutePath).availableBytes }.getOrDefault(0L)
+    }
 ) {
     private var lastUsedFile: File? = null
     private val dateFormatter
@@ -44,7 +49,8 @@ class LogFileWriter(
         mutex.withLock {
             withContext(dispatchers.io) {
                 if (logFile.length() >= MAX_LOG_FILE_SIZE_BYTES) {
-                    return@withContext
+                    logFile.delete()
+                    logFile.createNewFile()
                 }
                 logFile.appendText("$logs\n")
             }
@@ -153,12 +159,5 @@ class LogFileWriter(
         private const val MIN_DISK_SPACE_BYTES = 10L * 1024 * 1024
         private const val DISK_SPACE_CHECK_INTERVAL_MS = 5_000L
         private const val MIN_LOG_FILES_TO_KEEP = 2
-
-        fun defaultAvailableDiskBytes(logsDirectory: File): () -> Long = {
-            if (!logsDirectory.exists()) {
-                logsDirectory.mkdirs()
-            }
-            runCatching { StatFs(logsDirectory.absolutePath).availableBytes }.getOrDefault(0L)
-        }
     }
 }

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.util.logs
 
+import android.os.StatFs
 import com.woocommerce.android.util.CoroutineDispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -18,7 +19,10 @@ import java.util.Locale
 class LogFileWriter(
     private val logsDirectory: File,
     private val maxLogFiles: Int,
-    private val dispatchers: CoroutineDispatchers
+    private val dispatchers: CoroutineDispatchers,
+    private val availableDiskBytes: () -> Long = {
+        runCatching { StatFs(logsDirectory.absolutePath).availableBytes }.getOrDefault(Long.MAX_VALUE)
+    }
 ) {
     private var lastUsedFile: File? = null
     private val dateFormatter
@@ -27,6 +31,19 @@ class LogFileWriter(
 
     suspend fun writeLogs(logs: String) {
         val logFile = getLogFile()
+
+        val exceedsMaxSize = withContext(dispatchers.io) {
+            logFile.length() >= MAX_LOG_FILE_SIZE_BYTES
+        }
+
+        if (exceedsMaxSize) {
+            return
+        }
+
+        if (!hasEnoughDiskSpace()) {
+            deleteOldestLogFiles()
+            return
+        }
 
         mutex.withLock {
             withContext(dispatchers.io) {
@@ -103,8 +120,30 @@ class LogFileWriter(
         }
     }
 
+    private suspend fun hasEnoughDiskSpace(): Boolean {
+        return withContext(dispatchers.io) {
+            availableDiskBytes() >= MIN_DISK_SPACE_BYTES
+        }
+    }
+
+    private suspend fun deleteOldestLogFiles() {
+        withContext(dispatchers.io) {
+            mutex.withLock {
+                val logFiles = logsDirectory
+                    .listFiles { file -> file.isFile && file.name.startsWith(LOG_FILE_NAME_PREFIX) }
+                    ?.sortedByDescending { it.lastModified() }
+                    ?: return@withLock
+
+                logFiles.drop(1).forEach { it.delete() }
+            }
+        }
+    }
+
     companion object {
         const val LOG_FILE_NAME_PREFIX = "log_"
         const val DATE_FORMAT_PATTERN = "yyyy-MM-dd"
+
+        private const val MAX_LOG_FILE_SIZE_BYTES = 2L * 1024 * 1024 // 2 MB per file
+        private const val MIN_DISK_SPACE_BYTES = 50L * 1024 * 1024 // 50 MB
     }
 }

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
@@ -21,24 +21,23 @@ class LogFileWriter(
     private val maxLogFiles: Int,
     private val dispatchers: CoroutineDispatchers,
     private val availableDiskBytes: () -> Long = {
-        runCatching { StatFs(logsDirectory.absolutePath).availableBytes }.getOrDefault(Long.MAX_VALUE)
+        if (!logsDirectory.exists()) {
+            logsDirectory.mkdirs()
+        }
+        runCatching { StatFs(logsDirectory.absolutePath).availableBytes }.getOrDefault(0L)
     }
 ) {
     private var lastUsedFile: File? = null
     private val dateFormatter
         get() = SimpleDateFormat(DATE_FORMAT_PATTERN, Locale.ROOT)
     private val mutex = Mutex()
+    @Volatile
+    private var cachedDiskSpace: Long = Long.MAX_VALUE
+    @Volatile
+    private var lastDiskSpaceCheckTime: Long = 0L
 
     suspend fun writeLogs(logs: String) {
         val logFile = getLogFile()
-
-        val exceedsMaxSize = withContext(dispatchers.io) {
-            logFile.length() >= MAX_LOG_FILE_SIZE_BYTES
-        }
-
-        if (exceedsMaxSize) {
-            return
-        }
 
         if (!hasEnoughDiskSpace()) {
             deleteOldestLogFiles()
@@ -47,6 +46,9 @@ class LogFileWriter(
 
         mutex.withLock {
             withContext(dispatchers.io) {
+                if (logFile.length() >= MAX_LOG_FILE_SIZE_BYTES) {
+                    return@withContext
+                }
                 logFile.appendText("$logs\n")
             }
         }
@@ -122,7 +124,12 @@ class LogFileWriter(
 
     private suspend fun hasEnoughDiskSpace(): Boolean {
         return withContext(dispatchers.io) {
-            availableDiskBytes() >= MIN_DISK_SPACE_BYTES
+            val now = System.currentTimeMillis()
+            if (now - lastDiskSpaceCheckTime > DISK_SPACE_CHECK_INTERVAL_MS) {
+                cachedDiskSpace = availableDiskBytes()
+                lastDiskSpaceCheckTime = now
+            }
+            cachedDiskSpace >= MIN_DISK_SPACE_BYTES
         }
     }
 
@@ -134,7 +141,9 @@ class LogFileWriter(
                     ?.sortedByDescending { it.lastModified() }
                     ?: return@withLock
 
-                logFiles.drop(1).forEach { it.delete() }
+                if (logFiles.size > MIN_LOG_FILES_TO_KEEP) {
+                    logFiles.drop(MIN_LOG_FILES_TO_KEEP).forEach { it.delete() }
+                }
             }
         }
     }
@@ -143,7 +152,9 @@ class LogFileWriter(
         const val LOG_FILE_NAME_PREFIX = "log_"
         const val DATE_FORMAT_PATTERN = "yyyy-MM-dd"
 
-        private const val MAX_LOG_FILE_SIZE_BYTES = 2L * 1024 * 1024 // 2 MB per file
-        private const val MIN_DISK_SPACE_BYTES = 50L * 1024 * 1024 // 50 MB
+        private const val MAX_LOG_FILE_SIZE_BYTES = 2L * 1024 * 1024
+        private const val MIN_DISK_SPACE_BYTES = 10L * 1024 * 1024
+        private const val DISK_SPACE_CHECK_INTERVAL_MS = 5_000L
+        private const val MIN_LOG_FILES_TO_KEEP = 2
     }
 }

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
@@ -20,19 +20,16 @@ class LogFileWriter(
     private val logsDirectory: File,
     private val maxLogFiles: Int,
     private val dispatchers: CoroutineDispatchers,
-    private val availableDiskBytes: () -> Long = {
-        if (!logsDirectory.exists()) {
-            logsDirectory.mkdirs()
-        }
-        runCatching { StatFs(logsDirectory.absolutePath).availableBytes }.getOrDefault(0L)
-    }
+    private val availableDiskBytes: () -> Long = defaultAvailableDiskBytes(logsDirectory)
 ) {
     private var lastUsedFile: File? = null
     private val dateFormatter
         get() = SimpleDateFormat(DATE_FORMAT_PATTERN, Locale.ROOT)
     private val mutex = Mutex()
+
     @Volatile
     private var cachedDiskSpace: Long = Long.MAX_VALUE
+
     @Volatile
     private var lastDiskSpaceCheckTime: Long = 0L
 
@@ -156,5 +153,12 @@ class LogFileWriter(
         private const val MIN_DISK_SPACE_BYTES = 10L * 1024 * 1024
         private const val DISK_SPACE_CHECK_INTERVAL_MS = 5_000L
         private const val MIN_LOG_FILES_TO_KEEP = 2
+
+        fun defaultAvailableDiskBytes(logsDirectory: File): () -> Long = {
+            if (!logsDirectory.exists()) {
+                logsDirectory.mkdirs()
+            }
+            runCatching { StatFs(logsDirectory.absolutePath).availableBytes }.getOrDefault(0L)
+        }
     }
 }

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
@@ -31,7 +31,8 @@ class WooFileLogger(
     private val appCoroutineScope: CoroutineScope,
     private val dispatchers: CoroutineDispatchers,
     private val processLifecycleOwner: LifecycleOwner,
-    private val crashLogging: Provider<CrashLogging>? = null
+    private val crashLogging: Provider<CrashLogging>? = null,
+    availableDiskBytes: (() -> Long)? = null
 ) {
     @Inject
     constructor(
@@ -50,7 +51,8 @@ class WooFileLogger(
     private val logFileWriter: LogFileWriter = LogFileWriter(
         logsDirectory = logsDirectory,
         maxLogFiles = MAX_LOG_FILES,
-        dispatchers = dispatchers
+        dispatchers = dispatchers,
+        availableDiskBytes = availableDiskBytes ?: LogFileWriter.defaultAvailableDiskBytes(logsDirectory)
     )
 
     private val internalLogsBuffer = Channel<LogEntry>(Channel.UNLIMITED)

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
@@ -27,12 +27,11 @@ import javax.inject.Singleton
 
 @Singleton
 class WooFileLogger(
-    private val logsDirectory: File,
     private val appCoroutineScope: CoroutineScope,
     private val dispatchers: CoroutineDispatchers,
     private val processLifecycleOwner: LifecycleOwner,
     private val crashLogging: Provider<CrashLogging>? = null,
-    availableDiskBytes: (() -> Long)? = null
+    private val logFileWriter: LogFileWriter,
 ) {
     @Inject
     constructor(
@@ -41,18 +40,15 @@ class WooFileLogger(
         dispatchers: CoroutineDispatchers,
         crashLogging: Provider<CrashLogging>
     ) : this(
-        logsDirectory = File(context.filesDir, LOG_FILE_DIRECTORY),
         appCoroutineScope = appCoroutineScope,
         dispatchers = dispatchers,
         processLifecycleOwner = ProcessLifecycleOwner.get(),
-        crashLogging = crashLogging
-    )
-
-    private val logFileWriter: LogFileWriter = LogFileWriter(
-        logsDirectory = logsDirectory,
-        maxLogFiles = MAX_LOG_FILES,
-        dispatchers = dispatchers,
-        availableDiskBytes = availableDiskBytes ?: LogFileWriter.defaultAvailableDiskBytes(logsDirectory)
+        crashLogging = crashLogging,
+        logFileWriter = LogFileWriter(
+            logsDirectory = File(context.filesDir, LOG_FILE_DIRECTORY),
+            maxLogFiles = MAX_LOG_FILES,
+            dispatchers = dispatchers,
+        ),
     )
 
     private val internalLogsBuffer = Channel<LogEntry>(Channel.UNLIMITED)

--- a/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/LogFileWriterTest.kt
+++ b/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/LogFileWriterTest.kt
@@ -229,17 +229,17 @@ class LogFileWriterTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when log file exceeds max size, then writes should be skipped`() = testBlocking {
+    fun `when log file exceeds max size, then file is reset and new logs are written`() = testBlocking {
         val currentLogFile = logFileWriter.getCurrentLogFile()
 
         val largeContent = "x".repeat(2 * 1024 * 1024)
         currentLogFile.writeText(largeContent)
 
-        logFileWriter.writeLogs("This should not be written")
+        logFileWriter.writeLogs("New log entry after reset")
 
         val fileContent = currentLogFile.readText()
-        assertThat(fileContent).isEqualTo(largeContent)
-        assertThat(fileContent).doesNotContain("This should not be written")
+        assertThat(fileContent).doesNotContain(largeContent)
+        assertThat(fileContent).contains("New log entry after reset")
     }
 
     @Test

--- a/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/LogFileWriterTest.kt
+++ b/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/LogFileWriterTest.kt
@@ -260,13 +260,16 @@ class LogFileWriterTest : BaseUnitTest() {
         val today = dateFormatter.format(Date())
         val file1 = File(logsDirectory, "log_2025-01-01.txt")
         val file2 = File(logsDirectory, "log_2025-01-02.txt")
+        val file3 = File(logsDirectory, "log_2025-01-03.txt")
         val todayFile = File(logsDirectory, "log_$today.txt")
 
         logsDirectory.mkdirs()
         file1.writeText("oldest log")
         file2.writeText("older log")
-        file1.setLastModified(System.currentTimeMillis() - 3000)
-        file2.setLastModified(System.currentTimeMillis() - 2000)
+        file3.writeText("recent log")
+        file1.setLastModified(System.currentTimeMillis() - 4000)
+        file2.setLastModified(System.currentTimeMillis() - 3000)
+        file3.setLastModified(System.currentTimeMillis() - 2000)
 
         fakeDiskSpace = 0L
 
@@ -274,6 +277,7 @@ class LogFileWriterTest : BaseUnitTest() {
 
         assertThat(file1.exists()).isFalse()
         assertThat(file2.exists()).isFalse()
+        assertThat(file3.exists()).isTrue()
         assertThat(todayFile.exists()).isTrue()
         assertThat(todayFile.readText()).doesNotContain("This should not be written")
     }

--- a/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/LogFileWriterTest.kt
+++ b/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/LogFileWriterTest.kt
@@ -18,15 +18,18 @@ class LogFileWriterTest : BaseUnitTest() {
     private val logsDirectory = File(System.getProperty("java.io.tmpdir", "."), "logs_test")
     private val maxLogFiles = 3
     private val dateFormatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    private var fakeDiskSpace = Long.MAX_VALUE
 
     private lateinit var logFileWriter: LogFileWriter
 
     @Before
     fun setup() {
+        fakeDiskSpace = Long.MAX_VALUE
         logFileWriter = LogFileWriter(
             logsDirectory = logsDirectory,
             maxLogFiles = maxLogFiles,
-            dispatchers = coroutinesTestRule.testDispatchers
+            dispatchers = coroutinesTestRule.testDispatchers,
+            availableDiskBytes = { fakeDiskSpace }
         )
     }
 
@@ -223,5 +226,55 @@ class LogFileWriterTest : BaseUnitTest() {
         val fileContent = currentLogFile.readText()
         assertThat(fileContent).contains(logText1)
         assertThat(fileContent).contains(logText2)
+    }
+
+    @Test
+    fun `when log file exceeds max size, then writes should be skipped`() = testBlocking {
+        val currentLogFile = logFileWriter.getCurrentLogFile()
+
+        val largeContent = "x".repeat(2 * 1024 * 1024)
+        currentLogFile.writeText(largeContent)
+
+        logFileWriter.writeLogs("This should not be written")
+
+        val fileContent = currentLogFile.readText()
+        assertThat(fileContent).isEqualTo(largeContent)
+        assertThat(fileContent).doesNotContain("This should not be written")
+    }
+
+    @Test
+    fun `when log file is below max size, then writes should succeed`() = testBlocking {
+        val currentLogFile = logFileWriter.getCurrentLogFile()
+
+        val smallContent = "x".repeat(1024)
+        currentLogFile.writeText(smallContent)
+
+        logFileWriter.writeLogs("New log entry")
+
+        val fileContent = currentLogFile.readText()
+        assertThat(fileContent).contains("New log entry")
+    }
+
+    @Test
+    fun `when disk space is low, then writes should be skipped and oldest logs deleted`() = testBlocking {
+        val today = dateFormatter.format(Date())
+        val file1 = File(logsDirectory, "log_2025-01-01.txt")
+        val file2 = File(logsDirectory, "log_2025-01-02.txt")
+        val todayFile = File(logsDirectory, "log_$today.txt")
+
+        logsDirectory.mkdirs()
+        file1.writeText("oldest log")
+        file2.writeText("older log")
+        file1.setLastModified(System.currentTimeMillis() - 3000)
+        file2.setLastModified(System.currentTimeMillis() - 2000)
+
+        fakeDiskSpace = 0L
+
+        logFileWriter.writeLogs("This should not be written")
+
+        assertThat(file1.exists()).isFalse()
+        assertThat(file2.exists()).isFalse()
+        assertThat(todayFile.exists()).isTrue()
+        assertThat(todayFile.readText()).doesNotContain("This should not be written")
     }
 }

--- a/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/WooFileLoggerTest.kt
+++ b/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/WooFileLoggerTest.kt
@@ -28,11 +28,15 @@ class WooFileLoggerTest : BaseUnitTest() {
         testLifecycleOwner = TestLifecycleOwner(initialState = initialLifecycleState)
 
         wooFileLogger = WooFileLogger(
-            logsDirectory = logsDirectory,
             appCoroutineScope = testScope,
             processLifecycleOwner = testLifecycleOwner,
             dispatchers = coroutinesTestRule.testDispatchers,
-            availableDiskBytes = { Long.MAX_VALUE }
+            logFileWriter = LogFileWriter(
+                logsDirectory = logsDirectory,
+                maxLogFiles = 7,
+                dispatchers = coroutinesTestRule.testDispatchers,
+                availableDiskBytes = { Long.MAX_VALUE }
+            ),
         )
     }
 

--- a/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/WooFileLoggerTest.kt
+++ b/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/WooFileLoggerTest.kt
@@ -31,7 +31,8 @@ class WooFileLoggerTest : BaseUnitTest() {
             logsDirectory = logsDirectory,
             appCoroutineScope = testScope,
             processLifecycleOwner = testLifecycleOwner,
-            dispatchers = coroutinesTestRule.testDispatchers
+            dispatchers = coroutinesTestRule.testDispatchers,
+            availableDiskBytes = { Long.MAX_VALUE }
         )
     }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.di
 
 import android.content.Context
+import android.database.sqlite.SQLiteDiskIOException
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -15,6 +16,8 @@ import org.wordpress.android.fluxc.persistence.dao.CouponsDao
 import org.wordpress.android.fluxc.persistence.dao.CustomerFromAnalyticsDao
 import org.wordpress.android.fluxc.persistence.dao.OrdersDao
 import org.wordpress.android.fluxc.persistence.dao.ShippingMethodDao
+import org.wordpress.android.util.AppLog
+import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -32,11 +35,30 @@ interface WCDatabaseModule {
             currencyPositionConverter: CurrencyPositionConverter,
             statsGranularityConverter: StatsGranularityConverter,
         ): WCAndroidDatabase {
-            return WCAndroidDatabase.buildDb(
-                context,
-                currencyPositionConverter,
-                statsGranularityConverter,
-            )
+            return try {
+                WCAndroidDatabase.buildDb(
+                    context,
+                    currencyPositionConverter,
+                    statsGranularityConverter,
+                )
+            } catch (e: SQLiteDiskIOException) {
+                AppLog.e(
+                    AppLog.T.DB,
+                    "Database open failed due to disk I/O error, freeing space and retrying: $e"
+                )
+                clearLogFiles(context)
+                WCAndroidDatabase.buildDb(
+                    context,
+                    currencyPositionConverter,
+                    statsGranularityConverter,
+                )
+            }
+        }
+
+        private fun clearLogFiles(context: Context) {
+            val logsDir = File(context.filesDir, "logs")
+            logsDir.listFiles { file -> file.isFile && file.name.startsWith("log_") }
+                ?.forEach { it.delete() }
         }
 
         @Provides internal fun provideAddonsDao(database: WCAndroidDatabase): AddonsDao {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/di/WCDatabaseModule.kt
@@ -47,11 +47,19 @@ interface WCDatabaseModule {
                     "Database open failed due to disk I/O error, freeing space and retrying: $e"
                 )
                 clearLogFiles(context)
-                WCAndroidDatabase.buildDb(
-                    context,
-                    currencyPositionConverter,
-                    statsGranularityConverter,
-                )
+                try {
+                    WCAndroidDatabase.buildDb(
+                        context,
+                        currencyPositionConverter,
+                        statsGranularityConverter,
+                    )
+                } catch (retryException: SQLiteDiskIOException) {
+                    AppLog.e(
+                        AppLog.T.DB,
+                        "Database retry failed after clearing logs: $retryException"
+                    )
+                    throw retryException
+                }
             }
         }
 


### PR DESCRIPTION
Fixes: WOOMOB-2170

## Summary

Fixes the `SQLiteDiskIOException: disk I/O error (code 4874 SQLITE_IOERR_SHMSIZE)` crash that occurs when the device runs out of storage. The crash chain is:

1. **Unbounded log file growth** — `LogFileWriter` had no per-file size limit. On days with cascading errors, a single log file could grow indefinitely.
2. **Device storage exhaustion** — Between log files, databases, caches, and other apps, the device hits 0 bytes free. Sentry confirms `free_storage: 0`.
3. **SQLite SHM allocation failure** — Room executes `PRAGMA journal_mode` to configure WAL mode, which requires a `.db-shm` file. With no storage left, this fails with `SQLITE_IOERR_SHMSIZE` and the app crashes on launch.

This changes may also fix other related crashes we started seeing about device running out of memory and potentially related to saving too many logs on disk. 

### Changes

**1. Cap log file size and check disk space** (`LogFileWriter.kt`)
- Adds a **2 MB per-file size cap** — the size check runs inside the mutex to prevent concurrent writes from exceeding the limit.
- Adds a **disk space check** before writing — if available storage drops below 10 MB, log writes are skipped and oldest log files are proactively deleted, keeping at least the 2 most recent files for debugging.
- Disk space checks are **cached for 5 seconds** to avoid calling `StatFs` on every log write.
- `StatFs` fallback returns `0L` (treat as no space) instead of `Long.MAX_VALUE`, and ensures the directory exists before querying.
- `availableDiskBytes` is injected as a lambda to allow testing without real filesystem checks.

**2. Graceful database recovery** (`WCDatabaseModule.kt`)
- Wraps `WCAndroidDatabase.buildDb()` in a try-catch for `SQLiteDiskIOException`.
- On failure, clears log files (filtered by `log_` prefix) under `context.filesDir/logs` to free space, then retries the database open exactly once.
- The retry is also wrapped in try-catch — if it fails, the exception is logged with context before propagating (no silent crash).
- Uses `AppLog` for error logging, consistent with the rest of the fluxc-plugin module.

## Testing instructions

1. Install the app and verify logs are written normally under typical conditions (check `files/logs/` directory via Device File Explorer in Android Studio. View → Tool Windows → Device File Explorer (in some versions it is labeled Device Explorer).

<img width="625" height="468" alt="Screenshot 2026-02-23 at 18 58 46" src="https://github.com/user-attachments/assets/6f107f2a-5288-48fd-8304-1f0736360383" />

2. Fill device storage to near-zero:
   ```bash
   adb shell fallocate -l 10G /data/local/tmp/fill_disk.bin
   ```
3. Open the app and verify it does not crash on launch.
4. Verify the app writes to logcat: `"Database open failed due to disk I/O error, freeing space and retrying"`.
(I actually never saw this log despite filling the device disk completely). In any case I also wasn't able to make the DB initialization crash or the app crash at all. 
<img width="328" height="102" alt="Screenshot 2026-02-23 at 19 10 56" src="https://github.com/user-attachments/assets/74f9895c-dced-4ba5-8f80-df52fa102a82" />

5. Free space and verify logging resumes normally:
   ```bash
   adb shell rm /data/local/tmp/fill_disk.bin
   ```
6. Open the app again and confirm log files are written as expected under normal conditions.