### PR TITLE
[Push Notificiations] Update push notifications connection steps to support multi-step installation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
@@ -21,7 +21,7 @@ enum class HelpOrigin(private val stringValue: String) {
     SIGNUP_EMAIL("origin:signup-email"),
     SIGNUP_MAGIC_LINK("origin:signup-magic-link"),
     JETPACK_INSTALLATION("origin:jetpack-installation"),
-    WOO_PUSH_NOTIFICATIONS_SETUP("origin:woo-push-notifications-setup"), // TODO validate the value
+    WOO_PUSH_NOTIFICATIONS_SETUP("origin:woo-push-notifications-setup"),
     JETPACK_ACTIVATION_USER_ELIGIBILITY_ERROR("origin:jetpack-activation-user-eligibility-error"),
     LOGIN_HELP_NOTIFICATION("origin:login-local-notification"),
     SITE_PICKER_JETPACK_TIMEOUT("origin:site-picker-jetpack-error"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpOrigin.kt
@@ -21,6 +21,7 @@ enum class HelpOrigin(private val stringValue: String) {
     SIGNUP_EMAIL("origin:signup-email"),
     SIGNUP_MAGIC_LINK("origin:signup-magic-link"),
     JETPACK_INSTALLATION("origin:jetpack-installation"),
+    WOO_PUSH_NOTIFICATIONS_SETUP("origin:woo-push-notifications-setup"), // TODO validate the value
     JETPACK_ACTIVATION_USER_ELIGIBILITY_ERROR("origin:jetpack-activation-user-eligibility-error"),
     LOGIN_HELP_NOTIFICATION("origin:login-local-notification"),
     SITE_PICKER_JETPACK_TIMEOUT("origin:site-picker-jetpack-error"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsFragment.kt
@@ -21,11 +21,7 @@ class WooPushNotificationsConnectionStepsFragment : BaseFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
-            WooPushNotificationsConnectionStepsScreen(
-                viewModel = viewModel,
-                onCancelClick = viewModel::onCloseClick,
-                onContinueClick = { findNavController().navigateUp() }
-            )
+            WooPushNotificationsConnectionStepsScreen(viewModel = viewModel)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsFragment.kt
@@ -9,6 +9,7 @@ import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -22,9 +23,21 @@ class WooPushNotificationsConnectionStepsFragment : BaseFragment() {
         return composeView {
             WooPushNotificationsConnectionStepsScreen(
                 viewModel = viewModel,
-                onCancelClick = { findNavController().navigateUp() },
+                onCancelClick = viewModel::onCloseClick,
                 onContinueClick = { findNavController().navigateUp() }
             )
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is Exit -> findNavController().navigateUp()
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsFragment.kt
@@ -6,10 +6,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -32,6 +34,7 @@ class WooPushNotificationsConnectionStepsFragment : BaseFragment() {
     private fun setupObservers() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
+                is NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
                 is Exit -> findNavController().navigateUp()
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -29,9 +30,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -57,7 +60,8 @@ fun WooPushNotificationsConnectionStepsScreen(
             viewState = viewState,
             onCloseClick = viewModel::onCloseClick,
             onGoToStoreClick = viewModel::onGoToStoreClick,
-            onRetryClick = viewModel::onRetryClick
+            onRetryClick = viewModel::onRetryClick,
+            onContactSupportClick = viewModel::onContactSupportClick
         )
     }
 }
@@ -68,13 +72,24 @@ private fun WooPushNotificationsConnectionStepsScreen(
     onCloseClick: () -> Unit,
     onGoToStoreClick: () -> Unit,
     onRetryClick: () -> Unit,
+    onContactSupportClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Scaffold(
         modifier = modifier,
         topBar = {
             Toolbar(
-                onNavigationButtonClick = onCloseClick
+                onNavigationButtonClick = onCloseClick,
+                actions = {
+                    if (viewState.failedStep != null) {
+                        IconButton(onClick = onContactSupportClick) {
+                            Icon(
+                                imageVector = ImageVector.vectorResource(id = R.drawable.ic_help_24dp),
+                                contentDescription = stringResource(id = R.string.help),
+                            )
+                        }
+                    }
+                }
             )
         }
     ) { paddingValues ->
@@ -279,7 +294,8 @@ private fun WooPushNotificationsConnectionStepsPreview() {
             ),
             onCloseClick = {},
             onGoToStoreClick = {},
-            onRetryClick = {}
+            onRetryClick = {},
+            onContactSupportClick = {}
         )
     }
 }
@@ -308,7 +324,8 @@ private fun WooPushNotificationsConnectionStepsPreviewError() {
             ),
             onCloseClick = {},
             onGoToStoreClick = {},
-            onRetryClick = {}
+            onRetryClick = {},
+            onContactSupportClick = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
@@ -50,18 +50,14 @@ import com.woocommerce.android.ui.pushnotifications.connection.WooPushNotificati
 
 @Composable
 fun WooPushNotificationsConnectionStepsScreen(
-    viewModel: WooPushNotificationsConnectionStepsViewModel,
-    onCancelClick: () -> Unit,
-    onContinueClick: () -> Unit,
-    modifier: Modifier = Modifier
+    viewModel: WooPushNotificationsConnectionStepsViewModel
 ) {
     viewModel.viewState.observeAsState().value?.let { viewState ->
         WooPushNotificationsConnectionStepsScreen(
             viewState = viewState,
-            onCancelClick = onCancelClick,
-            onContinueClick = onContinueClick,
-            onRetryClick = viewModel::onRetryClick,
-            modifier = modifier
+            onCloseClick = viewModel::onCloseClick,
+            onGoToStoreClick = viewModel::onGoToStoreClick,
+            onRetryClick = viewModel::onRetryClick
         )
     }
 }
@@ -69,16 +65,16 @@ fun WooPushNotificationsConnectionStepsScreen(
 @Composable
 private fun WooPushNotificationsConnectionStepsScreen(
     viewState: ViewState,
-    onCancelClick: () -> Unit,
+    onCloseClick: () -> Unit,
+    onGoToStoreClick: () -> Unit,
     onRetryClick: () -> Unit,
-    onContinueClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Scaffold(
         modifier = modifier,
         topBar = {
             Toolbar(
-                onNavigationButtonClick = onCancelClick
+                onNavigationButtonClick = onCloseClick
             )
         }
     ) { paddingValues ->
@@ -150,7 +146,7 @@ private fun WooPushNotificationsConnectionStepsScreen(
                 exit = slideOutVertically { fullHeight -> fullHeight }
             ) {
                 WCColoredButton(
-                    onClick = onContinueClick,
+                    onClick = onGoToStoreClick,
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text(
@@ -281,8 +277,8 @@ private fun WooPushNotificationsConnectionStepsPreview() {
                     )
                 )
             ),
-            onCancelClick = {},
-            onContinueClick = {},
+            onCloseClick = {},
+            onGoToStoreClick = {},
             onRetryClick = {}
         )
     }
@@ -310,8 +306,8 @@ private fun WooPushNotificationsConnectionStepsPreviewError() {
                     )
                 )
             ),
-            onCancelClick = {},
-            onContinueClick = {},
+            onCloseClick = {},
+            onGoToStoreClick = {},
             onRetryClick = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
@@ -1,6 +1,13 @@
 package com.woocommerce.android.ui.pushnotifications.connection
 
 import androidx.annotation.StringRes
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.AnimationConstants.DefaultDurationMillis
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -29,12 +36,17 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.IdleCircle
 import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.getText
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.pushnotifications.WordPressWooBadge
+import com.woocommerce.android.ui.pushnotifications.connection.WooPushNotificationsConnectionStepsViewModel.StepState
+import com.woocommerce.android.ui.pushnotifications.connection.WooPushNotificationsConnectionStepsViewModel.StepType
+import com.woocommerce.android.ui.pushnotifications.connection.WooPushNotificationsConnectionStepsViewModel.ViewState
 
 @Composable
 fun WooPushNotificationsConnectionStepsScreen(
@@ -45,10 +57,10 @@ fun WooPushNotificationsConnectionStepsScreen(
 ) {
     viewModel.viewState.observeAsState().value?.let { viewState ->
         WooPushNotificationsConnectionStepsScreen(
-            siteAddress = viewState.siteAddress,
-            steps = viewState.steps,
+            viewState = viewState,
             onCancelClick = onCancelClick,
             onContinueClick = onContinueClick,
+            onRetryClick = viewModel::onRetryClick,
             modifier = modifier
         )
     }
@@ -56,14 +68,12 @@ fun WooPushNotificationsConnectionStepsScreen(
 
 @Composable
 private fun WooPushNotificationsConnectionStepsScreen(
-    siteAddress: String,
-    steps: List<ConnectionStepUiModel>,
+    viewState: ViewState,
     onCancelClick: () -> Unit,
+    onRetryClick: () -> Unit,
     onContinueClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val hasInProgressStep = steps.any { it.status == ConnectionStepStatus.IN_PROGRESS }
-
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -98,7 +108,7 @@ private fun WooPushNotificationsConnectionStepsScreen(
                 Text(
                     text = annotatedStringRes(
                         R.string.woo_push_notifications_connection_steps_body,
-                        siteAddress
+                        viewState.siteAddress
                     ),
                     modifier = Modifier.padding(top = 8.dp)
                 )
@@ -108,7 +118,7 @@ private fun WooPushNotificationsConnectionStepsScreen(
                         .fillMaxWidth()
                         .padding(top = 32.dp)
                 ) {
-                    steps.forEach { step ->
+                    viewState.steps.forEach { step ->
                         ConnectionStepRow(
                             step = step,
                             modifier = Modifier.padding(vertical = 8.dp)
@@ -117,12 +127,37 @@ private fun WooPushNotificationsConnectionStepsScreen(
                 }
             }
 
-            if (!hasInProgressStep) {
+            AnimatedVisibility(
+                visible = viewState.steps.any { it.state is StepState.Error },
+                enter = fadeIn(animationSpec = tween(DefaultDurationMillis)),
+                exit = fadeOut(animationSpec = tween(DefaultDurationMillis))
+            ) {
+                WCColoredButton(
+                    onClick = onRetryClick,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = stringResource(
+                            id = R.string.woo_push_notifications_connection_steps_retry
+                        )
+                    )
+                }
+            }
+
+            AnimatedVisibility(
+                visible = viewState.isDone,
+                enter = slideInVertically { fullHeight -> fullHeight },
+                exit = slideOutVertically { fullHeight -> fullHeight }
+            ) {
                 WCColoredButton(
                     onClick = onContinueClick,
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text(text = stringResource(id = R.string.woo_push_notifications_connection_steps_go_to_my_store))
+                    Text(
+                        text = stringResource(
+                            id = R.string.woo_push_notifications_connection_steps_go_to_my_store
+                        )
+                    )
                 }
             }
         }
@@ -131,7 +166,7 @@ private fun WooPushNotificationsConnectionStepsScreen(
 
 @Composable
 private fun ConnectionStepRow(
-    step: ConnectionStepUiModel,
+    step: WooPushNotificationsConnectionStepsViewModel.Step,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -141,15 +176,13 @@ private fun ConnectionStepRow(
             .fillMaxWidth()
             .defaultMinSize(minHeight = 48.dp)
     ) {
-        ConnectionStepStatusIcon(
-            status = step.status
-        )
+        ConnectionStepStatusIcon(state = step.state)
 
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = stringResource(id = step.title),
+                text = stringResource(id = step.type.title),
                 style = MaterialTheme.typography.titleMedium,
-                fontWeight = if (step.status == ConnectionStepStatus.NOT_STARTED) {
+                fontWeight = if (step.state == StepState.Idle) {
                     FontWeight.Normal
                 } else {
                     FontWeight.Bold
@@ -157,17 +190,11 @@ private fun ConnectionStepRow(
                 color = colorResource(id = R.color.color_on_surface_medium)
             )
             Text(
-                text = step.statusMessageRes?.let { stringResource(id = it) }
-                    ?: stringResource(id = step.status.defaultTextRes),
+                text = step.state.statusText,
                 style = MaterialTheme.typography.bodySmall,
-                fontWeight = if (step.status == ConnectionStepStatus.ERROR) {
-                    FontWeight.SemiBold
-                } else {
-                    FontWeight.Normal
-                },
-                color = when (step.status) {
-                    ConnectionStepStatus.COMPLETE -> colorResource(id = R.color.woo_green_50)
-                    ConnectionStepStatus.ERROR -> colorResource(id = R.color.color_error)
+                color = when (step.state) {
+                    StepState.Success -> colorResource(id = R.color.woo_green_50)
+                    is StepState.Error -> MaterialTheme.colorScheme.error
                     else -> colorResource(id = R.color.color_on_surface_medium)
                 }
             )
@@ -177,11 +204,11 @@ private fun ConnectionStepRow(
 
 @Composable
 private fun ConnectionStepStatusIcon(
-    status: ConnectionStepStatus,
+    state: StepState,
     modifier: Modifier = Modifier
 ) {
-    when (status) {
-        ConnectionStepStatus.COMPLETE -> {
+    when (state) {
+        StepState.Success -> {
             Image(
                 painter = painterResource(id = R.drawable.ic_progress_circle_complete),
                 contentDescription = null,
@@ -189,18 +216,18 @@ private fun ConnectionStepStatusIcon(
             )
         }
 
-        ConnectionStepStatus.IN_PROGRESS -> {
+        StepState.Ongoing -> {
             CircularProgressIndicator(
                 modifier = modifier.size(26.dp),
                 color = colorResource(id = R.color.woo_push_notifications_connection_steps_progressbar),
             )
         }
 
-        ConnectionStepStatus.NOT_STARTED -> {
+        StepState.Idle -> {
             IdleCircle()
         }
 
-        ConnectionStepStatus.ERROR -> {
+        is StepState.Error -> {
             Icon(
                 painter = painterResource(id = R.drawable.ic_gridicons_notice),
                 contentDescription = null,
@@ -211,49 +238,81 @@ private fun ConnectionStepStatusIcon(
     }
 }
 
-data class ConnectionStepUiModel(
-    @StringRes val title: Int,
-    val status: ConnectionStepStatus,
-    @StringRes val statusMessageRes: Int? = null
-)
-
-enum class ConnectionStepStatus {
-    COMPLETE,
-    IN_PROGRESS,
-    NOT_STARTED,
-    ERROR
-}
-
-private val ConnectionStepStatus.defaultTextRes: Int
+private val StepType.title: Int
     @StringRes get() = when (this) {
-        ConnectionStepStatus.COMPLETE -> R.string.woo_push_notifications_connection_steps_complete
-        ConnectionStepStatus.IN_PROGRESS -> R.string.woo_push_notifications_connection_steps_in_progress
-        ConnectionStepStatus.NOT_STARTED -> R.string.woo_push_notifications_connection_steps_not_started
-        ConnectionStepStatus.ERROR -> R.string.woo_push_notifications_connection_steps_error
+        StepType.ConnectStore ->
+            R.string.woo_push_notifications_connection_steps_step_connect_store
+
+        StepType.CheckPluginCompatibility ->
+            R.string.woo_push_notifications_connection_steps_step_check_plugin_compatibility
+
+        StepType.EnablePushNotifications ->
+            R.string.woo_push_notifications_connection_steps_step_enable_push_notifications
+    }
+
+private val StepState.statusText: String
+    @Composable
+    get() = when (this) {
+        StepState.Success -> stringResource(R.string.woo_push_notifications_connection_steps_complete)
+        StepState.Ongoing -> stringResource(R.string.woo_push_notifications_connection_steps_in_progress)
+        StepState.Idle -> stringResource(R.string.woo_push_notifications_connection_steps_not_started)
+        is StepState.Error -> errorMessage.getText()
     }
 
 @Composable
 @Preview
-private fun WooPushNotificationsConnectionStepsScreenPreview() {
+private fun WooPushNotificationsConnectionStepsPreview() {
     WooThemeWithBackground {
         WooPushNotificationsConnectionStepsScreen(
-            siteAddress = "coffeebeans.com",
-            steps = listOf(
-                ConnectionStepUiModel(
-                    title = R.string.woo_push_notifications_connection_steps_step_connect_store,
-                    status = ConnectionStepStatus.IN_PROGRESS
-                ),
-                ConnectionStepUiModel(
-                    title = R.string.woo_push_notifications_connection_steps_step_check_plugin_compatibility,
-                    status = ConnectionStepStatus.NOT_STARTED
-                ),
-                ConnectionStepUiModel(
-                    title = R.string.woo_push_notifications_connection_steps_step_enable_push_notifications,
-                    status = ConnectionStepStatus.NOT_STARTED
+            viewState = ViewState(
+                siteAddress = "coffeebeans.com",
+                steps = listOf(
+                    WooPushNotificationsConnectionStepsViewModel.Step(
+                        type = StepType.ConnectStore,
+                        state = StepState.Ongoing
+                    ),
+                    WooPushNotificationsConnectionStepsViewModel.Step(
+                        type = StepType.CheckPluginCompatibility,
+                        state = StepState.Idle
+                    ),
+                    WooPushNotificationsConnectionStepsViewModel.Step(
+                        type = StepType.EnablePushNotifications,
+                        state = StepState.Idle
+                    )
                 )
             ),
             onCancelClick = {},
-            onContinueClick = {}
+            onContinueClick = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun WooPushNotificationsConnectionStepsPreviewError() {
+    WooThemeWithBackground {
+        WooPushNotificationsConnectionStepsScreen(
+            viewState = ViewState(
+                siteAddress = "coffeebeans.com",
+                steps = listOf(
+                    WooPushNotificationsConnectionStepsViewModel.Step(
+                        type = StepType.ConnectStore,
+                        state = StepState.Success
+                    ),
+                    WooPushNotificationsConnectionStepsViewModel.Step(
+                        type = StepType.CheckPluginCompatibility,
+                        state = StepState.Error(UiString.UiStringText("Error connecting to store"))
+                    ),
+                    WooPushNotificationsConnectionStepsViewModel.Step(
+                        type = StepType.EnablePushNotifications,
+                        state = StepState.Idle
+                    )
+                )
+            ),
+            onCancelClick = {},
+            onContinueClick = {},
+            onRetryClick = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
@@ -81,7 +81,7 @@ private fun WooPushNotificationsConnectionStepsScreen(
             Toolbar(
                 onNavigationButtonClick = onCloseClick,
                 actions = {
-                    if (viewState.failedStep != null) {
+                    if (viewState.isError) {
                         IconButton(onClick = onContactSupportClick) {
                             Icon(
                                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_help_24dp),
@@ -139,7 +139,7 @@ private fun WooPushNotificationsConnectionStepsScreen(
             }
 
             AnimatedVisibility(
-                visible = viewState.steps.any { it.state is StepState.Error },
+                visible = viewState.isError,
                 enter = fadeIn(animationSpec = tween(DefaultDurationMillis)),
                 exit = fadeOut(animationSpec = tween(DefaultDurationMillis))
             ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -116,7 +116,7 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
         val steps: List<Step>
     ) {
         val isDone = steps.all { it.state == StepState.Success }
-        val failedStep = steps.firstOrNull { it.state is StepState.Error }
+        val isError = steps.any { it.state is StepState.Error }
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -56,6 +56,11 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
         startNextStep()
     }
 
+    fun onGoToStoreClick() {
+        // TODO
+        onCloseClick()
+    }
+
     fun onCloseClick() {
         triggerEvent(Exit)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -85,7 +85,7 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
     }
 
     private fun getSiteAddress(): String {
-        val site = selectedSite.getOrNull() ?: return ""
+        val site = selectedSite.get()
         return StringUtils.getSiteDomainAndPath(site).ifBlank { site.name.orEmpty() }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -1,13 +1,24 @@
 package com.woocommerce.android.ui.pushnotifications.connection
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.R
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @HiltViewModel
@@ -16,26 +27,61 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
 
-    private val _viewState = MutableLiveData(
-        ViewState(siteAddress = getSiteAddress())
+    private val siteAddress = getSiteAddress()
+
+    private val currentStep = savedStateHandle.getStateFlow(
+        scope = viewModelScope,
+        initialValue = Step(StepType.ConnectStore),
     )
-    val viewState: LiveData<ViewState> = _viewState
 
-    init {
-        startConnectStoreStep()
-    }
-
-    private fun startConnectStoreStep() {
-        val currentState = _viewState.value ?: return
-        _viewState.value = currentState.copy(
-            steps = currentState.steps.mapIndexed { index, step ->
-                if (index == 0) {
-                    step.copy(status = ConnectionStepStatus.IN_PROGRESS)
-                } else {
-                    step
-                }
+    val viewState = combine(
+        currentStep,
+        flowOf(StepType.entries.toList())
+    ) { currentStep, stepTypes ->
+        ViewState(
+            siteAddress = siteAddress,
+            steps = stepTypes.map { stepType ->
+                Step(
+                    type = stepType,
+                    state = when {
+                        currentStep.type == stepType -> currentStep.state
+                        currentStep.type > stepType -> StepState.Success
+                        else -> StepState.Idle
+                    }
+                )
             }
         )
+    }.asLiveData()
+
+    init {
+        monitorCurrentStep()
+        startNextStep()
+    }
+
+    fun onCloseClick() {
+        triggerEvent(Exit)
+    }
+
+    fun onRetryClick() {
+        startNextStep()
+    }
+
+    private fun startNextStep() {
+        currentStep.update { it.copy(state = StepState.Ongoing) }
+    }
+
+    private fun monitorCurrentStep() = launch {
+        currentStep
+            .collectLatest { step ->
+                if (step.state != StepState.Ongoing) return@collectLatest
+
+                @Suppress("NoOp")
+                when (step.type) {
+                    StepType.ConnectStore -> Unit
+                    StepType.CheckPluginCompatibility -> Unit
+                    StepType.EnablePushNotifications -> Unit
+                }
+            }
     }
 
     private fun getSiteAddress(): String {
@@ -43,21 +89,37 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
         return StringUtils.getSiteDomainAndPath(site).ifBlank { site.name.orEmpty() }
     }
 
+
     data class ViewState(
         val siteAddress: String,
-        val steps: List<ConnectionStepUiModel> = listOf(
-            ConnectionStepUiModel(
-                title = R.string.woo_push_notifications_connection_steps_step_connect_store,
-                status = ConnectionStepStatus.NOT_STARTED
-            ),
-            ConnectionStepUiModel(
-                title = R.string.woo_push_notifications_connection_steps_step_check_plugin_compatibility,
-                status = ConnectionStepStatus.NOT_STARTED,
-            ),
-            ConnectionStepUiModel(
-                title = R.string.woo_push_notifications_connection_steps_step_enable_push_notifications,
-                status = ConnectionStepStatus.NOT_STARTED
-            )
-        )
-    )
+        val steps: List<Step>
+    ) {
+        val isDone = steps.all { it.state == StepState.Success }
+    }
+
+    @Parcelize
+    data class Step(
+        val type: StepType,
+        val state: StepState = StepState.Idle
+    ) : Parcelable
+
+    enum class StepType {
+        ConnectStore,
+        CheckPluginCompatibility,
+        EnablePushNotifications
+    }
+
+    sealed interface StepState : Parcelable {
+        @Parcelize
+        data object Idle : StepState
+
+        @Parcelize
+        data object Ongoing : StepState
+
+        @Parcelize
+        data object Success : StepState
+
+        @Parcelize
+        data class Error(val errorMessage: UiString) : StepState
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -14,8 +14,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.pushnotifications.connection
 
 import android.os.Parcelable
+import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -93,6 +94,18 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
             }
     }
 
+    @Suppress("unused")
+    private fun advanceToNextStep() {
+        currentStep.update { current ->
+            val nextType = StepType.entries.getOrNull(current.type.ordinal + 1)
+            if (nextType != null) {
+                Step(type = nextType, state = StepState.Ongoing)
+            } else {
+                current.copy(state = StepState.Success)
+            }
+        }
+    }
+
     private fun getSiteAddress(): String {
         val site = selectedSite.get()
         return StringUtils.getSiteDomainAndPath(site).ifBlank { site.name.orEmpty() }
@@ -129,6 +142,9 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
         data object Success : StepState
 
         @Parcelize
-        data class Error(val errorMessage: UiString) : StepState
+        data class Error(val errorMessage: UiString) : StepState {
+            constructor(message: String) : this(UiString.UiStringText(message))
+            constructor(@StringRes messageRes: Int) : this(UiString.UiStringRes(messageRes))
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.model.UiString
+import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.StringUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
@@ -69,6 +71,10 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
         startNextStep()
     }
 
+    fun onContactSupportClick() {
+        triggerEvent(Event.NavigateToHelpScreen(HelpOrigin.WOO_PUSH_NOTIFICATIONS_SETUP))
+    }
+
     private fun startNextStep() {
         currentStep.update { it.copy(state = StepState.Ongoing) }
     }
@@ -98,6 +104,7 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
         val steps: List<Step>
     ) {
         val isDone = steps.all { it.state == StepState.Success }
+        val failedStep = steps.firstOrNull { it.state is StepState.Error }
     }
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -98,7 +98,6 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
         return StringUtils.getSiteDomainAndPath(site).ifBlank { site.name.orEmpty() }
     }
 
-
     data class ViewState(
         val siteAddress: String,
         val steps: List<Step>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2649,6 +2649,7 @@
     <string name="woo_push_notifications_connection_steps_not_started">Not started</string>
     <string name="woo_push_notifications_connection_steps_error">Error</string>
     <string name="woo_push_notifications_connection_steps_go_to_my_store">Go to My Store</string>
+    <string name="woo_push_notifications_connection_steps_retry">Try again</string>
 
     <string name="jetpack_install_start_title">Install Jetpack</string>
     <string name="jetpack_install_start_subtitle">Install the free Jetpack plugin to &lt;strong&gt;%s&lt;/strong&gt; to experience the best mobile experience.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
@@ -1,0 +1,89 @@
+package com.woocommerce.android.ui.pushnotifications.connection
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.pushnotifications.connection.WooPushNotificationsConnectionStepsViewModel.StepState
+import com.woocommerce.android.ui.pushnotifications.connection.WooPushNotificationsConnectionStepsViewModel.StepType
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
+    private val site = SiteModel().apply { name = "coffeebeans.com" }
+
+    private lateinit var viewModel: WooPushNotificationsConnectionStepsViewModel
+
+    private val selectedSite: SelectedSite = mock {
+        on { getOrNull() } doReturn site
+    }
+
+    private fun setup(prepareMocks: () -> Unit = {}) {
+        prepareMocks()
+        viewModel = WooPushNotificationsConnectionStepsViewModel(
+            selectedSite = selectedSite,
+            savedStateHandle = SavedStateHandle()
+        )
+    }
+
+    @Test
+    fun `when initialized, then first step is Ongoing and others are Idle`() {
+        setup()
+
+        val state = viewModel.viewState.getOrAwaitValue()
+
+        assertThat(state.steps).hasSize(3)
+        assertThat(state.steps[0].type).isEqualTo(StepType.ConnectStore)
+        assertThat(state.steps[0].state).isEqualTo(StepState.Ongoing)
+        assertThat(state.steps[1].type).isEqualTo(StepType.CheckPluginCompatibility)
+        assertThat(state.steps[1].state).isEqualTo(StepState.Idle)
+        assertThat(state.steps[2].type).isEqualTo(StepType.EnablePushNotifications)
+        assertThat(state.steps[2].state).isEqualTo(StepState.Idle)
+    }
+
+    @Test
+    fun `when initialized, then isDone is false`() {
+        setup()
+
+        val state = viewModel.viewState.getOrAwaitValue()
+
+        assertThat(state.isDone).isFalse()
+    }
+
+    @Test
+    fun `when initialized, then site address is set`() {
+        setup()
+
+        val state = viewModel.viewState.getOrAwaitValue()
+
+        assertThat(state.siteAddress).isEqualTo("coffeebeans.com")
+    }
+
+    @Test
+    fun `when close is clicked, then Exit event is triggered`() {
+        setup()
+
+        viewModel.onCloseClick()
+
+        val event = viewModel.event.value
+        assertThat(event).isEqualTo(Exit)
+    }
+
+    @Test
+    fun `when site is null, then site address is empty`() {
+        setup(prepareMocks = {
+            whenever(selectedSite.getOrNull()).thenReturn(null)
+        })
+
+        val state = viewModel.viewState.getOrAwaitValue() as ViewState.ProgressViewState
+
+        assertThat(state.siteAddress).isEmpty()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
@@ -12,7 +12,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -22,7 +21,7 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: WooPushNotificationsConnectionStepsViewModel
 
     private val selectedSite: SelectedSite = mock {
-        on { getOrNull() } doReturn site
+        on { get() } doReturn site
     }
 
     private fun setup(prepareMocks: () -> Unit = {}) {
@@ -74,16 +73,5 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
 
         val event = viewModel.event.value
         assertThat(event).isEqualTo(Exit)
-    }
-
-    @Test
-    fun `when site is null, then site address is empty`() {
-        setup(prepareMocks = {
-            whenever(selectedSite.getOrNull()).thenReturn(null)
-        })
-
-        val state = viewModel.viewState.getOrAwaitValue() as ViewState.ProgressViewState
-
-        assertThat(state.siteAddress).isEmpty()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
@@ -1,12 +1,12 @@
 package com.woocommerce.android.ui.pushnotifications.connection
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.pushnotifications.connection.WooPushNotificationsConnectionStepsViewModel.StepState
 import com.woocommerce.android.ui.pushnotifications.connection.WooPushNotificationsConnectionStepsViewModel.StepType
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
@@ -6,7 +6,9 @@ import com.woocommerce.android.ui.pushnotifications.connection.WooPushNotificati
 import com.woocommerce.android.ui.pushnotifications.connection.WooPushNotificationsConnectionStepsViewModel.StepType
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -73,5 +75,17 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
 
         val event = viewModel.event.value
         assertThat(event).isEqualTo(Exit)
+    }
+
+    @Test
+    fun `when contact support is clicked, then NavigateToHelpScreen event is triggered`() {
+        setup()
+
+        viewModel.onContactSupportClick()
+
+        val event = viewModel.event.value
+        assertThat(event).isInstanceOf(NavigateToHelpScreen::class.java)
+        assertThat((event as NavigateToHelpScreen).origin)
+            .isEqualTo(HelpOrigin.WOO_PUSH_NOTIFICATIONS_SETUP)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-2232

### Description
To allow simultaneous working on the different push notifications setup tasks (WOOMOB-1927 and WOOMOB-1931), this PR updates the WooPushNotificationsConnectionStepsViewModel` to offer a foundation for the steps implementation:
- Update `WooPushNotificationsConnectionStepsViewModel` to follow the same pattern used by `JetpackActivationMainViewModel` for driving a multi-step flow:
    - `StepType` enum, `StepState` sealed interface, and `Step` data class with `SavedStateHandle` persistence
    - Update `ViewState` according to the steps change.
    - `monitorCurrentStep()` skeleton for step execution (to be implemented separately)
- Error state with support of custom messages and retry.
- Unit tests for the ViewModel
- Contact support button in error state.

### Test Steps
Code review is what matters most here, but to ensure there is no regression, please follow:

1. Make sure push notifications M2 feature flag is enabled.
2. Open the app and start push notifications setup.
3. Go through the login steps.
4. Notice the steps screen shows an ongoing Connect Store step.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md --> 