### PR TITLE
[CIAB: POS] Fix navigation to home screen after successful cash payment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
@@ -26,9 +26,9 @@ fun NavController.navigateToHomeScreen() {
 }
 
 fun NavController.navigateToHomeScreenAfterSuccessfulCashPayment() {
-    previousBackStackEntry
-        ?.savedStateHandle
-        ?.set(HOME_PAYMENT_COMPLETED_VIA_CASH_KEY, true)
+    getBackStackEntry(HOME_ROUTE)
+        .savedStateHandle
+        .set(HOME_PAYMENT_COMPLETED_VIA_CASH_KEY, true)
 
     navigate(HOME_ROUTE) {
         popUpTo(HOME_ROUTE) { inclusive = false }


### PR DESCRIPTION
WOOPRD-2472

### Description

After a successful cash payment in POS, the payment successful screen was not displayed. The root cause was that `navigateToHomeScreenAfterSuccessfulCashPayment()` used `previousBackStackEntry` to set the `HOME_PAYMENT_COMPLETED_VIA_CASH_KEY` flag. However, `previousBackStackEntry` refers to the entry immediately before the current one in the back stack, which isn't necessarily the home screen. When navigating from a screen that isn't directly above home, the flag was set on the wrong entry and the home screen never received it.

Fixed by using `getBackStackEntry(HOME_ROUTE)` to explicitly target the home screen's back stack entry, ensuring the flag is always set correctly regardless of navigation depth.

### Test Steps

1. Open POS / Bookings
2. Complete payment using cash
3. Verify the payment successful screen is displayed with the correct animation before returning to the home screen

### Images/gif
—

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.