### PR TITLE
[WOOMOB-2277] Fix DashboardViewModel crash when STATS widget is missing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -240,7 +240,7 @@ class DashboardViewModel @Inject constructor(
         // We add the other cards even if they should not be visible, so that the addition/deletion
         // of the cards is animated properly
 
-        val shouldShowShareCard = !widgets.first { it.type == DashboardWidget.Type.STATS }.isAvailable &&
+        val shouldShowShareCard = widgets.firstOrNull { it.type == DashboardWidget.Type.STATS }?.isAvailable != true &&
             selectedSite.get().isSitePublic &&
             selectedSite.get().url != null
         add(DashboardWidgetUiModel.ShareStoreWidget(shouldShowShareCard, ::onShareStoreClicked))


### PR DESCRIPTION
### Description
Fixes WOOMOB-2277
This prevents a `NoSuchElementException` from being thrown when the `STATS` widget is missing from the list of widgets in the dashboard. It uses a safe `firstOrNull` check instead.

### Test Steps
1. Navigate to the Dashboard.
2. Ensure the app does not crash even if the `STATS` widget data is not returned or fails to load.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.