### PR TITLE
WOOMOB-2229: Send device locale and metadata on PN token registration

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -204,7 +204,14 @@ class PushNotificationRepository @Inject constructor(
 
     private fun getDeviceLocale(): String {
         val locale = localeProvider.provideLocale() ?: Locale.getDefault()
-        return "${locale.language}_${locale.country}".ifBlank { "en_US" }
+        val language = locale.language
+        val country = locale.country
+
+        return when {
+            language.isEmpty() -> "en_US"
+            country.isEmpty() -> language
+            else -> "${language}_${country}"
+        }
     }
 
     private fun buildDeviceMetadata(): Map<String, String> = mapOf(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore.SiteNotificationSetting
 import org.wordpress.android.fluxc.utils.PreferenceUtils
+import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
 
@@ -202,7 +203,7 @@ class PushNotificationRepository @Inject constructor(
     }
 
     private fun getDeviceLocale(): String {
-        val locale = localeProvider.provideLocale() ?: java.util.Locale.getDefault()
+        val locale = localeProvider.provideLocale() ?: Locale.getDefault()
         return "${locale.language}_${locale.country}".ifBlank { "en_US" }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.notifications.push
 
+import android.os.Build
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
@@ -12,6 +13,7 @@ import com.woocommerce.android.datastore.DataStoreType.WOO_CORE_PUSH_NOTIFICATIO
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.extensions.orNullIfEmpty
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.locale.LocaleProvider
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -36,7 +38,8 @@ class PushNotificationRepository @Inject constructor(
     private val prefsWrapper: PreferenceUtils.PreferenceUtilsWrapper,
     @DataStoreQualifier(WOO_CORE_PUSH_NOTIFICATIONS_TOKENS)
     private val pushNotificationsDataStore: DataStore<Preferences>,
-    private val notificationAnalyticsTracker: NotificationAnalyticsTracker
+    private val notificationAnalyticsTracker: NotificationAnalyticsTracker,
+    private val localeProvider: LocaleProvider
 ) {
 
     suspend fun registerPushTokenInWpComSystem(token: String) {
@@ -54,10 +57,14 @@ class PushNotificationRepository @Inject constructor(
         )
 
         val uuid = appPrefsWrapper.wooCorePushDeviceUUID.orNullIfEmpty() ?: generateAndStoreUUID()
+        val deviceLocale = getDeviceLocale()
+        val metadata = buildDeviceMetadata()
         val result = wooPushNotificationsStore.registerPushToken(
             site = selectedSite,
             token = token,
-            deviceUuid = uuid
+            deviceUuid = uuid,
+            deviceLocale = deviceLocale,
+            metadata = metadata
         )
         if (!result.isError) {
             result.model?.let { pushToken ->
@@ -193,6 +200,17 @@ class PushNotificationRepository @Inject constructor(
             .getString(WpComPushNotificationStore.WPCOM_PUSH_DEVICE_SERVER_ID, null)
         return wpComPushServerId.isNotNullOrEmpty()
     }
+
+    private fun getDeviceLocale(): String {
+        val locale = localeProvider.provideLocale() ?: java.util.Locale.getDefault()
+        return "${locale.language}_${locale.country}".ifBlank { "en_US" }
+    }
+
+    private fun buildDeviceMetadata(): Map<String, String> = mapOf(
+        "app_version" to BuildConfig.VERSION_NAME,
+        "device_model" to "${Build.MANUFACTURER} ${Build.MODEL}",
+        "os_version" to Build.VERSION.RELEASE
+    )
 
     companion object {
         private const val PUSH_TOKEN_KEY_PREFIX = "push_token_"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -210,7 +210,7 @@ class PushNotificationRepository @Inject constructor(
         return when {
             language.isEmpty() -> "en_US"
             country.isEmpty() -> language
-            else -> "${language}_${country}"
+            else -> "${language}_$country"
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.util.locale.LocaleProvider
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -32,6 +33,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore.SiteNotificationSetting
 import org.wordpress.android.fluxc.utils.PreferenceUtils
+import java.util.Locale
 
 @ExperimentalCoroutinesApi
 class PushNotificationRepositoryTest : BaseUnitTest() {
@@ -42,6 +44,9 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     private val prefsWrapper: PreferenceUtils.PreferenceUtilsWrapper = mock()
     private val sharedPreferences: SharedPreferences = mock()
     private val notificationAnalyticsTracker: NotificationAnalyticsTracker = mock()
+    private val localeProvider: LocaleProvider = mock {
+        on { provideLocale() } doReturn Locale.US
+    }
     private val siteModel: SiteModel = mock()
     private val preferences: Preferences = mock()
     private val pushNotificationsDataStore: DataStore<Preferences> = mock {
@@ -62,7 +67,8 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
             wooCommerceStore,
             prefsWrapper,
             pushNotificationsDataStore,
-            notificationAnalyticsTracker
+            notificationAnalyticsTracker,
+            localeProvider
         )
     }
 
@@ -70,7 +76,7 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     fun `given stored uuid, when registering push token succeeds, then saves token and disables wpcom notifications`() =
         testBlocking {
             whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
-            whenever(wooPushNotificationsStore.registerPushToken(siteModel, "token", "stored-uuid"))
+            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any(), any(), any()))
                 .thenReturn(WooResult(RETURNED_TOKEN))
 
             val mutablePreferences: MutablePreferences = mock()
@@ -83,7 +89,13 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
 
             sut.registerPushTokenInWooCoreSystem("token", siteModel)
 
-            verify(wooPushNotificationsStore).registerPushToken(siteModel, "token", "stored-uuid")
+            verify(wooPushNotificationsStore).registerPushToken(
+                eq(siteModel),
+                eq("token"),
+                eq("stored-uuid"),
+                any(),
+                any()
+            )
             val expectedTokenKey = stringPreferencesKey("push_token_$SITE_ID")
             verify(mutablePreferences)[expectedTokenKey] = RETURNED_TOKEN
             verify(wpComPushNotificationStore).updateNotificationSettingsFor(
@@ -102,13 +114,19 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     fun `given stored uuid and not wpcom registered, when registering push token fails, then falls back to wpcom registration`() =
         testBlocking {
             whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
-            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any()))
+            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any(), any(), any()))
                 .thenReturn(PN_REGISTRATION_ERROR)
             setupWpComRegistration(isRegistered = false)
 
             sut.registerPushTokenInWooCoreSystem("token", siteModel)
 
-            verify(wooPushNotificationsStore).registerPushToken(siteModel, "token", "stored-uuid")
+            verify(wooPushNotificationsStore).registerPushToken(
+                eq(siteModel),
+                eq("token"),
+                eq("stored-uuid"),
+                any(),
+                any()
+            )
             verify(wpComPushNotificationStore, never()).updateNotificationSettingsFor(any())
             verify(wpComPushNotificationStore).registerDevice(
                 "token",
@@ -120,13 +138,19 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     fun `given already wpcom registered, when registering push token fails, then does not fallback to wpcom registration`() =
         testBlocking {
             whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
-            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any()))
+            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any(), any(), any()))
                 .thenReturn(PN_REGISTRATION_ERROR)
             setupWpComRegistration(isRegistered = true)
 
             sut.registerPushTokenInWooCoreSystem("token", siteModel)
 
-            verify(wooPushNotificationsStore).registerPushToken(siteModel, "token", "stored-uuid")
+            verify(wooPushNotificationsStore).registerPushToken(
+                eq(siteModel),
+                eq("token"),
+                eq("stored-uuid"),
+                any(),
+                any()
+            )
             verify(wpComPushNotificationStore, never()).registerDevice(any(), any())
         }
 
@@ -134,7 +158,7 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     fun `when registering push token fails and falls back to wpcom, then does not save token to datastore`() =
         testBlocking {
             whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
-            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any()))
+            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any(), any(), any()))
                 .thenReturn(PN_REGISTRATION_ERROR)
             setupWpComRegistration(isRegistered = false)
 
@@ -147,7 +171,7 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     fun `given missing uuid, when registering push token called, then generates and stores new uuid`() =
         testBlocking {
             whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("")
-            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any()))
+            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any(), any(), any()))
                 .thenReturn(PN_REGISTRATION_ERROR)
             setupWpComRegistration(isRegistered = false)
 
@@ -158,7 +182,9 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
             verify(wooPushNotificationsStore).registerPushToken(
                 eq(siteModel),
                 eq("token"),
-                eq(uuidCaptor.firstValue)
+                eq(uuidCaptor.firstValue),
+                any(),
+                any()
             )
         }
 
@@ -237,7 +263,7 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     fun `given registration succeeds, when registering push token, then tracks success event`() =
         testBlocking {
             whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
-            whenever(wooPushNotificationsStore.registerPushToken(siteModel, "token", "stored-uuid"))
+            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any(), any(), any()))
                 .thenReturn(WooResult(RETURNED_TOKEN))
 
             val mutablePreferences: MutablePreferences = mock()
@@ -260,7 +286,7 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     fun `given registration fails, when registering push token, then tracks error event`() =
         testBlocking {
             whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
-            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any()))
+            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any(), any(), any()))
                 .thenReturn(PN_REGISTRATION_ERROR)
 
             sut.registerPushTokenInWooCoreSystem("token", siteModel)
@@ -272,6 +298,28 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
                 errorType = anyOrNull(),
                 errorCode = anyOrNull()
             )
+        }
+
+    @Test
+    fun `when registering push token, then sends device locale and metadata`() =
+        testBlocking {
+            whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
+            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any(), any(), any()))
+                .thenReturn(PN_REGISTRATION_ERROR)
+
+            sut.registerPushTokenInWooCoreSystem("token", siteModel)
+
+            val localeCaptor = argumentCaptor<String>()
+            val metadataCaptor = argumentCaptor<Map<String, String>>()
+            verify(wooPushNotificationsStore).registerPushToken(
+                any(),
+                any(),
+                any(),
+                localeCaptor.capture(),
+                metadataCaptor.capture()
+            )
+            assertThat(localeCaptor.firstValue).isEqualTo("en_US")
+            assertThat(metadataCaptor.firstValue).containsKeys("app_version", "device_model", "os_version")
         }
 
     private fun setupWpComRegistration(isRegistered: Boolean) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
@@ -285,6 +285,7 @@ class WooPosBookingViewStateMapperTest {
         runTest {
             // GIVEN
             val booking = sampleBooking(id = 42L)
+            whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
 
             // WHEN
             val result = mapper.mapToDetailsViewState(booking, resourceName = null)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsRestClient.kt
@@ -16,16 +16,14 @@ class PushNotificationsRestClient @Inject constructor(private val wooNetwork: Wo
         request: PushTokenRegistrationRequest
     ): WooPayload<PushTokenIdResponse> {
         val path = WOOCOMMERCE.push_tokens.pathPushNotifications
-        val body = mutableMapOf<String, Any>(
+        val body = mutableMapOf(
             "token" to request.token,
             "platform" to "android",
             "origin" to request.origin,
             "device_uuid" to request.deviceUuid,
             "device_locale" to request.deviceLocale,
+            "metadata" to request.metadata
         )
-        if (request.metadata.isNotEmpty()) {
-            body["metadata"] = request.metadata
-        }
         return wooNetwork.executePostGsonRequest(
             site = site,
             path = path,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsRestClient.kt
@@ -13,17 +13,19 @@ class PushNotificationsRestClient @Inject constructor(private val wooNetwork: Wo
 
     suspend fun registerPushToken(
         site: SiteModel,
-        token: String,
-        origin: String,
-        deviceUuid: String
+        request: PushTokenRegistrationRequest
     ): WooPayload<PushTokenIdResponse> {
         val path = WOOCOMMERCE.push_tokens.pathPushNotifications
-        val body = mapOf(
-            "token" to token,
+        val body = mutableMapOf<String, Any>(
+            "token" to request.token,
             "platform" to "android",
-            "origin" to origin,
-            "device_uuid" to deviceUuid,
+            "origin" to request.origin,
+            "device_uuid" to request.deviceUuid,
+            "device_locale" to request.deviceLocale,
         )
+        if (request.metadata.isNotEmpty()) {
+            body["metadata"] = request.metadata
+        }
         return wooNetwork.executePostGsonRequest(
             site = site,
             path = path,
@@ -40,6 +42,14 @@ class PushNotificationsRestClient @Inject constructor(private val wooNetwork: Wo
         path = WOOCOMMERCE.push_tokens.id(pushTokenId.toLong()).pathPushNotifications,
         clazz = Unit::class.java,
     ).toWooPayload()
+
+    data class PushTokenRegistrationRequest(
+        val token: String,
+        val origin: String,
+        val deviceUuid: String,
+        val deviceLocale: String,
+        val metadata: Map<String, String> = emptyMap()
+    )
 
     /**
      * @param id The unique ID of the push token record in Woo Core

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/WooPushNotificationsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/WooPushNotificationsStore.kt
@@ -17,11 +17,20 @@ class WooPushNotificationsStore @Inject internal constructor(
     suspend fun registerPushToken(
         site: SiteModel,
         token: String,
-        deviceUuid: String
+        deviceUuid: String,
+        deviceLocale: String,
+        metadata: Map<String, String> = emptyMap()
     ): WooResult<String> =
         coroutineEngine.withDefaultContext(T.API, this, "registerWooPushToken") {
             val origin = if (BuildConfig.DEBUG) ORIGIN_DEV else ORIGIN
-            val payload = pushNotificationsRestClient.registerPushToken(site, token, origin, deviceUuid)
+            val request = PushNotificationsRestClient.PushTokenRegistrationRequest(
+                token = token,
+                origin = origin,
+                deviceUuid = deviceUuid,
+                deviceLocale = deviceLocale,
+                metadata = metadata
+            )
+            val payload = pushNotificationsRestClient.registerPushToken(site, request)
 
             if (payload.isError || payload.result == null) {
                 WooResult(payload.error)

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/pushnotifications/PushNotificationsStoreTest.kt
@@ -31,10 +31,10 @@ class PushNotificationsStoreTest {
         runBlocking {
             val site = SiteModel().apply { id = 123 }
             val tokenId = "101"
-            whenever(restClient.registerPushToken(any(), any(), any(), any()))
+            whenever(restClient.registerPushToken(any(), any()))
                 .thenReturn(WooPayload(PushTokenIdResponse(tokenId)))
 
-            val result = sut.registerPushToken(site, "token", "uuid")
+            val result = sut.registerPushToken(site, "token", "uuid", "en_US")
 
             assertThat(result.isError).isFalse()
             assertThat(result.model).isEqualTo(tokenId)


### PR DESCRIPTION
## Summary
- Added `device_locale` (required, `xx_XX` format) and `metadata` (optional object with `app_version`, `device_model`, `os_version`) to the Woo Core push notification token registration endpoint payload
- Introduced `PushTokenRegistrationRequest` data class in `PushNotificationsRestClient` to group registration parameters
- Collected device locale via existing `LocaleProvider` and device metadata via `android.os.Build` / `BuildConfig` in `PushNotificationRepository`
- Updated all unit tests and added a dedicated test verifying locale and metadata are passed correctly

## Test plan
1. Install the [updated plugin](https://uploads.linear.app/f629fcde-6f9b-48e8-8af3-60eed8823bff/314c5bfe-02da-478e-9f20-ee187d673147/c0883e9d-d639-4ba8-a04b-82b7071b582e) on a test WooCommerce site
2. Build and install the app on a device/emulator with feature flag `WOO_PUSH_NOTIFICATIONS_SYSTEM` enabled
3. Log in into a Jetpack connected site. You can use WP.com creds or site creds doesn't matter, but site must be Jetpack connected. 
4. Monitor the network request to `POST /wp-json/wc-push-notifications/push-tokens`. Use app inspector.
5. Verify the request body now includes:
   - `device_locale` in `xx_XX` format (e.g., `en_US`)
   - `metadata` object with `app_version`, `device_model`, and `os_version`
  Expected request body: 
  ```
  {
  "token": "$token",
  "platform": "android",
  "origin": "com.woocommerce.android:dev",
  "device_uuid": "d1033aad-6cfdss-40d5-9059-898728f9a0f",
  "device_locale": "en_US",
  "metadata": {
    "app_version": "24.1-rc-2",
    "device_model": "Google sdk_gphone64_arm64",
    "os_version": "16"
  }
}
  ``` 
6. Change device locale in settings, re-trigger registration, and verify the locale value updates accordingly
7. Verify existing fields (`token`, `platform`, `origin`, `device_uuid`) remain unchanged