### PR TITLE
[WOOMOB-2352] Show Guest badge in POS Booking Detail when customerId is 0

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapper.kt
@@ -70,9 +70,8 @@ class WooPosBookingViewStateMapper @Inject constructor(
             customerName?.let { append(" \u00B7 $it") }
         }
 
-        val paymentStatus = paymentStatusResolver.resolve(
-            orderId = booking.orderId,
-        )
+        val paymentStatus = paymentStatusResolver.resolve(orderId = booking.orderId)
+        val actionsState = buildActionsState(booking, paymentStatus)
 
         return WooPosBookingsState.BookingDetailsViewState(
             id = booking.id.value,
@@ -80,24 +79,7 @@ class WooPosBookingViewStateMapper @Inject constructor(
             number = "#${booking.id.value}",
             paymentStatus = paymentStatus,
             isCancelled = booking.status == BookingEntity.Status.Cancelled,
-            actionsState = WooPosBookingsState.BookingActionsState.Loaded(
-                buildList {
-                    add(WooPosBookingsState.BookingAction.ViewOrder(booking.orderId))
-                    val paymentState = resolvePaymentState(booking.status, paymentStatus)
-                    if (paymentState == PaymentState.Paid) {
-                        add(WooPosBookingsState.BookingAction.EmailReceipt(booking.orderId))
-                        add(WooPosBookingsState.BookingAction.IssueRefund(booking.orderId))
-                    }
-                    if (booking.isCancellable) {
-                        add(
-                            WooPosBookingsState.BookingAction.CancelBooking(
-                                bookingId = booking.id.value,
-                                orderId = booking.orderId
-                            )
-                        )
-                    }
-                }
-            ),
+            actionsState = actionsState,
             headerTitle = appointmentTime,
             headerSubtitle = headerSubtitle,
             attendanceBadge = mapAttendanceBadge(booking.attendanceStatus),
@@ -109,10 +91,39 @@ class WooPosBookingViewStateMapper @Inject constructor(
                 .toHumanReadableFormat(resourceProvider),
             teamMember = resourceName,
             location = location?.ifBlank { null },
-            customerSection = buildCustomerSection(customerInfo, customerName, booking.customerNote),
+            customerSection = buildCustomerSection(
+                customerInfo,
+                customerName,
+                booking.customerNote,
+                booking.customerId
+            ),
             attendanceSection = buildAttendanceSection(booking),
             paymentSection = buildPaymentSection(booking, paymentStatus),
             bookingNote = booking.note.ifBlank { null },
+        )
+    }
+
+    private fun buildActionsState(
+        booking: BookingEntity,
+        paymentStatus: PaymentStatus,
+    ): WooPosBookingsState.BookingActionsState.Loaded {
+        return WooPosBookingsState.BookingActionsState.Loaded(
+            buildList {
+                add(WooPosBookingsState.BookingAction.ViewOrder(booking.orderId))
+                val paymentState = resolvePaymentState(booking.status, paymentStatus)
+                if (paymentState == PaymentState.Paid) {
+                    add(WooPosBookingsState.BookingAction.EmailReceipt(booking.orderId))
+                    add(WooPosBookingsState.BookingAction.IssueRefund(booking.orderId))
+                }
+                if (booking.isCancellable) {
+                    add(
+                        WooPosBookingsState.BookingAction.CancelBooking(
+                            bookingId = booking.id.value,
+                            orderId = booking.orderId
+                        )
+                    )
+                }
+            }
         )
     }
 
@@ -182,14 +193,16 @@ class WooPosBookingViewStateMapper @Inject constructor(
         customerInfo: BookingCustomerInfo?,
         customerName: String?,
         customerNote: String?,
+        customerId: Long,
     ): WooPosBookingsState.CustomerSection? {
+        val isGuest = customerId == 0L
         val email = customerInfo?.billingEmail?.ifBlank { null }
         val phone = customerInfo?.billingPhone?.ifBlank { null }
         val billingAddress = buildBillingAddress(customerInfo)
         val note = customerNote?.ifBlank { null }
 
         val hasContent = customerName != null || email != null || phone != null ||
-            billingAddress != null || note != null
+            billingAddress != null || note != null || isGuest
         if (!hasContent) return null
 
         return WooPosBookingsState.CustomerSection(
@@ -198,6 +211,7 @@ class WooPosBookingViewStateMapper @Inject constructor(
             phone = phone,
             billingAddress = billingAddress,
             note = note,
+            isGuest = isGuest,
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsBadges.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsBadges.kt
@@ -76,6 +76,24 @@ fun WooPosCancelledBadge() {
 }
 
 @Composable
+fun WooPosGuestBadge() {
+    WooPosText(
+        text = stringResource(R.string.customer_detail_guest_customer),
+        style = WooPosTypography.Caption,
+        color = WooPosTheme.colors.onDefault,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier
+            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
+            .background(WooPosTheme.colors.disabledContainer)
+            .padding(
+                horizontal = WooPosSpacing.Small.value,
+                vertical = WooPosSpacing.XSmall.value
+            )
+    )
+}
+
+@Composable
 fun WooPosAttendanceBadge(attendanceState: WooPosBookingsState.AttendanceState) {
     val text = when (attendanceState) {
         WooPosBookingsState.AttendanceState.ATTENDED ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsBadges.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsBadges.kt
@@ -78,7 +78,7 @@ fun WooPosCancelledBadge() {
 @Composable
 fun WooPosGuestBadge() {
     WooPosText(
-        text = stringResource(R.string.customer_detail_guest_customer),
+        text = stringResource(R.string.woopos_bookings_details_customer_guest_badge),
         style = WooPosTypography.Caption,
         color = WooPosTheme.colors.onDefault,
         maxLines = 1,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -751,6 +751,7 @@ private fun sampleBookingDetails(
         phone = "+1 555-123-4567",
         billingAddress = null,
         note = null,
+        isGuest = false,
     ),
     attendanceSection = WooPosBookingsState.AttendanceSection(
         selection = WooPosBookingsState.AttendanceState.ATTENDED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsState.kt
@@ -54,6 +54,7 @@ sealed class WooPosBookingsState {
         val phone: String?,
         val billingAddress: String?,
         val note: String?,
+        val isGuest: Boolean,
     )
 
     @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/details/WooPosBookingDetails.kt
@@ -40,6 +40,7 @@ import com.woocommerce.android.ui.woopos.bookings.WooPosAttendanceBadge
 import com.woocommerce.android.ui.woopos.bookings.WooPosBookingsState
 import com.woocommerce.android.ui.woopos.bookings.WooPosBookingsUIEvent
 import com.woocommerce.android.ui.woopos.bookings.WooPosCancelledBadge
+import com.woocommerce.android.ui.woopos.bookings.WooPosGuestBadge
 import com.woocommerce.android.ui.woopos.bookings.WooPosPaymentStatusBadge
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
@@ -277,12 +278,20 @@ private fun BookingCustomerCard(
     onUIEvent: (WooPosBookingsUIEvent) -> Unit
 ) {
     WooPosCard(shadowType = ShadowType.Soft) {
-        Column(Modifier.padding(WooPosSpacing.Medium.value)) {
-            WooPosText(
-                text = stringResource(R.string.woopos_bookings_details_customer_title),
-                style = WooPosTypography.BodyXLarge,
-                fontWeight = FontWeight.SemiBold,
-            )
+        Column(Modifier.fillMaxWidth().padding(WooPosSpacing.Medium.value)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                WooPosText(
+                    text = stringResource(R.string.woopos_bookings_details_customer_title),
+                    style = WooPosTypography.BodyXLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                if (customerSection.isGuest) {
+                    WooPosGuestBadge()
+                }
+            }
 
             customerSection.email?.let { email ->
                 Spacer(Modifier.height(WooPosSpacing.Medium.value))
@@ -600,6 +609,7 @@ fun WooPosBookingDetailsPreview() {
             phone = "+1 742582943798",
             billingAddress = "238 Willow Creek Drive, Montgomery, AL 36109",
             note = "Prefers eco-friendly products, shorter length cuts",
+            isGuest = false,
         ),
         attendanceSection = WooPosBookingsState.AttendanceSection(
             selection = WooPosBookingsState.AttendanceState.UNATTENDED,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3921,6 +3921,7 @@
     <string name="woopos_bookings_details_location_label">Location</string>
     <string name="woopos_bookings_details_duration_label">Duration</string>
     <string name="woopos_bookings_details_customer_title">Customer</string>
+    <string name="woopos_bookings_details_customer_guest_badge">Guest</string>
     <string name="woopos_bookings_details_billing_address_label">Billing address</string>
     <string name="woopos_bookings_details_customer_note_label">Note</string>
     <string name="woopos_bookings_payment_status_paid">Paid</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingViewStateMapperTest.kt
@@ -510,6 +510,50 @@ class WooPosBookingViewStateMapperTest {
         assertThat(result.teamMember).isNull()
     }
 
+    @Test
+    fun `given booking with customerId 0, when mapped to details, then customer section isGuest is true`() = runTest {
+        // GIVEN
+        val booking = sampleBooking(customerId = 0L)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
+
+        // WHEN
+        val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
+
+        // THEN
+        assertThat(result.customerSection).isNotNull
+        assertThat(result.customerSection?.isGuest).isTrue()
+    }
+
+    @Test
+    fun `given booking with non-zero customerId, when mapped to details, then customer section isGuest is false`() =
+        runTest {
+            // GIVEN
+            val booking = sampleBooking(customerId = 42L)
+            whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
+
+            // WHEN
+            val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
+
+            // THEN
+            assertThat(result.customerSection).isNotNull
+            assertThat(result.customerSection?.isGuest).isFalse()
+        }
+
+    @Test
+    fun `given guest booking with no customer info, when mapped to details, then customer section shows guest badge`() =
+        runTest {
+            // GIVEN
+            val booking = sampleBooking(customerId = 0L, customerInfo = null, customerNote = null)
+            whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
+
+            // WHEN
+            val result = mapper.mapToDetailsViewState(booking, resourceName = null, location = null)
+
+            // THEN
+            assertThat(result.customerSection).isNotNull
+            assertThat(result.customerSection?.isGuest).isTrue()
+        }
+
     private fun sampleResource(
         name: String = "John Doe",
         imageUrl: String? = null,
@@ -549,6 +593,7 @@ class WooPosBookingViewStateMapperTest {
             totalTax = BigDecimal("5.50"),
         ),
         customerNote: String? = "Customer Note",
+        customerId: Long = 1L,
     ): BookingEntity {
         return BookingEntity(
             id = RemoteId(id),
@@ -559,7 +604,7 @@ class WooPosBookingViewStateMapperTest {
             status = status,
             cost = "55.00",
             currency = "USD",
-            customerId = 1L,
+            customerId = customerId,
             productId = 1L,
             resourceId = 1L,
             dateCreated = start,


### PR DESCRIPTION
### Description
Fixes WOOMOB-2352

When a booking has `customerId == 0`, the customer is a guest. This PR adds a grey "Guest" badge next to the "Customer" title in the POS booking detail right pane. 

### Test Steps
1. Open POS and navigate to Bookings
2. Select a booking that has a guest customer (customerId = 0)
3. Verify a grey "Guest" badge appears next to the "Customer" title in the detail pane
4. Verify the Customer card stretches to full width even when there is no customer info (only the badge)
5. Select a booking with a registered customer (customerId != 0)
6. Verify no "Guest" badge is shown

### Images/gif
<img width="400" alt="Screenshot_20260303_090829" src="https://github.com/user-attachments/assets/7a37a566-07c8-460e-a533-f5eaec0ebb09" />
<img width="400" alt="Screenshot_20260303_090820" src="https://github.com/user-attachments/assets/993e6330-2230-49ac-9c1a-1c95ca0b95de" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.