### PR TITLE
Remove new strings.xml entries from hotfix branch

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
@@ -435,7 +435,7 @@ private fun CardPaymentCenteredLayout(
     ) {
         if (onBackClicked != null) {
             WooPosToolbar(
-                titleText = stringResource(R.string.woopos_card_payment_toolbar_title),
+                titleText = stringResource(R.string.payment),
                 onBackClicked = onBackClicked,
             )
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3797,7 +3797,6 @@
     <string name="woopos_variations_empty_list_image_description">No variations</string>
     <string name="woopos_variations_any_variation">Any %s</string>
 
-    <string name="woopos_totals_toolbar_title">Payment</string>
     <string name="woopos_success_totals_error_reader_not_connected_title">Reader not connected</string>
     <string name="woopos_success_totals_error_reader_not_connected_subtitle">To process this payment, please connect your reader.</string>
     <string name="woopos_success_totals_error_reader_not_connected_cta_button_label">Connect to reader</string>
@@ -3815,7 +3814,6 @@
     <string name="woo_pos_payment_failed_go_back_to_checkout">Go back to checkout</string>
     <string name="woo_pos_payment_failed_go_back">Go back</string>
 
-    <string name="woopos_card_payment_toolbar_title">Payment</string>
     <string name="woopos_card_payment_done_button">Done</string>
 
     <string name="woopos_floating_toolbar_overlay_menu_content_description">Dimmed background. Tap to close the menu.</string>


### PR DESCRIPTION
### Description
Removes two new string resources (`woopos_totals_toolbar_title` and `woopos_card_payment_toolbar_title`) that were added in the hotfix branch. Since **strings.xml cannot be changed in a hotfix**, the code now reuses the existing `R.string.payment` which has the same "Payment" value. `woopos_totals_toolbar_title` was unused entirely.

### Test Steps
1. Open POS and go to a card payment flow
2. Verify the toolbar title still shows "Payment"

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.