### PR TITLE
[WOOMOB-2283] Hide pull-to-refresh indicator after booking state changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -96,7 +96,7 @@ fun WooPosBookingsScreen(
 
     LaunchedEffect(cashPaymentResult.value) {
         if (cashPaymentResult.value) {
-            viewModel.onRefresh()
+            viewModel.onPullToRefresh()
             backStackEntry.savedStateHandle[BOOKING_CASH_PAYMENT_SUCCESS_KEY] = false
         }
     }
@@ -107,7 +107,7 @@ fun WooPosBookingsScreen(
 
     LaunchedEffect(cardPaymentResult.value) {
         if (cardPaymentResult.value) {
-            viewModel.onRefresh()
+            viewModel.onPullToRefresh()
             backStackEntry.savedStateHandle[BOOKING_CARD_PAYMENT_SUCCESS_KEY] = false
         }
     }
@@ -127,7 +127,7 @@ fun WooPosBookingsScreen(
         state = state,
         scrollToTopEvent = viewModel.scrollToTopEvent,
         onBackClicked = { onNavigationEvent(WooPosNavigationEvent.GoBack) },
-        onRefresh = viewModel::onRefresh,
+        onRefresh = viewModel::onPullToRefresh,
         onBookingSelected = viewModel::onBookingSelected,
         onEndOfBookingsListReached = viewModel::onEndOfBookingsListReached,
         onPaginationErrorTryAgain = viewModel::onPaginationErrorTryAgain,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -96,7 +96,7 @@ fun WooPosBookingsScreen(
 
     LaunchedEffect(cashPaymentResult.value) {
         if (cashPaymentResult.value) {
-            viewModel.onPullToRefresh()
+            viewModel.onPaymentCompleted()
             backStackEntry.savedStateHandle[BOOKING_CASH_PAYMENT_SUCCESS_KEY] = false
         }
     }
@@ -107,7 +107,7 @@ fun WooPosBookingsScreen(
 
     LaunchedEffect(cardPaymentResult.value) {
         if (cardPaymentResult.value) {
-            viewModel.onPullToRefresh()
+            viewModel.onPaymentCompleted()
             backStackEntry.savedStateHandle[BOOKING_CARD_PAYMENT_SUCCESS_KEY] = false
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -156,16 +156,18 @@ class WooPosBookingsViewModel @Inject constructor(
         )
     }
 
-    fun onRefresh(silent: Boolean = false) {
-        if (!silent) {
-            _state.value = when (val current = _state.value) {
-                is WooPosBookingsState.Content -> current.copy(
-                    pullToRefreshState = WooPosPullToRefreshState.Refreshing
-                )
-                else -> WooPosBookingsState.Loading
-            }
+    fun onPullToRefresh() {
+        _state.value = when (val current = _state.value) {
+            is WooPosBookingsState.Content -> current.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Refreshing
+            )
+            else -> WooPosBookingsState.Loading
         }
 
+        doRefresh()
+    }
+
+    private fun doRefresh() {
         fetchJob?.cancel()
         loadMoreJob?.cancel()
         fetchResources()
@@ -260,7 +262,7 @@ class WooPosBookingsViewModel @Inject constructor(
         _state.value = currentState.copy(
             dialogState = WooPosBookingsState.Content.DialogState.Hidden
         )
-        onRefresh(silent = true)
+        doRefresh()
     }
 
     private fun handleCollectPayment() {
@@ -349,7 +351,7 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     fun onBookingNoteSaved() {
-        onRefresh(silent = true)
+        doRefresh()
     }
 
     private fun handleBookingAction(action: WooPosBookingsState.BookingAction) {
@@ -437,7 +439,7 @@ class WooPosBookingsViewModel @Inject constructor(
                 )
             }
             if (result.isSuccess) {
-                onRefresh(silent = true)
+                doRefresh()
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -156,12 +156,14 @@ class WooPosBookingsViewModel @Inject constructor(
         )
     }
 
-    fun onRefresh() {
-        _state.value = when (val current = _state.value) {
-            is WooPosBookingsState.Content -> current.copy(
-                pullToRefreshState = WooPosPullToRefreshState.Refreshing
-            )
-            else -> WooPosBookingsState.Loading
+    fun onRefresh(silent: Boolean = false) {
+        if (!silent) {
+            _state.value = when (val current = _state.value) {
+                is WooPosBookingsState.Content -> current.copy(
+                    pullToRefreshState = WooPosPullToRefreshState.Refreshing
+                )
+                else -> WooPosBookingsState.Loading
+            }
         }
 
         fetchJob?.cancel()
@@ -258,7 +260,7 @@ class WooPosBookingsViewModel @Inject constructor(
         _state.value = currentState.copy(
             dialogState = WooPosBookingsState.Content.DialogState.Hidden
         )
-        onRefresh()
+        onRefresh(silent = true)
     }
 
     private fun handleCollectPayment() {
@@ -347,7 +349,7 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     fun onBookingNoteSaved() {
-        onRefresh()
+        onRefresh(silent = true)
     }
 
     private fun handleBookingAction(action: WooPosBookingsState.BookingAction) {
@@ -433,6 +435,9 @@ class WooPosBookingsViewModel @Inject constructor(
                         ),
                     )
                 )
+            }
+            if (result.isSuccess) {
+                onRefresh(silent = true)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -354,6 +354,10 @@ class WooPosBookingsViewModel @Inject constructor(
         doRefresh()
     }
 
+    fun onPaymentCompleted() {
+        doRefresh()
+    }
+
     private fun handleBookingAction(action: WooPosBookingsState.BookingAction) {
         when (action) {
             is WooPosBookingsState.BookingAction.ViewOrder -> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -980,6 +980,126 @@ class WooPosBookingsViewModelTest {
         }
 
     @Test
+    fun `given cancel confirmed successfully, when handling event, then pullToRefreshState stays Enabled`() =
+        runTest {
+            // GIVEN
+            whenever(bookingsRepository.cancelBooking(any()))
+                .thenReturn(Result.success(Unit))
+            viewModel = createViewModel()
+            advanceUntilIdle()
+            val content = viewModel.state.value as WooPosBookingsState.Content
+            val bookingId = content.selectedDetails!!.id
+
+            viewModel.onUIEvent(
+                WooPosBookingsUIEvent.BookingMenuActionClicked(
+                    WooPosBookingsState.BookingAction.CancelBooking(
+                        bookingId = bookingId,
+                        orderId = bookingId * 10
+                    )
+                )
+            )
+            advanceUntilIdle()
+
+            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+                .doSuspendableAnswer {
+                    delay(Long.MAX_VALUE)
+                    Result.success(Unit)
+                }
+
+            // WHEN
+            viewModel.onUIEvent(WooPosBookingsUIEvent.CancelBookingConfirmed)
+            advanceUntilIdle()
+
+            // THEN
+            val updatedContent = viewModel.state.value as WooPosBookingsState.Content
+            assertThat(updatedContent.pullToRefreshState)
+                .isEqualTo(WooPosPullToRefreshState.Enabled)
+        }
+
+    @Test
+    fun `given cancel confirmed successfully, when handling event, then bookings are refreshed`() =
+        runTest {
+            // GIVEN
+            whenever(bookingsRepository.cancelBooking(any()))
+                .thenReturn(Result.success(Unit))
+            viewModel = createViewModel()
+            advanceUntilIdle()
+            val content = viewModel.state.value as WooPosBookingsState.Content
+            val bookingId = content.selectedDetails!!.id
+
+            viewModel.onUIEvent(
+                WooPosBookingsUIEvent.BookingMenuActionClicked(
+                    WooPosBookingsState.BookingAction.CancelBooking(
+                        bookingId = bookingId,
+                        orderId = bookingId * 10
+                    )
+                )
+            )
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosBookingsUIEvent.CancelBookingConfirmed)
+            advanceUntilIdle()
+
+            // THEN
+            verify(bookingListHandler, times(2))
+                .loadBookings(sortBy = BookingListSortOption.NewestToOldest)
+        }
+
+    @Test
+    fun `given IssueRefund dialog dismissed, when refreshing, then pullToRefreshState stays Enabled`() =
+        runTest {
+            // GIVEN
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.onUIEvent(
+                WooPosBookingsUIEvent.BookingMenuActionClicked(
+                    WooPosBookingsState.BookingAction.IssueRefund(orderId = 10L)
+                )
+            )
+            advanceUntilIdle()
+
+            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+                .doSuspendableAnswer {
+                    delay(Long.MAX_VALUE)
+                    Result.success(Unit)
+                }
+
+            // WHEN
+            viewModel.onIssueRefundDialogDismissed()
+            advanceUntilIdle()
+
+            // THEN
+            val updatedState = viewModel.state.value as WooPosBookingsState.Content
+            assertThat(updatedState.pullToRefreshState)
+                .isEqualTo(WooPosPullToRefreshState.Enabled)
+        }
+
+    @Test
+    fun `given booking note saved, when refreshing, then pullToRefreshState stays Enabled`() =
+        runTest {
+            // GIVEN
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+                .doSuspendableAnswer {
+                    delay(Long.MAX_VALUE)
+                    Result.success(Unit)
+                }
+
+            // WHEN
+            viewModel.onBookingNoteSaved()
+            advanceUntilIdle()
+
+            // THEN
+            val content = viewModel.state.value as WooPosBookingsState.Content
+            assertThat(content.pullToRefreshState)
+                .isEqualTo(WooPosPullToRefreshState.Enabled)
+        }
+
+    @Test
     fun `given processing state, when dismiss event, then dialog stays open`() =
         runTest {
             // GIVEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -266,7 +266,7 @@ class WooPosBookingsViewModelTest {
     }
 
     @Test
-    fun `given content state, when onRefresh, then pullToRefreshState is Refreshing`() = runTest {
+    fun `given content state, when PTR, then pullToRefreshState is Refreshing`() = runTest {
         // GIVEN
         val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
         whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
@@ -284,7 +284,7 @@ class WooPosBookingsViewModelTest {
             }
 
         // WHEN
-        viewModel.onRefresh()
+        viewModel.onPullToRefresh()
         advanceUntilIdle()
 
         // THEN
@@ -293,7 +293,7 @@ class WooPosBookingsViewModelTest {
     }
 
     @Test
-    fun `given non-content state, when onRefresh, then state becomes Loading`() = runTest {
+    fun `given non-content state, when PTR, then state becomes Loading`() = runTest {
         // GIVEN
         whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
         whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
@@ -310,7 +310,7 @@ class WooPosBookingsViewModelTest {
             }
 
         // WHEN
-        viewModel.onRefresh()
+        viewModel.onPullToRefresh()
         advanceUntilIdle()
 
         // THEN
@@ -318,7 +318,7 @@ class WooPosBookingsViewModelTest {
     }
 
     @Test
-    fun `given refresh fails on content, when onRefresh, then pullToRefreshState returns to Enabled`() = runTest {
+    fun `given refresh fails on content, when PTR, then pullToRefreshState returns to Enabled`() = runTest {
         // GIVEN
         viewModel = createViewModel()
         advanceUntilIdle()
@@ -327,7 +327,7 @@ class WooPosBookingsViewModelTest {
             .thenReturn(Result.failure(RuntimeException("error")))
 
         // WHEN
-        viewModel.onRefresh()
+        viewModel.onPullToRefresh()
         advanceUntilIdle()
 
         // THEN
@@ -336,7 +336,7 @@ class WooPosBookingsViewModelTest {
     }
 
     @Test
-    fun `given refresh fails on non-content, when onRefresh, then state is Error`() = runTest {
+    fun `given refresh fails on non-content, when PTR, then state is Error`() = runTest {
         // GIVEN
         whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())
         whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
@@ -349,7 +349,7 @@ class WooPosBookingsViewModelTest {
             .thenReturn(Result.failure(RuntimeException("refresh error")))
 
         // WHEN
-        viewModel.onRefresh()
+        viewModel.onPullToRefresh()
         advanceUntilIdle()
 
         // THEN
@@ -358,13 +358,13 @@ class WooPosBookingsViewModelTest {
     }
 
     @Test
-    fun `given content state, when onRefresh, then cancels previous fetch job`() = runTest {
+    fun `given content state, when PTR, then cancels previous fetch job`() = runTest {
         // GIVEN
         viewModel = createViewModel()
         advanceUntilIdle()
 
         // WHEN
-        viewModel.onRefresh()
+        viewModel.onPullToRefresh()
         advanceUntilIdle()
 
         // THEN


### PR DESCRIPTION
Fixes WOOMOB-2283

### Description
When a booking state changes (cancel, refund dismissed, note saved), the pull-to-refresh indicator was being shown unnecessarily. This happened because `onRefresh()` always sets `pullToRefreshState = Refreshing`, even for programmatic refreshes that don't need a visible indicator.

Added a `silent` flag to `onRefresh()` that skips setting the refreshing state. After cancel success, refund dialog dismissal, and booking note save, the data now refreshes silently without flashing the pull-to-refresh indicator. Also fixed cancel success not triggering a data refresh at all.

### Test Steps
1. Open POS > Bookings
2. Cancel a booking and confirm — verify the list updates without showing the pull-to-refresh indicator
3. Open a booking > Add a note > Save — verify the list refreshes without the indicator
4. Trigger a refund dialog and dismiss it — verify no indicator flash
5. Manually pull-to-refresh — verify the indicator still shows as expected


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.