### PR TITLE
POS: Show receipt sent confirmation and prefill email receipt

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepository.kt
@@ -23,6 +23,11 @@ class WooPosEmailReceiptRepository @Inject constructor(
         }
     }
 
+    suspend fun getOrderBillingEmail(orderId: Long): String {
+        val order = orderStore.getOrderByIdAndSite(orderId, selectedSite.get())
+        return order?.billingEmail.orEmpty()
+    }
+
     fun isEmailValid(email: String): Boolean = provideEmailPattern().matcher(email).matches()
 
     fun posReceiptsAreEnabled(): Boolean = isWooCoreSupportsPOSReceipts()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptViewModel.kt
@@ -40,6 +40,10 @@ class WooPosEmailReceiptViewModel @Inject constructor(
 
     val state: StateFlow<WooPosEmailReceiptState> = _state
 
+    init {
+        prefillBillingEmail()
+    }
+
     fun onUIEvent(event: WooPosEmailReceiptUIEvent) {
         when (event) {
             WooPosEmailReceiptUIEvent.SendEmailClicked -> handleSendEmailClicked()
@@ -91,6 +95,30 @@ class WooPosEmailReceiptViewModel @Inject constructor(
                 email = email,
                 button = currentState.button.copy(
                     status = WooPosEmailReceiptState.Email.Button.Status.DISABLED
+                )
+            )
+        }
+    }
+
+    private fun prefillBillingEmail() {
+        viewModelScope.launch {
+            val currentState = _state.value as? WooPosEmailReceiptState.Email ?: return@launch
+            if (currentState.email.isNotEmpty()) return@launch
+
+            val billingEmail = repository.getOrderBillingEmail(orderId)
+            if (billingEmail.isBlank()) return@launch
+
+            val updatedState = _state.value as? WooPosEmailReceiptState.Email ?: return@launch
+            if (updatedState.email.isNotEmpty()) return@launch
+
+            _state.value = updatedState.copy(
+                email = billingEmail,
+                button = updatedState.button.copy(
+                    status = if (repository.isEmailValid(billingEmail)) {
+                        WooPosEmailReceiptState.Email.Button.Status.ENABLED
+                    } else {
+                        WooPosEmailReceiptState.Email.Button.Status.DISABLED
+                    }
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -683,10 +683,19 @@ class WooPosTotalsViewModel @Inject constructor(
                 template,
                 priceFormat(dataState.orderTotal)
             )
+            val receiptSentMessage = buildReceiptSentMessage(dataState.orderId)
             uiState.value = WooPosTotalsViewState.PaymentSuccess(
-                orderTotalText = orderTotalText
+                orderTotalText = orderTotalText,
+                receiptSentMessage = receiptSentMessage,
             )
         }
+    }
+
+    private suspend fun buildReceiptSentMessage(orderId: Long): String? {
+        val order = totalsRepository.getOrderById(orderId) ?: return null
+        val billingEmail = order.billingAddress.email
+        if (billingEmail.isBlank()) return null
+        return resourceProvider.getString(R.string.woopos_receipt_sent_message, billingEmail)
     }
 
     private suspend fun buildWooPosTotalsViewState(order: Order): WooPosTotalsViewState.Checkout {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
@@ -25,7 +25,10 @@ sealed class WooPosTotalsViewState : Parcelable {
         ) : Totals()
     }
 
-    data class PaymentSuccess(val orderTotalText: String) : WooPosTotalsViewState()
+    data class PaymentSuccess(
+        val orderTotalText: String,
+        val receiptSentMessage: String? = null,
+    ) : WooPosTotalsViewState()
 
     sealed class ReaderStatus : Parcelable {
         @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -62,7 +63,8 @@ fun WooPosPaymentSuccessScreen(
         val textsMargin = WooPosSpacing.Small.value
 
         ConstraintLayout {
-            val (icon, title, message, buttonNewOrder, buttonEmailReceipts) = createRefs()
+            val (icon, title, message, receiptSent, buttonNewOrder) = createRefs()
+            val buttonEmailReceipts = createRef()
 
             WooPosSuccessCheckmark(
                 contentDescription = stringResource(R.string.woopos_payment_successful_label),
@@ -97,9 +99,33 @@ fun WooPosPaymentSuccessScreen(
                 modifier = Modifier.constrainAs(message) {
                     start.linkTo(parent.start)
                     end.linkTo(parent.end)
-                    bottom.linkTo(buttonNewOrder.top, margin = marginBetweenButtonAndText)
+                    bottom.linkTo(receiptSent.top, margin = textsMargin)
                 }
             )
+
+            if (state.receiptSentMessage != null) {
+                WooPosText(
+                    text = state.receiptSentMessage,
+                    style = WooPosTypography.BodyMedium,
+                    color = WooPosTheme.colors.onSurfaceVariantHighest,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .constrainAs(receiptSent) {
+                            start.linkTo(parent.start)
+                            end.linkTo(parent.end)
+                            bottom.linkTo(buttonNewOrder.top, margin = marginBetweenButtonAndText)
+                        }
+                        .padding(horizontal = WooPosSpacing.XLarge.value)
+                )
+            } else {
+                Box(
+                    modifier = Modifier.constrainAs(receiptSent) {
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                        bottom.linkTo(buttonNewOrder.top, margin = marginBetweenButtonAndText)
+                    }
+                )
+            }
 
             val marginBetweenButtons = WooPosSpacing.Medium.value
             WooPosButton(
@@ -135,6 +161,21 @@ fun WooPosPaymentSuccessScreen(
 @WooPosPreview
 @Composable
 fun WooPosPaymentSuccessScreenPreview() {
+    WooPosTheme {
+        WooPosPaymentSuccessScreen(
+            state = WooPosTotalsViewState.PaymentSuccess(
+                orderTotalText = "A payment of 13.18 was successfully made",
+                receiptSentMessage = "Receipt sent to customer@example.com",
+            ),
+            onReceiptClicked = {},
+            onNewTransactionClicked = {}
+        )
+    }
+}
+
+@WooPosPreview
+@Composable
+fun WooPosPaymentSuccessScreenWithoutReceiptPreview() {
     WooPosTheme {
         WooPosPaymentSuccessScreen(
             state = WooPosTotalsViewState.PaymentSuccess(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
@@ -106,8 +106,8 @@ fun WooPosPaymentSuccessScreen(
             if (state.receiptSentMessage != null) {
                 WooPosText(
                     text = state.receiptSentMessage,
-                    style = WooPosTypography.BodyMedium,
-                    color = WooPosTheme.colors.onSurfaceVariantHighest,
+                    style = WooPosTypography.BodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
                     textAlign = TextAlign.Center,
                     modifier = Modifier
                         .constrainAs(receiptSent) {
@@ -165,7 +165,7 @@ fun WooPosPaymentSuccessScreenPreview() {
         WooPosPaymentSuccessScreen(
             state = WooPosTotalsViewState.PaymentSuccess(
                 orderTotalText = "A payment of 13.18 was successfully made",
-                receiptSentMessage = "Receipt sent to customer@example.com",
+                receiptSentMessage = "A receipt has been sent to customer@example.com.",
             ),
             onReceiptClicked = {},
             onNewTransactionClicked = {}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3739,6 +3739,7 @@
     <string name="woopos_payment_successful_label">Payment successful</string>
     <string name="woopos_new_order_button">New order</string>
     <string name="woopos_receipt_button">Email receipt</string>
+    <string name="woopos_receipt_sent_message">Receipt sent to %1$s</string>
     <string name="woopos_payment_discount_label">Discount total</string>
     <string name="woopos_payment_subtotal_label">Subtotal</string>
     <string name="woopos_payment_tax_label">Taxes</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3739,7 +3739,7 @@
     <string name="woopos_payment_successful_label">Payment successful</string>
     <string name="woopos_new_order_button">New order</string>
     <string name="woopos_receipt_button">Email receipt</string>
-    <string name="woopos_receipt_sent_message">Receipt sent to %1$s</string>
+    <string name="woopos_receipt_sent_message">A receipt has been sent to %1$s.</string>
     <string name="woopos_payment_discount_label">Discount total</string>
     <string name="woopos_payment_subtotal_label">Subtotal</string>
     <string name="woopos_payment_tax_label">Taxes</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepositoryTest.kt
@@ -9,11 +9,13 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
 import java.util.regex.Pattern
 
@@ -159,5 +161,54 @@ class WooPosEmailReceiptRepositoryTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
+    }
+
+    @Test
+    fun `given order with billing email, when getOrderBillingEmail, then return email`() = runTest {
+        // GIVEN
+        val orderId = 1L
+        val order = OrderEntity(
+            localSiteId = LocalId(0),
+            orderId = orderId,
+            billingEmail = "customer@example.com"
+        )
+        whenever(orderStore.getOrderByIdAndSite(orderId, siteModel)).thenReturn(order)
+
+        // WHEN
+        val result = repository.getOrderBillingEmail(orderId)
+
+        // THEN
+        assertThat(result).isEqualTo("customer@example.com")
+    }
+
+    @Test
+    fun `given order without billing email, when getOrderBillingEmail, then return empty string`() = runTest {
+        // GIVEN
+        val orderId = 1L
+        val order = OrderEntity(
+            localSiteId = LocalId(0),
+            orderId = orderId,
+            billingEmail = ""
+        )
+        whenever(orderStore.getOrderByIdAndSite(orderId, siteModel)).thenReturn(order)
+
+        // WHEN
+        val result = repository.getOrderBillingEmail(orderId)
+
+        // THEN
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `given no order found, when getOrderBillingEmail, then return empty string`() = runTest {
+        // GIVEN
+        val orderId = 1L
+        whenever(orderStore.getOrderByIdAndSite(orderId, siteModel)).thenReturn(null)
+
+        // WHEN
+        val result = repository.getOrderBillingEmail(orderId)
+
+        // THEN
+        assertThat(result).isEmpty()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptViewModelTest.kt
@@ -48,6 +48,7 @@ class WooPosEmailReceiptViewModelTest {
             .thenReturn("Error sending email")
 
         whenever(repository.isEmailValid(any())).thenReturn(false)
+        whenever(repository.getOrderBillingEmail(any())).thenReturn("")
 
         viewModel = WooPosEmailReceiptViewModel(
             repository = repository,
@@ -190,5 +191,70 @@ class WooPosEmailReceiptViewModelTest {
 
         // THEN
         verify(tracker).track(EmailReceiptSendSuccess(posReceiptsAreEnabled))
+    }
+
+    @Test
+    fun `given order has billing email, when view model is created, then email is prefilled and button enabled`() = runTest {
+        // GIVEN
+        whenever(repository.getOrderBillingEmail(123L)).thenReturn("customer@example.com")
+        whenever(repository.isEmailValid("customer@example.com")).thenReturn(true)
+
+        // WHEN
+        val vm = WooPosEmailReceiptViewModel(
+            repository = repository,
+            resourceProvider = resourceProvider,
+            savedState = SavedStateHandle(mapOf(EMAIL_RECEIPT_ROUTE_ORDER_ID_KEY to 123L)),
+            analyticsTracker = tracker,
+        )
+        advanceUntilIdle()
+        val state = vm.state.first()
+
+        // THEN
+        val emailState = state as WooPosEmailReceiptState.Email
+        assertThat(emailState.email).isEqualTo("customer@example.com")
+        assertThat(emailState.button.status).isEqualTo(WooPosEmailReceiptState.Email.Button.Status.ENABLED)
+    }
+
+    @Test
+    fun `given order has no billing email, when view model is created, then email remains empty and button disabled`() = runTest {
+        // GIVEN
+        whenever(repository.getOrderBillingEmail(123L)).thenReturn("")
+
+        // WHEN
+        val vm = WooPosEmailReceiptViewModel(
+            repository = repository,
+            resourceProvider = resourceProvider,
+            savedState = SavedStateHandle(mapOf(EMAIL_RECEIPT_ROUTE_ORDER_ID_KEY to 123L)),
+            analyticsTracker = tracker,
+        )
+        advanceUntilIdle()
+        val state = vm.state.first()
+
+        // THEN
+        val emailState = state as WooPosEmailReceiptState.Email
+        assertThat(emailState.email).isEmpty()
+        assertThat(emailState.button.status).isEqualTo(WooPosEmailReceiptState.Email.Button.Status.DISABLED)
+    }
+
+    @Test
+    fun `given order has invalid billing email, when view model is created, then email is prefilled but button disabled`() = runTest {
+        // GIVEN
+        whenever(repository.getOrderBillingEmail(123L)).thenReturn("not-an-email")
+        whenever(repository.isEmailValid("not-an-email")).thenReturn(false)
+
+        // WHEN
+        val vm = WooPosEmailReceiptViewModel(
+            repository = repository,
+            resourceProvider = resourceProvider,
+            savedState = SavedStateHandle(mapOf(EMAIL_RECEIPT_ROUTE_ORDER_ID_KEY to 123L)),
+            analyticsTracker = tracker,
+        )
+        advanceUntilIdle()
+        val state = vm.state.first()
+
+        // THEN
+        val emailState = state as WooPosEmailReceiptState.Email
+        assertThat(emailState.email).isEqualTo("not-an-email")
+        assertThat(emailState.button.status).isEqualTo(WooPosEmailReceiptState.Email.Button.Status.DISABLED)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1153,7 +1153,7 @@ class WooPosTotalsViewModelTest {
             whenever(resourceProvider.getString(R.string.woopos_totals_success_payment_card, "5.00$"))
                 .thenReturn("Paid 5.00$ in Card")
             whenever(resourceProvider.getString(R.string.woopos_receipt_sent_message, billingEmail))
-                .thenReturn("Receipt sent to customer@example.com")
+                .thenReturn("A receipt has been sent to customer@example.com.")
             val parentToChildrenEventFlow = MutableStateFlow<ParentToChildrenEvent>(
                 ParentToChildrenEvent.CheckoutClicked(
                     listOf(
@@ -1173,7 +1173,7 @@ class WooPosTotalsViewModelTest {
             // THEN
             assertThat(viewModel.state.value).isInstanceOf(WooPosTotalsViewState.PaymentSuccess::class.java)
             val successState = viewModel.state.value as WooPosTotalsViewState.PaymentSuccess
-            assertThat(successState.receiptSentMessage).isEqualTo("Receipt sent to customer@example.com")
+            assertThat(successState.receiptSentMessage).isEqualTo("A receipt has been sent to customer@example.com.")
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus
+import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Order.CouponLine
 import com.woocommerce.android.tools.SelectedSite
@@ -1145,6 +1146,64 @@ class WooPosTotalsViewModelTest {
         }
 
     @Test
+    fun `given order has billing email, when payment succeeds, then receiptSentMessage is set`() =
+        runTest {
+            // GIVEN
+            val billingEmail = "customer@example.com"
+            whenever(resourceProvider.getString(R.string.woopos_totals_success_payment_card, "5.00$"))
+                .thenReturn("Paid 5.00$ in Card")
+            whenever(resourceProvider.getString(R.string.woopos_receipt_sent_message, billingEmail))
+                .thenReturn("Receipt sent to customer@example.com")
+            val parentToChildrenEventFlow = MutableStateFlow<ParentToChildrenEvent>(
+                ParentToChildrenEvent.CheckoutClicked(
+                    listOf(
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 2L),
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 3L),
+                    )
+                )
+            )
+
+            val viewModel = createViewModelAndSetupForSuccessfulOrderCreation(
+                parentToChildrenEventFlow = parentToChildrenEventFlow,
+                billingEmail = billingEmail,
+            )
+            parentToChildrenEventFlow.value = ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.CARD)
+
+            // THEN
+            assertThat(viewModel.state.value).isInstanceOf(WooPosTotalsViewState.PaymentSuccess::class.java)
+            val successState = viewModel.state.value as WooPosTotalsViewState.PaymentSuccess
+            assertThat(successState.receiptSentMessage).isEqualTo("Receipt sent to customer@example.com")
+        }
+
+    @Test
+    fun `given order has no billing email, when payment succeeds, then receiptSentMessage is null`() =
+        runTest {
+            // GIVEN
+            whenever(resourceProvider.getString(R.string.woopos_totals_success_payment_card, "5.00$"))
+                .thenReturn("Paid 5.00$ in Card")
+            val parentToChildrenEventFlow = MutableStateFlow<ParentToChildrenEvent>(
+                ParentToChildrenEvent.CheckoutClicked(
+                    listOf(
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 2L),
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 3L),
+                    )
+                )
+            )
+
+            val viewModel = createViewModelAndSetupForSuccessfulOrderCreation(
+                parentToChildrenEventFlow = parentToChildrenEventFlow,
+            )
+            parentToChildrenEventFlow.value = ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.CARD)
+
+            // THEN
+            assertThat(viewModel.state.value).isInstanceOf(WooPosTotalsViewState.PaymentSuccess::class.java)
+            val successState = viewModel.state.value as WooPosTotalsViewState.PaymentSuccess
+            assertThat(successState.receiptSentMessage).isNull()
+        }
+
+    @Test
     fun `given checkout started and order contains only free products, when vm created, then totals state correctly calculated`() =
         runTest {
             // GIVEN
@@ -1997,6 +2056,7 @@ class WooPosTotalsViewModelTest {
             MutableStateFlow(ParentToChildrenEvent.CheckoutClicked(itemClickedData)),
         discountTotal: BigDecimal = BigDecimal.ZERO,
         couponLines: List<CouponLine> = emptyList(),
+        billingEmail: String = "",
     ): WooPosTotalsViewModel {
         whenever(resourceProvider.getString(R.string.woopos_success_totals_error_reader_not_connected_title))
             .thenReturn("Reader not connected")
@@ -2023,6 +2083,14 @@ class WooPosTotalsViewModelTest {
         whenever(uiStringParser.asString(any())).thenReturn("Unfortunately, this payment has been declined.")
 
         val orderId = 23L
+        val customer = if (billingEmail.isNotEmpty()) {
+            Order.Customer(
+                billingAddress = Address.EMPTY.copy(email = billingEmail),
+                shippingAddress = Address.EMPTY,
+            )
+        } else {
+            null
+        }
         val order = Order.getEmptyOrder(
             dateCreated = Date(),
             dateModified = Date()
@@ -2047,6 +2115,7 @@ class WooPosTotalsViewModelTest {
             discountTotal = discountTotal,
             total = BigDecimal("5.00"),
             couponLines = couponLines,
+            customer = customer,
         )
         val totalsRepository: WooPosTotalsRepository = mock {
             onBlocking {


### PR DESCRIPTION
WOOMOB-2161

### Description

Two improvements to the POS email receipt flow:

**1. Automatic receipt confirmation message**
When the server automatically sends a receipt email on order completion (for orders with a billing email), the payment success screen now displays "A receipt has been sent to {email}." to inform the merchant.

**Changes:**
- Added `receiptSentMessage` field to `PaymentSuccess` view state (nullable, only set when billing email exists)
- Added `buildReceiptSentMessage()` to `WooPosTotalsViewModel` to fetch billing email from the order and build the confirmation text
- Updated `WooPosTotalsPaymentSuccessScreen` to display the confirmation message between the payment total and the "New order" button
- Uses `WooPosTypography.BodyLarge` with `MaterialTheme.colorScheme.onSurface` color, matching the payment message styling
- Added string resource `woopos_receipt_sent_message` ("A receipt has been sent to %1$s.")
- Added unit tests for both billing email present and absent scenarios

**2. Email receipt prefill (previous commit)**
When a merchant taps "Email receipt" on the POS after-payment screen, the email field is pre-populated with the customer's billing email from the order (if one exists).

**Changes:**
- Added `getOrderBillingEmail()` to `WooPosEmailReceiptRepository` to fetch the billing email from the local order database
- Added `prefillBillingEmail()` to `WooPosEmailReceiptViewModel` that runs on init to load and set the billing email
- The send button is automatically enabled if the prefilled email is valid
- Added unit tests for all new behavior

### Test Steps

1. Open POS and create an order for a customer that has a billing email set
2. Complete payment (card or cash)
3. On the payment success screen, verify "A receipt has been sent to {email}." message appears below the payment total
4. Tap "Email receipt" and verify the email field is pre-populated with the customer's billing email
5. Verify the "Send" button is enabled
6. Repeat with an order that has no customer/billing email:
   - Verify no "A receipt has been sent to..." message appears on the success screen
   - Verify the email receipt field remains empty with the button disabled

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.