### PR TITLE
[WOOMOB-2331] Fix payment status resolver using line item total instead of order total

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolver.kt
@@ -9,13 +9,11 @@ class PaymentStatusResolver @Inject constructor(
     private val orderStore: WCOrderStore,
     private val selectedSite: SelectedSite,
 ) {
-    suspend fun resolve(orderId: Long, orderTotal: BigDecimal? = null): PaymentStatus {
+    suspend fun resolve(orderId: Long): PaymentStatus {
         val order = orderStore.getOrderByIdAndSite(orderId, selectedSite.get())
             ?: return PaymentStatus.UNPAID
 
-        val total = orderTotal
-            ?: order.total.toBigDecimalOrNull()
-            ?: BigDecimal.ZERO
+        val total = order.total.toBigDecimalOrNull() ?: BigDecimal.ZERO
         return computeStatus(order.refundTotal.abs(), total, order.datePaid, order.status)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
@@ -37,7 +37,6 @@ class WooPosBookingViewStateMapper @Inject constructor(
         val timeRange = formatTimeRange(booking)
         val paymentStatus = paymentStatusResolver.resolve(
             orderId = booking.orderId,
-            orderTotal = booking.order.paymentInfo?.total,
         )
 
         return WooPosBookingsState.BookingItemViewState(
@@ -72,7 +71,6 @@ class WooPosBookingViewStateMapper @Inject constructor(
 
         val paymentStatus = paymentStatusResolver.resolve(
             orderId = booking.orderId,
-            orderTotal = booking.order.paymentInfo?.total,
         )
 
         return WooPosBookingsState.BookingDetailsViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosPaymentStatusResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosPaymentStatusResolver.kt
@@ -1,13 +1,12 @@
 package com.woocommerce.android.ui.woopos.bookings
 
 import com.woocommerce.android.ui.bookings.PaymentStatusResolver
-import java.math.BigDecimal
 import javax.inject.Inject
 
 class WooPosPaymentStatusResolver @Inject constructor(
     private val paymentStatusResolver: PaymentStatusResolver,
 ) {
-    suspend fun resolve(orderId: Long, orderTotal: BigDecimal?): PaymentStatus {
-        return paymentStatusResolver.resolve(orderId, orderTotal)
+    suspend fun resolve(orderId: Long): PaymentStatus {
+        return paymentStatusResolver.resolve(orderId)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolverTest.kt
@@ -25,98 +25,99 @@ class PaymentStatusResolverTest {
 
     @Test
     fun `given order not found, when resolve, then returns UNPAID`() = runTest {
+        // GIVEN
         whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(null)
 
-        val result = sut.resolve(1L, BigDecimal.TEN)
+        // WHEN
+        val result = sut.resolve(1L)
 
+        // THEN
         assertThat(result).isEqualTo(PaymentStatus.UNPAID)
     }
 
     @Test
     fun `given order with datePaid, when resolve, then returns PAID`() = runTest {
+        // GIVEN
         val order = createOrder(datePaid = "2025-01-01", refundTotal = BigDecimal.ZERO)
         whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
 
-        val result = sut.resolve(1L, BigDecimal.TEN)
+        // WHEN
+        val result = sut.resolve(1L)
 
+        // THEN
         assertThat(result).isEqualTo(PaymentStatus.PAID)
     }
 
     @Test
     fun `given full refund, when resolve, then returns REFUNDED`() = runTest {
-        val order = createOrder(refundTotal = BigDecimal("-10"), datePaid = "2025-01-01")
+        // GIVEN
+        val order = createOrder(
+            total = "100",
+            refundTotal = BigDecimal("-100"),
+            datePaid = "2025-01-01"
+        )
         whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
 
-        val result = sut.resolve(1L, BigDecimal.TEN)
+        // WHEN
+        val result = sut.resolve(1L)
 
+        // THEN
         assertThat(result).isEqualTo(PaymentStatus.REFUNDED)
     }
 
     @Test
     fun `given partial refund, when resolve, then returns PARTIALLY_REFUNDED`() = runTest {
-        val order = createOrder(refundTotal = BigDecimal("-5"), datePaid = "2025-01-01")
+        // GIVEN
+        val order = createOrder(
+            total = "100",
+            refundTotal = BigDecimal("-50"),
+            datePaid = "2025-01-01"
+        )
         whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
 
-        val result = sut.resolve(1L, BigDecimal.TEN)
+        // WHEN
+        val result = sut.resolve(1L)
 
+        // THEN
         assertThat(result).isEqualTo(PaymentStatus.PARTIALLY_REFUNDED)
     }
 
     @Test
     fun `given failed order status, when resolve, then returns FAILED`() = runTest {
+        // GIVEN
         val order = createOrder(status = "failed", datePaid = "", refundTotal = BigDecimal.ZERO)
         whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
 
-        val result = sut.resolve(1L, BigDecimal.TEN)
+        // WHEN
+        val result = sut.resolve(1L)
 
+        // THEN
         assertThat(result).isEqualTo(PaymentStatus.FAILED)
     }
 
     @Test
     fun `given cancelled order status, when resolve, then returns FAILED`() = runTest {
+        // GIVEN
         val order = createOrder(status = "cancelled", datePaid = "", refundTotal = BigDecimal.ZERO)
         whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
 
-        val result = sut.resolve(1L, BigDecimal.TEN)
+        // WHEN
+        val result = sut.resolve(1L)
 
+        // THEN
         assertThat(result).isEqualTo(PaymentStatus.FAILED)
     }
 
     @Test
-    fun `given no orderTotal provided, when resolve, then uses order total from entity`() = runTest {
-        val order = createOrder(
-            datePaid = "2025-01-01",
-            refundTotal = BigDecimal("-50"),
-            total = "100"
-        )
-        whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
-
-        val result = sut.resolve(1L)
-
-        assertThat(result).isEqualTo(PaymentStatus.PARTIALLY_REFUNDED)
-    }
-
-    @Test
-    fun `given no orderTotal and full refund, when resolve, then returns REFUNDED`() = runTest {
-        val order = createOrder(
-            datePaid = "2025-01-01",
-            refundTotal = BigDecimal("-100"),
-            total = "100"
-        )
-        whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
-
-        val result = sut.resolve(1L)
-
-        assertThat(result).isEqualTo(PaymentStatus.REFUNDED)
-    }
-
-    @Test
     fun `given unpaid order with no refunds, when resolve, then returns UNPAID`() = runTest {
+        // GIVEN
         val order = createOrder(datePaid = "", refundTotal = BigDecimal.ZERO, status = "pending")
         whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
 
-        val result = sut.resolve(1L, BigDecimal.TEN)
+        // WHEN
+        val result = sut.resolve(1L)
 
+        // THEN
         assertThat(result).isEqualTo(PaymentStatus.UNPAID)
     }
 
@@ -124,7 +125,7 @@ class PaymentStatusResolverTest {
         status: String = "processing",
         datePaid: String = "",
         refundTotal: BigDecimal = BigDecimal.ZERO,
-        total: String = "",
+        total: String = "100",
     ) = OrderEntity(
         localSiteId = LocalId(1),
         orderId = 1L,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -59,7 +59,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         on { isConnected() } doReturn true
     }
     private val paymentStatusResolver = mock<PaymentStatusResolver> {
-        onBlocking { resolve(any(), anyOrNull()) } doReturn PaymentStatus.UNPAID
+        onBlocking { resolve(any()) } doReturn PaymentStatus.UNPAID
     }
 
     @Before

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -70,7 +70,7 @@ class BookingListViewModelTest : BaseUnitTest() {
     }
     private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact = mock()
     private val paymentStatusResolver: PaymentStatusResolver = mock {
-        onBlocking { resolve(any(), anyOrNull()) } doReturn PaymentStatus.UNPAID
+        onBlocking { resolve(any()) } doReturn PaymentStatus.UNPAID
     }
 
     private lateinit var viewModel: BookingListViewModel

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
@@ -83,7 +83,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given booking, when mapped to item view state, then maps fields correctly`() = runTest {
         // GIVEN
         val booking = sampleBooking()
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
         val result = mapper.mapToItemViewState(booking, selectedBookingId = null, resource = null)
@@ -101,7 +101,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given cancelled booking, when mapped to item view state, then isCancelled is true`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Cancelled)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.FAILED)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.FAILED)
 
         // WHEN
         val result = mapper.mapToItemViewState(booking, selectedBookingId = null, resource = null)
@@ -118,7 +118,7 @@ class WooPosBookingViewStateMapperTest {
             val start = Instant.parse("2025-07-05T11:00:00Z")
             val end = start.plus(Duration.ofMinutes(90))
             val booking = sampleBooking(start = start, end = end)
-            whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
+            whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
 
             // WHEN
             val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -139,7 +139,7 @@ class WooPosBookingViewStateMapperTest {
             val start = Instant.parse("2025-07-06T03:00:00Z")
             val end = start.plus(Duration.ofHours(1))
             val booking = sampleBooking(start = start, end = end)
-            whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
+            whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
 
             // WHEN
             val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -157,7 +157,7 @@ class WooPosBookingViewStateMapperTest {
         runTest {
             // GIVEN
             val booking = sampleBooking(paymentInfo = null)
-            whenever(paymentStatusResolver.resolve(any(), anyOrNull())).thenReturn(PaymentStatus.UNPAID)
+            whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
             // WHEN
             val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -181,7 +181,7 @@ class WooPosBookingViewStateMapperTest {
             totalTax = BigDecimal("9"),
         )
         val booking = sampleBooking(paymentInfo = paymentInfo)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -199,7 +199,7 @@ class WooPosBookingViewStateMapperTest {
                 status = BookingEntity.Status.Confirmed,
                 attendanceStatus = BookingEntity.AttendanceStatus.Attended,
             )
-            whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
+            whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
 
             // WHEN
             val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -217,7 +217,7 @@ class WooPosBookingViewStateMapperTest {
             status = BookingEntity.Status.Cancelled,
             attendanceStatus = BookingEntity.AttendanceStatus.Unattended,
         )
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.FAILED)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.FAILED)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -230,7 +230,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given booking with null customerInfo, when mapped, then customer section is null`() = runTest {
         // GIVEN
         val booking = sampleBooking(customerInfo = null, customerNote = null)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -249,7 +249,7 @@ class WooPosBookingViewStateMapperTest {
             billingPhone = "",
         )
         val booking = sampleBooking(customerInfo = customerInfo, customerNote = "")
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -262,7 +262,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given paid booking, when mapped to details, then actions include EmailReceipt`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Paid)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -276,7 +276,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given unpaid booking, when mapped to details, then actions do not include EmailReceipt`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Unpaid)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -290,7 +290,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given paid booking, when mapped to details, then actions include IssueRefund`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Paid)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -304,7 +304,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given complete booking, when mapped to details, then actions include IssueRefund`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Complete)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -318,7 +318,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given unpaid booking, when mapped to details, then actions do not include IssueRefund`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Unpaid)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -332,7 +332,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given cancelled booking, when mapped to details, then actions do not include IssueRefund`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Cancelled)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.FAILED)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.FAILED)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -346,7 +346,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given cancellable booking, when mapped to details, then actions include CancelBooking`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Unpaid)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -360,7 +360,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given cancelled booking, when mapped to details, then actions do not include CancelBooking`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Cancelled)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.FAILED)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.FAILED)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -374,7 +374,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given cancelled unpaid booking, when mapped to details, then collectPaymentLabel is shown`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Cancelled)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -387,7 +387,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given cancelled paid booking, when mapped to details, then collectPaymentLabel is null`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Cancelled)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -400,7 +400,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given cancelled refunded booking, when mapped to details, then collectPaymentLabel is null`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Cancelled)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.REFUNDED)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.REFUNDED)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -413,7 +413,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given complete booking, when mapped to details, then actions do not include CancelBooking`() = runTest {
         // GIVEN
         val booking = sampleBooking(status = BookingEntity.Status.Complete)
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.PAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
 
         // WHEN
         val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -428,7 +428,7 @@ class WooPosBookingViewStateMapperTest {
         runTest {
             // GIVEN
             val booking = sampleBooking(id = 42L)
-            whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+            whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
             // WHEN
             val result = mapper.mapToDetailsViewState(booking, resourceName = null)
@@ -445,7 +445,7 @@ class WooPosBookingViewStateMapperTest {
         // GIVEN
         val booking = sampleBooking()
         val resource = sampleResource(name = "John Doe")
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
         val result = mapper.mapToItemViewState(booking, selectedBookingId = null, resource = resource)
@@ -461,7 +461,7 @@ class WooPosBookingViewStateMapperTest {
         // GIVEN
         val booking = sampleBooking()
         val resource = sampleResource(name = "Jane", imageUrl = "https://example.com/avatar.jpg")
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
         val result = mapper.mapToItemViewState(booking, selectedBookingId = null, resource = resource)
@@ -475,7 +475,7 @@ class WooPosBookingViewStateMapperTest {
     fun `given null resource, when mapped to item, then team member is null`() = runTest {
         // GIVEN
         val booking = sampleBooking()
-        whenever(paymentStatusResolver.resolve(any(), any())).thenReturn(PaymentStatus.UNPAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
 
         // WHEN
         val result = mapper.mapToItemViewState(booking, selectedBookingId = null, resource = null)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -175,7 +175,7 @@ class WooPosBookingsViewModelTest {
         whenever(bookingListHandler.loadMore()).thenReturn(Result.success(0))
         whenever(bookingListHandler.hasMorePages).thenReturn(true)
         whenever(dateTimeProvider.now()).thenReturn(0L)
-        whenever(paymentStatusResolver.resolve(any(), anyOrNull())).thenReturn(PaymentStatus.UNPAID)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosPaymentStatusResolverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosPaymentStatusResolverTest.kt
@@ -5,19 +5,19 @@ import com.woocommerce.android.ui.bookings.PaymentStatusResolver
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
 class WooPosPaymentStatusResolverTest {
 
-    private val paymentStatusResolver: PaymentStatusResolver = mock()
+    private val paymentStatusResolver: PaymentStatusResolver = mock {
+        onBlocking { resolve(any()) } doReturn PaymentStatus.PAID
+    }
     private val sut = WooPosPaymentStatusResolver(paymentStatusResolver)
 
     @Test
     fun `when resolve called, then delegates to shared PaymentStatusResolver`() = runTest {
-        // GIVEN
-        whenever(paymentStatusResolver.resolve(1L)).thenReturn(PaymentStatus.PAID)
-
         // WHEN
         val result = sut.resolve(1L)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosPaymentStatusResolverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosPaymentStatusResolverTest.kt
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import java.math.BigDecimal
 
 class WooPosPaymentStatusResolverTest {
 
@@ -17,60 +16,12 @@ class WooPosPaymentStatusResolverTest {
     @Test
     fun `when resolve called, then delegates to shared PaymentStatusResolver`() = runTest {
         // GIVEN
-        whenever(paymentStatusResolver.resolve(1L, BigDecimal.TEN)).thenReturn(PaymentStatus.PAID)
+        whenever(paymentStatusResolver.resolve(1L)).thenReturn(PaymentStatus.PAID)
 
         // WHEN
-        val result = sut.resolve(1L, BigDecimal.TEN)
+        val result = sut.resolve(1L)
 
         // THEN
         assertThat(result).isEqualTo(PaymentStatus.PAID)
-    }
-
-    @Test
-    fun `given order not found, when resolve, then returns UNPAID`() = runTest {
-        // GIVEN
-        whenever(paymentStatusResolver.resolve(1L, BigDecimal.TEN)).thenReturn(PaymentStatus.UNPAID)
-
-        // WHEN
-        val result = sut.resolve(1L, BigDecimal.TEN)
-
-        // THEN
-        assertThat(result).isEqualTo(PaymentStatus.UNPAID)
-    }
-
-    @Test
-    fun `given full refund, when resolve, then returns REFUNDED`() = runTest {
-        // GIVEN
-        whenever(paymentStatusResolver.resolve(1L, BigDecimal.TEN)).thenReturn(PaymentStatus.REFUNDED)
-
-        // WHEN
-        val result = sut.resolve(1L, BigDecimal.TEN)
-
-        // THEN
-        assertThat(result).isEqualTo(PaymentStatus.REFUNDED)
-    }
-
-    @Test
-    fun `given partial refund, when resolve, then returns PARTIALLY_REFUNDED`() = runTest {
-        // GIVEN
-        whenever(paymentStatusResolver.resolve(1L, BigDecimal.TEN)).thenReturn(PaymentStatus.PARTIALLY_REFUNDED)
-
-        // WHEN
-        val result = sut.resolve(1L, BigDecimal.TEN)
-
-        // THEN
-        assertThat(result).isEqualTo(PaymentStatus.PARTIALLY_REFUNDED)
-    }
-
-    @Test
-    fun `given failed order, when resolve, then returns FAILED`() = runTest {
-        // GIVEN
-        whenever(paymentStatusResolver.resolve(1L, BigDecimal.TEN)).thenReturn(PaymentStatus.FAILED)
-
-        // WHEN
-        val result = sut.resolve(1L, BigDecimal.TEN)
-
-        // THEN
-        assertThat(result).isEqualTo(PaymentStatus.FAILED)
     }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2331

`WooPosPaymentStatusResolver` was receiving the booking's line item total as `orderTotal`, but comparing it against the order-level `refundTotal`. For multi-booking orders with partial refunds, this incorrectly showed all bookings as fully refunded. Now the resolver reads `order.total` from `OrderEntity` directly.

### Test Steps
1. Add 2 appointments to the cart in the storefront (creates 2 bookings in the same order)
2. Complete the order—both bookings show as Paid in POS
3. Refund one of the bookings (partial refund at order level)
4. Verify both bookings show as **Partially Refunded** (not Refunded)

### Images/gif
<img width="778" height="483" alt="image" src="https://github.com/user-attachments/assets/f967212d-14c2-4e7d-abcc-dd2b880f7b43" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.