### PR TITLE
[WOOMOB-2332] Fix booking detail empty when payment completes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -254,6 +254,14 @@ class WooPosBookingsViewModel @Inject constructor(
     private fun refreshSingleBooking(bookingId: Long) {
         viewModelScope.launch {
             bookingsRepository.fetchBooking(bookingId)
+                .onFailure {
+                    val messageResId = if (it.isNetworkError()) {
+                        R.string.offline_error
+                    } else {
+                        R.string.something_went_wrong_try_again
+                    }
+                    _toastEvent.emit(resourceProvider.getString(messageResId))
+                }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -251,6 +251,12 @@ class WooPosBookingsViewModel @Inject constructor(
         doRefresh()
     }
 
+    private fun refreshSingleBooking(bookingId: Long) {
+        viewModelScope.launch {
+            bookingsRepository.fetchBooking(bookingId)
+        }
+    }
+
     private fun doRefresh() {
         fetchJob?.cancel()
         loadMoreJob?.cancel()
@@ -381,7 +387,7 @@ class WooPosBookingsViewModel @Inject constructor(
         _state.value = currentState.copy(
             dialogState = WooPosBookingsState.Content.DialogState.Hidden
         )
-        doRefresh()
+        selectedBookingId?.let { refreshSingleBooking(it) } ?: doRefresh()
     }
 
     private fun handleCollectPayment() {
@@ -474,11 +480,11 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     fun onBookingNoteSaved() {
-        doRefresh()
+        selectedBookingId?.let { refreshSingleBooking(it) } ?: doRefresh()
     }
 
     fun onPaymentCompleted() {
-        doRefresh()
+        selectedBookingId?.let { refreshSingleBooking(it) } ?: doRefresh()
     }
 
     private fun handleBookingAction(action: WooPosBookingsState.BookingAction) {
@@ -577,7 +583,7 @@ class WooPosBookingsViewModel @Inject constructor(
                 )
             }
             if (result.isSuccess) {
-                doRefresh()
+                refreshSingleBooking(bookingId)
             }
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -1057,12 +1057,6 @@ class WooPosBookingsViewModelTest {
             )
             advanceUntilIdle()
 
-            whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
-                .doSuspendableAnswer {
-                    delay(Long.MAX_VALUE)
-                    Result.success(0)
-                }
-
             // WHEN
             viewModel.onUIEvent(WooPosBookingsUIEvent.CancelBookingConfirmed)
             advanceUntilIdle()
@@ -1074,7 +1068,7 @@ class WooPosBookingsViewModelTest {
         }
 
     @Test
-    fun `given cancel confirmed successfully, when handling event, then bookings are refreshed`() =
+    fun `given cancel confirmed successfully, when handling event, then single booking is refreshed`() =
         runTest {
             // GIVEN
             whenever(bookingsRepository.cancelBooking(any()))
@@ -1099,8 +1093,7 @@ class WooPosBookingsViewModelTest {
             advanceUntilIdle()
 
             // THEN
-            verify(bookingListHandler, times(2))
-                .loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest))
+            verify(bookingsRepository).fetchBooking(bookingId)
         }
 
     @Test
@@ -1116,12 +1109,6 @@ class WooPosBookingsViewModelTest {
                 )
             )
             advanceUntilIdle()
-
-            whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
-                .doSuspendableAnswer {
-                    delay(Long.MAX_VALUE)
-                    Result.success(0)
-                }
 
             // WHEN
             viewModel.onIssueRefundDialogDismissed()
@@ -1140,12 +1127,6 @@ class WooPosBookingsViewModelTest {
             viewModel = createViewModel()
             advanceUntilIdle()
 
-            whenever(bookingListHandler.loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest)))
-                .doSuspendableAnswer {
-                    delay(Long.MAX_VALUE)
-                    Result.success(0)
-                }
-
             // WHEN
             viewModel.onBookingNoteSaved()
             advanceUntilIdle()
@@ -1154,6 +1135,70 @@ class WooPosBookingsViewModelTest {
             val content = viewModel.state.value as WooPosBookingsState.Content
             assertThat(content.pullToRefreshState)
                 .isEqualTo(WooPosPullToRefreshState.Enabled)
+        }
+
+    @Test
+    fun `when payment completed, then single booking is fetched instead of full refresh`() =
+        runTest {
+            // GIVEN
+            viewModel = createViewModel()
+            advanceUntilIdle()
+            val content = viewModel.state.value as WooPosBookingsState.Content
+            val bookingId = content.selectedDetails!!.id
+
+            // WHEN
+            viewModel.onPaymentCompleted()
+            advanceUntilIdle()
+
+            // THEN
+            verify(bookingsRepository).fetchBooking(bookingId)
+            verify(bookingListHandler, times(1))
+                .loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest))
+        }
+
+    @Test
+    fun `when booking note saved, then single booking is fetched instead of full refresh`() =
+        runTest {
+            // GIVEN
+            viewModel = createViewModel()
+            advanceUntilIdle()
+            val content = viewModel.state.value as WooPosBookingsState.Content
+            val bookingId = content.selectedDetails!!.id
+
+            // WHEN
+            viewModel.onBookingNoteSaved()
+            advanceUntilIdle()
+
+            // THEN
+            verify(bookingsRepository).fetchBooking(bookingId)
+            verify(bookingListHandler, times(1))
+                .loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest))
+        }
+
+    @Test
+    fun `when issue refund dialog dismissed, then single booking is fetched instead of full refresh`() =
+        runTest {
+            // GIVEN
+            viewModel = createViewModel()
+            advanceUntilIdle()
+            val content = viewModel.state.value as WooPosBookingsState.Content
+            val bookingId = content.selectedDetails!!.id
+
+            viewModel.onUIEvent(
+                WooPosBookingsUIEvent.BookingMenuActionClicked(
+                    WooPosBookingsState.BookingAction.IssueRefund(orderId = 10L)
+                )
+            )
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onIssueRefundDialogDismissed()
+            advanceUntilIdle()
+
+            // THEN
+            verify(bookingsRepository).fetchBooking(bookingId)
+            verify(bookingListHandler, times(1))
+                .loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest))
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -178,6 +178,7 @@ class WooPosBookingsViewModelTest {
         whenever(bookingListHandler.hasMorePages).thenReturn(true)
         whenever(dateTimeProvider.now()).thenReturn(0L)
         whenever(paymentStatusResolver.resolve(any(), anyOrNull())).thenReturn(PaymentStatus.UNPAID)
+        whenever(bookingsRepository.fetchBooking(any())).thenReturn(Result.success(mock()))
     }
 
     @Test
@@ -1199,6 +1200,24 @@ class WooPosBookingsViewModelTest {
             verify(bookingsRepository).fetchBooking(bookingId)
             verify(bookingListHandler, times(1))
                 .loadBookings(anyOrNull(), any(), eq(BookingListSortOption.OldestToNewest))
+        }
+
+    @Test
+    fun `when single booking refresh fails, then error toast is shown`() =
+        runTest {
+            // GIVEN
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            whenever(bookingsRepository.fetchBooking(any()))
+                .thenReturn(Result.failure(RuntimeException("Network error")))
+
+            // WHEN
+            viewModel.onPaymentCompleted()
+            advanceUntilIdle()
+
+            // THEN
+            verify(resourceProvider).getString(R.string.something_went_wrong_try_again)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -178,7 +178,7 @@ class WooPosBookingsViewModelTest {
         whenever(bookingListHandler.hasMorePages).thenReturn(true)
         whenever(dateTimeProvider.now()).thenReturn(0L)
         whenever(paymentStatusResolver.resolve(any(), anyOrNull())).thenReturn(PaymentStatus.UNPAID)
-        whenever(bookingsRepository.fetchBooking(any())).thenReturn(Result.success(mock()))
+        whenever(bookingsRepository.fetchBooking(any())).thenReturn(Result.success(booking()))
     }
 
     @Test

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -28,7 +28,9 @@ interface BookingsDao {
             AND ((:productIdsSize = 0) OR productId IN (:productIds))
             ORDER BY
                 CASE WHEN :order = 'ASC' THEN start END ASC,
-                CASE WHEN :order = 'DESC' THEN start END DESC
+                CASE WHEN :order = 'DESC' THEN start END DESC,
+                CASE WHEN :order = 'ASC' THEN id END ASC,
+                CASE WHEN :order = 'DESC' THEN id END DESC
             LIMIT CASE WHEN :limit IS NULL THEN -1 ELSE :limit END
             """
     }


### PR DESCRIPTION
Fixes WOOMOB-2332

### Description

When completing a payment on a booking that was **not on the first page** of the list, the booking detail pane would go blank for several seconds before eventually re-appearing.

**Root cause:** After payment (and also after note save, refund, or cancel), `doRefresh()` was called which reset pagination back to page 1 via `BookingListHandler.loadBookings()`. This meant only the first 25 bookings were observed from Room. If the selected booking was on page 2+, it disappeared from the observed data, making `selectedDetails` null and the detail pane empty. The list scroll position near the bottom of the now-shorter list would trigger `onEndOfBookingsListReached()`, cascading pagination loads until the selected booking's page was eventually re-loaded — explaining the delay before the detail re-appeared.

**Fix:** For operations that affect a single known booking (payment completed, note saved, refund dismissed, booking cancelled), we now call `fetchBooking(bookingId)` instead of doing a full list refresh. This fetches just that one booking from the API and writes it to Room, where `bookingsFlow` automatically picks up the change. Pagination state, list position, and selection are all preserved.

### Test Steps

1. Open POS Bookings with enough bookings to have multiple pages (25+ for a single day)
2. Scroll down to load page 2+ and select a booking
3. Complete a payment on that booking
4. Verify the detail pane updates immediately without going blank
5. Verify the list stays at the same scroll position and the booking gets updated
6. Repeat with: adding a booking note, dismissing a refund dialog, and cancelling a booking


Before:

https://github.com/user-attachments/assets/a19de3cd-3b74-4fad-99ea-87ebf9137f35

After:

https://github.com/user-attachments/assets/7688713f-66ad-43ad-a45e-bb08238cf07a



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.