### PR TITLE
[CIAB:POS] Fix bookings pagination and polish loading indicator

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -29,7 +29,8 @@ class BookingListHandler @Inject constructor(
 
     private val mutex = Mutex()
     private var page = MutableStateFlow(1)
-    private val canLoadMore = AtomicBoolean(false)
+    private val _canLoadMore = AtomicBoolean(false)
+    val hasMorePages: Boolean get() = _canLoadMore.get()
 
     private val searchQuery = MutableStateFlow<String?>(null)
     private val filters = MutableStateFlow(BookingFilters.EMPTY)
@@ -62,7 +63,7 @@ class BookingListHandler @Inject constructor(
     ): Result<Unit> = mutex.withLock {
         // Reset pagination attributes
         page.value = 1
-        canLoadMore.set(true)
+        _canLoadMore.set(true)
 
         val previousQuery = this.searchQuery.value
         this.searchQuery.value = searchQuery
@@ -87,7 +88,7 @@ class BookingListHandler @Inject constructor(
     }
 
     suspend fun loadMore(): Result<Unit> = mutex.withLock {
-        if (!canLoadMore.get()) return@withLock Result.success(Unit)
+        if (!_canLoadMore.get()) return@withLock Result.success(Unit)
         return fetchBookings()
     }
 
@@ -102,7 +103,7 @@ class BookingListHandler @Inject constructor(
             filters = filters.value,
             order = order
         ).onSuccess { result ->
-            canLoadMore.set(result.hasMorePages)
+            _canLoadMore.set(result.hasMorePages)
             if (result.hasMorePages) {
                 page.update { it + 1 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsLoadingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsLoadingScreen.kt
@@ -109,7 +109,7 @@ private fun ShimmerBadge(text: String) {
     WooPosShimmerBox(
         modifier = Modifier
             .width(textWidth + WooPosSpacing.Small.value * 2)
-            .height(textHeight + WooPosSpacing.XSmall.value * 2)
+            .height(textHeight + WooPosSpacing.XXSmall.value * 2)
             .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsLoadingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsLoadingScreen.kt
@@ -11,24 +11,26 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.rememberTextMeasurer
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
@@ -57,50 +59,59 @@ fun WooPosBookingsLoadingScreen(modifier: Modifier = Modifier) {
 
 @Composable
 fun WooPosBookingsBookingLoadingRow() {
-    WooPosCard(shadowType = ShadowType.Soft) {
-        Row(
+    WooPosCard(
+        modifier = Modifier.wrapContentHeight(),
+        shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
+        backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        elevation = WooPosElevation.Medium,
+        shadowType = ShadowType.Soft,
+    ) {
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(MaterialTheme.shapes.medium)
-                .background(MaterialTheme.colorScheme.surfaceContainerLowest)
-                .padding(
-                    horizontal = WooPosSpacing.Medium.value,
-                    vertical = WooPosSpacing.Medium.value
-                )
-                .heightIn(min = 64.dp),
-            verticalAlignment = Alignment.Top
+                .padding(WooPosSpacing.Medium.value),
         ) {
-            Column(verticalArrangement = Arrangement.spacedBy(WooPosSpacing.XSmall.value)) {
-                WooPosShimmerText(
-                    text = "Booking #123",
-                    style = WooPosTypography.BodySmall.style,
-                    fontWeight = FontWeight.Bold
-                )
-                WooPosShimmerText(
-                    text = "January 1, 2024 at 12:00 PM",
-                    style = WooPosTypography.BodySmall.style
-                )
-                WooPosShimmerText(
-                    text = "customer@example.com",
-                    style = WooPosTypography.BodySmall.style
-                )
-                Spacer(Modifier.height(WooPosSpacing.XSmall.value))
-                WooPosShimmerBox(
-                    modifier = Modifier
-                        .fillMaxWidth(0.2f)
-                        .height(16.dp)
-                        .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
-                )
-            }
+            WooPosShimmerText(
+                text = "3:00-4:00 PM",
+                style = WooPosTypography.BodySmall.style,
+                fontWeight = FontWeight.Bold
+            )
 
-            Spacer(Modifier.weight(1f))
+            Spacer(Modifier.height(WooPosSpacing.XSmall.value))
 
             WooPosShimmerText(
-                text = "$100.00",
+                text = "Precision Haircut \u00B7 Customer",
                 style = WooPosTypography.BodySmall.style
             )
+
+            Spacer(Modifier.height(WooPosSpacing.Small.value))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.XSmall.value),
+            ) {
+                ShimmerBadge("Unattended")
+                ShimmerBadge("Paid")
+            }
         }
     }
+}
+
+@Composable
+private fun ShimmerBadge(text: String) {
+    val textMeasurer = rememberTextMeasurer()
+    val density = LocalDensity.current
+    val measured = textMeasurer.measure(
+        text = text,
+        style = WooPosTypography.Caption.style
+    )
+    val textWidth = with(density) { measured.size.width.toDp() }
+    val textHeight = with(density) { measured.size.height.toDp() }
+    WooPosShimmerBox(
+        modifier = Modifier
+            .width(textWidth + WooPosSpacing.Small.value * 2)
+            .height(textHeight + WooPosSpacing.XSmall.value * 2)
+            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
+    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -121,7 +121,8 @@ class WooPosBookingsViewModel @Inject constructor(
 
                 val currentContentState = _state.value as? WooPosBookingsState.Content
                 val paginationState = when (currentContentState?.paginationState) {
-                    WooPosPaginationState.Loading -> WooPosPaginationState.None
+                    WooPosPaginationState.Loading,
+                    WooPosPaginationState.Error -> WooPosPaginationState.None
                     else -> currentContentState?.paginationState ?: WooPosPaginationState.None
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -186,10 +186,12 @@ class WooPosBookingsViewModel @Inject constructor(
         if (loadMoreJob?.isActive == true) return
         val currentState = _state.value as? WooPosBookingsState.Content ?: return
         if (currentState.paginationState is WooPosPaginationState.Error) return
+        if (!bookingListHandler.hasMorePages) return
 
         loadMoreJob = viewModelScope.launch {
             fetchJob?.join()
 
+            if (!bookingListHandler.hasMorePages) return@launch
             val currentState = _state.value as? WooPosBookingsState.Content ?: return@launch
             _state.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -119,12 +119,19 @@ class WooPosBookingsViewModel @Inject constructor(
                     items.entries.find { it.key.id == id }?.value
                 }
 
+                val currentContentState = _state.value as? WooPosBookingsState.Content
+                val paginationState = when (currentContentState?.paginationState) {
+                    WooPosPaginationState.Loading -> WooPosPaginationState.None
+                    else -> currentContentState?.paginationState ?: WooPosPaginationState.None
+                }
+
                 _state.value = WooPosBookingsState.Content(
                     items = WooPosBookingsState.Content.Items.Loaded(items),
                     pullToRefreshState = WooPosPullToRefreshState.Enabled,
                     selectedDetails = selectedDetails,
-                    paginationState = WooPosPaginationState.None,
-                    dialogState = WooPosBookingsState.Content.DialogState.Hidden
+                    paginationState = paginationState,
+                    dialogState = currentContentState?.dialogState
+                        ?: WooPosBookingsState.Content.DialogState.Hidden
                 )
             }
         }
@@ -187,10 +194,6 @@ class WooPosBookingsViewModel @Inject constructor(
             _state.value = currentState.copy(paginationState = WooPosPaginationState.Loading)
 
             bookingListHandler.loadMore()
-                .onSuccess {
-                    val updated = _state.value as? WooPosBookingsState.Content ?: return@launch
-                    _state.value = updated.copy(paginationState = WooPosPaginationState.None)
-                }
                 .onFailure {
                     val updated = _state.value as? WooPosBookingsState.Content ?: return@launch
                     _state.value = updated.copy(
@@ -213,10 +216,6 @@ class WooPosBookingsViewModel @Inject constructor(
             }
 
             result
-                .onSuccess {
-                    val updated = _state.value as? WooPosBookingsState.Content ?: return@launch
-                    _state.value = updated.copy(paginationState = WooPosPaginationState.None)
-                }
                 .onFailure {
                     val updated = _state.value as? WooPosBookingsState.Content ?: return@launch
                     _state.value = updated.copy(paginationState = WooPosPaginationState.Error)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
@@ -143,12 +143,6 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
 
     private val toolbarMenuItems by lazy {
         buildList {
-            add(
-                WooPosHomeFloatingToolbarState.Menu.MenuItem(
-                    title = R.string.woopos_orders_title,
-                    icon = R.drawable.ic_description_filled_24dp,
-                )
-            )
             if (isPosBookingsEnabled()) {
                 add(
                     WooPosHomeFloatingToolbarState.Menu.MenuItem(
@@ -157,6 +151,12 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
                     )
                 )
             }
+            add(
+                WooPosHomeFloatingToolbarState.Menu.MenuItem(
+                    title = R.string.woopos_orders_title,
+                    icon = R.drawable.ic_description_filled_24dp,
+                )
+            )
             add(
                 WooPosHomeFloatingToolbarState.Menu.MenuItem(
                     title = R.string.woopos_settings_title,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
@@ -285,6 +285,7 @@ class WooPosBookingViewStateMapperTest {
         runTest {
             // GIVEN
             val booking = sampleBooking(id = 42L)
+            whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
 
             // WHEN
             val result = mapper.mapToDetailsViewState(booking, resourceName = null)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -374,11 +374,20 @@ class WooPosBookingsViewModelTest {
     @Test
     fun `given content state, when onEndOfBookingsListReached succeeds, then paginationState is None`() = runTest {
         // GIVEN
+        val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
+        whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
+
         viewModel = createViewModel()
+        advanceUntilIdle()
+
+        bookingsFlow.emit(listOf(booking(1), booking(2)))
         advanceUntilIdle()
 
         // WHEN
         viewModel.onEndOfBookingsListReached()
+        advanceUntilIdle()
+
+        bookingsFlow.emit(listOf(booking(1), booking(2), booking(3)))
         advanceUntilIdle()
 
         // THEN
@@ -428,7 +437,13 @@ class WooPosBookingsViewModelTest {
     @Test
     fun `given pagination error, when onPaginationErrorTryAgain succeeds, then paginationState is None`() = runTest {
         // GIVEN
+        val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
+        whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
+
         viewModel = createViewModel()
+        advanceUntilIdle()
+
+        bookingsFlow.emit(listOf(booking(1), booking(2)))
         advanceUntilIdle()
 
         whenever(bookingListHandler.loadMore()).thenReturn(Result.failure(RuntimeException("error")))
@@ -439,6 +454,9 @@ class WooPosBookingsViewModelTest {
 
         // WHEN
         viewModel.onPaginationErrorTryAgain()
+        advanceUntilIdle()
+
+        bookingsFlow.emit(listOf(booking(1), booking(2), booking(3)))
         advanceUntilIdle()
 
         // THEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -151,6 +151,7 @@ class WooPosBookingsViewModelTest {
             bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest)
         ).thenReturn(Result.success(Unit))
         whenever(bookingListHandler.loadMore()).thenReturn(Result.success(Unit))
+        whenever(bookingListHandler.hasMorePages).thenReturn(true)
         whenever(dateTimeProvider.now()).thenReturn(0L)
         whenever(paymentStatusResolver.resolve(any(), anyOrNull())).thenReturn(PaymentStatus.UNPAID)
     }


### PR DESCRIPTION
Closes: WOOMOB-2268

### Description

Fixes the bookings list pagination behavior where loading the next page caused a visual jump — the loading indicator disappeared before new items arrived, making the list scroll to the bottom with new items off-screen.

**Changes:**
- Fix the race condition between two state update paths during pagination. Now `observeBookings` flow handles clearing the loading state together with new items in a single state update, instead of `.onSuccess` clearing it prematurely
- Prevent showing the loading indicator when there are no more pages to load by exposing `hasMorePages` from `BookingListHandler`
- Redesign the pagination loading row to match the actual booking list item layout (time range, subtitle, badges) instead of the old order-style layout
- Move bookings above orders in the home screen menu

### Test Steps

1. Open POS and navigate to bookings (should be first in the menu now)
2. Scroll down the bookings list until a new page loads
3. Verify the loading indicator matches the booking item design (shimmer with time range, subtitle, and two badges)
4. Verify new items appear smoothly without the list jumping to the bottom
5. Scroll to the very end of the list — verify no stuck loading indicator when all pages are loaded


https://github.com/user-attachments/assets/f491384f-9feb-4ec1-9184-bd9750e676e1


- [ч] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.