### PR TITLE
[WOOMOB-2306] Add WordPress.com TOS to push notifications intro screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionScreen.kt
@@ -35,6 +35,7 @@ import com.woocommerce.android.ui.compose.component.Toolbar
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.login.wpcom.components.WPComConsent
 import com.woocommerce.android.ui.pushnotifications.WordPressWooBadge
 import com.woocommerce.android.ui.pushnotifications.introduction.WooPushNotificationsIntroductionViewModel.ViewState
 
@@ -260,6 +261,15 @@ private fun IntroContent(
             Text(
                 text = stringResource(id = R.string.woo_push_notifications_introduction_not_now),
                 color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+
+        if (!isUpdateRequired) {
+            WPComConsent(
+                forJetpackSetup = false,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp)
             )
         }
     }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2306

Adds the WordPress.com Terms of Service footer to the push notifications introduction screen when the site is not connected. Uses the existing reusable `WPComConsent` component with `forJetpackSetup = false`.

### Test Steps
1. Trigger the push notifications introduction screen (when site is not connected)
2. Verify the WordPress.com TOS footer appears below the \"Not now\" button
3. Verify the TOS footer does NOT appear when the update is required (UpdateRequired state)
4. Tap the \"Terms of Service\" link and verify it opens the WordPress.com TOS in a browser

(Alternatively just check the Compose preview)

### Images/gif
<img width="360" alt="Screenshot_20260224_180354" src="https://github.com/user-attachments/assets/d8e6c920-0fe1-4641-a4b3-cb13e2eafaf0" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.