### PR TITLE
[WOOMOB-2340] Fix bookings empty state icon and strings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.bookings
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -47,6 +48,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -267,13 +269,28 @@ private fun WooPosBookingsContent(
                         )
                     }
                     else -> {
-                        WooPosEmptyScreen(
-                            modifier = Modifier.fillMaxSize(),
-                            icon = WooPosIcons.OrdersEmpty,
-                            title = stringResource(R.string.woopos_bookings_no_booking_selected),
-                            message = "",
-                            contentDescription = stringResource(R.string.woopos_orders_empty_list_image_description)
-                        )
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(horizontal = WooPosSpacing.XLarge.value),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center,
+                        ) {
+                            Image(
+                                modifier = Modifier.size(80.dp),
+                                imageVector = WooPosIcons.BookingsEmpty,
+                                contentDescription = stringResource(
+                                    R.string.woopos_bookings_empty_image_description
+                                ),
+                            )
+                            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+                            WooPosText(
+                                text = stringResource(R.string.woopos_bookings_no_booking_selected),
+                                style = WooPosTypography.BodyMedium,
+                                color = WooPosTheme.colors.onSurfaceVariantLowest,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
                     }
                 }
             }
@@ -415,10 +432,10 @@ private fun WooPosBookingsList(
             WooPosEmptyScreen(
                 modifier = modifier
                     .imePadding()
-                    .padding(horizontal = WooPosSpacing.XLarge.value),
+                    .padding(horizontal = WooPosSpacing.XXLarge.value),
                 title = items.title,
                 message = items.message,
-                contentDescription = stringResource(id = R.string.woopos_search_empty_image_content_description)
+                contentDescription = stringResource(id = R.string.woopos_bookings_empty_image_description)
             )
         }
     }
@@ -615,8 +632,8 @@ private fun WooPosBookingsError(
 private fun WooPosBookingsPaginationErrorRow(onPaginationErrorTryAgain: () -> Unit) {
     WooPosPaginationErrorIndicator(
         icon = null,
-        message = stringResource(id = R.string.woopos_orders_pagination_error_title),
-        description = stringResource(id = R.string.woopos_orders_pagination_error_content_description),
+        message = stringResource(id = R.string.woopos_bookings_pagination_error_title),
+        description = stringResource(id = R.string.woopos_bookings_pagination_error_description),
         primaryButton = WooPosErrorScreenButtonState(
             text = stringResource(id = R.string.woopos_orders_pagination_try_again_label),
             click = onPaginationErrorTryAgain
@@ -697,8 +714,8 @@ fun WooPosBookingsNothingFoundStatePreview() {
         WooPosBookingsScreen(
             state = WooPosBookingsState.Content(
                 items = WooPosBookingsState.Content.Items.NothingFound(
-                    title = stringResource(R.string.woopos_search_orders_empty_title),
-                    message = stringResource(R.string.woopos_search_orders_empty_description)
+                    title = stringResource(R.string.woopos_bookings_no_bookings_for_date),
+                    message = stringResource(R.string.woopos_bookings_no_bookings_for_date_message)
                 ),
                 pullToRefreshState = WooPosPullToRefreshState.Enabled,
                 dateSelectorState = DateSelectorState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -269,28 +269,13 @@ private fun WooPosBookingsContent(
                         )
                     }
                     else -> {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(horizontal = WooPosSpacing.XLarge.value),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.Center,
-                        ) {
-                            Image(
-                                modifier = Modifier.size(80.dp),
-                                imageVector = WooPosIcons.BookingsEmpty,
-                                contentDescription = stringResource(
-                                    R.string.woopos_bookings_empty_image_description
-                                ),
-                            )
-                            Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
-                            WooPosText(
-                                text = stringResource(R.string.woopos_bookings_no_booking_selected),
-                                style = WooPosTypography.BodyMedium,
-                                color = WooPosTheme.colors.onSurfaceVariantLowest,
-                                textAlign = TextAlign.Center,
-                            )
-                        }
+                        WooPosEmptyScreen(
+                            modifier = Modifier.fillMaxSize(),
+                            icon = WooPosIcons.BookingsEmpty,
+                            title = stringResource(R.string.woopos_bookings_no_booking_selected),
+                            message = "",
+                            contentDescription = stringResource(R.string.woopos_bookings_empty_image_description)
+                        )
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.woopos.bookings
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -48,7 +47,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsScreen.kt
@@ -283,7 +283,7 @@ private fun WooPosBookingsContent(
                                     R.string.woopos_bookings_empty_image_description
                                 ),
                             )
-                            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+                            Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
                             WooPosText(
                                 text = stringResource(R.string.woopos_bookings_no_booking_selected),
                                 style = WooPosTypography.BodyMedium,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -109,10 +109,10 @@ class WooPosBookingsViewModel @Inject constructor(
                         _state.value = current.copy(
                             items = WooPosBookingsState.Content.Items.Error(
                                 title = resourceProvider.getString(
-                                    R.string.woopos_orders_loading_error_title
+                                    R.string.woopos_bookings_loading_error_title
                                 ),
                                 message = resourceProvider.getString(
-                                    R.string.woopos_orders_loading_error_message
+                                    R.string.woopos_bookings_loading_error_message
                                 )
                             ),
                             pullToRefreshState = WooPosPullToRefreshState.Enabled,
@@ -132,7 +132,9 @@ class WooPosBookingsViewModel @Inject constructor(
                                 title = resourceProvider.getString(
                                     R.string.woopos_bookings_no_bookings_for_date
                                 ),
-                                message = ""
+                                message = resourceProvider.getString(
+                                    R.string.woopos_bookings_no_bookings_for_date_message
+                                )
                             ),
                             pullToRefreshState = WooPosPullToRefreshState.Enabled,
                         )
@@ -176,7 +178,9 @@ class WooPosBookingsViewModel @Inject constructor(
                             title = resourceProvider.getString(
                                 R.string.woopos_bookings_no_bookings_for_date
                             ),
-                            message = ""
+                            message = resourceProvider.getString(
+                                R.string.woopos_bookings_no_bookings_for_date_message
+                            )
                         ),
                         pullToRefreshState = WooPosPullToRefreshState.Enabled,
                         dateSelectorState = dateSelectorState,
@@ -654,7 +658,9 @@ class WooPosBookingsViewModel @Inject constructor(
             title = resourceProvider.getString(
                 R.string.woopos_bookings_no_bookings_for_date
             ),
-            message = ""
+            message = resourceProvider.getString(
+                R.string.woopos_bookings_no_bookings_for_date_message
+            )
         ),
         pullToRefreshState = WooPosPullToRefreshState.Enabled,
         dateSelectorState = buildDateSelectorState(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/designsystem/WooPosIcons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/designsystem/WooPosIcons.kt
@@ -73,8 +73,8 @@ object WooPosIcons {
     val BookingsEmpty: ImageVector
         @Composable
         get() = bookingsEmpty(
-            bodyColor = WooPosTheme.colors.outlineVariant,
-            detailColor = WooPosTheme.colors.onSurfaceVariantLowest,
+            bodyColor = MaterialTheme.colorScheme.secondary,
+            detailColor = MaterialTheme.colorScheme.primary,
         )
 
     val CardReaderNotConnected: ImageVector

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/designsystem/WooPosIcons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/designsystem/WooPosIcons.kt
@@ -70,6 +70,13 @@ object WooPosIcons {
             tertiaryColor = WooPosTheme.colors.tertiaryIconColor
         )
 
+    val BookingsEmpty: ImageVector
+        @Composable
+        get() = bookingsEmpty(
+            bodyColor = WooPosTheme.colors.outlineVariant,
+            detailColor = WooPosTheme.colors.onSurfaceVariantLowest,
+        )
+
     val CardReaderNotConnected: ImageVector
         @Composable
         get() = cardReaderNotConnected(
@@ -622,6 +629,124 @@ object WooPosIcons {
             }
         }.build()
     }
+
+    private fun bookingsEmpty(
+        bodyColor: Color,
+        detailColor: Color,
+    ): ImageVector {
+        return ImageVector.Builder(
+            name = "BookingsEmpty",
+            defaultWidth = 48.dp,
+            defaultHeight = 48.dp,
+            viewportWidth = 48f,
+            viewportHeight = 48f
+        ).apply {
+            // Calendar body
+            path(fill = SolidColor(bodyColor)) {
+                moveTo(6.208f, 19.544f)
+                verticalLineTo(44.13f)
+                curveTo(6.208f, 46.586f, 7.57f, 48f, 9.975f, 48f)
+                horizontalLineTo(38.026f)
+                curveTo(40.431f, 48f, 41.793f, 46.578f, 41.793f, 44.13f)
+                verticalLineTo(19.544f)
+                curveTo(41.793f, 17.088f, 40.431f, 15.674f, 38.026f, 15.674f)
+                horizontalLineTo(9.975f)
+                curveTo(7.57f, 15.665f, 6.208f, 17.088f, 6.208f, 19.544f)
+                close()
+            }
+            // Dot row 1 col 1
+            path(fill = SolidColor(detailColor)) {
+                moveTo(15.543f, 33.768f)
+                curveTo(16.638f, 33.768f, 17.561f, 32.897f, 17.561f, 31.75f)
+                curveTo(17.561f, 30.604f, 16.69f, 29.733f, 15.543f, 29.733f)
+                curveTo(14.397f, 29.733f, 13.526f, 30.604f, 13.526f, 31.75f)
+                curveTo(13.526f, 32.897f, 14.397f, 33.768f, 15.543f, 33.768f)
+                close()
+            }
+            // Dot row 1 col 2
+            path(fill = SolidColor(detailColor)) {
+                moveTo(24f, 33.768f)
+                curveTo(25.094f, 33.768f, 26.017f, 32.897f, 26.017f, 31.75f)
+                curveTo(26.017f, 30.604f, 25.146f, 29.733f, 24f, 29.733f)
+                curveTo(22.853f, 29.733f, 21.982f, 30.604f, 21.982f, 31.75f)
+                curveTo(21.982f, 32.897f, 22.913f, 33.768f, 24f, 33.768f)
+                close()
+            }
+            // Dot row 1 col 3
+            path(fill = SolidColor(detailColor)) {
+                moveTo(32.457f, 33.768f)
+                curveTo(33.551f, 33.768f, 34.474f, 32.897f, 34.474f, 31.75f)
+                curveTo(34.474f, 30.604f, 33.603f, 29.733f, 32.457f, 29.733f)
+                curveTo(31.31f, 29.733f, 30.44f, 30.604f, 30.44f, 31.75f)
+                curveTo(30.44f, 32.897f, 31.37f, 33.768f, 32.457f, 33.768f)
+                close()
+            }
+            // Dot row 2 col 1
+            path(fill = SolidColor(detailColor)) {
+                moveTo(15.543f, 42.431f)
+                curveTo(16.638f, 42.431f, 17.561f, 41.56f, 17.561f, 40.414f)
+                curveTo(17.561f, 39.267f, 16.69f, 38.396f, 15.543f, 38.396f)
+                curveTo(14.397f, 38.396f, 13.526f, 39.267f, 13.526f, 40.414f)
+                curveTo(13.526f, 41.56f, 14.397f, 42.431f, 15.543f, 42.431f)
+                close()
+            }
+            // Dot row 2 col 2
+            path(fill = SolidColor(detailColor)) {
+                moveTo(24f, 42.431f)
+                curveTo(25.094f, 42.431f, 26.017f, 41.56f, 26.017f, 40.414f)
+                curveTo(26.017f, 39.267f, 25.146f, 38.396f, 24f, 38.396f)
+                curveTo(22.853f, 38.396f, 21.982f, 39.267f, 21.982f, 40.414f)
+                curveTo(21.982f, 41.56f, 22.913f, 42.431f, 24f, 42.431f)
+                close()
+            }
+            // Dot row 2 col 3
+            path(fill = SolidColor(detailColor)) {
+                moveTo(32.457f, 42.431f)
+                curveTo(33.551f, 42.431f, 34.474f, 41.56f, 34.474f, 40.414f)
+                curveTo(34.474f, 39.267f, 33.603f, 38.396f, 32.457f, 38.396f)
+                curveTo(31.31f, 38.396f, 30.44f, 39.267f, 30.44f, 40.414f)
+                curveTo(30.44f, 41.56f, 31.37f, 42.431f, 32.457f, 42.431f)
+                close()
+            }
+            // Header bar
+            path(fill = SolidColor(detailColor)) {
+                moveTo(6.208f, 19.544f)
+                verticalLineTo(24.156f)
+                horizontalLineTo(41.793f)
+                verticalLineTo(19.544f)
+                curveTo(41.793f, 17.088f, 40.431f, 15.674f, 38.026f, 15.674f)
+                horizontalLineTo(9.975f)
+                curveTo(7.57f, 15.674f, 6.208f, 17.096f, 6.208f, 19.544f)
+                close()
+            }
+            // Right tab
+            path(fill = SolidColor(bodyColor)) {
+                moveTo(33.008f, 8.002f)
+                horizontalLineTo(31.672f)
+                curveTo(30.198f, 8.002f, 29.327f, 8.821f, 29.327f, 10.347f)
+                verticalLineTo(18.208f)
+                curveTo(29.327f, 19.683f, 30.146f, 20.553f, 31.672f, 20.553f)
+                horizontalLineTo(33.008f)
+                curveTo(34.482f, 20.553f, 35.353f, 19.734f, 35.353f, 18.208f)
+                verticalLineTo(10.347f)
+                curveTo(35.353f, 8.873f, 34.534f, 8.002f, 33.008f, 8.002f)
+                close()
+            }
+            // Left tab
+            path(fill = SolidColor(bodyColor)) {
+                moveTo(16.319f, 8.002f)
+                horizontalLineTo(14.983f)
+                curveTo(13.509f, 8.002f, 12.639f, 8.821f, 12.639f, 10.347f)
+                verticalLineTo(18.208f)
+                curveTo(12.639f, 19.683f, 13.458f, 20.553f, 14.983f, 20.553f)
+                horizontalLineTo(16.319f)
+                curveTo(17.794f, 20.553f, 18.664f, 19.734f, 18.664f, 18.208f)
+                verticalLineTo(10.347f)
+                curveTo(18.664f, 8.873f, 17.845f, 8.002f, 16.319f, 8.002f)
+                close()
+            }
+        }.build()
+    }
 }
 
 @Suppress("UnusedPrivateMember")
@@ -708,6 +833,16 @@ private fun WooPosIconsPreview() {
                     Image(
                         imageVector = WooPosIcons.CardReaderNotConnected,
                         contentDescription = "CardReaderNotConnected",
+                        modifier = Modifier.size(80.dp)
+                    )
+                }
+                Box(
+                    modifier = Modifier.size(80.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        imageVector = WooPosIcons.BookingsEmpty,
+                        contentDescription = "BookingsEmpty",
                         modifier = Modifier.size(80.dp)
                     )
                 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3957,12 +3957,16 @@
     <string name="woopos_bookings_note_screen_hint">Type booking note</string>
     <string name="woopos_bookings_note_screen_button_save">Save</string>
     <string name="woopos_bookings_note_screen_save_error">Error saving booking note</string>
-    <string name="woopos_bookings_no_bookings_for_date">No bookings for this date</string>
+    <string name="woopos_bookings_no_bookings_for_date">No bookings for this day</string>
+    <string name="woopos_bookings_no_bookings_for_date_message">Any bookings scheduled for this date will appear here.</string>
     <string name="woopos_bookings_no_booking_selected">No booking selected.</string>
     <string name="woopos_bookings_date_selector_previous_day">Previous day</string>
     <string name="woopos_bookings_date_selector_next_day">Next day</string>
     <string name="woopos_bookings_loading_error_title">Unable to load bookings</string>
     <string name="woopos_bookings_loading_error_message">Please check your connection and try again.</string>
+    <string name="woopos_bookings_empty_image_description">No bookings</string>
+    <string name="woopos_bookings_pagination_error_title">Unable to load more bookings</string>
+    <string name="woopos_bookings_pagination_error_description">Please try again.</string>
 
     <string name="woopos_cash_payment_title">Cash payment</string>
     <string name="woopos_complete_cash_order_button">Mark payment as complete</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3959,7 +3959,7 @@
     <string name="woopos_bookings_note_screen_save_error">Error saving booking note</string>
     <string name="woopos_bookings_no_bookings_for_date">No bookings for this day</string>
     <string name="woopos_bookings_no_bookings_for_date_message">Any bookings scheduled for this date will appear here.</string>
-    <string name="woopos_bookings_no_booking_selected">No booking selected.</string>
+    <string name="woopos_bookings_no_booking_selected">No booking selected</string>
     <string name="woopos_bookings_date_selector_previous_day">Previous day</string>
     <string name="woopos_bookings_date_selector_next_day">Next day</string>
     <string name="woopos_bookings_loading_error_title">Unable to load bookings</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -3957,12 +3957,16 @@
     <string name="woopos_bookings_note_screen_hint">Type booking note</string>
     <string name="woopos_bookings_note_screen_button_save">Save</string>
     <string name="woopos_bookings_note_screen_save_error">Error saving booking note</string>
-    <string name="woopos_bookings_no_bookings_for_date">No bookings for this date</string>
+    <string name="woopos_bookings_no_bookings_for_date">No bookings for this day</string>
+    <string name="woopos_bookings_no_bookings_for_date_message">Any bookings scheduled for this date will appear here.</string>
     <string name="woopos_bookings_no_booking_selected">No booking selected.</string>
     <string name="woopos_bookings_date_selector_previous_day">Previous day</string>
     <string name="woopos_bookings_date_selector_next_day">Next day</string>
     <string name="woopos_bookings_loading_error_title">Unable to load bookings</string>
     <string name="woopos_bookings_loading_error_message">Please check your connection and try again.</string>
+    <string name="woopos_bookings_empty_image_description">No bookings</string>
+    <string name="woopos_bookings_pagination_error_title">Unable to load more bookings</string>
+    <string name="woopos_bookings_pagination_error_description">Please try again.</string>
 
     <string name="woopos_cash_payment_title">Cash payment</string>
     <string name="woopos_complete_cash_order_button">Mark payment as complete</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -3959,7 +3959,7 @@
     <string name="woopos_bookings_note_screen_save_error">Error saving booking note</string>
     <string name="woopos_bookings_no_bookings_for_date">No bookings for this day</string>
     <string name="woopos_bookings_no_bookings_for_date_message">Any bookings scheduled for this date will appear here.</string>
-    <string name="woopos_bookings_no_booking_selected">No booking selected.</string>
+    <string name="woopos_bookings_no_booking_selected">No booking selected</string>
     <string name="woopos_bookings_date_selector_previous_day">Previous day</string>
     <string name="woopos_bookings_date_selector_next_day">Next day</string>
     <string name="woopos_bookings_loading_error_title">Unable to load bookings</string>


### PR DESCRIPTION
### Description
Fixes WOOMOB-2340

Fix the bookings empty state screens to match the Figma design:
- **Right pane ("No booking selected")**: Replace magnifying glass icon with a calendar icon (`BookingsEmpty`) and use muted `BodyMedium` text instead of bold heading
- **Left pane ("Nothing found")**: Update title from "No bookings for this date" to "No bookings for this day" and add subtitle message "Any bookings scheduled for this date will appear here."
- Fix orders-specific string references (pagination errors, content descriptions, loading errors) to use bookings-specific strings

### Test Steps
1. Open POS > Bookings on a date with no bookings
2. Verify the left pane shows "No bookings for this day" with the subtitle "Any bookings scheduled for this date will appear here."

### Images/gif
<img width="800" alt="image" src="https://github.com/user-attachments/assets/b496f3ab-945c-4a43-933a-9000ba58a878" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.