### PR TITLE
[WOOMOB-2344] Fetch bookings data only when local cache is empty

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FlowExtensions.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.extensions
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onEach
 
 @Suppress("LongParameterList")
 inline fun <T1, T2, T3, T4, T5, T6, R> combine(
@@ -120,5 +121,15 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> combine(
             args[7] as T8,
             args[8] as T9,
         )
+    }
+}
+
+inline fun <T> Flow<T>.onFirst(crossinline action: suspend (T) -> Unit): Flow<T> {
+    var isFirst = true
+    return onEach {
+        if (isFirst) {
+            action(it)
+            isFirst = false
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibility.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibility.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.bookings.tab
 
 import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.extensions.isCIABSite
+import com.woocommerce.android.extensions.onFirst
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.ui.products.ProductStatus
@@ -11,7 +12,6 @@ import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -19,8 +19,6 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsOrderOption
@@ -52,7 +50,6 @@ class ObserveBookingsVisibility @Inject constructor(
                     .combine(bookingsCountFlow()) { productCount, bookingCount ->
                         productCount > 0 || bookingCount > 0
                     }
-                    .onStart { fetchBookableInfo() }
                     .distinctUntilChanged()
             )
         }
@@ -65,30 +62,33 @@ class ObserveBookingsVisibility @Inject constructor(
                 ProductFilterOption.TYPE to ProductType.BOOKABLE_SERVICE.value
             ),
             excludeSampleProducts = true
-        )
+        ).onFirst { count ->
+            if (count == 0L) {
+                appCoroutineScope.launch {
+                    productListRepository.fetchProductList(
+                        productFilterOptions = mapOf(ProductFilterOption.TYPE to ProductType.BOOKABLE_SERVICE.value)
+                    ).onFailure {
+                        WooLog.w(WooLog.T.BOOKINGS, "Failed to fetch bookable products")
+                    }
+                }
+            }
+        }
     }
 
     private fun bookingsCountFlow(): Flow<Long> {
         return bookingsRepository.observeBookingsCount()
-    }
-
-    private fun fetchBookableInfo() = appCoroutineScope.launch {
-        val products = async {
-            productListRepository.fetchProductList(
-                productFilterOptions = mapOf(ProductFilterOption.TYPE to ProductType.BOOKABLE_SERVICE.value)
-            ).onFailure {
-                WooLog.w(WooLog.T.BOOKINGS, "Failed to fetch bookable products")
+            .onFirst { count ->
+                if (count == 0L) {
+                    appCoroutineScope.launch {
+                        bookingsRepository.fetchBookings(
+                            page = 1,
+                            perPage = 25,
+                            order = BookingsOrderOption.DESC
+                        ).onFailure {
+                            WooLog.w(WooLog.T.BOOKINGS, "Failed to fetch bookings")
+                        }
+                    }
+                }
             }
-        }
-        val bookings = async {
-            bookingsRepository.fetchBookings(
-                page = 1,
-                perPage = 25,
-                order = BookingsOrderOption.DESC
-            ).onFailure {
-                WooLog.w(WooLog.T.BOOKINGS, "Failed to fetch bookings")
-            }
-        }
-        joinAll(products, bookings)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibilityTest.kt
@@ -17,6 +17,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -63,23 +64,26 @@ class ObserveBookingsVisibilityTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given site is CIAB, when invoke is called, then bookable products and bookings are fetched`() = testBlocking {
-        bookableProdsCountFlow.value = 2
-        selectedSiteFlow.value = ciabSite()
-        setup()
+    fun `given CIAB site with zero cached counts, when invoke, then both products and bookings are fetched`() =
+        testBlocking {
+            bookableProdsCountFlow.value = 0
+            bookingsCountFlow.value = 0
+            selectedSiteFlow.value = ciabSite()
+            setup()
 
-        sut().test {
-            verify(productListRepository).fetchProductList(
-                loadMore = any(),
-                productFilterOptions = eq(mapOf(ProductFilterOption.TYPE to ProductType.BOOKABLE_SERVICE.value)),
-                excludedProductIds = any(),
-                sortType = anyOrNull(),
-                pageSize = any()
-            )
-            verify(bookingsRepository).fetchBookings(any(), any(), anyOrNull(), anyOrNull(), any())
-            cancelAndIgnoreRemainingEvents()
+            sut().test {
+                awaitItem()
+                verify(productListRepository).fetchProductList(
+                    loadMore = any(),
+                    productFilterOptions = eq(mapOf(ProductFilterOption.TYPE to ProductType.BOOKABLE_SERVICE.value)),
+                    excludedProductIds = any(),
+                    sortType = anyOrNull(),
+                    pageSize = any()
+                )
+                verify(bookingsRepository).fetchBookings(any(), any(), anyOrNull(), anyOrNull(), any())
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
     fun `given CIAB site and bookings products published, when invoke, then emits true`() = testBlocking {
@@ -179,6 +183,46 @@ class ObserveBookingsVisibilityTest : BaseUnitTest() {
 
             sut().test {
                 assert(awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given CIAB site with non-zero cached product count, when invoke, then products are not fetched`() =
+        testBlocking {
+            bookableProdsCountFlow.value = 5
+            selectedSiteFlow.value = ciabSite()
+            setup()
+
+            sut().test {
+                awaitItem()
+                verify(productListRepository, never()).fetchProductList(
+                    loadMore = any(),
+                    productFilterOptions = any(),
+                    excludedProductIds = any(),
+                    sortType = anyOrNull(),
+                    pageSize = any()
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `given CIAB site with non-zero cached bookings count, when invoke, then bookings are not fetched`() =
+        testBlocking {
+            bookingsCountFlow.value = 3
+            selectedSiteFlow.value = ciabSite()
+            setup()
+
+            sut().test {
+                awaitItem()
+                verify(bookingsRepository, never()).fetchBookings(
+                    any(),
+                    any(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    any()
+                )
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibilityTest.kt
@@ -175,19 +175,6 @@ class ObserveBookingsVisibilityTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given bookable products fetch fails onStart, when invoke, then emits based on persisted values`() =
-        testBlocking {
-            bookableProdsCountFlow.value = 1
-            selectedSiteFlow.value = ciabSite()
-            setup()
-
-            sut().test {
-                assert(awaitItem())
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
     fun `given CIAB site with non-zero cached product count, when invoke, then products are not fetched`() =
         testBlocking {
             bookableProdsCountFlow.value = 5


### PR DESCRIPTION
### Description
Fixes WOOMOB-2344

Previously, `ObserveBookingsVisibility` always fetched bookable products and bookings from the network on every subscription start (via `onStart`). This caused an overhead of two additional requests on each app launch.

This PR changes the logic to make the fetch only when the cache is empty, the downside of this is that in case all bookable products or bookings get deleted (a rare case IMO), then we'll keep displaying the bookings tab until the user opens products or bookings screen. I think the advantages outweigh this downside, WDYT?

### Test Steps
1. Start with a fresh install.
2. Open the app on a CIAB site with bookable products
3. Check the logs and confirm `BookingsStore: fetchBookings` is logged.
4. Confirm the bookings tab appears after the fetch.
6. Close and re-open the app.
7. Confirm `BookingsStore: fetchBookings` is not logged.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.