### PR TITLE
Update release notes for 24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!--
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
+## 24.2
+Signing in just got easier and more secure! This update adds passkey support for WordPress.com accounts during Jetpack setup, so you can skip the password and log in with a tap. We also introduced booking management for eligible stores, helping you handle appointments right from the app.
+
 ## 24.1
 We've made some under-the-hood improvements to make your WooCommerce experience even better. No flashy new features this time—just good old-fashioned maintenance to keep things running smoothly.
 Thanks for selling with WooCommerce! 🚀

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,2 +1,1 @@
-- Add support for signing in using passkeys for WordPress.com accounts during Jetpack Setup [https://github.com/woocommerce/woocommerce-android/pull/15379]
-- [Internal] Enable Bookings MVP for CIAB sites [https://github.com/woocommerce/woocommerce-android/pull/15445]
+Signing in just got easier and more secure! This update adds passkey support for WordPress.com accounts during Jetpack setup, so you can skip the password and log in with a tap. We also introduced booking management for eligible stores, helping you handle appointments right from the app.


### PR DESCRIPTION
## Summary
- Updated `fastlane/metadata/android/en-US/changelogs/default.txt` with user-friendly release notes for 24.2
- Added the same copy to the top of `CHANGELOG.md`
- No Wear OS changes in this release, so `fastlane/metadata/wear/en-US/changelogs/default.txt` was not modified

## Test plan
- [x] Verify the changelog text in `fastlane/metadata/android/en-US/changelogs/default.txt` reads well
- [x] Verify `CHANGELOG.md` has the 24.2 entry at the top