### PR TITLE
[Push Notification] Support magic link flow for push notifications setup

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkFlow.kt
@@ -3,7 +3,8 @@ package com.woocommerce.android.ui.login
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailFlow
 
 enum class MagicLinkFlow(private val value: String) : AuthEmailFlow {
-    JetpackConnection("jetpack-connection");
+    JetpackConnection("jetpack-connection"),
+    PushNotificationsSetup("push-notifications-setup");
 
     override fun getName(): String = value
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkFlow.kt
@@ -10,7 +10,7 @@ enum class MagicLinkFlow(private val value: String) : AuthEmailFlow {
 
     companion object {
         fun fromString(value: String): MagicLinkFlow? {
-            return MagicLinkFlow.values().firstOrNull { it.value == value }
+            return entries.firstOrNull { it.value == value }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptActivity.kt
@@ -23,6 +23,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.doOnApplyWindowInsets
 import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.CancelJetpackActivation
 import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.ContinueJetpackActivation
+import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.ContinuePushNotificationsSetup
 import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.OpenLogin
 import com.woocommerce.android.ui.login.MagicLinkInterceptViewModel.OpenSitePicker
 import com.woocommerce.android.ui.login.jetpack.dispatcher.JetpackActivationDispatcherFragmentArgs
@@ -105,6 +106,7 @@ class MagicLinkInterceptActivity : AppCompatActivity() {
                 OpenSitePicker, CancelJetpackActivation -> openMainActivity()
                 OpenLogin -> showLoginScreen()
                 is ContinueJetpackActivation -> continueJetpackActivation(event)
+                is ContinuePushNotificationsSetup -> continuePushNotificationsSetup()
                 is ShowSnackbar -> showSnackBar(event.message)
             }
         }
@@ -179,6 +181,24 @@ class MagicLinkInterceptActivity : AppCompatActivity() {
                 R.id.wPComLoginMagicLinkHandlerFragment,
                 WPComLoginMagicLinkHandlerFragmentArgs(
                     wpComLoginMode = WPComLoginMode.JetpackSetup(event.jetpackStatus)
+                ).toBundle()
+            )
+            .createPendingIntent()
+            .send()
+
+        finish()
+    }
+
+    private fun continuePushNotificationsSetup() {
+        NavDeepLinkBuilder(this)
+            .setComponentName(MainActivity::class.java)
+            .setGraph(R.navigation.nav_graph_main)
+            .addDestination(R.id.dashboard)
+            .addDestination(R.id.wooPushNotificationsIntroductionDialog)
+            .addDestination(
+                R.id.wPComLoginMagicLinkHandlerFragment,
+                WPComLoginMagicLinkHandlerFragmentArgs(
+                    wpComLoginMode = WPComLoginMode.PushNotificationsSetup
                 ).toBundle()
             )
             .createPendingIntent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptViewModel.kt
@@ -56,12 +56,17 @@ class MagicLinkInterceptViewModel @Inject constructor(
         _isLoading.value = false
         when (requestResult) {
             RequestResult.SUCCESS -> {
-                if (flow == MagicLinkFlow.JetpackConnection &&
-                    selectedSite.connectionType == SiteConnectionType.ApplicationPasswords
-                ) {
-                    handleJetpackConnectionFlow()
-                } else {
-                    triggerEvent(OpenSitePicker)
+                when {
+                    flow == MagicLinkFlow.JetpackConnection &&
+                        selectedSite.connectionType == SiteConnectionType.ApplicationPasswords -> {
+                        handleJetpackConnectionFlow()
+                    }
+                    flow == MagicLinkFlow.PushNotificationsSetup -> {
+                        triggerEvent(ContinuePushNotificationsSetup)
+                    }
+                    else -> {
+                        triggerEvent(OpenSitePicker)
+                    }
                 }
             }
 
@@ -130,4 +135,5 @@ class MagicLinkInterceptViewModel @Inject constructor(
         val siteUrl: String
     ) : MultiLiveEvent.Event()
     data object CancelJetpackActivation : MultiLiveEvent.Event()
+    data object ContinuePushNotificationsSetup : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModel.kt
@@ -109,7 +109,7 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
         )
         wpComLoginRepository.requestMagicLink(
             emailOrUsername = navArgs.emailOrUsername,
-            flow = MagicLinkFlow.JetpackConnection,
+            flow = navArgs.wpComLoginMode.toMagicLinkFlow(),
             isSignup = navArgs.isNewWpComAccount
         ).fold(
             onSuccess = {
@@ -147,6 +147,11 @@ class WPComLoginMagicLinkRequestViewModel @Inject constructor(
     }
 
     private fun String.isAnEmail() = PatternsCompat.EMAIL_ADDRESS.matcher(this).matches()
+
+    private fun WPComLoginMode.toMagicLinkFlow(): MagicLinkFlow = when (this) {
+        is WPComLoginMode.JetpackSetup -> MagicLinkFlow.JetpackConnection
+        WPComLoginMode.PushNotificationsSetup -> MagicLinkFlow.PushNotificationsSetup
+    }
 
     sealed interface ViewState : Parcelable {
         val wpComLoginMode: WPComLoginMode

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/MagicLinkInterceptViewModelTest.kt
@@ -140,6 +140,20 @@ class MagicLinkInterceptViewModelTest : BaseUnitTest() {
             )
         }
 
+    @Test
+    fun `given push notifications setup flow, when auth token update succeeds, then continue push notifications setup`() =
+        testBlocking {
+            setup {
+                givenAuthTokenUpdateResult(RequestResult.SUCCESS)
+            }
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.handleMagicLink("authToken", MagicLinkFlow.PushNotificationsSetup)
+            }.last()
+
+            assertThat(event).isEqualTo(MagicLinkInterceptViewModel.ContinuePushNotificationsSetup)
+        }
+
     private suspend fun givenAuthTokenUpdateResult(result: RequestResult) {
         given(magicLinkInterceptRepository.updateMagicLinkAuthToken("authToken")).willReturn(result)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkRequestViewModelTest.kt
@@ -38,11 +38,12 @@ class WPComLoginMagicLinkRequestViewModelTest : BaseUnitTest() {
 
     fun setup(
         fallbackButton: MagicLinkFallbackButton,
-        requestEmailAtStart: Boolean = true
+        requestEmailAtStart: Boolean = true,
+        wpComLoginMode: WPComLoginMode = WPComLoginMode.JetpackSetup(JetpackStatus)
     ) {
         viewModel = WPComLoginMagicLinkRequestViewModel(
             WPComLoginMagicLinkRequestFragmentArgs(
-                wpComLoginMode = WPComLoginMode.JetpackSetup(JetpackStatus),
+                wpComLoginMode = wpComLoginMode,
                 emailOrUsername = EMAIL,
                 fallbackButton = fallbackButton,
                 requestAtStart = requestEmailAtStart,
@@ -133,4 +134,22 @@ class WPComLoginMagicLinkRequestViewModelTest : BaseUnitTest() {
             )
         )
     }
+
+    @Test
+    fun `given push notifications mode, when request magic link, then use push notifications flow`() =
+        testBlocking {
+            setup(
+                MagicLinkFallbackButton.None,
+                requestEmailAtStart = false,
+                wpComLoginMode = WPComLoginMode.PushNotificationsSetup
+            )
+
+            viewModel.onRequestMagicLinkClick()
+
+            verify(wpComLoginRepository).requestMagicLink(
+                emailOrUsername = EMAIL,
+                flow = MagicLinkFlow.PushNotificationsSetup,
+                isSignup = false
+            )
+        }
 }


### PR DESCRIPTION
Closes WOOMOB-1925.
Depends on #15358.

### Description
- Add `PushNotificationsSetup` enum value to `MagicLinkFlow` so the magic link email carries the correct flow identifier (`push-notifications-setup`)
- Resolve `MagicLinkFlow` from `WPComLoginMode` in `WPComLoginMagicLinkRequestViewModel` instead of hardcoding `JetpackConnection`
- Handle the new flow in `MagicLinkInterceptViewModel` — triggers `ContinuePushNotificationsSetup` event (no intermediate Jetpack status fetch needed)
- Handle the event in `MagicLinkInterceptActivity` — navigates via `NavDeepLinkBuilder` to the magic link handler with `WPComLoginMode.PushNotificationsSetup`
- Add unit tests for both the intercept ViewModel and magic link request ViewModel
- Replace deprecated `Enum.values()` with `entries` in `MagicLinkFlow`

### Test Steps
1. Enable the Push Notifications M2 feature flag.
2. Start Push Notifications setup from the dashboard or settings.
3. On the login email screen, proceed to the magic link request screen.
4. Request a magic link and open it from the email.
5. Confirm you are taken to the Push Notification connection steps screen (not the Jetpack activation flow).
6. Repeat steps 2–4 via the Jetpack setup flow and confirm that flow still works as before.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->