### PR TITLE
Implement "Connect to WordPress.com" setup steps UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/IdleCircle.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/IdleCircle.kt
@@ -1,0 +1,25 @@
+package com.woocommerce.android.ui.compose.component
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+
+@Composable
+fun IdleCircle() {
+    val indicatorColor = colorResource(id = R.color.color_on_surface_medium)
+
+    Canvas(modifier = Modifier.size(26.dp)) {
+        val stroke = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round)
+        drawCircle(
+            color = indicatorColor,
+            radius = (size.minDimension - stroke.width) / 2,
+            style = stroke
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -44,9 +43,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -58,6 +54,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.component.IdleCircle
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
@@ -340,7 +337,7 @@ private fun JetpackActivationStep(
         val indicatorModifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_60))
         when (step.state) {
             JetpackActivationMainViewModel.StepState.Idle -> {
-                IdleCircle(indicatorModifier)
+                IdleCircle()
             }
 
             JetpackActivationMainViewModel.StepState.Ongoing -> {
@@ -420,21 +417,6 @@ private fun ConnectionStepHint(connectionStep: JetpackActivationMainViewModel.Co
             color = colorResource(id = color),
             style = MaterialTheme.typography.caption,
             fontWeight = FontWeight.SemiBold
-        )
-    }
-}
-
-@Composable
-private fun IdleCircle(modifier: Modifier = Modifier) {
-    val color = colorResource(id = R.color.color_on_surface_medium)
-    val stroke = with(LocalDensity.current) {
-        Stroke(width = dimensionResource(id = R.dimen.minor_25).toPx(), cap = StrokeCap.Round)
-    }
-    Canvas(modifier = modifier) {
-        drawCircle(
-            color = color,
-            radius = (size.minDimension - stroke.width) / 2,
-            style = stroke
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsFragment.kt
@@ -1,0 +1,30 @@
+package com.woocommerce.android.ui.pushnotifications.connection
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class WooPushNotificationsConnectionStepsFragment : BaseFragment() {
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    private val viewModel: WooPushNotificationsConnectionStepsViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return composeView {
+            WooPushNotificationsConnectionStepsScreen(
+                viewModel = viewModel,
+                onCancelClick = { findNavController().navigateUp() },
+                onContinueClick = { findNavController().navigateUp() }
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
@@ -1,0 +1,262 @@
+package com.woocommerce.android.ui.pushnotifications.connection
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.annotatedStringRes
+import com.woocommerce.android.ui.compose.component.IdleCircle
+import com.woocommerce.android.ui.compose.component.Toolbar
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun WooPushNotificationsConnectionStepsScreen(
+    viewModel: WooPushNotificationsConnectionStepsViewModel,
+    onCancelClick: () -> Unit,
+    onContinueClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    viewModel.viewState.observeAsState().value?.let { viewState ->
+        WooPushNotificationsConnectionStepsScreen(
+            siteAddress = viewState.siteAddress,
+            steps = viewState.steps,
+            onCancelClick = onCancelClick,
+            onContinueClick = onContinueClick,
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+private fun WooPushNotificationsConnectionStepsScreen(
+    siteAddress: String,
+    steps: List<ConnectionStepUiModel>,
+    onCancelClick: () -> Unit,
+    onContinueClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val hasInProgressStep = steps.any { it.status == ConnectionStepStatus.IN_PROGRESS }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            Toolbar(
+                onNavigationButtonClick = onCancelClick
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surface)
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            Column(
+                horizontalAlignment = Alignment.Start,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.wp_woo),
+                    contentDescription = null,
+                    modifier = Modifier.size(width = 86.dp, height = 48.dp)
+                )
+
+                Text(
+                    text = stringResource(id = R.string.woo_push_notifications_connection_steps_title),
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(top = 32.dp)
+                )
+
+                Text(
+                    text = annotatedStringRes(
+                        R.string.woo_push_notifications_connection_steps_body,
+                        siteAddress
+                    ),
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 32.dp)
+                ) {
+                    steps.forEach { step ->
+                        ConnectionStepRow(
+                            step = step,
+                            modifier = Modifier.padding(vertical = 8.dp)
+                        )
+                    }
+                }
+            }
+
+            if (!hasInProgressStep) {
+                WCColoredButton(
+                    onClick = onContinueClick,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(text = stringResource(id = R.string.woo_push_notifications_connection_steps_go_to_my_store))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConnectionStepRow(
+    step: ConnectionStepUiModel,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = 48.dp)
+    ) {
+        ConnectionStepStatusIcon(
+            status = step.status
+        )
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(id = step.title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = if (step.status == ConnectionStepStatus.NOT_STARTED) {
+                    FontWeight.Normal
+                } else {
+                    FontWeight.Bold
+                },
+                color = colorResource(id = R.color.color_on_surface_medium)
+            )
+            Text(
+                text = step.statusMessageRes?.let { stringResource(id = it) }
+                    ?: stringResource(id = step.status.defaultTextRes),
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = if (step.status == ConnectionStepStatus.ERROR) {
+                    FontWeight.SemiBold
+                } else {
+                    FontWeight.Normal
+                },
+                color = when (step.status) {
+                    ConnectionStepStatus.COMPLETE -> colorResource(id = R.color.woo_green_50)
+                    ConnectionStepStatus.ERROR -> colorResource(id = R.color.color_error)
+                    else -> colorResource(id = R.color.color_on_surface_medium)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConnectionStepStatusIcon(
+    status: ConnectionStepStatus,
+    modifier: Modifier = Modifier
+) {
+    when (status) {
+        ConnectionStepStatus.COMPLETE -> {
+            Image(
+                painter = painterResource(id = R.drawable.ic_progress_circle_complete),
+                contentDescription = null,
+                modifier = modifier.size(26.dp)
+            )
+        }
+
+        ConnectionStepStatus.IN_PROGRESS -> {
+            CircularProgressIndicator(
+                modifier = modifier.size(26.dp),
+                color = colorResource(id = R.color.woo_push_notifications_connection_steps_progressbar),
+            )
+        }
+
+        ConnectionStepStatus.NOT_STARTED -> {
+            IdleCircle()
+        }
+
+        ConnectionStepStatus.ERROR -> {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_gridicons_notice),
+                contentDescription = null,
+                tint = colorResource(id = R.color.color_error),
+                modifier = modifier.size(26.dp)
+            )
+        }
+    }
+}
+
+data class ConnectionStepUiModel(
+    @StringRes val title: Int,
+    val status: ConnectionStepStatus,
+    @StringRes val statusMessageRes: Int? = null
+)
+
+enum class ConnectionStepStatus {
+    COMPLETE,
+    IN_PROGRESS,
+    NOT_STARTED,
+    ERROR
+}
+
+private val ConnectionStepStatus.defaultTextRes: Int
+    @StringRes get() = when (this) {
+        ConnectionStepStatus.COMPLETE -> R.string.woo_push_notifications_connection_steps_complete
+        ConnectionStepStatus.IN_PROGRESS -> R.string.woo_push_notifications_connection_steps_in_progress
+        ConnectionStepStatus.NOT_STARTED -> R.string.woo_push_notifications_connection_steps_not_started
+        ConnectionStepStatus.ERROR -> R.string.woo_push_notifications_connection_steps_error
+    }
+
+@Composable
+@Preview
+private fun WooPushNotificationsConnectionStepsScreenPreview() {
+    WooThemeWithBackground {
+        WooPushNotificationsConnectionStepsScreen(
+            siteAddress = "coffeebeans.com",
+            steps = listOf(
+                ConnectionStepUiModel(
+                    title = R.string.woo_push_notifications_connection_steps_step_connect_store,
+                    status = ConnectionStepStatus.IN_PROGRESS
+                ),
+                ConnectionStepUiModel(
+                    title = R.string.woo_push_notifications_connection_steps_step_check_plugin_compatibility,
+                    status = ConnectionStepStatus.NOT_STARTED
+                ),
+                ConnectionStepUiModel(
+                    title = R.string.woo_push_notifications_connection_steps_step_enable_push_notifications,
+                    status = ConnectionStepStatus.NOT_STARTED
+                )
+            ),
+            onCancelClick = {},
+            onContinueClick = {}
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -1,0 +1,63 @@
+package com.woocommerce.android.ui.pushnotifications.connection
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
+    private val selectedSite: SelectedSite,
+    savedStateHandle: SavedStateHandle
+) : ScopedViewModel(savedStateHandle) {
+
+    private val _viewState = MutableLiveData(
+        ViewState(siteAddress = getSiteAddress())
+    )
+    val viewState: LiveData<ViewState> = _viewState
+
+    init {
+        startConnectStoreStep()
+    }
+
+    private fun startConnectStoreStep() {
+        val currentState = _viewState.value ?: return
+        _viewState.value = currentState.copy(
+            steps = currentState.steps.mapIndexed { index, step ->
+                if (index == 0) {
+                    step.copy(status = ConnectionStepStatus.IN_PROGRESS)
+                } else {
+                    step
+                }
+            }
+        )
+    }
+
+    private fun getSiteAddress(): String {
+        val site = selectedSite.getOrNull() ?: return ""
+        return StringUtils.getSiteDomainAndPath(site).ifBlank { site.name.orEmpty() }
+    }
+
+    data class ViewState(
+        val siteAddress: String,
+        val steps: List<ConnectionStepUiModel> = listOf(
+            ConnectionStepUiModel(
+                title = R.string.woo_push_notifications_connection_steps_step_connect_store,
+                status = ConnectionStepStatus.NOT_STARTED
+            ),
+            ConnectionStepUiModel(
+                title = R.string.woo_push_notifications_connection_steps_step_check_plugin_compatibility,
+                status = ConnectionStepStatus.NOT_STARTED,
+            ),
+            ConnectionStepUiModel(
+                title = R.string.woo_push_notifications_connection_steps_step_enable_push_notifications,
+                status = ConnectionStepStatus.NOT_STARTED
+            )
+        )
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionDialog.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -22,6 +23,8 @@ class WooPushNotificationsIntroductionDialog : DialogFragment() {
     }
 
     private val viewModel: WooPushNotificationsIntroductionViewModel by viewModels()
+    private val openConnectionStepsAction =
+        R.id.action_wooPushNotificationsIntroductionDialog_to_wooPushNotificationsConnectionStepsFragment
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -47,6 +50,10 @@ class WooPushNotificationsIntroductionDialog : DialogFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                WooPushNotificationsIntroductionViewModel.OpenConnectionSteps -> {
+                    findNavController().navigateSafely(openConnectionStepsAction)
+                }
+
                 is WooPushNotificationsIntroductionViewModel.OpenUrlEvent -> {
                     ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -14,7 +14,7 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
 
     fun onContinueClick() {
-        // TODO Implement connection flow navigation when available
+        triggerEvent(OpenConnectionSteps)
     }
 
     fun onNotNowClick() {
@@ -24,6 +24,8 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
     fun onWhatIsWPComClick() {
         triggerEvent(OpenUrlEvent(AppUrls.LOGIN_WITH_EMAIL_WHAT_IS_WORDPRESS_COM_ACCOUNT))
     }
+
+    data object OpenConnectionSteps : Event()
 
     data class OpenUrlEvent(val url: String) : Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -14,6 +14,7 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
 
     fun onContinueClick() {
+        // Temporary flow: skip WordPress.com login and open steps screen directly.
         triggerEvent(OpenConnectionSteps)
     }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -11,6 +11,7 @@
     <include app:graph="@navigation/nav_graph_product_filters" />
     <include app:graph="@navigation/nav_graph_order_creations" />
     <include app:graph="@navigation/nav_graph_payment_flow" />
+    <include app:graph="@navigation/nav_graph_push_notifications" />
     <include app:graph="@navigation/nav_graph_jetpack_install" />
     <include app:graph="@navigation/nav_graph_coupons" />
     <include app:graph="@navigation/nav_graph_site_picker" />
@@ -88,7 +89,7 @@
             app:destination="@id/inboxFragment" />
         <action
             android:id="@+id/action_dashboard_to_wooPushNotificationsIntroductionDialog"
-            app:destination="@id/wooPushNotificationsIntroductionDialog" />
+            app:destination="@id/nav_graph_push_notifications" />
     </fragment>
     <fragment
         android:id="@+id/orders"
@@ -876,8 +877,4 @@
             android:name="positiveButtonLabel"
             app:argType="integer" />
     </dialog>
-    <dialog
-        android:id="@+id/wooPushNotificationsIntroductionDialog"
-        android:name="com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionDialog"
-        android:label="WooPushNotificationsIntroductionDialog" />
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_push_notifications.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_push_notifications.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph_push_notifications"
+    app:startDestination="@id/wooPushNotificationsIntroductionDialog">
+
+    <dialog
+        android:id="@+id/wooPushNotificationsIntroductionDialog"
+        android:name="com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionDialog"
+        android:label="WooPushNotificationsIntroductionDialog">
+        <action
+            android:id="@+id/action_wooPushNotificationsIntroductionDialog_to_wooPushNotificationsConnectionStepsFragment"
+            app:destination="@id/wooPushNotificationsConnectionStepsFragment"
+            app:popUpTo="@id/wooPushNotificationsIntroductionDialog"
+            app:popUpToInclusive="true" />
+    </dialog>
+    <fragment
+        android:id="@+id/wooPushNotificationsConnectionStepsFragment"
+        android:name="com.woocommerce.android.ui.pushnotifications.connection.WooPushNotificationsConnectionStepsFragment"
+        android:label="WooPushNotificationsConnectionStepsFragment" />
+</navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_settings"
     app:startDestination="@id/mainSettingsFragment">
+    <include app:graph="@navigation/nav_graph_push_notifications" />
     <include app:graph="@navigation/nav_graph_jetpack_install" />
     <include app:graph="@navigation/nav_graph_domain_change" />
     <include app:graph="@navigation/nav_graph_themes" />
@@ -64,7 +65,7 @@
             app:destination="@id/pluginsFragment" />
         <action
             android:id="@+id/action_mainSettingsFragment_to_wooPushNotificationsIntroductionDialog"
-            app:destination="@id/wooPushNotificationsIntroductionDialog" />
+            app:destination="@id/nav_graph_push_notifications" />
     </fragment>
     <fragment
         android:id="@+id/privacySettingsFragment"
@@ -217,8 +218,4 @@
         android:id="@+id/apiFakerHostFragment"
         android:name="com.woocommerce.android.apifaker.ApiFakerHostFragment"
         android:label="ApiFakerHostFragment" />
-    <dialog
-        android:id="@+id/wooPushNotificationsIntroductionDialog"
-        android:name="com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionDialog"
-        android:label="WooPushNotificationsIntroductionDialog" />
 </navigation>

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -198,6 +198,11 @@
     <color name="jetpack_install_progressbar">@color/jetpack_green_40</color>
 
     <!--
+        Woo Push notifications steps
+    -->
+    <color name="woo_push_notifications_connection_steps_progressbar">#70B954</color>
+
+    <!--
     More menu button
     -->
     <color name="more_menu_button_background">@color/color_surface</color>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2634,6 +2634,16 @@
     <string name="woo_push_notifications_introduction_what_is_wpcom">What is WordPress.com?</string>
     <string name="woo_push_notifications_introduction_continue">Continue</string>
     <string name="woo_push_notifications_introduction_not_now">Not now</string>
+    <string name="woo_push_notifications_connection_steps_title">Connect to WordPress.com</string>
+    <string name="woo_push_notifications_connection_steps_body">Please wait while we finalize connecting your store &lt;b>%1$s&lt;/b> to your WordPress.com account.</string>
+    <string name="woo_push_notifications_connection_steps_step_connect_store">Connect store to WordPress.com</string>
+    <string name="woo_push_notifications_connection_steps_step_check_plugin_compatibility">Check plugin compatibility</string>
+    <string name="woo_push_notifications_connection_steps_step_enable_push_notifications">Enable push notifications</string>
+    <string name="woo_push_notifications_connection_steps_complete">Complete</string>
+    <string name="woo_push_notifications_connection_steps_in_progress">In progress</string>
+    <string name="woo_push_notifications_connection_steps_not_started">Not started</string>
+    <string name="woo_push_notifications_connection_steps_error">Error</string>
+    <string name="woo_push_notifications_connection_steps_go_to_my_store">Go to My Store</string>
 
     <string name="jetpack_install_start_title">Install Jetpack</string>
     <string name="jetpack_install_start_subtitle">Install the free Jetpack plugin to &lt;strong&gt;%s&lt;/strong&gt; to experience the best mobile experience.</string>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Part of WOOMOB-1927

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the new Push Notifications connection steps screen and wires it from both My Store and Settings through a dedicated navigation graph. The new screen follows our Android-side visual style and reuses existing step indicator patterns. For now, tapping **Continue** on the Introduction screen navigates directly to this steps screen as a **temporary test flow**; the WordPress.com login step in between is intentionally skipped for now.  
Currently, the first step is set to `IN_PROGRESS` as a fake initial state, and step transitions will be updated once the real logic is added.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Log in with a site with site credentials.
2. Open the flow from either My Store (card) or Settings (Enable Push Notifications).
3. Continue from the Introduction dialog.
4. Verify the temporary navigation lands on the steps screen.
5. Confirm that the first step appears as **In progress**, the other steps are initially **Not started**.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
|Current JP activation screen|New Woo PN screen|
|-|-|
|<img width="300" alt="Screenshot_20260213_183332" src="https://github.com/user-attachments/assets/478c9767-0cd1-4791-a73b-2bb9c9f3e57e" />|<img width="300" alt="Screenshot_20260213_200217" src="https://github.com/user-attachments/assets/5391eb67-41b8-40bb-bd9c-164e12e2bccb" />|

|Dark Mode|All states|
|-|-|
|<img width="300" height="2856" alt="Screenshot_20260213_200320" src="https://github.com/user-attachments/assets/c6276214-9865-4c6b-99fc-20057979e027" />|<img width="300" height="2856" alt="Screenshot_20260213_200617" src="https://github.com/user-attachments/assets/75e111df-75f4-414c-93da-f52474569a28" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
