### PR TITLE
[WOOMOB-2319] Fix refund flow restarting when going back from email receipt

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
@@ -191,7 +191,7 @@ private fun DatePickerContent(datePickerState: DatePickerState) {
             .requiredWidth(360.dp),
         color = MaterialTheme.colorScheme.surface,
         shadowElevation = WooPosElevation.Medium.value,
-        shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
+        shape = RoundedCornerShape(WooPosCornerRadius.Large.value),
     ) {
         DatePicker(
             state = datePickerState,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
@@ -209,3 +209,28 @@ fun WooPosBookingsDateSelectorPreview() {
         )
     }
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@WooPosPreview
+@Composable
+fun DatePickerPopupPreview() {
+    WooPosTheme {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = System.currentTimeMillis(),
+        )
+        val colors = DatePickerDefaults.colors()
+        val shape = DatePickerDefaults.shape
+        Surface(
+            modifier = Modifier
+                .clip(shape)
+                .requiredWidth(360.dp),
+            color = colors.containerColor,
+            shape = shape,
+        ) {
+            DatePicker(
+                state = datePickerState,
+                colors = colors,
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsDateSelector.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.DatePickerState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -27,7 +27,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -40,12 +39,13 @@ import androidx.compose.ui.window.PopupProperties
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 
 private val DateSelectorButtonHeight = 40.dp
-private val DateSelectorButtonCornerRadius = 8.dp
 
 @Composable
 fun WooPosBookingsDateSelector(
@@ -55,7 +55,7 @@ fun WooPosBookingsDateSelector(
 ) {
     var showDatePicker by rememberSaveable { mutableStateOf(false) }
 
-    val buttonShape = RoundedCornerShape(DateSelectorButtonCornerRadius)
+    val buttonShape = RoundedCornerShape(WooPosCornerRadius.Medium.value)
     val buttonColor = MaterialTheme.colorScheme.surface
     val contentColor = MaterialTheme.colorScheme.onSurface
 
@@ -153,7 +153,6 @@ fun WooPosBookingsDateSelector(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DatePickerPopup(
     selectedDateMillis: Long,
@@ -169,8 +168,6 @@ private fun DatePickerPopup(
             onDateSelected(millis)
         }
     }
-    val colors = DatePickerDefaults.colors()
-    val shape = DatePickerDefaults.shape
     val density = LocalDensity.current
     val offsetY = with(density) { (DateSelectorButtonHeight + WooPosSpacing.XSmall.value).roundToPx() }
 
@@ -180,19 +177,26 @@ private fun DatePickerPopup(
         onDismissRequest = onDismiss,
         properties = PopupProperties(focusable = true),
     ) {
-        Surface(
-            modifier = Modifier
-                .clip(shape)
-                .requiredWidth(360.dp),
-            color = colors.containerColor,
-            shadowElevation = 8.dp,
-            shape = shape,
-        ) {
-            DatePicker(
-                state = datePickerState,
-                colors = colors,
-            )
-        }
+        DatePickerContent(datePickerState = datePickerState)
+    }
+}
+
+@Composable
+private fun DatePickerContent(datePickerState: DatePickerState) {
+    val colors = DatePickerDefaults.colors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    )
+    Surface(
+        modifier = Modifier
+            .requiredWidth(360.dp),
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = WooPosElevation.Medium.value,
+        shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
+    ) {
+        DatePicker(
+            state = datePickerState,
+            colors = colors,
+        )
     }
 }
 
@@ -210,27 +214,14 @@ fun WooPosBookingsDateSelectorPreview() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @WooPosPreview
 @Composable
-fun DatePickerPopupPreview() {
+fun DatePickerContentPreview() {
     WooPosTheme {
-        val datePickerState = rememberDatePickerState(
-            initialSelectedDateMillis = System.currentTimeMillis(),
+        DatePickerContent(
+            datePickerState = rememberDatePickerState(
+                initialSelectedDateMillis = System.currentTimeMillis(),
+            ),
         )
-        val colors = DatePickerDefaults.colors()
-        val shape = DatePickerDefaults.shape
-        Surface(
-            modifier = Modifier
-                .clip(shape)
-                .requiredWidth(360.dp),
-            color = colors.containerColor,
-            shape = shape,
-        ) {
-            DatePicker(
-                state = datePickerState,
-                colors = colors,
-            )
-        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -109,7 +109,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
     }
 
     private fun loadRefundableItems() {
-        if (_state.value is WooPosRefundState.Content) return
+        if (_state.value is WooPosRefundState.Content || _state.value is WooPosRefundState.RefundSuccess) return
         loadingJob?.cancel()
         loadingJob = viewModelScope.launch {
             _state.value = WooPosRefundState.Loading


### PR DESCRIPTION
### Description
Fixes WOOMOB-2319

Two changes:

1. **Fix refund flow restarting when going back from email receipt.** When returning from the email receipt screen after a successful refund, the refund dialog's `LaunchedEffect(Unit)` re-fires and calls `loadRefundableItems()`. The guard only checked for `Content` state, so when state was `RefundSuccess` it reset back to `Loading`, restarting the whole refund flow. Adding `RefundSuccess` to the guard prevents this.

2. **Update date picker popup styling.** Set the background to surface color, added shadow elevation, and extracted a `DatePickerContent` composable for preview support.

### Test Steps
1. In POS, complete a booking/order and pay
2. Open the order/booking, tap "Issue refund"
3. Complete the refund flow until you see the "Refund complete" screen
4. Tap "Email receipt"
5. Press back from the email receipt screen
6. Verify the "Refund complete" dialog is still shown (not restarted)
7. Go to Bookings, verify the date picker popup has a light background with shadow

### Images/gif

https://github.com/user-attachments/assets/30bd3f26-8edc-472f-8484-c24f9917553d




- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.