### PR TITLE
[Login] Handle suspicious emails at the password step

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordFragment.kt
@@ -31,7 +31,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.LaunchUrlInChromeTab
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.login.MagicLinkFallbackButton
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -102,8 +101,8 @@ class WPComLoginPasswordFragment : BaseFragment() {
                 .actionWPComLoginPasswordFragmentToWPComLoginMagicLinkRequestFragment(
                     emailOrUsername = event.emailOrUsername,
                     wpComLoginMode = event.wpComLoginMode,
-                    fallbackButton = MagicLinkFallbackButton.Password,
-                    requestAtStart = true,
+                    fallbackButton = event.magicLinkFallbackButton,
+                    requestAtStart = event.requestAtStart,
                     isNewWpComAccount = false
                 )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType
+import org.wordpress.android.login.MagicLinkFallbackButton
 import javax.inject.Inject
 
 @HiltViewModel
@@ -95,7 +96,9 @@ class WPComLoginPasswordViewModel @Inject constructor(
         triggerEvent(
             ShowMagicLinkScreen(
                 emailOrUsername = navArgs.emailOrUsername,
-                wpComLoginMode = navArgs.wpComLoginMode
+                wpComLoginMode = navArgs.wpComLoginMode,
+                magicLinkFallbackButton = MagicLinkFallbackButton.Password,
+                requestAtStart = true
             )
         )
     }
@@ -131,6 +134,17 @@ class WPComLoginPasswordViewModel @Inject constructor(
                     AuthenticationErrorType.INCORRECT_USERNAME_OR_PASSWORD,
                     AuthenticationErrorType.NOT_AUTHENTICATED -> {
                         errorMessage.value = R.string.password_incorrect
+                    }
+
+                    AuthenticationErrorType.EMAIL_LOGIN_NOT_ALLOWED -> {
+                        triggerEvent(
+                            ShowMagicLinkScreen(
+                                emailOrUsername = navArgs.emailOrUsername,
+                                wpComLoginMode = navArgs.wpComLoginMode,
+                                magicLinkFallbackButton = MagicLinkFallbackButton.UsernameAndPassword,
+                                requestAtStart = false
+                            )
+                        )
                     }
 
                     else -> {
@@ -191,6 +205,8 @@ class WPComLoginPasswordViewModel @Inject constructor(
 
     data class ShowMagicLinkScreen(
         val emailOrUsername: String,
-        val wpComLoginMode: WPComLoginMode
+        val wpComLoginMode: WPComLoginMode,
+        val magicLinkFallbackButton: MagicLinkFallbackButton,
+        val requestAtStart: Boolean
     ) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModelTest.kt
@@ -1,0 +1,90 @@
+package com.woocommerce.android.ui.login.wpcom
+
+import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.JetpackConnectionStatus
+import com.woocommerce.android.model.JetpackSiteRegistrationStatus
+import com.woocommerce.android.model.JetpackStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.ui.login.WPComLoginRepository
+import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
+import com.woocommerce.android.ui.login.wpcom.WPComLoginPasswordViewModel.ShowMagicLinkScreen
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationError
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType
+import org.wordpress.android.login.MagicLinkFallbackButton
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WPComLoginPasswordViewModelTest : BaseUnitTest() {
+    companion object {
+        const val EMAIL = "user@example.com"
+        const val PASSWORD = "password123"
+        val JETPACK_STATUS = JetpackStatus(
+            isJetpackInstalled = true,
+            jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                siteRegistrationStatus = JetpackSiteRegistrationStatus.REGISTERED,
+                blogId = 1
+            )
+        )
+    }
+
+    private val savedStateHandle = WPComLoginPasswordFragmentArgs(
+        wpComLoginMode = WPComLoginMode.JetpackSetup(JETPACK_STATUS),
+        emailOrUsername = EMAIL
+    ).toSavedStateHandle()
+    private val wpComLoginRepository: WPComLoginRepository = mock()
+    private val accountRepository: AccountRepository = mock()
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val resourceProvider: ResourceProvider = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val jetpackActivationRepository: JetpackActivationRepository = mock()
+
+    private lateinit var viewModel: WPComLoginPasswordViewModel
+
+    private fun setup() {
+        savedStateHandle["password"] = PASSWORD
+        viewModel = WPComLoginPasswordViewModel(
+            savedStateHandle = savedStateHandle,
+            selectedSite = selectedSite,
+            jetpackAccountRepository = jetpackActivationRepository,
+            wpComLoginRepository = wpComLoginRepository,
+            accountRepository = accountRepository,
+            resourceProvider = resourceProvider,
+            analyticsTrackerWrapper = analyticsTrackerWrapper
+        )
+    }
+
+    @Test
+    fun `given email login not allowed, when onContinueClick, then show magic link screen with UsernameAndPassword fallback`() =
+        testBlocking {
+            setup()
+            whenever(wpComLoginRepository.login(EMAIL, PASSWORD)).thenReturn(
+                Result.failure(
+                    OnChangedException(
+                        AuthenticationError(AuthenticationErrorType.EMAIL_LOGIN_NOT_ALLOWED, "")
+                    )
+                )
+            )
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onContinueClick()
+            }.last()
+
+            assertThat(event).isEqualTo(
+                ShowMagicLinkScreen(
+                    emailOrUsername = EMAIL,
+                    wpComLoginMode = WPComLoginMode.JetpackSetup(JETPACK_STATUS),
+                    magicLinkFallbackButton = MagicLinkFallbackButton.UsernameAndPassword,
+                    requestAtStart = false
+                )
+            )
+        }
+}

--- a/libs/login/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/libs/login/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -34,8 +34,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AutoForeground;
 import org.wordpress.android.util.NetworkUtils;
-import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.ToastUtils.Duration;
 
 import java.util.ArrayList;
 
@@ -404,11 +402,13 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
                 break;
             case FAILURE_USE_WPCOM_USERNAME_INSTEAD_OF_EMAIL:
                 onLoginFinished(false);
-                mLoginListener.loginViaWpcomUsernameInstead();
-                ToastUtils.showToast(getContext(), R.string.error_user_username_instead_of_email, Duration.LONG);
-
-                mAnalyticsListener.trackFailure(loginState.getStep().name());
-                // consume the state so we don't re-redirect to username login if user backs up
+                mAnalyticsListener.trackFailure("Login with username required");
+                if (mLoginListener != null) {
+                    mLoginListener.useMagicLinkInstead(mEmailAddress,
+                            false,
+                            false,
+                            MagicLinkFallbackButton.UsernameAndPassword);
+                }
                 LoginWpcomService.clearLoginServiceState();
                 break;
             case FAILURE:


### PR DESCRIPTION
WOOMOB-2174

### Description
The `/token` endpoint now also might return the `email_login_not_allowed` error. Previously we were handling the error only for the email step, this PR adds handling for the password step:

- Main Login Flow: Updates `LoginEmailPasswordFragment` to handle the error following the same pattern we use for `LoginEmailFragment`.
- Jetpack Setup/PN login flow: Updates `WPComLoginPasswordViewModel` following the same pattern we use  in `WPComLoginEmailViewModel`.

### Test Steps
#### Preparation
Open the APIFaker from developer options and import the following config:
<details>
<summary>Config</summary>

```
[
  {
    "request": {
      "id": 0,
      "path": "/oauth2/token",
      "queryParameters": [],
      "type": {
        "type": "wp-com"
      }
    },
    "response": {
      "body": "{\n        \"error\": \"email_login_not_allowed\",\n        \"message\": \"Please log in using your WordPress.com username instead of your email address.\"\n}\n",
      "endpointId": 0,
      "statusCode": 403
    }
  }
]
```

</details>

#### Main Login Flow
1. Logout from the app.
2. Login using WordPress.com
3. Confirm that after enterring the password, the app shows the magic link screen correctly.

#### Jetpack login flow
1. Sign in using site credentials.
2. Start Jetpack Setup flow.
3. Confirm that after entering WordPress.com password the app shows the magic link screen correctly.

</details>

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.