### PR TITLE
Always build mobile prototype, watch on demand

### DIFF
--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -15,14 +15,8 @@ install_gems
 echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
-echo "--- :mag: Retrieving app selection from metadata"
-APP_TO_BUILD="$(buildkite-agent meta-data get "app-to-build")"
+APP_TO_BUILD="${1:?Usage: prototype-build.sh <WooCommerce|WooCommerce-Wear>}"
 echo "Selected app: ${APP_TO_BUILD}"
 
 echo "--- :hammer_and_wrench: Building and uploading to Firebase App Distribution"
-if [[ "${APP_TO_BUILD}" == "Both" ]]; then
-  bundle exec fastlane build_and_upload_prototype_build app:"WooCommerce"
-  bundle exec fastlane build_and_upload_prototype_build app:"WooCommerce-Wear"
-else
-  bundle exec fastlane build_and_upload_prototype_build app:"${APP_TO_BUILD}"
-fi
+bundle exec fastlane build_and_upload_prototype_build app:"${APP_TO_BUILD}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,7 +67,7 @@ steps:
   ########################################
   - group: "🚀 Prototype Build"
     steps:
-      - label: ":firebase: Prototype Build"
+      - label: ":firebase: Mobile Prototype Build"
         command: .buildkite/commands/prototype-build.sh WooCommerce
         plugins: [$CI_TOOLKIT]
         artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,28 +67,21 @@ steps:
   ########################################
   - group: "🚀 Prototype Build"
     steps:
-      - input: Build Prototype?
-        prompt: Select which app to build and distribute via Firebase App Distribution
-        key: prototype_build_triggered
-        fields:
-          - select: "App to Build"
-            key: "app-to-build"
-            hint: "Which WooCommerce app should be built? 📱"
-            required: true
-            default: "WooCommerce"
-            options:
-              - label: "📱 WooCommerce Mobile"
-                value: "WooCommerce"
-              - label: "⌚️ WooCommerce Wear"
-                value: "WooCommerce-Wear"
-              - label: "📱⌚️ Both"
-                value: "Both"
       - label: ":firebase: Prototype Build"
-        depends_on: prototype_build_triggered
-        command: .buildkite/commands/prototype-build.sh
+        command: .buildkite/commands/prototype-build.sh WooCommerce
         plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "WooCommerce/build/outputs/apk/**/*"
+
+      - block: Build Watch Prototype?
+        prompt: Trigger an on-demand Wear OS prototype build
+        key: watch_prototype_build_triggered
+
+      - label: ":firebase: Watch Prototype Build"
+        depends_on: watch_prototype_build_triggered
+        command: .buildkite/commands/prototype-build.sh WooCommerce-Wear
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
           - "WooCommerce-Wear/build/outputs/apk/**/*"
 
   ########################################

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,12 +73,10 @@ steps:
         artifact_paths:
           - "WooCommerce/build/outputs/apk/**/*"
 
-  ########################################
-  - group: ":amazon-s3: Watch Prototype Build"
-    steps:
       - block: Build Watch Prototype?
         prompt: Trigger an on-demand Wear OS prototype build
         key: watch_prototype_build_triggered
+        depends_on: ~
 
       - label: ":amazon-s3: Watch Prototype Build"
         depends_on: watch_prototype_build_triggered

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -77,7 +77,7 @@ steps:
         prompt: Trigger an on-demand Wear OS prototype build
         key: watch_prototype_build_triggered
 
-      - label: ":firebase: Watch Prototype Build"
+      - label: ":amazon-s3: Watch Prototype Build"
         depends_on: watch_prototype_build_triggered
         command: .buildkite/commands/prototype-build.sh WooCommerce-Wear
         plugins: [$CI_TOOLKIT]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,6 +73,9 @@ steps:
         artifact_paths:
           - "WooCommerce/build/outputs/apk/**/*"
 
+  ########################################
+  - group: ":amazon-s3: Watch Prototype Build"
+    steps:
       - block: Build Watch Prototype?
         prompt: Trigger an on-demand Wear OS prototype build
         key: watch_prototype_build_triggered


### PR DESCRIPTION
## Summary

- Mobile prototype builds now run automatically on every PR and `trunk` push — no manual trigger needed
- Watch prototype builds remain on-demand behind a block step
- Removed the "Both" option from the input step; the script now takes the app name as an argument

Closes https://linear.app/a8c/issue/AINFRA-2037

## Context

The WooCommerce Android team p91TBi-dJK-p2#comment-14626 and voted for "always build for mobile, on demand for watch."

<img width="1420" height="568" alt="image" src="https://github.com/user-attachments/assets/a759294c-c99f-45d7-891c-b895322638da" />

<img width="1708" height="514" alt="image" src="https://github.com/user-attachments/assets/1c265c23-aec2-4dd9-a183-ebf3323fea5a" />

<img width="1205" height="641" alt="image" src="https://github.com/user-attachments/assets/686ac43b-a84f-47ff-80b3-a747f6b711da" />

<img width="2158" height="1050" alt="image" src="https://github.com/user-attachments/assets/c3364b1a-b9d4-4ff8-add1-51c3a0a69a05" />


## Test plan

- [x] Verify the mobile prototype build runs automatically (no block step)
- [x] Verify the watch prototype build is gated behind "Build Watch Prototype?" block step
- [x] Unblock the watch step and verify it builds the Wear app