### PR TITLE
[WOOMOB-2162] Add POS bookings analytics tracking

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -8,8 +8,8 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingDatePreviousTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingIssueRefundTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingListItemTapped
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingViewOrderTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingNoteAdded
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingViewOrderTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import javax.inject.Inject
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Error.BookingAttendanceChangeError
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Error.BookingCancelError
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Error.BookingNoteAddError
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Error.BookingRefundError
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingAddNoteTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingAttendanceChanged
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelled
@@ -16,7 +15,6 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingListItemTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingNoteAdded
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingViewOrderTapped
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingsListSearchButtonTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import java.time.Clock
 import java.time.Instant
@@ -34,10 +32,6 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
 
     suspend fun trackListItemTapped() {
         analyticsTracker.track(BookingListItemTapped)
-    }
-
-    suspend fun trackSearchButtonTapped() {
-        analyticsTracker.track(BookingsListSearchButtonTapped)
     }
 
     suspend fun trackBookingCancelled() {
@@ -104,16 +98,6 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
 
     suspend fun trackViewOrderTapped() {
         analyticsTracker.track(BookingViewOrderTapped)
-    }
-
-    suspend fun trackRefundFailed(errorContext: KClass<out Any>, error: Throwable) {
-        analyticsTracker.track(
-            BookingRefundError(
-                errorContext = errorContext,
-                errorType = null,
-                errorDescription = error.message,
-            )
-        )
     }
 
     private fun deltaFromToday(date: LocalDate): Long {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -1,10 +1,13 @@
 package com.woocommerce.android.ui.woopos.bookings
 
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingAttendanceChanged
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingNoteAdded
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelled
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingDateCalendarSelected
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingDateNextTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingDatePreviousTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingListItemTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingNoteAdded
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import javax.inject.Inject
 
@@ -29,5 +32,17 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
 
     suspend fun trackNoteAdded() {
         analyticsTracker.track(BookingNoteAdded)
+    }
+
+    suspend fun trackDatePreviousTapped(deltaFromToday: Long) {
+        analyticsTracker.track(BookingDatePreviousTapped(deltaFromToday))
+    }
+
+    suspend fun trackDateNextTapped(deltaFromToday: Long) {
+        analyticsTracker.track(BookingDateNextTapped(deltaFromToday))
+    }
+
+    suspend fun trackDateCalendarSelected(deltaFromToday: Long) {
+        analyticsTracker.track(BookingDateCalendarSelected(deltaFromToday))
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingDateCalendarSelected
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingDateNextTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingDatePreviousTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingIssueRefundTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingListItemTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingNoteAdded
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
@@ -44,5 +45,9 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
 
     suspend fun trackDateCalendarSelected(deltaFromToday: Long) {
         analyticsTracker.track(BookingDateCalendarSelected(deltaFromToday))
+    }
+
+    suspend fun trackIssueRefundTapped() {
+        analyticsTracker.track(BookingIssueRefundTapped)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingDatePreviousTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingIssueRefundTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingListItemTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingViewOrderTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingNoteAdded
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import javax.inject.Inject
@@ -49,5 +50,9 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
 
     suspend fun trackIssueRefundTapped() {
         analyticsTracker.track(BookingIssueRefundTapped)
+    }
+
+    suspend fun trackViewOrderTapped() {
+        analyticsTracker.track(BookingViewOrderTapped)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -44,12 +44,12 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
         analyticsTracker.track(BookingCancelled)
     }
 
-    suspend fun trackBookingCancelFailed(errorContext: KClass<out Any>, error: Throwable?) {
+    suspend fun trackBookingCancelFailed(errorContext: KClass<out Any>, error: Throwable) {
         analyticsTracker.track(
             BookingCancelError(
                 errorContext = errorContext,
                 errorType = null,
-                errorDescription = error?.message,
+                errorDescription = error.message,
             )
         )
     }
@@ -58,12 +58,12 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
         analyticsTracker.track(BookingAttendanceChanged)
     }
 
-    suspend fun trackAttendanceChangeFailed(errorContext: KClass<out Any>, error: Throwable?) {
+    suspend fun trackAttendanceChangeFailed(errorContext: KClass<out Any>, error: Throwable) {
         analyticsTracker.track(
             BookingAttendanceChangeError(
                 errorContext = errorContext,
                 errorType = null,
-                errorDescription = error?.message,
+                errorDescription = error.message,
             )
         )
     }
@@ -76,12 +76,12 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
         analyticsTracker.track(BookingNoteAdded)
     }
 
-    suspend fun trackNoteAddFailed(errorContext: KClass<out Any>, error: Throwable?) {
+    suspend fun trackNoteAddFailed(errorContext: KClass<out Any>, error: Throwable) {
         analyticsTracker.track(
             BookingNoteAddError(
                 errorContext = errorContext,
                 errorType = null,
-                errorDescription = error?.message,
+                errorDescription = error.message,
             )
         )
     }
@@ -106,12 +106,12 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
         analyticsTracker.track(BookingViewOrderTapped)
     }
 
-    suspend fun trackRefundFailed(errorContext: KClass<out Any>, error: Throwable?) {
+    suspend fun trackRefundFailed(errorContext: KClass<out Any>, error: Throwable) {
         analyticsTracker.track(
             BookingRefundError(
                 errorContext = errorContext,
                 errorType = null,
-                errorDescription = error?.message,
+                errorDescription = error.message,
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.bookings
 
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingAttendanceChanged
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingNoteAdded
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelled
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingListItemTapped
@@ -24,5 +25,9 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
 
     suspend fun trackAttendanceChanged() {
         analyticsTracker.track(BookingAttendanceChanged)
+    }
+
+    suspend fun trackNoteAdded() {
+        analyticsTracker.track(BookingNoteAdded)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -2,8 +2,12 @@ package com.woocommerce.android.ui.woopos.bookings
 
 import com.woocommerce.android.extensions.clock
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Error.BookingAttendanceChangeError
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Error.BookingCancelError
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Error.BookingNoteAddError
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Error.BookingRefundError
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingAddNoteTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingAttendanceChanged
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelled
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingDateCalendarSelected
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingDateNextTapped
@@ -12,12 +16,14 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingListItemTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingNoteAdded
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingViewOrderTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingsListSearchButtonTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
+import kotlin.reflect.KClass
 
 class WooPosBookingsAnalyticsTracker @Inject constructor(
     private val analyticsTracker: WooPosAnalyticsTracker,
@@ -30,20 +36,54 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
         analyticsTracker.track(BookingListItemTapped)
     }
 
+    suspend fun trackSearchButtonTapped() {
+        analyticsTracker.track(BookingsListSearchButtonTapped)
+    }
+
     suspend fun trackBookingCancelled() {
         analyticsTracker.track(BookingCancelled)
     }
 
-    suspend fun trackBookingCancelFailed() {
-        analyticsTracker.track(BookingCancelFailed)
+    suspend fun trackBookingCancelFailed(errorContext: KClass<out Any>, error: Throwable?) {
+        analyticsTracker.track(
+            BookingCancelError(
+                errorContext = errorContext,
+                errorType = null,
+                errorDescription = error?.message,
+            )
+        )
     }
 
     suspend fun trackAttendanceChanged() {
         analyticsTracker.track(BookingAttendanceChanged)
     }
 
+    suspend fun trackAttendanceChangeFailed(errorContext: KClass<out Any>, error: Throwable?) {
+        analyticsTracker.track(
+            BookingAttendanceChangeError(
+                errorContext = errorContext,
+                errorType = null,
+                errorDescription = error?.message,
+            )
+        )
+    }
+
+    suspend fun trackAddNoteTapped() {
+        analyticsTracker.track(BookingAddNoteTapped)
+    }
+
     suspend fun trackNoteAdded() {
         analyticsTracker.track(BookingNoteAdded)
+    }
+
+    suspend fun trackNoteAddFailed(errorContext: KClass<out Any>, error: Throwable?) {
+        analyticsTracker.track(
+            BookingNoteAddError(
+                errorContext = errorContext,
+                errorType = null,
+                errorDescription = error?.message,
+            )
+        )
     }
 
     suspend fun trackDatePreviousTapped(selectedDate: LocalDate) {
@@ -64,6 +104,16 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
 
     suspend fun trackViewOrderTapped() {
         analyticsTracker.track(BookingViewOrderTapped)
+    }
+
+    suspend fun trackRefundFailed(errorContext: KClass<out Any>, error: Throwable?) {
+        analyticsTracker.track(
+            BookingRefundError(
+                errorContext = errorContext,
+                errorType = null,
+                errorDescription = error?.message,
+            )
+        )
     }
 
     private fun deltaFromToday(date: LocalDate): Long {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.bookings
 
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingAttendanceChanged
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelled
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingListItemTapped
@@ -19,5 +20,9 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
 
     suspend fun trackBookingCancelFailed() {
         analyticsTracker.track(BookingCancelFailed)
+    }
+
+    suspend fun trackAttendanceChanged() {
+        analyticsTracker.track(BookingAttendanceChanged)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.woopos.bookings
+
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingListItemTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import javax.inject.Inject
+
+class WooPosBookingsAnalyticsTracker @Inject constructor(
+    private val analyticsTracker: WooPosAnalyticsTracker
+) {
+    suspend fun trackListItemTapped() {
+        analyticsTracker.track(BookingListItemTapped)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.woopos.bookings
 
+import com.woocommerce.android.extensions.clock
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingAttendanceChanged
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelled
@@ -11,11 +13,19 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingNoteAdded
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingViewOrderTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 
 class WooPosBookingsAnalyticsTracker @Inject constructor(
-    private val analyticsTracker: WooPosAnalyticsTracker
+    private val analyticsTracker: WooPosAnalyticsTracker,
+    private val clock: Clock,
+    selectedSite: SelectedSite,
 ) {
+    private val storeZoneId = selectedSite.get().clock.zone
+
     suspend fun trackListItemTapped() {
         analyticsTracker.track(BookingListItemTapped)
     }
@@ -36,16 +46,16 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
         analyticsTracker.track(BookingNoteAdded)
     }
 
-    suspend fun trackDatePreviousTapped(deltaFromToday: Long) {
-        analyticsTracker.track(BookingDatePreviousTapped(deltaFromToday))
+    suspend fun trackDatePreviousTapped(selectedDate: LocalDate) {
+        analyticsTracker.track(BookingDatePreviousTapped(deltaFromToday(selectedDate)))
     }
 
-    suspend fun trackDateNextTapped(deltaFromToday: Long) {
-        analyticsTracker.track(BookingDateNextTapped(deltaFromToday))
+    suspend fun trackDateNextTapped(selectedDate: LocalDate) {
+        analyticsTracker.track(BookingDateNextTapped(deltaFromToday(selectedDate)))
     }
 
-    suspend fun trackDateCalendarSelected(deltaFromToday: Long) {
-        analyticsTracker.track(BookingDateCalendarSelected(deltaFromToday))
+    suspend fun trackDateCalendarSelected(selectedDate: LocalDate) {
+        analyticsTracker.track(BookingDateCalendarSelected(deltaFromToday(selectedDate)))
     }
 
     suspend fun trackIssueRefundTapped() {
@@ -54,5 +64,10 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
 
     suspend fun trackViewOrderTapped() {
         analyticsTracker.track(BookingViewOrderTapped)
+    }
+
+    private fun deltaFromToday(date: LocalDate): Long {
+        val today = Instant.now(clock).atZone(storeZoneId).toLocalDate()
+        return ChronoUnit.DAYS.between(today, date)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsAnalyticsTracker.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.woopos.bookings
 
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelFailed
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingCancelled
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BookingListItemTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import javax.inject.Inject
@@ -9,5 +11,13 @@ class WooPosBookingsAnalyticsTracker @Inject constructor(
 ) {
     suspend fun trackListItemTapped() {
         analyticsTracker.track(BookingListItemTapped)
+    }
+
+    suspend fun trackBookingCancelled() {
+        analyticsTracker.track(BookingCancelled)
+    }
+
+    suspend fun trackBookingCancelFailed() {
+        analyticsTracker.track(BookingCancelFailed)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -484,6 +484,7 @@ class WooPosBookingsViewModel @Inject constructor(
         when (action) {
             is WooPosBookingsState.BookingAction.ViewOrder -> {
                 viewModelScope.launch {
+                    analyticsTracker.trackViewOrderTapped()
                     _navigationEvent.emit(
                         WooPosNavigationEvent.OpenOrderDetails(orderId = action.orderId)
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -564,7 +564,7 @@ class WooPosBookingsViewModel @Inject constructor(
             } else {
                 analyticsTracker.trackBookingCancelFailed(
                     this@WooPosBookingsViewModel::class,
-                    result.exceptionOrNull()
+                    result.exceptionOrNull() ?: Exception("Unknown error")
                 )
                 state.copy(
                     dialogState = WooPosBookingsState.Content.DialogState.CancelBooking.Error(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -431,7 +431,8 @@ class WooPosBookingsViewModel @Inject constructor(
                 attendanceStatus = entityStatus,
             ).onSuccess {
                 analyticsTracker.trackAttendanceChanged()
-            }.onFailure {
+            }.onFailure { error ->
+                analyticsTracker.trackAttendanceChangeFailed(this@WooPosBookingsViewModel::class, error)
                 val rollbackState = _state.value as? WooPosBookingsState.Content ?: return@onFailure
                 val rollbackDetails = rollbackState.selectedDetails ?: return@onFailure
                 if (rollbackDetails.id != details.id) return@onFailure
@@ -467,6 +468,7 @@ class WooPosBookingsViewModel @Inject constructor(
     private fun handleAddBookingNote() {
         val bookingId = selectedBookingId ?: return
         viewModelScope.launch {
+            analyticsTracker.trackAddNoteTapped()
             _navigationEvent.emit(WooPosNavigationEvent.OpenBookingNote(bookingId))
         }
     }
@@ -560,7 +562,10 @@ class WooPosBookingsViewModel @Inject constructor(
                     dialogState = WooPosBookingsState.Content.DialogState.Hidden
                 )
             } else {
-                analyticsTracker.trackBookingCancelFailed()
+                analyticsTracker.trackBookingCancelFailed(
+                    this@WooPosBookingsViewModel::class,
+                    result.exceptionOrNull()
+                )
                 state.copy(
                     dialogState = WooPosBookingsState.Content.DialogState.CancelBooking.Error(
                         bookingId = dialog.bookingId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -419,7 +419,9 @@ class WooPosBookingsViewModel @Inject constructor(
             bookingsRepository.updateAttendanceStatus(
                 bookingId = details.id,
                 attendanceStatus = entityStatus,
-            ).onFailure {
+            ).onSuccess {
+                analyticsTracker.trackAttendanceChanged()
+            }.onFailure {
                 val rollbackState = _state.value as? WooPosBookingsState.Content ?: return@onFailure
                 val rollbackDetails = rollbackState.selectedDetails ?: return@onFailure
                 if (rollbackDetails.id != details.id) return@onFailure

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -497,6 +497,7 @@ class WooPosBookingsViewModel @Inject constructor(
                 }
             }
             is WooPosBookingsState.BookingAction.IssueRefund -> {
+                viewModelScope.launch { analyticsTracker.trackIssueRefundTapped() }
                 val currentState = _state.value as? WooPosBookingsState.Content ?: return
                 _state.value = currentState.copy(
                     dialogState = WooPosBookingsState.Content.DialogState.IssueRefund(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -37,6 +37,7 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.Locale
 import javax.inject.Inject
 
@@ -354,11 +355,21 @@ class WooPosBookingsViewModel @Inject constructor(
             is WooPosBookingsUIEvent.CopyPhoneClicked -> handleCopyToClipboard(event.phone)
             is WooPosBookingsUIEvent.CancelBookingConfirmed -> handleCancelConfirmed()
             is WooPosBookingsUIEvent.CancelBookingDismissed -> handleCancelDismissed()
-            is WooPosBookingsUIEvent.PreviousDayClicked -> handleDateChange(selectedDate.minusDays(1))
-            is WooPosBookingsUIEvent.NextDayClicked -> handleDateChange(selectedDate.plusDays(1))
-            is WooPosBookingsUIEvent.DateSelected -> handleDateChange(
-                Instant.ofEpochMilli(event.dateMillis).atZone(ZoneOffset.UTC).toLocalDate()
-            )
+            is WooPosBookingsUIEvent.PreviousDayClicked -> {
+                val newDate = selectedDate.minusDays(1)
+                handleDateChange(newDate)
+                viewModelScope.launch { analyticsTracker.trackDatePreviousTapped(deltaFromToday(newDate)) }
+            }
+            is WooPosBookingsUIEvent.NextDayClicked -> {
+                val newDate = selectedDate.plusDays(1)
+                handleDateChange(newDate)
+                viewModelScope.launch { analyticsTracker.trackDateNextTapped(deltaFromToday(newDate)) }
+            }
+            is WooPosBookingsUIEvent.DateSelected -> {
+                val newDate = Instant.ofEpochMilli(event.dateMillis).atZone(ZoneOffset.UTC).toLocalDate()
+                handleDateChange(newDate)
+                viewModelScope.launch { analyticsTracker.trackDateCalendarSelected(deltaFromToday(newDate)) }
+            }
         }
     }
 
@@ -609,6 +620,11 @@ class WooPosBookingsViewModel @Inject constructor(
             formattedDate = selectedDate.format(formatter),
             selectedDateMillis = millis,
         )
+    }
+
+    private fun deltaFromToday(date: LocalDate): Long {
+        val today = Instant.now(clock).atZone(storeZoneId).toLocalDate()
+        return ChronoUnit.DAYS.between(today, date)
     }
 
     private fun dateRangeForDate(date: LocalDate): BookingsFilterOption.DateRange {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -49,6 +49,7 @@ class WooPosBookingsViewModel @Inject constructor(
     private val clipboardHelper: WooPosClipboardHelper,
     private val resourceProvider: ResourceProvider,
     private val clock: Clock,
+    private val analyticsTracker: WooPosBookingsAnalyticsTracker,
     selectedSite: SelectedSite,
 ) : ViewModel() {
 
@@ -221,6 +222,7 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     fun onBookingSelected(bookingId: Long) {
+        viewModelScope.launch { analyticsTracker.trackListItemTapped() }
         selectedBookingId = bookingId
         val currentState = _state.value as? WooPosBookingsState.Content ?: return
         val items = (currentState.items as? WooPosBookingsState.Content.Items.Loaded) ?: return

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -37,7 +37,6 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
 import java.util.Locale
 import javax.inject.Inject
 
@@ -358,17 +357,17 @@ class WooPosBookingsViewModel @Inject constructor(
             is WooPosBookingsUIEvent.PreviousDayClicked -> {
                 val newDate = selectedDate.minusDays(1)
                 handleDateChange(newDate)
-                viewModelScope.launch { analyticsTracker.trackDatePreviousTapped(deltaFromToday(newDate)) }
+                viewModelScope.launch { analyticsTracker.trackDatePreviousTapped(newDate) }
             }
             is WooPosBookingsUIEvent.NextDayClicked -> {
                 val newDate = selectedDate.plusDays(1)
                 handleDateChange(newDate)
-                viewModelScope.launch { analyticsTracker.trackDateNextTapped(deltaFromToday(newDate)) }
+                viewModelScope.launch { analyticsTracker.trackDateNextTapped(newDate) }
             }
             is WooPosBookingsUIEvent.DateSelected -> {
                 val newDate = Instant.ofEpochMilli(event.dateMillis).atZone(ZoneOffset.UTC).toLocalDate()
                 handleDateChange(newDate)
-                viewModelScope.launch { analyticsTracker.trackDateCalendarSelected(deltaFromToday(newDate)) }
+                viewModelScope.launch { analyticsTracker.trackDateCalendarSelected(newDate) }
             }
         }
     }
@@ -622,11 +621,6 @@ class WooPosBookingsViewModel @Inject constructor(
             formattedDate = selectedDate.format(formatter),
             selectedDateMillis = millis,
         )
-    }
-
-    private fun deltaFromToday(date: LocalDate): Long {
-        val today = Instant.now(clock).atZone(storeZoneId).toLocalDate()
-        return ChronoUnit.DAYS.between(today, date)
     }
 
     private fun dateRangeForDate(date: LocalDate): BookingsFilterOption.DateRange {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -541,10 +541,12 @@ class WooPosBookingsViewModel @Inject constructor(
             val result = bookingsRepository.cancelBooking(bookingId)
             val state = _state.value as? WooPosBookingsState.Content ?: return@launch
             _state.value = if (result.isSuccess) {
+                analyticsTracker.trackBookingCancelled()
                 state.copy(
                     dialogState = WooPosBookingsState.Content.DialogState.Hidden
                 )
             } else {
+                analyticsTracker.trackBookingCancelFailed()
                 state.copy(
                     dialogState = WooPosBookingsState.Content.DialogState.CancelBooking.Error(
                         bookingId = dialog.bookingId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.ui.bookings.BookingsRepository
+import com.woocommerce.android.ui.woopos.bookings.WooPosBookingsAnalyticsTracker
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -21,6 +22,7 @@ import javax.inject.Inject
 class WooPosBookingNoteViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val bookingsRepository: BookingsRepository,
+    private val analyticsTracker: WooPosBookingsAnalyticsTracker,
 ) : ViewModel() {
 
     private val bookingId: Long = requireNotNull(savedStateHandle[BOOKING_NOTE_ROUTE_BOOKING_ID_KEY])
@@ -74,6 +76,7 @@ class WooPosBookingNoteViewModel @Inject constructor(
                 _errorEvent.emit(Unit)
             }
             result.onSuccess {
+                analyticsTracker.trackNoteAdded()
                 _navigationEvent.emit(
                     WooPosNavigationEvent.GoBackWithResult(
                         key = BOOKING_NOTE_RESULT_KEY,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModel.kt
@@ -69,7 +69,8 @@ class WooPosBookingNoteViewModel @Inject constructor(
                 bookingId = bookingId,
                 note = currentState.noteText.trim()
             )
-            result.onFailure {
+            result.onFailure { error ->
+                analyticsTracker.trackNoteAddFailed(this@WooPosBookingNoteViewModel::class, error)
                 _state.update {
                     it.copy(buttonState = WooPosButtonState.ENABLED)
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarU
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarUIEvent.OnToolbarMenuClicked
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ExitTapped
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.GoToBookingsTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.GoToOrdersTapped
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -93,6 +94,7 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
             R.string.woopos_bookings_title -> {
                 viewModelScope.launch {
                     childrenToParentEventSender.sendToParent(ChildToParentEvent.NavigationEvent.ToBookings)
+                    analyticsTracker.track(GoToBookingsTapped)
                 }
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -40,6 +40,38 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
         ) : Error() {
             override val name: String = "order_creation_failed"
         }
+
+        data class BookingCancelError(
+            override val errorContext: KClass<out Any>,
+            override val errorType: String?,
+            override val errorDescription: String?,
+        ) : Error() {
+            override val name: String = "pos_booking_cancel_failed"
+        }
+
+        data class BookingAttendanceChangeError(
+            override val errorContext: KClass<out Any>,
+            override val errorType: String?,
+            override val errorDescription: String?,
+        ) : Error() {
+            override val name: String = "pos_booking_attendance_change_failed"
+        }
+
+        data class BookingNoteAddError(
+            override val errorContext: KClass<out Any>,
+            override val errorType: String?,
+            override val errorDescription: String?,
+        ) : Error() {
+            override val name: String = "pos_booking_note_add_failed"
+        }
+
+        data class BookingRefundError(
+            override val errorContext: KClass<out Any>,
+            override val errorType: String?,
+            override val errorDescription: String?,
+        ) : Error() {
+            override val name: String = "pos_booking_refund_failed"
+        }
     }
 
     sealed class Event : WooPosAnalyticsEvent() {
@@ -157,16 +189,20 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "pos_bookings_list_booking_tapped"
         }
 
+        data object BookingsListSearchButtonTapped : Event() {
+            override val name: String = "pos_bookings_list_search_button_tapped"
+        }
+
         data object BookingCancelled : Event() {
             override val name: String = "pos_booking_cancelled"
         }
 
-        data object BookingCancelFailed : Event() {
-            override val name: String = "pos_booking_cancel_failed"
-        }
-
         data object BookingAttendanceChanged : Event() {
             override val name: String = "pos_booking_attendance_changed"
+        }
+
+        data object BookingAddNoteTapped : Event() {
+            override val name: String = "pos_booking_add_note_tapped"
         }
 
         data object BookingNoteAdded : Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -169,6 +169,10 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "booking_attendance_changed"
         }
 
+        data object BookingNoteAdded : Event() {
+            override val name: String = "booking_note_added"
+        }
+
         data object OrdersListPullToRefreshTriggered : Event() {
             override val name: String = "orders_list_pull_to_refresh"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -46,7 +46,7 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val errorType: String?,
             override val errorDescription: String?,
         ) : Error() {
-            override val name: String = "pos_booking_cancel_failed"
+            override val name: String = "booking_cancel_failed"
         }
 
         data class BookingAttendanceChangeError(
@@ -54,7 +54,7 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val errorType: String?,
             override val errorDescription: String?,
         ) : Error() {
-            override val name: String = "pos_booking_attendance_change_failed"
+            override val name: String = "booking_attendance_change_failed"
         }
 
         data class BookingNoteAddError(
@@ -62,7 +62,7 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val errorType: String?,
             override val errorDescription: String?,
         ) : Error() {
-            override val name: String = "pos_booking_note_add_failed"
+            override val name: String = "booking_note_add_failed"
         }
 
         data class BookingRefundError(
@@ -70,7 +70,7 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val errorType: String?,
             override val errorDescription: String?,
         ) : Error() {
-            override val name: String = "pos_booking_refund_failed"
+            override val name: String = "booking_refund_failed"
         }
     }
 
@@ -182,31 +182,31 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
         }
 
         data object GoToBookingsTapped : Event() {
-            override val name: String = "pos_bookings_menu_item_tapped"
+            override val name: String = "bookings_menu_item_tapped"
         }
 
         data object BookingListItemTapped : Event() {
-            override val name: String = "pos_bookings_list_booking_tapped"
+            override val name: String = "bookings_list_booking_tapped"
         }
 
         data object BookingsListSearchButtonTapped : Event() {
-            override val name: String = "pos_bookings_list_search_button_tapped"
+            override val name: String = "bookings_list_search_button_tapped"
         }
 
         data object BookingCancelled : Event() {
-            override val name: String = "pos_booking_cancelled"
+            override val name: String = "booking_cancelled"
         }
 
         data object BookingAttendanceChanged : Event() {
-            override val name: String = "pos_booking_attendance_changed"
+            override val name: String = "booking_attendance_changed"
         }
 
         data object BookingAddNoteTapped : Event() {
-            override val name: String = "pos_booking_add_note_tapped"
+            override val name: String = "booking_add_note_tapped"
         }
 
         data object BookingNoteAdded : Event() {
-            override val name: String = "pos_booking_note_added"
+            override val name: String = "booking_note_added"
         }
 
         data class BookingDatePreviousTapped(val deltaFromToday: Long) : Event() {
@@ -234,11 +234,11 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
         }
 
         data object BookingIssueRefundTapped : Event() {
-            override val name: String = "pos_booking_issue_refund_tapped"
+            override val name: String = "booking_issue_refund_tapped"
         }
 
         data object BookingViewOrderTapped : Event() {
-            override val name: String = "pos_booking_view_order_tapped"
+            override val name: String = "booking_view_order_tapped"
         }
 
         data object OrdersListPullToRefreshTriggered : Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -173,6 +173,30 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "booking_note_added"
         }
 
+        data class BookingDatePreviousTapped(val deltaFromToday: Long) : Event() {
+            override val name: String = "booking_date_previous_tapped"
+
+            init {
+                addProperties(mapOf("delta_from_today" to deltaFromToday.toString()))
+            }
+        }
+
+        data class BookingDateNextTapped(val deltaFromToday: Long) : Event() {
+            override val name: String = "booking_date_next_tapped"
+
+            init {
+                addProperties(mapOf("delta_from_today" to deltaFromToday.toString()))
+            }
+        }
+
+        data class BookingDateCalendarSelected(val deltaFromToday: Long) : Event() {
+            override val name: String = "booking_date_calendar_selected"
+
+            init {
+                addProperties(mapOf("delta_from_today" to deltaFromToday.toString()))
+            }
+        }
+
         data object OrdersListPullToRefreshTriggered : Event() {
             override val name: String = "orders_list_pull_to_refresh"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -197,6 +197,10 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             }
         }
 
+        data object BookingIssueRefundTapped : Event() {
+            override val name: String = "booking_issue_refund_tapped"
+        }
+
         data object OrdersListPullToRefreshTriggered : Event() {
             override val name: String = "orders_list_pull_to_refresh"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -165,6 +165,10 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "booking_cancel_failed"
         }
 
+        data object BookingAttendanceChanged : Event() {
+            override val name: String = "booking_attendance_changed"
+        }
+
         data object OrdersListPullToRefreshTriggered : Event() {
             override val name: String = "orders_list_pull_to_refresh"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -201,6 +201,10 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "booking_issue_refund_tapped"
         }
 
+        data object BookingViewOrderTapped : Event() {
+            override val name: String = "booking_view_order_tapped"
+        }
+
         data object OrdersListPullToRefreshTriggered : Event() {
             override val name: String = "orders_list_pull_to_refresh"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -157,6 +157,14 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "booking_list_item_tapped"
         }
 
+        data object BookingCancelled : Event() {
+            override val name: String = "booking_cancelled"
+        }
+
+        data object BookingCancelFailed : Event() {
+            override val name: String = "booking_cancel_failed"
+        }
+
         data object OrdersListPullToRefreshTriggered : Event() {
             override val name: String = "orders_list_pull_to_refresh"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -150,27 +150,27 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
         }
 
         data object GoToBookingsTapped : Event() {
-            override val name: String = "bookings_menu_item_tapped"
+            override val name: String = "pos_bookings_menu_item_tapped"
         }
 
         data object BookingListItemTapped : Event() {
-            override val name: String = "booking_list_item_tapped"
+            override val name: String = "pos_bookings_list_booking_tapped"
         }
 
         data object BookingCancelled : Event() {
-            override val name: String = "booking_cancelled"
+            override val name: String = "pos_booking_cancelled"
         }
 
         data object BookingCancelFailed : Event() {
-            override val name: String = "booking_cancel_failed"
+            override val name: String = "pos_booking_cancel_failed"
         }
 
         data object BookingAttendanceChanged : Event() {
-            override val name: String = "booking_attendance_changed"
+            override val name: String = "pos_booking_attendance_changed"
         }
 
         data object BookingNoteAdded : Event() {
-            override val name: String = "booking_note_added"
+            override val name: String = "pos_booking_note_added"
         }
 
         data class BookingDatePreviousTapped(val deltaFromToday: Long) : Event() {
@@ -198,11 +198,11 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
         }
 
         data object BookingIssueRefundTapped : Event() {
-            override val name: String = "booking_issue_refund_tapped"
+            override val name: String = "pos_booking_issue_refund_tapped"
         }
 
         data object BookingViewOrderTapped : Event() {
-            override val name: String = "booking_view_order_tapped"
+            override val name: String = "pos_booking_view_order_tapped"
         }
 
         data object OrdersListPullToRefreshTriggered : Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -149,6 +149,14 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "orders_menu_item_tapped"
         }
 
+        data object GoToBookingsTapped : Event() {
+            override val name: String = "bookings_menu_item_tapped"
+        }
+
+        data object BookingListItemTapped : Event() {
+            override val name: String = "booking_list_item_tapped"
+        }
+
         data object OrdersListPullToRefreshTriggered : Event() {
             override val name: String = "orders_list_pull_to_refresh"
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -1417,4 +1417,94 @@ class WooPosBookingsViewModelTest {
             assertThat(dateRange.after).isEqualTo(Instant.parse("2026-03-15T05:00:00Z"))
             assertThat(dateRange.before).isEqualTo(Instant.parse("2026-03-16T04:59:59.999999999Z"))
         }
+
+    @Test
+    fun `given cancel confirmed successfully, when handling event, then tracks booking cancelled`() =
+        runTest {
+            // GIVEN
+            whenever(bookingsRepository.cancelBooking(any()))
+                .thenReturn(Result.success(Unit))
+            viewModel = createViewModel()
+            advanceUntilIdle()
+            val content = viewModel.state.value as WooPosBookingsState.Content
+            val bookingId = content.selectedDetails!!.id
+
+            viewModel.onUIEvent(
+                WooPosBookingsUIEvent.BookingMenuActionClicked(
+                    WooPosBookingsState.BookingAction.CancelBooking(
+                        bookingId = bookingId,
+                        orderId = bookingId * 10
+                    )
+                )
+            )
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosBookingsUIEvent.CancelBookingConfirmed)
+            advanceUntilIdle()
+
+            // THEN
+            verify(analyticsTracker).trackBookingCancelled()
+        }
+
+    @Test
+    fun `given cancel confirmed with failure, when handling event, then tracks cancel failed`() =
+        runTest {
+            // GIVEN
+            whenever(bookingsRepository.cancelBooking(any()))
+                .thenReturn(Result.failure(RuntimeException("Network error")))
+            viewModel = createViewModel()
+            advanceUntilIdle()
+            val content = viewModel.state.value as WooPosBookingsState.Content
+            val bookingId = content.selectedDetails!!.id
+
+            viewModel.onUIEvent(
+                WooPosBookingsUIEvent.BookingMenuActionClicked(
+                    WooPosBookingsState.BookingAction.CancelBooking(
+                        bookingId = bookingId,
+                        orderId = bookingId * 10
+                    )
+                )
+            )
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onUIEvent(WooPosBookingsUIEvent.CancelBookingConfirmed)
+            advanceUntilIdle()
+
+            // THEN
+            verify(analyticsTracker).trackBookingCancelFailed(any(), any())
+        }
+
+    @Test
+    fun `given attendance toggled successfully, when handling event, then tracks attendance changed`() = runTest {
+        // GIVEN
+        whenever(bookingsRepository.updateAttendanceStatus(any(), any()))
+            .thenReturn(Result.success(Unit))
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosBookingsUIEvent.AttendanceToggled(true))
+        advanceUntilIdle()
+
+        // THEN
+        verify(analyticsTracker).trackAttendanceChanged()
+    }
+
+    @Test
+    fun `given attendance toggle fails, when handling event, then tracks attendance change failed`() = runTest {
+        // GIVEN
+        whenever(bookingsRepository.updateAttendanceStatus(any(), any()))
+            .thenReturn(Result.failure(RuntimeException("network error")))
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosBookingsUIEvent.AttendanceToggled(false))
+        advanceUntilIdle()
+
+        // THEN
+        verify(analyticsTracker).trackAttendanceChangeFailed(any(), any())
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -99,6 +99,7 @@ class WooPosBookingsViewModelTest {
     }
     private val clipboardHelper: WooPosClipboardHelper = mock()
     private val paymentStatusResolver: WooPosPaymentStatusResolver = mock()
+    private val analyticsTracker: WooPosBookingsAnalyticsTracker = mock()
     private val clock: Clock = Clock.fixed(Instant.parse("2026-02-19T10:00:00Z"), ZoneOffset.UTC)
     private lateinit var viewModel: WooPosBookingsViewModel
 
@@ -156,6 +157,7 @@ class WooPosBookingsViewModelTest {
             clipboardHelper = clipboardHelper,
             resourceProvider = resourceProvider,
             clock = clock,
+            analyticsTracker = analyticsTracker,
             selectedSite = selectedSite,
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.bookings.note
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.woocommerce.android.ui.bookings.BookingsRepository
+import com.woocommerce.android.ui.woopos.bookings.WooPosBookingsAnalyticsTracker
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
@@ -62,6 +63,7 @@ class WooPosBookingNoteViewModelTest {
         customerNote = ""
     )
 
+    private val analyticsTracker: WooPosBookingsAnalyticsTracker = mock()
     private val bookingsRepository = mock<BookingsRepository> {
         onBlocking { getBooking(any()) } doReturn booking
         onBlocking { updateNote(any(), any()) } doReturn Result.success(Unit)
@@ -76,6 +78,7 @@ class WooPosBookingNoteViewModelTest {
     ) = WooPosBookingNoteViewModel(
         savedStateHandle = savedStateHandle,
         bookingsRepository = bookingsRepository,
+        analyticsTracker = analyticsTracker,
     )
 
     @Test


### PR DESCRIPTION
### Description
Fixes WOOMOB-2162

Add analytics tracking events for the POS bookings feature, based on the discussion in pdfdoF-8K5-p2.

Creates a dedicated `WooPosBookingsAnalyticsTracker` (following the existing `WooPosOrdersAnalyticsTracker` pattern) and wires events into the bookings ViewModels.

**Note:** All event names below are without the `pos_` prefix because `WooPosAnalyticsTracker` automatically prepends `woocommerceandroid_pos_` to all POS events. The final tracked names will be `woocommerceandroid_pos_<event_name>`.

**Changes after P2 review feedback:**
- Renamed `booking_list_item_tapped` → `bookings_list_booking_tapped`
- Converted failure events to proper Error type with error context/description
- Added new events: `booking_add_note_tapped`, `bookings_list_search_button_tapped`
- Added new failure events: `booking_attendance_change_failed`, `booking_note_add_failed`, `booking_refund_failed`
- Removed `booking_id` property from all events (per Jirka's feedback — tracking is for trends, not debugging)

#### Happy path events

| # | Event name | Property | Where tracked |
|---|------------|----------|---------------|
| 1 | `bookings_menu_item_tapped` | — | Toolbar VM, when bookings menu item is tapped |
| 2 | `bookings_list_booking_tapped` | — | Bookings VM, when a booking row is tapped |
| 3 | `bookings_list_search_button_tapped` | — | Ready in tracker, wired when search UI is added |
| 4 | `booking_cancelled` | — | Bookings VM, on successful cancellation |
| 5 | `booking_attendance_changed` | — | Bookings VM, on successful attendance toggle |
| 6 | `booking_add_note_tapped` | — | Bookings VM, when add note action is tapped |
| 7 | `booking_note_added` | — | BookingNote VM, on successful note save |
| 8 | `booking_issue_refund_tapped` | — | Bookings VM, Issue Refund action |
| 9 | `booking_view_order_tapped` | — | Bookings VM, View Order action |

#### Date picker events

| # | Event name | Property | Where tracked |
|---|------------|----------|---------------|
| 10 | `booking_date_previous_tapped` | `delta_from_today` | Bookings VM, previous day button |
| 11 | `booking_date_next_tapped` | `delta_from_today` | Bookings VM, next day button |
| 12 | `booking_date_calendar_selected` | `delta_from_today` | Bookings VM, calendar date picker |

#### Failure events (Error type with error context)

| # | Event name | Error info | Where tracked |
|---|------------|------------|---------------|
| 13 | `booking_cancel_failed` | errorContext, errorDescription | Bookings VM, on failed cancellation |
| 14 | `booking_attendance_change_failed` | errorContext, errorDescription | Bookings VM, on failed attendance toggle |
| 15 | `booking_note_add_failed` | errorContext, errorDescription | BookingNote VM, on failed note save |
| 16 | `booking_refund_failed` | errorContext, errorDescription | Ready in tracker, wired when refund failure is handled |

Payment events are not included — existing POS payment events are reused as agreed in the P2 discussion.

### Test Steps
1. Open POS mode on a CIAB site with bookings enabled
2. Tap the Bookings menu item in the toolbar → verify `bookings_menu_item_tapped` fires
3. Tap a booking row → verify `bookings_list_booking_tapped` fires
4. Tap previous/next day arrows and pick a date from calendar → verify date picker events fire with correct `delta_from_today`
5. Toggle attendance on a booking → verify `booking_attendance_changed` fires
6. Tap Add Note from actions → verify `booking_add_note_tapped` fires
7. Save a booking note → verify `booking_note_added` fires
8. Tap View Order from actions menu → verify `booking_view_order_tapped` fires
9. Tap Issue Refund from actions menu → verify `booking_issue_refund_tapped` fires
10. Cancel a booking → verify `booking_cancelled` fires on success, `booking_cancel_failed` on failure
11. Force attendance/note failures (e.g., airplane mode) → verify failure events fire with error info

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.