### PR TITLE
[WOOMOB-2348] Show error toast on attendance status update failure

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -468,6 +468,7 @@ class WooPosBookingsViewModel @Inject constructor(
                     selectedDetails = reverted,
                     items = updateItemsWithDetails(rollbackState.items, reverted),
                 )
+                _toastEvent.emit(resourceProvider.getString(R.string.booking_attendance_status_error))
             }
         }
     }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2348

When the attendance status optimistic update fails, the UI was silently rolling back without telling the user. This adds an error toast on failure so the user knows the update didn't go through.

Also, about cancelling the in-flight request when the user toggles again - this doesn't work well here because `updateAttendanceStatus` in the repository runs the actual network call in `appCoroutineScope`. Cancelling the viewmodel's job only cancels the await(), but the request keeps running and writes the stale value to
  DB. Then `observeBookings` picks it up and overwrites the optimistic UI state. Fixing this properly would need an override mechanism in the observer, which adds a lot of complexity, which may not be worth it as no common use case.
 
@malinajirka if you have any ideas on how to improve that, let me know

### Test Steps
1. Open WooPos bookings screen
2. Select a booking with editable attendance status
3. Toggle the attendance switch while in airplane mode
4. Verify that the toggle rolls back and an error toast is shown

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.