### PR TITLE
Fix WebView having 0 height in WCWebView composable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/web/WCWebView.kt
@@ -7,6 +7,7 @@ import android.widget.FrameLayout
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.CircularProgressIndicator
@@ -151,6 +152,7 @@ fun WCWebView(
                 }
             },
             modifier = Modifier
+                .fillMaxSize()
                 .alpha(webViewAlpha)
         )
 


### PR DESCRIPTION
Closes: WOOMOB-2251

### Description
The cause of the issue is that the `AndroidView` hosting the `WebView` inside `WCWebView` does end up with 0 height, I don't have an explanation on why this is happening now and not before. The fix I applied is forcing the `AndroidView` to `fillMaxSize` of the `Box` container.

### Test Steps
1. Use a CIAB site.
2. Open a bookable product.
3. Verify the WebView fills the available space and content is visible
4. Test with both authenticated and non-authenticated WebView screens

### Images/gif

https://github.com/user-attachments/assets/2ab8b995-8c80-4b38-af0b-76e216718b53

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.