### PR TITLE
[WOOMOB-2284] Show POS bookings menu only for CIAB sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.featureflags.IsPosBookingsEnabled
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
@@ -33,7 +34,8 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
     private val networkStatus: WooPosNetworkStatus,
     private val resourceProvider: ResourceProvider,
     private val analyticsTracker: WooPosAnalyticsTracker,
-    private val isPosBookingsEnabled: IsPosBookingsEnabled
+    private val isPosBookingsEnabled: IsPosBookingsEnabled,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) : ViewModel() {
     private val _state = MutableStateFlow(
         WooPosHomeFloatingToolbarState(
@@ -143,7 +145,7 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
 
     private val toolbarMenuItems by lazy {
         buildList {
-            if (isPosBookingsEnabled()) {
+            if (isPosBookingsEnabled() && ciabSiteGateKeeper.isCurrentSiteCIAB()) {
                 add(
                     WooPosHomeFloatingToolbarState.Menu.MenuItem(
                         title = R.string.woopos_bookings_title,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -285,8 +285,8 @@ class WooPosHomeFloatingToolbarViewModelTest {
 
         val menu = viewModel.state.value.menu
         assertThat(menu).isInstanceOf(WooPosHomeFloatingToolbarState.Menu.Visible::class.java)
-        val items = (menu as WooPosHomeFloatingToolbarState.Menu.Visible).menuItems
-        assertThat(items.any { it.title == R.string.woopos_bookings_title }).isFalse()
+        val items = (menu as WooPosHomeFloatingToolbarState.Menu.Visible).items
+        assertThat(items.any { it.title == R.string.woopos_bookings_title }).isFalse
     }
 
     private fun createViewModel() = WooPosHomeFloatingToolbarViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.home.toolbar
 
 import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.featureflags.IsPosBookingsEnabled
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
@@ -37,6 +38,9 @@ class WooPosHomeFloatingToolbarViewModelTest {
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val isPosBookingsEnabled: IsPosBookingsEnabled = mock {
         onBlocking { invoke() }.thenReturn(false)
+    }
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isCurrentSiteCIAB() }.thenReturn(false)
     }
 
     @Test
@@ -257,6 +261,34 @@ class WooPosHomeFloatingToolbarViewModelTest {
         assertThat(viewModel.state.value.menu).isEqualTo(WooPosHomeFloatingToolbarState.Menu.Hidden)
     }
 
+    @Test
+    fun `given bookings enabled and CIAB site, when menu opened, then bookings item is shown`() = runTest {
+        whenever(isPosBookingsEnabled.invoke()).thenReturn(true)
+        whenever(ciabSiteGateKeeper.isCurrentSiteCIAB()).thenReturn(true)
+        val viewModel = createViewModel()
+
+        viewModel.onUiEvent(WooPosHomeFloatingToolbarUIEvent.OnToolbarMenuClicked)
+
+        val menu = viewModel.state.value.menu
+        assertThat(menu).isInstanceOf(WooPosHomeFloatingToolbarState.Menu.Visible::class.java)
+        val items = (menu as WooPosHomeFloatingToolbarState.Menu.Visible).items
+        assertThat(items.any { it.title == R.string.woopos_bookings_title }).isTrue
+    }
+
+    @Test
+    fun `given bookings enabled and non-CIAB site, when menu opened, then bookings item is not shown`() = runTest {
+        whenever(isPosBookingsEnabled.invoke()).thenReturn(true)
+        whenever(ciabSiteGateKeeper.isCurrentSiteCIAB()).thenReturn(false)
+        val viewModel = createViewModel()
+
+        viewModel.onUiEvent(WooPosHomeFloatingToolbarUIEvent.OnToolbarMenuClicked)
+
+        val menu = viewModel.state.value.menu
+        assertThat(menu).isInstanceOf(WooPosHomeFloatingToolbarState.Menu.Visible::class.java)
+        val items = (menu as WooPosHomeFloatingToolbarState.Menu.Visible).menuItems
+        assertThat(items.any { it.title == R.string.woopos_bookings_title }).isFalse()
+    }
+
     private fun createViewModel() = WooPosHomeFloatingToolbarViewModel(
         cardReaderFacade,
         childrenToParentEventSender,
@@ -264,5 +296,6 @@ class WooPosHomeFloatingToolbarViewModelTest {
         resourceProvider,
         analyticsTracker,
         isPosBookingsEnabled,
+        ciabSiteGateKeeper,
     )
 }


### PR DESCRIPTION
Fixes WOOMOB-2284

### Description
The POS bookings menu item was gated only by the `POS_BOOKINGS` feature flag, making it visible on all sites. Since bookings is a CIAB-specific feature, added a `CIABSiteGateKeeper` check so the bookings menu item only appears for CIAB sites.

### Test Steps
1. Enable `POS_BOOKINGS` feature flag on a CIAB site → open POS toolbar menu → verify bookings item appears
2. Enable `POS_BOOKINGS` feature flag on a non-CIAB site → open POS toolbar menu → verify bookings item does **not** appear

### Images/gif
TBD

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.