### PR TITLE
[Push Notifications] Update branding of password, 2FA, and magic link screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
@@ -28,6 +28,9 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.model.JetpackConnectionStatus
+import com.woocommerce.android.model.JetpackSiteRegistrationStatus
+import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -177,14 +180,12 @@ private fun JetpackModePreview() {
         WPComLogin2FAScreen(
             viewState = WPComLogin2FAViewModel.ViewState(
                 wpComLoginMode = WPComLoginMode.JetpackSetup(
-                    com.woocommerce.android.model.JetpackStatus(
+                    JetpackStatus(
                         isJetpackInstalled = false,
-                        jetpackConnectionStatus = com.woocommerce.android.model.JetpackConnectionStatus
-                            .AccountNotConnected(
-                                siteRegistrationStatus = com.woocommerce.android.model
-                                    .JetpackSiteRegistrationStatus.UNKNOWN,
-                                blogId = null
-                            )
+                        jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                            siteRegistrationStatus = JetpackSiteRegistrationStatus.UNKNOWN,
+                            blogId = null
+                        )
                     )
                 ),
                 emailOrUsername = "test@email.com",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.login.wpcom
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -35,6 +37,7 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedTextField
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
+import com.woocommerce.android.ui.pushnotifications.WordPressWooBadge
 
 @Composable
 fun WPComLogin2FAScreen(viewModel: WPComLogin2FAViewModel) {
@@ -59,12 +62,13 @@ fun WPComLogin2FAScreen(
     onOTPChanged: (String) -> Unit = {}
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    val branding = viewState.resolveBranding()
 
     Scaffold(
         topBar = {
             Toolbar(
                 onNavigationButtonClick = onCloseClick,
-                navigationIcon = ImageVector.vectorResource(R.drawable.ic_close_24dp)
+                navigationIcon = ImageVector.vectorResource(branding.navIcon)
             )
         }
     ) { paddingValues ->
@@ -80,23 +84,20 @@ fun WPComLogin2FAScreen(
                     .fillMaxWidth()
                     .padding(dimensionResource(id = R.dimen.major_100)),
             ) {
-                JetpackToWooHeader()
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
-                val title = if (viewState.isJetpackInstalled) {
-                    R.string.login_jetpack_connect
+                if (viewState.wpComLoginMode is WPComLoginMode.PushNotificationsSetup) {
+                    WordPressWooBadge()
                 } else {
-                    R.string.login_jetpack_install
+                    JetpackToWooHeader()
                 }
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
                 Text(
-                    text = stringResource(id = title),
+                    text = stringResource(id = branding.title),
                     style = MaterialTheme.typography.h4,
                     fontWeight = FontWeight.Bold
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
                 Text(
-                    text = stringResource(
-                        id = R.string.enter_verification_code
-                    )
+                    text = stringResource(id = R.string.enter_verification_code)
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
                 WCOutlinedTextField(
@@ -135,15 +136,7 @@ fun WPComLogin2FAScreen(
                     .fillMaxWidth()
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))
             ) {
-                Text(
-                    text = stringResource(
-                        id = if (viewState.isJetpackInstalled) {
-                            R.string.login_jetpack_connect
-                        } else {
-                            R.string.login_jetpack_install
-                        }
-                    )
-                )
+                Text(text = stringResource(id = branding.buttonText))
             }
         }
     }
@@ -153,12 +146,69 @@ fun WPComLogin2FAScreen(
     }
 }
 
+private data class TwoFAScreenBranding(
+    @DrawableRes val navIcon: Int,
+    @StringRes val title: Int,
+    @StringRes val buttonText: Int,
+)
+
+private fun WPComLogin2FAViewModel.ViewState.resolveBranding(): TwoFAScreenBranding {
+    return when (wpComLoginMode) {
+        WPComLoginMode.PushNotificationsSetup -> TwoFAScreenBranding(
+            navIcon = R.drawable.ic_back_24dp,
+            title = R.string.login_wpcom_connect_title,
+            buttonText = R.string.login_wpcom_connect_title,
+        )
+
+        is WPComLoginMode.JetpackSetup -> TwoFAScreenBranding(
+            navIcon = R.drawable.ic_close_24dp,
+            title = if (isJetpackInstalled) {
+                R.string.login_jetpack_connect
+            } else {
+                R.string.login_jetpack_install
+            },
+            buttonText = if (isJetpackInstalled) {
+                R.string.login_jetpack_connect
+            } else {
+                R.string.login_jetpack_install
+            },
+        )
+    }
+}
+
 @Preview
 @Composable
-private fun WPComLogin2FAScreenPreview() {
+private fun JetpackModePreview() {
     WooThemeWithBackground {
         WPComLogin2FAScreen(
             viewState = WPComLogin2FAViewModel.ViewState(
+                wpComLoginMode = WPComLoginMode.JetpackSetup(
+                    com.woocommerce.android.model.JetpackStatus(
+                        isJetpackInstalled = false,
+                        jetpackConnectionStatus = com.woocommerce.android.model.JetpackConnectionStatus
+                            .AccountNotConnected(
+                                siteRegistrationStatus = com.woocommerce.android.model
+                                    .JetpackSiteRegistrationStatus.UNKNOWN,
+                                blogId = null
+                            )
+                    )
+                ),
+                emailOrUsername = "test@email.com",
+                password = "",
+                otp = "123456",
+                isJetpackInstalled = false
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun NotificationSetupModePreview() {
+    WooThemeWithBackground {
+        WPComLogin2FAScreen(
+            viewState = WPComLogin2FAViewModel.ViewState(
+                wpComLoginMode = WPComLoginMode.PushNotificationsSetup,
                 emailOrUsername = "test@email.com",
                 password = "",
                 otp = "123456",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
@@ -160,12 +160,12 @@ private fun WPComLogin2FAViewModel.ViewState.resolveBranding(): TwoFAScreenBrand
 
         is WPComLoginMode.JetpackSetup -> TwoFAScreenBranding(
             navIcon = R.drawable.ic_close_24dp,
-            title = if (isJetpackInstalled) {
+            title = if (wpComLoginMode.jetpackStatus.isJetpackInstalled) {
                 R.string.login_jetpack_connect
             } else {
                 R.string.login_jetpack_install
             },
-            buttonText = if (isJetpackInstalled) {
+            buttonText = if (wpComLoginMode.jetpackStatus.isJetpackInstalled) {
                 R.string.login_jetpack_connect
             } else {
                 R.string.login_jetpack_install
@@ -193,8 +193,7 @@ private fun JetpackModePreview() {
                 ),
                 emailOrUsername = "test@email.com",
                 password = "",
-                otp = "123456",
-                isJetpackInstalled = false
+                otp = "123456"
             )
         )
     }
@@ -209,8 +208,7 @@ private fun NotificationSetupModePreview() {
                 wpComLoginMode = WPComLoginMode.PushNotificationsSetup,
                 emailOrUsername = "test@email.com",
                 password = "",
-                otp = "123456",
-                isJetpackInstalled = false
+                otp = "123456"
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.login.wpcom
 
-import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -66,7 +65,7 @@ fun WPComLogin2FAScreen(
         topBar = {
             Toolbar(
                 onNavigationButtonClick = onCloseClick,
-                navigationIcon = ImageVector.vectorResource(branding.navIcon)
+                navigationIcon = ImageVector.vectorResource(R.drawable.ic_close_24dp)
             )
         }
     ) { paddingValues ->
@@ -145,7 +144,6 @@ fun WPComLogin2FAScreen(
 }
 
 private data class TwoFAScreenBranding(
-    @DrawableRes val navIcon: Int,
     @StringRes val title: Int,
     @StringRes val buttonText: Int,
 )
@@ -153,13 +151,11 @@ private data class TwoFAScreenBranding(
 private fun WPComLogin2FAViewModel.ViewState.resolveBranding(): TwoFAScreenBranding {
     return when (wpComLoginMode) {
         WPComLoginMode.PushNotificationsSetup -> TwoFAScreenBranding(
-            navIcon = R.drawable.ic_back_24dp,
             title = R.string.login_wpcom_connect_title,
             buttonText = R.string.login_wpcom_connect_title,
         )
 
         is WPComLoginMode.JetpackSetup -> TwoFAScreenBranding(
-            navIcon = R.drawable.ic_close_24dp,
             title = if (wpComLoginMode.jetpackStatus.isJetpackInstalled) {
                 R.string.login_jetpack_connect
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAScreen.kt
@@ -13,22 +13,21 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
@@ -52,7 +51,6 @@ fun WPComLogin2FAScreen(viewModel: WPComLogin2FAViewModel) {
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun WPComLogin2FAScreen(
     viewState: WPComLogin2FAViewModel.ViewState,
@@ -74,7 +72,7 @@ fun WPComLogin2FAScreen(
     ) { paddingValues ->
         Column(
             modifier = Modifier
-                .background(MaterialTheme.colors.surface)
+                .background(MaterialTheme.colorScheme.surface)
                 .padding(paddingValues)
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState()),
@@ -82,24 +80,24 @@ fun WPComLogin2FAScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(dimensionResource(id = R.dimen.major_100)),
+                    .padding(16.dp),
             ) {
                 if (viewState.wpComLoginMode is WPComLoginMode.PushNotificationsSetup) {
                     WordPressWooBadge()
                 } else {
                     JetpackToWooHeader()
                 }
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+                Spacer(modifier = Modifier.height(32.dp))
                 Text(
                     text = stringResource(id = branding.title),
-                    style = MaterialTheme.typography.h4,
+                    style = MaterialTheme.typography.headlineLarge,
                     fontWeight = FontWeight.Bold
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                Spacer(modifier = Modifier.height(16.dp))
                 Text(
                     text = stringResource(id = R.string.enter_verification_code)
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                Spacer(modifier = Modifier.height(8.dp))
                 WCOutlinedTextField(
                     value = viewState.otp,
                     onValueChange = onOTPChanged,
@@ -121,7 +119,7 @@ fun WPComLogin2FAScreen(
                 WCTextButton(onClick = onSMSLinkClick) {
                     Text(text = stringResource(id = R.string.login_text_otp))
                 }
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                Spacer(modifier = Modifier.height(16.dp))
             }
 
             Spacer(modifier = Modifier.weight(1f))
@@ -134,7 +132,7 @@ fun WPComLogin2FAScreen(
                 enabled = viewState.enableSubmit,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+                    .padding(horizontal = 16.dp)
             ) {
                 Text(text = stringResource(id = branding.buttonText))
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAViewModel.kt
@@ -57,6 +57,7 @@ class WPComLogin2FAViewModel @Inject constructor(
         loadingMessage,
     ) { (emailOrUsername, password), otp, errorMessage, loadingMessage, ->
         ViewState(
+            wpComLoginMode = navArgs.wpComLoginMode,
             emailOrUsername = emailOrUsername,
             password = password,
             otp = otp,
@@ -153,6 +154,7 @@ class WPComLogin2FAViewModel @Inject constructor(
     }
 
     data class ViewState(
+        val wpComLoginMode: WPComLoginMode,
         val emailOrUsername: String,
         val password: String,
         val otp: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAViewModel.kt
@@ -61,8 +61,6 @@ class WPComLogin2FAViewModel @Inject constructor(
             emailOrUsername = emailOrUsername,
             password = password,
             otp = otp,
-            isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
-                ?.jetpackStatus?.isJetpackInstalled ?: false,
             errorMessage = errorMessage.takeIf { it != 0 },
             loadingMessage = loadingMessage.takeIf { it != 0 }
         )
@@ -158,7 +156,6 @@ class WPComLogin2FAViewModel @Inject constructor(
         val emailOrUsername: String,
         val password: String,
         val otp: String,
-        val isJetpackInstalled: Boolean,
         val errorMessage: Int? = null,
         val loadingMessage: Int? = null
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.login.wpcom
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -8,23 +10,21 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
@@ -66,26 +66,26 @@ fun WPComLoginMagicLinkRequestScreen(
                 navigationIcon = ImageVector.vectorResource(branding.navIcon)
             )
         },
-        backgroundColor = MaterialTheme.colors.surface
+        containerColor = MaterialTheme.colorScheme.surface
     ) { paddingValues ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(dimensionResource(id = R.dimen.major_100))
+                .padding(16.dp)
         ) {
             if (viewState.wpComLoginMode is WPComLoginMode.PushNotificationsSetup) {
                 WordPressWooBadge()
             } else {
                 JetpackToWooHeader()
             }
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+            Spacer(modifier = Modifier.height(32.dp))
             Text(
                 text = stringResource(id = branding.title),
-                style = MaterialTheme.typography.h4,
+                style = MaterialTheme.typography.headlineLarge,
                 fontWeight = FontWeight.Bold
             )
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            Spacer(modifier = Modifier.height(16.dp))
 
             when (viewState) {
                 is WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkRequestState -> {
@@ -121,7 +121,7 @@ private fun MagicLinkRequestContent(
     modifier: Modifier = Modifier
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
         modifier = modifier
     ) {
         UserInfo(
@@ -168,43 +168,43 @@ private fun MagicLinkSentContent(
                 ),
                 contentDescription = null
             )
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = stringResource(id = R.string.login_magic_links_sent_label_short),
-                style = MaterialTheme.typography.h6,
+                style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center
             )
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            Spacer(modifier = Modifier.height(16.dp))
             if (viewState.email != null) {
                 Text(
                     text = stringResource(id = R.string.login_magic_links_email_sent),
-                    style = MaterialTheme.typography.subtitle1,
+                    style = MaterialTheme.typography.titleMedium,
                     textAlign = TextAlign.Center
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_50)))
+                Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = viewState.email,
-                    style = MaterialTheme.typography.subtitle1,
+                    style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     textAlign = TextAlign.Center
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                Spacer(modifier = Modifier.height(16.dp))
                 Text(
                     text = stringResource(id = R.string.login_magic_links_email_sent_double_check_email),
-                    style = MaterialTheme.typography.body2,
+                    style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center
                 )
             } else {
                 Text(
                     text = stringResource(id = R.string.login_magic_links_email_sent_to_unknown_email),
-                    style = MaterialTheme.typography.subtitle1,
+                    style = MaterialTheme.typography.titleMedium,
                     textAlign = TextAlign.Center
                 )
             }
         }
 
-        Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        Spacer(modifier = Modifier.height(16.dp))
 
         WCColoredButton(
             onClick = onOpenEmailClientClick,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
@@ -221,7 +221,7 @@ private data class MagicLinkScreenBranding(
 )
 
 private fun WPComLoginMagicLinkRequestViewModel.ViewState.resolveBranding(): MagicLinkScreenBranding {
-    return when (wpComLoginMode) {
+    return when (val wpComLoginMode = this.wpComLoginMode) {
         WPComLoginMode.PushNotificationsSetup -> MagicLinkScreenBranding(
             navIcon = R.drawable.ic_back_24dp,
             title = R.string.login_wpcom_connect_title,
@@ -229,7 +229,7 @@ private fun WPComLoginMagicLinkRequestViewModel.ViewState.resolveBranding(): Mag
 
         is WPComLoginMode.JetpackSetup -> MagicLinkScreenBranding(
             navIcon = R.drawable.ic_close_24dp,
-            title = if (isJetpackInstalled) {
+            title = if (wpComLoginMode.jetpackStatus.isJetpackInstalled) {
                 R.string.login_jetpack_connect
             } else {
                 R.string.login_jetpack_install
@@ -257,7 +257,6 @@ private fun JetpackModeRequestPreview() {
                 ),
                 emailOrUsername = "test@email.com",
                 avatarUrl = "avatar",
-                isJetpackInstalled = false,
                 magicLinkFallbackButton = MagicLinkFallbackButton.Password,
                 isLoadingDialogShown = false
             )
@@ -274,7 +273,6 @@ private fun NotificationSetupModeRequestPreview() {
                 wpComLoginMode = WPComLoginMode.PushNotificationsSetup,
                 emailOrUsername = "test@email.com",
                 avatarUrl = "avatar",
-                isJetpackInstalled = false,
                 magicLinkFallbackButton = MagicLinkFallbackButton.Password,
                 isLoadingDialogShown = false
             )
@@ -290,7 +288,6 @@ private fun MagicLinkSentPreview() {
             viewState = WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkSentState(
                 wpComLoginMode = WPComLoginMode.PushNotificationsSetup,
                 email = null,
-                isJetpackInstalled = false,
                 magicLinkFallbackButton = MagicLinkFallbackButton.Password,
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
@@ -31,6 +33,7 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 import com.woocommerce.android.ui.login.wpcom.components.UserInfo
+import com.woocommerce.android.ui.pushnotifications.WordPressWooBadge
 import org.wordpress.android.login.MagicLinkFallbackButton
 
 @Composable
@@ -54,11 +57,13 @@ fun WPComLoginMagicLinkRequestScreen(
     onOpenEmailClientClick: () -> Unit = {},
     onFallbackButtonClick: () -> Unit = {}
 ) {
+    val branding = viewState.resolveBranding()
+
     Scaffold(
         topBar = {
             Toolbar(
                 onNavigationButtonClick = onCloseClick,
-                navigationIcon = ImageVector.vectorResource(R.drawable.ic_close_24dp)
+                navigationIcon = ImageVector.vectorResource(branding.navIcon)
             )
         },
         backgroundColor = MaterialTheme.colors.surface
@@ -69,15 +74,14 @@ fun WPComLoginMagicLinkRequestScreen(
                 .padding(paddingValues)
                 .padding(dimensionResource(id = R.dimen.major_100))
         ) {
-            JetpackToWooHeader()
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
-            val title = if (viewState.isJetpackInstalled) {
-                R.string.login_jetpack_connect
+            if (viewState.wpComLoginMode is WPComLoginMode.PushNotificationsSetup) {
+                WordPressWooBadge()
             } else {
-                R.string.login_jetpack_install
+                JetpackToWooHeader()
             }
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
             Text(
-                text = stringResource(id = title),
+                text = stringResource(id = branding.title),
                 style = MaterialTheme.typography.h4,
                 fontWeight = FontWeight.Bold
             )
@@ -148,7 +152,6 @@ private fun MagicLinkSentContent(
     onOpenEmailClientClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    viewState.toString()
     Column(
         modifier = modifier
     ) {
@@ -212,12 +215,63 @@ private fun MagicLinkSentContent(
     }
 }
 
+private data class MagicLinkScreenBranding(
+    @DrawableRes val navIcon: Int,
+    @StringRes val title: Int,
+)
+
+private fun WPComLoginMagicLinkRequestViewModel.ViewState.resolveBranding(): MagicLinkScreenBranding {
+    return when (wpComLoginMode) {
+        WPComLoginMode.PushNotificationsSetup -> MagicLinkScreenBranding(
+            navIcon = R.drawable.ic_back_24dp,
+            title = R.string.login_wpcom_connect_title,
+        )
+
+        is WPComLoginMode.JetpackSetup -> MagicLinkScreenBranding(
+            navIcon = R.drawable.ic_close_24dp,
+            title = if (isJetpackInstalled) {
+                R.string.login_jetpack_connect
+            } else {
+                R.string.login_jetpack_install
+            },
+        )
+    }
+}
+
 @Preview
 @Composable
-private fun MagicLinkRequestPreview() {
+private fun JetpackModeRequestPreview() {
     WooThemeWithBackground {
         WPComLoginMagicLinkRequestScreen(
             viewState = WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkRequestState(
+                wpComLoginMode = WPComLoginMode.JetpackSetup(
+                    com.woocommerce.android.model.JetpackStatus(
+                        isJetpackInstalled = false,
+                        jetpackConnectionStatus = com.woocommerce.android.model.JetpackConnectionStatus
+                            .AccountNotConnected(
+                                siteRegistrationStatus = com.woocommerce.android.model
+                                    .JetpackSiteRegistrationStatus.UNKNOWN,
+                                blogId = null
+                            )
+                    )
+                ),
+                emailOrUsername = "test@email.com",
+                avatarUrl = "avatar",
+                isJetpackInstalled = false,
+                magicLinkFallbackButton = MagicLinkFallbackButton.Password,
+                isLoadingDialogShown = false
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun NotificationSetupModeRequestPreview() {
+    WooThemeWithBackground {
+        WPComLoginMagicLinkRequestScreen(
+            viewState = WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkRequestState(
+                wpComLoginMode = WPComLoginMode.PushNotificationsSetup,
                 emailOrUsername = "test@email.com",
                 avatarUrl = "avatar",
                 isJetpackInstalled = false,
@@ -234,6 +288,7 @@ private fun MagicLinkSentPreview() {
     WooThemeWithBackground {
         WPComLoginMagicLinkRequestScreen(
             viewState = WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkSentState(
+                wpComLoginMode = WPComLoginMode.PushNotificationsSetup,
                 email = null,
                 isJetpackInstalled = false,
                 magicLinkFallbackButton = MagicLinkFallbackButton.Password,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
@@ -25,6 +25,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.model.JetpackConnectionStatus
+import com.woocommerce.android.model.JetpackSiteRegistrationStatus
+import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -241,14 +244,12 @@ private fun JetpackModeRequestPreview() {
         WPComLoginMagicLinkRequestScreen(
             viewState = WPComLoginMagicLinkRequestViewModel.ViewState.MagicLinkRequestState(
                 wpComLoginMode = WPComLoginMode.JetpackSetup(
-                    com.woocommerce.android.model.JetpackStatus(
+                    JetpackStatus(
                         isJetpackInstalled = false,
-                        jetpackConnectionStatus = com.woocommerce.android.model.JetpackConnectionStatus
-                            .AccountNotConnected(
-                                siteRegistrationStatus = com.woocommerce.android.model
-                                    .JetpackSiteRegistrationStatus.UNKNOWN,
-                                blogId = null
-                            )
+                        jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                            siteRegistrationStatus = JetpackSiteRegistrationStatus.UNKNOWN,
+                            blogId = null
+                        )
                     )
                 ),
                 emailOrUsername = "test@email.com",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestScreen.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.login.wpcom
 
-import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -63,7 +62,7 @@ fun WPComLoginMagicLinkRequestScreen(
         topBar = {
             Toolbar(
                 onNavigationButtonClick = onCloseClick,
-                navigationIcon = ImageVector.vectorResource(branding.navIcon)
+                navigationIcon = ImageVector.vectorResource(R.drawable.ic_close_24dp)
             )
         },
         containerColor = MaterialTheme.colorScheme.surface
@@ -216,19 +215,16 @@ private fun MagicLinkSentContent(
 }
 
 private data class MagicLinkScreenBranding(
-    @DrawableRes val navIcon: Int,
     @StringRes val title: Int,
 )
 
 private fun WPComLoginMagicLinkRequestViewModel.ViewState.resolveBranding(): MagicLinkScreenBranding {
     return when (val wpComLoginMode = this.wpComLoginMode) {
         WPComLoginMode.PushNotificationsSetup -> MagicLinkScreenBranding(
-            navIcon = R.drawable.ic_back_24dp,
             title = R.string.login_wpcom_connect_title,
         )
 
         is WPComLoginMode.JetpackSetup -> MagicLinkScreenBranding(
-            navIcon = R.drawable.ic_close_24dp,
             title = if (wpComLoginMode.jetpackStatus.isJetpackInstalled) {
                 R.string.login_jetpack_connect
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModel.kt
@@ -42,6 +42,7 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
     private val _viewState = savedStateHandle.getStateFlow<ViewState>(
         scope = viewModelScope,
         initialValue = ViewState.MagicLinkRequestState(
+            wpComLoginMode = navArgs.wpComLoginMode,
             emailOrUsername = navArgs.emailOrUsername,
             avatarUrl = avatarUrlFromEmail(navArgs.emailOrUsername),
             isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
@@ -102,6 +103,7 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
         )
 
         _viewState.value = ViewState.MagicLinkRequestState(
+            wpComLoginMode = navArgs.wpComLoginMode,
             emailOrUsername = navArgs.emailOrUsername,
             avatarUrl = avatarUrlFromEmail(navArgs.emailOrUsername),
             isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
@@ -116,6 +118,7 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
         ).fold(
             onSuccess = {
                 _viewState.value = ViewState.MagicLinkSentState(
+                    wpComLoginMode = navArgs.wpComLoginMode,
                     email = navArgs.emailOrUsername.takeIf { it.isAnEmail() },
                     isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
                         ?.jetpackStatus?.isJetpackInstalled ?: false,
@@ -152,11 +155,13 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
     private fun String.isAnEmail() = PatternsCompat.EMAIL_ADDRESS.matcher(this).matches()
 
     sealed interface ViewState : Parcelable {
+        val wpComLoginMode: WPComLoginMode
         val isJetpackInstalled: Boolean
         val magicLinkFallbackButton: MagicLinkFallbackButton
 
         @Parcelize
         data class MagicLinkRequestState(
+            override val wpComLoginMode: WPComLoginMode,
             val emailOrUsername: String,
             val avatarUrl: String,
             override val isJetpackInstalled: Boolean,
@@ -166,6 +171,7 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
 
         @Parcelize
         data class MagicLinkSentState(
+            override val wpComLoginMode: WPComLoginMode,
             val email: String?,
             override val isJetpackInstalled: Boolean,
             override val magicLinkFallbackButton: MagicLinkFallbackButton

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModel.kt
@@ -45,8 +45,6 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
             wpComLoginMode = navArgs.wpComLoginMode,
             emailOrUsername = navArgs.emailOrUsername,
             avatarUrl = avatarUrlFromEmail(navArgs.emailOrUsername),
-            isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
-                ?.jetpackStatus?.isJetpackInstalled ?: false,
             magicLinkFallbackButton = navArgs.fallbackButton,
             isLoadingDialogShown = false
         )
@@ -106,8 +104,6 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
             wpComLoginMode = navArgs.wpComLoginMode,
             emailOrUsername = navArgs.emailOrUsername,
             avatarUrl = avatarUrlFromEmail(navArgs.emailOrUsername),
-            isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
-                ?.jetpackStatus?.isJetpackInstalled ?: false,
             magicLinkFallbackButton = navArgs.fallbackButton,
             isLoadingDialogShown = true
         )
@@ -120,8 +116,6 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
                 _viewState.value = ViewState.MagicLinkSentState(
                     wpComLoginMode = navArgs.wpComLoginMode,
                     email = navArgs.emailOrUsername.takeIf { it.isAnEmail() },
-                    isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
-                        ?.jetpackStatus?.isJetpackInstalled ?: false,
                     magicLinkFallbackButton = navArgs.fallbackButton,
                 )
             },
@@ -156,7 +150,6 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
 
     sealed interface ViewState : Parcelable {
         val wpComLoginMode: WPComLoginMode
-        val isJetpackInstalled: Boolean
         val magicLinkFallbackButton: MagicLinkFallbackButton
 
         @Parcelize
@@ -164,7 +157,6 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
             override val wpComLoginMode: WPComLoginMode,
             val emailOrUsername: String,
             val avatarUrl: String,
-            override val isJetpackInstalled: Boolean,
             override val magicLinkFallbackButton: MagicLinkFallbackButton,
             val isLoadingDialogShown: Boolean
         ) : ViewState
@@ -173,7 +165,6 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
         data class MagicLinkSentState(
             override val wpComLoginMode: WPComLoginMode,
             val email: String?,
-            override val isJetpackInstalled: Boolean,
             override val magicLinkFallbackButton: MagicLinkFallbackButton
         ) : ViewState
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
@@ -27,6 +27,9 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.model.JetpackConnectionStatus
+import com.woocommerce.android.model.JetpackSiteRegistrationStatus
+import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
@@ -201,14 +204,12 @@ private fun JetpackModePreview() {
         WPComLoginPasswordScreen(
             viewState = WPComLoginPasswordViewModel.ViewState(
                 wpComLoginMode = WPComLoginMode.JetpackSetup(
-                    com.woocommerce.android.model.JetpackStatus(
+                    JetpackStatus(
                         isJetpackInstalled = false,
-                        jetpackConnectionStatus = com.woocommerce.android.model.JetpackConnectionStatus
-                            .AccountNotConnected(
-                                siteRegistrationStatus = com.woocommerce.android.model
-                                    .JetpackSiteRegistrationStatus.UNKNOWN,
-                                blogId = null
-                            )
+                        jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                            siteRegistrationStatus = JetpackSiteRegistrationStatus.UNKNOWN,
+                            blogId = null
+                        )
                     )
                 ),
                 emailOrUsername = "test@email.com",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
@@ -36,6 +38,7 @@ import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.components.JetpackToWooHeader
 import com.woocommerce.android.ui.login.wpcom.components.UserInfo
+import com.woocommerce.android.ui.pushnotifications.WordPressWooBadge
 
 @Composable
 fun WPComLoginPasswordScreen(viewModel: WPComLoginPasswordViewModel) {
@@ -62,12 +65,13 @@ fun WPComLoginPasswordScreen(
     onResetPasswordClick: () -> Unit = {}
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    val branding = viewState.resolveBranding()
 
     Scaffold(
         topBar = {
             Toolbar(
                 onNavigationButtonClick = onCloseClick,
-                navigationIcon = ImageVector.vectorResource(R.drawable.ic_close_24dp)
+                navigationIcon = ImageVector.vectorResource(branding.navIcon)
             )
         }
     ) { paddingValues ->
@@ -83,15 +87,14 @@ fun WPComLoginPasswordScreen(
                     .fillMaxWidth()
                     .padding(dimensionResource(id = R.dimen.major_100)),
             ) {
-                JetpackToWooHeader()
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
-                val title = if (viewState.isJetpackInstalled) {
-                    R.string.login_jetpack_connect
+                if (viewState.wpComLoginMode is WPComLoginMode.PushNotificationsSetup) {
+                    WordPressWooBadge()
                 } else {
-                    R.string.login_jetpack_install
+                    JetpackToWooHeader()
                 }
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
                 Text(
-                    text = stringResource(id = title),
+                    text = stringResource(id = branding.title),
                     style = MaterialTheme.typography.h4,
                     fontWeight = FontWeight.Bold
                 )
@@ -102,15 +105,9 @@ fun WPComLoginPasswordScreen(
                     modifier = Modifier.fillMaxWidth()
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
-                Text(
-                    text = stringResource(
-                        id = if (viewState.isJetpackInstalled) {
-                            R.string.login_jetpack_connection_enter_wpcom_password
-                        } else {
-                            R.string.login_jetpack_installation_enter_wpcom_password
-                        }
-                    )
-                )
+                branding.subtitle?.let {
+                    Text(text = stringResource(id = it))
+                }
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
                 WCPasswordField(
                     value = viewState.password,
@@ -145,15 +142,7 @@ fun WPComLoginPasswordScreen(
                     .fillMaxWidth()
                     .padding(horizontal = dimensionResource(id = R.dimen.major_100))
             ) {
-                Text(
-                    text = stringResource(
-                        id = if (viewState.isJetpackInstalled) {
-                            R.string.login_jetpack_connect
-                        } else {
-                            R.string.login_jetpack_install
-                        }
-                    )
-                )
+                Text(text = stringResource(id = branding.buttonText))
             }
             WCOutlinedButton(
                 onClick = onMagicLinkClick,
@@ -174,12 +163,76 @@ fun WPComLoginPasswordScreen(
     }
 }
 
+private data class PasswordScreenBranding(
+    @DrawableRes val navIcon: Int,
+    @StringRes val title: Int,
+    @StringRes val subtitle: Int?,
+    @StringRes val buttonText: Int,
+)
+
+private fun WPComLoginPasswordViewModel.ViewState.resolveBranding(): PasswordScreenBranding {
+    return when (wpComLoginMode) {
+        WPComLoginMode.PushNotificationsSetup -> PasswordScreenBranding(
+            navIcon = R.drawable.ic_back_24dp,
+            title = R.string.login_wpcom_connect_title,
+            subtitle = null,
+            buttonText = R.string.continue_button,
+        )
+
+        is WPComLoginMode.JetpackSetup -> PasswordScreenBranding(
+            navIcon = R.drawable.ic_close_24dp,
+            title = if (isJetpackInstalled) {
+                R.string.login_jetpack_connect
+            } else {
+                R.string.login_jetpack_install
+            },
+            subtitle = if (isJetpackInstalled) {
+                R.string.login_jetpack_connection_enter_wpcom_password
+            } else {
+                R.string.login_jetpack_installation_enter_wpcom_password
+            },
+            buttonText = if (isJetpackInstalled) {
+                R.string.login_jetpack_connect
+            } else {
+                R.string.login_jetpack_install
+            },
+        )
+    }
+}
+
 @Preview
 @Composable
-private fun JetpackActivationWPComScreenPreview() {
+private fun JetpackModePreview() {
     WooThemeWithBackground {
         WPComLoginPasswordScreen(
             viewState = WPComLoginPasswordViewModel.ViewState(
+                wpComLoginMode = WPComLoginMode.JetpackSetup(
+                    com.woocommerce.android.model.JetpackStatus(
+                        isJetpackInstalled = false,
+                        jetpackConnectionStatus = com.woocommerce.android.model.JetpackConnectionStatus
+                            .AccountNotConnected(
+                                siteRegistrationStatus = com.woocommerce.android.model
+                                    .JetpackSiteRegistrationStatus.UNKNOWN,
+                                blogId = null
+                            )
+                    )
+                ),
+                emailOrUsername = "test@email.com",
+                password = "",
+                avatarUrl = "",
+                isJetpackInstalled = false
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun NotificationSetupModePreview() {
+    WooThemeWithBackground {
+        WPComLoginPasswordScreen(
+            viewState = WPComLoginPasswordViewModel.ViewState(
+                wpComLoginMode = WPComLoginMode.PushNotificationsSetup,
                 emailOrUsername = "test@email.com",
                 password = "",
                 avatarUrl = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
@@ -179,17 +179,17 @@ private fun WPComLoginPasswordViewModel.ViewState.resolveBranding(): PasswordScr
 
         is WPComLoginMode.JetpackSetup -> PasswordScreenBranding(
             navIcon = R.drawable.ic_close_24dp,
-            title = if (isJetpackInstalled) {
+            title = if (wpComLoginMode.jetpackStatus.isJetpackInstalled) {
                 R.string.login_jetpack_connect
             } else {
                 R.string.login_jetpack_install
             },
-            subtitle = if (isJetpackInstalled) {
+            subtitle = if (wpComLoginMode.jetpackStatus.isJetpackInstalled) {
                 R.string.login_jetpack_connection_enter_wpcom_password
             } else {
                 R.string.login_jetpack_installation_enter_wpcom_password
             },
-            buttonText = if (isJetpackInstalled) {
+            buttonText = if (wpComLoginMode.jetpackStatus.isJetpackInstalled) {
                 R.string.login_jetpack_connect
             } else {
                 R.string.login_jetpack_install
@@ -217,8 +217,7 @@ private fun JetpackModePreview() {
                 ),
                 emailOrUsername = "test@email.com",
                 password = "",
-                avatarUrl = "",
-                isJetpackInstalled = false
+                avatarUrl = ""
             )
         )
     }
@@ -233,8 +232,7 @@ private fun NotificationSetupModePreview() {
                 wpComLoginMode = WPComLoginMode.PushNotificationsSetup,
                 emailOrUsername = "test@email.com",
                 password = "",
-                avatarUrl = "",
-                isJetpackInstalled = false
+                avatarUrl = ""
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.login.wpcom
 
-import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -69,7 +68,7 @@ fun WPComLoginPasswordScreen(
         topBar = {
             Toolbar(
                 onNavigationButtonClick = onCloseClick,
-                navigationIcon = ImageVector.vectorResource(branding.navIcon)
+                navigationIcon = ImageVector.vectorResource(R.drawable.ic_close_24dp)
             )
         }
     ) { paddingValues ->
@@ -162,7 +161,6 @@ fun WPComLoginPasswordScreen(
 }
 
 private data class PasswordScreenBranding(
-    @DrawableRes val navIcon: Int,
     @StringRes val title: Int,
     @StringRes val subtitle: Int?,
     @StringRes val buttonText: Int,
@@ -171,14 +169,12 @@ private data class PasswordScreenBranding(
 private fun WPComLoginPasswordViewModel.ViewState.resolveBranding(): PasswordScreenBranding {
     return when (wpComLoginMode) {
         WPComLoginMode.PushNotificationsSetup -> PasswordScreenBranding(
-            navIcon = R.drawable.ic_back_24dp,
             title = R.string.login_wpcom_connect_title,
             subtitle = null,
             buttonText = R.string.continue_button,
         )
 
         is WPComLoginMode.JetpackSetup -> PasswordScreenBranding(
-            navIcon = R.drawable.ic_close_24dp,
             title = if (wpComLoginMode.jetpackStatus.isJetpackInstalled) {
                 R.string.login_jetpack_connect
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordScreen.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.login.wpcom
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -11,23 +13,20 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProgressDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
@@ -54,7 +53,6 @@ fun WPComLoginPasswordScreen(viewModel: WPComLoginPasswordViewModel) {
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun WPComLoginPasswordScreen(
     viewState: WPComLoginPasswordViewModel.ViewState,
@@ -77,7 +75,7 @@ fun WPComLoginPasswordScreen(
     ) { paddingValues ->
         Column(
             modifier = Modifier
-                .background(MaterialTheme.colors.surface)
+                .background(MaterialTheme.colorScheme.surface)
                 .padding(paddingValues)
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState()),
@@ -85,30 +83,30 @@ fun WPComLoginPasswordScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(dimensionResource(id = R.dimen.major_100)),
+                    .padding(16.dp),
             ) {
                 if (viewState.wpComLoginMode is WPComLoginMode.PushNotificationsSetup) {
                     WordPressWooBadge()
                 } else {
                     JetpackToWooHeader()
                 }
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
+                Spacer(modifier = Modifier.height(32.dp))
                 Text(
                     text = stringResource(id = branding.title),
-                    style = MaterialTheme.typography.h4,
+                    style = MaterialTheme.typography.headlineLarge,
                     fontWeight = FontWeight.Bold
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                Spacer(modifier = Modifier.height(16.dp))
                 UserInfo(
                     emailOrUsername = viewState.emailOrUsername,
                     avatarUrl = viewState.avatarUrl,
                     modifier = Modifier.fillMaxWidth()
                 )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                Spacer(modifier = Modifier.height(16.dp))
                 branding.subtitle?.let {
                     Text(text = stringResource(id = it))
                 }
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                Spacer(modifier = Modifier.height(16.dp))
                 WCPasswordField(
                     value = viewState.password,
                     onValueChange = onPasswordChanged,
@@ -140,7 +138,7 @@ fun WPComLoginPasswordScreen(
                 enabled = viewState.enableSubmit,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+                    .padding(horizontal = 16.dp)
             ) {
                 Text(text = stringResource(id = branding.buttonText))
             }
@@ -148,13 +146,13 @@ fun WPComLoginPasswordScreen(
                 onClick = onMagicLinkClick,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = dimensionResource(id = R.dimen.major_100))
+                    .padding(horizontal = 16.dp)
             ) {
                 Text(
                     text = stringResource(id = R.string.login_jetpack_installation_continue_magic_link)
                 )
             }
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
@@ -65,6 +65,7 @@ class WPComLoginPasswordViewModel @Inject constructor(
         flowOf(Pair(navArgs.emailOrUsername, avatarUrlFromEmail(navArgs.emailOrUsername)))
     ) { password, isLoadingDialogShown, errorMessage, (emailOrUsername, avatarUrl) ->
         ViewState(
+            wpComLoginMode = navArgs.wpComLoginMode,
             emailOrUsername = emailOrUsername,
             password = password,
             avatarUrl = avatarUrl,
@@ -174,6 +175,7 @@ class WPComLoginPasswordViewModel @Inject constructor(
     }
 
     data class ViewState(
+        val wpComLoginMode: WPComLoginMode,
         val emailOrUsername: String,
         val password: String,
         val avatarUrl: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
@@ -69,8 +69,6 @@ class WPComLoginPasswordViewModel @Inject constructor(
             emailOrUsername = emailOrUsername,
             password = password,
             avatarUrl = avatarUrl,
-            isJetpackInstalled = (navArgs.wpComLoginMode as? WPComLoginMode.JetpackSetup)
-                ?.jetpackStatus?.isJetpackInstalled ?: false,
             isLoadingDialogShown = isLoadingDialogShown,
             errorMessage = errorMessage.takeIf { it != 0 }
         )
@@ -179,7 +177,6 @@ class WPComLoginPasswordViewModel @Inject constructor(
         val emailOrUsername: String,
         val password: String,
         val avatarUrl: String,
-        val isJetpackInstalled: Boolean,
         val isLoadingDialogShown: Boolean = false,
         val errorMessage: Int? = null
     ) {


### PR DESCRIPTION
Part of WOOMOB-1925.
Depends on #15353.

### Description
- Add `wpComLoginMode` to ViewState for password, 2FA, and magic link request screens
- Branch UI elements (header, nav icon, title, subtitle, button text) based on login mode using the same `resolveBranding()` pattern from the email screen
- PushNotificationsSetup mode shows WP+Woo badge, back arrow, "Connect to WordPress.com" branding
- JetpackSetup mode preserves existing Jetpack branding

> [!NOTE]
>  The last commit (3fb3035a8fef7af1fe5fbb577c07812241296b43) is not related to the main branding changes and should be reviewed individually. It migrates the three screens from Material 2 to Material 3, following the same pattern as the email screen migration in the parent PR. 

### Test Steps
1. Enable the Push Notifications M2 feature flag.
2. Start Push Notifications setup from the dashboard or settings.
3. Check the auth flow UI, and confirm the branding matches the expected designs.

### Images/gif
| Light | Dark |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260216_123427" src="https://github.com/user-attachments/assets/8e33594b-1f9b-4dda-bd5e-0aa3fbf52a51" /> | <img width="1080" height="2400" alt="Screenshot_20260216_123439" src="https://github.com/user-attachments/assets/090a90e2-1bcb-4d0f-85bb-a67c2c5955e7" /> |
| <img width="1080" height="2400" alt="Screenshot_20260216_124103" src="https://github.com/user-attachments/assets/2e33d2e2-0896-4850-aa62-8c5ce0c094e6" /> | <img width="1080" height="2400" alt="Screenshot_20260216_124052" src="https://github.com/user-attachments/assets/cfaabc13-7f8d-4a7f-a710-27550e64f96c" /> |
| <img width="1080" height="2400" alt="Screenshot_20260216_124425" src="https://github.com/user-attachments/assets/6ae61bda-4f14-4ceb-9120-38f2ca4f6149" /> | <img width="1080" height="2400" alt="Screenshot_20260216_124433" src="https://github.com/user-attachments/assets/f1d853f5-7510-428c-b22b-5bb66e5f8cdc" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md --> 