### PR TITLE
[WOOMOB-2376] Fix stale order details after sending email receipt

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -512,7 +512,7 @@ class WooPosOrdersViewModel @Inject constructor(
 
         _state.value = current.copy(
             items = WooPosOrdersState.Content.Items.Loaded(newMap),
-            selectedDetails = if (selectedId == updated.id) newDetailsViewState else current.selectedDetails
+            selectedDetails = if (current.selectedDetails?.id == updated.id) newDetailsViewState else current.selectedDetails
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -510,9 +510,10 @@ class WooPosOrdersViewModel @Inject constructor(
             if (item.id == updated.id) newItem to newDetails else item to details
         }
 
+        val shouldUpdateDetails = current.selectedDetails?.id == updated.id
         _state.value = current.copy(
             items = WooPosOrdersState.Content.Items.Loaded(newMap),
-            selectedDetails = if (current.selectedDetails?.id == updated.id) newDetailsViewState else current.selectedDetails
+            selectedDetails = if (shouldUpdateDetails) newDetailsViewState else current.selectedDetails
         )
     }
 


### PR DESCRIPTION
Continuation of #15459 (closed because `release/24.2` branch was deleted), now targeting `release/24.2.1`.

### Description
Fixes WOOMOB-2376

In single-order mode (e.g. POS booking detail), `applyOrderUpdate` was checking `selectedId` from the items map to decide whether to update `selectedDetails`. Since the items map is empty in single-order mode, `selectedId` was always `null`, so `selectedDetails` was never updated after refreshing the order. This fix checks `current.selectedDetails?.id` directly instead.

### Test Steps
1. Open POS and create an order
2. Navigate to the order details
3. Tap "Email receipt" and send an email
4. After returning to the order details, verify that the order details state is refreshed (e.g. the email field reflects the updated billing email)

### Images/gif

https://github.com/user-attachments/assets/0678030f-90c4-48ce-8c07-ecba03314f97

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.