### PR TITLE
[Push Notification] Navigate to connection steps after WordPress.com login

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAFragment.kt
@@ -11,6 +11,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
 import com.woocommerce.android.NavGraphJetpackActivationDirections
 import com.woocommerce.android.NavGraphJetpackInstallDirections
+import com.woocommerce.android.NavGraphPushNotificationsDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
@@ -18,6 +19,7 @@ import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackCPInstallationScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowPushNotificationsConnectionSteps
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -55,10 +57,17 @@ class WPComLogin2FAFragment : BaseFragment() {
             when (event) {
                 is ShowJetpackActivationScreen -> navigateToJetpackActivationScreen(event)
                 is ShowJetpackCPInstallationScreen -> navigateToJetpackCPInstallationScreen()
+                is ShowPushNotificationsConnectionSteps -> navigateToPushNotificationsConnectionSteps()
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is Exit -> findNavController().navigateUp()
             }
         }
+    }
+
+    private fun navigateToPushNotificationsConnectionSteps() {
+        findNavController().navigateSafely(
+            NavGraphPushNotificationsDirections.actionGlobalToWooPushNotificationsConnectionStepsFragment()
+        )
     }
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerFragment.kt
@@ -12,6 +12,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
 import com.woocommerce.android.NavGraphJetpackActivationDirections
 import com.woocommerce.android.NavGraphJetpackInstallDirections
+import com.woocommerce.android.NavGraphPushNotificationsDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
@@ -20,6 +21,7 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.login.jetpack.GoToStore
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackCPInstallationScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowPushNotificationsConnectionSteps
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -55,10 +57,17 @@ class WPComLoginMagicLinkHandlerFragment : BaseFragment() {
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
                 is ShowJetpackActivationScreen -> navigateToJetpackActivationScreen(event)
                 is ShowJetpackCPInstallationScreen -> navigateToJetpackCPInstallationScreen()
+                is ShowPushNotificationsConnectionSteps -> navigateToPushNotificationsConnectionSteps()
                 is GoToStore -> goToStore()
                 is Exit -> findNavController().popBackStack(R.id.jetpackActivationDispatcherFragment, true)
             }
         }
+    }
+
+    private fun navigateToPushNotificationsConnectionSteps() {
+        findNavController().navigateSafely(
+            NavGraphPushNotificationsDirections.actionGlobalToWooPushNotificationsConnectionStepsFragment()
+        )
     }
 
     private fun navigateToJetpackActivationScreen(event: ShowJetpackActivationScreen) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
@@ -12,6 +12,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
 import com.woocommerce.android.NavGraphJetpackActivationDirections
 import com.woocommerce.android.NavGraphJetpackInstallDirections
+import com.woocommerce.android.NavGraphPushNotificationsDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
@@ -22,6 +23,7 @@ import com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordViewModel.Show2F
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordViewModel.ShowMagicLinkScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
 import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackCPInstallationScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowPushNotificationsConnectionSteps
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.ChromeCustomTabUtils
@@ -65,6 +67,7 @@ class WPComLoginPasswordFragment : BaseFragment() {
                 is ShowMagicLinkScreen -> navigateToMagicLinkScreen(event)
                 is ShowJetpackActivationScreen -> navigateToJetpackActivationScreen(event)
                 is ShowJetpackCPInstallationScreen -> navigateToJetpackCPInstallationScreen()
+                is ShowPushNotificationsConnectionSteps -> navigateToPushNotificationsConnectionSteps()
                 is GoToStore -> goToStore()
                 is LaunchUrlInChromeTab -> ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
@@ -103,6 +106,12 @@ class WPComLoginPasswordFragment : BaseFragment() {
                     requestAtStart = true,
                     isNewWpComAccount = false
                 )
+        )
+    }
+
+    private fun navigateToPushNotificationsConnectionSteps() {
+        findNavController().navigateSafely(
+            NavGraphPushNotificationsDirections.actionGlobalToWooPushNotificationsConnectionStepsFragment()
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModel.kt
@@ -35,6 +35,7 @@ open class WPComLoginPostLoginViewModel(
 
         val siteUrl = selectedSite.get().url
         if (jetpackStatus.isCurrentUserConnected) {
+            // Attempt returning the site from the DB if it exists, otherwise fetch it from API
             val jetpackSite = jetpackActivationRepository.getJetpackSiteByUrl(siteUrl)
                 .takeIf { it?.hasWooCommerce == true }
                 ?: jetpackActivationRepository.fetchJetpackSite(siteUrl)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.wpcom
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_LOGIN_COMPLETED
@@ -18,10 +19,14 @@ open class WPComLoginPostLoginViewModel(
     private val jetpackActivationRepository: JetpackActivationRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
-    protected suspend fun onLoginSuccess(wpComLoginMode: WPComLoginMode): Result<Unit> {
+    @VisibleForTesting
+    internal suspend fun onLoginSuccess(wpComLoginMode: WPComLoginMode): Result<Unit> {
         return when (wpComLoginMode) {
             is WPComLoginMode.JetpackSetup -> handleJetpackSetupPostLogin(wpComLoginMode.jetpackStatus)
-            WPComLoginMode.PushNotificationsSetup -> TODO()
+            WPComLoginMode.PushNotificationsSetup -> {
+                triggerEvent(ShowPushNotificationsConnectionSteps)
+                Result.success(Unit)
+            }
         }
     }
 
@@ -30,7 +35,6 @@ open class WPComLoginPostLoginViewModel(
 
         val siteUrl = selectedSite.get().url
         if (jetpackStatus.isCurrentUserConnected) {
-            // Attempt returning the site from the DB if it exists, otherwise fetch it from API
             val jetpackSite = jetpackActivationRepository.getJetpackSiteByUrl(siteUrl)
                 .takeIf { it?.hasWooCommerce == true }
                 ?: jetpackActivationRepository.fetchJetpackSite(siteUrl)
@@ -63,4 +67,6 @@ open class WPComLoginPostLoginViewModel(
     ) : MultiLiveEvent.Event()
 
     object ShowJetpackCPInstallationScreen : MultiLiveEvent.Event()
+
+    object ShowPushNotificationsConnectionSteps : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_push_notifications.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_push_notifications.xml
@@ -8,7 +8,9 @@
 
     <action
         android:id="@+id/action_global_to_wooPushNotificationsConnectionStepsFragment"
-        app:destination="@id/wooPushNotificationsConnectionStepsFragment" />
+        app:destination="@id/wooPushNotificationsConnectionStepsFragment"
+        app:popUpTo="@id/nav_graph_wpcom_login"
+        app:popUpToInclusive="true" />
 
     <dialog
         android:id="@+id/wooPushNotificationsIntroductionDialog"

--- a/WooCommerce/src/main/res/navigation/nav_graph_push_notifications.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_push_notifications.xml
@@ -6,6 +6,10 @@
 
     <include app:graph="@navigation/nav_graph_wpcom_login" />
 
+    <action
+        android:id="@+id/action_global_to_wooPushNotificationsConnectionStepsFragment"
+        app:destination="@id/wooPushNotificationsConnectionStepsFragment" />
+
     <dialog
         android:id="@+id/wooPushNotificationsIntroductionDialog"
         android:name="com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionDialog"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModelTest.kt
@@ -1,0 +1,114 @@
+package com.woocommerce.android.ui.login.wpcom
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.JetpackConnectionStatus
+import com.woocommerce.android.model.JetpackSiteRegistrationStatus
+import com.woocommerce.android.model.JetpackStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.jetpack.GoToStore
+import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackActivationScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowJetpackCPInstallationScreen
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPostLoginViewModel.ShowPushNotificationsConnectionSteps
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WPComLoginPostLoginViewModelTest : BaseUnitTest() {
+    companion object {
+        private const val SITE_URL = "https://example.com"
+    }
+
+    private val site = SiteModel().apply { url = SITE_URL }
+    private val selectedSite: SelectedSite = mock {
+        on { get() } doReturn site
+    }
+    private val jetpackActivationRepository: JetpackActivationRepository = mock()
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+
+    private fun createViewModel() = WPComLoginPostLoginViewModel(
+        savedStateHandle = SavedStateHandle(),
+        selectedSite = selectedSite,
+        jetpackActivationRepository = jetpackActivationRepository,
+        analyticsTrackerWrapper = analyticsTrackerWrapper
+    )
+
+    @Test
+    fun `given push notifications setup, when login succeeds, then navigate to connection steps`() = testBlocking {
+        val viewModel = createViewModel()
+        val events = viewModel.event.captureValues()
+
+        val result = viewModel.onLoginSuccess(WPComLoginMode.PushNotificationsSetup)
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(events.last()).isEqualTo(ShowPushNotificationsConnectionSteps)
+    }
+
+    @Test
+    fun `given jetpack setup with user not connected, when login succeeds, then show activation screen`() =
+        testBlocking {
+            val jetpackStatus = JetpackStatus(
+                isJetpackInstalled = true,
+                jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                    siteRegistrationStatus = JetpackSiteRegistrationStatus.REGISTERED,
+                    blogId = 1
+                )
+            )
+            val viewModel = createViewModel()
+            val events = viewModel.event.captureValues()
+
+            val result = viewModel.onLoginSuccess(WPComLoginMode.JetpackSetup(jetpackStatus))
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(events.last()).isEqualTo(
+                ShowJetpackActivationScreen(
+                    jetpackStatus = jetpackStatus,
+                    siteUrl = SITE_URL
+                )
+            )
+        }
+
+    @Test
+    fun `given jetpack setup with user connected and jetpack installed, when login succeeds, then go to store`() =
+        testBlocking {
+            val jetpackStatus = JetpackStatus(
+                isJetpackInstalled = true,
+                jetpackConnectionStatus = JetpackConnectionStatus.AccountConnected(wpComEmail = "test@example.com")
+            )
+            whenever(jetpackActivationRepository.getJetpackSiteByUrl(SITE_URL))
+                .thenReturn(SiteModel().apply { hasWooCommerce = true })
+            val viewModel = createViewModel()
+            val events = viewModel.event.captureValues()
+
+            val result = viewModel.onLoginSuccess(WPComLoginMode.JetpackSetup(jetpackStatus))
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(events.last()).isEqualTo(GoToStore)
+        }
+
+    @Test
+    fun `given jetpack setup with user connected and jetpack not installed, when login succeeds, then show CP install`() =
+        testBlocking {
+            val jetpackStatus = JetpackStatus(
+                isJetpackInstalled = false,
+                jetpackConnectionStatus = JetpackConnectionStatus.AccountConnected(wpComEmail = "test@example.com")
+            )
+            whenever(jetpackActivationRepository.getJetpackSiteByUrl(SITE_URL))
+                .thenReturn(SiteModel().apply { hasWooCommerce = true })
+            val viewModel = createViewModel()
+            val events = viewModel.event.captureValues()
+
+            val result = viewModel.onLoginSuccess(WPComLoginMode.JetpackSetup(jetpackStatus))
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(events.last()).isEqualTo(ShowJetpackCPInstallationScreen)
+        }
+}


### PR DESCRIPTION
Part of WOOMOB-1925.
Depends on #15355.

### Description
- Implement post-login navigation for PushNotificationsSetup mode, the logic follows the same approach we use for Jetpack Setup: WPComLoginPostLoginViewModel#onLoginSuccess is invoked when login is successful, and this triggers the navigation.
- After successful WPCom login, navigate to `WooPushNotificationsConnectionStepsFragment` using a global action in `nav_graph_push_notifications`
- Add unit tests for `WPComLoginPostLoginViewModel#onLoginSuccess` covering both PushNotificationsSetup and JetpackSetup scenarios

> [!NOTE]
> Magic Link support is handled in a separate PR https://github.com/woocommerce/woocommerce-android/pull/15361 

### Test Steps
1. Enable the Push Notifications M2 feature flag.
2. Start Push Notifications setup from the dashboard or settings.
3. Sign in to your WordPress.com account. (Test regular login, Magic login is not supported yet)
4. Confirm the Push Notification steps screen is shown.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->