### PR TITLE
[Push Notifications] Make Login screens reusable for the Push Notifications setup flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptActivity.kt
@@ -20,13 +20,14 @@ import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.CancelJetpackActivation
 import com.woocommerce.android.extensions.doOnApplyWindowInsets
+import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.CancelJetpackActivation
 import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.ContinueJetpackActivation
 import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.OpenLogin
 import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.OpenSitePicker
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherFragmentArgs
 import com.woocommerce.android.ui.login.wpcom.WPComLoginMagicLinkHandlerFragmentArgs
+import com.woocommerce.android.ui.login.wpcom.WPComLoginMode
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -177,7 +178,7 @@ class MagicLinkInterceptActivity : AppCompatActivity() {
             .addDestination(
                 R.id.wPComLoginMagicLinkHandlerFragment,
                 WPComLoginMagicLinkHandlerFragmentArgs(
-                    jetpackStatus = event.jetpackStatus
+                    wpComLoginMode = WPComLoginMode.JetpackSetup(event.jetpackStatus)
                 ).toBundle()
             )
             .createPendingIntent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
@@ -1,12 +1,18 @@
 package com.woocommerce.android.ui.login.jetpack.dispatcher
 
 import android.os.Bundle
+import androidx.annotation.IdRes
 import androidx.fragment.app.viewModels
+import androidx.navigation.NavGraph
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartJetpackActivationForNewSite
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartWPComAuthenticationForEmail
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartWPComLoginForJetpackActivation
+import com.woocommerce.android.ui.login.wpcom.WPComLoginEmailFragmentArgs
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordFragmentArgs
 import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -27,8 +33,19 @@ class JetpackActivationDispatcherFragment : BaseFragment() {
         viewModel.event.observe(this) { event ->
             when (event) {
                 is StartJetpackActivationForNewSite -> navigateToJetpackActivationStartScreen(event)
-                is StartWPComLoginForJetpackActivation -> navigateToWPComEmailScreen(event)
-                is StartWPComAuthenticationForEmail -> navigateToWPComPasswordScreen(event)
+                is StartWPComLoginForJetpackActivation -> navigateToWPComLoginGraph(
+                    startDestination = R.id.wPComLoginEmailFragment,
+                    args = WPComLoginEmailFragmentArgs(
+                        jetpackStatus = event.jetpackStatus
+                    ).toBundle()
+                )
+                is StartWPComAuthenticationForEmail -> navigateToWPComLoginGraph(
+                    startDestination = R.id.wPComLoginPasswordFragment,
+                    args = WPComLoginPasswordFragmentArgs(
+                        jetpackStatus = event.jetpackStatus,
+                        emailOrUsername = event.wpComEmail
+                    ).toBundle()
+                )
             }
         }
     }
@@ -43,22 +60,15 @@ class JetpackActivationDispatcherFragment : BaseFragment() {
         )
     }
 
-    private fun navigateToWPComEmailScreen(event: StartWPComLoginForJetpackActivation) {
-        findNavController().navigate(
-            JetpackActivationDispatcherFragmentDirections
-                .actionJetpackActivationDispatcherFragmentToWPComLoginEmailFragment(
-                    jetpackStatus = event.jetpackStatus
-                )
-        )
-    }
+    private fun navigateToWPComLoginGraph(@IdRes startDestination: Int, args: Bundle) {
+        val navController = findNavController()
+        val wpComLoginGraph = navController.currentDestination?.parent
+            ?.findNode(R.id.nav_graph_wpcom_login) as? NavGraph ?: return
+        wpComLoginGraph.setStartDestination(startDestination)
 
-    private fun navigateToWPComPasswordScreen(event: StartWPComAuthenticationForEmail) {
-        findNavController().navigate(
-            JetpackActivationDispatcherFragmentDirections
-                .actionJetpackActivationDispatcherFragmentToWPComLoginPasswordFragment(
-                    emailOrUsername = event.wpComEmail,
-                    jetpackStatus = event.jetpackStatus
-                )
+        navController.navigateSafely(
+            R.id.action_jetpackActivationDispatcherFragment_to_nav_graph_wpcom_login,
+            args
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/jetpack/dispatcher/JetpackActivationDispatcherFragment.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDisp
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartWPComAuthenticationForEmail
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherViewModel.StartWPComLoginForJetpackActivation
 import com.woocommerce.android.ui.login.wpcom.WPComLoginEmailFragmentArgs
+import com.woocommerce.android.ui.login.wpcom.WPComLoginMode
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordFragmentArgs
 import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,13 +37,13 @@ class JetpackActivationDispatcherFragment : BaseFragment() {
                 is StartWPComLoginForJetpackActivation -> navigateToWPComLoginGraph(
                     startDestination = R.id.wPComLoginEmailFragment,
                     args = WPComLoginEmailFragmentArgs(
-                        jetpackStatus = event.jetpackStatus
+                        wpComLoginMode = WPComLoginMode.JetpackSetup(event.jetpackStatus)
                     ).toBundle()
                 )
                 is StartWPComAuthenticationForEmail -> navigateToWPComLoginGraph(
                     startDestination = R.id.wPComLoginPasswordFragment,
                     args = WPComLoginPasswordFragmentArgs(
-                        jetpackStatus = event.jetpackStatus,
+                        wpComLoginMode = WPComLoginMode.JetpackSetup(event.jetpackStatus),
                         emailOrUsername = event.wpComEmail
                     ).toBundle()
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
@@ -62,11 +63,11 @@ class WPComLogin2FAFragment : BaseFragment() {
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
-            WPComLogin2FAFragmentDirections
-                .actionWPComLogin2FAFragmentToJetpackActivationMainFragment(
-                    jetpackStatus = event.jetpackStatus,
-                    siteUrl = event.siteUrl
-                )
+            R.id.action_global_to_jetpackActivationMainFragment,
+            bundleOf(
+                "siteUrl" to event.siteUrl,
+                "jetpackStatus" to event.jetpackStatus
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAFragment.kt
@@ -9,13 +9,13 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
+import com.woocommerce.android.NavGraphJetpackActivationDirections
 import com.woocommerce.android.NavGraphJetpackInstallDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainFragmentArgs
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackCPInstallationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -63,11 +63,10 @@ class WPComLogin2FAFragment : BaseFragment() {
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
-            R.id.action_global_to_jetpackActivationMainFragment,
-            JetpackActivationMainFragmentArgs(
+            NavGraphJetpackActivationDirections.actionGlobalToJetpackActivationMainFragment(
                 siteUrl = event.siteUrl,
                 jetpackStatus = event.jetpackStatus
-            ).toBundle()
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
@@ -16,6 +15,7 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainFragmentArgs
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackCPInstallationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -64,10 +64,10 @@ class WPComLogin2FAFragment : BaseFragment() {
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
             R.id.action_global_to_jetpackActivationMainFragment,
-            bundleOf(
-                "siteUrl" to event.siteUrl,
-                "jetpackStatus" to event.jetpackStatus
-            )
+            JetpackActivationMainFragmentArgs(
+                siteUrl = event.siteUrl,
+                jetpackStatus = event.jetpackStatus
+            ).toBundle()
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAViewModel.kt
@@ -60,7 +60,8 @@ class WPComLogin2FAViewModel @Inject constructor(
             emailOrUsername = emailOrUsername,
             password = password,
             otp = otp,
-            isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled,
+            isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
+                ?.jetpackStatus?.isJetpackInstalled ?: false,
             errorMessage = errorMessage.takeIf { it != 0 },
             loadingMessage = loadingMessage.takeIf { it != 0 }
         )
@@ -138,7 +139,7 @@ class WPComLogin2FAViewModel @Inject constructor(
     private suspend fun fetchAccount() {
         accountRepository.fetchUserAccount().fold(
             onSuccess = {
-                onLoginSuccess(navArgs.jetpackStatus)
+                onLoginSuccess(navArgs.wpComLoginMode)
             },
             onFailure = {
                 triggerEvent(ShowSnackbar(R.string.error_fetch_my_profile))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailFragment.kt
@@ -67,7 +67,7 @@ class WPComLoginEmailFragment : BaseFragment() {
         findNavController().navigateSafely(
             WPComLoginEmailFragmentDirections
                 .actionWPComLoginEmailFragmentToWPComLoginPasswordFragment(
-                    jetpackStatus = event.jetpackStatus,
+                    wpComLoginMode = event.wpComLoginMode,
                     emailOrUsername = event.emailOrUsername
                 )
         )
@@ -78,7 +78,7 @@ class WPComLoginEmailFragment : BaseFragment() {
             WPComLoginEmailFragmentDirections
                 .actionWPComLoginEmailFragmentToWPComLoginMagicLinkRequestFragment(
                     emailOrUsername = event.emailOrUsername,
-                    jetpackStatus = event.jetpackStatus,
+                    wpComLoginMode = event.wpComLoginMode,
                     fallbackButton = event.magicLinkFallbackButton,
                     requestAtStart = event.requestAtStart,
                     isNewWpComAccount = event.isNewWpComAccount

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailViewModel.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_LOGIN_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.ui.login.WPComLoginRepository
 import com.woocommerce.android.util.StringUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -55,7 +54,8 @@ class WPComLoginEmailViewModel @Inject constructor(
         ViewState(
             usernameOnly = navArgs.usernameOnly,
             emailOrUsername = emailOrUsername,
-            isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled,
+            isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
+                ?.jetpackStatus?.isJetpackInstalled ?: false,
             isLoadingDialogShown = isLoadingDialogShown,
             errorMessage = errorMessage.takeIf { it != 0 }
         )
@@ -97,14 +97,14 @@ class WPComLoginEmailViewModel @Inject constructor(
                     triggerEvent(
                         ShowMagicLinkScreen(
                             emailOrUsername = emailOrUsername,
-                            jetpackStatus = navArgs.jetpackStatus,
+                            wpComLoginMode = navArgs.wpComLoginMode,
                             magicLinkFallbackButton = MagicLinkFallbackButton.None,
                             requestAtStart = true,
                             isNewWpComAccount = false
                         )
                     )
                 } else {
-                    triggerEvent(ShowPasswordScreen(emailOrUsername, navArgs.jetpackStatus))
+                    triggerEvent(ShowPasswordScreen(emailOrUsername, navArgs.wpComLoginMode))
                 }
             },
             onFailure = {
@@ -128,7 +128,7 @@ class WPComLoginEmailViewModel @Inject constructor(
                         triggerEvent(
                             ShowMagicLinkScreen(
                                 emailOrUsername = emailOrUsername,
-                                jetpackStatus = navArgs.jetpackStatus,
+                                wpComLoginMode = navArgs.wpComLoginMode,
                                 magicLinkFallbackButton = MagicLinkFallbackButton.None,
                                 requestAtStart = true,
                                 isNewWpComAccount = true
@@ -143,7 +143,7 @@ class WPComLoginEmailViewModel @Inject constructor(
                 triggerEvent(
                     ShowMagicLinkScreen(
                         emailOrUsername = emailOrUsername,
-                        jetpackStatus = navArgs.jetpackStatus,
+                        wpComLoginMode = navArgs.wpComLoginMode,
                         magicLinkFallbackButton = MagicLinkFallbackButton.UsernameAndPassword,
                         requestAtStart = false,
                         isNewWpComAccount = false
@@ -182,12 +182,12 @@ class WPComLoginEmailViewModel @Inject constructor(
 
     data class ShowPasswordScreen(
         val emailOrUsername: String,
-        val jetpackStatus: JetpackStatus
+        val wpComLoginMode: WPComLoginMode
     ) : MultiLiveEvent.Event()
 
     data class ShowMagicLinkScreen(
         val emailOrUsername: String,
-        val jetpackStatus: JetpackStatus,
+        val wpComLoginMode: WPComLoginMode,
         val magicLinkFallbackButton: MagicLinkFallbackButton,
         val requestAtStart: Boolean,
         val isNewWpComAccount: Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
@@ -18,6 +17,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.GoToStore
+import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainFragmentArgs
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackCPInstallationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -64,10 +64,10 @@ class WPComLoginMagicLinkHandlerFragment : BaseFragment() {
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
             R.id.action_global_to_jetpackActivationMainFragment,
-            bundleOf(
-                "siteUrl" to event.siteUrl,
-                "jetpackStatus" to event.jetpackStatus
-            )
+            JetpackActivationMainFragmentArgs(
+                siteUrl = event.siteUrl,
+                jetpackStatus = event.jetpackStatus
+            ).toBundle()
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerFragment.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
+import com.woocommerce.android.NavGraphJetpackActivationDirections
 import com.woocommerce.android.NavGraphJetpackInstallDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
@@ -17,7 +18,6 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.GoToStore
-import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainFragmentArgs
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackCPInstallationScreen
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -63,11 +63,10 @@ class WPComLoginMagicLinkHandlerFragment : BaseFragment() {
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
-            R.id.action_global_to_jetpackActivationMainFragment,
-            JetpackActivationMainFragmentArgs(
+            NavGraphJetpackActivationDirections.actionGlobalToJetpackActivationMainFragment(
                 siteUrl = event.siteUrl,
                 jetpackStatus = event.jetpackStatus
-            ).toBundle()
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
@@ -62,11 +63,11 @@ class WPComLoginMagicLinkHandlerFragment : BaseFragment() {
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
-            WPComLoginMagicLinkHandlerFragmentDirections
-                .actionWPComLoginMagicLinkHandlerFragmentToJetpackActivationMainFragment(
-                    jetpackStatus = event.jetpackStatus,
-                    siteUrl = event.siteUrl
-                )
+            R.id.action_global_to_jetpackActivationMainFragment,
+            bundleOf(
+                "siteUrl" to event.siteUrl,
+                "jetpackStatus" to event.jetpackStatus
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerViewModel.kt
@@ -37,7 +37,7 @@ class WPComLoginMagicLinkHandlerViewModel @Inject constructor(
 
     fun continueLogin() = launch {
         _viewState.value = ViewState.Loading
-        onLoginSuccess(navArgs.jetpackStatus).onFailure {
+        onLoginSuccess(navArgs.wpComLoginMode).onFailure {
             _viewState.value = ViewState.Error
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestFragment.kt
@@ -71,7 +71,7 @@ class WPComLoginMagicLinkRequestFragment : BaseFragment() {
             WPComLoginMagicLinkRequestFragmentDirections
                 .actionWPComLoginMagicLinkRequestFragmentToWPComLoginPasswordFragment(
                     emailOrUsername = event.emailOrUsername,
-                    jetpackStatus = event.jetpackStatus
+                    wpComLoginMode = event.wpComLoginMode
                 )
         )
     }
@@ -81,7 +81,7 @@ class WPComLoginMagicLinkRequestFragment : BaseFragment() {
             WPComLoginMagicLinkRequestFragmentDirections
                 .actionWPComLoginMagicLinkRequestFragmentToWPComLoginEmailFragment(
                     usernameOnly = true,
-                    jetpackStatus = event.jetpackStatus
+                    wpComLoginMode = event.wpComLoginMode
                 )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModel.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_LOGIN_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.ui.login.MagicLinkFlow
 import com.woocommerce.android.ui.login.WPComLoginRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -45,7 +44,8 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
         initialValue = ViewState.MagicLinkRequestState(
             emailOrUsername = navArgs.emailOrUsername,
             avatarUrl = avatarUrlFromEmail(navArgs.emailOrUsername),
-            isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled,
+            isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
+                ?.jetpackStatus?.isJetpackInstalled ?: false,
             magicLinkFallbackButton = navArgs.fallbackButton,
             isLoadingDialogShown = false
         )
@@ -69,11 +69,11 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
             MagicLinkFallbackButton.Password -> triggerEvent(
                 ShowPasswordScreen(
                     emailOrUsername = navArgs.emailOrUsername,
-                    jetpackStatus = navArgs.jetpackStatus
+                    wpComLoginMode = navArgs.wpComLoginMode
                 )
             )
 
-            MagicLinkFallbackButton.UsernameAndPassword -> triggerEvent(ShowUsernameScreen(navArgs.jetpackStatus))
+            MagicLinkFallbackButton.UsernameAndPassword -> triggerEvent(ShowUsernameScreen(navArgs.wpComLoginMode))
             MagicLinkFallbackButton.None -> error("No fallback button should be shown")
         }
     }
@@ -104,7 +104,8 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
         _viewState.value = ViewState.MagicLinkRequestState(
             emailOrUsername = navArgs.emailOrUsername,
             avatarUrl = avatarUrlFromEmail(navArgs.emailOrUsername),
-            isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled,
+            isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
+                ?.jetpackStatus?.isJetpackInstalled ?: false,
             magicLinkFallbackButton = navArgs.fallbackButton,
             isLoadingDialogShown = true
         )
@@ -116,7 +117,8 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
             onSuccess = {
                 _viewState.value = ViewState.MagicLinkSentState(
                     email = navArgs.emailOrUsername.takeIf { it.isAnEmail() },
-                    isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled,
+                    isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
+                        ?.jetpackStatus?.isJetpackInstalled ?: false,
                     magicLinkFallbackButton = navArgs.fallbackButton,
                 )
             },
@@ -174,8 +176,8 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
 
     data class ShowPasswordScreen(
         val emailOrUsername: String,
-        val jetpackStatus: JetpackStatus
+        val wpComLoginMode: WPComLoginMode
     ) : MultiLiveEvent.Event()
 
-    data class ShowUsernameScreen(val jetpackStatus: JetpackStatus) : MultiLiveEvent.Event()
+    data class ShowUsernameScreen(val wpComLoginMode: WPComLoginMode) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMode.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMode.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.login.wpcom
+
+import android.os.Parcelable
+import com.woocommerce.android.model.JetpackStatus
+import kotlinx.parcelize.Parcelize
+
+sealed interface WPComLoginMode : Parcelable {
+    @Parcelize
+    data class JetpackSetup(val jetpackStatus: JetpackStatus) : WPComLoginMode
+
+    @Parcelize
+    data object PushNotificationsSetup : WPComLoginMode
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
@@ -85,11 +86,11 @@ class WPComLoginPasswordFragment : BaseFragment() {
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
-            WPComLoginPasswordFragmentDirections
-                .actionWPComLoginPasswordFragmentToJetpackActivationMainFragment(
-                    jetpackStatus = event.jetpackStatus,
-                    siteUrl = event.siteUrl
-                )
+            R.id.action_global_to_jetpackActivationMainFragment,
+            bundleOf(
+                "siteUrl" to event.siteUrl,
+                "jetpackStatus" to event.jetpackStatus
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
+import com.woocommerce.android.NavGraphJetpackActivationDirections
 import com.woocommerce.android.NavGraphJetpackInstallDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
@@ -17,7 +18,6 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.GoToStore
-import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainFragmentArgs
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordViewModel.Show2FAScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordViewModel.ShowMagicLinkScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
@@ -86,11 +86,10 @@ class WPComLoginPasswordFragment : BaseFragment() {
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
-            R.id.action_global_to_jetpackActivationMainFragment,
-            JetpackActivationMainFragmentArgs(
+            NavGraphJetpackActivationDirections.actionGlobalToJetpackActivationMainFragment(
                 siteUrl = event.siteUrl,
                 jetpackStatus = event.jetpackStatus
-            ).toBundle()
+            )
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
@@ -18,6 +17,7 @@ import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.GoToStore
+import com.woocommerce.android.ui.login.jetpack.main.JetpackActivationMainFragmentArgs
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordViewModel.Show2FAScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordViewModel.ShowMagicLinkScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
@@ -87,10 +87,10 @@ class WPComLoginPasswordFragment : BaseFragment() {
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {
         findNavController().navigateSafely(
             R.id.action_global_to_jetpackActivationMainFragment,
-            bundleOf(
-                "siteUrl" to event.siteUrl,
-                "jetpackStatus" to event.jetpackStatus
-            )
+            JetpackActivationMainFragmentArgs(
+                siteUrl = event.siteUrl,
+                jetpackStatus = event.jetpackStatus
+            ).toBundle()
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
@@ -77,7 +77,7 @@ class WPComLoginPasswordFragment : BaseFragment() {
         findNavController().navigateSafely(
             WPComLoginPasswordFragmentDirections
                 .actionWPComLoginPasswordFragmentToWPComLogin2FAFragment(
-                    jetpackStatus = event.jetpackStatus,
+                    wpComLoginMode = event.wpComLoginMode,
                     emailOrUsername = event.emailOrUsername,
                     password = event.password
                 )
@@ -99,7 +99,7 @@ class WPComLoginPasswordFragment : BaseFragment() {
             WPComLoginPasswordFragmentDirections
                 .actionWPComLoginPasswordFragmentToWPComLoginMagicLinkRequestFragment(
                     emailOrUsername = event.emailOrUsername,
-                    jetpackStatus = event.jetpackStatus,
+                    wpComLoginMode = event.wpComLoginMode,
                     fallbackButton = MagicLinkFallbackButton.Password,
                     requestAtStart = true,
                     isNewWpComAccount = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
@@ -12,7 +12,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_LOGIN_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPComLoginRepository
@@ -69,7 +68,8 @@ class WPComLoginPasswordViewModel @Inject constructor(
             emailOrUsername = emailOrUsername,
             password = password,
             avatarUrl = avatarUrl,
-            isJetpackInstalled = navArgs.jetpackStatus.isJetpackInstalled,
+            isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
+                ?.jetpackStatus?.isJetpackInstalled ?: false,
             isLoadingDialogShown = isLoadingDialogShown,
             errorMessage = errorMessage.takeIf { it != 0 }
         )
@@ -96,7 +96,7 @@ class WPComLoginPasswordViewModel @Inject constructor(
         triggerEvent(
             ShowMagicLinkScreen(
                 emailOrUsername = navArgs.emailOrUsername,
-                jetpackStatus = navArgs.jetpackStatus
+                wpComLoginMode = navArgs.wpComLoginMode
             )
         )
     }
@@ -126,7 +126,7 @@ class WPComLoginPasswordViewModel @Inject constructor(
 
                 when (failure?.type) {
                     AuthenticationErrorType.NEEDS_2FA -> {
-                        triggerEvent(Show2FAScreen(navArgs.emailOrUsername, password.value, navArgs.jetpackStatus))
+                        triggerEvent(Show2FAScreen(navArgs.emailOrUsername, password.value, navArgs.wpComLoginMode))
                     }
 
                     AuthenticationErrorType.INCORRECT_USERNAME_OR_PASSWORD,
@@ -154,7 +154,7 @@ class WPComLoginPasswordViewModel @Inject constructor(
     private suspend fun fetchAccount() {
         accountRepository.fetchUserAccount().fold(
             onSuccess = {
-                onLoginSuccess(navArgs.jetpackStatus)
+                onLoginSuccess(navArgs.wpComLoginMode)
             },
             onFailure = {
                 triggerEvent(ShowSnackbar(R.string.error_fetch_my_profile))
@@ -187,11 +187,11 @@ class WPComLoginPasswordViewModel @Inject constructor(
     data class Show2FAScreen(
         val emailOrUsername: String,
         val password: String,
-        val jetpackStatus: JetpackStatus
+        val wpComLoginMode: WPComLoginMode
     ) : MultiLiveEvent.Event()
 
     data class ShowMagicLinkScreen(
         val emailOrUsername: String,
-        val jetpackStatus: JetpackStatus
+        val wpComLoginMode: WPComLoginMode
     ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModel.kt
@@ -18,7 +18,14 @@ open class WPComLoginPostLoginViewModel(
     private val jetpackActivationRepository: JetpackActivationRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
-    protected suspend fun onLoginSuccess(jetpackStatus: JetpackStatus): Result<Unit> {
+    protected suspend fun onLoginSuccess(wpComLoginMode: WPComLoginMode): Result<Unit> {
+        return when (wpComLoginMode) {
+            is WPComLoginMode.JetpackSetup -> handleJetpackSetupPostLogin(wpComLoginMode.jetpackStatus)
+            WPComLoginMode.PushNotificationsSetup -> TODO()
+        }
+    }
+
+    private suspend fun handleJetpackSetupPostLogin(jetpackStatus: JetpackStatus): Result<Unit> {
         analyticsTrackerWrapper.track(JETPACK_SETUP_LOGIN_COMPLETED)
 
         val siteUrl = selectedSite.get().url

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionDialog.kt
@@ -10,6 +10,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.login.wpcom.WPComLoginMode
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,8 +24,6 @@ class WooPushNotificationsIntroductionDialog : DialogFragment() {
     }
 
     private val viewModel: WooPushNotificationsIntroductionViewModel by viewModels()
-    private val openConnectionStepsAction =
-        R.id.action_wooPushNotificationsIntroductionDialog_to_wooPushNotificationsConnectionStepsFragment
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -50,8 +49,13 @@ class WooPushNotificationsIntroductionDialog : DialogFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
-                WooPushNotificationsIntroductionViewModel.OpenConnectionSteps -> {
-                    findNavController().navigateSafely(openConnectionStepsAction)
+                WooPushNotificationsIntroductionViewModel.StartWPComLogin -> {
+                    findNavController().navigateSafely(
+                        WooPushNotificationsIntroductionDialogDirections
+                            .actionWooPushNotificationsIntroductionDialogToWpcomLogin(
+                                wpComLoginMode = WPComLoginMode.PushNotificationsSetup
+                            )
+                    )
                 }
 
                 is WooPushNotificationsIntroductionViewModel.OpenUrlEvent -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -14,8 +14,7 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
 
     fun onContinueClick() {
-        // Temporary flow: skip WordPress.com login and open steps screen directly.
-        triggerEvent(OpenConnectionSteps)
+        triggerEvent(StartWPComLogin)
     }
 
     fun onNotNowClick() {
@@ -26,7 +25,7 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
         triggerEvent(OpenUrlEvent(AppUrls.LOGIN_WITH_EMAIL_WHAT_IS_WORDPRESS_COM_ACCOUNT))
     }
 
-    data object OpenConnectionSteps : Event()
+    data object StartWPComLogin : Event()
 
     data class OpenUrlEvent(val url: String) : Event()
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_jetpack_activation.xml
@@ -4,6 +4,14 @@
     android:id="@+id/nav_graph_jetpack_activation"
     app:startDestination="@id/jetpackActivationDispatcherFragment">
 
+    <include app:graph="@navigation/nav_graph_wpcom_login" />
+
+    <!-- Global action to allow us continuing the Jetpack Setup flow after login,
+         login flow uses its own nav graph -->
+    <action
+        android:id="@+id/action_global_to_jetpackActivationMainFragment"
+        app:destination="@id/jetpackActivationMainFragment" />
+
     <fragment
         android:id="@+id/jetpackActivationDispatcherFragment"
         android:name="com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherFragment"
@@ -20,18 +28,8 @@
             app:popUpTo="@id/jetpackActivationDispatcherFragment"
             app:popUpToInclusive="true" />
         <action
-            android:id="@+id/action_jetpackActivationDispatcherFragment_to_wPComLoginEmailFragment"
-            app:destination="@id/wPComLoginEmailFragment"
-            app:popUpTo="@id/jetpackActivationDispatcherFragment"
-            app:popUpToInclusive="true" />
-        <action
-            android:id="@+id/action_jetpackActivationDispatcherFragment_to_wPComLoginPasswordFragment"
-            app:destination="@id/wPComLoginPasswordFragment"
-            app:popUpTo="@id/jetpackActivationDispatcherFragment"
-            app:popUpToInclusive="true" />
-        <action
-            android:id="@+id/action_jetpackActivationDispatcherFragment_to_wPComLoginMagicLinkHandlerFragment"
-            app:destination="@id/wPComLoginMagicLinkHandlerFragment"
+            android:id="@+id/action_jetpackActivationDispatcherFragment_to_nav_graph_wpcom_login"
+            app:destination="@id/nav_graph_wpcom_login"
             app:popUpTo="@id/jetpackActivationDispatcherFragment"
             app:popUpToInclusive="true" />
     </fragment>
@@ -81,106 +79,6 @@
         <action
             android:id="@+id/action_jetpackActivationMainFragment_to_jetpackActivationWebViewFragment"
             app:destination="@id/jetpackActivationWebViewFragment" />
-    </fragment>
-    <fragment
-        android:id="@+id/wPComLoginEmailFragment"
-        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginEmailFragment"
-        android:label="WPComLoginEmailFragment">
-        <argument
-            android:name="jetpackStatus"
-            app:argType="com.woocommerce.android.model.JetpackStatus" />
-        <action
-            android:id="@+id/action_wPComLoginEmailFragment_to_wPComLoginPasswordFragment"
-            app:destination="@id/wPComLoginPasswordFragment" />
-        <action
-            android:id="@+id/action_wPComLoginEmailFragment_to_wPComLoginMagicLinkRequestFragment"
-            app:destination="@id/wPComLoginMagicLinkRequestFragment" />
-        <argument
-            android:name="usernameOnly"
-            app:argType="boolean"
-            android:defaultValue="false" />
-    </fragment>
-    <fragment
-        android:id="@+id/wPComLoginPasswordFragment"
-        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordFragment"
-        android:label="WPComLoginPasswordFragment">
-        <argument
-            android:name="jetpackStatus"
-            app:argType="com.woocommerce.android.model.JetpackStatus" />
-        <argument
-            android:name="emailOrUsername"
-            app:argType="string" />
-        <action
-            android:id="@+id/action_wPComLoginPasswordFragment_to_jetpackActivationMainFragment"
-            app:destination="@id/jetpackActivationMainFragment" />
-        <action
-            android:id="@+id/action_wPComLoginPasswordFragment_to_wPComLogin2FAFragment"
-            app:destination="@id/wPComLogin2FAFragment" />
-        <action
-            android:id="@+id/action_wPComLoginPasswordFragment_to_wPComLoginMagicLinkRequestFragment"
-            app:destination="@id/wPComLoginMagicLinkRequestFragment" />
-    </fragment>
-    <fragment
-        android:id="@+id/wPComLogin2FAFragment"
-        android:name="com.woocommerce.android.ui.login.wpcom.WPComLogin2FAFragment"
-        android:label="WPComLogin2FAFragment">
-        <argument
-            android:name="jetpackStatus"
-            app:argType="com.woocommerce.android.model.JetpackStatus" />
-        <argument
-            android:name="emailOrUsername"
-            app:argType="string" />
-        <argument
-            android:name="password"
-            app:argType="string" />
-        <action
-            android:id="@+id/action_wPComLogin2FAFragment_to_jetpackActivationMainFragment"
-            app:destination="@id/jetpackActivationMainFragment" />
-    </fragment>
-    <fragment
-        android:id="@+id/wPComLoginMagicLinkRequestFragment"
-        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginMagicLinkRequestFragment"
-        android:label="WPComLoginMagicLinkRequestFragment">
-        <argument
-            android:name="jetpackStatus"
-            app:argType="com.woocommerce.android.model.JetpackStatus" />
-        <argument
-            android:name="emailOrUsername"
-            app:argType="string" />
-        <argument
-            android:name="fallbackButton"
-            app:argType="org.wordpress.android.login.MagicLinkFallbackButton" />
-        <argument
-            android:name="requestAtStart"
-            app:argType="boolean" />
-        <argument
-            android:name="isNewWpComAccount"
-            app:argType="boolean" />
-        <action
-            android:id="@+id/action_wPComLoginMagicLinkRequestFragment_to_wPComLoginPasswordFragment"
-            app:destination="@id/wPComLoginPasswordFragment"
-            app:launchSingleTop="true"
-            app:popUpTo="@id/wPComLoginMagicLinkRequestFragment"
-            app:popUpToInclusive="true" />
-        <action
-            android:id="@+id/action_wPComLoginMagicLinkRequestFragment_to_wPComLoginEmailFragment"
-            app:destination="@id/wPComLoginEmailFragment"
-            app:launchSingleTop="true"
-            app:popUpTo="@id/wPComLoginMagicLinkRequestFragment"
-            app:popUpToInclusive="true" />
-    </fragment>
-    <fragment
-        android:id="@+id/wPComLoginMagicLinkHandlerFragment"
-        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginMagicLinkHandlerFragment"
-        android:label="WPComLoginMagicLinkHandlerFragment">
-        <argument
-            android:name="jetpackStatus"
-            app:argType="com.woocommerce.android.model.JetpackStatus" />
-        <action
-            android:id="@+id/action_wPComLoginMagicLinkHandlerFragment_to_jetpackActivationMainFragment"
-            app:destination="@id/jetpackActivationMainFragment"
-            app:popUpTo="@id/jetpackActivationDispatcherFragment"
-            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/jetpackActivationWebViewFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_push_notifications.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_push_notifications.xml
@@ -4,10 +4,21 @@
     android:id="@+id/nav_graph_push_notifications"
     app:startDestination="@id/wooPushNotificationsIntroductionDialog">
 
+    <include app:graph="@navigation/nav_graph_wpcom_login" />
+
     <dialog
         android:id="@+id/wooPushNotificationsIntroductionDialog"
         android:name="com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionDialog"
         android:label="WooPushNotificationsIntroductionDialog">
+        <action
+            android:id="@+id/action_wooPushNotificationsIntroductionDialog_to_wpcom_login"
+            app:destination="@id/nav_graph_wpcom_login"
+            app:popUpTo="@id/wooPushNotificationsIntroductionDialog"
+            app:popUpToInclusive="true" >
+            <argument
+                android:name="wpComLoginMode"
+                app:argType="com.woocommerce.android.ui.login.wpcom.WPComLoginMode" />
+        </action>
         <action
             android:id="@+id/action_wooPushNotificationsIntroductionDialog_to_wooPushNotificationsConnectionStepsFragment"
             app:destination="@id/wooPushNotificationsConnectionStepsFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_wpcom_login.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_wpcom_login.xml
@@ -9,8 +9,8 @@
         android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginEmailFragment"
         android:label="WPComLoginEmailFragment">
         <argument
-            android:name="jetpackStatus"
-            app:argType="com.woocommerce.android.model.JetpackStatus" />
+            android:name="wpComLoginMode"
+            app:argType="com.woocommerce.android.ui.login.wpcom.WPComLoginMode" />
         <action
             android:id="@+id/action_wPComLoginEmailFragment_to_wPComLoginPasswordFragment"
             app:destination="@id/wPComLoginPasswordFragment" />
@@ -19,16 +19,16 @@
             app:destination="@id/wPComLoginMagicLinkRequestFragment" />
         <argument
             android:name="usernameOnly"
-            app:argType="boolean"
-            android:defaultValue="false" />
+            android:defaultValue="false"
+            app:argType="boolean" />
     </fragment>
     <fragment
         android:id="@+id/wPComLoginPasswordFragment"
         android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordFragment"
         android:label="WPComLoginPasswordFragment">
         <argument
-            android:name="jetpackStatus"
-            app:argType="com.woocommerce.android.model.JetpackStatus" />
+            android:name="wpComLoginMode"
+            app:argType="com.woocommerce.android.ui.login.wpcom.WPComLoginMode" />
         <argument
             android:name="emailOrUsername"
             app:argType="string" />
@@ -44,8 +44,8 @@
         android:name="com.woocommerce.android.ui.login.wpcom.WPComLogin2FAFragment"
         android:label="WPComLogin2FAFragment">
         <argument
-            android:name="jetpackStatus"
-            app:argType="com.woocommerce.android.model.JetpackStatus" />
+            android:name="wpComLoginMode"
+            app:argType="com.woocommerce.android.ui.login.wpcom.WPComLoginMode" />
         <argument
             android:name="emailOrUsername"
             app:argType="string" />
@@ -58,8 +58,8 @@
         android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginMagicLinkRequestFragment"
         android:label="WPComLoginMagicLinkRequestFragment">
         <argument
-            android:name="jetpackStatus"
-            app:argType="com.woocommerce.android.model.JetpackStatus" />
+            android:name="wpComLoginMode"
+            app:argType="com.woocommerce.android.ui.login.wpcom.WPComLoginMode" />
         <argument
             android:name="emailOrUsername"
             app:argType="string" />
@@ -90,7 +90,7 @@
         android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginMagicLinkHandlerFragment"
         android:label="WPComLoginMagicLinkHandlerFragment">
         <argument
-            android:name="jetpackStatus"
-            app:argType="com.woocommerce.android.model.JetpackStatus" />
+            android:name="wpComLoginMode"
+            app:argType="com.woocommerce.android.ui.login.wpcom.WPComLoginMode" />
     </fragment>
 </navigation>

--- a/WooCommerce/src/main/res/navigation/nav_graph_wpcom_login.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_wpcom_login.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph_wpcom_login"
+    app:startDestination="@id/wPComLoginEmailFragment">
+
+    <fragment
+        android:id="@+id/wPComLoginEmailFragment"
+        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginEmailFragment"
+        android:label="WPComLoginEmailFragment">
+        <argument
+            android:name="jetpackStatus"
+            app:argType="com.woocommerce.android.model.JetpackStatus" />
+        <action
+            android:id="@+id/action_wPComLoginEmailFragment_to_wPComLoginPasswordFragment"
+            app:destination="@id/wPComLoginPasswordFragment" />
+        <action
+            android:id="@+id/action_wPComLoginEmailFragment_to_wPComLoginMagicLinkRequestFragment"
+            app:destination="@id/wPComLoginMagicLinkRequestFragment" />
+        <argument
+            android:name="usernameOnly"
+            app:argType="boolean"
+            android:defaultValue="false" />
+    </fragment>
+    <fragment
+        android:id="@+id/wPComLoginPasswordFragment"
+        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordFragment"
+        android:label="WPComLoginPasswordFragment">
+        <argument
+            android:name="jetpackStatus"
+            app:argType="com.woocommerce.android.model.JetpackStatus" />
+        <argument
+            android:name="emailOrUsername"
+            app:argType="string" />
+        <action
+            android:id="@+id/action_wPComLoginPasswordFragment_to_wPComLogin2FAFragment"
+            app:destination="@id/wPComLogin2FAFragment" />
+        <action
+            android:id="@+id/action_wPComLoginPasswordFragment_to_wPComLoginMagicLinkRequestFragment"
+            app:destination="@id/wPComLoginMagicLinkRequestFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/wPComLogin2FAFragment"
+        android:name="com.woocommerce.android.ui.login.wpcom.WPComLogin2FAFragment"
+        android:label="WPComLogin2FAFragment">
+        <argument
+            android:name="jetpackStatus"
+            app:argType="com.woocommerce.android.model.JetpackStatus" />
+        <argument
+            android:name="emailOrUsername"
+            app:argType="string" />
+        <argument
+            android:name="password"
+            app:argType="string" />
+    </fragment>
+    <fragment
+        android:id="@+id/wPComLoginMagicLinkRequestFragment"
+        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginMagicLinkRequestFragment"
+        android:label="WPComLoginMagicLinkRequestFragment">
+        <argument
+            android:name="jetpackStatus"
+            app:argType="com.woocommerce.android.model.JetpackStatus" />
+        <argument
+            android:name="emailOrUsername"
+            app:argType="string" />
+        <argument
+            android:name="fallbackButton"
+            app:argType="org.wordpress.android.login.MagicLinkFallbackButton" />
+        <argument
+            android:name="requestAtStart"
+            app:argType="boolean" />
+        <argument
+            android:name="isNewWpComAccount"
+            app:argType="boolean" />
+        <action
+            android:id="@+id/action_wPComLoginMagicLinkRequestFragment_to_wPComLoginPasswordFragment"
+            app:destination="@id/wPComLoginPasswordFragment"
+            app:launchSingleTop="true"
+            app:popUpTo="@id/wPComLoginMagicLinkRequestFragment"
+            app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_wPComLoginMagicLinkRequestFragment_to_wPComLoginEmailFragment"
+            app:destination="@id/wPComLoginEmailFragment"
+            app:launchSingleTop="true"
+            app:popUpTo="@id/wPComLoginMagicLinkRequestFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
+    <fragment
+        android:id="@+id/wPComLoginMagicLinkHandlerFragment"
+        android:name="com.woocommerce.android.ui.login.wpcom.WPComLoginMagicLinkHandlerFragment"
+        android:label="WPComLoginMagicLinkHandlerFragment">
+        <argument
+            android:name="jetpackStatus"
+            app:argType="com.woocommerce.android.model.JetpackStatus" />
+    </fragment>
+</navigation>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginEmailViewModelTest.kt
@@ -41,7 +41,7 @@ class WPComLoginEmailViewModelTest : BaseUnitTest() {
     }
 
     private val saveStateHandle = WPComLoginEmailFragmentArgs(
-        jetpackStatus = JETPACK_STATUS,
+        wpComLoginMode = WPComLoginMode.JetpackSetup(JETPACK_STATUS),
     ).toSavedStateHandle()
     private val wpComLoginRepository: WPComLoginRepository = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
@@ -86,7 +86,7 @@ class WPComLoginEmailViewModelTest : BaseUnitTest() {
             assertThat(event).isEqualTo(
                 ShowMagicLinkScreen(
                     emailOrUsername = UNKNOWN_EMAIL,
-                    jetpackStatus = JETPACK_STATUS,
+                    wpComLoginMode = WPComLoginMode.JetpackSetup(JETPACK_STATUS),
                     magicLinkFallbackButton = MagicLinkFallbackButton.None,
                     requestAtStart = true,
                     isNewWpComAccount = true
@@ -134,7 +134,7 @@ class WPComLoginEmailViewModelTest : BaseUnitTest() {
             assertThat(event).isEqualTo(
                 ShowMagicLinkScreen(
                     emailOrUsername = suspiciousEmail,
-                    jetpackStatus = JETPACK_STATUS,
+                    wpComLoginMode = WPComLoginMode.JetpackSetup(JETPACK_STATUS),
                     magicLinkFallbackButton = MagicLinkFallbackButton.UsernameAndPassword,
                     requestAtStart = false,
                     isNewWpComAccount = false
@@ -162,7 +162,7 @@ class WPComLoginEmailViewModelTest : BaseUnitTest() {
             assertThat(event).isEqualTo(
                 ShowPasswordScreen(
                     WPCOM_EMAIL,
-                    JETPACK_STATUS
+                    WPComLoginMode.JetpackSetup(JETPACK_STATUS)
                 )
             )
         }
@@ -187,7 +187,7 @@ class WPComLoginEmailViewModelTest : BaseUnitTest() {
             assertThat(event).isEqualTo(
                 ShowMagicLinkScreen(
                     emailOrUsername = WPCOM_EMAIL,
-                    jetpackStatus = JETPACK_STATUS,
+                    wpComLoginMode = WPComLoginMode.JetpackSetup(JETPACK_STATUS),
                     magicLinkFallbackButton = MagicLinkFallbackButton.None,
                     requestAtStart = true,
                     isNewWpComAccount = false

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModelTest.kt
@@ -42,7 +42,7 @@ class WPComLoginMagicLinkRequestViewModelTest : BaseUnitTest() {
     ) {
         viewModel = WPComLoginMagicLinkRequestViewModel(
             WPComLoginMagicLinkRequestFragmentArgs(
-                jetpackStatus = JetpackStatus,
+                wpComLoginMode = WPComLoginMode.JetpackSetup(JetpackStatus),
                 emailOrUsername = EMAIL,
                 fallbackButton = fallbackButton,
                 requestAtStart = requestEmailAtStart,
@@ -114,7 +114,7 @@ class WPComLoginMagicLinkRequestViewModelTest : BaseUnitTest() {
         assertThat(event).isEqualTo(
             WPComLoginMagicLinkRequestViewModel.ShowPasswordScreen(
                 emailOrUsername = EMAIL,
-                jetpackStatus = JetpackStatus
+                wpComLoginMode = WPComLoginMode.JetpackSetup(JetpackStatus)
             )
         )
     }
@@ -129,7 +129,7 @@ class WPComLoginMagicLinkRequestViewModelTest : BaseUnitTest() {
 
         assertThat(event).isEqualTo(
             WPComLoginMagicLinkRequestViewModel.ShowUsernameScreen(
-                jetpackStatus = JetpackStatus
+                wpComLoginMode = WPComLoginMode.JetpackSetup(JetpackStatus)
             )
         )
     }


### PR DESCRIPTION
Part of WOOMOB-1925

### Description
   This PR makes the WPCom login screens reusable beyond the Jetpack activation flow, so they can also be used for the push notifications setup flow.

Key changes:
- **Extracted `nav_graph_wpcom_login.xml`**: All 5 WPCom login screens (email, password, 2FA, magic link request, magic link handler) are moved into a standalone nav graph, removed from `nav_graph_jetpack_activation.xml`.
- **Introduced `WPComLoginMode` sealed interface**: Replaces the direct `JetpackStatus` nav arg with a mode-aware type (`JetpackSetup` carrying `JetpackStatus`, and `PushNotificationsSetup`), decoupling the login screens from Jetpack-specific data.
- **Dynamic start destination**: The Jetpack dispatcher uses `setStartDestination` on the nested login graph to choose the entry point (email vs password), then navigates with a single action.
- **Global action for post-login**: A global action in the Jetpack activation graph allows login screens to navigate back to `JetpackActivationMainFragment` after login completes.
- **Connected push notifications flow**: `nav_graph_push_notifications` includes the login graph, and the introduction dialog navigates to it with `PushNotificationsSetup` mode on Continue click.

### Test Steps
1. From the Jetpack installation flow (application passwords site), verify the WPCom login screens (email → password → 2FA / magic link) work as before.
2. Enable push notifications feature flag, trigger the push notifications introduction dialog from Dashboard or Settings, tap Continue, and verify it navigates to the WPCom email login screen.

### Images/gif

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes."
