### PR TITLE
Add label assignment step to PR creation skill

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -61,7 +61,6 @@ EOF
 9. **Add labels.** After creating the PR, add labels using `gh pr edit <number> --add-label "<label>"`. Pick labels from these categories:
    - **Type** (pick one): `type: bug`, `type: crash`, `type: enhancement`, `type: task`, `type: technical debt`, `type: documentation`, `type: question`
    - **Feature** (pick one if applicable): match the changed area to a `feature: *` label (e.g., `feature: order list`, `feature: point of sale`, `feature: product details`, `feature: login`, etc.)
-   - **Priority** (pick one if known): `priority: low`, `priority: medium`, `priority: high`, `priority: critical`
    - **Category** (pick any that apply): `category: accessibility`, `category: design`, `category: performance`, `category: tracks`, `category: unit tests`, `category: ui tests`, `category: tooling`, `category: parity`, etc.
    - If the feature is behind a flag, also add `status: feature-flagged`
    - Infer labels from the diff and branch name. If unsure about feature label, ask the user.

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -58,4 +58,12 @@ EOF
 )"
 ```
 
-9. **Report the PR URL** to the user.
+9. **Add labels.** After creating the PR, add labels using `gh pr edit <number> --add-label "<label>"`. Pick labels from these categories:
+   - **Type** (pick one): `type: bug`, `type: crash`, `type: enhancement`, `type: task`, `type: technical debt`, `type: documentation`, `type: question`
+   - **Feature** (pick one if applicable): match the changed area to a `feature: *` label (e.g., `feature: order list`, `feature: point of sale`, `feature: product details`, `feature: login`, etc.)
+   - **Priority** (pick one if known): `priority: low`, `priority: medium`, `priority: high`, `priority: critical`
+   - **Category** (pick any that apply): `category: accessibility`, `category: design`, `category: performance`, `category: tracks`, `category: unit tests`, `category: ui tests`, `category: tooling`, `category: parity`, etc.
+   - If the feature is behind a flag, also add `status: feature-flagged`
+   - Infer labels from the diff and branch name. If unsure about feature label, ask the user.
+
+10. **Report the PR URL** to the user.


### PR DESCRIPTION
### Description
The PR skill was missing a step to add GitHub labels after creating PRs. This adds a new step (step 9) that picks and applies labels from these categories:

- **Type**: bug, crash, enhancement, task, etc.
- **Feature**: matched from the changed area (order list, point of sale, etc.)
- **Priority**: low, medium, high, critical
- **Category**: accessibility, design, performance, tracks, etc.

Labels are inferred from the diff and branch name. If the feature label is unclear, the skill asks the user.

### Test Steps
1. Run `/pr` skill on a branch with changes
2. Verify that after the PR is created, the skill also adds appropriate labels

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.