### PR TITLE
Enable BOOKINGS_MVP feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 24.2
 -----
 - Add support for signing in using passkeys for WordPress.com accounts during Jetpack Setup [https://github.com/woocommerce/woocommerce-android/pull/15379]
+- [Internal] Enable Bookings MVP for CIAB sites [https://github.com/woocommerce/woocommerce-android/pull/15445]
 
 24.1
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -37,10 +37,11 @@ enum class FeatureFlag {
                 PackageUtils.isDebugBuild() || context != null && PackageUtils.isBetaBuild(context)
             }
 
+            BOOKINGS_MVP -> true
+
             WC_SHIPPING_BANNER,
             BETTER_CUSTOMER_SEARCH_M2,
             ORDER_CREATION_AUTO_TAX_RATE,
-            BOOKINGS_MVP,
             POS_PRODUCTS_FTS,
             POS_REFUNDS,
             WOO_POS_CLIENT_SIDE_BANNER,


### PR DESCRIPTION
### Description
Enable the `BOOKINGS_MVP` feature flag for all build types so that the Bookings tab is visible in production for CIAB sites.

### Test Steps
1. Install release app on a device/emulator connected to a CIAB site
2. Verify the Bookings tab appears in the bottom navigation
3. Verify bookings list loads and booking details are accessible

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.