### PR TITLE
[WOOMOB-2349] Disable partial refunds in POS bookings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -203,7 +203,8 @@ private fun WooPosBookingsScreen(
                         orderId = dialogState.orderId,
                         onDismissRequest = onIssueRefundDialogDismissed,
                         onNavigationEvent = onNavigationEvent,
-                        refundReasonUpdate = refundReasonUpdate
+                        refundReasonUpdate = refundReasonUpdate,
+                        disablePartialRefund = true
                     )
                 }
                 WooPosBookingsState.Content.DialogState.Hidden -> Unit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundDialog.kt
@@ -66,7 +66,8 @@ fun WooPosIssueRefundDialog(
     orderId: Long,
     onDismissRequest: () -> Unit,
     onNavigationEvent: (WooPosNavigationEvent) -> Unit,
-    refundReasonUpdate: String? = null
+    refundReasonUpdate: String? = null,
+    disablePartialRefund: Boolean = false
 ) {
     val viewModel: WooPosRefundViewModel =
         hiltViewModel<WooPosRefundViewModel, WooPosRefundViewModel.Factory>(key = "refund_$orderId") { factory ->
@@ -115,7 +116,8 @@ fun WooPosIssueRefundDialog(
                 orderId = orderId,
                 viewModel = viewModel,
                 onNavigationEvent = onNavigationEvent,
-                onEvent = handleEvent
+                onEvent = handleEvent,
+                disablePartialRefund = disablePartialRefund
             )
             is WooPosRefundState.Error -> ErrorContent(currentState, handleEvent, handleDismiss)
             is WooPosRefundState.NoRefundableItems -> NoItemsContent(handleDismiss)
@@ -134,7 +136,8 @@ private fun ContentStateHandler(
     orderId: Long,
     viewModel: WooPosRefundViewModel,
     onNavigationEvent: (WooPosNavigationEvent) -> Unit,
-    onEvent: (WooPosRefundUIEvent) -> Unit
+    onEvent: (WooPosRefundUIEvent) -> Unit,
+    disablePartialRefund: Boolean = false
 ) {
     when (state.step) {
         WooPosRefundState.Content.RefundStep.SelectItems -> {
@@ -143,7 +146,8 @@ private fun ContentStateHandler(
                 onEvent = onEvent,
                 onContinue = {
                     viewModel.onUIEvent(WooPosRefundUIEvent.ContinueToReviewClicked)
-                }
+                },
+                disableItemSelection = disablePartialRefund
             )
         }
 
@@ -163,7 +167,8 @@ private fun ContentStateHandler(
                             initialReason = state.refundReason
                         )
                     )
-                }
+                },
+                showEditRefundButton = !disablePartialRefund
             )
         }
 
@@ -397,7 +402,8 @@ private fun RefundSuccessContent(
 private fun SelectItemsContent(
     state: WooPosRefundState.Content,
     onEvent: (WooPosRefundUIEvent) -> Unit,
-    onContinue: () -> Unit
+    onContinue: () -> Unit,
+    disableItemSelection: Boolean = false
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         RefundDialogHeader()
@@ -405,7 +411,8 @@ private fun SelectItemsContent(
         ItemsHeaderRow(
             allItemsSelected = state.allItemsSelected,
             selectedCount = state.selectedItemIds.size,
-            onSelectAllToggled = { onEvent(WooPosRefundUIEvent.SelectAllToggled) }
+            onSelectAllToggled = { onEvent(WooPosRefundUIEvent.SelectAllToggled) },
+            enabled = !disableItemSelection
         )
 
         Divider()
@@ -421,7 +428,8 @@ private fun SelectItemsContent(
                 RefundableItemRow(
                     item = item,
                     isSelected = item.uniqueId in state.selectedItemIds,
-                    onItemClick = { onEvent(WooPosRefundUIEvent.ItemSelectionToggled(item.uniqueId)) }
+                    onItemClick = { onEvent(WooPosRefundUIEvent.ItemSelectionToggled(item.uniqueId)) },
+                    enabled = !disableItemSelection
                 )
                 if (index < state.refundableItems.lastIndex) {
                     Divider()
@@ -464,7 +472,8 @@ private fun RefundDialogHeader() {
 private fun ItemsHeaderRow(
     allItemsSelected: Boolean,
     selectedCount: Int,
-    onSelectAllToggled: () -> Unit
+    onSelectAllToggled: () -> Unit,
+    enabled: Boolean = true
 ) {
     val selectAllContentDescription = stringResource(R.string.order_refunds_items_select_all)
     Row(
@@ -476,6 +485,7 @@ private fun ItemsHeaderRow(
         Checkbox(
             checked = allItemsSelected,
             onCheckedChange = { onSelectAllToggled() },
+            enabled = enabled,
             modifier = Modifier
                 .size(32.dp)
                 .semantics {
@@ -509,23 +519,31 @@ private fun ItemsHeaderRow(
 private fun RefundableItemRow(
     item: WooPosRefundableItem,
     isSelected: Boolean,
-    onItemClick: () -> Unit
+    onItemClick: () -> Unit,
+    enabled: Boolean = true
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = WooPosSpacing.XSmall.value)
             .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                onClick = onItemClick
+            .then(
+                if (enabled) {
+                    Modifier.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onItemClick
+                    )
+                } else {
+                    Modifier
+                }
             ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Checkbox(
             checked = isSelected,
             onCheckedChange = { onItemClick() },
+            enabled = enabled,
             modifier = Modifier
                 .size(32.dp)
                 .semantics {
@@ -573,7 +591,8 @@ private fun ReviewRefundContent(
     state: WooPosRefundState.Content,
     onContinue: () -> Unit,
     onEditRefund: () -> Unit,
-    onEditReason: () -> Unit
+    onEditReason: () -> Unit,
+    showEditRefundButton: Boolean = true
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         ReviewRefundHeader()
@@ -661,7 +680,8 @@ private fun ReviewRefundContent(
 
         ReviewActionButtons(
             onContinue = onContinue,
-            onEditRefund = onEditRefund
+            onEditRefund = onEditRefund,
+            showEditRefundButton = showEditRefundButton
         )
     }
 }
@@ -709,7 +729,8 @@ private fun ReviewSummaryRow(
 @Composable
 private fun ReviewActionButtons(
     onContinue: () -> Unit,
-    onEditRefund: () -> Unit
+    onEditRefund: () -> Unit,
+    showEditRefundButton: Boolean = true
 ) {
     Column(
         modifier = Modifier
@@ -722,11 +743,13 @@ private fun ReviewActionButtons(
             onClick = onContinue,
             modifier = Modifier.fillMaxWidth()
         )
-        WooPosOutlinedButton(
-            text = stringResource(R.string.woopos_orders_edit_refund),
-            onClick = onEditRefund,
-            modifier = Modifier.fillMaxWidth()
-        )
+        if (showEditRefundButton) {
+            WooPosOutlinedButton(
+                text = stringResource(R.string.woopos_orders_edit_refund),
+                onClick = onEditRefund,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Fixes WOOMOB-2349

Do not merge - we are targeting 24.2 but we plan to target hotfix branch when it is available.

### Description


Partial refunds are broken on the backend for bookings. This disables item selection in the refund dialog when issuing a refund from POS booking detail, so the user always refunds all items. The POS orders refund flow is unchanged.

### Test Steps

**Bookings refund flow (partial refund disabled):**
1. Open the POS bookings screen
2. Select a paid booking that is in an order with multiple bookins and tap "Issue Refund"
3. Verify the item selection step shows all items checked with **disabled checkboxes** (greyed out, not tappable)
4. Verify tapping on individual items or the "Select All" checkbox does nothing
5. Tap "Continue" to proceed to the review step
6. Verify there is **no "Edit Refund" button** on the review step
7. Continue through the confirm and complete the refund flow normally

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.