### PR TITLE
[WOOMOB-2367] Fix POS order details showing full total as paid for unpaid orders

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -48,7 +48,11 @@ class WooPosOrderDetailsMapper @Inject constructor(
             lineItems = lineItems,
             breakdown = breakdown,
             total = formatPrice(order.total, order.currency),
-            totalPaid = formatPrice(order.total, order.currency),
+            totalPaid = if (order.isOrderPaid) {
+                formatPrice(order.total, order.currency)
+            } else {
+                formatPrice(BigDecimal.ZERO, order.currency)
+            },
             paymentMethodTitle = order.paymentMethodTitle.takeIf { it.isNotBlank() },
             actionsState = WooPosOrdersState.OrderActionsState.Loaded(actions)
         )
@@ -73,7 +77,11 @@ class WooPosOrderDetailsMapper @Inject constructor(
             lineItems = lineItems,
             breakdown = breakdown,
             total = formatPrice(order.total),
-            totalPaid = formatPrice(order.total),
+            totalPaid = if (order.isOrderPaid) {
+                formatPrice(order.total)
+            } else {
+                formatPrice(BigDecimal.ZERO)
+            },
             paymentMethodTitle = order.paymentMethodTitle.takeIf { it.isNotBlank() },
             actionsState = WooPosOrdersState.OrderActionsState.Loading
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -36,6 +36,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
 import java.util.Date
 import java.util.Locale
@@ -63,7 +64,9 @@ class WooPosOrdersViewModelTest {
     private lateinit var orderActionsProvider: WooPosOrderActionsProvider
     private lateinit var orderStatusMapper: WooPosOrderStatusMapper
 
-    private fun order(id: Long = 1L): Order = OrderTestUtils.generateTestOrder(orderId = id)
+    private fun order(id: Long = 1L): Order = OrderTestUtils.generateTestOrder(orderId = id).copy(
+        datePaid = DateTimeUtils.dateUTCFromIso8601("2018-02-02T16:11:13Z")
+    )
 
     private fun ordersMap(vararg orders: Order): Map<Order, RefundsFetchResult> =
         orders.associateWith { RefundsFetchResult.Success(emptyList()) }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -1,0 +1,103 @@
+package com.woocommerce.android.ui.woopos.orders.details
+
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
+import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
+import com.woocommerce.android.ui.woopos.orders.details.refund.RefundInfo
+import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.util.Date
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosOrderDetailsMapperTest : BaseUnitTest() {
+
+    private val resourceProvider: ResourceProvider = mock()
+    private val getProductById: com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById = mock()
+    private val formatPrice: WooPosFormatPrice = mock()
+    private val orderStatusMapper: WooPosOrderStatusMapper = mock()
+    private val refundInfoBuilder: WooPosRefundInfoBuilder = mock()
+    private val orderActionsProvider: WooPosOrderActionsProvider = mock()
+    private val bookingInfoMapper: WooPosBookingInfoMapper = mock()
+
+    private val sut = WooPosOrderDetailsMapper(
+        resourceProvider = resourceProvider,
+        getProductById = getProductById,
+        formatPrice = formatPrice,
+        orderStatusMapper = orderStatusMapper,
+        refundInfoBuilder = refundInfoBuilder,
+        orderActionsProvider = orderActionsProvider,
+        bookingInfoMapper = bookingInfoMapper,
+    )
+
+    private suspend fun setupMocks() {
+        whenever(orderStatusMapper.mapOrderStatus(any())).thenReturn(mock())
+        whenever(resourceProvider.getString(any())).thenReturn("at")
+        whenever(refundInfoBuilder.buildRefundInfo(any(), any())).thenReturn(
+            RefundInfo(emptyList(), BigDecimal.ZERO)
+        )
+        whenever(refundInfoBuilder.buildTotalsBreakdown(any(), any())).thenReturn(mock())
+        whenever(orderActionsProvider.getAvailableActions(any())).thenReturn(emptyList())
+        whenever(formatPrice(any<BigDecimal>(), anyOrNull<String>())).thenReturn("")
+        whenever(formatPrice(any<BigDecimal>())).thenReturn("")
+    }
+
+    @Test
+    fun `given order is paid, when mapOrderDetails, then totalPaid equals formatted total`() = testBlocking {
+        setupMocks()
+        val order = OrderTestUtils.generateTestOrder().copy(datePaid = Date())
+        whenever(formatPrice(order.total, order.currency)).thenReturn("$106.00")
+        whenever(formatPrice(any<BigDecimal>())).thenReturn("")
+
+        val result = sut.mapOrderDetails(order, RefundsFetchResult.Success(emptyList()))
+
+        assertThat(result.totalPaid).isEqualTo("$106.00")
+    }
+
+    @Test
+    fun `given order is unpaid, when mapOrderDetails, then totalPaid equals formatted zero`() = testBlocking {
+        setupMocks()
+        val order = OrderTestUtils.generateTestOrder().copy(datePaid = null)
+        whenever(formatPrice(BigDecimal.ZERO, order.currency)).thenReturn("$0.00")
+        whenever(formatPrice(order.total, order.currency)).thenReturn("$106.00")
+        whenever(formatPrice(any<BigDecimal>())).thenReturn("")
+
+        val result = sut.mapOrderDetails(order, RefundsFetchResult.Success(emptyList()))
+
+        assertThat(result.totalPaid).isEqualTo("$0.00")
+    }
+
+    @Test
+    fun `given order is paid, when mapOrderDetailsWithoutActions, then totalPaid equals formatted total`() =
+        testBlocking {
+            setupMocks()
+            val order = OrderTestUtils.generateTestOrder().copy(datePaid = Date())
+            whenever(formatPrice(order.total)).thenReturn("$106.00")
+
+            val result = sut.mapOrderDetailsWithoutActions(order)
+
+            assertThat(result.totalPaid).isEqualTo("$106.00")
+        }
+
+    @Test
+    fun `given order is unpaid, when mapOrderDetailsWithoutActions, then totalPaid equals formatted zero`() =
+        testBlocking {
+            setupMocks()
+            val order = OrderTestUtils.generateTestOrder().copy(datePaid = null)
+            whenever(formatPrice(BigDecimal.ZERO)).thenReturn("$0.00")
+            whenever(formatPrice(order.total)).thenReturn("$106.00")
+
+            val result = sut.mapOrderDetailsWithoutActions(order)
+
+            assertThat(result.totalPaid).isEqualTo("$0.00")
+        }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -1,15 +1,21 @@
 package com.woocommerce.android.ui.woopos.orders.details
 
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.woopos.orders.OrderStatusColorKey
+import com.woocommerce.android.ui.woopos.orders.PosOrderStatus
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.TotalsBreakdown
 import com.woocommerce.android.ui.woopos.orders.details.refund.RefundInfo
 import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -39,40 +45,53 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         bookingInfoMapper = bookingInfoMapper,
     )
 
-    private suspend fun setupMocks() {
-        whenever(orderStatusMapper.mapOrderStatus(any())).thenReturn(mock())
+    private val paidOrder: Order = OrderTestUtils.generateTestOrder().copy(
+        datePaid = DateTimeUtils.dateUTCFromIso8601("2018-02-02T16:11:13Z"),
+        status = Order.Status.Completed,
+    )
+
+    @Before
+    fun setup() = runBlocking {
+        whenever(orderStatusMapper.mapOrderStatus(any())).thenReturn(
+            PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED)
+        )
         whenever(resourceProvider.getString(any())).thenReturn("at")
         whenever(refundInfoBuilder.buildRefundInfo(any(), any())).thenReturn(
             RefundInfo(emptyList(), BigDecimal.ZERO)
         )
-        whenever(refundInfoBuilder.buildTotalsBreakdown(any(), any())).thenReturn(mock())
+        whenever(refundInfoBuilder.buildTotalsBreakdown(any(), any())).thenReturn(
+            TotalsBreakdown(
+                products = "$10.00",
+                discount = null,
+                discountCode = null,
+                taxes = "$0.00",
+                shipping = null,
+                refunds = emptyList(),
+                netPayment = null,
+            )
+        )
         whenever(orderActionsProvider.getAvailableActions(any())).thenReturn(emptyList())
-        whenever(formatPrice(any<BigDecimal>(), anyOrNull<String>())).thenReturn("")
-        whenever(formatPrice(any<BigDecimal>())).thenReturn("")
+        whenever(formatPrice(any<BigDecimal>(), anyOrNull<String>())).thenReturn("$0.00")
+        whenever(formatPrice(any<BigDecimal>())).thenReturn("$0.00")
+        Unit
     }
 
     @Test
     fun `given order is paid, when mapOrderDetails, then totalPaid equals formatted total`() = testBlocking {
-        setupMocks()
-        val order = OrderTestUtils.generateTestOrder()
-            .copy(datePaid = DateTimeUtils.dateUTCFromIso8601("2018-02-02T16:11:13Z"))
-        whenever(formatPrice(order.total, order.currency)).thenReturn("$106.00")
-        whenever(formatPrice(any<BigDecimal>())).thenReturn("")
+        whenever(formatPrice(paidOrder.total, paidOrder.currency)).thenReturn("$106.00")
 
-        val result = sut.mapOrderDetails(order, RefundsFetchResult.Success(emptyList()))
+        val result = sut.mapOrderDetails(paidOrder, RefundsFetchResult.Success(emptyList()))
 
         assertThat(result.totalPaid).isEqualTo("$106.00")
     }
 
     @Test
     fun `given order is unpaid, when mapOrderDetails, then totalPaid equals formatted zero`() = testBlocking {
-        setupMocks()
-        val order = OrderTestUtils.generateTestOrder().copy(datePaid = null)
-        whenever(formatPrice(BigDecimal.ZERO, order.currency)).thenReturn("$0.00")
-        whenever(formatPrice(order.total, order.currency)).thenReturn("$106.00")
-        whenever(formatPrice(any<BigDecimal>())).thenReturn("")
+        val unpaidOrder = paidOrder.copy(datePaid = null)
+        whenever(formatPrice(unpaidOrder.total, unpaidOrder.currency)).thenReturn("$106.00")
+        whenever(formatPrice(BigDecimal.ZERO, unpaidOrder.currency)).thenReturn("$0.00")
 
-        val result = sut.mapOrderDetails(order, RefundsFetchResult.Success(emptyList()))
+        val result = sut.mapOrderDetails(unpaidOrder, RefundsFetchResult.Success(emptyList()))
 
         assertThat(result.totalPaid).isEqualTo("$0.00")
     }
@@ -80,12 +99,9 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     @Test
     fun `given order is paid, when mapOrderDetailsWithoutActions, then totalPaid equals formatted total`() =
         testBlocking {
-            setupMocks()
-            val order = OrderTestUtils.generateTestOrder()
-                .copy(datePaid = DateTimeUtils.dateUTCFromIso8601("2018-02-02T16:11:13Z"))
-            whenever(formatPrice(order.total)).thenReturn("$106.00")
+            whenever(formatPrice(paidOrder.total)).thenReturn("$106.00")
 
-            val result = sut.mapOrderDetailsWithoutActions(order)
+            val result = sut.mapOrderDetailsWithoutActions(paidOrder)
 
             assertThat(result.totalPaid).isEqualTo("$106.00")
         }
@@ -93,12 +109,11 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     @Test
     fun `given order is unpaid, when mapOrderDetailsWithoutActions, then totalPaid equals formatted zero`() =
         testBlocking {
-            setupMocks()
-            val order = OrderTestUtils.generateTestOrder().copy(datePaid = null)
+            val unpaidOrder = paidOrder.copy(datePaid = null)
+            whenever(formatPrice(unpaidOrder.total)).thenReturn("$106.00")
             whenever(formatPrice(BigDecimal.ZERO)).thenReturn("$0.00")
-            whenever(formatPrice(order.total)).thenReturn("$106.00")
 
-            val result = sut.mapOrderDetailsWithoutActions(order)
+            val result = sut.mapOrderDetailsWithoutActions(unpaidOrder)
 
             assertThat(result.totalPaid).isEqualTo("$0.00")
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -15,8 +15,8 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
-import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooPosOrderDetailsMapperTest : BaseUnitTest() {
@@ -54,7 +54,8 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     @Test
     fun `given order is paid, when mapOrderDetails, then totalPaid equals formatted total`() = testBlocking {
         setupMocks()
-        val order = OrderTestUtils.generateTestOrder().copy(datePaid = Date())
+        val order = OrderTestUtils.generateTestOrder()
+            .copy(datePaid = DateTimeUtils.dateUTCFromIso8601("2018-02-02T16:11:13Z"))
         whenever(formatPrice(order.total, order.currency)).thenReturn("$106.00")
         whenever(formatPrice(any<BigDecimal>())).thenReturn("")
 
@@ -80,7 +81,8 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     fun `given order is paid, when mapOrderDetailsWithoutActions, then totalPaid equals formatted total`() =
         testBlocking {
             setupMocks()
-            val order = OrderTestUtils.generateTestOrder().copy(datePaid = Date())
+            val order = OrderTestUtils.generateTestOrder()
+                .copy(datePaid = DateTimeUtils.dateUTCFromIso8601("2018-02-02T16:11:13Z"))
             whenever(formatPrice(order.total)).thenReturn("$106.00")
 
             val result = sut.mapOrderDetailsWithoutActions(order)


### PR DESCRIPTION
### Description
Fixes WOOMOB-2367

Do not merge label - this will go out as a hotfix.

POS order details was showing the full order total as "Total paid" even for unpaid orders (e.g. Cash on Delivery bookings). The root cause was that `WooPosOrderDetailsMapper` unconditionally set `totalPaid = formatPrice(order.total)`, ignoring whether the order had actually been paid. Now it checks `order.isOrderPaid` (`datePaid != null`) and shows `$0.00` for unpaid orders.

### Test Steps
1. Create a Booking on the web and select `Cash on delivery`
2. Open POS -> Bookings
3. Select the booking created in step 1
4. Open order details and verify "Total paid" shows $0.00
5. Collect payment
6. Open order details and verify "Total paid" shows the correct total

### Images/gif

Before
<img width="400" alt="image" src="https://github.com/user-attachments/assets/db006575-cbfd-4851-b9d0-90ac28300d79" />



After

<img width="400" alt="image" src="https://github.com/user-attachments/assets/96c4eb8b-e21c-4257-8e55-f8dd2eeb9e08" />



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.