### PR TITLE
[WOOMOB-2379] Hide Connect Store step when site is already connected

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsScreen.kt
@@ -110,7 +110,7 @@ private fun WooPushNotificationsConnectionStepsScreen(
                 WordPressWooBadge()
 
                 Text(
-                    text = stringResource(id = R.string.woo_push_notifications_connection_steps_title),
+                    text = stringResource(id = viewState.titleRes),
                     style = MaterialTheme.typography.headlineLarge,
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(top = 32.dp)
@@ -118,7 +118,7 @@ private fun WooPushNotificationsConnectionStepsScreen(
 
                 Text(
                     text = annotatedStringRes(
-                        R.string.woo_push_notifications_connection_steps_body,
+                        viewState.bodyRes,
                         viewState.siteAddress
                     ),
                     modifier = Modifier.padding(top = 8.dp)
@@ -276,6 +276,8 @@ private fun WooPushNotificationsConnectionStepsPreview() {
     WooThemeWithBackground {
         WooPushNotificationsConnectionStepsScreen(
             viewState = ViewState(
+                titleRes = R.string.woo_push_notifications_connection_steps_title_connect,
+                bodyRes = R.string.woo_push_notifications_connection_steps_body_connect,
                 siteAddress = "coffeebeans.com",
                 steps = listOf(
                     WooPushNotificationsConnectionStepsViewModel.Step(
@@ -306,6 +308,8 @@ private fun WooPushNotificationsConnectionStepsPreviewError() {
     WooThemeWithBackground {
         WooPushNotificationsConnectionStepsScreen(
             viewState = ViewState(
+                titleRes = R.string.woo_push_notifications_connection_steps_title_connect,
+                bodyRes = R.string.woo_push_notifications_connection_steps_body_connect,
                 siteAddress = "coffeebeans.com",
                 steps = listOf(
                     WooPushNotificationsConnectionStepsViewModel.Step(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -50,6 +50,10 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
     private val siteAddress = getSiteAddress()
     private val navArgs by savedStateHandle.navArgs<WooPushNotificationsConnectionStepsFragmentArgs>()
 
+    private val visibleStepTypes = StepType.entries.filter {
+        it != StepType.ConnectStore || !navArgs.isSiteConnectedToJetpack
+    }
+
     private val currentStep = savedStateHandle.getStateFlow(
         scope = viewModelScope,
         initialValue = Step(type = StepType.CheckPluginCompatibility),
@@ -58,7 +62,7 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
 
     val viewState = combine(
         currentStep,
-        flowOf(StepType.entries.toList())
+        flowOf(visibleStepTypes)
     ) { currentStep, stepTypes ->
         ViewState(
             siteAddress = siteAddress,
@@ -127,12 +131,6 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
     }
 
     private suspend fun connectStoreToJetpack() {
-        if (navArgs.isSiteConnectedToJetpack) {
-            markCurrentStepAsCompleted()
-            advanceToNextStep()
-            return
-        }
-
         jetpackActivationRepository.registerSite(
             site = selectedSite.get(),
             useApplicationPasswords = true
@@ -174,7 +172,8 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
     @Suppress("unused")
     private fun advanceToNextStep() {
         currentStep.update { current ->
-            val nextType = StepType.entries.getOrNull(current.type.ordinal + 1)
+            val currentIndex = visibleStepTypes.indexOf(current.type)
+            val nextType = visibleStepTypes.getOrNull(currentIndex + 1)
             if (nextType != null) {
                 Step(type = nextType, state = StepState.Ongoing)
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModel.kt
@@ -54,6 +54,18 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
         it != StepType.ConnectStore || !navArgs.isSiteConnectedToJetpack
     }
 
+    private val titleRes = if (navArgs.isSiteConnectedToJetpack) {
+        R.string.woo_push_notifications_connection_steps_title_setup
+    } else {
+        R.string.woo_push_notifications_connection_steps_title_connect
+    }
+
+    private val bodyRes = if (navArgs.isSiteConnectedToJetpack) {
+        R.string.woo_push_notifications_connection_steps_body_setup
+    } else {
+        R.string.woo_push_notifications_connection_steps_body_connect
+    }
+
     private val currentStep = savedStateHandle.getStateFlow(
         scope = viewModelScope,
         initialValue = Step(type = StepType.CheckPluginCompatibility),
@@ -65,6 +77,8 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
         flowOf(visibleStepTypes)
     ) { currentStep, stepTypes ->
         ViewState(
+            titleRes = titleRes,
+            bodyRes = bodyRes,
             siteAddress = siteAddress,
             steps = stepTypes.map { stepType ->
                 Step(
@@ -257,6 +271,8 @@ class WooPushNotificationsConnectionStepsViewModel @Inject constructor(
     }
 
     data class ViewState(
+        @StringRes val titleRes: Int,
+        @StringRes val bodyRes: Int,
         val siteAddress: String,
         val steps: List<Step>
     ) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2642,8 +2642,10 @@
     <string name="woo_push_notifications_introduction_update_required_title">Get push notifications for your store</string>
     <string name="woo_push_notifications_introduction_update_required_body">Your store is already connected to WordPress.com, but you\'ll need to update the WooCommerce plugin to enable push notifications for new orders, reviews, and more.</string>
     <string name="woo_push_notifications_introduction_update_plugin">Update plugin</string>
-    <string name="woo_push_notifications_connection_steps_title">Connect to WordPress.com</string>
-    <string name="woo_push_notifications_connection_steps_body">Please wait while we finalize connecting your store &lt;b&gt;%1$s&lt;/b&gt; to WordPress.com.</string>
+    <string name="woo_push_notifications_connection_steps_title_connect">Connect to WordPress.com</string>
+    <string name="woo_push_notifications_connection_steps_body_connect">Please wait while we finalize connecting your store &lt;b&gt;%1$s&lt;/b&gt; to WordPress.com.</string>
+    <string name="woo_push_notifications_connection_steps_title_setup">Set up push notifications</string>
+    <string name="woo_push_notifications_connection_steps_body_setup">Please wait while we set up push notifications for &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="woo_push_notifications_connection_steps_step_connect_store">Connect store to WordPress.com</string>
     <string name="woo_push_notifications_connection_steps_step_check_plugin_compatibility">Check plugin compatibility</string>
     <string name="woo_push_notifications_connection_steps_step_enable_push_notifications">Enable push notifications</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
@@ -114,6 +114,30 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given site not connected, when initialized, then connect strings are used`() = testBlocking {
+        setup()
+
+        val state = viewModel.viewState.getOrAwaitValue()
+
+        assertThat(state.titleRes)
+            .isEqualTo(R.string.woo_push_notifications_connection_steps_title_connect)
+        assertThat(state.bodyRes)
+            .isEqualTo(R.string.woo_push_notifications_connection_steps_body_connect)
+    }
+
+    @Test
+    fun `given site already connected, when initialized, then setup strings are used`() = testBlocking {
+        setup(isStoreAlreadyConnected = true)
+
+        val state = viewModel.viewState.getOrAwaitValue()
+
+        assertThat(state.titleRes)
+            .isEqualTo(R.string.woo_push_notifications_connection_steps_title_setup)
+        assertThat(state.bodyRes)
+            .isEqualTo(R.string.woo_push_notifications_connection_steps_body_setup)
+    }
+
+    @Test
     fun `when close is clicked, then Exit event is triggered`() = testBlocking {
         setup {
             whenever(appPrefsWrapper.getFCMToken()).thenReturn("test-token")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
@@ -354,4 +354,15 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
             eq(mapOf(AnalyticsTracker.KEY_STEP to "enable_push_notifications"))
         )
     }
+
+    @Test
+    fun `given site already connected, when initialized, then ConnectStore step is hidden`() = testBlocking {
+        setup(isStoreAlreadyConnected = true)
+
+        val state = viewModel.viewState.getOrAwaitValue()
+
+        assertThat(state.steps).hasSize(2)
+        assertThat(state.steps[0].type).isEqualTo(StepType.CheckPluginCompatibility)
+        assertThat(state.steps[1].type).isEqualTo(StepType.EnablePushNotifications)
+    }
 }


### PR DESCRIPTION
Fixes WOOMOB-2379

### Description

When a site is already connected to Jetpack, the push notification setup flow now hides the "Connect Store" step entirely instead of showing it as auto-completed. The screen also displays context-appropriate title and subtitle text — "Set up push notifications" instead of "Connect to WordPress.com".

### Test Steps
1. Log into a site that is already connected to Jetpack (e.g., a Jurassic Ninja site)
2. Enable Push Notifications feature flags
3. Tap the push notification banner on the My Store screen
4. On the introduction dialog, tap "Update plugin"
5. Verify the connection steps screen shows:
   - Title: "Set up push notifications"
   - Subtitle: "Please wait while we set up push notifications for {site}."
   - Only 2 steps: "Check plugin compatibility" and "Enable push notifications" (no "Connect Store" step)

### Images/gif
<img width="360" alt="Screenshot_20260302_134116" src="https://github.com/user-attachments/assets/45ccd821-3f6b-475a-8338-ed1e7bcd9180" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.