### PR TITLE
[CIAB: POS] Update POS booking details card title and information section

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
@@ -42,6 +42,7 @@ class WooPosBookingViewStateMapper @Inject constructor(
 
     suspend fun mapToDetailsViewState(
         booking: BookingEntity,
+        resourceName: String?,
     ): WooPosBookingsState.BookingDetailsViewState {
         val detailsDateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
             .withZone(ZoneOffset.UTC)
@@ -84,7 +85,7 @@ class WooPosBookingViewStateMapper @Inject constructor(
             duration = Duration.between(booking.start, booking.end)
                 .normalizeDuration()
                 .toHumanReadableFormat(resourceProvider),
-            teamMember = null,
+            teamMember = resourceName,
             location = null,
             customerSection = buildCustomerSection(customerInfo, customerName, booking.customerNote),
             attendanceSection = buildAttendanceSection(booking),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
@@ -48,7 +48,7 @@ class WooPosBookingViewStateMapper @Inject constructor(
             .withZone(ZoneOffset.UTC)
 
         val bookingName = booking.order.productInfo?.name ?: "#${booking.id.value}"
-        val appointmentTime = "${dateFormatter.formatTime(booking.start)} - ${dateFormatter.formatTime(booking.end)}"
+        val appointmentTime = formatTimeRange(booking)
 
         val customerInfo = booking.order.customerInfo
         val customerName = buildCustomerName(customerInfo)
@@ -184,6 +184,19 @@ class WooPosBookingViewStateMapper @Inject constructor(
             BookingEntity.AttendanceStatus.Attended -> WooPosBookingsState.AttendanceState.ATTENDED
             BookingEntity.AttendanceStatus.Unattended -> WooPosBookingsState.AttendanceState.UNATTENDED
             else -> null
+        }
+    }
+
+    private fun formatTimeRange(booking: BookingEntity): String {
+        val startTime = dateFormatter.formatTime(booking.start)
+        val endTime = dateFormatter.formatTime(booking.end)
+        val amPmPattern = Regex("\\s*([AaPp][Mm])$")
+        val startSuffix = amPmPattern.find(startTime)?.groupValues?.get(1)
+        val endSuffix = amPmPattern.find(endTime)?.groupValues?.get(1)
+        return if (startSuffix != null && startSuffix.equals(endSuffix, ignoreCase = true)) {
+            "${startTime.replace(amPmPattern, "")}-$endTime"
+        } else {
+            "$startTime-$endTime"
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import javax.inject.Inject
@@ -29,9 +30,9 @@ import javax.inject.Inject
 @HiltViewModel
 class WooPosBookingsViewModel @Inject constructor(
     private val bookingListHandler: BookingListHandler,
+    private val bookingsRepository: BookingsRepository,
     private val dateTimeProvider: DateTimeProvider,
     private val mapper: WooPosBookingViewStateMapper,
-    private val bookingsRepository: BookingsRepository,
     private val resourceProvider: ResourceProvider,
 ) : ViewModel() {
 
@@ -55,6 +56,7 @@ class WooPosBookingsViewModel @Inject constructor(
     init {
         observeBookings()
         fetchBookings()
+        fetchResources()
     }
 
     private fun fetchBookings() {
@@ -78,9 +80,20 @@ class WooPosBookingsViewModel @Inject constructor(
         }
     }
 
+    private fun fetchResources() {
+        viewModelScope.launch {
+            bookingsRepository.fetchResources()
+        }
+    }
+
     private fun observeBookings() {
         viewModelScope.launch {
-            bookingListHandler.bookingsFlow.collectLatest { bookings ->
+            combine(
+                bookingListHandler.bookingsFlow,
+                bookingsRepository.observeResources()
+            ) { bookings, resources ->
+                bookings to resources.associateBy { it.id.value }
+            }.collectLatest { (bookings, resourcesMap) ->
                 if (bookings.isEmpty() && _state.value is WooPosBookingsState.Loading) {
                     return@collectLatest
                 }
@@ -95,8 +108,9 @@ class WooPosBookingsViewModel @Inject constructor(
                 }
 
                 val items = bookings.associate { booking ->
+                    val resourceName = resourcesMap[booking.resourceId]?.name
                     mapper.mapToItemViewState(booking, selectedBookingId) to
-                        mapper.mapToDetailsViewState(booking)
+                        mapper.mapToDetailsViewState(booking, resourceName)
                 }
 
                 val selectedDetails = selectedBookingId?.let { id ->
@@ -142,6 +156,7 @@ class WooPosBookingsViewModel @Inject constructor(
 
         fetchJob?.cancel()
         loadMoreJob?.cancel()
+        fetchResources()
         fetchJob = viewModelScope.launch {
             bookingListHandler.loadBookings(
                 sortBy = BookingListSortOption.NewestToOldest

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -132,7 +132,7 @@ private fun BookingHeader(
     WooPosText(
         text = details.headerSubtitle,
         style = WooPosTypography.BodyMedium,
-        color = WooPosTheme.colors.onSurfaceVariantHighest
+        color = WooPosTheme.colors.onSurfaceVariantLowest
     )
 
     Spacer(Modifier.height(WooPosSpacing.Small.value))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -178,48 +178,27 @@ private fun BookingDetailsCard(
         Column(Modifier.padding(WooPosSpacing.Medium.value)) {
             WooPosText(
                 text = stringResource(R.string.woopos_bookings_details_title, details.number.removePrefix("#")),
-                style = WooPosTypography.BodyLarge,
+                style = WooPosTypography.BodyXLarge,
                 fontWeight = FontWeight.Bold,
             )
 
             Spacer(Modifier.height(WooPosSpacing.Medium.value))
 
-            DetailRowLine(
-                label = stringResource(R.string.woopos_bookings_details_service_name_label),
-                value = details.bookingName,
-            )
-
-            Spacer(Modifier.height(WooPosSpacing.Medium.value))
-
-            DetailRowLine(
-                label = stringResource(R.string.woopos_bookings_details_date_label),
-                value = details.appointmentDate,
-            )
-
-            Spacer(Modifier.height(WooPosSpacing.Medium.value))
-
-            DetailRowLine(
-                label = stringResource(R.string.woopos_bookings_details_time_label),
-                value = details.appointmentTime,
-            )
-
             details.teamMember?.let {
-                Spacer(Modifier.height(WooPosSpacing.Medium.value))
                 DetailRowLine(
                     label = stringResource(R.string.woopos_bookings_details_team_member_label),
                     value = it,
                 )
+                DividerWithSpacing()
             }
 
             details.location?.let {
-                Spacer(Modifier.height(WooPosSpacing.Medium.value))
                 DetailRowLine(
                     label = stringResource(R.string.woopos_bookings_details_location_label),
                     value = it,
                 )
+                DividerWithSpacing()
             }
-
-            Spacer(Modifier.height(WooPosSpacing.Medium.value))
 
             DetailRowLine(
                 label = stringResource(R.string.woopos_bookings_details_duration_label),

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3904,7 +3904,7 @@
     <string name="woopos_bookings_empty_action_label">Refresh</string>
     <string name="woopos_bookings_details_attendance_attended">Attended</string>
     <string name="woopos_bookings_details_attendance_unattended">Unattended</string>
-    <string name="woopos_bookings_details_title">Booking #%s details</string>
+    <string name="woopos_bookings_details_title">Booking #%s</string>
     <string name="woopos_bookings_details_service_name_label">Service name</string>
     <string name="woopos_bookings_details_date_label">Date</string>
     <string name="woopos_bookings_details_time_label">Time</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
@@ -94,13 +94,13 @@ class WooPosBookingViewStateMapperTest {
         val end = start.plus(Duration.ofMinutes(90))
         val booking = sampleBooking(start = start, end = end)
 
-        val result = mapper.mapToDetailsViewState(booking)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
         val expectedDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
             .withZone(ZoneOffset.UTC)
             .format(start)
         assertThat(result.appointmentDate).isEqualTo(expectedDate)
-        assertThat(result.appointmentTime).isEqualTo("$FORMATTED_TIME - $FORMATTED_TIME")
+        assertThat(result.appointmentTime).isEqualTo("11:00-11:00 AM")
         assertThat(result.duration).isEqualTo("1 hour 30 minutes")
     }
 
@@ -108,7 +108,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given booking with null paymentInfo, when mapped to details, then payment section shows dashes`() = runTest {
         val booking = sampleBooking(paymentInfo = null)
 
-        val result = mapper.mapToDetailsViewState(booking)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
         assertThat(result.paymentSection.serviceAmount).isEqualTo("-")
         assertThat(result.paymentSection.taxAmount).isEqualTo("-")
@@ -128,7 +128,7 @@ class WooPosBookingViewStateMapperTest {
         )
         val booking = sampleBooking(paymentInfo = paymentInfo)
 
-        val result = mapper.mapToDetailsViewState(booking)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
         assertThat(result.paymentSection.discountAmount).isEqualTo("-$10")
         assertThat(result.paymentSection.totalAmount).isEqualTo("$99")
@@ -141,7 +141,7 @@ class WooPosBookingViewStateMapperTest {
             attendanceStatus = BookingEntity.AttendanceStatus.Attended,
         )
 
-        val result = mapper.mapToDetailsViewState(booking)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
         assertThat(result.attendanceSection).isNotNull
         assertThat(result.attendanceSection?.selection).isEqualTo(WooPosBookingsState.AttendanceState.ATTENDED)
@@ -154,7 +154,7 @@ class WooPosBookingViewStateMapperTest {
             attendanceStatus = BookingEntity.AttendanceStatus.Unattended,
         )
 
-        val result = mapper.mapToDetailsViewState(booking)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
         assertThat(result.attendanceSection).isNull()
     }
@@ -163,7 +163,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given booking with null customerInfo, when mapped, then customer section is null`() = runTest {
         val booking = sampleBooking(customerInfo = null, customerNote = null)
 
-        val result = mapper.mapToDetailsViewState(booking)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
         assertThat(result.customerSection).isNull()
     }
@@ -178,7 +178,7 @@ class WooPosBookingViewStateMapperTest {
         )
         val booking = sampleBooking(customerInfo = customerInfo, customerNote = "")
 
-        val result = mapper.mapToDetailsViewState(booking)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
         assertThat(result.customerSection).isNull()
     }
@@ -189,7 +189,7 @@ class WooPosBookingViewStateMapperTest {
         val booking = sampleBooking(status = BookingEntity.Status.Unpaid)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions
@@ -202,7 +202,7 @@ class WooPosBookingViewStateMapperTest {
         val booking = sampleBooking(status = BookingEntity.Status.Cancelled)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions
@@ -213,7 +213,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given cancelled booking, when mapped to details, then collectPaymentLabel is null`() = runTest {
         val booking = sampleBooking(status = BookingEntity.Status.Cancelled)
 
-        val result = mapper.mapToDetailsViewState(booking)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
         assertThat(result.paymentSection.collectPaymentLabel).isNull()
     }
@@ -224,7 +224,7 @@ class WooPosBookingViewStateMapperTest {
         val booking = sampleBooking(status = BookingEntity.Status.Complete)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -50,6 +50,10 @@ class WooPosBookingsViewModelTest {
     val coroutineTestRule = WooPosCoroutineTestRule(StandardTestDispatcher())
 
     private val bookingListHandler: BookingListHandler = mock()
+    private val bookingsRepository: BookingsRepository = mock {
+        on { observeResources() } doAnswer { flowOf(emptyList()) }
+        onBlocking { fetchResources() } doAnswer { Result.success(Unit) }
+    }
     private val dateTimeProvider: DateTimeProvider = mock()
     private val dateFormatter: DateFormatter = mock()
     private val formatPrice: WooPosFormatPrice = mock {
@@ -85,7 +89,6 @@ class WooPosBookingsViewModelTest {
             "Cancel dialog message"
         }
     }
-    private val bookingsRepository: BookingsRepository = mock()
     private lateinit var viewModel: WooPosBookingsViewModel
 
     private fun booking(id: Long = 1L) = BookingEntity(
@@ -119,9 +122,9 @@ class WooPosBookingsViewModelTest {
     private fun createViewModel(): WooPosBookingsViewModel {
         return WooPosBookingsViewModel(
             bookingListHandler = bookingListHandler,
+            bookingsRepository = bookingsRepository,
             dateTimeProvider = dateTimeProvider,
             mapper = WooPosBookingViewStateMapper(dateFormatter, resourceProvider, formatPrice),
-            bookingsRepository = bookingsRepository,
             resourceProvider = resourceProvider,
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
@@ -56,7 +56,7 @@ class WooPosBookingNoteViewModelTest {
         parentId = 0L,
         personCounts = listOf(1L),
         localTimezone = "",
-        attendanceStatus = BookingEntity.AttendanceStatus.Attended,
+        attendanceStatus = BookingEntity.AttendanceStatus.Unattended,
         note = "Existing note",
         order = BookingOrderInfo(),
         customerNote = ""


### PR DESCRIPTION
WOOMOB-2146

### Description

Update the booking details card to match the Figma design:

- Redesign the booking information card: remove service name, date, and time rows (already shown in header), keep only team member, location, and duration with dividers between rows
- Update card title from "Booking #X details" to "Booking #X" with larger font
- Update header subtitle color

**Note:** Team member and location fields may appear empty because:
- **Team member (WOOMOB-2222):** The app uses the v2 team-members endpoint, which returns empty on sites with old-style bookable resources. Needs backend clarification.
- **Location (WOOMOB-2221):** Location is a product-level field (`booking_location`), not included in the booking response. Needs a separate product fetch.

### Test Steps

1. Open POS bookings
2. Select a booking
3. Verify the details card shows "Booking #X" as title (larger font, no "details" suffix)
4. Verify only team member, location, and duration rows are shown (with dividers between them) (Try previews for that)
5. Verify service name, date, and time rows are removed from the card
6. Verify the header subtitle color is lighter


<img width="561" height="352" alt="image" src="https://github.com/user-attachments/assets/0911cbd8-f41a-4f19-9bf6-8a873b7938e1" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.