### PR TITLE
Clarify ViewModel passing rules for Composables in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,7 @@ fun `given user is logged in, when refresh is pulled, then data reloads`() = tes
 - Don't force unwrap with `!!` — handle nullability properly
 - Don't create new XML layouts for Compose screens — use `ComposeView` in Fragment
 - Don't use `remember` outside of `@Composable` functions
-- Don't pass `ViewModel` instances between composables — pass state and callbacks instead
+- Don't pass `ViewModel` instances between composables — pass state and callbacks instead. Exception: a single top-level wrapper composable that accepts the ViewModel, observes its state, and delegates to a stateless overload is acceptable.
 
 ## Environment Setup
 


### PR DESCRIPTION
Clarifies the ViewModel passing guideline in `AGENTS.md`. The existing rule ("Don't pass ViewModel instances between composables") was too absolute and conflicted with the two-overload pattern widely used in our codebase and in official Google samples. 

Adds an explicit exception for a single top-level wrapper composable that accepts the ViewModel, observes its state, and delegates to a stateless overload.

[Context](https://github.com/woocommerce/woocommerce-android/pull/15400#discussion_r2842231344)