### PR TITLE
[WOOMOB-2203] Make log file parsing resilient to corrupted entries

### DIFF
--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogEntry.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogEntry.kt
@@ -42,24 +42,26 @@ class LogEntry(
             get() = SimpleDateFormat("MMM-dd kk:mm:ss:SSS", Locale.US)
 
         @Suppress("MagicNumber")
-        fun fromString(log: String): LogEntry {
-            val firstParts = log.removePrefix("[").substringBefore("]")
-            val parts = firstParts.split(" ")
+        fun fromString(log: String): LogEntry? {
+            return runCatching {
+                val firstParts = log.removePrefix("[").substringBefore("]")
+                val parts = firstParts.split(" ")
 
-            val logDate = formatter.parse(parts[0] + " " + parts[1])
-                ?: Date()
-            val tagName = migrateDeprecatedTagNames(parts[2])
-            val tag = WooLog.T.valueOf(tagName)
-            val level = WooLog.LogLevel.valueOf(parts[3])
+                val logDate = formatter.parse(parts[0] + " " + parts[1])
+                    ?: Date()
+                val tagName = migrateDeprecatedTagNames(parts[2])
+                val tag = WooLog.T.valueOf(tagName)
+                val level = WooLog.LogLevel.valueOf(parts[3])
 
-            val text = log.substringAfter("] ").takeIf { it.isNotEmpty() }?.trim()
+                val text = log.substringAfter("] ").takeIf { it.isNotEmpty() }?.trim()
 
-            return LogEntry(
-                tag = tag,
-                level = level,
-                text = text,
-                logDate = logDate
-            )
+                LogEntry(
+                    tag = tag,
+                    level = level,
+                    text = text,
+                    logDate = logDate
+                )
+            }.getOrNull()
         }
 
         // TODO WOOMOB-2212 remove this migration code after a couple of releases,

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
@@ -32,6 +32,10 @@ class LogFileWriter(
         get() = SimpleDateFormat(DATE_FORMAT_PATTERN, Locale.ROOT)
     private val mutex = Mutex()
 
+    private val logFiles: Array<File>
+        get() = logsDirectory.listFiles { file -> file.isFile && file.name.startsWith(LOG_FILE_NAME_PREFIX) }
+            ?: emptyArray()
+
     @Volatile
     private var cachedDiskSpace: Long = Long.MAX_VALUE
 
@@ -65,8 +69,7 @@ class LogFileWriter(
         ensureDirectoryExists()
         return mutex.withLock {
             withContext(dispatchers.io) {
-                logsDirectory.listFiles { file -> file.isFile && file.name.startsWith(LOG_FILE_NAME_PREFIX) }
-                    ?.find { it.name == fileName }
+                logFiles.find { it.name == fileName }
                     ?.readText()
             }
         }
@@ -75,9 +78,7 @@ class LogFileWriter(
     suspend fun getLogFiles(): List<File> {
         ensureDirectoryExists()
         return withContext(dispatchers.io) {
-            logsDirectory.listFiles { file -> file.isFile && file.name.startsWith(LOG_FILE_NAME_PREFIX) }
-                ?.sortedByDescending { it.lastModified() }
-                ?: emptyList()
+            logFiles.sortedByDescending { it.lastModified() }
         }
     }
 
@@ -123,12 +124,11 @@ class LogFileWriter(
 
     private suspend fun rotateLogFilesIfNeeded() {
         withContext(dispatchers.io) {
-            val logFiles = logsDirectory.listFiles { file -> file.isFile && file.name.startsWith(LOG_FILE_NAME_PREFIX) }
-                ?.sortedByDescending { it.lastModified() } ?: return@withContext
+            val sortedLogFiles = logFiles.sortedByDescending { it.lastModified() }
 
             mutex.withLock {
-                if (logFiles.size > maxLogFiles) {
-                    logFiles.takeLast(logFiles.size - maxLogFiles).forEach { file ->
+                if (sortedLogFiles.size > maxLogFiles) {
+                    sortedLogFiles.takeLast(sortedLogFiles.size - maxLogFiles).forEach { file ->
                         file.delete()
                     }
                 }
@@ -150,13 +150,10 @@ class LogFileWriter(
     private suspend fun deleteOldestLogFiles() {
         withContext(dispatchers.io) {
             mutex.withLock {
-                val logFiles = logsDirectory
-                    .listFiles { file -> file.isFile && file.name.startsWith(LOG_FILE_NAME_PREFIX) }
-                    ?.sortedByDescending { it.lastModified() }
-                    ?: return@withLock
+                val sortedLogFiles = logFiles.sortedByDescending { it.lastModified() }
 
-                if (logFiles.size > MIN_LOG_FILES_TO_KEEP) {
-                    logFiles.drop(MIN_LOG_FILES_TO_KEEP).forEach { it.delete() }
+                if (sortedLogFiles.size > MIN_LOG_FILES_TO_KEEP) {
+                    sortedLogFiles.drop(MIN_LOG_FILES_TO_KEEP).forEach { it.delete() }
                 }
             }
         }

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
@@ -61,6 +61,17 @@ class LogFileWriter(
         return getLogFile()
     }
 
+    suspend fun readFileContent(fileName: String): String? {
+        ensureDirectoryExists()
+        return mutex.withLock {
+            withContext(dispatchers.io) {
+                logsDirectory.listFiles { file -> file.isFile && file.name.startsWith(LOG_FILE_NAME_PREFIX) }
+                    ?.find { it.name == fileName }
+                    ?.readText()
+            }
+        }
+    }
+
     suspend fun getLogFiles(): List<File> {
         ensureDirectoryExists()
         return withContext(dispatchers.io) {

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/LogFileWriter.kt
@@ -50,8 +50,8 @@ class LogFileWriter(
             return
         }
 
-        mutex.withLock {
-            withContext(dispatchers.io) {
+        withContext(dispatchers.io) {
+            mutex.withLock {
                 if (logFile.length() >= MAX_LOG_FILE_SIZE_BYTES) {
                     logFile.delete()
                     logFile.createNewFile()
@@ -67,8 +67,8 @@ class LogFileWriter(
 
     suspend fun readFileContent(fileName: String): String? {
         ensureDirectoryExists()
-        return mutex.withLock {
-            withContext(dispatchers.io) {
+        return withContext(dispatchers.io) {
+            mutex.withLock {
                 logFiles.find { it.name == fileName }
                     ?.readText()
             }

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
@@ -106,9 +106,9 @@ class WooFileLogger(
     suspend fun getLogFileContent(fileName: String): List<LogEntry>? {
         return withContext(dispatchers.io) {
             runCatching {
-                logFileWriter.getLogFiles().find { it.name == fileName }?.readText()?.let { text ->
+                logFileWriter.readFileContent(fileName)?.let { text ->
                     if (text.isBlank()) return@let emptyList<LogEntry>()
-                    text.split("\n${LOG_ENTRY_PREFIX}").map {
+                    text.split("\n${LOG_ENTRY_PREFIX}").mapNotNull {
                         LogEntry.fromString(it.removePrefix(LOG_ENTRY_PREFIX))
                     }
                 }

--- a/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/LogEntryTest.kt
+++ b/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/LogEntryTest.kt
@@ -1,0 +1,55 @@
+package com.woocommerce.android.util.logs
+
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LogEntryTest : BaseUnitTest() {
+    @Test
+    fun `when parsing a valid serialized entry, then the entry is correctly reconstructed`() {
+        // GIVEN
+        val original = LogEntry(WooLog.T.ORDERS, WooLog.LogLevel.d, "Test message")
+
+        // WHEN
+        val parsed = LogEntry.fromString(original.toString())
+
+        // THEN
+        assertThat(parsed).isEqualTo(original)
+    }
+
+    @Test
+    fun `when parsing an entry with multiline text, then the entry is correctly reconstructed`() {
+        // GIVEN
+        val multilineText = "StackTrace: java.lang.Exception\n    at com.foo.Bar.run(Bar.kt:10)"
+        val original = LogEntry(WooLog.T.UTILS, WooLog.LogLevel.e, multilineText)
+
+        // WHEN
+        val parsed = LogEntry.fromString(original.toString())
+
+        // THEN
+        val entry = requireNotNull(parsed)
+        assertThat(entry.tag).isEqualTo(WooLog.T.UTILS)
+        assertThat(entry.text).isEqualTo(multilineText)
+    }
+
+    @Test
+    fun `when parsing corrupted input, then null is returned`() {
+        assertThat(LogEntry.fromString("not a log entry at all")).isNull()
+    }
+
+    @Test
+    fun `when parsing an entry with deprecated NOTIFS tag, then it is migrated to NOTIFICATIONS`() {
+        // GIVEN
+        val input = "[Mar-02 14:00:00:000 NOTIFS d] Some notification"
+
+        // WHEN
+        val parsed = LogEntry.fromString(input)
+
+        // THEN
+        val entry = requireNotNull(parsed)
+        assertThat(entry.tag).isEqualTo(WooLog.T.NOTIFICATIONS)
+    }
+}

--- a/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/WooFileLoggerTest.kt
+++ b/libs/commons/src/test/kotlin/com/woocommerce/android/util/logs/WooFileLoggerTest.kt
@@ -255,4 +255,27 @@ class WooFileLoggerTest : BaseUnitTest() {
         assertThat(logFileContent).isNotNull()
         assertThat(logFileContent).isEmpty()
     }
+
+    @Test
+    fun `given file has corrupted entries, when reading content, then only valid entries are returned`() =
+        testBlocking {
+            // GIVEN
+            setup()
+            val validEntry = LogEntry(WooLog.T.UTILS, WooLog.LogLevel.i, "Valid message")
+            wooFileLogger.addEntry(validEntry)
+            wooFileLogger.forceFlush()
+            advanceTimeBy(100)
+
+            val logFile = wooFileLogger.getCurrentLogFile()
+            logFile.appendText("\n--garbled content that is not a valid log entry")
+            logFile.appendText("\n--[Mar-02 14:00:00:000 UNKNOWN_TAG d] unknown tag entry")
+
+            // WHEN
+            val logFileContent = wooFileLogger.getLogFileContent(logFile.name)
+
+            // THEN
+            val entries = requireNotNull(logFileContent)
+            assertThat(entries).hasSize(1)
+            assertThat(entries.first()).isEqualTo(validEntry)
+        }
 }


### PR DESCRIPTION
Fixes WOOMOB-2203

### Description
After Jorge's fix mapping `NOTIFS → NOTIFICATIONS` (#15340), we still see a few crashes in `LogEntry.fromString()` with values like `T.02:54:19:441` or `T.UTIL`. These are most likely caused by corrupted log file content:
- `File.appendText()` is not atomic, so a process kill mid-write can leave a truncated entry, causing the next batch to concatenate directly onto it. 
- There's also a race condition where `getLogFileContent()` reads the file without the mutex while `writeLogs()` writes under it.

This PR makes the parsing defensive:
- `fromString()` returns `LogEntry?` wrapped in `runCatching` — malformed entries return `null` instead of throwing
- `getLogFileContent()` uses `mapNotNull` to skip corrupted entries
- New `LogFileWriter.readFileContent()` reads the file under the same mutex used for writes

> [!NOTE]
> The main fix is in the commit 4bc0d565bb5371ecea64c58b81a6004f80556807, the two other commits are just other readability and performance improvements.

### Test Steps
1. Install the app and use it normally to generate log entries.
2. Open **Android Studio → Device Explorer**, navigate to `/data/data/com.woocommerce.android/files/logs/`.
3. Pull the current `log_*.txt` file, insert corrupted entries manually, e.g.:
   - `--garbled content`
   - `--[Mar-02 14:00:00:000 FAKE_TAG d] msg`
   - `--[Mar-02 14:00:00:000 UTILS` (truncated, no closing bracket)
4. Push the modified file back to the device.
5. Navigate to logs screen, and open current log.
6. Verify the logs are retrieved (on `trunk` this leads to an empty screen, and an error is logged)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.