### PR TITLE
[WOOMOB-2313] Restart card payment when returning from cash payment

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -32,6 +33,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieClipSpec
 import com.airbnb.lottie.compose.LottieCompositionSpec
@@ -60,6 +64,19 @@ fun WooPosCardPaymentScreen(
 
     LaunchedEffect(Unit) {
         viewModel.navigationEvent.collect { onNavigationEvent(it) }
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> viewModel.onScreenResumed()
+                Lifecycle.Event.ON_PAUSE -> viewModel.onScreenPaused()
+                else -> Unit
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     BackHandler { viewModel.onBackClicked() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -269,6 +269,18 @@ class WooPosCardPaymentViewModel @Inject constructor(
         ),
     )
 
+    fun onScreenResumed() {
+        if (_state.value is WooPosCardPaymentState.Collecting) {
+            collectPayment()
+        }
+    }
+
+    fun onScreenPaused() {
+        if (_state.value is WooPosCardPaymentState.Collecting) {
+            cancelPayment()
+        }
+    }
+
     fun onRetryClicked() {
         val paymentState = cardReaderPaymentController?.paymentState?.value
         check(paymentState != null) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -510,6 +510,27 @@ class WooPosCardPaymentViewModelTest {
     }
 
     @Test
+    fun `given payment failed, when screen resumed, then payment is not restarted`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.PaymentFailed
+            .ExternalReaderFailedPayment.Cancelable(
+                errorType = PaymentFlowError.Generic,
+                amountWithCurrencyLabel = "$50.00",
+                onCancel = {},
+                onRetry = {},
+            )
+        advanceUntilIdle()
+
+        viewModel.onScreenResumed()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
+    }
+
+    @Test
     fun `given collecting state, when screen paused, then payment is cancelled`() = runTest {
         viewModel = createViewModel()
         advanceUntilIdle()
@@ -538,6 +559,30 @@ class WooPosCardPaymentViewModelTest {
 
         assertThat(viewModel.state.value)
             .isInstanceOf(WooPosCardPaymentState.PaymentInProgress::class.java)
+    }
+
+    @Test
+    fun `given payment succeeded, when screen paused, then payment is not cancelled`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.PaymentSuccessful
+            .ExternalReaderPaymentSuccessful(
+                amountWithCurrencyLabel = "$50.00",
+                onPrintReceiptClicked = {},
+                onSendReceiptClicked = {},
+                onSaveUserClicked = {}
+            )
+        advanceUntilIdle()
+
+        viewModel.onScreenPaused()
+        advanceUntilIdle()
+
+        viewModel.onScreenResumed()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentSuccess::class.java)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -455,6 +455,92 @@ class WooPosCardPaymentViewModelTest {
     }
 
     @Test
+    fun `given payment cancelled by cash navigation, when screen resumed, then payment restarts`() = runTest {
+        viewModel = createViewModel(source = CardPaymentSource.BOOKINGS)
+        advanceUntilIdle()
+
+        viewModel.onCashPaymentClicked()
+        advanceUntilIdle()
+
+        viewModel.onScreenResumed()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.Collecting.Preparing::class.java)
+    }
+
+    @Test
+    fun `given reader disconnected after cash navigation, when screen resumed, then payment does not restart`() =
+        runTest {
+            viewModel = createViewModel(source = CardPaymentSource.BOOKINGS)
+            advanceUntilIdle()
+
+            viewModel.onCashPaymentClicked()
+            advanceUntilIdle()
+
+            readerStatusFlow.value = CardReaderStatus.NotConnected()
+            advanceUntilIdle()
+
+            viewModel.onScreenResumed()
+            advanceUntilIdle()
+
+            assertThat(viewModel.state.value)
+                .isInstanceOf(WooPosCardPaymentState.Collecting.ReaderDisconnected::class.java)
+        }
+
+    @Test
+    fun `given payment succeeded, when screen resumed, then payment is not restarted`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.PaymentSuccessful
+            .ExternalReaderPaymentSuccessful(
+                amountWithCurrencyLabel = "$50.00",
+                onPrintReceiptClicked = {},
+                onSendReceiptClicked = {},
+                onSaveUserClicked = {}
+            )
+        advanceUntilIdle()
+
+        viewModel.onScreenResumed()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentSuccess::class.java)
+    }
+
+    @Test
+    fun `given collecting state, when screen paused, then payment is cancelled`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onScreenPaused()
+        advanceUntilIdle()
+
+        verify(paymentController).onBackPressed()
+        verify(paymentController).stop()
+    }
+
+    @Test
+    fun `given payment in progress, when screen paused, then payment is not cancelled`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        controllerPaymentState.value = CardReaderPaymentState.ProcessingPayment
+            .ExternalReaderProcessingPayment(
+                amountWithCurrencyLabel = "$50.00",
+                onCancel = {}
+            )
+        advanceUntilIdle()
+
+        viewModel.onScreenPaused()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value)
+            .isInstanceOf(WooPosCardPaymentState.PaymentInProgress::class.java)
+    }
+
+    @Test
     fun `given order with billing email, when payment succeeds, then receiptSentMessage is set`() = runTest {
         val orderWithEmail = Order.getEmptyOrder(Date(), Date()).copy(
             total = BigDecimal("50.00"),


### PR DESCRIPTION
Fixes WOOMOB-2313

### Description
Note: Considering this is potentially a breaking change, would be nice to get reviews from both of you. Thanks!

Adds lifecycle-aware payment management to the card payment screen. When the screen pauses (e.g., navigating to cash payment or app going to background), payment collection is cancelled. When the screen resumes, payment collection restarts. This only applies while in `Collecting` state — `PaymentInProgress` and `PaymentSuccess` are left untouched.

### Test Steps
1. Open a booking with an unpaid order
2. Tap "Collect Payment" to start card payment
3. Tap the "Cash Payment" button to switch to cash payment
4. Press back to return to card payment
5. Verify the card reader starts collecting payment again
6. Complete a card payment successfully, verify the success screen is not affected by the lifecycle handling
7. During payment processing (card tapped), verify the payment is not interrupted

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.