### PR TITLE
Add ADB broadcast receiver for ApiFaker control

### DIFF
--- a/.agents/skills/verify-on-device/SKILL.md
+++ b/.agents/skills/verify-on-device/SKILL.md
@@ -287,6 +287,7 @@ When the user requests verification of a specific scenario, follow this workflow
 For all ADB commands, extras, API types, examples, and debugging tips, read `docs/api-faker-adb.md`.
 
 **Key tips:**
+- All am broadcast commands must include -p com.woocommerce.android.dev — without it, Android 8.0+ silently drops the broadcast.
 - ApiFaker requires at least one endpoint before it can be enabled.
 - All actions log results to logcat under the `WCApiFaker` tag — use `adb logcat -s WCApiFaker -d` to check feedback.
 

--- a/.agents/skills/verify-on-device/SKILL.md
+++ b/.agents/skills/verify-on-device/SKILL.md
@@ -131,16 +131,20 @@ Use `mobile_install_app` with:
 
 Optionally call `mobile_list_apps` first to check if the app is already installed.
 
-### 4. Launch the App
+### 4. Set Up API Mocks (Optional)
+
+If the user requests verification of a specific scenario (error states, empty data, custom responses), set up ApiFaker mock endpoints **before** launching the app. See the "API Mocking with ApiFaker" section and `docs/api-faker-adb.md` for commands and workflow.
+
+### 5. Launch the App
 
 Use `mobile_launch_app` with:
 - **packageName:** `com.woocommerce.android.dev`
 
-### 5. Handle Post-Launch Dialogs
+### 6. Handle Post-Launch Dialogs
 
 Call `mobile_list_elements_on_screen` to check what appeared. If a dialog or overlay is blocking the main UI, dismiss it using the guidance in "Handling Unexpected Dialogs" above. Repeat until you reach the dashboard or the expected screen.
 
-### 6. Start Screen Recording (Optional)
+### 7. Start Screen Recording (Optional)
 
 If the user requests a recording or demo video, start an ADB screen recording **before** navigating:
 
@@ -151,7 +155,7 @@ adb -s <device_id> shell "screenrecord --size 720x1280 /sdcard/_agent_rec.mp4" &
 
 Use `--size 720x1280` to keep the file small. The recording runs in the background while you perform navigation steps. See the Screen Recording section below for full details.
 
-### 7. Navigate and Verify
+### 8. Navigate and Verify
 
 Navigate as needed per the user's request. After each navigation action:
 1. Wait for the screen to stabilize (see "Waiting for Screen Transitions").
@@ -163,7 +167,7 @@ If the expected screen identifier is NOT present after retries:
 2. Call `mobile_list_elements_on_screen` and identify which screen you are actually on.
 3. Report to the user: "Navigation to [target] failed. Currently on [detected screen]."
 
-### 8. Stop Recording and Save Evidence
+### 9. Stop Recording and Save Evidence
 
 **If recording:** stop the recording, pull the file, and clean up:
 
@@ -176,7 +180,7 @@ adb -s <device_id> shell rm /sdcard/_agent_rec.mp4
 
 **Always:** use `mobile_save_screenshot` at each verification step to save screenshots to disk.
 
-### 9. Report Results
+### 10. Report Results
 
 Summarize what was verified, include saved screenshot and recording paths, and flag any issues found.
 
@@ -267,6 +271,24 @@ Note: with `--time-limit`, the command blocks until done, so navigation must hap
 | Recording stops after 3 min | Hit 180s Android limit | Use chained recordings |
 | Black screen in video | DRM-protected content on screen | OS-level restriction, cannot be avoided |
 | `screenrecord: not found` | Android < 4.4 | Not supported on very old devices |
+
+## API Mocking with ApiFaker
+
+ApiFaker intercepts API calls at the OkHttp layer and returns fake responses from a local database. Control it via ADB broadcast commands to test specific scenarios (error states, empty lists, custom data) during device verification. ApiFaker is available only in debug builds.
+
+When the user requests verification of a specific scenario, follow this workflow:
+1. Clear any existing endpoints
+2. Add mock endpoint(s) for the scenario
+3. Enable ApiFaker
+4. Launch or navigate the app — mocked endpoints return fake responses
+5. Verify the UI shows the expected behavior
+6. Disable ApiFaker and clear endpoints when done
+
+For all ADB commands, extras, API types, examples, and debugging tips, read `docs/api-faker-adb.md`.
+
+**Key tips:**
+- ApiFaker requires at least one endpoint before it can be enabled.
+- All actions log results to logcat under the `WCApiFaker` tag — use `adb logcat -s WCApiFaker -d` to check feedback.
 
 ## WooCommerce Navigation Reference
 

--- a/.agents/skills/verify-on-device/SKILL.md
+++ b/.agents/skills/verify-on-device/SKILL.md
@@ -288,7 +288,6 @@ For all ADB commands, extras, API types, examples, and debugging tips, read `doc
 
 **Key tips:**
 - All am broadcast commands must include -p com.woocommerce.android.dev — without it, Android 8.0+ silently drops the broadcast.
-- ApiFaker requires at least one endpoint before it can be enabled.
 - All actions log results to logcat under the `WCApiFaker` tag — use `adb logcat -s WCApiFaker -d` to check feedback.
 
 ## WooCommerce Navigation Reference

--- a/docs/api-faker-adb.md
+++ b/docs/api-faker-adb.md
@@ -7,16 +7,18 @@ The ApiFaker module can be controlled via ADB broadcast commands, enabling autom
 - Debug build installed on the device/emulator
 - ADB connected to the device
 
+**Note:** All commands include `-p com.woocommerce.android.dev` to target the debug app package. This is required on Android 8.0+ because implicit broadcasts are not delivered to manifest-registered receivers without a package qualifier.
+
 ## Commands
 
 ### Enable / Disable
 
 ```bash
 # Enable
-adb shell am broadcast -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
 
 # Disable
-adb shell am broadcast -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
 ```
 
 Note: ApiFaker can only be enabled when at least one endpoint is configured. If no endpoints exist, the status will remain disabled even after sending `enabled true`.
@@ -24,7 +26,7 @@ Note: ApiFaker can only be enabled when at least one endpoint is configured. If 
 ### Add Endpoint
 
 ```bash
-adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
   --es api_type "<type>" \
   --es path "<path>" \
   [--es http_method "<method>"] \
@@ -58,7 +60,7 @@ adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
 
 **WP-API** (`wp-api`): WordPress REST API endpoints accessed via `/wp-json`.
 ```bash
-adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
   --es api_type "wp-api" \
   --es path "/wc/v3/products" \
   --es http_method "GET" \
@@ -68,7 +70,7 @@ adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
 
 **WP.COM** (`wp-com`): WordPress.com Public API endpoints on `public-api.wordpress.com`.
 ```bash
-adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
   --es api_type "wp-com" \
   --es path "/rest/v1.1/me" \
   --es http_method "GET" \
@@ -78,7 +80,7 @@ adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
 
 **Custom** (`custom`): Third-party API endpoints with an arbitrary host.
 ```bash
-adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
   --es api_type "custom" \
   --es custom_host "api.stripe.com" \
   --es path "/v1/tokens" \
@@ -92,7 +94,7 @@ adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
 Partially updates an existing endpoint. Only the extras you provide will be changed; all other fields are preserved.
 
 ```bash
-adb shell am broadcast -a com.woocommerce.android.apifaker.EDIT_ENDPOINT \
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.EDIT_ENDPOINT \
   --el endpoint_id <id> \
   [--es path "<new_path>"] \
   [--ei response_status_code <new_code>] \
@@ -109,14 +111,14 @@ All other extras from `ADD_ENDPOINT` are accepted and optional.
 ### Remove Endpoint
 
 ```bash
-adb shell am broadcast -a com.woocommerce.android.apifaker.REMOVE_ENDPOINT \
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.REMOVE_ENDPOINT \
   --el endpoint_id <id>
 ```
 
 ### Clear All Endpoints
 
 ```bash
-adb shell am broadcast -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
 ```
 
 ### List Endpoints
@@ -124,7 +126,7 @@ adb shell am broadcast -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
 Outputs all configured endpoints to logcat as JSON.
 
 ```bash
-adb shell am broadcast -a com.woocommerce.android.apifaker.LIST_ENDPOINTS
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.LIST_ENDPOINTS
 ```
 
 Read the output:
@@ -149,7 +151,7 @@ Import multiple endpoints from a JSON file. The file format matches the ApiFaker
 adb push endpoints.json /data/local/tmp/endpoints.json
 
 # Import it
-adb shell am broadcast -a com.woocommerce.android.apifaker.IMPORT_ENDPOINTS \
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.IMPORT_ENDPOINTS \
   --es file "/data/local/tmp/endpoints.json"
 ```
 
@@ -193,7 +195,7 @@ EOF
 adb push /tmp/response.json /data/local/tmp/response.json
 
 # Reference the file in the broadcast
-adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
   --es api_type "wp-api" \
   --es path "/wc/v3/products" \
   --es http_method "GET" \
@@ -205,21 +207,21 @@ adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
 
 ```bash
 # 1. Clear any existing endpoints
-adb shell am broadcast -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
 
 # 2. Add mock endpoints
-adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
   --es api_type "wp-api" --es path "/wc/v3/products" --es http_method "GET" \
   --ei response_status_code 200 --es response_body '[]'
 
 # 3. Enable ApiFaker
-adb shell am broadcast -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
 
 # 4. Run your test scenario...
 
 # 5. Disable and clean up
-adb shell am broadcast -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
-adb shell am broadcast -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
+adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
 ```
 
 ## Feedback and Debugging

--- a/docs/api-faker-adb.md
+++ b/docs/api-faker-adb.md
@@ -48,7 +48,7 @@ adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android
 | Extra | Type | Default | Description |
 |-------|------|---------|-------------|
 | `custom_host` | string | - | Required when `api_type` is `custom`. The host to match (e.g., `api.stripe.com`) |
-| `http_method` | string | any | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH` |
+| `http_method` | string | any | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `OPTIONS`, `HEAD`, `TRACE`, `CONNECT` |
 | `query_params` | string | - | Comma-separated `key=value` pairs (e.g., `per_page=10,status=publish`). Note: values cannot contain commas |
 | `request_body` | string | - | Request body pattern to match |
 | `request_body_file` | string | - | Path to file containing request body pattern (takes priority over `request_body`) |

--- a/docs/api-faker-adb.md
+++ b/docs/api-faker-adb.md
@@ -1,0 +1,237 @@
+# ApiFaker ADB Commands
+
+The ApiFaker module can be controlled via ADB broadcast commands, enabling automated testing scenarios driven by scripts or AI agents.
+
+## Prerequisites
+
+- Debug build installed on the device/emulator
+- ADB connected to the device
+
+## Commands
+
+### Enable / Disable
+
+```bash
+# Enable
+adb shell am broadcast -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
+
+# Disable
+adb shell am broadcast -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
+```
+
+Note: ApiFaker can only be enabled when at least one endpoint is configured. If no endpoints exist, the status will remain disabled even after sending `enabled true`.
+
+### Add Endpoint
+
+```bash
+adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+  --es api_type "<type>" \
+  --es path "<path>" \
+  [--es http_method "<method>"] \
+  [--es query_params "<params>"] \
+  [--es request_body "<body>"] \
+  [--es request_body_file "<file_path>"] \
+  [--ei response_status_code <code>] \
+  [--es response_body "<body>"] \
+  [--es response_body_file "<file_path>"]
+```
+
+**Required extras:**
+| Extra | Type | Description |
+|-------|------|-------------|
+| `api_type` | string | One of: `wp-api`, `wp-com`, `custom` |
+| `path` | string | The API path to match (e.g., `/wc/v3/products`) |
+
+**Optional extras:**
+| Extra | Type | Default | Description |
+|-------|------|---------|-------------|
+| `custom_host` | string | - | Required when `api_type` is `custom`. The host to match (e.g., `api.stripe.com`) |
+| `http_method` | string | any | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH` |
+| `query_params` | string | - | Comma-separated `key=value` pairs (e.g., `per_page=10,status=publish`) |
+| `request_body` | string | - | Request body pattern to match |
+| `request_body_file` | string | - | Path to file containing request body pattern (takes priority over `request_body`) |
+| `response_status_code` | int | 200 | HTTP status code for the mocked response |
+| `response_body` | string | - | JSON body for the mocked response |
+| `response_body_file` | string | - | Path to file containing response body (takes priority over `response_body`) |
+
+#### API Types
+
+**WP-API** (`wp-api`): WordPress REST API endpoints accessed via `/wp-json`.
+```bash
+adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+  --es api_type "wp-api" \
+  --es path "/wc/v3/products" \
+  --es http_method "GET" \
+  --ei response_status_code 200 \
+  --es response_body '[{"id":1,"name":"Test Product"}]'
+```
+
+**WP.COM** (`wp-com`): WordPress.com Public API endpoints on `public-api.wordpress.com`.
+```bash
+adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+  --es api_type "wp-com" \
+  --es path "/rest/v1.1/me" \
+  --es http_method "GET" \
+  --ei response_status_code 200 \
+  --es response_body '{"ID":123,"display_name":"Test User"}'
+```
+
+**Custom** (`custom`): Third-party API endpoints with an arbitrary host.
+```bash
+adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+  --es api_type "custom" \
+  --es custom_host "api.stripe.com" \
+  --es path "/v1/tokens" \
+  --es http_method "POST" \
+  --ei response_status_code 200 \
+  --es response_body '{"id":"tok_test"}'
+```
+
+### Edit Endpoint
+
+Partially updates an existing endpoint. Only the extras you provide will be changed; all other fields are preserved.
+
+```bash
+adb shell am broadcast -a com.woocommerce.android.apifaker.EDIT_ENDPOINT \
+  --el endpoint_id <id> \
+  [--es path "<new_path>"] \
+  [--ei response_status_code <new_code>] \
+  [--es response_body "<new_body>"]
+```
+
+**Required extras:**
+| Extra | Type | Description |
+|-------|------|-------------|
+| `endpoint_id` | long | The ID of the endpoint to edit (use `LIST_ENDPOINTS` to find IDs) |
+
+All other extras from `ADD_ENDPOINT` are accepted and optional.
+
+### Remove Endpoint
+
+```bash
+adb shell am broadcast -a com.woocommerce.android.apifaker.REMOVE_ENDPOINT \
+  --el endpoint_id <id>
+```
+
+### Clear All Endpoints
+
+```bash
+adb shell am broadcast -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
+```
+
+### List Endpoints
+
+Outputs all configured endpoints to logcat as JSON.
+
+```bash
+adb shell am broadcast -a com.woocommerce.android.apifaker.LIST_ENDPOINTS
+```
+
+Read the output:
+```bash
+adb logcat -s WCApiFaker -d
+```
+
+The output is bracketed by markers for easy parsing:
+```
+I/WCApiFaker: ADB: === ENDPOINTS_START (2 endpoints) ===
+I/WCApiFaker: ADB: ENDPOINT: {"request":{"id":1,...},"response":{...}}
+I/WCApiFaker: ADB: ENDPOINT: {"request":{"id":2,...},"response":{...}}
+I/WCApiFaker: ADB: === ENDPOINTS_END ===
+```
+
+### Bulk Import
+
+Import multiple endpoints from a JSON file. The file format matches the ApiFaker export format.
+
+```bash
+# Push the file to the device
+adb push endpoints.json /data/local/tmp/endpoints.json
+
+# Import it
+adb shell am broadcast -a com.woocommerce.android.apifaker.IMPORT_ENDPOINTS \
+  --es file "/data/local/tmp/endpoints.json"
+```
+
+**JSON file format:**
+```json
+[
+  {
+    "request": {
+      "id": 0,
+      "type": {"type": "wp-api"},
+      "path": "/wc/v3/products",
+      "httpMethod": "GET",
+      "queryParameters": [],
+      "body": null
+    },
+    "response": {
+      "endpointId": 0,
+      "statusCode": 200,
+      "body": "[{\"id\":1,\"name\":\"Test Product\"}]"
+    }
+  }
+]
+```
+
+The `type` field is a JSON object:
+- WP-API: `{"type": "wp-api"}`
+- WP.COM: `{"type": "wp-com"}`
+- Custom: `{"type": "custom", "host": "api.example.com"}`
+
+## Using Large Response Bodies
+
+For responses larger than a few hundred characters, use the file-based approach to avoid shell escaping issues:
+
+```bash
+# Write the response body to a file
+cat > /tmp/response.json << 'EOF'
+{"products": [{"id": 1, "name": "Product 1"}, {"id": 2, "name": "Product 2"}]}
+EOF
+
+# Push to device
+adb push /tmp/response.json /data/local/tmp/response.json
+
+# Reference the file in the broadcast
+adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+  --es api_type "wp-api" \
+  --es path "/wc/v3/products" \
+  --es http_method "GET" \
+  --ei response_status_code 200 \
+  --es response_body_file "/data/local/tmp/response.json"
+```
+
+## Typical Workflow
+
+```bash
+# 1. Clear any existing endpoints
+adb shell am broadcast -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
+
+# 2. Add mock endpoints
+adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
+  --es api_type "wp-api" --es path "/wc/v3/products" --es http_method "GET" \
+  --ei response_status_code 200 --es response_body '[]'
+
+# 3. Enable ApiFaker
+adb shell am broadcast -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
+
+# 4. Run your test scenario...
+
+# 5. Disable and clean up
+adb shell am broadcast -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
+adb shell am broadcast -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
+```
+
+## Feedback and Debugging
+
+All actions log their results to logcat under the `WCApiFaker` tag:
+
+```bash
+# Watch ApiFaker logs in real-time
+adb logcat -s WCApiFaker
+
+# Dump recent logs
+adb logcat -s WCApiFaker -d
+```
+
+Success messages are logged at INFO level, errors at ERROR level.

--- a/docs/api-faker-adb.md
+++ b/docs/api-faker-adb.md
@@ -47,7 +47,7 @@ adb shell am broadcast -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
 |-------|------|---------|-------------|
 | `custom_host` | string | - | Required when `api_type` is `custom`. The host to match (e.g., `api.stripe.com`) |
 | `http_method` | string | any | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH` |
-| `query_params` | string | - | Comma-separated `key=value` pairs (e.g., `per_page=10,status=publish`) |
+| `query_params` | string | - | Comma-separated `key=value` pairs (e.g., `per_page=10,status=publish`). Note: values cannot contain commas |
 | `request_body` | string | - | Request body pattern to match |
 | `request_body_file` | string | - | Path to file containing request body pattern (takes priority over `request_body`) |
 | `response_status_code` | int | 200 | HTTP status code for the mocked response |

--- a/libs/apifaker/src/main/AndroidManifest.xml
+++ b/libs/apifaker/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <application>
         <receiver
             android:name=".adb.ApiFakerBroadcastReceiver"
-            android:exported="true">
+            android:exported="true"
+            android:permission="android.permission.DUMP">
             <intent-filter>
                 <action android:name="com.woocommerce.android.apifaker.SET_STATUS" />
                 <action android:name="com.woocommerce.android.apifaker.ADD_ENDPOINT" />

--- a/libs/apifaker/src/main/AndroidManifest.xml
+++ b/libs/apifaker/src/main/AndroidManifest.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <application>
+        <receiver
+            android:name=".adb.ApiFakerBroadcastReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.woocommerce.android.apifaker.SET_STATUS" />
+                <action android:name="com.woocommerce.android.apifaker.ADD_ENDPOINT" />
+                <action android:name="com.woocommerce.android.apifaker.EDIT_ENDPOINT" />
+                <action android:name="com.woocommerce.android.apifaker.REMOVE_ENDPOINT" />
+                <action android:name="com.woocommerce.android.apifaker.CLEAR_ENDPOINTS" />
+                <action android:name="com.woocommerce.android.apifaker.LIST_ENDPOINTS" />
+                <action android:name="com.woocommerce.android.apifaker.IMPORT_ENDPOINTS" />
+            </intent-filter>
+        </receiver>
+    </application>
+
 </manifest>

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerConfig.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerConfig.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.apifaker
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.woocommerce.android.apifaker.db.EndpointDao
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -39,7 +40,7 @@ internal class ApiFakerConfig @Inject constructor(
     )
 
     fun setStatus(enabled: Boolean) {
-        preferences.edit().putBoolean(PREFERENCE_KEY, enabled).apply()
+        preferences.edit { putBoolean(PREFERENCE_KEY, enabled) }
     }
 
     private fun SharedPreferences.prefFlow(key: String, defaultValue: Boolean) = callbackFlow {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/Actions.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/Actions.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.apifaker.adb
+
+internal object Actions {
+    private const val PREFIX = "com.woocommerce.android.apifaker"
+    const val SET_STATUS = "$PREFIX.SET_STATUS"
+    const val ADD_ENDPOINT = "$PREFIX.ADD_ENDPOINT"
+    const val EDIT_ENDPOINT = "$PREFIX.EDIT_ENDPOINT"
+    const val REMOVE_ENDPOINT = "$PREFIX.REMOVE_ENDPOINT"
+    const val CLEAR_ENDPOINTS = "$PREFIX.CLEAR_ENDPOINTS"
+    const val LIST_ENDPOINTS = "$PREFIX.LIST_ENDPOINTS"
+    const val IMPORT_ENDPOINTS = "$PREFIX.IMPORT_ENDPOINTS"
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/ApiFakerBroadcastReceiver.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/ApiFakerBroadcastReceiver.kt
@@ -1,0 +1,31 @@
+package com.woocommerce.android.apifaker.adb
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.woocommerce.android.apifaker.LOG_TAG
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class ApiFakerBroadcastReceiver : BroadcastReceiver() {
+    @Inject
+    internal lateinit var actionHandler: BroadcastActionHandler
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                actionHandler.handle(intent)
+            } catch (e: Exception) {
+                Log.e(LOG_TAG, "ADB: Command failed: ${e.message}", e)
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/ApiFakerBroadcastReceiver.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/ApiFakerBroadcastReceiver.kt
@@ -21,7 +21,7 @@ class ApiFakerBroadcastReceiver : BroadcastReceiver() {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 actionHandler.handle(intent)
-            } catch (e: Exception) {
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                 Log.e(LOG_TAG, "ADB: Command failed: ${e.message}", e)
             } finally {
                 pendingResult.finish()

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/BroadcastActionHandler.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/BroadcastActionHandler.kt
@@ -1,0 +1,145 @@
+package com.woocommerce.android.apifaker.adb
+
+import android.content.Intent
+import android.util.Log
+import com.google.gson.Gson
+import com.woocommerce.android.apifaker.ApiFakerConfig
+import com.woocommerce.android.apifaker.LOG_TAG
+import com.woocommerce.android.apifaker.db.EndpointDao
+import com.woocommerce.android.apifaker.models.Request
+import com.woocommerce.android.apifaker.models.Response
+import java.io.File
+import javax.inject.Inject
+
+internal class BroadcastActionHandler @Inject constructor(
+    private val endpointDao: EndpointDao,
+    private val apiFakerConfig: ApiFakerConfig,
+    private val gson: Gson
+) {
+    suspend fun handle(intent: Intent) {
+        when (intent.action) {
+            Actions.SET_STATUS -> handleSetStatus(intent)
+            Actions.ADD_ENDPOINT -> handleAddEndpoint(intent)
+            Actions.EDIT_ENDPOINT -> handleEditEndpoint(intent)
+            Actions.REMOVE_ENDPOINT -> handleRemoveEndpoint(intent)
+            Actions.CLEAR_ENDPOINTS -> handleClearEndpoints()
+            Actions.LIST_ENDPOINTS -> handleListEndpoints()
+            Actions.IMPORT_ENDPOINTS -> handleImportEndpoints(intent)
+            else -> Log.w(LOG_TAG, "ADB: Unknown action: ${intent.action}")
+        }
+    }
+
+    private fun handleSetStatus(intent: Intent) {
+        val enabled = intent.getBooleanExtra(Extras.ENABLED, false)
+        apiFakerConfig.setStatus(enabled)
+        Log.i(LOG_TAG, "ADB: ApiFaker status set to $enabled")
+    }
+
+    private suspend fun handleAddEndpoint(intent: Intent) {
+        val request = Request(
+            type = IntentExtrasParser.parseApiType(intent),
+            path = intent.getStringExtra(Extras.PATH)
+                ?: error("Missing required extra: ${Extras.PATH}"),
+            httpMethod = IntentExtrasParser.parseHttpMethod(intent),
+            queryParameters = IntentExtrasParser.parseQueryParameters(intent),
+            body = IntentExtrasParser.parseRequestBody(intent)
+        )
+        val response = Response(
+            statusCode = intent.getIntExtra(Extras.RESPONSE_STATUS_CODE, 200),
+            body = IntentExtrasParser.parseResponseBody(intent)
+        )
+        endpointDao.insertEndpoint(request, response)
+        Log.i(LOG_TAG, "ADB: Endpoint added - ${request.type} ${request.httpMethod ?: "ANY"} ${request.path}")
+    }
+
+    private suspend fun handleEditEndpoint(intent: Intent) {
+        val id = intent.getLongExtra(Extras.ENDPOINT_ID, -1)
+        require(id > 0) { "Missing or invalid ${Extras.ENDPOINT_ID}" }
+
+        val existing = endpointDao.getEndpoint(id)
+            ?: error("Endpoint with id $id not found")
+
+        val request = existing.request.copy(
+            type = if (intent.hasExtra(Extras.API_TYPE)) {
+                IntentExtrasParser.parseApiType(intent)
+            } else {
+                existing.request.type
+            },
+            path = intent.getStringExtra(Extras.PATH) ?: existing.request.path,
+            httpMethod = if (intent.hasExtra(Extras.HTTP_METHOD)) {
+                IntentExtrasParser.parseHttpMethod(intent)
+            } else {
+                existing.request.httpMethod
+            },
+            queryParameters = if (intent.hasExtra(Extras.QUERY_PARAMS)) {
+                IntentExtrasParser.parseQueryParameters(intent)
+            } else {
+                existing.request.queryParameters
+            },
+            body = if (intent.hasExtra(Extras.REQUEST_BODY) || intent.hasExtra(Extras.REQUEST_BODY_FILE)) {
+                IntentExtrasParser.parseRequestBody(intent)
+            } else {
+                existing.request.body
+            }
+        )
+        val response = existing.response.copy(
+            statusCode = intent.getIntExtra(
+                Extras.RESPONSE_STATUS_CODE,
+                existing.response.statusCode
+            ),
+            body = if (intent.hasExtra(Extras.RESPONSE_BODY) || intent.hasExtra(Extras.RESPONSE_BODY_FILE)) {
+                IntentExtrasParser.parseResponseBody(intent)
+            } else {
+                existing.response.body
+            }
+        )
+        endpointDao.insertEndpoint(request, response)
+        Log.i(LOG_TAG, "ADB: Endpoint $id updated")
+    }
+
+    private suspend fun handleRemoveEndpoint(intent: Intent) {
+        val id = intent.getLongExtra(Extras.ENDPOINT_ID, -1)
+        require(id > 0) { "Missing or invalid ${Extras.ENDPOINT_ID}" }
+
+        val endpoint = endpointDao.getEndpoint(id)
+            ?: error("Endpoint with id $id not found")
+
+        endpointDao.deleteRequest(endpoint.request)
+        Log.i(LOG_TAG, "ADB: Endpoint $id removed")
+    }
+
+    private suspend fun handleClearEndpoints() {
+        endpointDao.deleteAllRequests()
+        Log.i(LOG_TAG, "ADB: All endpoints cleared")
+    }
+
+    private suspend fun handleListEndpoints() {
+        val endpoints = endpointDao.getAllEndpoints()
+        Log.i(LOG_TAG, "ADB: === ENDPOINTS_START (${endpoints.size} endpoints) ===")
+        endpoints.forEach { endpoint ->
+            val json = gson.toJson(endpoint)
+            // Log.i has a ~4000 char limit per call, so chunk long entries
+            json.chunked(MAX_LOG_LENGTH).forEach { chunk ->
+                Log.i(LOG_TAG, "ADB: ENDPOINT: $chunk")
+            }
+        }
+        Log.i(LOG_TAG, "ADB: === ENDPOINTS_END ===")
+    }
+
+    private suspend fun handleImportEndpoints(intent: Intent) {
+        val filePath = intent.getStringExtra(Extras.FILE)
+            ?: error("Missing required extra: ${Extras.FILE}")
+        val file = File(filePath)
+        require(file.exists()) { "File not found: $filePath" }
+
+        val endpoints = file.bufferedReader().use { reader ->
+            gson.fromJson(reader, Array<com.woocommerce.android.apifaker.models.MockedEndpoint>::class.java).toList()
+        }
+        endpointDao.insertEndpoints(endpoints)
+        Log.i(LOG_TAG, "ADB: Imported ${endpoints.size} endpoints from $filePath")
+    }
+
+    companion object {
+        private const val MAX_LOG_LENGTH = 3000
+    }
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/BroadcastActionHandler.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/BroadcastActionHandler.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.apifaker.ApiFakerConfig
 import com.woocommerce.android.apifaker.LOG_TAG
 import com.woocommerce.android.apifaker.db.EndpointDao
 import com.woocommerce.android.apifaker.di.ApiFakerGson
+import com.woocommerce.android.apifaker.models.MockedEndpoint
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import java.io.File
@@ -46,7 +47,7 @@ internal class BroadcastActionHandler @Inject constructor(
             body = IntentExtrasParser.parseRequestBody(intent)
         )
         val response = Response(
-            statusCode = intent.getIntExtra(Extras.RESPONSE_STATUS_CODE, 200),
+            statusCode = intent.getIntExtra(Extras.RESPONSE_STATUS_CODE, DEFAULT_STATUS_CODE),
             body = IntentExtrasParser.parseResponseBody(intent)
         )
         endpointDao.insertEndpoint(request, response)
@@ -134,13 +135,14 @@ internal class BroadcastActionHandler @Inject constructor(
         require(file.exists()) { "File not found: $filePath" }
 
         val endpoints = file.bufferedReader().use { reader ->
-            gson.fromJson(reader, Array<com.woocommerce.android.apifaker.models.MockedEndpoint>::class.java).toList()
+            gson.fromJson(reader, Array<MockedEndpoint>::class.java).toList()
         }
         endpointDao.insertEndpoints(endpoints)
         Log.i(LOG_TAG, "ADB: Imported ${endpoints.size} endpoints from $filePath")
     }
 
     companion object {
+        private const val DEFAULT_STATUS_CODE = 200
         private const val MAX_LOG_LENGTH = 3000
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/BroadcastActionHandler.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/BroadcastActionHandler.kt
@@ -6,6 +6,7 @@ import com.google.gson.Gson
 import com.woocommerce.android.apifaker.ApiFakerConfig
 import com.woocommerce.android.apifaker.LOG_TAG
 import com.woocommerce.android.apifaker.db.EndpointDao
+import com.woocommerce.android.apifaker.di.ApiFakerGson
 import com.woocommerce.android.apifaker.models.Request
 import com.woocommerce.android.apifaker.models.Response
 import java.io.File
@@ -14,7 +15,7 @@ import javax.inject.Inject
 internal class BroadcastActionHandler @Inject constructor(
     private val endpointDao: EndpointDao,
     private val apiFakerConfig: ApiFakerConfig,
-    private val gson: Gson
+    @ApiFakerGson private val gson: Gson
 ) {
     suspend fun handle(intent: Intent) {
         when (intent.action) {

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/Extras.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/Extras.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.apifaker.adb
+
+internal object Extras {
+    const val ENABLED = "enabled"
+    const val API_TYPE = "api_type"
+    const val CUSTOM_HOST = "custom_host"
+    const val PATH = "path"
+    const val HTTP_METHOD = "http_method"
+    const val QUERY_PARAMS = "query_params"
+    const val REQUEST_BODY = "request_body"
+    const val REQUEST_BODY_FILE = "request_body_file"
+    const val RESPONSE_STATUS_CODE = "response_status_code"
+    const val RESPONSE_BODY = "response_body"
+    const val RESPONSE_BODY_FILE = "response_body_file"
+    const val ENDPOINT_ID = "endpoint_id"
+    const val FILE = "file"
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/IntentExtrasParser.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/IntentExtrasParser.kt
@@ -1,0 +1,56 @@
+package com.woocommerce.android.apifaker.adb
+
+import android.content.Intent
+import com.woocommerce.android.apifaker.models.ApiType
+import com.woocommerce.android.apifaker.models.HttpMethod
+import com.woocommerce.android.apifaker.models.QueryParameter
+import java.io.File
+
+internal object IntentExtrasParser {
+    fun parseApiType(intent: Intent): ApiType {
+        val typeStr = intent.getStringExtra(Extras.API_TYPE)
+            ?: error("Missing required extra: ${Extras.API_TYPE}")
+        return when (typeStr) {
+            "wp-api" -> ApiType.WPApi
+            "wp-com" -> ApiType.WPCom
+            "custom" -> ApiType.Custom(
+                host = intent.getStringExtra(Extras.CUSTOM_HOST)
+                    ?: error("Custom API type requires '${Extras.CUSTOM_HOST}' extra")
+            )
+            else -> error("Unknown api_type: $typeStr. Expected: wp-api, wp-com, or custom")
+        }
+    }
+
+    fun parseHttpMethod(intent: Intent): HttpMethod? {
+        return intent.getStringExtra(Extras.HTTP_METHOD)?.let {
+            HttpMethod.valueOf(it.uppercase())
+        }
+    }
+
+    fun parseQueryParameters(intent: Intent): List<QueryParameter> {
+        return intent.getStringExtra(Extras.QUERY_PARAMS)
+            ?.split(",")
+            ?.map { param ->
+                val parts = param.split("=", limit = 2)
+                require(parts.size == 2) {
+                    "Invalid query parameter format: '$param'. Expected: name=value"
+                }
+                QueryParameter(parts[0].trim(), parts[1].trim())
+            }
+            ?: emptyList()
+    }
+
+    fun parseResponseBody(intent: Intent): String? {
+        intent.getStringExtra(Extras.RESPONSE_BODY_FILE)?.let { filePath ->
+            return File(filePath).readText()
+        }
+        return intent.getStringExtra(Extras.RESPONSE_BODY)
+    }
+
+    fun parseRequestBody(intent: Intent): String? {
+        intent.getStringExtra(Extras.REQUEST_BODY_FILE)?.let { filePath ->
+            return File(filePath).readText()
+        }
+        return intent.getStringExtra(Extras.REQUEST_BODY)
+    }
+}

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/IntentExtrasParser.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/IntentExtrasParser.kt
@@ -29,6 +29,7 @@ internal object IntentExtrasParser {
 
     fun parseQueryParameters(intent: Intent): List<QueryParameter> {
         return intent.getStringExtra(Extras.QUERY_PARAMS)
+            ?.takeIf { it.isNotBlank() }
             ?.split(",")
             ?.map { param ->
                 val parts = param.split("=", limit = 2)

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/IntentExtrasParser.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/adb/IntentExtrasParser.kt
@@ -42,15 +42,21 @@ internal object IntentExtrasParser {
 
     fun parseResponseBody(intent: Intent): String? {
         intent.getStringExtra(Extras.RESPONSE_BODY_FILE)?.let { filePath ->
-            return File(filePath).readText()
+            return readFileContent(filePath)
         }
         return intent.getStringExtra(Extras.RESPONSE_BODY)
     }
 
     fun parseRequestBody(intent: Intent): String? {
         intent.getStringExtra(Extras.REQUEST_BODY_FILE)?.let { filePath ->
-            return File(filePath).readText()
+            return readFileContent(filePath)
         }
         return intent.getStringExtra(Extras.REQUEST_BODY)
+    }
+
+    private fun readFileContent(filePath: String): String {
+        val file = File(filePath)
+        require(file.exists()) { "File not found: $filePath" }
+        return file.readText()
     }
 }

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
@@ -27,7 +27,7 @@ internal interface EndpointDao {
         """Select * FROM Request WHERE
         type = :type AND
         (httpMethod is NULL OR httpMethod = :httpMethod) AND
-        :path LIKE path AND
+        :path LIKE RTRIM(path, '/') AND
         :body LIKE COALESCE(body, '%')
         """
     )

--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/db/EndpointDao.kt
@@ -43,6 +43,13 @@ internal interface EndpointDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertResponse(response: Response)
 
+    @Transaction
+    @Query("SELECT * FROM Request")
+    suspend fun getAllEndpoints(): List<MockedEndpoint>
+
+    @Query("DELETE FROM Request")
+    suspend fun deleteAllRequests()
+
     @Delete
     suspend fun deleteRequest(request: Request)
 

--- a/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/adb/BroadcastActionHandlerTest.kt
+++ b/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/adb/BroadcastActionHandlerTest.kt
@@ -1,0 +1,527 @@
+package com.woocommerce.android.apifaker.adb
+
+import android.content.Intent
+import android.util.Log
+import com.google.gson.Gson
+import com.woocommerce.android.apifaker.ApiFakerConfig
+import com.woocommerce.android.apifaker.db.EndpointDao
+import com.woocommerce.android.apifaker.models.ApiType
+import com.woocommerce.android.apifaker.models.HttpMethod
+import com.woocommerce.android.apifaker.models.MockedEndpoint
+import com.woocommerce.android.apifaker.models.QueryParameter
+import com.woocommerce.android.apifaker.models.Request
+import com.woocommerce.android.apifaker.models.Response
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class BroadcastActionHandlerTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val endpointDao: EndpointDao = mock()
+    private val apiFakerConfig: ApiFakerConfig = mock()
+    private val gson = Gson()
+
+    private lateinit var logMock: MockedStatic<Log>
+
+    private val sut = BroadcastActionHandler(
+        endpointDao = endpointDao,
+        apiFakerConfig = apiFakerConfig,
+        gson = gson
+    )
+
+    private val defaultRequest = Request(
+        id = 1L,
+        type = ApiType.WPApi,
+        path = "/wc/v3/products",
+        httpMethod = HttpMethod.GET,
+        queryParameters = listOf(QueryParameter("page", "1")),
+        body = null
+    )
+    private val defaultResponse = Response(
+        endpointId = 1L,
+        statusCode = 200,
+        body = "{\"id\":1}"
+    )
+    private val defaultEndpoint = MockedEndpoint(
+        request = defaultRequest,
+        response = defaultResponse
+    )
+
+    @Before
+    fun setUp() {
+        logMock = Mockito.mockStatic(Log::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        logMock.close()
+    }
+
+    @Test
+    fun `given enabled is true, when handling SET_STATUS, then sets status to true`() = runTest {
+        // GIVEN
+        val intent = createIntent(Actions.SET_STATUS) {
+            whenever(it.getBooleanExtra(Extras.ENABLED, false)).thenReturn(true)
+        }
+
+        // WHEN
+        sut.handle(intent)
+
+        // THEN
+        verify(apiFakerConfig).setStatus(true)
+    }
+
+    @Test
+    fun `given enabled is false, when handling SET_STATUS, then sets status to false`() = runTest {
+        // GIVEN
+        val intent = createIntent(Actions.SET_STATUS) {
+            whenever(it.getBooleanExtra(Extras.ENABLED, false)).thenReturn(false)
+        }
+
+        // WHEN
+        sut.handle(intent)
+
+        // THEN
+        verify(apiFakerConfig).setStatus(false)
+    }
+
+    @Test
+    fun `given happy path, when handling ADD_ENDPOINT, then inserts endpoint with parsed request and response`() =
+        runTest {
+            // GIVEN
+            val intent = createAddEndpointIntent(
+                apiType = "wp-api",
+                path = "/wc/v3/products",
+                httpMethod = "GET",
+                responseStatusCode = 200,
+                responseBody = "{\"id\":1}"
+            )
+
+            // WHEN
+            sut.handle(intent)
+
+            // THEN
+            verify(endpointDao).insertEndpoint(
+                argThat {
+                    type == ApiType.WPApi &&
+                        path == "/wc/v3/products" &&
+                        httpMethod == HttpMethod.GET &&
+                        body == null
+                },
+                argThat {
+                    statusCode == 200 &&
+                        body == "{\"id\":1}"
+                }
+            )
+        }
+
+    @Test
+    fun `given wp-com api type, when handling ADD_ENDPOINT, then inserts endpoint with WPCom type`() = runTest {
+        // GIVEN
+        val intent = createAddEndpointIntent(
+            apiType = "wp-com",
+            path = "/rest/v1.1/me"
+        )
+
+        // WHEN
+        sut.handle(intent)
+
+        // THEN
+        verify(endpointDao).insertEndpoint(
+            argThat { type == ApiType.WPCom },
+            any()
+        )
+    }
+
+    @Test
+    fun `given custom api type with host, when handling ADD_ENDPOINT, then inserts endpoint with Custom type`() =
+        runTest {
+            // GIVEN
+            val intent = createAddEndpointIntent(
+                apiType = "custom",
+                customHost = "my-api.example.com",
+                path = "/v1/resource"
+            )
+
+            // WHEN
+            sut.handle(intent)
+
+            // THEN
+            verify(endpointDao).insertEndpoint(
+                argThat { type == ApiType.Custom("my-api.example.com") },
+                any()
+            )
+        }
+
+    @Test
+    fun `given query parameters, when handling ADD_ENDPOINT, then inserts endpoint with parsed query params`() =
+        runTest {
+            // GIVEN
+            val intent = createAddEndpointIntent(
+                apiType = "wp-api",
+                path = "/wc/v3/products",
+                queryParams = "page=1,per_page=10"
+            )
+
+            // WHEN
+            sut.handle(intent)
+
+            // THEN
+            verify(endpointDao).insertEndpoint(
+                argThat {
+                    queryParameters == listOf(
+                        QueryParameter("page", "1"),
+                        QueryParameter("per_page", "10")
+                    )
+                },
+                any()
+            )
+        }
+
+    @Test
+    fun `given default status code, when handling ADD_ENDPOINT, then inserts response with status 200`() = runTest {
+        // GIVEN
+        val intent = createAddEndpointIntent(
+            apiType = "wp-api",
+            path = "/wc/v3/products",
+            responseStatusCode = null
+        )
+
+        // WHEN
+        sut.handle(intent)
+
+        // THEN
+        verify(endpointDao).insertEndpoint(
+            any(),
+            argThat { statusCode == 200 }
+        )
+    }
+
+    @Test
+    fun `given custom status code, when handling ADD_ENDPOINT, then inserts response with that status code`() =
+        runTest {
+            // GIVEN
+            val intent = createAddEndpointIntent(
+                apiType = "wp-api",
+                path = "/wc/v3/products",
+                responseStatusCode = 404
+            )
+
+            // WHEN
+            sut.handle(intent)
+
+            // THEN
+            verify(endpointDao).insertEndpoint(
+                any(),
+                argThat { statusCode == 404 }
+            )
+        }
+
+    @Test
+    fun `given missing path, when handling ADD_ENDPOINT, then throws error`() {
+        // GIVEN
+        val intent = createIntent(Actions.ADD_ENDPOINT) {
+            whenever(it.getStringExtra(Extras.API_TYPE)).thenReturn("wp-api")
+            whenever(it.getStringExtra(Extras.PATH)).thenReturn(null)
+        }
+
+        // WHEN / THEN
+        assertThrows(IllegalStateException::class.java) {
+            runTest { sut.handle(intent) }
+        }
+    }
+
+    @Test
+    fun `given existing endpoint and new path, when handling EDIT_ENDPOINT, then updates only the path`() = runTest {
+        // GIVEN
+        whenever(endpointDao.getEndpoint(1L)).thenReturn(defaultEndpoint)
+        val intent = createIntent(Actions.EDIT_ENDPOINT) {
+            whenever(it.getLongExtra(Extras.ENDPOINT_ID, -1)).thenReturn(1L)
+            whenever(it.getStringExtra(Extras.PATH)).thenReturn("/wc/v3/orders")
+            whenever(it.hasExtra(Extras.API_TYPE)).thenReturn(false)
+            whenever(it.hasExtra(Extras.HTTP_METHOD)).thenReturn(false)
+            whenever(it.hasExtra(Extras.QUERY_PARAMS)).thenReturn(false)
+            whenever(it.hasExtra(Extras.REQUEST_BODY)).thenReturn(false)
+            whenever(it.hasExtra(Extras.REQUEST_BODY_FILE)).thenReturn(false)
+            whenever(it.getIntExtra(Extras.RESPONSE_STATUS_CODE, 200)).thenReturn(200)
+            whenever(it.hasExtra(Extras.RESPONSE_BODY)).thenReturn(false)
+            whenever(it.hasExtra(Extras.RESPONSE_BODY_FILE)).thenReturn(false)
+        }
+
+        // WHEN
+        sut.handle(intent)
+
+        // THEN
+        verify(endpointDao).insertEndpoint(
+            argThat {
+                path == "/wc/v3/orders" &&
+                    type == defaultRequest.type &&
+                    httpMethod == defaultRequest.httpMethod &&
+                    queryParameters == defaultRequest.queryParameters &&
+                    body == defaultRequest.body
+            },
+            argThat {
+                statusCode == defaultResponse.statusCode &&
+                    body == defaultResponse.body
+            }
+        )
+    }
+
+    @Test
+    fun `given existing endpoint and new response body, when handling EDIT_ENDPOINT, then updates only the response body`() =
+        runTest {
+            // GIVEN
+            whenever(endpointDao.getEndpoint(1L)).thenReturn(defaultEndpoint)
+            val intent = createIntent(Actions.EDIT_ENDPOINT) {
+                whenever(it.getLongExtra(Extras.ENDPOINT_ID, -1)).thenReturn(1L)
+                whenever(it.getStringExtra(Extras.PATH)).thenReturn(null)
+                whenever(it.hasExtra(Extras.API_TYPE)).thenReturn(false)
+                whenever(it.hasExtra(Extras.HTTP_METHOD)).thenReturn(false)
+                whenever(it.hasExtra(Extras.QUERY_PARAMS)).thenReturn(false)
+                whenever(it.hasExtra(Extras.REQUEST_BODY)).thenReturn(false)
+                whenever(it.hasExtra(Extras.REQUEST_BODY_FILE)).thenReturn(false)
+                whenever(it.getIntExtra(Extras.RESPONSE_STATUS_CODE, 200)).thenReturn(200)
+                whenever(it.hasExtra(Extras.RESPONSE_BODY)).thenReturn(true)
+                whenever(it.getStringExtra(Extras.RESPONSE_BODY_FILE)).thenReturn(null)
+                whenever(it.getStringExtra(Extras.RESPONSE_BODY)).thenReturn("{\"updated\":true}")
+                whenever(it.hasExtra(Extras.RESPONSE_BODY_FILE)).thenReturn(false)
+            }
+
+            // WHEN
+            sut.handle(intent)
+
+            // THEN
+            verify(endpointDao).insertEndpoint(
+                argThat {
+                    path == defaultRequest.path &&
+                        type == defaultRequest.type
+                },
+                argThat {
+                    body == "{\"updated\":true}" &&
+                        statusCode == defaultResponse.statusCode
+                }
+            )
+        }
+
+    @Test
+    fun `given missing endpoint ID, when handling EDIT_ENDPOINT, then throws error`() {
+        // GIVEN
+        val intent = createIntent(Actions.EDIT_ENDPOINT) {
+            whenever(it.getLongExtra(Extras.ENDPOINT_ID, -1)).thenReturn(-1L)
+        }
+
+        // WHEN / THEN
+        assertThrows(IllegalArgumentException::class.java) {
+            runTest { sut.handle(intent) }
+        }
+    }
+
+    @Test
+    fun `given non-existent endpoint ID, when handling EDIT_ENDPOINT, then throws error`() {
+        // GIVEN
+        val intent = createIntent(Actions.EDIT_ENDPOINT) {
+            whenever(it.getLongExtra(Extras.ENDPOINT_ID, -1)).thenReturn(999L)
+        }
+
+        // WHEN / THEN
+        assertThrows(IllegalStateException::class.java) {
+            runTest {
+                whenever(endpointDao.getEndpoint(999L)).thenReturn(null)
+                sut.handle(intent)
+            }
+        }
+    }
+
+    @Test
+    fun `given existing endpoint, when handling REMOVE_ENDPOINT, then deletes the request`() = runTest {
+        // GIVEN
+        whenever(endpointDao.getEndpoint(1L)).thenReturn(defaultEndpoint)
+        val intent = createIntent(Actions.REMOVE_ENDPOINT) {
+            whenever(it.getLongExtra(Extras.ENDPOINT_ID, -1)).thenReturn(1L)
+        }
+
+        // WHEN
+        sut.handle(intent)
+
+        // THEN
+        verify(endpointDao).deleteRequest(defaultRequest)
+    }
+
+    @Test
+    fun `given missing endpoint ID, when handling REMOVE_ENDPOINT, then throws error`() {
+        // GIVEN
+        val intent = createIntent(Actions.REMOVE_ENDPOINT) {
+            whenever(it.getLongExtra(Extras.ENDPOINT_ID, -1)).thenReturn(-1L)
+        }
+
+        // WHEN / THEN
+        assertThrows(IllegalArgumentException::class.java) {
+            runTest { sut.handle(intent) }
+        }
+    }
+
+    @Test
+    fun `given non-existent endpoint ID, when handling REMOVE_ENDPOINT, then throws error`() {
+        // GIVEN
+        val intent = createIntent(Actions.REMOVE_ENDPOINT) {
+            whenever(it.getLongExtra(Extras.ENDPOINT_ID, -1)).thenReturn(42L)
+        }
+
+        // WHEN / THEN
+        assertThrows(IllegalStateException::class.java) {
+            runTest {
+                whenever(endpointDao.getEndpoint(42L)).thenReturn(null)
+                sut.handle(intent)
+            }
+        }
+    }
+
+    @Test
+    fun `given happy path, when handling CLEAR_ENDPOINTS, then deletes all requests`() = runTest {
+        // GIVEN
+        val intent = createIntent(Actions.CLEAR_ENDPOINTS)
+
+        // WHEN
+        sut.handle(intent)
+
+        // THEN
+        verify(endpointDao).deleteAllRequests()
+    }
+
+    @Test
+    fun `given happy path, when handling LIST_ENDPOINTS, then calls getAllEndpoints`() = runTest {
+        // GIVEN
+        whenever(endpointDao.getAllEndpoints()).thenReturn(listOf(defaultEndpoint))
+        val intent = createIntent(Actions.LIST_ENDPOINTS)
+
+        // WHEN
+        sut.handle(intent)
+
+        // THEN
+        verify(endpointDao).getAllEndpoints()
+    }
+
+    @Test
+    fun `given empty endpoint list, when handling LIST_ENDPOINTS, then calls getAllEndpoints`() = runTest {
+        // GIVEN
+        whenever(endpointDao.getAllEndpoints()).thenReturn(emptyList())
+        val intent = createIntent(Actions.LIST_ENDPOINTS)
+
+        // WHEN
+        sut.handle(intent)
+
+        // THEN
+        verify(endpointDao).getAllEndpoints()
+    }
+
+    @Test
+    fun `given valid file, when handling IMPORT_ENDPOINTS, then inserts parsed endpoints`() = runTest {
+        // GIVEN
+        val file = temporaryFolder.newFile("endpoints.json")
+        val endpoints = listOf(defaultEndpoint)
+        file.writeText(gson.toJson(endpoints))
+
+        val intent = createIntent(Actions.IMPORT_ENDPOINTS) {
+            whenever(it.getStringExtra(Extras.FILE)).thenReturn(file.absolutePath)
+        }
+
+        // WHEN
+        sut.handle(intent)
+
+        // THEN
+        verify(endpointDao).insertEndpoints(
+            argThat {
+                size == 1 &&
+                    first().request.path == defaultRequest.path &&
+                    first().response.statusCode == defaultResponse.statusCode
+            }
+        )
+    }
+
+    @Test
+    fun `given missing file extra, when handling IMPORT_ENDPOINTS, then throws error`() {
+        // GIVEN
+        val intent = createIntent(Actions.IMPORT_ENDPOINTS) {
+            whenever(it.getStringExtra(Extras.FILE)).thenReturn(null)
+        }
+
+        // WHEN / THEN
+        assertThrows(IllegalStateException::class.java) {
+            runTest { sut.handle(intent) }
+        }
+    }
+
+    @Test
+    fun `given non-existent file, when handling IMPORT_ENDPOINTS, then throws error`() {
+        // GIVEN
+        val intent = createIntent(Actions.IMPORT_ENDPOINTS) {
+            whenever(it.getStringExtra(Extras.FILE)).thenReturn("/non/existent/file.json")
+        }
+
+        // WHEN / THEN
+        assertThrows(IllegalArgumentException::class.java) {
+            runTest { sut.handle(intent) }
+        }
+    }
+
+    @Test
+    fun `given unknown action, when handling intent, then no dao or config interaction occurs`() = runTest {
+        // GIVEN
+        val intent = createIntent("com.unknown.ACTION")
+
+        // WHEN
+        sut.handle(intent)
+
+        // THEN
+        verify(endpointDao, never()).insertEndpoint(any(), any())
+        verify(endpointDao, never()).deleteRequest(any())
+        verify(endpointDao, never()).deleteAllRequests()
+        verify(apiFakerConfig, never()).setStatus(any())
+    }
+
+    private fun createIntent(
+        action: String,
+        configure: (Intent) -> Unit = {}
+    ): Intent = mock<Intent> {
+        on { getAction() } doReturn action
+    }.also(configure)
+
+    private fun createAddEndpointIntent(
+        apiType: String,
+        path: String,
+        httpMethod: String? = null,
+        queryParams: String? = null,
+        requestBody: String? = null,
+        responseStatusCode: Int? = 200,
+        responseBody: String? = null,
+        customHost: String? = null
+    ): Intent = createIntent(Actions.ADD_ENDPOINT) { intent ->
+        whenever(intent.getStringExtra(Extras.API_TYPE)).thenReturn(apiType)
+        whenever(intent.getStringExtra(Extras.PATH)).thenReturn(path)
+        whenever(intent.getStringExtra(Extras.HTTP_METHOD)).thenReturn(httpMethod)
+        whenever(intent.getStringExtra(Extras.QUERY_PARAMS)).thenReturn(queryParams)
+        whenever(intent.getStringExtra(Extras.REQUEST_BODY_FILE)).thenReturn(null)
+        whenever(intent.getStringExtra(Extras.REQUEST_BODY)).thenReturn(requestBody)
+        whenever(intent.getStringExtra(Extras.RESPONSE_BODY_FILE)).thenReturn(null)
+        whenever(intent.getStringExtra(Extras.RESPONSE_BODY)).thenReturn(responseBody)
+        whenever(intent.getStringExtra(Extras.CUSTOM_HOST)).thenReturn(customHost)
+        whenever(intent.getIntExtra(eq(Extras.RESPONSE_STATUS_CODE), any()))
+            .thenReturn(responseStatusCode ?: 200)
+    }
+}

--- a/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/adb/IntentExtrasParserTest.kt
+++ b/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/adb/IntentExtrasParserTest.kt
@@ -146,6 +146,15 @@ class IntentExtrasParserTest {
     }
 
     @Test
+    fun `when parseQueryParameters with empty String, then returns empty list`() {
+        whenever(intent.getStringExtra(Extras.QUERY_PARAMS)).thenReturn("")
+
+        val result = IntentExtrasParser.parseQueryParameters(intent)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
     fun `when parseQueryParameters with single param, then returns single parameter`() {
         whenever(intent.getStringExtra(Extras.QUERY_PARAMS)).thenReturn("key=value")
 

--- a/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/adb/IntentExtrasParserTest.kt
+++ b/libs/apifaker/src/test/java/com/woocommerce/android/apifaker/adb/IntentExtrasParserTest.kt
@@ -1,0 +1,287 @@
+package com.woocommerce.android.apifaker.adb
+
+import android.content.Intent
+import com.woocommerce.android.apifaker.models.ApiType
+import com.woocommerce.android.apifaker.models.HttpMethod
+import com.woocommerce.android.apifaker.models.QueryParameter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class IntentExtrasParserTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val intent: Intent = mock()
+
+    @Test
+    fun `when parseApiType with wp-api, then returns WPApi`() {
+        whenever(intent.getStringExtra(Extras.API_TYPE)).thenReturn("wp-api")
+
+        val result = IntentExtrasParser.parseApiType(intent)
+
+        assertEquals(ApiType.WPApi, result)
+    }
+
+    @Test
+    fun `when parseApiType with wp-com, then returns WPCom`() {
+        whenever(intent.getStringExtra(Extras.API_TYPE)).thenReturn("wp-com")
+
+        val result = IntentExtrasParser.parseApiType(intent)
+
+        assertEquals(ApiType.WPCom, result)
+    }
+
+    @Test
+    fun `when parseApiType with custom and host provided, then returns Custom with host`() {
+        whenever(intent.getStringExtra(Extras.API_TYPE)).thenReturn("custom")
+        whenever(intent.getStringExtra(Extras.CUSTOM_HOST)).thenReturn("my-api.example.com")
+
+        val result = IntentExtrasParser.parseApiType(intent)
+
+        assertEquals(ApiType.Custom("my-api.example.com"), result)
+    }
+
+    @Test
+    fun `when parseApiType with custom and no host, then throws error`() {
+        whenever(intent.getStringExtra(Extras.API_TYPE)).thenReturn("custom")
+        whenever(intent.getStringExtra(Extras.CUSTOM_HOST)).thenReturn(null)
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            IntentExtrasParser.parseApiType(intent)
+        }
+
+        assertTrue(exception.message!!.contains(Extras.CUSTOM_HOST))
+    }
+
+    @Test
+    fun `when parseApiType with missing extra, then throws error`() {
+        whenever(intent.getStringExtra(Extras.API_TYPE)).thenReturn(null)
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            IntentExtrasParser.parseApiType(intent)
+        }
+
+        assertTrue(exception.message!!.contains(Extras.API_TYPE))
+    }
+
+    @Test
+    fun `when parseApiType with unknown type, then throws error`() {
+        whenever(intent.getStringExtra(Extras.API_TYPE)).thenReturn("unknown-type")
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            IntentExtrasParser.parseApiType(intent)
+        }
+
+        assertTrue(exception.message!!.contains("unknown-type"))
+    }
+
+    @Test
+    fun `when parseHttpMethod with GET, then returns GET`() {
+        whenever(intent.getStringExtra(Extras.HTTP_METHOD)).thenReturn("GET")
+
+        val result = IntentExtrasParser.parseHttpMethod(intent)
+
+        assertEquals(HttpMethod.GET, result)
+    }
+
+    @Test
+    fun `when parseHttpMethod with POST, then returns POST`() {
+        whenever(intent.getStringExtra(Extras.HTTP_METHOD)).thenReturn("POST")
+
+        val result = IntentExtrasParser.parseHttpMethod(intent)
+
+        assertEquals(HttpMethod.POST, result)
+    }
+
+    @Test
+    fun `when parseHttpMethod with lowercase input, then returns correct method`() {
+        whenever(intent.getStringExtra(Extras.HTTP_METHOD)).thenReturn("delete")
+
+        val result = IntentExtrasParser.parseHttpMethod(intent)
+
+        assertEquals(HttpMethod.DELETE, result)
+    }
+
+    @Test
+    fun `when parseHttpMethod with mixed case input, then returns correct method`() {
+        whenever(intent.getStringExtra(Extras.HTTP_METHOD)).thenReturn("pAtCh")
+
+        val result = IntentExtrasParser.parseHttpMethod(intent)
+
+        assertEquals(HttpMethod.PATCH, result)
+    }
+
+    @Test
+    fun `when parseHttpMethod with null, then returns null`() {
+        whenever(intent.getStringExtra(Extras.HTTP_METHOD)).thenReturn(null)
+
+        val result = IntentExtrasParser.parseHttpMethod(intent)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `when parseHttpMethod with invalid value, then throws exception`() {
+        whenever(intent.getStringExtra(Extras.HTTP_METHOD)).thenReturn("INVALID")
+
+        assertThrows(IllegalArgumentException::class.java) {
+            IntentExtrasParser.parseHttpMethod(intent)
+        }
+    }
+
+    @Test
+    fun `when parseQueryParameters with null, then returns empty list`() {
+        whenever(intent.getStringExtra(Extras.QUERY_PARAMS)).thenReturn(null)
+
+        val result = IntentExtrasParser.parseQueryParameters(intent)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `when parseQueryParameters with single param, then returns single parameter`() {
+        whenever(intent.getStringExtra(Extras.QUERY_PARAMS)).thenReturn("key=value")
+
+        val result = IntentExtrasParser.parseQueryParameters(intent)
+
+        assertEquals(listOf(QueryParameter("key", "value")), result)
+    }
+
+    @Test
+    fun `when parseQueryParameters with multiple params, then returns all parameters`() {
+        whenever(intent.getStringExtra(Extras.QUERY_PARAMS)).thenReturn("key1=value1,key2=value2,key3=value3")
+
+        val result = IntentExtrasParser.parseQueryParameters(intent)
+
+        assertEquals(
+            listOf(
+                QueryParameter("key1", "value1"),
+                QueryParameter("key2", "value2"),
+                QueryParameter("key3", "value3")
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `when parseQueryParameters with spaces around values, then trims whitespace`() {
+        whenever(intent.getStringExtra(Extras.QUERY_PARAMS)).thenReturn(" key = value ")
+
+        val result = IntentExtrasParser.parseQueryParameters(intent)
+
+        assertEquals(listOf(QueryParameter("key", "value")), result)
+    }
+
+    @Test
+    fun `when parseQueryParameters with value containing equals sign, then splits only on first equals`() {
+        whenever(intent.getStringExtra(Extras.QUERY_PARAMS)).thenReturn("key=val=ue")
+
+        val result = IntentExtrasParser.parseQueryParameters(intent)
+
+        assertEquals(listOf(QueryParameter("key", "val=ue")), result)
+    }
+
+    @Test
+    fun `when parseQueryParameters with invalid format, then throws exception`() {
+        whenever(intent.getStringExtra(Extras.QUERY_PARAMS)).thenReturn("invalid-no-equals")
+
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            IntentExtrasParser.parseQueryParameters(intent)
+        }
+
+        assertTrue(exception.message!!.contains("invalid-no-equals"))
+    }
+
+    @Test
+    fun `when parseResponseBody with inline body, then returns body string`() {
+        whenever(intent.getStringExtra(Extras.RESPONSE_BODY_FILE)).thenReturn(null)
+        whenever(intent.getStringExtra(Extras.RESPONSE_BODY)).thenReturn("{\"status\":\"ok\"}")
+
+        val result = IntentExtrasParser.parseResponseBody(intent)
+
+        assertEquals("{\"status\":\"ok\"}", result)
+    }
+
+    @Test
+    fun `when parseResponseBody with file path, then returns file contents`() {
+        val file = temporaryFolder.newFile("response.json")
+        file.writeText("{\"from\":\"file\"}")
+        whenever(intent.getStringExtra(Extras.RESPONSE_BODY_FILE)).thenReturn(file.absolutePath)
+
+        val result = IntentExtrasParser.parseResponseBody(intent)
+
+        assertEquals("{\"from\":\"file\"}", result)
+    }
+
+    @Test
+    fun `when parseResponseBody with both file and inline, then file takes priority`() {
+        val file = temporaryFolder.newFile("response.json")
+        file.writeText("{\"from\":\"file\"}")
+        whenever(intent.getStringExtra(Extras.RESPONSE_BODY_FILE)).thenReturn(file.absolutePath)
+        whenever(intent.getStringExtra(Extras.RESPONSE_BODY)).thenReturn("{\"from\":\"inline\"}")
+
+        val result = IntentExtrasParser.parseResponseBody(intent)
+
+        assertEquals("{\"from\":\"file\"}", result)
+    }
+
+    @Test
+    fun `when parseResponseBody with neither file nor inline, then returns null`() {
+        whenever(intent.getStringExtra(Extras.RESPONSE_BODY_FILE)).thenReturn(null)
+        whenever(intent.getStringExtra(Extras.RESPONSE_BODY)).thenReturn(null)
+
+        val result = IntentExtrasParser.parseResponseBody(intent)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `when parseRequestBody with inline body, then returns body string`() {
+        whenever(intent.getStringExtra(Extras.REQUEST_BODY_FILE)).thenReturn(null)
+        whenever(intent.getStringExtra(Extras.REQUEST_BODY)).thenReturn("{\"name\":\"test\"}")
+
+        val result = IntentExtrasParser.parseRequestBody(intent)
+
+        assertEquals("{\"name\":\"test\"}", result)
+    }
+
+    @Test
+    fun `when parseRequestBody with file path, then returns file contents`() {
+        val file = temporaryFolder.newFile("request.json")
+        file.writeText("{\"from\":\"request-file\"}")
+        whenever(intent.getStringExtra(Extras.REQUEST_BODY_FILE)).thenReturn(file.absolutePath)
+
+        val result = IntentExtrasParser.parseRequestBody(intent)
+
+        assertEquals("{\"from\":\"request-file\"}", result)
+    }
+
+    @Test
+    fun `when parseRequestBody with both file and inline, then file takes priority`() {
+        val file = temporaryFolder.newFile("request.json")
+        file.writeText("{\"from\":\"file\"}")
+        whenever(intent.getStringExtra(Extras.REQUEST_BODY_FILE)).thenReturn(file.absolutePath)
+        whenever(intent.getStringExtra(Extras.REQUEST_BODY)).thenReturn("{\"from\":\"inline\"}")
+
+        val result = IntentExtrasParser.parseRequestBody(intent)
+
+        assertEquals("{\"from\":\"file\"}", result)
+    }
+
+    @Test
+    fun `when parseRequestBody with neither file nor inline, then returns null`() {
+        whenever(intent.getStringExtra(Extras.REQUEST_BODY_FILE)).thenReturn(null)
+        whenever(intent.getStringExtra(Extras.REQUEST_BODY)).thenReturn(null)
+
+        val result = IntentExtrasParser.parseRequestBody(intent)
+
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Don't be alarmed by the size of the PR, the biggest part of the PR is just documentation and unit tests, the logic that needs to be reviewed is only in two files: `BroadcastActionHandler` and `IntentExtrasParser`. 

### Description

Add a BroadcastReceiver to the ApiFaker module that allows controlling API mocking via ADB commands. This enables AI agents and scripts to automate testing scenarios by setting up mock endpoints, enabling/disabling the faker, and managing endpoint configurations — all through `adb shell am broadcast` commands.

**What's included:**
- BroadcastReceiver with 7 actions: SET_STATUS, ADD_ENDPOINT, EDIT_ENDPOINT, REMOVE_ENDPOINT, CLEAR_ENDPOINTS, LIST_ENDPOINTS, IMPORT_ENDPOINTS
- Support for all 3 API types (WP-API, WP.COM, Custom)
- File-based payload support for large response bodies
- Logcat feedback under `WCApiFaker` tag
- Unit tests covering the handler and parser
- ADB command documentation in `docs/api-faker-adb.md`
- Integration into the `verify-on-device` agent skill

### Test Steps
#### Manual interaction
1. Build and install the debug APK on an emulator
2. Run: `adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT --es api_type "wp-api" --es path "/wc/v3/products" --es http_method "GET" --ei response_status_code 200 --es response_body '[]'`
3. Run: `adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true`
4. Check logcat: `adb logcat -s WCApiFaker -d` — should show success messages
5. Open the app, navigate to Products — should show empty list
6. Run: `adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.LIST_ENDPOINTS` and verify output in logcat
7. Run: `adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS`
8. Run unit tests: `./gradlew :libs:apifaker:testDebugUnitTest`

#### Using an AI agent
Use Claude Code or any other AI agent that can use the skill `/verify-on-device` and ask it to test some API failure, check the recording below for an example.

### Images/gif

With the prompt:

```
/verify-on-device Test how the app behaves when fetching orders fails.
Record the interaction.
```

The agent was able to understand the requirement, and it controlled the ApiFaker to make `/wc/v3/orders` return `403`, then recorded the following:

https://github.com/user-attachments/assets/76dca902-4ac9-4adc-b2de-85e63ac6c968


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.