### PR TITLE
WOOMOB-2321: Hide store setup card on CIAB sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
@@ -11,5 +11,6 @@ enum class CIABAffectedFeature {
     CompositeProducts,
     GiftCardEditing,
     ProductsStockDashboardCard,
+    Onboarding,
     POS
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveOnboardingWidgetStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveOnboardingWidgetStatus.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.dashboard.data
 
 import com.woocommerce.android.R
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.onboarding.ShouldShowOnboarding
@@ -17,12 +19,18 @@ import javax.inject.Inject
 class ObserveOnboardingWidgetStatus @Inject constructor(
     private val selectedSite: SelectedSite,
     private val storeOnboardingRepository: StoreOnboardingRepository,
-    private val shouldShowOnboarding: ShouldShowOnboarding
+    private val shouldShowOnboarding: ShouldShowOnboarding,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
     operator fun invoke() = selectedSite.observe()
         .filterNotNull()
         .transformLatest {
+            if (ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.Onboarding)) {
+                emit(DashboardWidget.Status.Hidden)
+                return@transformLatest
+            }
+
             // Start with the cached value
             if (shouldShowOnboarding.isOnboardingMarkedAsCompleted()) {
                 emit(DashboardWidget.Status.Unavailable(R.string.my_store_widget_onboarding_completed))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveOnboardingWidgetStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveOnboardingWidgetStatusTest.kt
@@ -1,0 +1,86 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.onboarding.ShouldShowOnboarding
+import com.woocommerce.android.ui.onboarding.StoreOnboardingRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.SiteModel
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObserveOnboardingWidgetStatusTest : BaseUnitTest() {
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureUnsupported(any()) } doReturn false
+    }
+    private val shouldShowOnboarding: ShouldShowOnboarding = mock()
+    private val storeOnboardingRepository: StoreOnboardingRepository = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { observe() } doReturn flowOf(SiteModel())
+    }
+
+    private val sut = ObserveOnboardingWidgetStatus(
+        selectedSite,
+        storeOnboardingRepository,
+        shouldShowOnboarding,
+        ciabSiteGateKeeper
+    )
+
+    @Test
+    fun `given CIAB feature unsupported, when observing onboarding widget status, then status is Hidden`() =
+        testBlocking {
+            given(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.Onboarding))
+                .willReturn(true)
+
+            val status = sut().first()
+
+            assertThat(status).isEqualTo(DashboardWidget.Status.Hidden)
+        }
+
+    @Test
+    fun `given CIAB feature supported and onboarding not completed, when observing, then status is Available`() =
+        testBlocking {
+            given(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.Onboarding))
+                .willReturn(false)
+            given(shouldShowOnboarding.isOnboardingMarkedAsCompleted())
+                .willReturn(false)
+            given(storeOnboardingRepository.observeOnboardingTasks())
+                .willReturn(flowOf(emptyList()))
+            given(shouldShowOnboarding.showForTasks(emptyList()))
+                .willReturn(true)
+
+            val status = sut().first()
+
+            assertThat(status).isEqualTo(DashboardWidget.Status.Available)
+        }
+
+    @Test
+    fun `given CIAB feature supported and onboarding completed, when observing, then status is Unavailable`() =
+        testBlocking {
+            given(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.Onboarding))
+                .willReturn(false)
+            given(shouldShowOnboarding.isOnboardingMarkedAsCompleted())
+                .willReturn(true)
+            given(storeOnboardingRepository.observeOnboardingTasks())
+                .willReturn(flowOf(emptyList()))
+            given(shouldShowOnboarding.showForTasks(emptyList()))
+                .willReturn(false)
+
+            val status = sut().first()
+
+            assertThat(status).isEqualTo(
+                DashboardWidget.Status.Unavailable(R.string.my_store_widget_onboarding_completed)
+            )
+        }
+}


### PR DESCRIPTION
Fixes: WOOMOB-2321

### Description
The store setup (onboarding) card on the Dashboard doesn't align with the CIAB onboarding flow and its "Get paid" links direct to WP Admin, which is inappropriate for CIAB sites.

This hides the onboarding card entirely on CIAB sites using the established CIAB feature gating pattern:

- Add `Onboarding` to the `CIABAffectedFeature` enum (automatically unsupported on CIAB via the `else` branch in `CIABSiteGateKeeper`)
- Check CIAB support in `ObserveOnboardingWidgetStatus` and return `Hidden` status for CIAB sites — same pattern as `ObserveStockWidgetStatus`


### Test Steps
1. Connect to a CIAB site
2. Navigate to the Dashboard
3. Verify the store setup card is not displayed
4. Switch to a non-CIAB site
5. Verify the store setup card appears as expected (if onboarding tasks remain)

### Images/gif


https://github.com/user-attachments/assets/4d819fb7-ec07-4d31-83f7-677928e9e617



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary.