### PR TITLE
[WOOMOB-2296] Fix bookings showing no bookings screen before loading

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -60,7 +60,7 @@ class BookingListHandler @Inject constructor(
         searchQuery: String? = null,
         filters: BookingFilters = BookingFilters.EMPTY,
         sortBy: BookingListSortOption
-    ): Result<Unit> = mutex.withLock {
+    ): Result<Int> = mutex.withLock {
         // Reset pagination attributes
         page.value = 1
         _canLoadMore.set(true)
@@ -80,19 +80,19 @@ class BookingListHandler @Inject constructor(
                 // If the query is empty, return cached results directly
                 // Mimic network delay to allow the UI to show then hide the refreshing indicator
                 delay(MIN_FETCH_DURATION_MS)
-                Result.success(Unit)
+                Result.success(0)
             } else {
                 fetchBookings()
             }
         }
     }
 
-    suspend fun loadMore(): Result<Unit> = mutex.withLock {
-        if (!_canLoadMore.get()) return@withLock Result.success(Unit)
+    suspend fun loadMore(): Result<Int> = mutex.withLock {
+        if (!_canLoadMore.get()) return@withLock Result.success(0)
         return fetchBookings()
     }
 
-    private suspend fun fetchBookings(): Result<Unit> {
+    private suspend fun fetchBookings(): Result<Int> {
         val pageToFetch = page.value
         val isSearching = !searchQuery.value.isNullOrEmpty()
         val order = sortBy.value.toBookingsOrderOption()
@@ -114,7 +114,7 @@ class BookingListHandler @Inject constructor(
                     searchResults.update { it + result.bookings }
                 }
             }
-        }.map { }
+        }.map { it.bookings.size }
     }
 
     private fun BookingListSortOption.toBookingsOrderOption() = when (this) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsLoadingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsLoadingScreen.kt
@@ -36,17 +36,32 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 
 @Composable
-fun WooPosBookingsLoadingScreen(modifier: Modifier = Modifier) {
+fun WooPosBookingsLoadingScreen(
+    dateSelectorState: DateSelectorState,
+    onUIEvent: (WooPosBookingsUIEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Row(
         modifier = modifier.fillMaxSize()
     ) {
-        WooPosBookingsListLoadingPane(
+        Column(
             modifier = Modifier
                 .background(MaterialTheme.colorScheme.surfaceBright)
-                .padding(top = WOO_POS_BOOKINGS_TOOLBAR_HEIGHT + WooPosSpacing.Small.value)
                 .weight(0.3f)
                 .fillMaxHeight()
-        )
+                .statusBarsPadding()
+        ) {
+            Spacer(Modifier.height(WOO_POS_BOOKINGS_TOOLBAR_HEIGHT))
+
+            WooPosBookingsDateSelector(
+                dateSelectorState = dateSelectorState,
+                onUIEvent = onUIEvent,
+            )
+
+            WooPosBookingsListLoadingPane(
+                modifier = Modifier.fillMaxSize()
+            )
+        }
 
         Box(
             modifier = Modifier
@@ -136,6 +151,12 @@ fun BookingDetailsLoadingPane(modifier: Modifier = Modifier) {
 @Composable
 fun WooPosBookingsLoadingStatePreview() {
     WooPosTheme {
-        WooPosBookingsLoadingScreen()
+        WooPosBookingsLoadingScreen(
+            dateSelectorState = DateSelectorState(
+                formattedDate = "23 Feb, Mon",
+                selectedDateMillis = System.currentTimeMillis(),
+            ),
+            onUIEvent = {},
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -140,7 +140,6 @@ fun WooPosBookingsScreen(
         onBookingSelected = viewModel::onBookingSelected,
         onEndOfBookingsListReached = viewModel::onEndOfBookingsListReached,
         onPaginationErrorTryAgain = viewModel::onPaginationErrorTryAgain,
-        onBookingsEmptyActionClicked = viewModel::onBookingsEmptyActionClicked,
         onBookingsLoadingErrorRetryButtonClicked = viewModel::onBookingsLoadingErrorRetryButtonClicked,
         onUIEvent = viewModel::onUIEvent,
         onIssueRefundDialogDismissed = viewModel::onIssueRefundDialogDismissed,
@@ -159,7 +158,6 @@ private fun WooPosBookingsScreen(
     onBookingSelected: (Long) -> Unit,
     onEndOfBookingsListReached: () -> Unit,
     onPaginationErrorTryAgain: () -> Unit,
-    onBookingsEmptyActionClicked: () -> Unit,
     onBookingsLoadingErrorRetryButtonClicked: () -> Unit,
     onUIEvent: (WooPosBookingsUIEvent) -> Unit,
     onIssueRefundDialogDismissed: () -> Unit,
@@ -181,11 +179,6 @@ private fun WooPosBookingsScreen(
                 onEndOfBookingsListReached = onEndOfBookingsListReached,
                 onPaginationErrorTryAgain = onPaginationErrorTryAgain,
                 onUIEvent = onUIEvent
-            )
-
-            is WooPosBookingsState.Empty -> WooPosBookingsEmpty(
-                onActionClicked = onBookingsEmptyActionClicked,
-                modifier = Modifier.statusBarsPadding()
             )
 
             is WooPosBookingsState.Error -> WooPosBookingsError(
@@ -551,22 +544,6 @@ private fun WooPosBookingListItem(
 }
 
 @Composable
-private fun WooPosBookingsEmpty(
-    onActionClicked: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    WooPosEmptyScreen(
-        modifier = modifier.fillMaxSize(),
-        icon = WooPosIcons.OrdersEmpty,
-        title = stringResource(id = R.string.woopos_bookings_empty_list_title),
-        message = "",
-        contentDescription = stringResource(id = R.string.woopos_bookings_empty_list_image_description),
-        actionLabel = stringResource(id = R.string.woopos_bookings_empty_action_label),
-        onActionClicked = onActionClicked
-    )
-}
-
-@Composable
 private fun WooPosBookingsError(
     onRetryClicked: () -> Unit,
     modifier: Modifier = Modifier
@@ -644,7 +621,6 @@ fun WooPosBookingsScreenPreview() {
             onBookingSelected = {},
             onEndOfBookingsListReached = {},
             onPaginationErrorTryAgain = {},
-            onBookingsEmptyActionClicked = {},
             onBookingsLoadingErrorRetryButtonClicked = {},
             onUIEvent = {},
             onIssueRefundDialogDismissed = {},
@@ -679,34 +655,10 @@ fun WooPosBookingsNothingFoundStatePreview() {
             onBookingSelected = {},
             onEndOfBookingsListReached = {},
             onPaginationErrorTryAgain = {},
-            onBookingsEmptyActionClicked = {},
             onBookingsLoadingErrorRetryButtonClicked = {},
             onUIEvent = {},
             onIssueRefundDialogDismissed = {},
             onNavigationEvent = {}
-        )
-    }
-}
-
-@WooPosPreview
-@Composable
-fun WooPosBookingsEmptyStatePreview() {
-    WooPosTheme {
-        WooPosBookingsScreen(
-            state = WooPosBookingsState.Empty(
-                pullToRefreshState = WooPosPullToRefreshState.Enabled,
-            ),
-            scrollToTopEvent = MutableSharedFlow(),
-            onBackClicked = {},
-            onRefresh = {},
-            onBookingSelected = {},
-            onEndOfBookingsListReached = {},
-            onPaginationErrorTryAgain = {},
-            onBookingsEmptyActionClicked = {},
-            onBookingsLoadingErrorRetryButtonClicked = {},
-            onUIEvent = {},
-            onIssueRefundDialogDismissed = {},
-            onNavigationEvent = {},
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -255,7 +255,7 @@ private fun WooPosBookingsContent(
                             onUIEvent = onUIEvent
                         )
                     }
-                    state.items is WooPosBookingsState.Content.Items.Searching -> {
+                    state.items is WooPosBookingsState.Content.Items.Loading -> {
                         BookingDetailsLoadingPane(
                             modifier = Modifier
                                 .fillMaxHeight()
@@ -386,7 +386,7 @@ private fun WooPosBookingsList(
             )
         }
 
-        is WooPosBookingsState.Content.Items.Searching -> {
+        is WooPosBookingsState.Content.Items.Loading -> {
             WooPosBookingsListLoadingPane(
                 modifier = modifier.imePadding()
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -186,7 +186,10 @@ private fun WooPosBookingsScreen(
                 modifier = Modifier.statusBarsPadding()
             )
 
-            is WooPosBookingsState.Loading -> WooPosBookingsLoadingScreen()
+            is WooPosBookingsState.Loading -> WooPosBookingsLoadingScreen(
+                dateSelectorState = state.dateSelectorState,
+                onUIEvent = onUIEvent,
+            )
         }
 
         WooPosToolbar(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
@@ -159,9 +159,10 @@ sealed class WooPosBookingsState {
     }
 
     @Immutable
-    data object Loading : WooPosBookingsState() {
+    data class Loading(
+        override val dateSelectorState: DateSelectorState,
+    ) : WooPosBookingsState() {
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Disabled
-        override val dateSelectorState: DateSelectorState? = null
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
@@ -116,7 +116,7 @@ sealed class WooPosBookingsState {
     ) : WooPosBookingsState() {
         sealed class Items {
             data class Loaded(val items: Map<BookingItemViewState, BookingDetailsViewState>) : Items()
-            object Searching : Items()
+            object Loading : Items()
             data class Error(val title: String, val message: String) : Items()
             data class NothingFound(val title: String, val message: String) : Items()
         }
@@ -163,7 +163,6 @@ sealed class WooPosBookingsState {
         override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Disabled
         override val dateSelectorState: DateSelectorState? = null
     }
-
 }
 
 enum class PaymentStatus {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
@@ -164,11 +164,6 @@ sealed class WooPosBookingsState {
         override val dateSelectorState: DateSelectorState? = null
     }
 
-    @Immutable
-    data class Empty(
-        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
-        override val dateSelectorState: DateSelectorState? = null,
-    ) : WooPosBookingsState()
 }
 
 enum class PaymentStatus {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -93,7 +93,7 @@ class WooPosBookingsViewModel @Inject constructor(
                         )
                     }
                     current is WooPosBookingsState.Content &&
-                        current.items is WooPosBookingsState.Content.Items.Searching -> {
+                        current.items is WooPosBookingsState.Content.Items.Loading -> {
                         _state.value = current.copy(
                             items = WooPosBookingsState.Content.Items.Error(
                                 title = resourceProvider.getString(
@@ -113,7 +113,7 @@ class WooPosBookingsViewModel @Inject constructor(
                         _state.value = buildNothingFoundState()
                     }
                     current is WooPosBookingsState.Content &&
-                        current.items is WooPosBookingsState.Content.Items.Searching -> {
+                        current.items is WooPosBookingsState.Content.Items.Loading -> {
                         _state.value = current.copy(
                             items = WooPosBookingsState.Content.Items.NothingFound(
                                 title = resourceProvider.getString(
@@ -150,7 +150,7 @@ class WooPosBookingsViewModel @Inject constructor(
                 }
 
                 if (bookings.isEmpty() && current is WooPosBookingsState.Content &&
-                    current.items is WooPosBookingsState.Content.Items.Searching
+                    current.items is WooPosBookingsState.Content.Items.Loading
                 ) {
                     return@collectLatest
                 }
@@ -555,7 +555,7 @@ class WooPosBookingsViewModel @Inject constructor(
         selectedBookingId = null
         _state.value = when (val current = _state.value) {
             is WooPosBookingsState.Content -> current.copy(
-                items = WooPosBookingsState.Content.Items.Searching,
+                items = WooPosBookingsState.Content.Items.Loading,
                 dateSelectorState = buildDateSelectorState(),
                 selectedDetails = null,
                 pullToRefreshState = WooPosPullToRefreshState.Disabled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -46,14 +46,21 @@ class WooPosBookingsViewModel @Inject constructor(
     private val mapper: WooPosBookingViewStateMapper,
     private val clipboardHelper: WooPosClipboardHelper,
     private val resourceProvider: ResourceProvider,
-    private val clock: Clock,
+    clock: Clock,
 ) : ViewModel() {
 
     companion object {
         private const val MIN_LOADING_DURATION_MS = 300L
     }
 
-    private val _state = MutableStateFlow<WooPosBookingsState>(WooPosBookingsState.Loading)
+    private var selectedBookingId: Long? = null
+    private var selectedDate: LocalDate = LocalDate.now(clock)
+    private var fetchJob: Job? = null
+    private var loadMoreJob: Job? = null
+
+    private val _state = MutableStateFlow<WooPosBookingsState>(
+        WooPosBookingsState.Loading(dateSelectorState = buildDateSelectorState())
+    )
     val state: StateFlow<WooPosBookingsState> = _state.asStateFlow()
 
     private val _scrollToTopEvent = MutableSharedFlow<Unit>()
@@ -64,11 +71,6 @@ class WooPosBookingsViewModel @Inject constructor(
 
     private val _toastEvent = MutableSharedFlow<String>()
     val toastEvent: SharedFlow<String> = _toastEvent.asSharedFlow()
-
-    private var selectedBookingId: Long? = null
-    private var selectedDate: LocalDate = LocalDate.now(clock)
-    private var fetchJob: Job? = null
-    private var loadMoreJob: Job? = null
 
     init {
         observeBookings()
@@ -235,7 +237,7 @@ class WooPosBookingsViewModel @Inject constructor(
             is WooPosBookingsState.Content -> current.copy(
                 pullToRefreshState = WooPosPullToRefreshState.Refreshing
             )
-            else -> WooPosBookingsState.Loading
+            else -> WooPosBookingsState.Loading(dateSelectorState = buildDateSelectorState())
         }
 
         doRefresh()
@@ -325,7 +327,7 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     fun onBookingsLoadingErrorRetryButtonClicked() {
-        _state.value = WooPosBookingsState.Loading
+        _state.value = WooPosBookingsState.Loading(dateSelectorState = buildDateSelectorState())
         fetchBookings()
     }
 
@@ -560,7 +562,7 @@ class WooPosBookingsViewModel @Inject constructor(
                 selectedDetails = null,
                 pullToRefreshState = WooPosPullToRefreshState.Disabled
             )
-            else -> WooPosBookingsState.Loading
+            else -> WooPosBookingsState.Loading(dateSelectorState = buildDateSelectorState())
         }
         fetchBookings()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -114,7 +114,8 @@ class WooPosBookingsViewModel @Inject constructor(
                         )
                     }
                 }
-            }.onSuccess {
+            }.onSuccess { fetchedCount ->
+                if (fetchedCount > 0) return@onSuccess
                 when {
                     current is WooPosBookingsState.Loading -> {
                         _state.value = buildNothingFoundState()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -58,6 +58,11 @@ class WooPosBookingsViewModel @Inject constructor(
 
     private val storeZoneId = selectedSite.get().clock.zone
 
+    private var selectedBookingId: Long? = null
+    private var selectedDate: LocalDate = Instant.now(clock).atZone(storeZoneId).toLocalDate()
+    private var fetchJob: Job? = null
+    private var loadMoreJob: Job? = null
+
     private val _state = MutableStateFlow<WooPosBookingsState>(
         WooPosBookingsState.Loading(dateSelectorState = buildDateSelectorState())
     )
@@ -71,12 +76,6 @@ class WooPosBookingsViewModel @Inject constructor(
 
     private val _toastEvent = MutableSharedFlow<String>()
     val toastEvent: SharedFlow<String> = _toastEvent.asSharedFlow()
-
-    private var selectedBookingId: Long? = null
-    private var selectedDate: LocalDate = Instant.now(clock).atZone(storeZoneId).toLocalDate()
-    private var fetchJob: Job? = null
-    private var loadMoreJob: Job? = null
-
 
     init {
         observeBookings()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -329,11 +329,6 @@ class WooPosBookingsViewModel @Inject constructor(
         fetchBookings()
     }
 
-    fun onBookingsEmptyActionClicked() {
-        _state.value = WooPosBookingsState.Loading
-        fetchBookings()
-    }
-
     fun onUIEvent(event: WooPosBookingsUIEvent) {
         when (event) {
             is WooPosBookingsUIEvent.BookingMenuActionClicked -> handleBookingAction(event.action)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -110,9 +110,7 @@ class WooPosBookingsViewModel @Inject constructor(
             }.onSuccess {
                 when {
                     current is WooPosBookingsState.Loading -> {
-                        _state.value = WooPosBookingsState.Empty(
-                            dateSelectorState = buildDateSelectorState()
-                        )
+                        _state.value = buildNothingFoundState()
                     }
                     current is WooPosBookingsState.Content &&
                         current.items is WooPosBookingsState.Content.Items.Searching -> {
@@ -571,6 +569,20 @@ class WooPosBookingsViewModel @Inject constructor(
         }
         fetchBookings()
     }
+
+    private fun buildNothingFoundState() = WooPosBookingsState.Content(
+        items = WooPosBookingsState.Content.Items.NothingFound(
+            title = resourceProvider.getString(
+                R.string.woopos_bookings_no_bookings_for_date
+            ),
+            message = ""
+        ),
+        pullToRefreshState = WooPosPullToRefreshState.Enabled,
+        dateSelectorState = buildDateSelectorState(),
+        selectedDetails = null,
+        paginationState = WooPosPaginationState.None,
+        dialogState = WooPosBookingsState.Content.DialogState.Hidden
+    )
 
     private fun buildDateSelectorState(): DateSelectorState {
         val formatter = DateTimeFormatter.ofPattern("dd MMM, EEE", Locale.getDefault())

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3907,9 +3907,6 @@
     <string name="woopos_orders_status_refunded">Refunded</string>
 
     <string name="woopos_bookings_title">Bookings</string>
-    <string name="woopos_bookings_empty_list_title">No bookings found</string>
-    <string name="woopos_bookings_empty_list_image_description">No bookings</string>
-    <string name="woopos_bookings_empty_action_label">Refresh</string>
     <string name="woopos_bookings_details_attendance_attended">Attended</string>
     <string name="woopos_bookings_details_attendance_unattended">Unattended</string>
     <string name="woopos_bookings_details_title">Booking #%s</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
@@ -142,7 +142,7 @@ class BookingListHandlerTest : BaseUnitTest() {
     fun `when last page is reached, then can load more becomes false`() = testBlocking {
         bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest)
 
-        var result: Result<Unit>? = null
+        var result: Result<Int>? = null
         repeat(availablePages - 1) {
             result = bookingListHandler.loadMore()
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -51,8 +51,8 @@ class BookingListViewModelTest : BaseUnitTest() {
                 filters = any(),
                 sortBy = any()
             )
-        } doReturn Result.success(Unit)
-        onBlocking { loadMore() } doReturn Result.success(Unit)
+        } doReturn Result.success(0)
+        onBlocking { loadMore() } doReturn Result.success(0)
     }
     private val mockedNow = Instant.parse("2025-01-01T12:00:00Z")
     private val filtersBuilder = BookingListDateFilterBuilder(Clock.fixed(mockedNow, ZoneId.of("UTC")))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -172,8 +172,8 @@ class WooPosBookingsViewModelTest {
         )
         whenever(
             bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest))
-        ).thenReturn(Result.success(Unit))
-        whenever(bookingListHandler.loadMore()).thenReturn(Result.success(Unit))
+        ).thenReturn(Result.success(0))
+        whenever(bookingListHandler.loadMore()).thenReturn(Result.success(0))
         whenever(bookingListHandler.hasMorePages).thenReturn(true)
         whenever(dateTimeProvider.now()).thenReturn(0L)
         whenever(paymentStatusResolver.resolve(any(), anyOrNull())).thenReturn(PaymentStatus.UNPAID)
@@ -222,7 +222,7 @@ class WooPosBookingsViewModelTest {
         // GIVEN
         whenever(bookingListHandler.bookingsFlow).thenReturn(flowOf(emptyList()))
         whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
-            .thenReturn(Result.success(Unit))
+            .thenReturn(Result.success(0))
 
         // WHEN
         viewModel = createViewModel()
@@ -264,7 +264,7 @@ class WooPosBookingsViewModelTest {
         whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
             .doSuspendableAnswer {
                 delay(Long.MAX_VALUE)
-                Result.success(Unit)
+                Result.success(0)
             }
 
         // WHEN
@@ -306,7 +306,7 @@ class WooPosBookingsViewModelTest {
         whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
             .doSuspendableAnswer {
                 delay(Long.MAX_VALUE)
-                Result.success(Unit)
+                Result.success(0)
             }
 
         // WHEN
@@ -332,7 +332,7 @@ class WooPosBookingsViewModelTest {
         whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
             .doSuspendableAnswer {
                 delay(Long.MAX_VALUE)
-                Result.success(Unit)
+                Result.success(0)
             }
 
         // WHEN
@@ -477,7 +477,7 @@ class WooPosBookingsViewModelTest {
         viewModel.onEndOfBookingsListReached()
         advanceUntilIdle()
 
-        whenever(bookingListHandler.loadMore()).thenReturn(Result.success(Unit))
+        whenever(bookingListHandler.loadMore()).thenReturn(Result.success(0))
 
         // WHEN
         viewModel.onPaginationErrorTryAgain()
@@ -499,7 +499,7 @@ class WooPosBookingsViewModelTest {
         whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
             .doSuspendableAnswer {
                 delay(1000)
-                Result.success(Unit)
+                Result.success(0)
             }
 
         viewModel = createViewModel()
@@ -534,7 +534,7 @@ class WooPosBookingsViewModelTest {
             whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
                 .doSuspendableAnswer {
                     delay(Long.MAX_VALUE)
-                    Result.success(Unit)
+                    Result.success(0)
                 }
 
             // WHEN
@@ -561,7 +561,7 @@ class WooPosBookingsViewModelTest {
         whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
             .doSuspendableAnswer {
                 delay(Long.MAX_VALUE)
-                Result.success(Unit)
+                Result.success(0)
             }
 
         // WHEN
@@ -1059,7 +1059,7 @@ class WooPosBookingsViewModelTest {
             whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
                 .doSuspendableAnswer {
                     delay(Long.MAX_VALUE)
-                    Result.success(Unit)
+                    Result.success(0)
                 }
 
             // WHEN
@@ -1119,7 +1119,7 @@ class WooPosBookingsViewModelTest {
             whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
                 .doSuspendableAnswer {
                     delay(Long.MAX_VALUE)
-                    Result.success(Unit)
+                    Result.success(0)
                 }
 
             // WHEN
@@ -1142,7 +1142,7 @@ class WooPosBookingsViewModelTest {
             whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
                 .doSuspendableAnswer {
                     delay(Long.MAX_VALUE)
-                    Result.success(Unit)
+                    Result.success(0)
                 }
 
             // WHEN
@@ -1240,7 +1240,7 @@ class WooPosBookingsViewModelTest {
         whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
             .doSuspendableAnswer {
                 delay(Long.MAX_VALUE)
-                Result.success(Unit)
+                Result.success(0)
             }
 
         // WHEN
@@ -1271,7 +1271,7 @@ class WooPosBookingsViewModelTest {
         whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
             .doSuspendableAnswer {
                 delay(Long.MAX_VALUE)
-                Result.success(Unit)
+                Result.success(0)
             }
 
         // WHEN
@@ -1302,7 +1302,7 @@ class WooPosBookingsViewModelTest {
         assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Content::class.java)
 
         whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
-            .thenReturn(Result.success(Unit))
+            .thenReturn(Result.success(0))
 
         // WHEN
         viewModel.onUIEvent(WooPosBookingsUIEvent.NextDayClicked)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -533,35 +533,6 @@ class WooPosBookingsViewModelTest {
         }
 
     @Test
-    fun `given NothingFound state, when onBookingsEmptyActionClicked, then resets to Loading and fetches`() = runTest {
-        // GIVEN
-        whenever(bookingListHandler.bookingsFlow).thenReturn(flowOf(emptyList()))
-        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
-            .thenReturn(Result.success(Unit))
-
-        viewModel = createViewModel()
-        advanceUntilIdle()
-
-        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
-            .doSuspendableAnswer {
-                delay(Long.MAX_VALUE)
-                Result.success(Unit)
-            }
-
-        // WHEN
-        viewModel.onBookingsEmptyActionClicked()
-        advanceUntilIdle()
-
-        // THEN
-        assertThat(viewModel.state.value).isInstanceOf(WooPosBookingsState.Loading::class.java)
-        verify(bookingListHandler, times(2)).loadBookings(
-            anyOrNull(),
-            any(),
-            eq(BookingListSortOption.NewestToOldest)
-        )
-    }
-
-    @Test
     fun `given non-content state, when onIssueRefundDialogDismissed, then state remains unchanged`() = runTest {
         // GIVEN
         whenever(bookingListHandler.bookingsFlow).thenReturn(MutableSharedFlow())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -1155,7 +1155,7 @@ class WooPosBookingsViewModelTest {
     }
 
     @Test
-    fun `given date changed and cache empty, when fetch in progress, then state stays Searching`() = runTest {
+    fun `given date changed and cache empty, when fetch in progress, then state stays Loading`() = runTest {
         // GIVEN
         val bookingsFlow = MutableSharedFlow<List<BookingEntity>>()
         whenever(bookingListHandler.bookingsFlow).thenReturn(bookingsFlow)
@@ -1182,7 +1182,7 @@ class WooPosBookingsViewModelTest {
 
         // THEN
         val content = viewModel.state.value as WooPosBookingsState.Content
-        assertThat(content.items).isInstanceOf(WooPosBookingsState.Content.Items.Searching::class.java)
+        assertThat(content.items).isInstanceOf(WooPosBookingsState.Content.Items.Loading::class.java)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -533,9 +533,11 @@ class WooPosBookingsViewModelTest {
         }
 
     @Test
-    fun `given empty state, when onBookingsEmptyActionClicked, then resets to Loading and fetches`() = runTest {
+    fun `given NothingFound state, when onBookingsEmptyActionClicked, then resets to Loading and fetches`() = runTest {
         // GIVEN
         whenever(bookingListHandler.bookingsFlow).thenReturn(flowOf(emptyList()))
+        whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
+            .thenReturn(Result.success(Unit))
 
         viewModel = createViewModel()
         advanceUntilIdle()
@@ -1013,7 +1015,7 @@ class WooPosBookingsViewModelTest {
             )
             advanceUntilIdle()
 
-            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+            whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
                 .doSuspendableAnswer {
                     delay(Long.MAX_VALUE)
                     Result.success(Unit)
@@ -1056,7 +1058,7 @@ class WooPosBookingsViewModelTest {
 
             // THEN
             verify(bookingListHandler, times(2))
-                .loadBookings(sortBy = BookingListSortOption.NewestToOldest)
+                .loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest))
         }
 
     @Test
@@ -1073,7 +1075,7 @@ class WooPosBookingsViewModelTest {
             )
             advanceUntilIdle()
 
-            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+            whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
                 .doSuspendableAnswer {
                     delay(Long.MAX_VALUE)
                     Result.success(Unit)
@@ -1096,7 +1098,7 @@ class WooPosBookingsViewModelTest {
             viewModel = createViewModel()
             advanceUntilIdle()
 
-            whenever(bookingListHandler.loadBookings(sortBy = BookingListSortOption.NewestToOldest))
+            whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.NewestToOldest)))
                 .doSuspendableAnswer {
                     delay(Long.MAX_VALUE)
                     Result.success(Unit)


### PR DESCRIPTION
### Description
Fixes WOOMOB-2296

When opening POS bookings, a "no bookings" empty screen flashed briefly before bookings loaded. This happened because `fetchBookings()` onSuccess handler set the state to `Empty` before Room had a chance to deliver the fetched data. PR #15390 (date filtering) surfaced this race condition since `cleanAndUpsertBookings` in Room now triggers a re-emission that arrives after the `Empty` state was already set.

**The fix:** When `fetchBookings()` succeeds and no bookings are available yet, set `Content(NothingFound)` with the date selector instead of the full-screen `Empty` state. This way the UI shows the date picker and a contextual "no bookings for this date" message instead of a generic empty screen.

**Dead code cleanup:** The `Empty` state became unreachable after this fix. With date filtering always active, the bookings screen always has a selected date and should show the date selector - even when there are no results. The full-screen `Empty` state (which had no date selector) no longer makes sense, so it was removed along with its composable, preview, test, and string resources.

**Other improvements:**
- Renamed `Content.Items.Searching` to `Content.Items.Loading` since there is no search in POS bookings - this state represents loading items when switching dates
- `Loading` state now shows the date selector so users always see which date is selected

### Test Steps
1. Open POS bookings on a site with bookings for today
2. Verify bookings load without flashing a "no bookings" screen
3. Switch to a date with no bookings - verify "no bookings for this date" message shows with date selector
4. Switch back to a date with bookings - verify they load correctly
5. Pull to refresh - verify it works

### Images/gif


https://github.com/user-attachments/assets/82be6308-35b7-41d5-b0cd-ed8e5aecf3d6





- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.