### PR TITLE
[CIAB: POS] Redesign booking list's date picker

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,7 +56,7 @@ fun WooPosBookingsDateSelector(
     onUIEvent: (WooPosBookingsUIEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var showDatePicker by remember { mutableStateOf(false) }
+    var showDatePicker by rememberSaveable { mutableStateOf(false) }
 
     val buttonShape = RoundedCornerShape(DateSelectorButtonCornerRadius)
     val buttonColor = MaterialTheme.colorScheme.surface

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
-
 package com.woocommerce.android.ui.woopos.bookings
 
 import androidx.compose.foundation.clickable
@@ -25,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -156,6 +153,7 @@ fun WooPosBookingsDateSelector(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DatePickerPopup(
     selectedDateMillis: Long,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
@@ -5,12 +5,10 @@ package com.woocommerce.android.ui.woopos.bookings
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
@@ -24,6 +22,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,7 +40,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
@@ -166,6 +164,12 @@ private fun DatePickerPopup(
     val datePickerState = rememberDatePickerState(
         initialSelectedDateMillis = selectedDateMillis,
     )
+    LaunchedEffect(datePickerState.selectedDateMillis) {
+        val millis = datePickerState.selectedDateMillis ?: return@LaunchedEffect
+        if (millis != selectedDateMillis) {
+            onDateSelected(millis)
+        }
+    }
     val colors = DatePickerDefaults.colors()
     val shape = DatePickerDefaults.shape
     val density = LocalDensity.current
@@ -185,36 +189,10 @@ private fun DatePickerPopup(
             shadowElevation = 8.dp,
             shape = shape,
         ) {
-            Column {
-                Box {
-                    DatePicker(
-                        state = datePickerState,
-                        colors = colors,
-                    )
-                }
-
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(
-                            horizontal = WooPosSpacing.Small.value,
-                            vertical = WooPosSpacing.XSmall.value,
-                        ),
-                    horizontalArrangement = Arrangement.End,
-                ) {
-                    WCTextButton(
-                        text = stringResource(id = android.R.string.cancel),
-                        onClick = onDismiss,
-                    )
-                    WCTextButton(
-                        text = stringResource(id = android.R.string.ok),
-                        enabled = datePickerState.selectedDateMillis != null,
-                        onClick = {
-                            datePickerState.selectedDateMillis?.let { onDateSelected(it) }
-                        },
-                    )
-                }
-            }
+            DatePicker(
+                state = datePickerState,
+                colors = colors,
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
@@ -1,19 +1,28 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.woocommerce.android.ui.woopos.bookings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,19 +30,23 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.DatePickerDialog
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
-import java.util.Date
 
 private val DateSelectorButtonHeight = 40.dp
 private val DateSelectorButtonCornerRadius = 8.dp
@@ -79,34 +92,47 @@ fun WooPosBookingsDateSelector(
             }
         }
 
-        Surface(
-            shape = buttonShape,
-            color = buttonColor,
-            modifier = Modifier.weight(1f),
-        ) {
-            Box(
-                modifier = Modifier
-                    .height(DateSelectorButtonHeight)
-                    .clickable { showDatePicker = true },
-                contentAlignment = Alignment.Center,
+        Box(modifier = Modifier.weight(1f)) {
+            Surface(
+                shape = buttonShape,
+                color = buttonColor,
             ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(DateSelectorButtonHeight)
+                        .clickable { showDatePicker = true },
+                    contentAlignment = Alignment.Center,
                 ) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.ic_date_range_24dp),
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp),
-                        tint = contentColor,
-                    )
-                    Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
-                    WooPosText(
-                        text = dateSelectorState.formattedDate,
-                        style = WooPosTypography.BodySmall,
-                        fontWeight = FontWeight.Bold,
-                        color = contentColor,
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = ImageVector.vectorResource(R.drawable.ic_date_range_24dp),
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = contentColor,
+                        )
+                        Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
+                        WooPosText(
+                            text = dateSelectorState.formattedDate,
+                            style = WooPosTypography.BodySmall,
+                            fontWeight = FontWeight.Bold,
+                            color = contentColor,
+                        )
+                    }
                 }
+            }
+
+            if (showDatePicker) {
+                DatePickerPopup(
+                    selectedDateMillis = dateSelectorState.selectedDateMillis,
+                    onDateSelected = { selectedMillis ->
+                        showDatePicker = false
+                        onUIEvent(WooPosBookingsUIEvent.DateSelected(selectedMillis))
+                    },
+                    onDismiss = { showDatePicker = false },
+                )
             }
         }
 
@@ -129,16 +155,67 @@ fun WooPosBookingsDateSelector(
             }
         }
     }
+}
 
-    if (showDatePicker) {
-        DatePickerDialog(
-            currentDate = Date(dateSelectorState.selectedDateMillis),
-            onDateSelected = { selectedDate ->
-                showDatePicker = false
-                onUIEvent(WooPosBookingsUIEvent.DateSelected(selectedDate.time))
-            },
-            onDismissRequest = { showDatePicker = false },
-        )
+@Composable
+private fun DatePickerPopup(
+    selectedDateMillis: Long,
+    onDateSelected: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = selectedDateMillis,
+    )
+    val colors = DatePickerDefaults.colors()
+    val shape = DatePickerDefaults.shape
+    val density = LocalDensity.current
+    val offsetY = with(density) { (DateSelectorButtonHeight + WooPosSpacing.XSmall.value).roundToPx() }
+
+    Popup(
+        alignment = Alignment.TopCenter,
+        offset = IntOffset(0, offsetY),
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true),
+    ) {
+        Surface(
+            modifier = Modifier
+                .clip(shape)
+                .requiredWidth(360.dp),
+            color = colors.containerColor,
+            shadowElevation = 8.dp,
+            shape = shape,
+        ) {
+            Column {
+                Box {
+                    DatePicker(
+                        state = datePickerState,
+                        colors = colors,
+                    )
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            horizontal = WooPosSpacing.Small.value,
+                            vertical = WooPosSpacing.XSmall.value,
+                        ),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    WCTextButton(
+                        text = stringResource(id = android.R.string.cancel),
+                        onClick = onDismiss,
+                    )
+                    WCTextButton(
+                        text = stringResource(id = android.R.string.ok),
+                        enabled = datePickerState.selectedDateMillis != null,
+                        onClick = {
+                            datePickerState.selectedDateMillis?.let { onDateSelected(it) }
+                        },
+                    )
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
WOOMOB-2298

### Description

The POS Bookings date selector previously opened a modal `DatePickerDialog` (centered overlay) when tapping the date button. This PR replaces it with an inline `Popup` anchored directly below the date button, keeping the user's spatial context.

Key changes:
- Replace the modal `DatePickerDialog` with a `Popup` containing a Material3 `DatePicker`, positioned below the date button
- Remove Cancel/OK confirmation buttons — selecting a day immediately updates the date and dismisses the picker
- Use `rememberSaveable` for the picker visibility state so it survives configuration changes
- Extract `DatePickerPopup` as a private composable for clarity

### Test Steps

1. Navigate to POS > Bookings
2. Tap the date button in the date selector row
3. Verify the calendar picker appears as a popup below the date button
4. Tap a different date → the bookings list should update immediately and the picker should dismiss
5. Open the picker again, tap outside → it should dismiss without changing the date
6. Verify date picker's state survives config changes
 
### Images/gif
Screen_recording_20260224_161304.mp4

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.