### PR TITLE
[CIAB: POS] Show collect payment button for cancelled bookings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentCollectibilityChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/CardReaderPaymentCollectibilityChecker.kt
@@ -21,11 +21,11 @@ class CardReaderPaymentCollectibilityChecker @Inject constructor(
     private val cardReaderPaymentCurrencySupportedChecker: CardReaderPaymentCurrencySupportedChecker,
     private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) {
-    suspend fun isCollectable(order: Order): Boolean {
+    suspend fun isCollectable(order: Order, allowCancelledStatus: Boolean = false): Boolean {
         return ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooPayments) &&
             with(order) {
                 cardReaderPaymentCurrencySupportedChecker.isCurrencySupported(currency) &&
-                    isStatusCollectable() &&
+                    isStatusCollectable(allowCancelledStatus) &&
                     !isOrderPaid &&
                     order.total.compareTo(BigDecimal.ZERO) == 1 &&
                     BigDecimal.ZERO.compareTo(order.refundTotal) == 0 &&
@@ -45,11 +45,11 @@ class CardReaderPaymentCollectibilityChecker @Inject constructor(
             WOOCOMMERCE_BOOKINGS_PAYMENT_TYPE,
         )
 
-    private fun Order.isStatusCollectable() = status in arrayOf(
+    private fun Order.isStatusCollectable(allowCancelledStatus: Boolean) = status in arrayOf(
         Pending,
         Processing,
         OnHold,
         Custom(Order.Status.AUTO_DRAFT),
         Failed,
-    )
+    ) || (allowCancelledStatus && status == Order.Status.Cancelled)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -111,6 +111,7 @@ class CardReaderPaymentController(
     private val paymentOrRefund: CardReaderFlowParam.PaymentOrRefund,
     private val cardReaderType: CardReaderType,
     private val isTTPPaymentInProgress: KMutableProperty0<Boolean>,
+    private val allowCancelledStatus: Boolean = false,
 ) {
     private var scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
@@ -202,7 +203,7 @@ class CardReaderPaymentController(
             fetchOrder()?.let { order ->
                 cardReaderTrackingInfoKeeper.setCurrency(order.currency)
 
-                if (!paymentCollectibilityChecker.isCollectable(order)) {
+                if (!paymentCollectibilityChecker.isCollectable(order, allowCancelledStatus)) {
                     exitWithSnackbar(R.string.card_reader_payment_order_paid_payment_cancelled)
                     return@launch
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -116,6 +116,7 @@ class WooPosCardPaymentViewModel @Inject constructor(
             orderId = orderId,
             paymentType = PaymentOrRefund.Payment.PaymentType.WOO_POS,
             isTTPPaymentInProgress = ::isTTPPaymentInProgress,
+            allowCancelledStatus = source == CardPaymentSource.BOOKINGS,
         )
         cardReaderPaymentController?.start()
         listenToPaymentState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
@@ -52,6 +52,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
         orderId: Long,
         paymentType: PaymentType,
         isTTPPaymentInProgress: KMutableProperty0<Boolean>,
+        allowCancelledStatus: Boolean = false,
     ): CardReaderPaymentController = CardReaderPaymentController(
         cardReaderManager = cardReaderManager,
         orderRepository = orderRepository,
@@ -78,5 +79,6 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
         ),
         cardReaderType = CardReaderType.EXTERNAL,
         isTTPPaymentInProgress = isTTPPaymentInProgress,
+        allowCancelledStatus = allowCancelledStatus,
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -244,7 +244,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         }
         doReturn(site).whenever(selectedSite).getIfExists()
         testBlocking {
-            doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
+            doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
         }
 
         pluginsInfo.clear()
@@ -274,7 +274,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
             orderInfo = orderInfo.copy(order = nonRefundedOrder)
         )
 
-        doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
+        doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
 
         doReturn(nonRefundedOrder).whenever(orderDetailRepository).getOrderById(any())
 
@@ -347,7 +347,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(paymentReceiptHelper.isReceiptAvailable(any())).thenReturn(true)
-            whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(false)
+            whenever(paymentCollectibilityChecker.isCollectable(any(), any())).thenReturn(false)
             whenever(orderDetailRepository.getOrderById(any())).thenReturn(
                 order.copy(
                     datePaid = Date()
@@ -376,7 +376,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(paymentReceiptHelper.isReceiptAvailable(any())).thenReturn(true)
-            whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(true)
+            whenever(paymentCollectibilityChecker.isCollectable(any(), any())).thenReturn(true)
             whenever(orderDetailRepository.getOrderById(any())).thenReturn(
                 order.copy(
                     datePaid = null
@@ -405,7 +405,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             whenever(paymentReceiptHelper.isReceiptAvailable(any())).thenReturn(false)
-            whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(false)
+            whenever(paymentCollectibilityChecker.isCollectable(any(), any())).thenReturn(false)
             whenever(orderDetailRepository.getOrderById(any())).thenReturn(order)
             whenever(orderDetailRepository.fetchOrderNotes(any())).thenReturn(true)
             whenever(orderDetailRepository.getOrderNotes(any())).thenReturn(testOrderNotes)
@@ -429,7 +429,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `collect button hidden if payment is not collectable`() =
         testBlocking {
             // GIVEN
-            doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
+            doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
             doReturn(order).whenever(orderDetailRepository).getOrderById(any())
             doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
             doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
@@ -445,7 +445,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     fun `collect button shown if payment is collectable`() =
         testBlocking {
             // GIVEN
-            doReturn(true).whenever(paymentCollectibilityChecker).isCollectable(any())
+            doReturn(true).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
             doReturn(order).whenever(orderDetailRepository).getOrderById(any())
             doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
             doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
@@ -682,7 +682,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         testBlocking {
             doReturn(order).whenever(orderDetailRepository).getOrderById(any())
             doReturn(order).whenever(orderDetailRepository).fetchOrderById(any())
-            doReturn(true).whenever(paymentCollectibilityChecker).isCollectable(any())
+            doReturn(true).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
 
             doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
             doReturn(testOrderNotes).whenever(orderDetailRepository).getOrderNotes(any())
@@ -2253,7 +2253,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(order).whenever(orderDetailRepository).getOrderById(any())
         doReturn(flowOf(emptyList<ShippingMethod>())).whenever(getShippingMethodsWithOtherValue).invoke()
 
-        doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
+        doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
         doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
         doReturn(testOrderNotes).whenever(orderDetailRepository).getOrderNotes(any())
         doReturn(testOrderShipmentTrackings).whenever(orderDetailRepository).getOrderShipmentTrackings(any())
@@ -2277,7 +2277,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
         doReturn(order).whenever(orderDetailRepository).getOrderById(any())
         doReturn(flowOf(emptyList<ShippingMethod>())).whenever(getShippingMethodsWithOtherValue).invoke()
 
-        doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any())
+        doReturn(false).whenever(paymentCollectibilityChecker).isCollectable(any(), any())
         doReturn(true).whenever(orderDetailRepository).fetchOrderNotes(any())
         doReturn(testOrderNotes).whenever(orderDetailRepository).getOrderNotes(any())
         doReturn(testOrderShipmentTrackings).whenever(orderDetailRepository).getOrderShipmentTrackings(any())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentViewModelTest.kt
@@ -230,7 +230,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
             flow<CardPaymentStatus> { }
         }
         whenever(selectedSite.get()).thenReturn(siteModel)
-        whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(true)
+        whenever(paymentCollectibilityChecker.isCollectable(any(), any())).thenReturn(true)
         whenever(interacRefundableChecker.isRefundable(any())).thenReturn(true)
         whenever(appPrefs.getCardReaderStatementDescriptor(anyOrNull(), anyOrNull(), anyOrNull()))
             .thenReturn("test statement descriptor")
@@ -500,7 +500,7 @@ class CardReaderPaymentViewModelTest : BaseUnitTest() {
     @Test
     fun `when payment not collectable, then flow terminated and snackbar shown`() =
         testBlocking {
-            whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(false)
+            whenever(paymentCollectibilityChecker.isCollectable(any(), any())).thenReturn(false)
             val events = mutableListOf<Event>()
             viewModel.event.observeForever {
                 events.add(it)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -158,7 +158,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         whenever(mockedOrder.orderKey).thenReturn("wc_order_j0LMK3bFhalEL")
         whenever(mockedOrder.id).thenReturn(ORDER_ID)
 
-        whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(true)
+        whenever(paymentCollectibilityChecker.isCollectable(any(), any())).thenReturn(true)
         whenever(selectedSite.get()).thenReturn(siteModel)
         whenever(wooStore.getStoreCountryCode(any())).thenReturn("US")
         whenever(appPrefs.getCardReaderStatementDescriptor(anyOrNull(), anyOrNull(), anyOrNull()))
@@ -429,7 +429,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
     @Test
     fun `when payment not collectable, then error event emitted and flow terminated`() =
         testBlocking {
-            whenever(paymentCollectibilityChecker.isCollectable(any())).thenReturn(false)
+            whenever(paymentCollectibilityChecker.isCollectable(any(), any())).thenReturn(false)
             val events = mutableListOf<CardReaderPaymentEvent>()
             val job = launch {
                 controller.event.collect {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
@@ -313,12 +313,28 @@ class WooPosBookingViewStateMapperTest {
     }
 
     @Test
-    fun `given cancelled booking, when mapped to details, then collectPaymentLabel is null`() = runTest {
+    fun `given cancelled unpaid booking, when mapped to details, then collectPaymentLabel is shown`() = runTest {
+        // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Cancelled)
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
 
+        // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
 
+        // THEN
+        assertThat(result.paymentSection.collectPaymentLabel).isNotNull()
+    }
+
+    @Test
+    fun `given cancelled paid booking, when mapped to details, then collectPaymentLabel is null`() = runTest {
+        // GIVEN
+        val booking = sampleBooking(status = BookingEntity.Status.Cancelled)
+        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
+
+        // WHEN
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+
+        // THEN
         assertThat(result.paymentSection.collectPaymentLabel).isNull()
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
@@ -316,7 +316,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given cancelled unpaid booking, when mapped to details, then collectPaymentLabel is shown`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Cancelled)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
+        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -54,7 +54,7 @@ class WooPosCardPaymentViewModelTest {
         on { event }.thenReturn(controllerEventFlow)
     }
     private val cardReaderPaymentControllerFactory: WooPosCardReaderPaymentControllerFactory = mock {
-        on { create(any(), any(), any()) }.thenReturn(paymentController)
+        on { create(any(), any(), any(), any()) }.thenReturn(paymentController)
     }
     private val networkStatus: WooPosNetworkStatus = mock {
         on { isConnected() }.thenReturn(true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -594,7 +594,7 @@ class WooPosTotalsViewModelTest {
 
         val mockCardReaderPaymentController: CardReaderPaymentController = mock()
         val factory: WooPosCardReaderPaymentControllerFactory = mock()
-        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
         val paymentState =
             MutableStateFlow<CardReaderPaymentOrRefundState>(
                 CardReaderPaymentState.LoadingData({})
@@ -729,7 +729,7 @@ class WooPosTotalsViewModelTest {
 
         val mockCardReaderPaymentController: CardReaderPaymentController = mock()
         val factory: WooPosCardReaderPaymentControllerFactory = mock()
-        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
         createViewModelAndSetupForSuccessfulOrderCreation(controllerFactory = factory)
 
         readerStatus.value = CardReaderStatus.Connected(mock())
@@ -747,7 +747,7 @@ class WooPosTotalsViewModelTest {
 
         val mockCardReaderPaymentController: CardReaderPaymentController = mock()
         val factory: WooPosCardReaderPaymentControllerFactory = mock()
-        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
         createViewModelAndSetupForSuccessfulOrderCreation(controllerFactory = factory)
 
         // WHEN
@@ -775,7 +775,7 @@ class WooPosTotalsViewModelTest {
             givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
-            whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+            whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
             val paymentState =
                 MutableStateFlow<CardReaderPaymentOrRefundState>(
                     CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
@@ -808,7 +808,7 @@ class WooPosTotalsViewModelTest {
             givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
-            whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+            whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
             val paymentState =
                 MutableStateFlow<CardReaderPaymentOrRefundState>(
                     CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
@@ -842,7 +842,7 @@ class WooPosTotalsViewModelTest {
             givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
-            whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+            whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
             val paymentState =
                 MutableStateFlow<CardReaderPaymentOrRefundState>(
                     CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
@@ -870,7 +870,7 @@ class WooPosTotalsViewModelTest {
             givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
-            whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+            whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
             val paymentState =
                 MutableStateFlow<CardReaderPaymentOrRefundState>(
                     CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
@@ -915,7 +915,7 @@ class WooPosTotalsViewModelTest {
             givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
-            whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+            whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
             val paymentState =
                 MutableStateFlow<CardReaderPaymentOrRefundState>(
                     CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
@@ -956,7 +956,7 @@ class WooPosTotalsViewModelTest {
             givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
-            whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+            whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
             val paymentState =
                 MutableStateFlow<CardReaderPaymentOrRefundState>(
                     CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
@@ -998,7 +998,7 @@ class WooPosTotalsViewModelTest {
         givenCardReaderConnectedAndNetworkAvailable()
         val mockCardReaderPaymentController: CardReaderPaymentController = mock()
         val factory: WooPosCardReaderPaymentControllerFactory = mock()
-        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
         val paymentState =
             MutableStateFlow<CardReaderPaymentOrRefundState>(
                 CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
@@ -1037,7 +1037,7 @@ class WooPosTotalsViewModelTest {
             givenCardReaderConnectedAndNetworkAvailable()
             val mockCardReaderPaymentController: CardReaderPaymentController = mock()
             val factory: WooPosCardReaderPaymentControllerFactory = mock()
-            whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+            whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
             val paymentState =
                 MutableStateFlow<CardReaderPaymentOrRefundState>(
                     CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
@@ -1268,7 +1268,7 @@ class WooPosTotalsViewModelTest {
         givenCardReaderConnectedAndNetworkAvailable()
         val mockCardReaderPaymentController: CardReaderPaymentController = mock()
         val factory: WooPosCardReaderPaymentControllerFactory = mock()
-        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
         val paymentState =
             MutableStateFlow<CardReaderPaymentOrRefundState>(
                 CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
@@ -1294,7 +1294,7 @@ class WooPosTotalsViewModelTest {
         givenCardReaderConnectedAndNetworkAvailable()
         val mockCardReaderPaymentController: CardReaderPaymentController = mock()
         val factory: WooPosCardReaderPaymentControllerFactory = mock()
-        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
         val paymentState =
             MutableStateFlow<CardReaderPaymentOrRefundState>(
                 CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
@@ -1320,7 +1320,7 @@ class WooPosTotalsViewModelTest {
         givenCardReaderConnectedAndNetworkAvailable()
         val mockCardReaderPaymentController: CardReaderPaymentController = mock()
         val factory: WooPosCardReaderPaymentControllerFactory = mock()
-        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
         val paymentState =
             MutableStateFlow<CardReaderPaymentOrRefundState>(
                 CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}
@@ -1345,7 +1345,7 @@ class WooPosTotalsViewModelTest {
         givenCardReaderConnectedAndNetworkAvailable()
         val mockCardReaderPaymentController: CardReaderPaymentController = mock()
         val factory: WooPosCardReaderPaymentControllerFactory = mock()
-        whenever(factory.create(any(), any(), any())).thenReturn(mockCardReaderPaymentController)
+        whenever(factory.create(any(), any(), any(), any())).thenReturn(mockCardReaderPaymentController)
         val paymentState =
             MutableStateFlow<CardReaderPaymentOrRefundState>(
                 CardReaderPaymentState.CollectingPayment.ExternalReaderCollectPaymentState("") {}


### PR DESCRIPTION
Closes WOOMOB-2225

### Description

**Cancelled bookings: show collect payment button when unpaid**

Previously, the `buildPaymentSection` method treated cancelled bookings the same as paid/complete bookings — all three statuses were grouped together to determine `isPaid = true`. This meant that the "Collect payment" button was always hidden for cancelled bookings, even when they were never actually paid.

The fix introduces `isBookingPaid()`, which checks the actual `PaymentStatus` (resolved from the order) for cancelled bookings. If the booking was paid before cancellation, `isPaid` remains true and the button stays hidden. If it was never paid (status `FAILED` or `UNPAID`), `isPaid` is false and the "Collect payment" button is shown.

**Card payment screen: standardise button layout**

Refactored the card payment screen composables (`CardPaymentSuccess`, `CardPaymentReaderDisconnected`, `CardPaymentFailed`) to use a consistent layout pattern: content is vertically centered with weighted spacers, and buttons are bottom-aligned with uniform sizing (604dp width, 80dp height). Replaced `ConstraintLayout` in the success state and nested `Box`/`Column` in the disconnected state with simpler `Column`-based layouts. Added compose previews for the main screen states.

### Test Steps

1. Open POS Bookings
2. Select a cancelled booking that was **not paid** -> verify the "Collect payment" button is visible
3. Select a cancelled booking that was **paid** -> verify the "Collect payment" button is hidden
4. Verify the attendance section is still hidden for cancelled bookings
5. Tap "Collect payment" on a cancelled unpaid booking -> verify the card payment screen shows buttons aligned to the bottom with consistent sizing

<img width="621" height="387" alt="image" src="https://github.com/user-attachments/assets/b30b44bc-d2ad-4a14-b414-5a426b46ca43" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.