### PR TITLE
[WOOMOB-2347] Optimize booking location loading

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -61,6 +61,18 @@ class BookingsRepository @Inject constructor(
             order = order
         )
 
+    suspend fun getBookingsList(
+        limit: Int? = null,
+        filters: BookingFilters? = null,
+        order: BookingsOrderOption
+    ): List<Booking> =
+        bookingsStore.getBookings(
+            site = selectedSite.get(),
+            limit = limit,
+            filters = filters,
+            order = order
+        )
+
     fun observeBookingsCount(): Flow<Long> = bookingsStore.observeBookingCount(site = selectedSite.get())
 
     fun observeBooking(bookingId: Long): Flow<Booking?> =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandler.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
@@ -38,6 +40,13 @@ class BookingListHandler @Inject constructor(
 
     private val searchResults = MutableStateFlow(emptyList<Booking>())
 
+    private data class QueryParams(
+        val searchQuery: String?,
+        val filters: BookingFilters,
+        val page: Int,
+        val sortBy: BookingListSortOption
+    )
+
     @OptIn(ExperimentalCoroutinesApi::class)
     val bookingsFlow: Flow<List<Booking>> = combine(
         searchQuery,
@@ -45,16 +54,32 @@ class BookingListHandler @Inject constructor(
         page,
         sortBy
     ) { query, filters, page, sortBy ->
-        if (query.isNullOrEmpty()) {
-            bookingsRepository.observeBookings(
-                limit = page * PAGE_SIZE,
-                filters = filters,
-                order = sortBy.toBookingsOrderOption()
-            )
+        QueryParams(query, filters, page, sortBy)
+    }.flatMapLatest { params ->
+        if (params.searchQuery.isNullOrEmpty()) {
+            val limit = params.page * PAGE_SIZE
+            val order = params.sortBy.toBookingsOrderOption()
+            flow {
+                // Emit a snapshot from the DB immediately so cached data shows without delay
+                val snapshot = bookingsRepository.getBookingsList(
+                    limit = limit,
+                    filters = params.filters,
+                    order = order
+                )
+                emit(snapshot)
+                // Then subscribe to Room flow for ongoing updates
+                emitAll(
+                    bookingsRepository.observeBookings(
+                        limit = limit,
+                        filters = params.filters,
+                        order = order
+                    )
+                )
+            }
         } else {
-            searchResults.map { it.take(page * PAGE_SIZE) }
+            searchResults.map { it.take(params.page * PAGE_SIZE) }
         }
-    }.flatMapLatest { it }
+    }
 
     suspend fun loadBookings(
         searchQuery: String? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -161,9 +161,10 @@ class WooPosBookingsViewModel @Inject constructor(
                     return@collectLatest
                 }
 
-                val isFetchingContent = current is WooPosBookingsState.Content &&
-                    (current.items is WooPosBookingsState.Content.Items.Loading || fetchJob?.isActive == true)
-                if (bookings.isEmpty() && isFetchingContent) {
+                if (bookings.isEmpty() && current is WooPosBookingsState.Content && fetchJob?.isActive == true) {
+                    _state.value = current.copy(
+                        items = WooPosBookingsState.Content.Items.Loading,
+                    )
                     return@collectLatest
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -105,8 +105,7 @@ class WooPosBookingsViewModel @Inject constructor(
                             message = error.message ?: "Failed to load bookings"
                         )
                     }
-                    current is WooPosBookingsState.Content &&
-                        current.items is WooPosBookingsState.Content.Items.Loading -> {
+                    current is WooPosBookingsState.Content -> {
                         _state.value = current.copy(
                             items = WooPosBookingsState.Content.Items.Error(
                                 title = resourceProvider.getString(
@@ -126,8 +125,7 @@ class WooPosBookingsViewModel @Inject constructor(
                     current is WooPosBookingsState.Loading -> {
                         _state.value = buildNothingFoundState()
                     }
-                    current is WooPosBookingsState.Content &&
-                        current.items is WooPosBookingsState.Content.Items.Loading -> {
+                    current is WooPosBookingsState.Content -> {
                         _state.value = current.copy(
                             items = WooPosBookingsState.Content.Items.NothingFound(
                                 title = resourceProvider.getString(
@@ -164,7 +162,8 @@ class WooPosBookingsViewModel @Inject constructor(
                 }
 
                 if (bookings.isEmpty() && current is WooPosBookingsState.Content &&
-                    current.items is WooPosBookingsState.Content.Items.Loading
+                    (current.items is WooPosBookingsState.Content.Items.Loading ||
+                        fetchJob?.isActive == true)
                 ) {
                     return@collectLatest
                 }
@@ -671,7 +670,6 @@ class WooPosBookingsViewModel @Inject constructor(
         selectedBookingId = null
         _state.value = when (val current = _state.value) {
             is WooPosBookingsState.Content -> current.copy(
-                items = WooPosBookingsState.Content.Items.Loading,
                 dateSelectorState = buildDateSelectorState(),
                 selectedDetails = null,
                 pullToRefreshState = WooPosPullToRefreshState.Disabled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -161,10 +161,9 @@ class WooPosBookingsViewModel @Inject constructor(
                     return@collectLatest
                 }
 
-                if (bookings.isEmpty() && current is WooPosBookingsState.Content &&
-                    (current.items is WooPosBookingsState.Content.Items.Loading ||
-                        fetchJob?.isActive == true)
-                ) {
+                val isFetchingContent = current is WooPosBookingsState.Content &&
+                    (current.items is WooPosBookingsState.Content.Items.Loading || fetchJob?.isActive == true)
+                if (bookings.isEmpty() && isFetchingContent) {
                     return@collectLatest
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import org.wordpress.android.fluxc.persistence.entity.BookingResourceEntity
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -191,8 +192,6 @@ class WooPosBookingsViewModel @Inject constructor(
                     selectedBookingId = bookings.first().id.value
                 }
 
-                fetchBookingLocations(bookings)
-
                 val items = bookings.associate { booking ->
                     val resource = resourcesMap[booking.resourceId]
                     mapper.mapToItemViewState(booking, selectedBookingId, resource) to
@@ -227,8 +226,42 @@ class WooPosBookingsViewModel @Inject constructor(
                     dialogState = currentContentState?.dialogState
                         ?: WooPosBookingsState.Content.DialogState.Hidden
                 )
+
+                val hasMissingLocations = bookings.any {
+                    it.productId != 0L && it.productId !in locationCache
+                }
+                if (hasMissingLocations) {
+                    fetchBookingLocations(bookings)
+                    rebuildStateWithLocations(bookings, resourcesMap)
+                }
             }
         }
+    }
+
+    private suspend fun rebuildStateWithLocations(
+        bookings: List<BookingEntity>,
+        resourcesMap: Map<Long, BookingResourceEntity>
+    ) {
+        val currentState = _state.value as? WooPosBookingsState.Content ?: return
+
+        val items = bookings.associate { booking ->
+            val resource = resourcesMap[booking.resourceId]
+            mapper.mapToItemViewState(booking, selectedBookingId, resource) to
+                mapper.mapToDetailsViewState(
+                    booking,
+                    resource?.name,
+                    locationCache[booking.productId]
+                )
+        }
+
+        val selectedDetails = selectedBookingId?.let { id ->
+            items.entries.find { it.key.id == id }?.value
+        }
+
+        _state.value = currentState.copy(
+            items = WooPosBookingsState.Content.Items.Loaded(items),
+            selectedDetails = selectedDetails,
+        )
     }
 
     fun onBookingSelected(bookingId: Long) {
@@ -636,7 +669,6 @@ class WooPosBookingsViewModel @Inject constructor(
     private fun handleDateChange(newDate: LocalDate) {
         selectedDate = newDate
         selectedBookingId = null
-        locationCache.clear()
         _state.value = when (val current = _state.value) {
             is WooPosBookingsState.Content -> current.copy(
                 items = WooPosBookingsState.Content.Items.Loading,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -149,7 +149,7 @@ class WooPosBookingsViewModel @Inject constructor(
         }
     }
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "CyclomaticComplexMethod")
     private fun observeBookings() {
         viewModelScope.launch {
             combine(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -237,32 +237,6 @@ class WooPosBookingsViewModel @Inject constructor(
         }
     }
 
-    private suspend fun rebuildStateWithLocations(
-        bookings: List<BookingEntity>,
-        resourcesMap: Map<Long, BookingResourceEntity>
-    ) {
-        val currentState = _state.value as? WooPosBookingsState.Content ?: return
-
-        val items = bookings.associate { booking ->
-            val resource = resourcesMap[booking.resourceId]
-            mapper.mapToItemViewState(booking, selectedBookingId, resource) to
-                mapper.mapToDetailsViewState(
-                    booking,
-                    resource?.name,
-                    locationCache[booking.productId]
-                )
-        }
-
-        val selectedDetails = selectedBookingId?.let { id ->
-            items.entries.find { it.key.id == id }?.value
-        }
-
-        _state.value = currentState.copy(
-            items = WooPosBookingsState.Content.Items.Loaded(items),
-            selectedDetails = selectedDetails,
-        )
-    }
-
     fun onBookingSelected(bookingId: Long) {
         viewModelScope.launch { analyticsTracker.trackListItemTapped() }
         selectedBookingId = bookingId
@@ -663,6 +637,32 @@ class WooPosBookingsViewModel @Inject constructor(
                 }.awaitAll()
             }
         }
+    }
+
+    private suspend fun rebuildStateWithLocations(
+        bookings: List<BookingEntity>,
+        resourcesMap: Map<Long, BookingResourceEntity>
+    ) {
+        val currentState = _state.value as? WooPosBookingsState.Content ?: return
+
+        val items = bookings.associate { booking ->
+            val resource = resourcesMap[booking.resourceId]
+            mapper.mapToItemViewState(booking, selectedBookingId, resource) to
+                mapper.mapToDetailsViewState(
+                    booking,
+                    resource?.name,
+                    locationCache[booking.productId]
+                )
+        }
+
+        val selectedDetails = selectedBookingId?.let { id ->
+            items.entries.find { it.key.id == id }?.value
+        }
+
+        _state.value = currentState.copy(
+            items = WooPosBookingsState.Content.Items.Loaded(items),
+            selectedDetails = selectedDetails,
+        )
     }
 
     private fun handleDateChange(newDate: LocalDate) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
@@ -40,6 +40,10 @@ class BookingListHandlerTest : BaseUnitTest() {
             val limit = invocation.getArgument<Int>(0)
             results.map { it.take(limit) }
         }
+        onBlocking { getBookingsList(any(), anyOrNull(), any()) } doAnswer { invocation ->
+            val limit = invocation.getArgument<Int>(0)
+            results.value.take(limit)
+        }
         onBlocking {
             fetchBookings(
                 any(),
@@ -68,6 +72,7 @@ class BookingListHandlerTest : BaseUnitTest() {
     @Test
     fun `given repository returns bookings, when observing bookings flow, then returns bookings`() = testBlocking {
         val sampleBookings = List(10) { getSampleBooking(it) }
+        given(bookingsRepository.getBookingsList(any(), anyOrNull(), any())).willReturn(sampleBookings)
         given(bookingsRepository.observeBookings(any(), anyOrNull(), any())).willReturn(flowOf(sampleBookings))
 
         val bookings = bookingListHandler.bookingsFlow.first()

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -96,6 +96,13 @@ class BookingsStore @Inject internal constructor(
         order: BookingsOrderOption
     ): Flow<List<BookingEntity>> = bookingsDao.observeBookings(site.localId(), limit, filters, order)
 
+    suspend fun getBookings(
+        site: SiteModel,
+        limit: Int? = null,
+        filters: BookingFilters? = null,
+        order: BookingsOrderOption
+    ): List<BookingEntity> = bookingsDao.getBookings(site.localId(), limit, filters, order)
+
     fun observeBookingCount(
         site: SiteModel
     ): Flow<Long> = bookingsDao.observeBookingsCount(site.localId())

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -53,6 +53,24 @@ interface BookingsDao {
         order: BookingsOrderOption
     ): Flow<List<BookingEntity>>
 
+    @Suppress("LongParameterList")
+    @Query(DEFAULT_SELECT_QUERY)
+    suspend fun getBookings(
+        localSiteId: LocalId,
+        limit: Int?,
+        startDateBefore: Long?,
+        startDateAfter: Long?,
+        customerId: Long?,
+        resourceIds: List<Long>,
+        resourceIdsSize: Int,
+        attendanceStatuses: List<String>,
+        attendanceStatusesSize: Int,
+        excludedBookingStatuses: List<String>,
+        productIds: List<Long>,
+        productIdsSize: Int,
+        order: BookingsOrderOption
+    ): List<BookingEntity>
+
     @Query("SELECT * FROM Bookings WHERE localSiteId = :localSiteId AND id = :bookingId LIMIT 1")
     fun observeBooking(localSiteId: LocalId, bookingId: Long): Flow<BookingEntity?>
 
@@ -161,6 +179,33 @@ interface BookingsDao {
         val excludedBookingStatusKeySet = filters?.excludedBookingStatuses?.values?.map { it.key }.orEmpty()
         val productIds = filters?.serviceEvents?.values?.map { it.productId }.orEmpty()
         return observeBookings(
+            localSiteId = localSiteId,
+            limit = limit,
+            startDateBefore = filters?.dateRange?.before?.epochSecond,
+            startDateAfter = filters?.dateRange?.after?.epochSecond,
+            customerId = filters?.customer?.customerId,
+            resourceIds = resourceIdsKeySet.toList(),
+            resourceIdsSize = resourceIdsKeySet.size,
+            attendanceStatuses = attendanceStatusKeySet.toList(),
+            attendanceStatusesSize = attendanceStatusKeySet.size,
+            excludedBookingStatuses = excludedBookingStatusKeySet.toList(),
+            productIds = productIds,
+            productIdsSize = productIds.size,
+            order = order
+        )
+    }
+
+    suspend fun getBookings(
+        localSiteId: LocalId,
+        limit: Int? = null,
+        filters: BookingFilters? = null,
+        order: BookingsOrderOption
+    ): List<BookingEntity> {
+        val resourceIdsKeySet = filters?.teamMembers?.values?.map { it.value }.orEmpty()
+        val attendanceStatusKeySet = filters?.attendanceStatuses?.values?.map { it.key }.orEmpty()
+        val excludedBookingStatusKeySet = filters?.excludedBookingStatuses?.values?.map { it.key }.orEmpty()
+        val productIds = filters?.serviceEvents?.values?.map { it.productId }.orEmpty()
+        return getBookings(
             localSiteId = localSiteId,
             limit = limit,
             startDateBefore = filters?.dateRange?.before?.epochSecond,


### PR DESCRIPTION
### Description
Fixes WOOMOB-2347

Do not merge because probably we will need to rebase that to the hotfix branch

Optimizes booking location loading and removes the loading flash when switching dates.

**Location caching:** Previously, the location cache was cleared on every date change, forcing a re-fetch even for already-seen products. Since locations are per-product (not per-date), the cache now persists across date changes. Bookings are also shown immediately while missing locations are fetched in the background.

**No loading flash on date change:** Previously, switching dates would briefly show a loading state because `Items.Loading` was set before the Room flow re-queried. Now the current bookings stay visible until the new ones arrive from the database flow. The "nothing found" state is also suppressed while a fetch is still in progress.

@malinajirka wdyt about the second one? It feels it's better to it like that when we switch between dates with bookings, but when there is a date without booking the it feels a bit off. Not sure

### Test Steps
1. Open POS Bookings screen
2. Navigate between dates with bookings that share the same products
3. Verify bookings appear immediately without a loading flash
4. Verify locations show up correctly (either instantly from cache or shortly after)
5. Navigate to a date with no bookings — verify "nothing found" appears after fetch completes, not before

### Images/gif

https://github.com/user-attachments/assets/62ada4de-0a16-49a0-89a5-20076149fd56



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.