### PR TITLE
[WOOMOB-2266] Add date selector with calendar picker to POS Bookings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -27,7 +29,6 @@ import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.DatePickerDialog
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosIconButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
@@ -43,48 +44,60 @@ fun WooPosBookingsDateSelector(
 ) {
     var showDatePicker by remember { mutableStateOf(false) }
 
+    val primaryColor = MaterialTheme.colorScheme.primary
+
     Column(modifier = modifier.fillMaxWidth()) {
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
         Row(
             modifier = Modifier
-                .fillMaxWidth()
                 .padding(vertical = WooPosSpacing.XSmall.value),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center,
         ) {
-            WooPosIconButton(
-                icon = ImageVector.vectorResource(R.drawable.ic_chevron_left_24dp),
-                contentDescription = stringResource(R.string.woopos_bookings_date_selector_previous_day),
+            IconButton(
                 onClick = { onUIEvent(WooPosBookingsUIEvent.PreviousDayClicked) }
-            )
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_chevron_left_24dp),
+                    contentDescription = stringResource(R.string.woopos_bookings_date_selector_previous_day),
+                    tint = primaryColor,
+                    modifier = Modifier.size(24.dp),
+                )
+            }
 
             Row(
                 modifier = Modifier
+                    .widthIn(min = 130.dp)
                     .clickable { showDatePicker = true }
                     .padding(horizontal = WooPosSpacing.XSmall.value),
                 verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_calendar_16),
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.size(20.dp),
+                    tint = primaryColor,
+                    modifier = Modifier.size(16.dp),
                 )
                 Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
                 WooPosText(
                     text = dateSelectorState.formattedDate,
-                    style = WooPosTypography.BodyLarge,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    style = WooPosTypography.BodySmall,
+                    fontWeight = FontWeight.Normal,
+                    color = primaryColor,
                 )
             }
 
-            WooPosIconButton(
-                icon = ImageVector.vectorResource(R.drawable.ic_chevron_right_24dp),
-                contentDescription = stringResource(R.string.woopos_bookings_date_selector_next_day),
+            IconButton(
                 onClick = { onUIEvent(WooPosBookingsUIEvent.NextDayClicked) }
-            )
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_chevron_right_24dp),
+                    contentDescription = stringResource(R.string.woopos_bookings_date_selector_next_day),
+                    tint = primaryColor,
+                    modifier = Modifier.size(24.dp),
+                )
+            }
         }
 
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
@@ -1,0 +1,119 @@
+package com.woocommerce.android.ui.woopos.bookings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.DatePickerDialog
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosIconButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import java.util.Calendar
+import java.util.Date
+
+@Composable
+fun WooPosBookingsDateSelector(
+    dateSelectorState: DateSelectorState,
+    onUIEvent: (WooPosBookingsUIEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showDatePicker by remember { mutableStateOf(false) }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = WooPosSpacing.XSmall.value),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            WooPosIconButton(
+                icon = ImageVector.vectorResource(R.drawable.ic_chevron_left_24dp),
+                contentDescription = stringResource(R.string.woopos_bookings_date_selector_previous_day),
+                onClick = { onUIEvent(WooPosBookingsUIEvent.PreviousDayClicked) }
+            )
+
+            Row(
+                modifier = Modifier
+                    .clickable { showDatePicker = true }
+                    .padding(horizontal = WooPosSpacing.XSmall.value),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_calendar_16),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
+                WooPosText(
+                    text = dateSelectorState.formattedDate,
+                    style = WooPosTypography.BodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            WooPosIconButton(
+                icon = ImageVector.vectorResource(R.drawable.ic_chevron_right_24dp),
+                contentDescription = stringResource(R.string.woopos_bookings_date_selector_next_day),
+                onClick = { onUIEvent(WooPosBookingsUIEvent.NextDayClicked) }
+            )
+        }
+
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+    }
+
+    if (showDatePicker) {
+        DatePickerDialog(
+            currentDate = Date(dateSelectorState.selectedDateMillis),
+            onDateSelected = { selectedDate ->
+                showDatePicker = false
+                val calendar = Calendar.getInstance().apply { time = selectedDate }
+                calendar.set(Calendar.HOUR_OF_DAY, 12)
+                onUIEvent(WooPosBookingsUIEvent.DateSelected(calendar.timeInMillis))
+            },
+            onDismissRequest = { showDatePicker = false },
+        )
+    }
+}
+
+@WooPosPreview
+@Composable
+fun WooPosBookingsDateSelectorPreview() {
+    WooPosTheme {
+        WooPosBookingsDateSelector(
+            dateSelectorState = DateSelectorState(
+                formattedDate = "19 Feb, Wed",
+                selectedDateMillis = System.currentTimeMillis(),
+            ),
+            onUIEvent = {},
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
@@ -33,7 +33,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
-import java.util.Calendar
 import java.util.Date
 
 @Composable
@@ -108,9 +107,7 @@ fun WooPosBookingsDateSelector(
             currentDate = Date(dateSelectorState.selectedDateMillis),
             onDateSelected = { selectedDate ->
                 showDatePicker = false
-                val calendar = Calendar.getInstance().apply { time = selectedDate }
-                calendar.set(Calendar.HOUR_OF_DAY, 12)
-                onUIEvent(WooPosBookingsUIEvent.DateSelected(calendar.timeInMillis))
+                onUIEvent(WooPosBookingsUIEvent.DateSelected(selectedDate.time))
             },
             onDismissRequest = { showDatePicker = false },
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -212,6 +212,7 @@ private fun WooPosBookingsContent(
                 onBookingSelected = onBookingSelected,
                 onEndOfBookingsListReached = onEndOfBookingsListReached,
                 onPaginationErrorTryAgain = onPaginationErrorTryAgain,
+                onUIEvent = onUIEvent,
                 modifier = Modifier
                     .weight(0.3f)
                     .fillMaxHeight()
@@ -284,6 +285,7 @@ private fun WooPosBookingsListPane(
     onBookingSelected: (Long) -> Unit,
     onEndOfBookingsListReached: () -> Unit,
     onPaginationErrorTryAgain: () -> Unit,
+    onUIEvent: (WooPosBookingsUIEvent) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -296,7 +298,12 @@ private fun WooPosBookingsListPane(
                 .heightIn(min = WOO_POS_BOOKINGS_TOOLBAR_HEIGHT),
         )
 
-        Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
+        state.dateSelectorState?.let { dateSelectorState ->
+            WooPosBookingsDateSelector(
+                dateSelectorState = dateSelectorState,
+                onUIEvent = onUIEvent,
+            )
+        }
 
         val pullRefreshState = rememberPullRefreshState(
             refreshing = isRefreshing,
@@ -592,6 +599,10 @@ fun WooPosBookingsScreenPreview() {
                     )
                 ),
                 pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                dateSelectorState = DateSelectorState(
+                    formattedDate = "19 Feb, Wed",
+                    selectedDateMillis = System.currentTimeMillis(),
+                ),
                 selectedDetails = details1,
                 paginationState = WooPosPaginationState.None,
                 dialogState = WooPosBookingsState.Content.DialogState.Hidden
@@ -622,6 +633,10 @@ fun WooPosBookingsNothingFoundStatePreview() {
                     message = stringResource(R.string.woopos_search_orders_empty_description)
                 ),
                 pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                dateSelectorState = DateSelectorState(
+                    formattedDate = "19 Feb, Wed",
+                    selectedDateMillis = System.currentTimeMillis(),
+                ),
                 selectedDetails = details,
                 paginationState = WooPosPaginationState.None,
                 dialogState = WooPosBookingsState.Content.DialogState.Hidden

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -325,6 +325,7 @@ private fun WooPosBookingsListPane(
                 onBookingSelected = onBookingSelected,
                 onEndOfBookingsListReached = onEndOfBookingsListReached,
                 onPaginationErrorTryAgain = onPaginationErrorTryAgain,
+                onRetry = onRefresh,
             )
 
             PullRefreshIndicator(
@@ -348,6 +349,7 @@ private fun WooPosBookingsList(
     onBookingSelected: (Long) -> Unit,
     onEndOfBookingsListReached: () -> Unit,
     onPaginationErrorTryAgain: () -> Unit,
+    onRetry: () -> Unit,
 ) {
     when (val items = state.items) {
         is WooPosBookingsState.Content.Items.Loaded -> {
@@ -382,7 +384,7 @@ private fun WooPosBookingsList(
                     reason = items.message,
                     primaryButton = WooPosErrorScreenButtonState(
                         text = stringResource(id = R.string.retry),
-                        click = { throw NotImplementedError("Retry button clicked") }
+                        click = onRetry
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -249,7 +249,7 @@ private fun WooPosBookingsContent(
                         WooPosEmptyScreen(
                             modifier = Modifier.fillMaxSize(),
                             icon = WooPosIcons.OrdersEmpty,
-                            title = stringResource(R.string.woopos_orders_no_order_selected),
+                            title = stringResource(R.string.woopos_bookings_no_booking_selected),
                             message = "",
                             contentDescription = stringResource(R.string.woopos_orders_empty_list_image_description)
                         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
@@ -5,8 +5,15 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 
 @Immutable
+data class DateSelectorState(
+    val formattedDate: String,
+    val selectedDateMillis: Long,
+)
+
+@Immutable
 sealed class WooPosBookingsState {
     abstract val pullToRefreshState: WooPosPullToRefreshState
+    abstract val dateSelectorState: DateSelectorState?
 
     @Immutable
     sealed interface BookingAction {
@@ -96,6 +103,7 @@ sealed class WooPosBookingsState {
     data class Content(
         val items: Items,
         override val pullToRefreshState: WooPosPullToRefreshState,
+        override val dateSelectorState: DateSelectorState?,
         val selectedDetails: BookingDetailsViewState?,
         val paginationState: WooPosPaginationState,
         val dialogState: DialogState
@@ -141,16 +149,19 @@ sealed class WooPosBookingsState {
         val message: String,
     ) : WooPosBookingsState() {
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Disabled
+        override val dateSelectorState: DateSelectorState? = null
     }
 
     @Immutable
     data object Loading : WooPosBookingsState() {
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Disabled
+        override val dateSelectorState: DateSelectorState? = null
     }
 
     @Immutable
     data class Empty(
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+        override val dateSelectorState: DateSelectorState? = null,
     ) : WooPosBookingsState()
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsUIEvent.kt
@@ -9,4 +9,7 @@ sealed interface WooPosBookingsUIEvent {
     data class CopyPhoneClicked(val phone: String) : WooPosBookingsUIEvent
     data object CancelBookingConfirmed : WooPosBookingsUIEvent
     data object CancelBookingDismissed : WooPosBookingsUIEvent
+    data object PreviousDayClicked : WooPosBookingsUIEvent
+    data object NextDayClicked : WooPosBookingsUIEvent
+    data class DateSelected(val dateMillis: Long) : WooPosBookingsUIEvent
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -78,17 +78,48 @@ class WooPosBookingsViewModel @Inject constructor(
                 filters = BookingFilters(dateRange = dateRangeForDate(selectedDate)),
                 sortBy = BookingListSortOption.NewestToOldest
             )
-            result.onFailure {
-                if (_state.value is WooPosBookingsState.Loading) {
-                    _state.value = WooPosBookingsState.Error(
-                        message = it.message ?: "Failed to load bookings"
-                    )
+            val current = _state.value
+            result.onFailure { error ->
+                when {
+                    current is WooPosBookingsState.Loading -> {
+                        _state.value = WooPosBookingsState.Error(
+                            message = error.message ?: "Failed to load bookings"
+                        )
+                    }
+                    current is WooPosBookingsState.Content &&
+                        current.items is WooPosBookingsState.Content.Items.Searching -> {
+                        _state.value = current.copy(
+                            items = WooPosBookingsState.Content.Items.Error(
+                                title = resourceProvider.getString(
+                                    R.string.woopos_orders_loading_error_title
+                                ),
+                                message = resourceProvider.getString(
+                                    R.string.woopos_orders_loading_error_message
+                                )
+                            ),
+                            pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                        )
+                    }
                 }
             }.onSuccess {
-                if (_state.value is WooPosBookingsState.Loading) {
-                    _state.value = WooPosBookingsState.Empty(
-                        dateSelectorState = buildDateSelectorState()
-                    )
+                when {
+                    current is WooPosBookingsState.Loading -> {
+                        _state.value = WooPosBookingsState.Empty(
+                            dateSelectorState = buildDateSelectorState()
+                        )
+                    }
+                    current is WooPosBookingsState.Content &&
+                        current.items is WooPosBookingsState.Content.Items.Searching -> {
+                        _state.value = current.copy(
+                            items = WooPosBookingsState.Content.Items.NothingFound(
+                                title = resourceProvider.getString(
+                                    R.string.woopos_bookings_no_bookings_for_date
+                                ),
+                                message = ""
+                            ),
+                            pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                        )
+                    }
                 }
             }
         }
@@ -108,7 +139,14 @@ class WooPosBookingsViewModel @Inject constructor(
             ) { bookings, resources ->
                 bookings to resources.associateBy { it.id.value }
             }.collectLatest { (bookings, resourcesMap) ->
-                if (bookings.isEmpty() && _state.value is WooPosBookingsState.Loading) {
+                val current = _state.value
+                if (bookings.isEmpty() && current is WooPosBookingsState.Loading) {
+                    return@collectLatest
+                }
+
+                if (bookings.isEmpty() && current is WooPosBookingsState.Content &&
+                    current.items is WooPosBookingsState.Content.Items.Searching
+                ) {
                     return@collectLatest
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -44,6 +45,7 @@ class WooPosBookingsViewModel @Inject constructor(
     private val mapper: WooPosBookingViewStateMapper,
     private val clipboardHelper: WooPosClipboardHelper,
     private val resourceProvider: ResourceProvider,
+    private val clock: Clock,
 ) : ViewModel() {
 
     companion object {
@@ -60,7 +62,7 @@ class WooPosBookingsViewModel @Inject constructor(
     val navigationEvent: SharedFlow<WooPosNavigationEvent> = _navigationEvent.asSharedFlow()
 
     private var selectedBookingId: Long? = null
-    private var selectedDate: LocalDate = LocalDate.now()
+    private var selectedDate: LocalDate = LocalDate.now(clock)
     private var fetchJob: Job? = null
     private var loadMoreJob: Job? = null
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -25,7 +25,15 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -52,6 +60,7 @@ class WooPosBookingsViewModel @Inject constructor(
     val navigationEvent: SharedFlow<WooPosNavigationEvent> = _navigationEvent.asSharedFlow()
 
     private var selectedBookingId: Long? = null
+    private var selectedDate: LocalDate = LocalDate.now()
     private var fetchJob: Job? = null
     private var loadMoreJob: Job? = null
 
@@ -66,6 +75,7 @@ class WooPosBookingsViewModel @Inject constructor(
         loadMoreJob?.cancel()
         fetchJob = viewModelScope.launch {
             val result = bookingListHandler.loadBookings(
+                filters = BookingFilters(dateRange = dateRangeForDate(selectedDate)),
                 sortBy = BookingListSortOption.NewestToOldest
             )
             result.onFailure {
@@ -76,7 +86,9 @@ class WooPosBookingsViewModel @Inject constructor(
                 }
             }.onSuccess {
                 if (_state.value is WooPosBookingsState.Loading) {
-                    _state.value = WooPosBookingsState.Empty()
+                    _state.value = WooPosBookingsState.Empty(
+                        dateSelectorState = buildDateSelectorState()
+                    )
                 }
             }
         }
@@ -100,8 +112,22 @@ class WooPosBookingsViewModel @Inject constructor(
                     return@collectLatest
                 }
 
+                val dateSelectorState = buildDateSelectorState()
+
                 if (bookings.isEmpty()) {
-                    _state.value = WooPosBookingsState.Empty()
+                    _state.value = WooPosBookingsState.Content(
+                        items = WooPosBookingsState.Content.Items.NothingFound(
+                            title = resourceProvider.getString(
+                                R.string.woopos_bookings_no_bookings_for_date
+                            ),
+                            message = ""
+                        ),
+                        pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                        dateSelectorState = dateSelectorState,
+                        selectedDetails = null,
+                        paginationState = WooPosPaginationState.None,
+                        dialogState = WooPosBookingsState.Content.DialogState.Hidden
+                    )
                     return@collectLatest
                 }
 
@@ -122,6 +148,7 @@ class WooPosBookingsViewModel @Inject constructor(
                 _state.value = WooPosBookingsState.Content(
                     items = WooPosBookingsState.Content.Items.Loaded(items),
                     pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                    dateSelectorState = dateSelectorState,
                     selectedDetails = selectedDetails,
                     paginationState = WooPosPaginationState.None,
                     dialogState = WooPosBookingsState.Content.DialogState.Hidden
@@ -161,6 +188,7 @@ class WooPosBookingsViewModel @Inject constructor(
         fetchResources()
         fetchJob = viewModelScope.launch {
             bookingListHandler.loadBookings(
+                filters = BookingFilters(dateRange = dateRangeForDate(selectedDate)),
                 sortBy = BookingListSortOption.NewestToOldest
             ).onFailure {
                 _state.value = when (val current = _state.value) {
@@ -244,6 +272,11 @@ class WooPosBookingsViewModel @Inject constructor(
             is WooPosBookingsUIEvent.CopyPhoneClicked -> handleCopyToClipboard(event.phone)
             is WooPosBookingsUIEvent.CancelBookingConfirmed -> handleCancelConfirmed()
             is WooPosBookingsUIEvent.CancelBookingDismissed -> handleCancelDismissed()
+            is WooPosBookingsUIEvent.PreviousDayClicked -> handleDateChange(selectedDate.minusDays(1))
+            is WooPosBookingsUIEvent.NextDayClicked -> handleDateChange(selectedDate.plusDays(1))
+            is WooPosBookingsUIEvent.DateSelected -> handleDateChange(
+                Instant.ofEpochMilli(event.dateMillis).atZone(ZoneOffset.UTC).toLocalDate()
+            )
         }
     }
 
@@ -425,5 +458,36 @@ class WooPosBookingsViewModel @Inject constructor(
         _state.value = currentState.copy(
             dialogState = WooPosBookingsState.Content.DialogState.Hidden
         )
+    }
+
+    private fun handleDateChange(newDate: LocalDate) {
+        selectedDate = newDate
+        selectedBookingId = null
+        _state.value = when (val current = _state.value) {
+            is WooPosBookingsState.Content -> current.copy(
+                items = WooPosBookingsState.Content.Items.Searching,
+                dateSelectorState = buildDateSelectorState(),
+                selectedDetails = null,
+                pullToRefreshState = WooPosPullToRefreshState.Disabled
+            )
+            else -> WooPosBookingsState.Loading
+        }
+        fetchBookings()
+    }
+
+    private fun buildDateSelectorState(): DateSelectorState {
+        val formatter = DateTimeFormatter.ofPattern("dd MMM, EEE", Locale.getDefault())
+        val formatted = selectedDate.format(formatter)
+        val millis = selectedDate.atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli()
+        return DateSelectorState(
+            formattedDate = formatted,
+            selectedDateMillis = millis,
+        )
+    }
+
+    private fun dateRangeForDate(date: LocalDate): BookingsFilterOption.DateRange {
+        val start = date.atTime(LocalTime.MIDNIGHT).atOffset(ZoneOffset.UTC).toInstant()
+        val end = date.atTime(LocalTime.MAX).atOffset(ZoneOffset.UTC).toInstant()
+        return BookingsFilterOption.DateRange(before = end, after = start)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosEmptyScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosEmptyScreen.kt
@@ -93,6 +93,7 @@ private fun WooPosItemsEmptyListInternal(
                 text = title,
                 style = WooPosTypography.Heading,
                 fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
             )
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3949,6 +3949,7 @@
     <string name="woopos_bookings_note_screen_button_save">Save</string>
     <string name="woopos_bookings_note_screen_save_error">Error saving booking note</string>
     <string name="woopos_bookings_no_bookings_for_date">No bookings for this date</string>
+    <string name="woopos_bookings_no_booking_selected">No booking selected.</string>
     <string name="woopos_bookings_date_selector_previous_day">Previous day</string>
     <string name="woopos_bookings_date_selector_next_day">Next day</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3948,6 +3948,9 @@
     <string name="woopos_bookings_note_screen_hint">Type booking note</string>
     <string name="woopos_bookings_note_screen_button_save">Save</string>
     <string name="woopos_bookings_note_screen_save_error">Error saving booking note</string>
+    <string name="woopos_bookings_no_bookings_for_date">No bookings for this date</string>
+    <string name="woopos_bookings_date_selector_previous_day">Previous day</string>
+    <string name="woopos_bookings_date_selector_next_day">Next day</string>
 
     <string name="woopos_cash_payment_title">Cash payment</string>
     <string name="woopos_complete_cash_order_button">Mark payment as complete</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -30,6 +30,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -148,7 +149,7 @@ class WooPosBookingsViewModelTest {
             flowOf(listOf(booking(1), booking(2)))
         )
         whenever(
-            bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest)
+            bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest))
         ).thenReturn(Result.success(Unit))
         whenever(bookingListHandler.loadMore()).thenReturn(Result.success(Unit))
         whenever(dateTimeProvider.now()).thenReturn(0L)
@@ -181,7 +182,7 @@ class WooPosBookingsViewModelTest {
     fun `given fetch fails and state is Loading, when init, then state is Error`() = runTest {
         // GIVEN
         whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .thenReturn(Result.failure(RuntimeException("Network error")))
 
         // WHEN
@@ -194,10 +195,10 @@ class WooPosBookingsViewModelTest {
     }
 
     @Test
-    fun `given no bookings exist, when init completes, then state is Empty`() = runTest {
+    fun `given no bookings exist, when init completes, then state is Content with NothingFound`() = runTest {
         // GIVEN
         whenever(bookingListHandler.bookingsFlow).thenReturn(flowOf(emptyList()))
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .thenReturn(Result.success(Unit))
 
         // WHEN
@@ -205,36 +206,39 @@ class WooPosBookingsViewModelTest {
         advanceUntilIdle()
 
         // THEN
-        assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Empty::class.java)
+        val state = viewModel.state.value as WooPosBookingsState.Content
+        assertThat(state.items).isInstanceOf(WooPosBookingsState.Content.Items.NothingFound::class.java)
     }
 
     @Test
-    fun `given empty bookings after content was shown, when flow emits empty, then state is Empty`() = runTest {
-        // GIVEN
-        val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
-        whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
+    fun `given empty bookings after content was shown, when flow emits empty, then state is Content with NothingFound`() =
+        runTest {
+            // GIVEN
+            val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
+            whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
 
-        viewModel = createViewModel()
-        advanceUntilIdle()
+            viewModel = createViewModel()
+            advanceUntilIdle()
 
-        bookingsFlow.emit(listOf(booking(1)))
-        advanceUntilIdle()
-        assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Content::class.java)
+            bookingsFlow.emit(listOf(booking(1)))
+            advanceUntilIdle()
+            assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Content::class.java)
 
-        // WHEN
-        bookingsFlow.emit(emptyList())
-        advanceUntilIdle()
+            // WHEN
+            bookingsFlow.emit(emptyList())
+            advanceUntilIdle()
 
-        // THEN
-        assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Empty::class.java)
-    }
+            // THEN
+            val state = viewModel.state.value as WooPosBookingsState.Content
+            assertThat(state.items).isInstanceOf(WooPosBookingsState.Content.Items.NothingFound::class.java)
+        }
 
     @Test
     fun `given empty bookings while Loading, when flow emits empty, then state stays Loading`() = runTest {
         // GIVEN
         val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
         whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .doSuspendableAnswer {
                 delay(Long.MAX_VALUE)
                 Result.success(Unit)
@@ -276,7 +280,7 @@ class WooPosBookingsViewModelTest {
         bookingsFlow.emit(listOf(booking(1)))
         advanceUntilIdle()
 
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .doSuspendableAnswer {
                 delay(Long.MAX_VALUE)
                 Result.success(Unit)
@@ -295,14 +299,14 @@ class WooPosBookingsViewModelTest {
     fun `given non-content state, when onRefresh, then state becomes Loading`() = runTest {
         // GIVEN
         whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .thenReturn(Result.failure(RuntimeException("error")))
 
         viewModel = createViewModel()
         advanceUntilIdle()
         assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Error::class.java)
 
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .doSuspendableAnswer {
                 delay(Long.MAX_VALUE)
                 Result.success(Unit)
@@ -322,7 +326,7 @@ class WooPosBookingsViewModelTest {
         viewModel = createViewModel()
         advanceUntilIdle()
 
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .thenReturn(Result.failure(RuntimeException("error")))
 
         // WHEN
@@ -338,13 +342,13 @@ class WooPosBookingsViewModelTest {
     fun `given refresh fails on non-content, when onRefresh, then state is Error`() = runTest {
         // GIVEN
         whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .thenReturn(Result.failure(RuntimeException("first error")))
 
         viewModel = createViewModel()
         advanceUntilIdle()
 
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .thenReturn(Result.failure(RuntimeException("refresh error")))
 
         // WHEN
@@ -368,7 +372,7 @@ class WooPosBookingsViewModelTest {
 
         // THEN
         verify(bookingListHandler, times(2))
-            .loadBookings(sortBy = BookingListSortOption.NewestToOldest)
+            .loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest))
     }
 
     @Test
@@ -451,7 +455,7 @@ class WooPosBookingsViewModelTest {
         // GIVEN
         val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
         whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .doSuspendableAnswer {
                 delay(1000)
                 Result.success(Unit)
@@ -479,14 +483,14 @@ class WooPosBookingsViewModelTest {
         runTest {
             // GIVEN
             whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
-            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+            whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
                 .thenReturn(Result.failure(RuntimeException("error")))
 
             viewModel = createViewModel()
             advanceUntilIdle()
             assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Error::class.java)
 
-            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+            whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
                 .doSuspendableAnswer {
                     delay(Long.MAX_VALUE)
                     Result.success(Unit)
@@ -498,26 +502,22 @@ class WooPosBookingsViewModelTest {
 
             // THEN
             assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Loading::class.java)
-            verify(bookingListHandler, times(2)).loadBookings(sortBy = BookingListSortOption.NewestToOldest)
+            verify(bookingListHandler, times(2)).loadBookings(
+                anyOrNull(),
+                any(),
+                eq(BookingListSortOption.NewestToOldest)
+            )
         }
 
     @Test
     fun `given empty state, when onBookingsEmptyActionClicked, then resets to Loading and fetches`() = runTest {
         // GIVEN
-        val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
-        whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
+        whenever(bookingListHandler.bookingsFlow).thenReturn(flowOf(emptyList()))
 
         viewModel = createViewModel()
         advanceUntilIdle()
 
-        bookingsFlow.emit(listOf(booking(1)))
-        advanceUntilIdle()
-
-        bookingsFlow.emit(emptyList())
-        advanceUntilIdle()
-        assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Empty::class.java)
-
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .doSuspendableAnswer {
                 delay(Long.MAX_VALUE)
                 Result.success(Unit)
@@ -529,14 +529,18 @@ class WooPosBookingsViewModelTest {
 
         // THEN
         assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Loading::class.java)
-        verify(bookingListHandler, times(2)).loadBookings(sortBy = BookingListSortOption.NewestToOldest)
+        verify(bookingListHandler, times(2)).loadBookings(
+            anyOrNull(),
+            any(),
+            eq(BookingListSortOption.NewestToOldest)
+        )
     }
 
     @Test
     fun `given non-content state, when onIssueRefundDialogDismissed, then state remains unchanged`() = runTest {
         // GIVEN
         whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .thenReturn(Result.failure(RuntimeException("error")))
 
         viewModel = createViewModel()
@@ -554,7 +558,7 @@ class WooPosBookingsViewModelTest {
     fun `given non-content state, when onBookingSelected, then state remains unchanged`() = runTest {
         // GIVEN
         whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
-        whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
             .thenReturn(Result.failure(RuntimeException("error")))
 
         viewModel = createViewModel()
@@ -629,7 +633,7 @@ class WooPosBookingsViewModelTest {
         runTest {
             // GIVEN
             whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
-            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+            whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
                 .thenReturn(Result.failure(RuntimeException("error")))
 
             viewModel = createViewModel()
@@ -894,4 +898,39 @@ class WooPosBookingsViewModelTest {
                     WooPosBookingsState.Content.DialogState.CancelBooking.Processing::class.java
                 )
         }
+
+    @Test
+    fun `given date changed, when state becomes Content, then dateSelectorState is updated`() = runTest {
+        // GIVEN
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val contentBefore = viewModel.state.value as WooPosBookingsState.Content
+        val dateBefore = contentBefore.dateSelectorState?.formattedDate
+
+        // WHEN
+        viewModel.onUIEvent(WooPosBookingsUIEvent.NextDayClicked)
+        advanceUntilIdle()
+
+        // THEN
+        val contentAfter = viewModel.state.value as WooPosBookingsState.Content
+        assertThat(contentAfter.dateSelectorState).isNotNull
+        assertThat(contentAfter.dateSelectorState?.formattedDate).isNotEqualTo(dateBefore)
+    }
+
+    @Test
+    fun `given date changed, when previous day clicked, then fetch called with new date`() = runTest {
+        // GIVEN
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosBookingsUIEvent.PreviousDayClicked)
+        advanceUntilIdle()
+
+        // THEN
+        verify(bookingListHandler, times(2))
+            .loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest))
+    }
+
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -41,7 +41,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingOrderIn
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingProductInfo
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import java.math.BigDecimal
+import java.time.Clock
 import java.time.Instant
+import java.time.ZoneOffset
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooPosBookingsViewModelTest {
@@ -92,6 +94,7 @@ class WooPosBookingsViewModelTest {
     }
     private val clipboardHelper: WooPosClipboardHelper = mock()
     private val paymentStatusResolver: WooPosPaymentStatusResolver = mock()
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-02-19T10:00:00Z"), ZoneOffset.UTC)
     private lateinit var viewModel: WooPosBookingsViewModel
 
     private fun booking(id: Long = 1L) = BookingEntity(
@@ -135,6 +138,7 @@ class WooPosBookingsViewModelTest {
             ),
             clipboardHelper = clipboardHelper,
             resourceProvider = resourceProvider,
+            clock = clock,
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -933,4 +933,139 @@ class WooPosBookingsViewModelTest {
             .loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest))
     }
 
+    @Test
+    fun `given date changed and cache empty, when fetch in progress, then state stays Searching`() = runTest {
+        // GIVEN
+        val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
+        whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        bookingsFlow.emit(listOf(booking(1)))
+        advanceUntilIdle()
+        assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Content::class.java)
+
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
+            .doSuspendableAnswer {
+                delay(Long.MAX_VALUE)
+                Result.success(Unit)
+            }
+
+        // WHEN
+        viewModel.onUIEvent(WooPosBookingsUIEvent.NextDayClicked)
+        advanceUntilIdle()
+
+        bookingsFlow.emit(emptyList())
+        advanceUntilIdle()
+
+        // THEN
+        val content = viewModel.state.value as WooPosBookingsState.Content
+        assertThat(content.items).isInstanceOf(WooPosBookingsState.Content.Items.Searching::class.java)
+    }
+
+    @Test
+    fun `given date changed and cache has data, when observe emits, then cached data shown immediately`() = runTest {
+        // GIVEN
+        val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
+        whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        bookingsFlow.emit(listOf(booking(1)))
+        advanceUntilIdle()
+        assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Content::class.java)
+
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
+            .doSuspendableAnswer {
+                delay(Long.MAX_VALUE)
+                Result.success(Unit)
+            }
+
+        // WHEN
+        viewModel.onUIEvent(WooPosBookingsUIEvent.NextDayClicked)
+        advanceUntilIdle()
+
+        bookingsFlow.emit(listOf(booking(5)))
+        advanceUntilIdle()
+
+        // THEN
+        val content = viewModel.state.value as WooPosBookingsState.Content
+        assertThat(content.items).isInstanceOf(WooPosBookingsState.Content.Items.Loaded::class.java)
+        val loaded = content.items as WooPosBookingsState.Content.Items.Loaded
+        assertThat(loaded.items.keys.first().id).isEqualTo(5L)
+    }
+
+    @Test
+    fun `given date changed and cache empty, when fetch succeeds with no data, then state is NothingFound`() = runTest {
+        // GIVEN
+        val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
+        whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        bookingsFlow.emit(listOf(booking(1)))
+        advanceUntilIdle()
+        assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Content::class.java)
+
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
+            .thenReturn(Result.success(Unit))
+
+        // WHEN
+        viewModel.onUIEvent(WooPosBookingsUIEvent.NextDayClicked)
+        advanceUntilIdle()
+
+        // THEN
+        val content = viewModel.state.value as WooPosBookingsState.Content
+        assertThat(content.items).isInstanceOf(WooPosBookingsState.Content.Items.NothingFound::class.java)
+    }
+
+    @Test
+    fun `given date changed and cache empty, when fetch fails, then state is Error`() = runTest {
+        // GIVEN
+        val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
+        whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        bookingsFlow.emit(listOf(booking(1)))
+        advanceUntilIdle()
+        assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Content::class.java)
+
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
+            .thenReturn(Result.failure(RuntimeException("network error")))
+
+        // WHEN
+        viewModel.onUIEvent(WooPosBookingsUIEvent.NextDayClicked)
+        advanceUntilIdle()
+
+        // THEN
+        val content = viewModel.state.value as WooPosBookingsState.Content
+        assertThat(content.items).isInstanceOf(WooPosBookingsState.Content.Items.Error::class.java)
+    }
+
+    @Test
+    fun `given rapid date changes, when multiple next day clicks, then intermediate fetches are cancelled`() = runTest {
+        // GIVEN
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val initialDate = (viewModel.state.value as WooPosBookingsState.Content)
+            .dateSelectorState?.formattedDate
+
+        // WHEN - rapid tapping next 3 times without advancing the dispatcher
+        viewModel.onUIEvent(WooPosBookingsUIEvent.NextDayClicked)
+        viewModel.onUIEvent(WooPosBookingsUIEvent.NextDayClicked)
+        viewModel.onUIEvent(WooPosBookingsUIEvent.NextDayClicked)
+        advanceUntilIdle()
+
+        // THEN - only 2 loadBookings calls: initial + last date change (intermediate ones cancelled)
+        verify(bookingListHandler, times(2))
+            .loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest))
+        val content = viewModel.state.value as WooPosBookingsState.Content
+        assertThat(content.dateSelectorState?.formattedDate).isNotEqualTo(initialDate)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -786,8 +786,13 @@ class WooPosBookingsViewModelTest {
         runTest {
             // GIVEN
             whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
-            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
-                .thenReturn(Result.failure(RuntimeException("error")))
+            whenever(
+                bookingListHandler.loadBookings(
+                    filters = anyOrNull(),
+                    sortBy = anyOrNull(),
+                    searchQuery = anyOrNull()
+                )
+            ).thenReturn(Result.failure(RuntimeException("error")))
 
             viewModel = createViewModel()
             advanceUntilIdle()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -1072,4 +1072,24 @@ class WooPosBookingsViewModelTest {
         val content = viewModel.state.value as WooPosBookingsState.Content
         assertThat(content.dateSelectorState?.formattedDate).isNotEqualTo(initialDate)
     }
+
+    @Test
+    fun `given date selected from calendar picker, when DateSelected dispatched, then fetch called for selected date`() =
+        runTest {
+            // GIVEN
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            val selectedDateMillis = Instant.parse("2026-03-15T00:00:00Z").toEpochMilli()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosBookingsUIEvent.DateSelected(selectedDateMillis))
+            advanceUntilIdle()
+
+            // THEN
+            verify(bookingListHandler, times(2))
+                .loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest))
+            val content = viewModel.state.value as WooPosBookingsState.Content
+            assertThat(content.dateSelectorState?.selectedDateMillis).isEqualTo(selectedDateMillis)
+        }
 }


### PR DESCRIPTION
Fixes WOOMOB-2266

### Description
Adds a date selector to the POS Bookings list pane that lets users filter bookings by day. The selector defaults to today and supports navigating via left/right chevron arrows or picking a date from a calendar dialog. Styling matches the Figma design (purple primary color, BodySmall font, left-aligned).

When changing dates, cached bookings are shown immediately if available. If no cache exists, a loading indicator is displayed. Fetch failures during date navigation show an inline error with a retry button. Rapid date changes cancel in-flight fetches so only the final date loads.

Also fixes empty screen title centering in `WooPosEmptyScreen` and updates the bookings detail placeholder to say "No booking selected." instead of "No order selected."

### Test Steps
1. Open POS Bookings — verify today's date appears in the date selector with purple styling
2. Tap chevron arrows to navigate between days and verify the bookings list updates
3. Tap the date text to open the calendar picker, select a date, and verify filtering
4. Navigate to a date with no bookings — verify "No bookings for this date" empty state
5. Rapidly tap next-day chevron multiple times — verify no flicker, only final date loads
6. Disable network and change date — verify inline error with retry button appears
7. Verify right pane shows "No booking selected." when no booking is selected

### Images/gif

<img width="350" alt="Screenshot_1771509150" src="https://github.com/user-attachments/assets/930f4fee-0e47-4e72-b499-74403d85bec8" />

<img width="350" alt="Screenshot_1771509144" src="https://github.com/user-attachments/assets/d9bec95a-6a6a-4408-9e54-c6cf2188d4ec" />

<img width="350" alt="Screenshot_1771509139" src="https://github.com/user-attachments/assets/13b9b2da-3997-4384-a397-d7c38d1f4653" />



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.