### PR TITLE
Update media picker library to fix crash derived from dagger update

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,7 +106,7 @@ wiremock = '2.26.3'
 wordpress-aztec = 'v2.1.6'
 wordpress-libaddressinput = '0.0.2'
 wordpress-lint = "2.2.0"
-wordpress-mediapicker = '0.3.4'
+wordpress-mediapicker = '89-d325065f0102e02c21c2a51cd427c8105d3f149a'
 wordpress-utils = '3.15.0'
 zendesk = '5.5.2'
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,7 +106,7 @@ wiremock = '2.26.3'
 wordpress-aztec = 'v2.1.6'
 wordpress-libaddressinput = '0.0.2'
 wordpress-lint = "2.2.0"
-wordpress-mediapicker = '89-d325065f0102e02c21c2a51cd427c8105d3f149a'
+wordpress-mediapicker = '0.3.5'
 wordpress-utils = '3.15.0'
 zendesk = '5.5.2'
 


### PR DESCRIPTION
Fixes: WOOMOB-2219

⚠️ Do not merge until I replace the commit hash dependency with a proper release version of media picker lib. This PR needs to be merged first: https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/pull/89

### Description

Fixes a `NoSuchMethodError` crash affecting 20 users with 1124 crashes since `24.1-rc-2`. The crash occurs when launching `MediaPickerActivity`:

```
java.lang.NoSuchMethodError: No virtual method getSavedStateHandleHolder()
  in class Ldagger/hilt/android/internal/managers/ActivityComponentManager;
  at org.wordpress.android.mediapicker.ui.Hilt_MediaPickerActivity.initSavedStateHandleHolder
```

#### Root cause

In version 24.1, Dagger was upgraded from 2.57.2 to 2.58 to support Kotlin 2.3.  Dagger 2.58 introduced a breaking internal API change: `ActivityComponentManager.getSavedStateHandleHolder()` was **removed** and replaced with `initSavedStateHandleHolders()` / `clearSavedStateHandleHolders()`.

The MediaPicker library (v0.3.4) is a pre-compiled AAR that was built with Dagger 2.55. Its Hilt-generated `Hilt_MediaPickerActivity` code still calls the removed `getSavedStateHandleHolder()` method. At runtime, the app loads Dagger 2.58's `ActivityComponentManager` which no longer has that method, causing the `NoSuchMethodError`.

#### Reproduce the crash

1. Run the app from `release/.24.1` branch. 
2. Open product details
3. Go to add image
4. Select WP media library source
5. See the crash happen: 
```
NoSuchMethodError: No virtual method getSavedStateHandleHolder()Ldagger/hilt/android/internal/managers
```

https://github.com/user-attachments/assets/b5f96fb3-9b47-4da2-8ccb-ce9be2f0527a

#### Fix

This PR updates the MediaPicker library dependency to a version compiled against Dagger 2.58, so the Hilt-generated code calls the correct runtime API. The companion PR in the MediaPicker repo upgrades Dagger 2.55 → 2.58, Kotlin 1.9.24 → 2.1.20, and AGP 8.1.0 → 8.4.0 (minimum versions required by Dagger 2.58):

👉 https://github.com/wordpress-mobile/WordPress-MediaPicker-Android/pull/89

### Test Steps
1. Open a product for editing
2. Tap on a product image to open the media picker
3. Add a few images from different sources (device, camera, WP media lib)