### PR TITLE
[Push Notifications] Check Jetpack connection status on Continue tap

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/JetpackStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/JetpackStatus.kt
@@ -10,6 +10,13 @@ data class JetpackStatus(
 ) : Parcelable {
     val isCurrentUserConnected: Boolean
         get() = jetpackConnectionStatus is JetpackConnectionStatus.AccountConnected
+
+    val isSiteConnected: Boolean
+        get() = when (jetpackConnectionStatus) {
+            is JetpackConnectionStatus.AccountConnected -> true
+            is JetpackConnectionStatus.AccountNotConnected ->
+                jetpackConnectionStatus.siteRegistrationStatus == JetpackSiteRegistrationStatus.REGISTERED
+        }
 }
 
 sealed interface JetpackConnectionStatus : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionDialog.kt
@@ -9,10 +9,12 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.extensions.navigateToHelpScreen
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.login.wpcom.WPComLoginMode
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DisplayUtils
 
@@ -34,11 +36,7 @@ class WooPushNotificationsIntroductionDialog : DialogFragment() {
         dialog?.window?.attributes?.windowAnimations = R.style.Woo_Animations_Dialog
 
         return composeView {
-            WooPushNotificationsIntroductionScreen(
-                onContinueClick = viewModel::onContinueClick,
-                onNotNowClick = viewModel::onNotNowClick,
-                onWhatIsWPComClick = viewModel::onWhatIsWPComClick
-            )
+            WooPushNotificationsIntroductionScreen(viewModel)
         }
     }
 
@@ -57,6 +55,15 @@ class WooPushNotificationsIntroductionDialog : DialogFragment() {
                             )
                     )
                 }
+
+                WooPushNotificationsIntroductionViewModel.NavigateToConnectionSteps -> {
+                    findNavController().navigateSafely(
+                        WooPushNotificationsIntroductionDialogDirections
+                            .actionWooPushNotificationsIntroductionDialogToWooPushNotificationsConnectionStepsFragment()
+                    )
+                }
+
+                is NavigateToHelpScreen -> navigateToHelpScreen(event.origin)
 
                 is WooPushNotificationsIntroductionViewModel.OpenUrlEvent -> {
                     ChromeCustomTabUtils.launchUrl(requireContext(), event.url)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
@@ -333,7 +333,7 @@ private fun ErrorContent(
             onClick = onContactSupportClick,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text(text = stringResource(id = R.string.help))
+            Text(text = stringResource(id = R.string.support_contact))
         }
 
         WCOutlinedButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
@@ -7,13 +7,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -28,11 +29,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.pushnotifications.WordPressWooBadge
-import com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionViewModel.ErrorType
 import com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionViewModel.ViewState
 
 @Composable
@@ -41,6 +42,7 @@ fun WooPushNotificationsIntroductionScreen(viewModel: WooPushNotificationsIntrod
         WooPushNotificationsIntroductionScreen(
             viewState = viewState,
             onContinueClick = viewModel::onContinueClick,
+            onUpdatePluginClick = viewModel::onUpdatePluginClick,
             onNotNowClick = viewModel::onNotNowClick,
             onWhatIsWPComClick = viewModel::onWhatIsWPComClick,
             onContactSupportClick = viewModel::onContactSupportClick
@@ -52,6 +54,7 @@ fun WooPushNotificationsIntroductionScreen(viewModel: WooPushNotificationsIntrod
 fun WooPushNotificationsIntroductionScreen(
     viewState: ViewState,
     onContinueClick: () -> Unit,
+    onUpdatePluginClick: () -> Unit,
     onNotNowClick: () -> Unit,
     onWhatIsWPComClick: () -> Unit,
     onContactSupportClick: () -> Unit,
@@ -64,20 +67,33 @@ fun WooPushNotificationsIntroductionScreen(
             .padding(16.dp)
             .windowInsetsPadding(WindowInsets.safeDrawing)
     ) {
-        val errorType = viewState.errorType
-        if (errorType != null) {
-            ErrorContent(
-                errorType = errorType,
+        when (viewState) {
+            ViewState.Loading -> LoadingContent(modifier = Modifier.fillMaxWidth())
+            ViewState.NotConnected -> IntroContent(
+                onContinueClick = onContinueClick,
+                onNotNowClick = onNotNowClick,
+                onWhatIsWPComClick = onWhatIsWPComClick,
+                modifier = Modifier.fillMaxWidth()
+            )
+            ViewState.UpdateRequired -> UpdateRequiredContent(
+                onUpdatePluginClick = onUpdatePluginClick,
+                onNotNowClick = onNotNowClick,
+                modifier = Modifier.fillMaxWidth()
+            )
+            ViewState.ForbiddenError -> ErrorContent(
+                bodyText = stringResource(
+                    id = R.string.woo_push_notifications_introduction_error_forbidden_body
+                ),
                 onContactSupportClick = onContactSupportClick,
                 onNotNowClick = onNotNowClick,
                 modifier = Modifier.fillMaxWidth()
             )
-        } else {
-            IntroContent(
-                viewState = viewState,
-                onContinueClick = onContinueClick,
+            ViewState.GenericError -> ErrorContent(
+                bodyText = stringResource(
+                    id = R.string.woo_push_notifications_introduction_error_body
+                ),
+                onContactSupportClick = onContactSupportClick,
                 onNotNowClick = onNotNowClick,
-                onWhatIsWPComClick = onWhatIsWPComClick,
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -85,8 +101,68 @@ fun WooPushNotificationsIntroductionScreen(
 }
 
 @Composable
+private fun LoadingContent(modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Column(
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(vertical = 16.dp)
+        ) {
+            SkeletonView(
+                modifier = Modifier
+                    .width(100.dp)
+                    .height(64.dp)
+            )
+
+            SkeletonView(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(28.dp)
+                    .padding(top = 24.dp)
+            )
+
+            SkeletonView(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .padding(top = 24.dp)
+            )
+
+            SkeletonView(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .padding(top = 24.dp)
+            )
+
+            SkeletonView(
+                modifier = Modifier
+                    .fillMaxWidth(0.5f)
+                    .height(20.dp)
+                    .padding(top = 24.dp)
+            )
+        }
+
+        SkeletonView(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp)
+        )
+
+        SkeletonView(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp)
+                .padding(top = 8.dp)
+        )
+    }
+}
+
+@Composable
 private fun IntroContent(
-    viewState: ViewState,
     onContinueClick: () -> Unit,
     onNotNowClick: () -> Unit,
     onWhatIsWPComClick: () -> Unit,
@@ -139,23 +215,69 @@ private fun IntroContent(
 
         WCColoredButton(
             onClick = onContinueClick,
-            enabled = !viewState.isLoading,
             modifier = Modifier.fillMaxWidth()
         ) {
-            if (viewState.isLoading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(24.dp),
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    strokeWidth = 2.dp
-                )
-            } else {
-                Text(text = stringResource(id = R.string.woo_push_notifications_introduction_continue))
-            }
+            Text(text = stringResource(id = R.string.woo_push_notifications_introduction_continue))
         }
 
         WCOutlinedButton(
             onClick = onNotNowClick,
-            enabled = !viewState.isLoading,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.woo_push_notifications_introduction_not_now),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@Composable
+private fun UpdateRequiredContent(
+    onUpdatePluginClick: () -> Unit,
+    onNotNowClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        Column(
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(vertical = 16.dp)
+        ) {
+            WordPressWooBadge(
+                iconSize = 64.dp
+            )
+
+            Text(
+                text = stringResource(id = R.string.woo_push_notifications_introduction_update_required_title),
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.padding(top = 24.dp)
+            )
+
+            Text(
+                text = stringResource(id = R.string.woo_push_notifications_introduction_update_required_body),
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.padding(top = 24.dp)
+            )
+        }
+
+        WCColoredButton(
+            onClick = onUpdatePluginClick,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(text = stringResource(id = R.string.woo_push_notifications_introduction_update_plugin))
+        }
+
+        WCOutlinedButton(
+            onClick = onNotNowClick,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 8.dp)
@@ -170,20 +292,11 @@ private fun IntroContent(
 
 @Composable
 private fun ErrorContent(
-    errorType: ErrorType,
+    bodyText: String,
     onContactSupportClick: () -> Unit,
     onNotNowClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val bodyText = when (errorType) {
-        ErrorType.Generic -> stringResource(
-            id = R.string.woo_push_notifications_introduction_error_body
-        )
-        ErrorType.Forbidden -> stringResource(
-            id = R.string.woo_push_notifications_introduction_error_forbidden_body
-        )
-    }
-
     Column(modifier = modifier) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -239,11 +352,12 @@ private fun ErrorContent(
 
 @Composable
 @Preview
-private fun WooPushNotificationsIntroductionScreenPreview() {
+private fun WooPushNotificationsIntroductionLoadingPreview() {
     WooThemeWithBackground {
         WooPushNotificationsIntroductionScreen(
-            viewState = ViewState(),
+            viewState = ViewState.Loading,
             onContinueClick = {},
+            onUpdatePluginClick = {},
             onNotNowClick = {},
             onWhatIsWPComClick = {},
             onContactSupportClick = {}
@@ -253,11 +367,12 @@ private fun WooPushNotificationsIntroductionScreenPreview() {
 
 @Composable
 @Preview
-private fun WooPushNotificationsIntroductionScreenLoadingPreview() {
+private fun WooPushNotificationsIntroductionNotConnectedPreview() {
     WooThemeWithBackground {
         WooPushNotificationsIntroductionScreen(
-            viewState = ViewState(isLoading = true),
+            viewState = ViewState.NotConnected,
             onContinueClick = {},
+            onUpdatePluginClick = {},
             onNotNowClick = {},
             onWhatIsWPComClick = {},
             onContactSupportClick = {}
@@ -267,11 +382,12 @@ private fun WooPushNotificationsIntroductionScreenLoadingPreview() {
 
 @Composable
 @Preview
-private fun WooPushNotificationsIntroductionScreenErrorPreview() {
+private fun WooPushNotificationsIntroductionUpdateRequiredPreview() {
     WooThemeWithBackground {
         WooPushNotificationsIntroductionScreen(
-            viewState = ViewState(errorType = ErrorType.Generic),
+            viewState = ViewState.UpdateRequired,
             onContinueClick = {},
+            onUpdatePluginClick = {},
             onNotNowClick = {},
             onWhatIsWPComClick = {},
             onContactSupportClick = {}
@@ -281,11 +397,27 @@ private fun WooPushNotificationsIntroductionScreenErrorPreview() {
 
 @Composable
 @Preview
-private fun WooPushNotificationsIntroductionScreenForbiddenErrorPreview() {
+private fun WooPushNotificationsIntroductionGenericErrorPreview() {
     WooThemeWithBackground {
         WooPushNotificationsIntroductionScreen(
-            viewState = ViewState(errorType = ErrorType.Forbidden),
+            viewState = ViewState.GenericError,
             onContinueClick = {},
+            onUpdatePluginClick = {},
+            onNotNowClick = {},
+            onWhatIsWPComClick = {},
+            onContactSupportClick = {}
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun WooPushNotificationsIntroductionForbiddenErrorPreview() {
+    WooThemeWithBackground {
+        WooPushNotificationsIntroductionScreen(
+            viewState = ViewState.ForbiddenError,
+            onContinueClick = {},
+            onUpdatePluginClick = {},
             onNotNowClick = {},
             onWhatIsWPComClick = {},
             onContactSupportClick = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
@@ -44,7 +44,6 @@ fun WooPushNotificationsIntroductionScreen(viewModel: WooPushNotificationsIntrod
         WooPushNotificationsIntroductionScreen(
             viewState = viewState,
             onContinueClick = viewModel::onContinueClick,
-            onUpdatePluginClick = viewModel::onUpdatePluginClick,
             onNotNowClick = viewModel::onNotNowClick,
             onWhatIsWPComClick = viewModel::onWhatIsWPComClick,
             onContactSupportClick = viewModel::onContactSupportClick
@@ -56,7 +55,6 @@ fun WooPushNotificationsIntroductionScreen(viewModel: WooPushNotificationsIntrod
 fun WooPushNotificationsIntroductionScreen(
     viewState: ViewState,
     onContinueClick: () -> Unit,
-    onUpdatePluginClick: () -> Unit,
     onNotNowClick: () -> Unit,
     onWhatIsWPComClick: () -> Unit,
     onContactSupportClick: () -> Unit,
@@ -80,16 +78,11 @@ fun WooPushNotificationsIntroductionScreen(
         ) {
             when (viewState) {
                 ViewState.Loading -> LoadingContent(modifier = Modifier.fillMaxWidth())
-                ViewState.NotConnected -> IntroContent(
+                ViewState.NotConnected, ViewState.UpdateRequired -> IntroContent(
+                    isUpdateRequired = viewState is ViewState.UpdateRequired,
                     onContinueClick = onContinueClick,
                     onNotNowClick = onNotNowClick,
                     onWhatIsWPComClick = onWhatIsWPComClick,
-                    modifier = Modifier.fillMaxWidth()
-                )
-
-                ViewState.UpdateRequired -> UpdateRequiredContent(
-                    onUpdatePluginClick = onUpdatePluginClick,
-                    onNotNowClick = onNotNowClick,
                     modifier = Modifier.fillMaxWidth()
                 )
 
@@ -178,6 +171,7 @@ private fun LoadingContent(modifier: Modifier = Modifier) {
 
 @Composable
 private fun IntroContent(
+    isUpdateRequired: Boolean,
     onContinueClick: () -> Unit,
     onNotNowClick: () -> Unit,
     onWhatIsWPComClick: () -> Unit,
@@ -198,97 +192,63 @@ private fun IntroContent(
             )
 
             Text(
-                text = stringResource(id = R.string.woo_push_notifications_introduction_title),
+                text = stringResource(
+                    id = if (isUpdateRequired) {
+                        R.string.woo_push_notifications_introduction_update_required_title
+                    } else {
+                        R.string.woo_push_notifications_introduction_title
+                    }
+                ),
                 style = MaterialTheme.typography.headlineMedium,
                 textAlign = TextAlign.Start,
                 modifier = Modifier.padding(top = 24.dp)
             )
 
             Text(
-                text = stringResource(id = R.string.woo_push_notifications_introduction_body),
+                text = stringResource(
+                    id = if (isUpdateRequired) {
+                        R.string.woo_push_notifications_introduction_update_required_body
+                    } else {
+                        R.string.woo_push_notifications_introduction_body
+                    }
+                ),
                 style = MaterialTheme.typography.titleMedium,
                 textAlign = TextAlign.Start,
                 modifier = Modifier.padding(top = 24.dp)
             )
 
-            Text(
-                text = stringResource(id = R.string.woo_push_notifications_introduction_body2),
-                style = MaterialTheme.typography.titleMedium,
-                textAlign = TextAlign.Start,
-                modifier = Modifier.padding(top = 24.dp)
-            )
+            if (!isUpdateRequired) {
+                Text(
+                    text = stringResource(id = R.string.woo_push_notifications_introduction_body2),
+                    style = MaterialTheme.typography.titleMedium,
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier.padding(top = 24.dp)
+                )
 
-            Text(
-                text = stringResource(id = R.string.woo_push_notifications_introduction_what_is_wpcom),
-                style = MaterialTheme.typography.bodyMedium,
-                color = colorResource(id = R.color.color_primary),
-                modifier = Modifier
-                    .padding(top = 24.dp)
-                    .clickable { onWhatIsWPComClick() }
-            )
+                Text(
+                    text = stringResource(id = R.string.woo_push_notifications_introduction_what_is_wpcom),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colorResource(id = R.color.color_primary),
+                    modifier = Modifier
+                        .padding(top = 24.dp)
+                        .clickable { onWhatIsWPComClick() }
+                )
+            }
         }
 
         WCColoredButton(
             onClick = onContinueClick,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text(text = stringResource(id = R.string.woo_push_notifications_introduction_continue))
-        }
-
-        WCOutlinedButton(
-            onClick = onNotNowClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp)
-        ) {
             Text(
-                text = stringResource(id = R.string.woo_push_notifications_introduction_not_now),
-                color = MaterialTheme.colorScheme.onSurface
+                text = stringResource(
+                    if (isUpdateRequired) {
+                        R.string.woo_push_notifications_introduction_update_plugin
+                    } else {
+                        R.string.woo_push_notifications_introduction_continue
+                    }
+                )
             )
-        }
-    }
-}
-
-@Composable
-private fun UpdateRequiredContent(
-    onUpdatePluginClick: () -> Unit,
-    onNotNowClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Column(modifier = modifier) {
-        Column(
-            horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.Center,
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
-                .padding(vertical = 16.dp)
-        ) {
-            WordPressWooBadge(
-                iconSize = 64.dp
-            )
-
-            Text(
-                text = stringResource(id = R.string.woo_push_notifications_introduction_update_required_title),
-                style = MaterialTheme.typography.headlineMedium,
-                textAlign = TextAlign.Start,
-                modifier = Modifier.padding(top = 24.dp)
-            )
-
-            Text(
-                text = stringResource(id = R.string.woo_push_notifications_introduction_update_required_body),
-                style = MaterialTheme.typography.titleMedium,
-                textAlign = TextAlign.Start,
-                modifier = Modifier.padding(top = 24.dp)
-            )
-        }
-
-        WCColoredButton(
-            onClick = onUpdatePluginClick,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text(text = stringResource(id = R.string.woo_push_notifications_introduction_update_plugin))
         }
 
         WCOutlinedButton(
@@ -372,7 +332,6 @@ private fun WooPushNotificationsIntroductionLoadingPreview() {
         WooPushNotificationsIntroductionScreen(
             viewState = ViewState.Loading,
             onContinueClick = {},
-            onUpdatePluginClick = {},
             onNotNowClick = {},
             onWhatIsWPComClick = {},
             onContactSupportClick = {}
@@ -387,7 +346,6 @@ private fun WooPushNotificationsIntroductionNotConnectedPreview() {
         WooPushNotificationsIntroductionScreen(
             viewState = ViewState.NotConnected,
             onContinueClick = {},
-            onUpdatePluginClick = {},
             onNotNowClick = {},
             onWhatIsWPComClick = {},
             onContactSupportClick = {}
@@ -402,7 +360,6 @@ private fun WooPushNotificationsIntroductionUpdateRequiredPreview() {
         WooPushNotificationsIntroductionScreen(
             viewState = ViewState.UpdateRequired,
             onContinueClick = {},
-            onUpdatePluginClick = {},
             onNotNowClick = {},
             onWhatIsWPComClick = {},
             onContactSupportClick = {}
@@ -412,27 +369,11 @@ private fun WooPushNotificationsIntroductionUpdateRequiredPreview() {
 
 @Composable
 @Preview
-private fun WooPushNotificationsIntroductionGenericErrorPreview() {
+private fun WooPushNotificationsIntroductionErrorPreview() {
     WooThemeWithBackground {
         WooPushNotificationsIntroductionScreen(
             viewState = ViewState.GenericError,
             onContinueClick = {},
-            onUpdatePluginClick = {},
-            onNotNowClick = {},
-            onWhatIsWPComClick = {},
-            onContactSupportClick = {}
-        )
-    }
-}
-
-@Composable
-@Preview
-private fun WooPushNotificationsIntroductionForbiddenErrorPreview() {
-    WooThemeWithBackground {
-        WooPushNotificationsIntroductionScreen(
-            viewState = ViewState.ForbiddenError,
-            onContinueClick = {},
-            onUpdatePluginClick = {},
             onNotNowClick = {},
             onWhatIsWPComClick = {},
             onContactSupportClick = {}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
@@ -9,15 +9,20 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,12 +32,29 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.pushnotifications.WordPressWooBadge
+import com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionViewModel.ErrorType
+import com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionViewModel.ViewState
+
+@Composable
+fun WooPushNotificationsIntroductionScreen(viewModel: WooPushNotificationsIntroductionViewModel) {
+    viewModel.viewState.observeAsState().value?.let { viewState ->
+        WooPushNotificationsIntroductionScreen(
+            viewState = viewState,
+            onContinueClick = viewModel::onContinueClick,
+            onNotNowClick = viewModel::onNotNowClick,
+            onWhatIsWPComClick = viewModel::onWhatIsWPComClick,
+            onContactSupportClick = viewModel::onContactSupportClick
+        )
+    }
+}
 
 @Composable
 fun WooPushNotificationsIntroductionScreen(
+    viewState: ViewState,
     onContinueClick: () -> Unit,
     onNotNowClick: () -> Unit,
     onWhatIsWPComClick: () -> Unit,
+    onContactSupportClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -42,7 +64,35 @@ fun WooPushNotificationsIntroductionScreen(
             .padding(16.dp)
             .windowInsetsPadding(WindowInsets.safeDrawing)
     ) {
-        // Content centered in remaining space
+        val errorType = viewState.errorType
+        if (errorType != null) {
+            ErrorContent(
+                errorType = errorType,
+                onContactSupportClick = onContactSupportClick,
+                onNotNowClick = onNotNowClick,
+                modifier = Modifier.fillMaxWidth()
+            )
+        } else {
+            IntroContent(
+                viewState = viewState,
+                onContinueClick = onContinueClick,
+                onNotNowClick = onNotNowClick,
+                onWhatIsWPComClick = onWhatIsWPComClick,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun IntroContent(
+    viewState: ViewState,
+    onContinueClick: () -> Unit,
+    onNotNowClick: () -> Unit,
+    onWhatIsWPComClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
         Column(
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.Center,
@@ -56,7 +106,6 @@ fun WooPushNotificationsIntroductionScreen(
                 iconSize = 64.dp
             )
 
-            // Title
             Text(
                 text = stringResource(id = R.string.woo_push_notifications_introduction_title),
                 style = MaterialTheme.typography.headlineMedium,
@@ -64,7 +113,6 @@ fun WooPushNotificationsIntroductionScreen(
                 modifier = Modifier.padding(top = 24.dp)
             )
 
-            // Body
             Text(
                 text = stringResource(id = R.string.woo_push_notifications_introduction_body),
                 style = MaterialTheme.typography.titleMedium,
@@ -72,7 +120,6 @@ fun WooPushNotificationsIntroductionScreen(
                 modifier = Modifier.padding(top = 24.dp)
             )
 
-            // Body 2
             Text(
                 text = stringResource(id = R.string.woo_push_notifications_introduction_body2),
                 style = MaterialTheme.typography.titleMedium,
@@ -80,7 +127,6 @@ fun WooPushNotificationsIntroductionScreen(
                 modifier = Modifier.padding(top = 24.dp)
             )
 
-            // What is WordPress.com? link
             Text(
                 text = stringResource(id = R.string.woo_push_notifications_introduction_what_is_wpcom),
                 style = MaterialTheme.typography.bodyMedium,
@@ -91,15 +137,92 @@ fun WooPushNotificationsIntroductionScreen(
             )
         }
 
-        // Continue button
         WCColoredButton(
             onClick = onContinueClick,
+            enabled = !viewState.isLoading,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text(text = stringResource(id = R.string.woo_push_notifications_introduction_continue))
+            if (viewState.isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    strokeWidth = 2.dp
+                )
+            } else {
+                Text(text = stringResource(id = R.string.woo_push_notifications_introduction_continue))
+            }
         }
 
-        // Not now button
+        WCOutlinedButton(
+            onClick = onNotNowClick,
+            enabled = !viewState.isLoading,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.woo_push_notifications_introduction_not_now),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    errorType: ErrorType,
+    onContactSupportClick: () -> Unit,
+    onNotNowClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val bodyText = when (errorType) {
+        ErrorType.Generic -> stringResource(
+            id = R.string.woo_push_notifications_introduction_error_body
+        )
+        ErrorType.Forbidden -> stringResource(
+            id = R.string.woo_push_notifications_introduction_error_forbidden_body
+        )
+    }
+
+    Column(modifier = modifier) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(vertical = 16.dp)
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_gridicons_notice),
+                contentDescription = null,
+                tint = colorResource(id = R.color.color_error),
+                modifier = Modifier.size(64.dp)
+            )
+
+            Text(
+                text = stringResource(id = R.string.woo_push_notifications_introduction_error_title),
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 24.dp)
+            )
+
+            Text(
+                text = bodyText,
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 16.dp)
+            )
+        }
+
+        WCColoredButton(
+            onClick = onContactSupportClick,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(text = stringResource(id = R.string.help))
+        }
+
         WCOutlinedButton(
             onClick = onNotNowClick,
             modifier = Modifier
@@ -119,9 +242,53 @@ fun WooPushNotificationsIntroductionScreen(
 private fun WooPushNotificationsIntroductionScreenPreview() {
     WooThemeWithBackground {
         WooPushNotificationsIntroductionScreen(
+            viewState = ViewState(),
             onContinueClick = {},
             onNotNowClick = {},
-            onWhatIsWPComClick = {}
+            onWhatIsWPComClick = {},
+            onContactSupportClick = {}
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun WooPushNotificationsIntroductionScreenLoadingPreview() {
+    WooThemeWithBackground {
+        WooPushNotificationsIntroductionScreen(
+            viewState = ViewState(isLoading = true),
+            onContinueClick = {},
+            onNotNowClick = {},
+            onWhatIsWPComClick = {},
+            onContactSupportClick = {}
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun WooPushNotificationsIntroductionScreenErrorPreview() {
+    WooThemeWithBackground {
+        WooPushNotificationsIntroductionScreen(
+            viewState = ViewState(errorType = ErrorType.Generic),
+            onContinueClick = {},
+            onNotNowClick = {},
+            onWhatIsWPComClick = {},
+            onContactSupportClick = {}
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun WooPushNotificationsIntroductionScreenForbiddenErrorPreview() {
+    WooThemeWithBackground {
+        WooPushNotificationsIntroductionScreen(
+            viewState = ViewState(errorType = ErrorType.Forbidden),
+            onContinueClick = {},
+            onNotNowClick = {},
+            onWhatIsWPComClick = {},
+            onContactSupportClick = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
@@ -4,32 +4,34 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -60,42 +62,55 @@ fun WooPushNotificationsIntroductionScreen(
     onContactSupportClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
-        modifier = modifier
-            .background(MaterialTheme.colorScheme.surface)
-            .fillMaxSize()
-            .padding(16.dp)
-            .windowInsetsPadding(WindowInsets.safeDrawing)
-    ) {
-        when (viewState) {
-            ViewState.Loading -> LoadingContent(modifier = Modifier.fillMaxWidth())
-            ViewState.NotConnected -> IntroContent(
-                onContinueClick = onContinueClick,
-                onNotNowClick = onNotNowClick,
-                onWhatIsWPComClick = onWhatIsWPComClick,
-                modifier = Modifier.fillMaxWidth()
+    Scaffold(
+        topBar = {
+            Toolbar(
+                onNavigationButtonClick = onNotNowClick,
+                navigationIcon = ImageVector.vectorResource(R.drawable.ic_close_24dp),
+                windowInsets = TopAppBarDefaults.windowInsets
             )
-            ViewState.UpdateRequired -> UpdateRequiredContent(
-                onUpdatePluginClick = onUpdatePluginClick,
-                onNotNowClick = onNotNowClick,
-                modifier = Modifier.fillMaxWidth()
-            )
-            ViewState.ForbiddenError -> ErrorContent(
-                bodyText = stringResource(
-                    id = R.string.woo_push_notifications_introduction_error_forbidden_body
-                ),
-                onContactSupportClick = onContactSupportClick,
-                onNotNowClick = onNotNowClick,
-                modifier = Modifier.fillMaxWidth()
-            )
-            ViewState.GenericError -> ErrorContent(
-                bodyText = stringResource(
-                    id = R.string.woo_push_notifications_introduction_error_body
-                ),
-                onContactSupportClick = onContactSupportClick,
-                onNotNowClick = onNotNowClick,
-                modifier = Modifier.fillMaxWidth()
-            )
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = modifier
+                .background(MaterialTheme.colorScheme.surface)
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            when (viewState) {
+                ViewState.Loading -> LoadingContent(modifier = Modifier.fillMaxWidth())
+                ViewState.NotConnected -> IntroContent(
+                    onContinueClick = onContinueClick,
+                    onNotNowClick = onNotNowClick,
+                    onWhatIsWPComClick = onWhatIsWPComClick,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                ViewState.UpdateRequired -> UpdateRequiredContent(
+                    onUpdatePluginClick = onUpdatePluginClick,
+                    onNotNowClick = onNotNowClick,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                ViewState.ForbiddenError -> ErrorContent(
+                    bodyText = stringResource(
+                        id = R.string.woo_push_notifications_introduction_error_forbidden_body
+                    ),
+                    onContactSupportClick = onContactSupportClick,
+                    onNotNowClick = onNotNowClick,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                ViewState.GenericError -> ErrorContent(
+                    bodyText = stringResource(
+                        id = R.string.woo_push_notifications_introduction_error_body
+                    ),
+                    onContactSupportClick = onContactSupportClick,
+                    onNotNowClick = onNotNowClick,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -4,9 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.extensions.isVersionAtLeast
-import com.woocommerce.android.model.JetpackConnectionStatus
-import com.woocommerce.android.model.JetpackSiteRegistrationStatus
-import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
@@ -27,16 +24,8 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
     private val fetchActiveWCPluginVersion: FetchActiveWCPluginVersion,
     private val selectedSite: SelectedSite
 ) : ScopedViewModel(savedStateHandle) {
-
     companion object {
         const val PUSH_NOTIFICATIONS_MIN_WC_VERSION = "10.6.0" // TODO CHECK CORRECT VERSION LATER
-
-        private val JetpackStatus.isSiteConnected: Boolean
-            get() = when (jetpackConnectionStatus) {
-                is JetpackConnectionStatus.AccountConnected -> true
-                is JetpackConnectionStatus.AccountNotConnected ->
-                    jetpackConnectionStatus.siteRegistrationStatus == JetpackSiteRegistrationStatus.REGISTERED
-            }
     }
 
     private val _viewState = MutableStateFlow<ViewState>(ViewState.Loading)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -1,20 +1,97 @@
 package com.woocommerce.android.ui.pushnotifications.introduction
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppUrls
+import com.woocommerce.android.extensions.isVersionAtLeast
+import com.woocommerce.android.model.JetpackConnectionStatus
+import com.woocommerce.android.model.JetpackSiteRegistrationStatus
+import com.woocommerce.android.model.JetpackStatus
+import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
+import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
+import com.woocommerce.android.util.FetchActiveWCPluginVersion
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class WooPushNotificationsIntroductionViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val fetchJetpackStatus: FetchJetpackStatus,
+    private val fetchActiveWCPluginVersion: FetchActiveWCPluginVersion,
+    private val selectedSite: SelectedSite
 ) : ScopedViewModel(savedStateHandle) {
 
+    companion object {
+        const val PUSH_NOTIFICATIONS_MIN_WC_VERSION = "10.6.0" // TODO CHECK CORRECT VERSION LATER
+
+        private val JetpackStatus.isSiteConnected: Boolean
+            get() = when (jetpackConnectionStatus) {
+                is JetpackConnectionStatus.AccountConnected -> true
+                is JetpackConnectionStatus.AccountNotConnected ->
+                    jetpackConnectionStatus.siteRegistrationStatus == JetpackSiteRegistrationStatus.REGISTERED
+            }
+    }
+
+    private val _viewState = MutableStateFlow(ViewState())
+    val viewState = _viewState.asLiveData()
+
     fun onContinueClick() {
-        triggerEvent(StartWPComLogin)
+        launch {
+            _viewState.update { it.copy(isLoading = true, errorType = null) }
+
+            val site = selectedSite.get()
+
+            val result = fetchJetpackStatus(
+                site = site,
+                useApplicationPasswords = true
+            )
+
+            result.fold(
+                onSuccess = { response ->
+                    when (response) {
+                        is JetpackStatusFetchResponse.ConnectionForbidden -> {
+                            _viewState.update {
+                                it.copy(isLoading = false, errorType = ErrorType.Forbidden)
+                            }
+                        }
+
+                        is JetpackStatusFetchResponse.Success -> {
+                            if (response.status.isSiteConnected) {
+                                checkWCVersion()
+                            } else {
+                                _viewState.update { it.copy(isLoading = false) }
+                                triggerEvent(StartWPComLogin)
+                            }
+                        }
+                    }
+                },
+                onFailure = {
+                    _viewState.update {
+                        it.copy(isLoading = false, errorType = ErrorType.Generic)
+                    }
+                }
+            )
+        }
+    }
+
+    private suspend fun checkWCVersion() {
+        val wcVersion = fetchActiveWCPluginVersion()
+        if (wcVersion != null && wcVersion.isVersionAtLeast(PUSH_NOTIFICATIONS_MIN_WC_VERSION)) {
+            _viewState.update {
+                it.copy(isLoading = false, errorType = ErrorType.Generic)
+            }
+        } else {
+            _viewState.update { it.copy(isLoading = false) }
+            triggerEvent(NavigateToConnectionSteps)
+        }
     }
 
     fun onNotNowClick() {
@@ -25,7 +102,25 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
         triggerEvent(OpenUrlEvent(AppUrls.LOGIN_WITH_EMAIL_WHAT_IS_WORDPRESS_COM_ACCOUNT))
     }
 
+    fun onContactSupportClick() {
+        triggerEvent(Event.NavigateToHelpScreen(HelpOrigin.WOO_PUSH_NOTIFICATIONS_SETUP))
+    }
+
+    data class ViewState(
+        val isLoading: Boolean = false,
+        val errorType: ErrorType? = null
+    ) {
+        val isError: Boolean get() = errorType != null
+    }
+
+    enum class ErrorType {
+        Generic,
+        Forbidden
+    }
+
     data object StartWPComLogin : Event()
+
+    data object NavigateToConnectionSteps : Event()
 
     data class OpenUrlEvent(val url: String) : Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -81,7 +81,7 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
     }
 
     fun onContinueClick() {
-        if (viewState.value is ViewState.UpdateRequired) {
+        if (_viewState.value is ViewState.UpdateRequired) {
             triggerEvent(NavigateToConnectionSteps)
         } else {
             triggerEvent(StartWPComLogin)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -77,11 +77,11 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
     }
 
     fun onContinueClick() {
-        triggerEvent(StartWPComLogin)
-    }
-
-    fun onUpdatePluginClick() {
-        triggerEvent(NavigateToConnectionSteps)
+        if (viewState.value is ViewState.UpdateRequired) {
+            triggerEvent(NavigateToConnectionSteps)
+        } else {
+            triggerEvent(StartWPComLogin)
+        }
     }
 
     fun onNotNowClick() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -68,8 +68,12 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
     }
 
     private suspend fun checkWCVersion() {
-        val wcVersion = fetchActiveWCPluginVersion()
-        if (wcVersion != null && wcVersion.isVersionAtLeast(PUSH_NOTIFICATIONS_MIN_WC_VERSION)) {
+        val wcVersion = fetchActiveWCPluginVersion() ?: run {
+            _viewState.value = ViewState.GenericError
+            return
+        }
+
+        if (wcVersion.isVersionAtLeast(PUSH_NOTIFICATIONS_MIN_WC_VERSION)) {
             _viewState.value = ViewState.GenericError
         } else {
             _viewState.value = ViewState.UpdateRequired

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -40,13 +39,15 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
             }
     }
 
-    private val _viewState = MutableStateFlow(ViewState())
+    private val _viewState = MutableStateFlow<ViewState>(ViewState.Loading)
     val viewState = _viewState.asLiveData()
 
-    fun onContinueClick() {
-        launch {
-            _viewState.update { it.copy(isLoading = true, errorType = null) }
+    init {
+        fetchStatus()
+    }
 
+    private fun fetchStatus() {
+        launch {
             val site = selectedSite.get()
 
             val result = fetchJetpackStatus(
@@ -58,25 +59,20 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
                 onSuccess = { response ->
                     when (response) {
                         is JetpackStatusFetchResponse.ConnectionForbidden -> {
-                            _viewState.update {
-                                it.copy(isLoading = false, errorType = ErrorType.Forbidden)
-                            }
+                            _viewState.value = ViewState.ForbiddenError
                         }
 
                         is JetpackStatusFetchResponse.Success -> {
                             if (response.status.isSiteConnected) {
                                 checkWCVersion()
                             } else {
-                                _viewState.update { it.copy(isLoading = false) }
-                                triggerEvent(StartWPComLogin)
+                                _viewState.value = ViewState.NotConnected
                             }
                         }
                     }
                 },
                 onFailure = {
-                    _viewState.update {
-                        it.copy(isLoading = false, errorType = ErrorType.Generic)
-                    }
+                    _viewState.value = ViewState.GenericError
                 }
             )
         }
@@ -85,13 +81,18 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
     private suspend fun checkWCVersion() {
         val wcVersion = fetchActiveWCPluginVersion()
         if (wcVersion != null && wcVersion.isVersionAtLeast(PUSH_NOTIFICATIONS_MIN_WC_VERSION)) {
-            _viewState.update {
-                it.copy(isLoading = false, errorType = ErrorType.Generic)
-            }
+            _viewState.value = ViewState.GenericError
         } else {
-            _viewState.update { it.copy(isLoading = false) }
-            triggerEvent(NavigateToConnectionSteps)
+            _viewState.value = ViewState.UpdateRequired
         }
+    }
+
+    fun onContinueClick() {
+        triggerEvent(StartWPComLogin)
+    }
+
+    fun onUpdatePluginClick() {
+        triggerEvent(NavigateToConnectionSteps)
     }
 
     fun onNotNowClick() {
@@ -106,16 +107,12 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
         triggerEvent(Event.NavigateToHelpScreen(HelpOrigin.WOO_PUSH_NOTIFICATIONS_SETUP))
     }
 
-    data class ViewState(
-        val isLoading: Boolean = false,
-        val errorType: ErrorType? = null
-    ) {
-        val isError: Boolean get() = errorType != null
-    }
-
-    enum class ErrorType {
-        Generic,
-        Forbidden
+    sealed interface ViewState {
+        data object Loading : ViewState
+        data object NotConnected : ViewState
+        data object UpdateRequired : ViewState
+        data object ForbiddenError : ViewState
+        data object GenericError : ViewState
     }
 
     data object StartWPComLogin : Event()

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2639,6 +2639,9 @@
     <string name="woo_push_notifications_introduction_what_is_wpcom">What is WordPress.com?</string>
     <string name="woo_push_notifications_introduction_continue">Continue</string>
     <string name="woo_push_notifications_introduction_not_now">Not now</string>
+    <string name="woo_push_notifications_introduction_error_title">Something went wrong</string>
+    <string name="woo_push_notifications_introduction_error_body">We could not complete the push notifications setup. Please contact support for assistance.</string>
+    <string name="woo_push_notifications_introduction_error_forbidden_body">Your account does not have permission to complete push notifications setup. Please ask your store administrator to handle this.</string>
     <string name="woo_push_notifications_connection_steps_title">Connect to WordPress.com</string>
     <string name="woo_push_notifications_connection_steps_body">Please wait while we finalize connecting your store &lt;b>%1$s&lt;/b> to your WordPress.com account.</string>
     <string name="woo_push_notifications_connection_steps_step_connect_store">Connect store to WordPress.com</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2642,6 +2642,9 @@
     <string name="woo_push_notifications_introduction_error_title">Something went wrong</string>
     <string name="woo_push_notifications_introduction_error_body">We could not complete the push notifications setup. Please contact support for assistance.</string>
     <string name="woo_push_notifications_introduction_error_forbidden_body">Your account does not have permission to complete push notifications setup. Please ask your store administrator to handle this.</string>
+    <string name="woo_push_notifications_introduction_update_required_title">Get push notifications for your store</string>
+    <string name="woo_push_notifications_introduction_update_required_body">Your store is already connected to a WordPress.com account, but you\'ll need to update WooCommerce plugin to enable push notifications for new orders, reviews, and more.</string>
+    <string name="woo_push_notifications_introduction_update_plugin">Update plugin</string>
     <string name="woo_push_notifications_connection_steps_title">Connect to WordPress.com</string>
     <string name="woo_push_notifications_connection_steps_body">Please wait while we finalize connecting your store &lt;b>%1$s&lt;/b> to your WordPress.com account.</string>
     <string name="woo_push_notifications_connection_steps_step_connect_store">Connect store to WordPress.com</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
@@ -157,7 +157,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given user is connected and WC version is null, when screen opens, then UpdateRequired state is shown`() =
+    fun `given checking WC version fails, when screen opens, then Error state is shown`() =
         testBlocking {
             val jetpackStatus = JetpackStatus(
                 isJetpackInstalled = true,
@@ -172,7 +172,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
             setup()
 
             val viewState = viewModel.viewState.getOrAwaitValue()
-            assertThat(viewState).isEqualTo(ViewState.UpdateRequired)
+            assertThat(viewState).isEqualTo(ViewState.GenericError)
         }
 
     @Test
@@ -210,10 +210,21 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when update plugin is clicked, then NavigateToConnectionSteps event is triggered`() {
+    fun `when update plugin is clicked, then NavigateToConnectionSteps event is triggered`() = testBlocking {
+        val jetpackStatus = JetpackStatus(
+            isJetpackInstalled = true,
+            jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                siteRegistrationStatus = JetpackSiteRegistrationStatus.REGISTERED,
+                blogId = 123L
+            )
+        )
+        whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
+            .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
+        whenever(fetchActiveWCPluginVersion()).thenReturn("9.0.0")
+
         setup()
 
-        viewModel.onUpdatePluginClick()
+        viewModel.onContinueClick()
 
         val event = viewModel.event.value
         assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.NavigateToConnectionSteps)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
@@ -2,20 +2,212 @@ package com.woocommerce.android.ui.pushnotifications.introduction
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppUrls
+import com.woocommerce.android.model.JetpackConnectionStatus
+import com.woocommerce.android.model.JetpackSiteRegistrationStatus
+import com.woocommerce.android.model.JetpackStatus
+import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
+import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
+import com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionViewModel.ErrorType
+import com.woocommerce.android.util.FetchActiveWCPluginVersion
+import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScreen
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
+    private val site = SiteModel()
+
+    private val selectedSite: SelectedSite = mock {
+        on { get() } doReturn site
+    }
+
+    private val fetchJetpackStatus: FetchJetpackStatus = mock()
+    private val fetchActiveWCPluginVersion: FetchActiveWCPluginVersion = mock()
+
     private lateinit var viewModel: WooPushNotificationsIntroductionViewModel
 
     private fun setup() {
         viewModel = WooPushNotificationsIntroductionViewModel(
-            savedStateHandle = SavedStateHandle()
+            savedStateHandle = SavedStateHandle(),
+            fetchJetpackStatus = fetchJetpackStatus,
+            fetchActiveWCPluginVersion = fetchActiveWCPluginVersion,
+            selectedSite = selectedSite
         )
+    }
+
+    @Test
+    fun `given site is not registered, when continue is clicked, then StartWPComLogin event is triggered`() =
+        testBlocking {
+            val jetpackStatus = JetpackStatus(
+                isJetpackInstalled = false,
+                jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                    siteRegistrationStatus = JetpackSiteRegistrationStatus.NOT_REGISTERED,
+                    blogId = null
+                )
+            )
+            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+                .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
+
+            setup()
+            viewModel.onContinueClick()
+
+            val event = viewModel.event.value
+            assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.StartWPComLogin)
+        }
+
+    @Test
+    fun `given site registration status is unknown, when continue is clicked, then StartWPComLogin event is triggered`() =
+        testBlocking {
+            val jetpackStatus = JetpackStatus(
+                isJetpackInstalled = true,
+                jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                    siteRegistrationStatus = JetpackSiteRegistrationStatus.UNKNOWN,
+                    blogId = null
+                )
+            )
+            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+                .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
+
+            setup()
+            viewModel.onContinueClick()
+
+            val event = viewModel.event.value
+            assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.StartWPComLogin)
+        }
+
+    @Test
+    fun `given site is registered but user not connected and WC version is incompatible, when continue is clicked, then NavigateToConnectionSteps event is triggered`() =
+        testBlocking {
+            val jetpackStatus = JetpackStatus(
+                isJetpackInstalled = true,
+                jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                    siteRegistrationStatus = JetpackSiteRegistrationStatus.REGISTERED,
+                    blogId = 123L
+                )
+            )
+            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+                .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
+            whenever(fetchActiveWCPluginVersion()).thenReturn("9.0.0")
+
+            setup()
+            viewModel.onContinueClick()
+
+            val event = viewModel.event.value
+            assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.NavigateToConnectionSteps)
+        }
+
+    @Test
+    fun `given user is connected and WC version is incompatible, when continue is clicked, then NavigateToConnectionSteps event is triggered`() =
+        testBlocking {
+            val jetpackStatus = JetpackStatus(
+                isJetpackInstalled = true,
+                jetpackConnectionStatus = JetpackConnectionStatus.AccountConnected(
+                    wpComEmail = "test@test.com"
+                )
+            )
+            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+                .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
+            whenever(fetchActiveWCPluginVersion()).thenReturn("9.0.0")
+
+            setup()
+            viewModel.onContinueClick()
+
+            val event = viewModel.event.value
+            assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.NavigateToConnectionSteps)
+        }
+
+    @Test
+    fun `given user is connected and WC version is compatible, when continue is clicked, then generic error state is shown`() =
+        testBlocking {
+            val jetpackStatus = JetpackStatus(
+                isJetpackInstalled = true,
+                jetpackConnectionStatus = JetpackConnectionStatus.AccountConnected(
+                    wpComEmail = "test@test.com"
+                )
+            )
+            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+                .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
+            whenever(fetchActiveWCPluginVersion())
+                .thenReturn(WooPushNotificationsIntroductionViewModel.PUSH_NOTIFICATIONS_MIN_WC_VERSION)
+
+            setup()
+            viewModel.onContinueClick()
+
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState.errorType).isEqualTo(ErrorType.Generic)
+            assertThat(viewState.isLoading).isFalse()
+        }
+
+    @Test
+    fun `given user is connected and WC version is null, when continue is clicked, then NavigateToConnectionSteps event is triggered`() =
+        testBlocking {
+            val jetpackStatus = JetpackStatus(
+                isJetpackInstalled = true,
+                jetpackConnectionStatus = JetpackConnectionStatus.AccountConnected(
+                    wpComEmail = "test@test.com"
+                )
+            )
+            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+                .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
+            whenever(fetchActiveWCPluginVersion()).thenReturn(null)
+
+            setup()
+            viewModel.onContinueClick()
+
+            val event = viewModel.event.value
+            assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.NavigateToConnectionSteps)
+        }
+
+    @Test
+    fun `given fetching jetpack status fails, when continue is clicked, then generic error state is shown`() =
+        testBlocking {
+            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+                .thenReturn(Result.failure(Exception("Network error")))
+
+            setup()
+            viewModel.onContinueClick()
+
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState.errorType).isEqualTo(ErrorType.Generic)
+            assertThat(viewState.isLoading).isFalse()
+        }
+
+    @Test
+    fun `given connection is forbidden, when continue is clicked, then forbidden error state is shown`() =
+        testBlocking {
+            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+                .thenReturn(Result.success(JetpackStatusFetchResponse.ConnectionForbidden))
+
+            setup()
+            viewModel.onContinueClick()
+
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState.errorType).isEqualTo(ErrorType.Forbidden)
+            assertThat(viewState.isLoading).isFalse()
+        }
+
+    @Test
+    fun `when contact support is clicked, then NavigateToHelpScreen event is triggered`() {
+        setup()
+
+        viewModel.onContactSupportClick()
+
+        val event = viewModel.event.value
+        assertThat(event).isInstanceOf(NavigateToHelpScreen::class.java)
+        assertThat((event as NavigateToHelpScreen).origin)
+            .isEqualTo(HelpOrigin.WOO_PUSH_NOTIFICATIONS_SETUP)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
-import com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionViewModel.ErrorType
+import com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionViewModel.ViewState
 import com.woocommerce.android.util.FetchActiveWCPluginVersion
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -18,9 +18,9 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.NavigateToHelpScre
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -33,7 +33,19 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
         on { get() } doReturn site
     }
 
-    private val fetchJetpackStatus: FetchJetpackStatus = mock()
+    private val fetchJetpackStatus: FetchJetpackStatus = mock {
+        onBlocking { invoke(any(), any(), anyOrNull()) } doReturn Result.success(
+            JetpackStatusFetchResponse.Success(
+                JetpackStatus(
+                    isJetpackInstalled = false,
+                    jetpackConnectionStatus = JetpackConnectionStatus.AccountNotConnected(
+                        siteRegistrationStatus = JetpackSiteRegistrationStatus.NOT_REGISTERED,
+                        blogId = null
+                    )
+                )
+            )
+        )
+    }
     private val fetchActiveWCPluginVersion: FetchActiveWCPluginVersion = mock()
 
     private lateinit var viewModel: WooPushNotificationsIntroductionViewModel
@@ -48,7 +60,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given site is not registered, when continue is clicked, then StartWPComLogin event is triggered`() =
+    fun `given site is not registered, when screen opens, then NotConnected state is shown`() =
         testBlocking {
             val jetpackStatus = JetpackStatus(
                 isJetpackInstalled = false,
@@ -57,18 +69,17 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
                     blogId = null
                 )
             )
-            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+            whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
                 .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
 
             setup()
-            viewModel.onContinueClick()
 
-            val event = viewModel.event.value
-            assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.StartWPComLogin)
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState).isEqualTo(ViewState.NotConnected)
         }
 
     @Test
-    fun `given site registration status is unknown, when continue is clicked, then StartWPComLogin event is triggered`() =
+    fun `given site registration status is unknown, when screen opens, then NotConnected state is shown`() =
         testBlocking {
             val jetpackStatus = JetpackStatus(
                 isJetpackInstalled = true,
@@ -77,18 +88,17 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
                     blogId = null
                 )
             )
-            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+            whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
                 .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
 
             setup()
-            viewModel.onContinueClick()
 
-            val event = viewModel.event.value
-            assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.StartWPComLogin)
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState).isEqualTo(ViewState.NotConnected)
         }
 
     @Test
-    fun `given site is registered but user not connected and WC version is incompatible, when continue is clicked, then NavigateToConnectionSteps event is triggered`() =
+    fun `given site is registered but user not connected and WC version is incompatible, when screen opens, then UpdateRequired state is shown`() =
         testBlocking {
             val jetpackStatus = JetpackStatus(
                 isJetpackInstalled = true,
@@ -97,19 +107,18 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
                     blogId = 123L
                 )
             )
-            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+            whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
                 .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
             whenever(fetchActiveWCPluginVersion()).thenReturn("9.0.0")
 
             setup()
-            viewModel.onContinueClick()
 
-            val event = viewModel.event.value
-            assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.NavigateToConnectionSteps)
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState).isEqualTo(ViewState.UpdateRequired)
         }
 
     @Test
-    fun `given user is connected and WC version is incompatible, when continue is clicked, then NavigateToConnectionSteps event is triggered`() =
+    fun `given user is connected and WC version is incompatible, when screen opens, then UpdateRequired state is shown`() =
         testBlocking {
             val jetpackStatus = JetpackStatus(
                 isJetpackInstalled = true,
@@ -117,19 +126,18 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
                     wpComEmail = "test@test.com"
                 )
             )
-            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+            whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
                 .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
             whenever(fetchActiveWCPluginVersion()).thenReturn("9.0.0")
 
             setup()
-            viewModel.onContinueClick()
 
-            val event = viewModel.event.value
-            assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.NavigateToConnectionSteps)
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState).isEqualTo(ViewState.UpdateRequired)
         }
 
     @Test
-    fun `given user is connected and WC version is compatible, when continue is clicked, then generic error state is shown`() =
+    fun `given user is connected and WC version is compatible, when screen opens, then GenericError state is shown`() =
         testBlocking {
             val jetpackStatus = JetpackStatus(
                 isJetpackInstalled = true,
@@ -137,21 +145,19 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
                     wpComEmail = "test@test.com"
                 )
             )
-            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+            whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
                 .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
             whenever(fetchActiveWCPluginVersion())
                 .thenReturn(WooPushNotificationsIntroductionViewModel.PUSH_NOTIFICATIONS_MIN_WC_VERSION)
 
             setup()
-            viewModel.onContinueClick()
 
             val viewState = viewModel.viewState.getOrAwaitValue()
-            assertThat(viewState.errorType).isEqualTo(ErrorType.Generic)
-            assertThat(viewState.isLoading).isFalse()
+            assertThat(viewState).isEqualTo(ViewState.GenericError)
         }
 
     @Test
-    fun `given user is connected and WC version is null, when continue is clicked, then NavigateToConnectionSteps event is triggered`() =
+    fun `given user is connected and WC version is null, when screen opens, then UpdateRequired state is shown`() =
         testBlocking {
             val jetpackStatus = JetpackStatus(
                 isJetpackInstalled = true,
@@ -159,44 +165,59 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
                     wpComEmail = "test@test.com"
                 )
             )
-            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+            whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
                 .thenReturn(Result.success(JetpackStatusFetchResponse.Success(jetpackStatus)))
             whenever(fetchActiveWCPluginVersion()).thenReturn(null)
 
             setup()
-            viewModel.onContinueClick()
 
-            val event = viewModel.event.value
-            assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.NavigateToConnectionSteps)
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState).isEqualTo(ViewState.UpdateRequired)
         }
 
     @Test
-    fun `given fetching jetpack status fails, when continue is clicked, then generic error state is shown`() =
+    fun `given fetching jetpack status fails, when screen opens, then GenericError state is shown`() =
         testBlocking {
-            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+            whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
                 .thenReturn(Result.failure(Exception("Network error")))
 
             setup()
-            viewModel.onContinueClick()
 
             val viewState = viewModel.viewState.getOrAwaitValue()
-            assertThat(viewState.errorType).isEqualTo(ErrorType.Generic)
-            assertThat(viewState.isLoading).isFalse()
+            assertThat(viewState).isEqualTo(ViewState.GenericError)
         }
 
     @Test
-    fun `given connection is forbidden, when continue is clicked, then forbidden error state is shown`() =
+    fun `given connection is forbidden, when screen opens, then ForbiddenError state is shown`() =
         testBlocking {
-            whenever(fetchJetpackStatus(eq(site), eq(true), anyOrNull()))
+            whenever(fetchJetpackStatus(any(), any(), anyOrNull()))
                 .thenReturn(Result.success(JetpackStatusFetchResponse.ConnectionForbidden))
 
             setup()
-            viewModel.onContinueClick()
 
             val viewState = viewModel.viewState.getOrAwaitValue()
-            assertThat(viewState.errorType).isEqualTo(ErrorType.Forbidden)
-            assertThat(viewState.isLoading).isFalse()
+            assertThat(viewState).isEqualTo(ViewState.ForbiddenError)
         }
+
+    @Test
+    fun `when continue is clicked, then StartWPComLogin event is triggered`() {
+        setup()
+
+        viewModel.onContinueClick()
+
+        val event = viewModel.event.value
+        assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.StartWPComLogin)
+    }
+
+    @Test
+    fun `when update plugin is clicked, then NavigateToConnectionSteps event is triggered`() {
+        setup()
+
+        viewModel.onUpdatePluginClick()
+
+        val event = viewModel.event.value
+        assertThat(event).isEqualTo(WooPushNotificationsIntroductionViewModel.NavigateToConnectionSteps)
+    }
 
     @Test
     fun `when contact support is clicked, then NavigateToHelpScreen event is triggered`() {


### PR DESCRIPTION
Closes WOOMOB-2270
Closes WOOMOB-2282
Closes WOOMOB-2265
Closes WOOMOB-1994

> [!NOTE]
> - Sorry for the size of the PR, the big part of the changes are Compose code and tests, I couldn't split it further. 
> - The text still mentions WordPress.com account, I didn't want to modify it in this PR, I'll update the wording in the PR that removes the login flow.
> - We don't have designs for the error screen, so I just used a generic error for now, we can update it if needed later.
> - We don't pass connection status to the steps screen yet, I'll handle that in a separate PR.

### Description

Check Jetpack connection status and WooCommerce version on the push notifications introduction screen to determine what to show the user.

**Fetching happens on screen open** , with a skeleton shimmer shown while loading. The `ViewState` is modeled as a sealed interface with five variants:

1. **Loading** → skeleton shimmer placeholder
2. **NotConnected** (site not registered / unknown) → intro screen with "Continue" button → WPCom login
3. **UpdateRequired** (connected, WC version incompatible) → "Update plugin" screen → connection steps
4. **GenericError** (connected + WC compatible, or fetch failure) → error screen with "Contact Support"
5. **ForbiddenError** (403) → error explaining the user needs to ask their store admin

A site is considered "connected" if it has site level connection with Jetpack, this matches: the Jetpack status is `AccountConnected` or `AccountNotConnected` with `JetpackSiteRegistrationStatus.REGISTERED`.

I also added a close button to the dialog.

### Test Steps
#### Requirements
- Enable the PN M2 feature flag.
- Sign in using site credentials.

#### Jetpack not connected
1. Open the app
1. Tap on the Push Notification setup card in the dashboard.
1. Confirm the intro dialog shows the connection information.

#### Jetpack Connected and Woo outdated
1. Connect your site to Jetpack.
1. Make sure you have a Woo version less than `PUSH_NOTIFICATIONS_MIN_WC_VERSION` (set to 10.6.0 for now)
1. Tap on the Push Notification setup card in the dashboard.
1. Confirm the intro dialog shows the plugin update content.

#### Jetpack Connected and Woo up-to-date
1. Connect your site to Jetpack.
1. Modify `PUSH_NOTIFICATIONS_MIN_WC_VERSION` to be lower than your current plugin version.
1. Tap on the Push Notification setup card in the dashboard.
1. Confirm the intro dialog shows the error screen.

#### No permissions for checking Jetpack status
1. Sign in using a Shop Manager account.
1. Tap on the Push Notification setup card in the dashboard.
1. Confirm the intro dialog shows the forbidden error screen.

### Images/gif
<img width="360" alt="Screenshot_20260220_144906" src="https://github.com/user-attachments/assets/d350e6af-5128-4ec5-a818-604349c838c0" />
<img width="360" alt="Screenshot_20260220_144827" src="https://github.com/user-attachments/assets/b15ec3bd-85b8-4c72-9091-c6bf185a25f2" />
<img width="360" alt="Screenshot_20260220_144651" src="https://github.com/user-attachments/assets/1bb9dacd-7003-45a5-b219-0339a3b7298a" />
<img width="360" alt="Screenshot_20260220_145013" src="https://github.com/user-attachments/assets/3229d362-42e6-4bd0-97c0-4e5b39d128b2" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.