### PR TITLE
[CIAB: POS] Do not offer payment retry for CardReaderPaymentEvent events

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
@@ -135,8 +135,7 @@ class WooPosBookingViewStateMapper @Inject constructor(
         val paymentInfo = booking.order.paymentInfo
         val currency = booking.currency
         val isPaid = booking.status == BookingEntity.Status.Paid ||
-            booking.status == BookingEntity.Status.Complete ||
-            booking.status == BookingEntity.Status.Cancelled
+            booking.status == BookingEntity.Status.Complete
 
         val totalAmount = paymentInfo?.let { formatPrice(it.total + it.totalTax, currency) } ?: "-"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
@@ -420,13 +420,15 @@ private fun CardPaymentFailed(
             style = WooPosTypography.BodyLarge,
         )
         Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
-        WooPosButton(
-            text = state.actionButtonLabel,
-            modifier = Modifier
-                .height(80.dp)
-                .width(604.dp),
-            onClick = onRetryClicked,
-        )
+        if (state.actionButtonLabel != null) {
+            WooPosButton(
+                text = state.actionButtonLabel,
+                modifier = Modifier
+                    .height(80.dp)
+                    .width(604.dp),
+                onClick = onRetryClicked,
+            )
+        }
         if (state.isDismissButtonVisible) {
             Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
             WooPosOutlinedButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentState.kt
@@ -29,7 +29,7 @@ sealed class WooPosCardPaymentState {
     data class PaymentFailed(
         val title: String,
         val subtitle: String,
-        val actionButtonLabel: String,
+        val actionButtonLabel: String? = null,
         val isDismissButtonVisible: Boolean,
     ) : WooPosCardPaymentState()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -196,10 +196,7 @@ class WooPosCardPaymentViewModel @Inject constructor(
                                 R.string.woopos_success_totals_payment_failed_title
                             ),
                             subtitle = resourceProvider.getString(messageRes),
-                            actionButtonLabel = resourceProvider.getString(
-                                R.string.woo_pos_payment_failed_go_back
-                            ),
-                            isDismissButtonVisible = false
+                            isDismissButtonVisible = true
                         )
                     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -310,7 +310,7 @@ class WooPosCardPaymentViewModelTest {
     }
 
     @Test
-    fun `given controller emits ShowErrorMessage, when collecting, then state is PaymentFailed`() =
+    fun `given controller emits ShowErrorMessage, when collecting, then state is PaymentFailed with no action button`() =
         runTest {
             viewModel = createViewModel()
             advanceUntilIdle()
@@ -324,11 +324,13 @@ class WooPosCardPaymentViewModelTest {
 
             val state = viewModel.state.value
             assertThat(state).isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
-            assertThat((state as WooPosCardPaymentState.PaymentFailed).isDismissButtonVisible).isFalse()
+            val failedState = state as WooPosCardPaymentState.PaymentFailed
+            assertThat(failedState.actionButtonLabel).isNull()
+            assertThat(failedState.isDismissButtonVisible).isTrue()
         }
 
     @Test
-    fun `given controller emits ShowPaymentErrorMessage, when collecting, then state is PaymentFailed`() =
+    fun `given controller emits ShowPaymentErrorMessage, when collecting, then state is PaymentFailed with no action button`() =
         runTest {
             viewModel = createViewModel()
             advanceUntilIdle()
@@ -342,7 +344,9 @@ class WooPosCardPaymentViewModelTest {
 
             val state = viewModel.state.value
             assertThat(state).isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
-            assertThat((state as WooPosCardPaymentState.PaymentFailed).isDismissButtonVisible).isFalse()
+            val failedState = state as WooPosCardPaymentState.PaymentFailed
+            assertThat(failedState.actionButtonLabel).isNull()
+            assertThat(failedState.isDismissButtonVisible).isTrue()
         }
 
     @Test


### PR DESCRIPTION
WOOMOB-2257

### Description

When `CardReaderPaymentEvent.ShowErrorMessage` or `ShowPaymentErrorMessage` events fire, the `PaymentFailed` screen was showing an action button ("Go Back") that calls `onRetryClicked()`. This crashes because `onRetryClicked()` requires the payment state to be `ExternalReaderFailedPayment`, which isn't the case for these event-driven errors.

These error events are designed to hard-end the payment flow (originally a dialog flow), so retry should not be offered. This PR hides the action button for these error cases and only shows the dismiss button.

Changes:
- Make `actionButtonLabel` nullable in `PaymentFailed` state (defaults to `null`)
- Omit `actionButtonLabel` in the `ShowErrorMessage`/`ShowPaymentErrorMessage` handler so only the dismiss button shows
- Conditionally render the action button in `CardPaymentFailed` composable
- Fix `WooPosBookingViewStateMapper` to no longer treat cancelled bookings as paid

### Test Steps

1. In POS, initiate a card payment that triggers a `ShowErrorMessage` or `ShowPaymentErrorMessage` event (e.g., a payment for an already-paid order)
2. Verify the error screen shows only the dismiss button — no "Go Back" or retry button
3. Tap dismiss and verify navigation back works without a crash
4. Initiate a normal payment failure (e.g., reader timeout) and verify the retry/action button still appears as expected

### Images/gif


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.