### PR TITLE
[CIAB:POS][WOOMOB-2271][WOOMOB-2272] Fix POS Bookings PTR and error screen strings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -73,6 +74,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import org.wordpress.android.util.ToastUtils
 
 val WOO_POS_BOOKINGS_TOOLBAR_HEIGHT = 56.dp
 
@@ -83,9 +85,16 @@ fun WooPosBookingsScreen(
 ) {
     val viewModel: WooPosBookingsViewModel = hiltViewModel()
     val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         viewModel.navigationEvent.collect { onNavigationEvent(it) }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.toastEvent.collect { message ->
+            ToastUtils.showToast(context, message, ToastUtils.Duration.LONG)
+        }
     }
 
     val cashPaymentResult = backStackEntry.savedStateHandle

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -535,8 +535,8 @@ private fun WooPosBookingsError(
 ) {
     WooPosErrorScreen(
         modifier = modifier,
-        message = stringResource(id = R.string.woopos_orders_loading_error_title),
-        reason = stringResource(id = R.string.woopos_orders_loading_error_message),
+        message = stringResource(id = R.string.woopos_bookings_loading_error_title),
+        reason = stringResource(id = R.string.woopos_bookings_loading_error_message),
         primaryButton = WooPosErrorScreenButtonState(
             text = stringResource(id = R.string.woopos_orders_loading_error_retry_button),
             click = onRetryClicked

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -51,6 +51,9 @@ class WooPosBookingsViewModel @Inject constructor(
     private val _navigationEvent = MutableSharedFlow<WooPosNavigationEvent>()
     val navigationEvent: SharedFlow<WooPosNavigationEvent> = _navigationEvent.asSharedFlow()
 
+    private val _toastEvent = MutableSharedFlow<String>()
+    val toastEvent: SharedFlow<String> = _toastEvent.asSharedFlow()
+
     private var selectedBookingId: Long? = null
     private var fetchJob: Job? = null
     private var loadMoreJob: Job? = null
@@ -119,9 +122,14 @@ class WooPosBookingsViewModel @Inject constructor(
                     items.entries.find { it.key.id == id }?.value
                 }
 
+                val currentPTRState = (_state.value as? WooPosBookingsState.Content)
+                    ?.pullToRefreshState
+                    ?.takeIf { it == WooPosPullToRefreshState.Refreshing }
+                    ?: WooPosPullToRefreshState.Enabled
+
                 _state.value = WooPosBookingsState.Content(
                     items = WooPosBookingsState.Content.Items.Loaded(items),
-                    pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                    pullToRefreshState = currentPTRState,
                     selectedDetails = selectedDetails,
                     paginationState = WooPosPaginationState.None,
                     dialogState = WooPosBookingsState.Content.DialogState.Hidden
@@ -162,14 +170,28 @@ class WooPosBookingsViewModel @Inject constructor(
         fetchJob = viewModelScope.launch {
             bookingListHandler.loadBookings(
                 sortBy = BookingListSortOption.NewestToOldest
-            ).onFailure {
-                _state.value = when (val current = _state.value) {
-                    is WooPosBookingsState.Content -> current.copy(
+            ).onSuccess {
+                val current = _state.value
+                if (current is WooPosBookingsState.Content) {
+                    _state.value = current.copy(
                         pullToRefreshState = WooPosPullToRefreshState.Enabled
                     )
-                    else -> WooPosBookingsState.Error(
-                        message = it.message ?: "Failed to load bookings"
-                    )
+                }
+            }.onFailure {
+                when (val current = _state.value) {
+                    is WooPosBookingsState.Content -> {
+                        _state.value = current.copy(
+                            pullToRefreshState = WooPosPullToRefreshState.Enabled
+                        )
+                        _toastEvent.emit(
+                            resourceProvider.getString(R.string.woo_pos_ptr_offline_error)
+                        )
+                    }
+                    else -> {
+                        _state.value = WooPosBookingsState.Error(
+                            message = it.message ?: "Failed to load bookings"
+                        )
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.bookings.list.BookingListHandler
 import com.woocommerce.android.ui.bookings.list.BookingListSortOption
 import com.woocommerce.android.ui.woopos.cardpayment.CardPaymentSource
 import com.woocommerce.android.ui.woopos.common.util.WooPosClipboardHelper
+import com.woocommerce.android.ui.woopos.common.util.isNetworkError
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.localcatalog.DateTimeProvider
@@ -190,8 +191,13 @@ class WooPosBookingsViewModel @Inject constructor(
                         _state.value = current.copy(
                             pullToRefreshState = WooPosPullToRefreshState.Enabled
                         )
+                        val messageResId = if (it.isNetworkError()) {
+                            R.string.woo_pos_ptr_offline_error
+                        } else {
+                            R.string.something_went_wrong_try_again
+                        }
                         _toastEvent.emit(
-                            resourceProvider.getString(R.string.woo_pos_ptr_offline_error)
+                            resourceProvider.getString(messageResId)
                         )
                     }
                     else -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/util/WooPosNetworkErrorUtils.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/util/WooPosNetworkErrorUtils.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.ui.woopos.common.util
+
+import com.woocommerce.android.WooException
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+
+fun Throwable.isNetworkError(): Boolean {
+    return this is WooException &&
+        (error.type == WooErrorType.TIMEOUT || error.type == WooErrorType.NO_CONNECTION)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -3,8 +3,8 @@ package com.woocommerce.android.ui.woopos.home.items.products
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.WooException
 import com.woocommerce.android.ui.woopos.common.data.models.WooPosProductModel
+import com.woocommerce.android.ui.woopos.common.util.isNetworkError
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
@@ -33,7 +33,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import javax.inject.Inject
 
 @HiltViewModel
@@ -355,9 +354,7 @@ class WooPosProductsViewModel @Inject constructor(
 
     private fun isNetworkError(error: Any?): Boolean {
         return when (error) {
-            is WooException ->
-                error.error.type == WooErrorType.TIMEOUT ||
-                    error.error.type == WooErrorType.NO_CONNECTION
+            is Throwable -> error.isNetworkError()
             is PosLocalCatalogSyncResult.Failure.NetworkError -> true
             else -> false
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3836,7 +3836,7 @@
     <string name="woopos_orders_empty_list_image_description">No orders</string>
     <string name="woopos_orders_no_order_selected">No order selected.</string>
     <string name="woopos_orders_loading_error_title">Unable to load orders</string>
-    <string name="woopos_orders_loading_error_message">Please check your connection try again.</string>
+    <string name="woopos_orders_loading_error_message">Please check your connection and try again.</string>
     <string name="woopos_orders_loading_error_retry_button">Retry</string>
     <string name="woopos_orders_pagination_error_title">Unable to load more orders</string>
     <string name="woopos_orders_pagination_error_content_description">Please try again.</string>
@@ -3949,6 +3949,8 @@
     <string name="woopos_bookings_note_screen_hint">Type booking note</string>
     <string name="woopos_bookings_note_screen_button_save">Save</string>
     <string name="woopos_bookings_note_screen_save_error">Error saving booking note</string>
+    <string name="woopos_bookings_loading_error_title">Unable to load bookings</string>
+    <string name="woopos_bookings_loading_error_message">Please check your connection and try again.</string>
 
     <string name="woopos_cash_payment_title">Cash payment</string>
     <string name="woopos_complete_cash_order_button">Mark payment as complete</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -3808,7 +3808,7 @@
     <string name="woopos_orders_empty_list_image_description">No orders</string>
     <string name="woopos_orders_no_order_selected">No order selected.</string>
     <string name="woopos_orders_loading_error_title">Unable to load orders</string>
-    <string name="woopos_orders_loading_error_message">Please check your connection try again.</string>
+    <string name="woopos_orders_loading_error_message">Please check your connection and try again.</string>
     <string name="woopos_orders_loading_error_retry_button">Retry</string>
     <string name="woopos_orders_pagination_error_title">Unable to load more orders</string>
     <string name="woopos_orders_pagination_error_content_description">Please try again.</string>


### PR DESCRIPTION
Closes WOOMOB-2271
Closes WOOMOB-2272

### Description

**PTR spinner disappears too early (WOOMOB-2271)**

When pulling to refresh in POS Bookings, the spinner disappeared as soon as cached data emitted from Room — before the network call finished. This happened because `observeBookings()` always reset `pullToRefreshState` to `Enabled` on every emission, racing with the ongoing fetch.

Now `observeBookings()` preserves the `Refreshing` state if a refresh is in progress, and `onRefresh()` explicitly resets it when the network call completes or fails.

Also, when a refresh fails while content is displayed, a toast is now shown (same message as the Products list uses).

Note: there is still a brief visual "blink" when cached data re-emits during refresh. This is inherent to the current approach of subscribing to the Room DB flow — the flow re-emits whenever the underlying query changes. Avoiding this would require a different data layer architecture, which is out of scope for this fix.

**Error screen shows wrong text (WOOMOB-2272)**

The bookings error screen was reusing the orders error strings ("Unable to load orders"). Added bookings-specific strings ("Unable to load bookings"). Also fixed a typo in the existing orders error message — "Please check your connection try again" was missing "and".

### Test Steps

1. Open POS, navigate to Bookings
2. With bookings loaded, turn off network and pull to refresh — you should see a toast and the spinner should disappear only after the network call fails
3. To test the error screen: either clear the app data (Settings → Apps → WooCommerce → Clear Data) or delete bookings from the local DB via adb, then open Bookings with the network off — the error should say "Unable to load **bookings**" and "Please check your connection **and** try again"



https://github.com/user-attachments/assets/85a9ff42-6075-4283-9b2e-fd81f935bc32



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.