### PR TITLE
[WOOMOB-2366] Prevent double-tap on cash payment from charging order twice

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -502,7 +502,20 @@ class WooPosBookingsViewModel @Inject constructor(
     }
 
     fun onPaymentCompleted() {
+        hideCollectPaymentButton()
         selectedBookingId?.let { refreshSingleBooking(it) } ?: doRefresh()
+    }
+
+    private fun hideCollectPaymentButton() {
+        val currentState = _state.value as? WooPosBookingsState.Content ?: return
+        val selectedDetails = currentState.selectedDetails ?: return
+        _state.value = currentState.copy(
+            selectedDetails = selectedDetails.copy(
+                paymentSection = selectedDetails.paymentSection.copy(
+                    collectPaymentLabel = null
+                )
+            )
+        )
     }
 
     private fun handleBookingAction(action: WooPosBookingsState.BookingAction) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModel.kt
@@ -120,6 +120,9 @@ class WooPosCashPaymentViewModel @Inject constructor(
     }
 
     private fun handleOrderCompletion() {
+        val currentState = _state.value as? WooPosCashPaymentState.Collecting ?: return
+        if (currentState.button.status != WooPosCashPaymentState.Collecting.Button.Status.ENABLED) return
+
         viewModelScope.launch {
             analyticsTracker.track(CashPaymentTapped)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -1591,4 +1591,24 @@ class WooPosBookingsViewModelTest {
         // THEN
         verify(analyticsTracker).trackAttendanceChangeFailed(any(), any())
     }
+
+    @Test
+    fun `when payment completed, then collect payment button is hidden immediately`() = runTest {
+        // GIVEN
+        whenever(bookingsRepository.fetchBooking(any())).doSuspendableAnswer {
+            delay(5000)
+            Result.success(booking())
+        }
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        val contentBefore = viewModel.state.value as WooPosBookingsState.Content
+        assertThat(contentBefore.selectedDetails!!.paymentSection.collectPaymentLabel).isNotNull()
+
+        // WHEN
+        viewModel.onPaymentCompleted()
+
+        // THEN
+        val contentAfter = viewModel.state.value as WooPosBookingsState.Content
+        assertThat(contentAfter.selectedDetails!!.paymentSection.collectPaymentLabel).isNull()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cashpayment/WooPosCashPaymentViewModelTest.kt
@@ -26,6 +26,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.settings.CurrencyPosition
@@ -325,6 +326,19 @@ class WooPosCashPaymentViewModelTest {
             val event = awaitItem()
             assertThat(event).isEqualTo(WooPosNavigationEvent.GoBack)
         }
+    }
+
+    @Test
+    fun `given button is loading, when CompleteOrderClicked again, then completeOrder is called only once`() = runTest {
+        // GIVEN
+        whenever(repository.completeOrder(any(), any())).thenReturn(Result.success(Unit))
+
+        // WHEN
+        viewModel.onUIEvent(WooPosCashPaymentUIEvent.CompleteOrderClicked)
+        viewModel.onUIEvent(WooPosCashPaymentUIEvent.CompleteOrderClicked)
+
+        // THEN
+        verify(repository, times(1)).completeOrder(any(), any())
     }
 
     private suspend fun givenRepoFailsToCompleteOrder(): String {


### PR DESCRIPTION
### Description
Fixes WOOMOB-2366

After completing a cash payment for a booking in POS, the user returns to the bookings screen. On slow networks, the server refresh hasn't updated the local data yet, so the "Collect Payment" button is still visible and the user can start a second payment for the same booking.

**Fix:** Optimistically hide the "Collect Payment" button in `onPaymentCompleted()` by immediately setting `collectPaymentLabel = null` in the UI state, before the server refresh completes. The server refresh will eventually confirm the paid status.

Additionally, the cash payment VM has a guard that rejects taps on "Mark order as complete" when the button is already in LOADING state.

### Test Steps
1. Open POS, select a booking, tap "Collect Payment"
2. Complete the cash payment flow, tap "Done" on the success screen
3. On a slow network (or throttled connection), quickly try to tap "Collect Payment" again for the same booking
4. **Expected:** The "Collect Payment" button should be gone immediately after returning from the payment flow

### Images/gif

https://github.com/user-attachments/assets/e8902b09-90de-42bf-92db-65f76ca5833f



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.