### PR TITLE
[CIAB: POS] Make collect payment button sticky in POS booking details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -79,7 +79,8 @@ fun WooPosBookingDetails(
                 .padding(
                     start = WooPosSpacing.Medium.value,
                     end = WooPosSpacing.Medium.value,
-                    bottom = 92.dp + WooPosSpacing.Large.value)
+                    bottom = 92.dp + WooPosSpacing.Large.value
+                )
         ) {
             BookingHeader(details = details, onUIEvent = onUIEvent)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -63,49 +64,88 @@ fun WooPosBookingDetails(
     details: WooPosBookingsState.BookingDetailsViewState,
     onUIEvent: (WooPosBookingsUIEvent) -> Unit
 ) {
-    Column(
+    val hasCollectButton = details.paymentSection.collectPaymentLabel != null
+    val scrollState = rememberScrollState()
+
+    Box(
         modifier = modifier
             .fillMaxSize()
             .statusBarsPadding()
-            .verticalScroll(rememberScrollState())
-            .padding(
-                start = WooPosSpacing.Medium.value,
-                end = WooPosSpacing.Medium.value,
-                bottom = WooPosSpacing.Large.value
-            )
     ) {
-        BookingHeader(details = details, onUIEvent = onUIEvent)
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(
+                    start = WooPosSpacing.Medium.value,
+                    end = WooPosSpacing.Medium.value,
+                    bottom = 92.dp + WooPosSpacing.Large.value)
+        ) {
+            BookingHeader(details = details, onUIEvent = onUIEvent)
 
-        Spacer(Modifier.height(WooPosSpacing.Large.value))
-
-        BookingDetailsCard(details = details)
-
-        details.customerSection?.let { section ->
-            Spacer(Modifier.height(WooPosSpacing.Medium.value))
-            BookingCustomerCard(customerSection = section, onUIEvent = onUIEvent)
-        }
-
-        details.attendanceSection?.let { section ->
             Spacer(Modifier.height(WooPosSpacing.Large.value))
-            BookingAttendanceSection(attendanceSection = section, onUIEvent = onUIEvent)
-        }
 
-        Spacer(Modifier.height(WooPosSpacing.Large.value))
+            BookingDetailsCard(details = details)
 
-        BookingPaymentCard(paymentSection = details.paymentSection)
+            details.customerSection?.let { section ->
+                Spacer(Modifier.height(WooPosSpacing.Medium.value))
+                BookingCustomerCard(customerSection = section, onUIEvent = onUIEvent)
+            }
 
-        details.paymentSection.collectPaymentLabel?.let { label ->
+            details.attendanceSection?.let { section ->
+                Spacer(Modifier.height(WooPosSpacing.Large.value))
+                BookingAttendanceSection(attendanceSection = section, onUIEvent = onUIEvent)
+            }
+
             Spacer(Modifier.height(WooPosSpacing.Large.value))
-            WooPosButton(
-                text = stringResource(R.string.woopos_bookings_details_collect_payment, label),
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { onUIEvent(WooPosBookingsUIEvent.CollectPaymentClicked) }
-            )
+
+            BookingPaymentCard(paymentSection = details.paymentSection)
+
+            Spacer(Modifier.height(WooPosSpacing.Large.value))
+
+            BookingNoteSection(bookingNote = details.bookingNote, onUIEvent = onUIEvent)
         }
 
-        Spacer(Modifier.height(WooPosSpacing.Large.value))
+        if (hasCollectButton) {
+            val panelFadeDistance = WooPosSpacing.Huge.value.value
+            val panelAlpha by remember {
+                derivedStateOf {
+                    val maxScroll = scrollState.maxValue
+                    if (maxScroll == 0) return@derivedStateOf 0f
+                    val distanceFromBottom = maxScroll - scrollState.value
+                    (distanceFromBottom / panelFadeDistance).coerceIn(0f, 1f)
+                }
+            }
 
-        BookingNoteSection(bookingNote = details.bookingNote, onUIEvent = onUIEvent)
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .background(
+                        MaterialTheme.colorScheme.surfaceContainerLowest.copy(alpha = panelAlpha)
+                    )
+            ) {
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = panelAlpha),
+                    thickness = 0.5.dp,
+                )
+                WooPosButton(
+                    text = stringResource(
+                        R.string.woopos_bookings_details_collect_payment,
+                        details.paymentSection.collectPaymentLabel
+                    ),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            top = WooPosSpacing.Medium.value,
+                            bottom = WooPosSpacing.Large.value,
+                            start = WooPosSpacing.Medium.value,
+                            end = WooPosSpacing.Medium.value,
+                        ),
+                    onClick = { onUIEvent(WooPosBookingsUIEvent.CollectPaymentClicked) }
+                )
+            }
+        }
     }
 }
 
@@ -529,6 +569,7 @@ private fun BookingOverflowMenu(
                                 stringResource(R.string.woopos_orders_email_receipt) to
                                     MaterialTheme.colorScheme.onSurface
                             }
+
                             is WooPosBookingsState.BookingAction.CancelBooking -> {
                                 stringResource(R.string.woopos_bookings_cancel_menu_item) to
                                     MaterialTheme.colorScheme.error


### PR DESCRIPTION
Closes: WOOMOB-2223

### Description

Makes the "Collect payment" button in POS booking details sticky at the bottom of the screen. The button now floats on a white panel with a top divider so it's always visible regardless of scroll position. As the user scrolls to the bottom, the panel background and divider fade out smoothly.

### Test Steps

1. Open POS bookings and select an unpaid booking
2. Scroll through the booking details — the collect payment button should stay fixed at the bottom on a white panel with a divider
3. Scroll all the way to the bottom — the white panel and divider should fade out
4. Verify the button works correctly when tapped


https://github.com/user-attachments/assets/0230e526-1fec-4c84-b5aa-22a1a88043fc



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.