### PR TITLE
Move the plugin check to the first setup step

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
@@ -279,11 +279,11 @@ private fun WooPushNotificationsConnectionStepsPreview() {
                 siteAddress = "coffeebeans.com",
                 steps = listOf(
                     WooPushNotificationsConnectionStepsViewModel.Step(
-                        type = StepType.ConnectStore,
+                        type = StepType.CheckPluginCompatibility,
                         state = StepState.Ongoing
                     ),
                     WooPushNotificationsConnectionStepsViewModel.Step(
-                        type = StepType.CheckPluginCompatibility,
+                        type = StepType.ConnectStore,
                         state = StepState.Idle
                     ),
                     WooPushNotificationsConnectionStepsViewModel.Step(
@@ -309,11 +309,11 @@ private fun WooPushNotificationsConnectionStepsPreviewError() {
                 siteAddress = "coffeebeans.com",
                 steps = listOf(
                     WooPushNotificationsConnectionStepsViewModel.Step(
-                        type = StepType.ConnectStore,
+                        type = StepType.CheckPluginCompatibility,
                         state = StepState.Success
                     ),
                     WooPushNotificationsConnectionStepsViewModel.Step(
-                        type = StepType.CheckPluginCompatibility,
+                        type = StepType.ConnectStore,
                         state = StepState.Error(UiString.UiStringText("Error connecting to store"))
                     ),
                     WooPushNotificationsConnectionStepsViewModel.Step(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -47,7 +47,7 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
 
     private val currentStep = savedStateHandle.getStateFlow(
         scope = viewModelScope,
-        initialValue = Step(type = StepType.ConnectStore),
+        initialValue = Step(type = StepType.CheckPluginCompatibility),
         key = KEY_CURRENT_STEP
     )
 
@@ -230,8 +230,8 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
     ) : Parcelable
 
     enum class StepType {
-        ConnectStore,
         CheckPluginCompatibility,
+        ConnectStore,
         EnablePushNotifications
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
@@ -19,13 +19,11 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runCurrent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.JetpackStore
@@ -79,8 +77,8 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
             val state = viewModel.viewState.getOrAwaitValue()
 
             assertThat(state.steps).hasSize(3)
-            assertThat(state.steps[0].type).isEqualTo(StepType.ConnectStore)
-            assertThat(state.steps[1].type).isEqualTo(StepType.CheckPluginCompatibility)
+            assertThat(state.steps[0].type).isEqualTo(StepType.CheckPluginCompatibility)
+            assertThat(state.steps[1].type).isEqualTo(StepType.ConnectStore)
             assertThat(state.steps[2].type).isEqualTo(StepType.EnablePushNotifications)
         }
     }
@@ -162,8 +160,8 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
                 advanceUntilIdle()
             }
 
-            assertThat(state.steps[0].type).isEqualTo(StepType.ConnectStore)
-            assertThat(state.steps[0].state)
+            assertThat(state.steps[1].type).isEqualTo(StepType.ConnectStore)
+            assertThat(state.steps[1].state)
                 .isEqualTo(StepState.Error(R.string.woo_push_notifications_connection_steps_error_connection_permission_message))
         }
 
@@ -178,26 +176,27 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
             advanceUntilIdle()
         }
 
-        assertThat(state.steps[0].type).isEqualTo(StepType.ConnectStore)
-        assertThat(state.steps[0].state)
+        assertThat(state.steps[1].type).isEqualTo(StepType.ConnectStore)
+        assertThat(state.steps[1].state)
             .isEqualTo(StepState.Error(R.string.woo_push_notifications_connection_steps_generic_error_message))
     }
 
     @Test
-    fun `when connect store succeeds, then plugin compatibility step becomes ongoing`() = testBlocking {
-        setup()
+    fun `when connect store succeeds, then flow advances to enable push notifications step`() = testBlocking {
+        setup {
+            whenever(appPrefsWrapper.getFCMToken()).thenReturn("")
+        }
 
-        runCurrent()
+        val state = viewModel.viewState.runAndGetValue {
+            advanceUntilIdle()
+        }
 
-        val state = viewModel.viewState.getOrAwaitValue()
-
-        verify(jetpackActivationRepository).fetchJetpackSite("https://coffeebeans.com")
-        assertThat(state.steps[0].type).isEqualTo(StepType.ConnectStore)
+        assertThat(state.steps[0].type).isEqualTo(StepType.CheckPluginCompatibility)
         assertThat(state.steps[0].state).isEqualTo(StepState.Success)
-        assertThat(state.steps[1].type).isEqualTo(StepType.CheckPluginCompatibility)
-        assertThat(state.steps[1].state).isEqualTo(StepState.Ongoing)
+        assertThat(state.steps[1].type).isEqualTo(StepType.ConnectStore)
+        assertThat(state.steps[1].state).isEqualTo(StepState.Success)
         assertThat(state.steps[2].type).isEqualTo(StepType.EnablePushNotifications)
-        assertThat(state.steps[2].state).isEqualTo(StepState.Idle)
+        assertThat(state.steps[2].state).isInstanceOf(StepState.Error::class.java)
     }
 
     @Test
@@ -253,7 +252,7 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `when all steps succeed, then ConnectStore and CheckPluginCompatibility show as Success`() = testBlocking {
+    fun `when all steps succeed, then CheckPluginCompatibility and ConnectStore show as Success`() = testBlocking {
         setup {
             whenever(appPrefsWrapper.getFCMToken()).thenReturn("test-token")
             whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any()))
@@ -264,9 +263,9 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
             advanceUntilIdle()
         }
 
-        assertThat(state.steps[0].type).isEqualTo(StepType.ConnectStore)
+        assertThat(state.steps[0].type).isEqualTo(StepType.CheckPluginCompatibility)
         assertThat(state.steps[0].state).isEqualTo(StepState.Success)
-        assertThat(state.steps[1].type).isEqualTo(StepType.CheckPluginCompatibility)
+        assertThat(state.steps[1].type).isEqualTo(StepType.ConnectStore)
         assertThat(state.steps[1].state).isEqualTo(StepState.Success)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
@@ -161,8 +161,9 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
             }
 
             assertThat(state.steps[1].type).isEqualTo(StepType.ConnectStore)
-            assertThat(state.steps[1].state)
-                .isEqualTo(StepState.Error(R.string.woo_push_notifications_connection_steps_error_connection_permission_message))
+            assertThat(state.steps[1].state).isEqualTo(
+                StepState.Error(R.string.woo_push_notifications_connection_steps_error_connection_permission_message)
+            )
         }
 
     @Test


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR reorders the setup steps in the Push Notifications connection flow.

The plugin compatibility step now appears before the WordPress.com connection step, matching the agreed flow order.

### Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->
1. Use a site that isn’t connected to WordPress.com.
2. Log in.
3. Enable the `WOO_PUSH_NOTIFICATIONS_SYSTEM` and `WOO_PUSH_NOTIFICATIONS_SYSTEM_M2` flags, then Restart.
4. Tap the "Never miss a new order card".
5. Complete the login flow.

### Images/gif
<!-- Include before and after images or gifs when appropriate. -->
<img width="300" alt="Screenshot_20260219_233415" src="https://github.com/user-attachments/assets/4ce758c1-c73c-4ee9-b726-bc70bc1a237c" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->
