### PR TITLE
[WOOMOB-2369] Add back button to POS card payment screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
@@ -45,6 +45,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCircularLoadingIndicator
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToolbar
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIcons
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
@@ -130,6 +131,7 @@ private fun WooPosCardPaymentScreenContent(
                     onConnectReaderClicked = onConnectReaderClicked,
                     showCashPaymentButton = showCashPaymentButton,
                     onCashPaymentClicked = onCashPaymentClicked,
+                    onBackClicked = onBackClicked,
                 )
             }
         }
@@ -270,9 +272,11 @@ private fun CardPaymentReaderDisconnected(
     onConnectReaderClicked: () -> Unit,
     showCashPaymentButton: Boolean,
     onCashPaymentClicked: () -> Unit,
+    onBackClicked: () -> Unit,
 ) {
     CardPaymentCenteredLayout(
         modifier = Modifier.background(MaterialTheme.colorScheme.surface),
+        onBackClicked = onBackClicked,
         content = {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Image(
@@ -374,6 +378,7 @@ private fun CardPaymentFailed(
 ) {
     BackHandler { onBackClicked() }
     CardPaymentCenteredLayout(
+        onBackClicked = onBackClicked,
         content = {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Icon(
@@ -420,22 +425,34 @@ private fun CardPaymentFailed(
 @Composable
 private fun CardPaymentCenteredLayout(
     modifier: Modifier = Modifier,
+    onBackClicked: (() -> Unit)? = null,
     content: @Composable () -> Unit,
     buttons: @Composable ColumnScope.() -> Unit,
 ) {
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(vertical = WooPosSpacing.XXXLarge.value),
+        modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Box(
-            modifier = Modifier.weight(1f),
-            contentAlignment = Alignment.Center,
-        ) {
-            content()
+        if (onBackClicked != null) {
+            WooPosToolbar(
+                titleText = stringResource(R.string.woopos_card_payment_toolbar_title),
+                onBackClicked = onBackClicked,
+            )
         }
-        buttons()
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(vertical = WooPosSpacing.XXXLarge.value),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(
+                modifier = Modifier.weight(1f),
+                contentAlignment = Alignment.Center,
+            ) {
+                content()
+            }
+            buttons()
+        }
     }
 }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3797,6 +3797,7 @@
     <string name="woopos_variations_empty_list_image_description">No variations</string>
     <string name="woopos_variations_any_variation">Any %s</string>
 
+    <string name="woopos_totals_toolbar_title">Payment</string>
     <string name="woopos_success_totals_error_reader_not_connected_title">Reader not connected</string>
     <string name="woopos_success_totals_error_reader_not_connected_subtitle">To process this payment, please connect your reader.</string>
     <string name="woopos_success_totals_error_reader_not_connected_cta_button_label">Connect to reader</string>
@@ -3814,6 +3815,7 @@
     <string name="woo_pos_payment_failed_go_back_to_checkout">Go back to checkout</string>
     <string name="woo_pos_payment_failed_go_back">Go back</string>
 
+    <string name="woopos_card_payment_toolbar_title">Payment</string>
     <string name="woopos_card_payment_done_button">Done</string>
 
     <string name="woopos_floating_toolbar_overlay_menu_content_description">Dimmed background. Tap to close the menu.</string>


### PR DESCRIPTION
### Description
Fixes WOOMOB-2369

Adds a toolbar with a back button to the card payment collection screen in POS. The toolbar shows only on the `ReaderDisconnected` and `PaymentFailed` states via an optional `onBackClicked` parameter in `CardPaymentCenteredLayout`.

### Test Steps
1. Open POS and add items to the cart
2. Proceed to the payment collection screen
3. Verify a back arrow + "Payment" toolbar appears when the reader is disconnected
4. Tap the back button and verify it navigates back
5. Trigger a payment failure and verify the toolbar with back button also appears
6. Verify other states (Preparing, ReadyForPayment, PaymentInProgress) do **not** show the toolbar

### Images/gif
<img width="673" height="419" alt="image" src="https://github.com/user-attachments/assets/5675112a-785a-4080-a6aa-421598eb4773" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.