### PR TITLE
[WOOMOB-2221] Fetch and display booking location from product data in POS

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -180,6 +180,18 @@ class BookingsRepository @Inject constructor(
         }
     }.await()
 
+    suspend fun fetchProductBookingLocation(productId: Long): Result<String?> {
+        val result = bookingsStore.fetchProductBookingLocation(
+            site = selectedSite.get(),
+            productId = productId
+        )
+        return if (result.isError) {
+            Result.failure(WooException(result.error))
+        } else {
+            Result.success(result.model)
+        }
+    }
+
     suspend fun markAsPaid(
         bookingId: Long,
     ): Result<Unit> = appCoroutineScope.async {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
@@ -55,6 +55,7 @@ class WooPosBookingViewStateMapper @Inject constructor(
     suspend fun mapToDetailsViewState(
         booking: BookingEntity,
         resourceName: String?,
+        location: String?,
     ): WooPosBookingsState.BookingDetailsViewState {
         val detailsDateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
             .withZone(ZoneOffset.UTC)
@@ -109,7 +110,7 @@ class WooPosBookingViewStateMapper @Inject constructor(
                 .normalizeDuration()
                 .toHumanReadableFormat(resourceProvider),
             teamMember = resourceName,
-            location = null,
+            location = location?.ifBlank { null },
             customerSection = buildCustomerSection(customerInfo, customerName, booking.customerNote),
             attendanceSection = buildAttendanceSection(booking),
             paymentSection = buildPaymentSection(booking, paymentStatus),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -18,6 +18,9 @@ import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -62,6 +65,7 @@ class WooPosBookingsViewModel @Inject constructor(
     private var selectedDate: LocalDate = Instant.now(clock).atZone(storeZoneId).toLocalDate()
     private var fetchJob: Job? = null
     private var loadMoreJob: Job? = null
+    private val locationCache = mutableMapOf<Long, String?>()
 
     private val _state = MutableStateFlow<WooPosBookingsState>(
         WooPosBookingsState.Loading(dateSelectorState = buildDateSelectorState())
@@ -186,10 +190,16 @@ class WooPosBookingsViewModel @Inject constructor(
                     selectedBookingId = bookings.first().id.value
                 }
 
+                fetchBookingLocations(bookings)
+
                 val items = bookings.associate { booking ->
                     val resource = resourcesMap[booking.resourceId]
                     mapper.mapToItemViewState(booking, selectedBookingId, resource) to
-                        mapper.mapToDetailsViewState(booking, resource?.name)
+                        mapper.mapToDetailsViewState(
+                            booking,
+                            resource?.name,
+                            locationCache[booking.productId]
+                        )
                 }
 
                 val selectedDetails = selectedBookingId?.let { id ->
@@ -567,9 +577,29 @@ class WooPosBookingsViewModel @Inject constructor(
         )
     }
 
+    private suspend fun fetchBookingLocations(bookings: List<BookingEntity>) {
+        val newProductIds = bookings
+            .map { it.productId }
+            .distinct()
+            .filter { it != 0L && it !in locationCache }
+        if (newProductIds.isNotEmpty()) {
+            coroutineScope {
+                newProductIds.map { productId ->
+                    async {
+                        val location = bookingsRepository
+                            .fetchProductBookingLocation(productId)
+                            .getOrNull()
+                        locationCache[productId] = location
+                    }
+                }.awaitAll()
+            }
+        }
+    }
+
     private fun handleDateChange(newDate: LocalDate) {
         selectedDate = newDate
         selectedBookingId = null
+        locationCache.clear()
         _state.value = when (val current = _state.value) {
             is WooPosBookingsState.Content -> current.copy(
                 items = WooPosBookingsState.Content.Items.Loading,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
@@ -121,7 +121,7 @@ class WooPosBookingViewStateMapperTest {
             whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
 
             // WHEN
-            val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+            val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
             // THEN
             val expectedDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
@@ -142,7 +142,7 @@ class WooPosBookingViewStateMapperTest {
             whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
 
             // WHEN
-            val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+            val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
             // THEN
             val expectedDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
@@ -160,7 +160,7 @@ class WooPosBookingViewStateMapperTest {
             whenever(paymentStatusResolver.resolve(any(), anyOrNull())).thenReturn(PaymentStatus.UNPAID)
 
             // WHEN
-            val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+            val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
             // THEN
             assertThat(result.paymentSection.serviceAmount).isEqualTo("-")
@@ -184,7 +184,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         assertThat(result.paymentSection.discountAmount).isEqualTo("-$10")
@@ -202,7 +202,7 @@ class WooPosBookingViewStateMapperTest {
             whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
 
             // WHEN
-            val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+            val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
             // THEN
             assertThat(result.attendanceSection).isNotNull
@@ -220,7 +220,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.FAILED)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         assertThat(result.attendanceSection).isNull()
@@ -233,7 +233,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         assertThat(result.customerSection).isNull()
@@ -252,7 +252,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         assertThat(result.customerSection).isNull()
@@ -265,7 +265,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions
@@ -279,7 +279,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions
@@ -293,7 +293,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions
@@ -307,7 +307,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions
@@ -321,7 +321,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions
@@ -335,7 +335,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.FAILED)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions
@@ -349,7 +349,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions
@@ -363,7 +363,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.FAILED)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions
@@ -377,7 +377,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         assertThat(result.paymentSection.collectPaymentLabel).isNotNull()
@@ -390,7 +390,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         assertThat(result.paymentSection.collectPaymentLabel).isNull()
@@ -403,7 +403,7 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.REFUNDED)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         assertThat(result.paymentSection.collectPaymentLabel).isNull()
@@ -416,11 +416,37 @@ class WooPosBookingViewStateMapperTest {
         whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
-        val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
         // THEN
         val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions
         assertThat(actions).noneMatch { it is WooPosBookingsState.BookingAction.CancelBooking }
+    }
+
+    @Test
+    fun `given location provided, when mapped to details, then location is passed through`() = runTest {
+        // GIVEN
+        val booking = sampleBooking()
+        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+
+        // WHEN
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = "Room 5")
+
+        // THEN
+        assertThat(result.location).isEqualTo("Room 5")
+    }
+
+    @Test
+    fun `given blank location, when mapped to details, then location is null`() = runTest {
+        // GIVEN
+        val booking = sampleBooking()
+        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+
+        // WHEN
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = "   ")
+
+        // THEN
+        assertThat(result.location).isNull()
     }
 
     @Test
@@ -431,7 +457,7 @@ class WooPosBookingViewStateMapperTest {
             whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
 
             // WHEN
-            val result = mapper.mapToDetailsViewState(booking, resourceName = null)
+            val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
 
             // THEN
             val actions = (result.actionsState as WooPosBookingsState.BookingActionsState.Loaded).actions

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings
 
+import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse.Error
@@ -102,6 +103,23 @@ class BookingsRestClient @Inject constructor(
         }
     }
 
+    suspend fun fetchProductBookingLocation(
+        site: SiteModel,
+        productId: Long
+    ): WooPayload<ProductBookingLocationDto> {
+        val url = WOOCOMMERCE.products.id(productId).pathV3
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = ProductBookingLocationDto::class.java,
+            params = mapOf("_fields" to "id,booking_location")
+        )
+        return when (response) {
+            is Success -> WooPayload(response.data)
+            is Error -> WooPayload(response.error.toWooError())
+        }
+    }
+
     suspend fun fetchResource(
         site: SiteModel,
         resourceId: Long
@@ -157,6 +175,12 @@ class BookingsRestClient @Inject constructor(
         if (location != null) TODO()
     }
 }
+
+data class ProductBookingLocationDto(
+    val id: Long? = null,
+    @SerializedName("booking_location")
+    val bookingLocation: String? = null,
+)
 
 private val BookingUpdatePayload.asMap: Map<String, Any>
     get() = mutableMapOf<String, Any>().putIfNotNull(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -191,6 +191,20 @@ class BookingsStore @Inject internal constructor(
         site: SiteModel
     ): Flow<List<BookingResourceEntity>> = bookingsDao.observeResources(site.localId())
 
+    suspend fun fetchProductBookingLocation(
+        site: SiteModel,
+        productId: Long
+    ): WooResult<String?> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchProductBookingLocation") {
+            val response = bookingsRestClient.fetchProductBookingLocation(site, productId)
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> WooResult(response.result.bookingLocation)
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
+
     suspend fun updateBooking(
         site: SiteModel,
         bookingId: Long,


### PR DESCRIPTION
### Description
Fixes WOOMOB-2221

The POS booking details screen has a location row that was always empty because the booking API doesn't include location data. Location is a product-level field (`booking_location`) exposed by the WooCommerce Bookings plugin on the product REST endpoint.

This PR adds a lightweight fetch for the product's `booking_location` field (using `_fields` to minimize the response) and wires it through to the POS booking details. Locations are cached by productId and fetched in parallel for all visible bookings.

### Test Steps
1. Set up a site with WooCommerce Bookings plugin
2. Create a bookable product with a location set (e.g. "238 Willow Creek Drive")
3. Create a booking for that product
4. Open WooPos and navigate to the Bookings tab
5. Select the booking to see its details
6. Verify the location row shows the correct address
7. Verify a booking for a product without a location set does not show the location row

### Images/gif
<img width="811" height="514" alt="image" src="https://github.com/user-attachments/assets/35dbd569-d1bc-42ea-a422-fa7f1d353249" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.