### PR TITLE
[WOOMOB-2273] Refactor WooPos orders screen to separate single order and orders list views

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -146,18 +146,24 @@ private fun WooPosOrdersScreen(
             .fillMaxSize()
     ) {
         when (state) {
-            is WooPosOrdersState.Content -> OrdersContent(
-                state = state,
-                isSingleOrderMode = isSingleOrderMode,
-                scrollToTopEvent = scrollToTopEvent,
-                onRefresh = onRefresh,
-                onOrderSelected = onOrderSelected,
-                onEndOfOrdersListReached = onEndOfOrdersListReached,
-                onPaginationErrorTryAgain = onPaginationErrorTryAgain,
-                onSearchEvent = onSearchEvent,
-                onSearchErrorRetry = onSearchErrorRetry,
-                onUIEvent = onUIEvent
-            )
+            is WooPosOrdersState.Content -> if (isSingleOrderMode) {
+                SingleOrderDetails(
+                    state = state,
+                    onUIEvent = onUIEvent
+                )
+            } else {
+                OrdersListWithDetails(
+                    state = state,
+                    scrollToTopEvent = scrollToTopEvent,
+                    onRefresh = onRefresh,
+                    onOrderSelected = onOrderSelected,
+                    onEndOfOrdersListReached = onEndOfOrdersListReached,
+                    onPaginationErrorTryAgain = onPaginationErrorTryAgain,
+                    onSearchEvent = onSearchEvent,
+                    onSearchErrorRetry = onSearchErrorRetry,
+                    onUIEvent = onUIEvent
+                )
+            }
 
             is WooPosOrdersState.Empty -> OrdersEmpty(
                 onActionClicked = onOrdersEmptyActionClicked,
@@ -221,9 +227,50 @@ private fun WooPosOrdersScreen(
 }
 
 @Composable
-private fun OrdersContent(
+private fun OrderDetailsPane(
     state: WooPosOrdersState.Content,
-    isSingleOrderMode: Boolean = false,
+    onUIEvent: (WooPosOrdersUIEvent) -> Unit,
+    modifier: Modifier = Modifier,
+    showOrderNumber: Boolean = true,
+) {
+    Box(modifier = modifier.background(MaterialTheme.colorScheme.surface)) {
+        when {
+            state.selectedDetails != null -> {
+                WooPosOrderDetails(
+                    modifier = Modifier.fillMaxHeight(),
+                    details = state.selectedDetails,
+                    showOrderNumber = showOrderNumber,
+                    onUIEvent = onUIEvent
+                )
+            }
+            state.items is WooPosOrdersState.Content.Items.Searching -> {
+                OrderDetailsLoadingPane(
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .padding(
+                            start = WooPosSpacing.Medium.value,
+                            end = WooPosSpacing.Medium.value,
+                            top = WooPosSpacing.XLarge.value,
+                            bottom = WooPosSpacing.XLarge.value
+                        )
+                )
+            }
+            else -> {
+                WooPosEmptyScreen(
+                    modifier = Modifier.fillMaxSize(),
+                    icon = WooPosIcons.OrdersEmpty,
+                    title = stringResource(R.string.woopos_orders_no_order_selected),
+                    message = "",
+                    contentDescription = stringResource(R.string.woopos_orders_empty_list_image_description)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OrdersListWithDetails(
+    state: WooPosOrdersState.Content,
     scrollToTopEvent: SharedFlow<Unit>,
     onRefresh: () -> Unit,
     onOrderSelected: (Long) -> Unit,
@@ -234,63 +281,41 @@ private fun OrdersContent(
     onUIEvent: (WooPosOrdersUIEvent) -> Unit
 ) {
     Row(modifier = Modifier.fillMaxSize()) {
-        if (!isSingleOrderMode) {
-            OrdersListPane(
-                state = state,
-                scrollToTopEvent = scrollToTopEvent,
-                onRefresh = onRefresh,
-                isRefreshing = state.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
-                onOrderSelected = onOrderSelected,
-                onEndOfOrdersListReached = onEndOfOrdersListReached,
-                onPaginationErrorTryAgain = onPaginationErrorTryAgain,
-                onSearchEvent = onSearchEvent,
-                onSearchErrorRetry = onSearchErrorRetry,
-                modifier = Modifier
-                    .weight(0.3f)
-                    .fillMaxHeight()
-                    .background(MaterialTheme.colorScheme.surfaceBright)
-            )
-        }
-
-        Box(
+        OrdersListPane(
+            state = state,
+            scrollToTopEvent = scrollToTopEvent,
+            onRefresh = onRefresh,
+            isRefreshing = state.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
+            onOrderSelected = onOrderSelected,
+            onEndOfOrdersListReached = onEndOfOrdersListReached,
+            onPaginationErrorTryAgain = onPaginationErrorTryAgain,
+            onSearchEvent = onSearchEvent,
+            onSearchErrorRetry = onSearchErrorRetry,
             modifier = Modifier
-                .weight(if (isSingleOrderMode) 1f else 0.7f)
-                .background(MaterialTheme.colorScheme.surface)
-        ) {
-            when {
-                state.selectedDetails != null -> {
-                    WooPosOrderDetails(
-                        modifier = Modifier
-                            .fillMaxHeight(),
-                        details = state.selectedDetails,
-                        showOrderNumber = !isSingleOrderMode,
-                        onUIEvent = onUIEvent
-                    )
-                }
-                state.items is WooPosOrdersState.Content.Items.Searching -> {
-                    OrderDetailsLoadingPane(
-                        modifier = Modifier
-                            .fillMaxHeight()
-                            .padding(
-                                start = WooPosSpacing.Medium.value,
-                                end = WooPosSpacing.Medium.value,
-                                top = WooPosSpacing.XLarge.value,
-                                bottom = WooPosSpacing.XLarge.value
-                            )
-                    )
-                }
-                else -> {
-                    WooPosEmptyScreen(
-                        modifier = Modifier.fillMaxSize(),
-                        icon = WooPosIcons.OrdersEmpty,
-                        title = stringResource(R.string.woopos_orders_no_order_selected),
-                        message = "",
-                        contentDescription = stringResource(R.string.woopos_orders_empty_list_image_description)
-                    )
-                }
-            }
-        }
+                .weight(0.3f)
+                .fillMaxHeight()
+                .background(MaterialTheme.colorScheme.surfaceBright)
+        )
+        OrderDetailsPane(
+            state = state,
+            onUIEvent = onUIEvent,
+            showOrderNumber = true,
+            modifier = Modifier.weight(0.7f)
+        )
     }
+}
+
+@Composable
+private fun SingleOrderDetails(
+    state: WooPosOrdersState.Content,
+    onUIEvent: (WooPosOrdersUIEvent) -> Unit
+) {
+    OrderDetailsPane(
+        state = state,
+        onUIEvent = onUIEvent,
+        showOrderNumber = false,
+        modifier = Modifier.fillMaxSize()
+    )
 }
 
 @OptIn(ExperimentalMaterialApi::class)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
@@ -285,6 +285,7 @@ class WooPosBookingViewStateMapperTest {
         runTest {
             // GIVEN
             val booking = sampleBooking(id = 42L)
+            whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
 
             // WHEN
             val result = mapper.mapToDetailsViewState(booking, resourceName = null)


### PR DESCRIPTION
Fixes WOOMOB-2273

### Description
Refactored `WooPosOrdersScreen` composable to cleanly separate the single order mode from the orders list+details mode. Previously, the `isSingleOrderMode` boolean was threaded through `OrdersContent`, which conditionally hid/showed the list pane and adjusted weights. Now the screen branches at the top level into two distinct composables (`SingleOrderDetails` and `OrdersListWithDetails`), with shared order details logic extracted into a reusable `OrderDetailsPane`.

### Test Steps
1. Open POS
2. Open Order list
3. Smoke test it
4. Go back to POS
5. Open Bookings
6. Smoke test it

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary.