### PR TITLE
Fix unit tests after a PR merge with outdated changes

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
@@ -56,7 +56,7 @@ class WooPosBookingNoteViewModelTest {
         parentId = 0L,
         personCounts = listOf(1L),
         localTimezone = "",
-        attendanceStatus = BookingEntity.AttendanceStatus.Booked,
+        attendanceStatus = BookingEntity.AttendanceStatus.Attended,
         note = "Existing note",
         order = BookingOrderInfo(),
         customerNote = ""


### PR DESCRIPTION
### Description
PR #15339 referenced an outdated value, and this broke unit tests in `trunk`, this PR simply changes the value to fix the issue.

### Test Steps
Green CI is enough.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
