### PR TITLE
Update gitignore to allow ignoring `.local.` files in nested .claude folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,7 @@ google-upload-credentials.json
 # Agent config local files (Claude, Codex, etc.)
 # Keep main config files under version control, ignore user-local overrides
 **/CLAUDE.local.md
-**/.claude/*.local.*
-**/.codex/*.local.*
+**/.claude/**/*.local.*
+**/.codex/**/*.local.*
 
 .grepai/


### PR DESCRIPTION
### Description

The previous gitignore patterns for `.local.` files in `.claude/` and `.codex/` directories only matched files directly inside those directories (`**/.claude/*.local.*`). This change updates the patterns to use `**/.claude/**/*.local.*` so that `.local.` files in nested subdirectories (e.g., `.claude/memory/something.local.md`) are also ignored.

### Test Steps

1. Verify that files like `.claude/agents/foo.local.md` are ignored by git.
2. Verify that top-level `.local.` files like `.claude/foo.local.md` are still ignored.
3. Verify that non-local files in `.claude/` directories are still tracked.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->