### PR TITLE
[WOOMOB-2255] Fix spacing and typography in booking details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -276,8 +276,8 @@ private fun BookingCustomerCard(
         Column(Modifier.padding(WooPosSpacing.Medium.value)) {
             WooPosText(
                 text = stringResource(R.string.woopos_bookings_details_customer_title),
-                style = WooPosTypography.BodyLarge,
-                fontWeight = FontWeight.Bold,
+                style = WooPosTypography.BodyXLarge,
+                fontWeight = FontWeight.SemiBold,
             )
 
             customerSection.email?.let { email ->
@@ -372,7 +372,7 @@ private fun BookingPaymentCard(
             WooPosText(
                 text = stringResource(R.string.woopos_bookings_details_payment_title),
                 style = WooPosTypography.BodyXLarge,
-                fontWeight = FontWeight.Bold,
+                fontWeight = FontWeight.SemiBold,
             )
 
             Spacer(Modifier.height(WooPosSpacing.Medium.value))
@@ -426,8 +426,8 @@ private fun BookingNoteSection(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     WooPosText(
                         text = stringResource(R.string.woopos_bookings_details_booking_note_title),
-                        style = WooPosTypography.BodyLarge,
-                        fontWeight = FontWeight.Bold,
+                        style = WooPosTypography.BodyXLarge,
+                        fontWeight = FontWeight.SemiBold,
                         modifier = Modifier.weight(1f)
                     )
                     WooPosOutlinedButtonSmall(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -130,7 +130,7 @@ fun WooPosBookingDetails(
                     )
             ) {
                 HorizontalDivider(
-                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = panelAlpha),
+                    color = WooPosTheme.colors.outlineVariant.copy(alpha = panelAlpha),
                     thickness = 0.5.dp,
                 )
                 WooPosButton(
@@ -532,7 +532,10 @@ private fun CopyableRow(
 @Composable
 private fun DividerWithSpacing() {
     Spacer(Modifier.height(WooPosSpacing.Medium.value))
-    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+    HorizontalDivider(
+        color = WooPosTheme.colors.outlineVariant,
+        thickness = 0.5.dp,
+    )
     Spacer(Modifier.height(WooPosSpacing.Medium.value))
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -78,7 +78,11 @@ fun WooPosBookingDetails(
                 .padding(
                     start = WooPosSpacing.Medium.value,
                     end = WooPosSpacing.Medium.value,
-                    bottom = 92.dp + WooPosSpacing.Large.value
+                    bottom = if (hasCollectButton) {
+                        92.dp + WooPosSpacing.Large.value + WooPosSpacing.Medium.value
+                    } else {
+                        WooPosSpacing.XLarge.value
+                    }
                 )
         ) {
             BookingHeader(details = details, onUIEvent = onUIEvent)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -307,7 +307,7 @@ private fun BookingCustomerCard(
                 WooPosText(
                     text = stringResource(R.string.woopos_bookings_details_customer_note_label),
                     style = WooPosTypography.BodyMedium,
-                    color = WooPosTheme.colors.onSurfaceVariantLowest,
+                    color = WooPosTheme.colors.onSurfaceVariantHighest,
                 )
                 Spacer(Modifier.height(WooPosSpacing.Small.value))
                 WooPosText(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -91,14 +91,14 @@ fun WooPosBookingDetails(
 
             BookingDetailsCard(details = details)
 
-            details.customerSection?.let { section ->
-                Spacer(Modifier.height(WooPosSpacing.Large.value))
-                BookingCustomerCard(customerSection = section, onUIEvent = onUIEvent)
-            }
-
             details.attendanceSection?.let { section ->
                 Spacer(Modifier.height(WooPosSpacing.Large.value))
                 BookingAttendanceSection(attendanceSection = section, onUIEvent = onUIEvent)
+            }
+
+            details.customerSection?.let { section ->
+                Spacer(Modifier.height(WooPosSpacing.Large.value))
+                BookingCustomerCard(customerSection = section, onUIEvent = onUIEvent)
             }
 
             Spacer(Modifier.height(WooPosSpacing.Large.value))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -88,7 +88,7 @@ fun WooPosBookingDetails(
             BookingDetailsCard(details = details)
 
             details.customerSection?.let { section ->
-                Spacer(Modifier.height(WooPosSpacing.Medium.value))
+                Spacer(Modifier.height(WooPosSpacing.Large.value))
                 BookingCustomerCard(customerSection = section, onUIEvent = onUIEvent)
             }
 


### PR DESCRIPTION
### Description
Fixes WOOMOB-2255
Fix spacing, typography, dividers, section order, and bottom padding in WooPosBookingDetails to match the Figma design:
- Use 24dp spacing between all cards (details → customer was 16dp)
- Use BodyXLarge + SemiBold for Customer, Payment, and Booking note card titles
- Adjust bottom padding: larger when collect button is visible (avoid hint text overlapping panel), smaller when hidden (avoid excessive empty space, matching orders screen)
- Fix dividers to use WooPosTheme outlineVariant color (#DCDCDE) and 0.5dp thickness
- Fix section order: Booking → Attendance → Customer → Payment → Booking note

### Test Steps
1. Open POS Bookings and select a booking with all sections visible (customer, attendance, payment, note)
2. Verify section order is: Booking details → Attendance → Customer → Payment → Booking note
3. Verify spacing between all cards is consistent (24dp)
4. Verify card titles (Customer, Payment, Booking note) are the same size and weight as Attendance status title
5. For an unpaid booking, verify the hint text below Booking note has enough space above the Collect payment button
6. For a paid booking (no collect button), verify there is no excessive empty space at the bottom
7. Verify dividers inside cards are thin (0.5dp) and use the correct gray color

### Images/gif
<img width="1145" height="718" alt="image" src="https://github.com/user-attachments/assets/05588117-21ef-4655-9746-fec8de297e8d" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.