### PR TITLE
[WOOMOB-2336] Align canceled spelling in POS and Bookings

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4433,7 +4433,7 @@
     <string name="booking_note_screen_title">Booking note</string>
     <string name="booking_note_screen_done">DONE</string>
     <string name="booking_note_screen_update_error">Error saving booking note</string>
-    <string name="booking_cancel_error">Error cancelling the booking</string>
+    <string name="booking_cancel_error">Error canceling the booking</string>
     <string name="booking_mark_as_paid_error">Error marking the booking as paid</string>
     <string name="booking_not_selected">Booking not selected</string>
     <string name="booking_overflow_refund">Issue refund</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3906,7 +3906,7 @@
     <string name="woopos_orders_status_processing">Processing</string>
     <string name="woopos_orders_status_on_hold">On hold</string>
     <string name="woopos_orders_status_failed">Failed</string>
-    <string name="woopos_orders_status_cancelled">Cancelled</string>
+    <string name="woopos_orders_status_cancelled">Canceled</string>
     <string name="woopos_orders_status_completed">Completed</string>
     <string name="woopos_orders_status_refunded">Refunded</string>
 
@@ -3928,7 +3928,7 @@
     <string name="woopos_bookings_payment_status_failed">Failed</string>
     <string name="woopos_bookings_payment_status_refunded">Refunded</string>
     <string name="woopos_bookings_payment_status_partially_refunded">Partially Refunded</string>
-    <string name="woopos_bookings_status_cancelled">Cancelled</string>
+    <string name="woopos_bookings_status_cancelled">Canceled</string>
     <string name="woopos_bookings_details_attendance_title">Attendance status</string>
     <string name="woopos_bookings_details_attendance_hint">Mark attendance to keep your reports accurate and spot booking trends.</string>
     <string name="woopos_bookings_details_payment_title">Payment</string>
@@ -4391,7 +4391,7 @@
     <string name="booking_payment_status_unpaid">Unpaid</string>
     <string name="booking_payment_status_paid">Paid</string>
     <string name="booking_payment_status_pending_confirmation">Pending Confirmation</string>
-    <string name="booking_payment_status_cancelled">Cancelled</string>
+    <string name="booking_payment_status_cancelled">Canceled</string>
     <string name="booking_payment_status_in_cart">In Cart</string>
     <string name="booking_payment_status_confirmed">Confirmed</string>
     <string name="booking_payment_status_complete">Complete</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -110,7 +110,7 @@ class WooPosOrdersViewModelTest {
         whenever(resourceProvider.getString(R.string.woopos_orders_status_processing)).thenReturn("Processing")
         whenever(resourceProvider.getString(R.string.woopos_orders_status_on_hold)).thenReturn("On hold")
         whenever(resourceProvider.getString(R.string.woopos_orders_status_failed)).thenReturn("Failed")
-        whenever(resourceProvider.getString(R.string.woopos_orders_status_cancelled)).thenReturn("Cancelled")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_cancelled)).thenReturn("Canceled")
         whenever(resourceProvider.getString(R.string.woopos_orders_status_completed)).thenReturn("Completed")
         whenever(resourceProvider.getString(R.string.woopos_orders_status_refunded)).thenReturn("Refunded")
         whenever(resourceProvider.getString(R.string.woopos_orders_loading_error_message))


### PR DESCRIPTION
### Description
Fixes WOOMOB-2336

Aligns all POS and Bookings status labels to use "Canceled" (single L, American English). Changes 3 string resources from "Cancelled" to "Canceled" and updates the corresponding test mock.

### Test Steps
1. Open the POS and create/view an order with a "Canceled" status — verify it shows "Canceled" (not "Cancelled")
2. Open the POS Bookings tab and view a canceled booking — verify the badge shows "Canceled"
3. Open the Bookings tab (non-POS) and view a booking with canceled payment status — verify it shows "Canceled"

### Images/gif
—

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.