### PR TITLE
Change booking fetch order to descending in ObserveBookingsVisibility

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibility.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibility.kt
@@ -84,7 +84,7 @@ class ObserveBookingsVisibility @Inject constructor(
             bookingsRepository.fetchBookings(
                 page = 1,
                 perPage = 25,
-                order = BookingsOrderOption.ASC
+                order = BookingsOrderOption.DESC
             ).onFailure {
                 WooLog.w(WooLog.T.BOOKINGS, "Failed to fetch bookings")
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses, e.g., WOOMOB-373. -->
Closes WOOMOB-2345

### Description
@malinajirka identified a problem with retrieving the oldest bookings at app launch to decide the visibility of the bookings tab: after fetching the oldest bookings, the cache is cleared, and since the Today tab is shown first, the bookings for today are often missing. (discussion pdfdoF-8Kf-p2#comment-10146)

This PR changes the order parameter to make sure we fetch the newest bookings first.

**Note:** this won't solve the issue completely, because if the store has more than 25 bookings that are set for future dates, we'll hit the same issue, but it will just make the occuring less likely to happen. We have another ticket to look into disabling the fetch completely WOOMOB-2344

### Test Steps
1. Make sure your store has more than 25 bookings in the past.
2. Open the app and navigate to bookings screen (Today tab).
3. Close and re-open the app.
4. Navigate to bookings tab.
5. Confirm that Today bookings were kept in the cache.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

<!-- Pull request guidelines: https://github.com/woocommerce/woocommerce-android/blob/develop/docs/pull-request-guidelines.md -->