### PR TITLE
[CIAB:POS] Set View Order as primary action in overflow menu

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -18,18 +18,13 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -51,6 +46,9 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButtonSmall
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverflowMenu
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverflowMenuItem
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverflowPrimaryAction
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToggleButton
@@ -208,9 +206,24 @@ private fun BookingActions(
         }
 
         is WooPosBookingsState.BookingActionsState.Loaded -> {
-            BookingOverflowMenu(
-                actions = actionsState.actions,
-                onClick = { onUIEvent(WooPosBookingsUIEvent.BookingMenuActionClicked(it)) }
+            val viewOrder = actionsState.actions
+                .filterIsInstance<WooPosBookingsState.BookingAction.ViewOrder>()
+                .firstOrNull()
+            val otherActions = actionsState.actions
+                .filter { it !is WooPosBookingsState.BookingAction.ViewOrder }
+
+            WooPosOverflowMenu(
+                primaryAction = viewOrder?.let { action ->
+                    WooPosOverflowPrimaryAction(
+                        label = stringResource(R.string.booking_payment_view_order),
+                        onClick = { onUIEvent(WooPosBookingsUIEvent.BookingMenuActionClicked(action)) }
+                    )
+                },
+                items = otherActions.map { action ->
+                    bookingActionToMenuItem(action) {
+                        onUIEvent(WooPosBookingsUIEvent.BookingMenuActionClicked(it))
+                    }
+                }
             )
         }
     }
@@ -520,62 +533,33 @@ private fun DividerWithSpacing() {
 }
 
 @Composable
-private fun BookingOverflowMenu(
-    actions: List<WooPosBookingsState.BookingAction>,
+private fun bookingActionToMenuItem(
+    action: WooPosBookingsState.BookingAction,
     onClick: (WooPosBookingsState.BookingAction) -> Unit
-) {
-    var showMenu by remember { mutableStateOf(false) }
-
-    Box {
-        IconButton(onClick = { showMenu = true }) {
-            Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.ic_menu_more_vert),
-                contentDescription = stringResource(R.string.more_menu),
-                tint = MaterialTheme.colorScheme.onSurface
-            )
+): WooPosOverflowMenuItem {
+    val (label, color) = when (action) {
+        is WooPosBookingsState.BookingAction.ViewOrder -> {
+            stringResource(R.string.booking_payment_view_order) to
+                MaterialTheme.colorScheme.onSurface
         }
-
-        DropdownMenu(
-            modifier = Modifier.background(color = MaterialTheme.colorScheme.surfaceContainerLowest),
-            expanded = showMenu,
-            onDismissRequest = { showMenu = false }
-        ) {
-            actions.forEach { action ->
-                DropdownMenuItem(
-                    text = {
-                        val (text, textColor) = when (action) {
-                            is WooPosBookingsState.BookingAction.ViewOrder -> {
-                                stringResource(R.string.booking_payment_view_order) to
-                                    MaterialTheme.colorScheme.onSurface
-                            }
-                            is WooPosBookingsState.BookingAction.EmailReceipt -> {
-                                stringResource(R.string.woopos_orders_email_receipt) to
-                                    MaterialTheme.colorScheme.onSurface
-                            }
-                            is WooPosBookingsState.BookingAction.IssueRefund -> {
-                                stringResource(R.string.booking_overflow_refund) to
-                                    MaterialTheme.colorScheme.onSurface
-                            }
-
-                            is WooPosBookingsState.BookingAction.CancelBooking -> {
-                                stringResource(R.string.woopos_bookings_cancel_menu_item) to
-                                    MaterialTheme.colorScheme.error
-                            }
-                        }
-                        WooPosText(
-                            text = text,
-                            style = WooPosTypography.BodyMedium,
-                            color = textColor
-                        )
-                    },
-                    onClick = {
-                        showMenu = false
-                        onClick(action)
-                    }
-                )
-            }
+        is WooPosBookingsState.BookingAction.EmailReceipt -> {
+            stringResource(R.string.woopos_orders_email_receipt) to
+                MaterialTheme.colorScheme.onSurface
+        }
+        is WooPosBookingsState.BookingAction.IssueRefund -> {
+            stringResource(R.string.booking_overflow_refund) to
+                MaterialTheme.colorScheme.onSurface
+        }
+        is WooPosBookingsState.BookingAction.CancelBooking -> {
+            stringResource(R.string.woopos_bookings_cancel_menu_item) to
+                MaterialTheme.colorScheme.error
         }
     }
+    return WooPosOverflowMenuItem(
+        label = label,
+        color = color,
+        onClick = { onClick(action) }
+    )
 }
 
 @WooPosPreview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosOverflowMenu.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosOverflowMenu.kt
@@ -1,0 +1,97 @@
+package com.woocommerce.android.ui.woopos.common.composeui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+
+@Composable
+fun WooPosOverflowMenu(
+    modifier: Modifier = Modifier,
+    primaryAction: WooPosOverflowPrimaryAction? = null,
+    items: List<WooPosOverflowMenuItem>,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (primaryAction != null) {
+            WooPosButtonSmall(
+                text = primaryAction.label,
+                onClick = primaryAction.onClick
+            )
+        }
+
+        if (items.isNotEmpty()) {
+            OverflowDropdown(items = items)
+        }
+    }
+}
+
+@Composable
+private fun OverflowDropdown(items: List<WooPosOverflowMenuItem>) {
+    var showMenu by remember { mutableStateOf(false) }
+
+    Box {
+        IconButton(onClick = { showMenu = true }) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_menu_more_vert),
+                contentDescription = stringResource(R.string.more_menu),
+                tint = MaterialTheme.colorScheme.onSurface
+            )
+        }
+
+        DropdownMenu(
+            modifier = Modifier.background(color = MaterialTheme.colorScheme.surfaceContainerLowest),
+            expanded = showMenu,
+            onDismissRequest = { showMenu = false }
+        ) {
+            items.forEach { item ->
+                DropdownMenuItem(
+                    text = {
+                        WooPosText(
+                            text = item.label,
+                            style = WooPosTypography.BodyMedium,
+                            color = item.color
+                        )
+                    },
+                    onClick = {
+                        showMenu = false
+                        item.onClick()
+                    }
+                )
+            }
+        }
+    }
+}
+
+data class WooPosOverflowPrimaryAction(
+    val label: String,
+    val onClick: () -> Unit,
+)
+
+data class WooPosOverflowMenuItem(
+    val label: String,
+    val color: Color = Color.Unspecified,
+    val onClick: () -> Unit,
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
@@ -1,7 +1,5 @@
 package com.woocommerce.android.ui.woopos.orders.details
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,17 +14,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,9 +31,11 @@ import androidx.constraintlayout.compose.Dimension
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonSmall
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosItemImage
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverflowMenu
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverflowMenuItem
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverflowPrimaryAction
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerText
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
@@ -123,31 +116,22 @@ private fun OrderActions(
 
         is WooPosOrdersState.OrderActionsState.Loaded -> {
             val actions = actionsState.actions
-            when {
-                actions.size > 1 -> {
-                    val primaryAction = actions.first()
-                    val overflowActions = actions.drop(1)
+            val primaryAction = actions.firstOrNull()
+            val overflowActions = actions.drop(1)
 
-                    OrderActionButton(
-                        action = primaryAction,
-                        onClick = { onUIEvent(WooPosOrdersUIEvent.OrderActionClicked(it)) }
+            WooPosOverflowMenu(
+                primaryAction = primaryAction?.let { action ->
+                    WooPosOverflowPrimaryAction(
+                        label = orderActionLabel(action),
+                        onClick = { onUIEvent(WooPosOrdersUIEvent.OrderActionClicked(action)) }
                     )
-
-                    Spacer(Modifier.width(WooPosSpacing.Small.value))
-
-                    OrderDetailsOverflowMenu(
-                        actions = overflowActions,
-                        onClick = { onUIEvent(WooPosOrdersUIEvent.OrderActionClicked(it)) }
-                    )
+                },
+                items = overflowActions.map { action ->
+                    orderActionToMenuItem(action) {
+                        onUIEvent(WooPosOrdersUIEvent.OrderActionClicked(it))
+                    }
                 }
-
-                actions.size == 1 -> {
-                    OrderActionButton(
-                        action = actions.first(),
-                        onClick = { onUIEvent(WooPosOrdersUIEvent.OrderActionClicked(it)) }
-                    )
-                }
-            }
+            )
         }
     }
 }
@@ -455,73 +439,26 @@ private fun DividerWithSpacing() {
 }
 
 @Composable
-private fun OrderActionButton(
-    action: WooPosOrdersState.OrderAction,
-    onClick: (WooPosOrdersState.OrderAction) -> Unit
-) {
-    when (action) {
-        is WooPosOrdersState.OrderAction.IssueRefund -> {
-            WooPosButtonSmall(
-                text = stringResource(R.string.orderdetail_issue_refund_button),
-                onClick = { onClick(action) }
-            )
-        }
-
-        is WooPosOrdersState.OrderAction.EmailReceipt -> {
-            WooPosButtonSmall(
-                text = stringResource(R.string.woopos_orders_email_receipt),
-                onClick = { onClick(action) }
-            )
-        }
+private fun orderActionLabel(action: WooPosOrdersState.OrderAction): String {
+    return when (action) {
+        is WooPosOrdersState.OrderAction.IssueRefund -> stringResource(R.string.orderdetail_issue_refund_button)
+        is WooPosOrdersState.OrderAction.EmailReceipt -> stringResource(R.string.woopos_orders_email_receipt)
     }
 }
 
 @Composable
-private fun OrderDetailsOverflowMenu(
-    actions: List<WooPosOrdersState.OrderAction>,
+private fun orderActionToMenuItem(
+    action: WooPosOrdersState.OrderAction,
     onClick: (WooPosOrdersState.OrderAction) -> Unit
-) {
-    var showMenu by remember { mutableStateOf(false) }
-
-    Box {
-        IconButton(onClick = { showMenu = true }) {
-            Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.ic_menu_more_vert),
-                contentDescription = stringResource(R.string.more_menu),
-                tint = MaterialTheme.colorScheme.onSurface
-            )
-        }
-
-        DropdownMenu(
-            modifier = Modifier.background(color = MaterialTheme.colorScheme.surfaceContainerLowest),
-            expanded = showMenu,
-            onDismissRequest = { showMenu = false }
-        ) {
-            actions.forEach { action ->
-                DropdownMenuItem(
-                    text = {
-                        val text = when (action) {
-                            is WooPosOrdersState.OrderAction.IssueRefund -> stringResource(
-                                R.string.orderdetail_issue_refund_button
-                            )
-
-                            is WooPosOrdersState.OrderAction.EmailReceipt -> stringResource(
-                                R.string.woopos_orders_email_receipt
-                            )
-                        }
-                        WooPosText(
-                            text = text,
-                            style = WooPosTypography.BodyMedium
-                        )
-                    },
-                    onClick = {
-                        showMenu = false
-                        onClick(action)
-                    }
-                )
-            }
-        }
+): WooPosOverflowMenuItem {
+    val label = when (action) {
+        is WooPosOrdersState.OrderAction.IssueRefund -> stringResource(R.string.orderdetail_issue_refund_button)
+        is WooPosOrdersState.OrderAction.EmailReceipt -> stringResource(R.string.woopos_orders_email_receipt)
     }
+    return WooPosOverflowMenuItem(
+        label = label,
+        onClick = { onClick(action) }
+    )
 }
 
 @WooPosPreview


### PR DESCRIPTION
Closes: WOOMOB-2292

## Description

The order and booking detail screens had duplicate overflow menu implementations. This PR extracts a shared `WooPosOverflowMenu` component and sets "View Order" as the primary action (displayed as a button outside the overflow) in booking details.

Also cleaned up the API by combining two separate nullable parameters (`primaryActionLabel` + `onPrimaryActionClick`) into a single nullable `WooPosOverflowPrimaryAction` data class.

## Testing instructions

1. Open POS and complete a booking order
2. Open booking details - verify "View Order" appears as a button (primary action) and other actions are in the overflow menu
3. Open a regular order details - verify the primary action button and overflow menu still work
4. Tap each menu item and verify it dismisses the dropdown and triggers the correct action


https://github.com/user-attachments/assets/913bd4ec-450d-46a4-abe5-cc0768b1aff8

