### PR TITLE
[WOOMOB-2341] Use 1-second inclusive bounds for bookings date range

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -10,7 +10,6 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.utils.extensions.filterNotNull
 import org.wordpress.android.fluxc.utils.extensions.putIfNotNull
-import java.time.ZoneOffset
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -162,14 +161,11 @@ class BookingsRestClient @Inject constructor(
         if (paymentStatus != null) TODO()
         if (customer != null) set("customer", customer.customerId.toString())
         if (dateRange != BookingsFilterOption.DateRange.DEFAULT) {
-            // Plus/minus one second to make the range inclusive
             dateRange.before?.let {
-                val inclusiveBefore = it.atZone(ZoneOffset.UTC).plusSeconds(1).toInstant()
-                set("start_date_before", inclusiveBefore.toString())
+                set("start_date_before", it.toString())
             }
             dateRange.after?.let {
-                val inclusiveAfter = it.atZone(ZoneOffset.UTC).minusSeconds(1).toInstant()
-                set("start_date_after", inclusiveAfter.toString())
+                set("start_date_after", it.toString())
             }
         }
         if (location != null) TODO()

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -162,13 +162,13 @@ class BookingsRestClient @Inject constructor(
         if (paymentStatus != null) TODO()
         if (customer != null) set("customer", customer.customerId.toString())
         if (dateRange != BookingsFilterOption.DateRange.DEFAULT) {
-            // Plus/minus one minute to make the range inclusive
+            // Plus/minus one second to make the range inclusive
             dateRange.before?.let {
-                val inclusiveBefore = it.atZone(ZoneOffset.UTC).plusMinutes(1).toInstant()
+                val inclusiveBefore = it.atZone(ZoneOffset.UTC).plusSeconds(1).toInstant()
                 set("start_date_before", inclusiveBefore.toString())
             }
             dateRange.after?.let {
-                val inclusiveAfter = it.atZone(ZoneOffset.UTC).minusMinutes(1).toInstant()
+                val inclusiveAfter = it.atZone(ZoneOffset.UTC).minusSeconds(1).toInstant()
                 set("start_date_after", inclusiveAfter.toString())
             }
         }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -36,7 +36,8 @@ class BookingsStore @Inject internal constructor(
         order: BookingsOrderOption
     ): WooResult<BookingsFetchResult> {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchBookings") {
-            val response = bookingsRestClient.fetchBookings(site, perPage, page, query, filters, order)
+            val restFilters = filters.withInclusiveDateRangeOffset()
+            val response = bookingsRestClient.fetchBookings(site, perPage, page, query, restFilters, order)
             when {
                 response.isError -> WooResult(response.error)
                 response.result != null -> {
@@ -293,4 +294,13 @@ class BookingsStore @Inject internal constructor(
         }
         return entity
     }
+}
+
+private fun BookingFilters.withInclusiveDateRangeOffset(): BookingFilters {
+    return copy(
+        dateRange = dateRange.copy(
+            before = dateRange.before?.plusSeconds(1),
+            after = dateRange.after?.minusSeconds(1),
+        )
+    )
 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStoreTest.kt
@@ -6,6 +6,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -184,12 +185,12 @@ class BookingsStoreTest {
             )
             whenever(
                 bookingsRestClient.fetchBookings(
-                    site,
-                    perPage = 25,
-                    page = 1,
-                    query = null,
-                    filters = filters,
-                    order = BookingsOrderOption.DESC
+                    site = eq(site),
+                    perPage = eq(25),
+                    page = eq(1),
+                    query = eq(null),
+                    filters = any(),
+                    order = eq(BookingsOrderOption.DESC)
                 )
             ).thenReturn(WooPayload(arrayOf(dto)))
             whenever(headersParser.getTotalPages(any())).thenReturn(null)
@@ -227,12 +228,12 @@ class BookingsStoreTest {
             )
             whenever(
                 bookingsRestClient.fetchBookings(
-                    site,
-                    perPage = 25,
-                    page = 1,
-                    query = null,
-                    filters = filters,
-                    order = BookingsOrderOption.DESC
+                    site = eq(site),
+                    perPage = eq(25),
+                    page = eq(1),
+                    query = eq(null),
+                    filters = any(),
+                    order = eq(BookingsOrderOption.DESC)
                 )
             ).thenReturn(WooPayload(arrayOf(dto)))
             whenever(headersParser.getTotalPages(any())).thenReturn(null)
@@ -270,12 +271,12 @@ class BookingsStoreTest {
             )
             whenever(
                 bookingsRestClient.fetchBookings(
-                    site,
-                    perPage = 25,
-                    page = 1,
-                    query = null,
-                    filters = filters,
-                    order = BookingsOrderOption.DESC
+                    site = eq(site),
+                    perPage = eq(25),
+                    page = eq(1),
+                    query = eq(null),
+                    filters = any(),
+                    order = eq(BookingsOrderOption.DESC)
                 )
             ).thenReturn(WooPayload(arrayOf(dto)))
             whenever(headersParser.getTotalPages(any())).thenReturn(null)
@@ -313,12 +314,12 @@ class BookingsStoreTest {
             )
             whenever(
                 bookingsRestClient.fetchBookings(
-                    site,
-                    perPage = 25,
-                    page = 2,
-                    query = null,
-                    filters = filters,
-                    order = BookingsOrderOption.DESC
+                    site = eq(site),
+                    perPage = eq(25),
+                    page = eq(2),
+                    query = eq(null),
+                    filters = any(),
+                    order = eq(BookingsOrderOption.DESC)
                 )
             )
                 .thenReturn(WooPayload(arrayOf(dto)))
@@ -387,18 +388,18 @@ class BookingsStoreTest {
             // given
             val site = SiteModel().apply { id = TEST_LOCAL_SITE_ID.value }
             val dto = sampleBookingDto().copy(orderId = 0L)
-            val filters = BookingFilters(
+            val requestedFilters = BookingFilters(
                 dateRange = BookingsFilterOption.DateRange(before = Instant.now(), after = Instant.now()),
                 customer = BookingsFilterOption.Customer(customerId = 1L, customerName = "name"),
             )
             whenever(
                 bookingsRestClient.fetchBookings(
-                    site,
-                    perPage = 25,
-                    page = 1,
-                    query = null,
-                    filters = filters,
-                    order = BookingsOrderOption.DESC
+                    site = eq(site),
+                    perPage = eq(25),
+                    page = eq(1),
+                    query = eq(null),
+                    filters = any(),
+                    order = eq(BookingsOrderOption.DESC)
                 )
             ).thenReturn(WooPayload(arrayOf(dto)))
             whenever(headersParser.getTotalPages(any())).thenReturn(null)
@@ -409,15 +410,27 @@ class BookingsStoreTest {
                 perPage = 25,
                 page = 1,
                 query = null,
-                filters = filters,
+                filters = requestedFilters,
                 order = BookingsOrderOption.DESC
             )
 
             // then
             assertThat(result.isError).isFalse()
+            verify(bookingsRestClient).fetchBookings(
+                site = eq(site),
+                perPage = eq(25),
+                page = eq(1),
+                query = eq(null),
+                filters = argThat {
+                    dateRange.before == requestedFilters.dateRange.before?.plusSeconds(1) &&
+                        dateRange.after == requestedFilters.dateRange.after?.minusSeconds(1) &&
+                        customer == requestedFilters.customer
+                },
+                order = eq(BookingsOrderOption.DESC)
+            )
             verify(bookingsDao).cleanAndUpsertBookings(
                 any(),
-                any<BookingFilters>(),
+                eq(requestedFilters),
                 any<List<BookingEntity>>()
             )
         }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2341
This updates bookings date-range query normalization from +/-1 minute to +/-1 second when building request parameters.
The matches the duration with iOS.

### Test Steps
1. Log in to a CIAB site.
2. Note a time from a booking, (for example at`07:09` on a given date, `2026-02-22 07:09:00`).
3. Open Bookings (or POS Bookings) and set the date filter start to `07:09`.
4. Verify the `07:09` booking is visible in the list.
5. Change start to `07:10` and verify the same booking is no longer included.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.