### PR TITLE
[WOOMOB-2383] Refactor bookings payment status resolution to single DB call

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolver.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings
 
 import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -13,6 +14,22 @@ class PaymentStatusResolver @Inject constructor(
         val order = orderStore.getOrderByIdAndSite(orderId, selectedSite.get())
             ?: return PaymentStatus.UNPAID
 
+        return statusForOrder(order)
+    }
+
+    suspend fun resolveAll(orderIds: List<Long>): Map<Long, PaymentStatus> {
+        val uniqueOrderIds = orderIds.distinct()
+        if (uniqueOrderIds.isEmpty()) return emptyMap()
+
+        val ordersById = orderStore.getOrdersByIdsAndSite(uniqueOrderIds, selectedSite.get())
+            .associateBy { it.orderId }
+
+        return uniqueOrderIds.associateWith { orderId ->
+            ordersById[orderId]?.let(::statusForOrder) ?: PaymentStatus.UNPAID
+        }
+    }
+
+    private fun statusForOrder(order: OrderEntity): PaymentStatus {
         val total = order.total.toBigDecimalOrNull() ?: BigDecimal.ZERO
         return computeStatus(order.refundTotal.abs(), total, order.datePaid, order.status)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -83,18 +84,23 @@ class BookingListViewModel @Inject constructor(
     private var bookingsFetchJob: Job? = null
     private var bookingsLoadMoreJob: Job? = null
 
-    private val contentState = combine(
-        bookingListHandler.bookingsFlow,
-        loadingState,
-        selectedBookingIdFlow,
-    ) { bookings, loadingState, selectedBookingId ->
-        openFirstLoadedBookingOnTablet(bookings)
-        val listItems = with(bookingMapper) {
-            bookings.map {
-                val paymentStatus = paymentStatusResolver.resolve(it.orderId)
-                it.toListItem(paymentStatus)
+    private val bookingListItems = bookingListHandler.bookingsFlow
+        .distinctUntilChanged()
+        .map { bookings ->
+            openFirstLoadedBookingOnTablet(bookings)
+            val paymentStatusesByOrderId = paymentStatusResolver.resolveAll(bookings.map { it.orderId })
+            with(bookingMapper) {
+                bookings.map { booking ->
+                    booking.toListItem(paymentStatusesByOrderId.getValue(booking.orderId))
+                }
             }
         }
+
+    private val contentState = combine(
+        bookingListItems,
+        loadingState,
+        selectedBookingIdFlow,
+    ) { listItems, loadingState, selectedBookingId ->
         BookingListContentState(
             bookings = listItems,
             loadingState = loadingState,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolverTest.kt
@@ -15,9 +15,7 @@ import java.math.BigDecimal
 class PaymentStatusResolverTest {
 
     private val orderStore: WCOrderStore = mock()
-    private val site: SiteModel = mock {
-        on { localId() }.thenReturn(LocalId(1))
-    }
+    private val site: SiteModel = mock()
     private val selectedSite: SelectedSite = mock {
         on { get() }.thenReturn(site)
     }
@@ -121,14 +119,84 @@ class PaymentStatusResolverTest {
         assertThat(result).isEqualTo(PaymentStatus.UNPAID)
     }
 
+    @Test
+    fun `given unique order ids, when resolve list, then returns status for each id`() = runTest {
+        // GIVEN
+        val paidOrder = createOrder(orderId = 11L, datePaid = "2025-01-01")
+        val refundedOrder = createOrder(
+            orderId = 22L,
+            total = "100",
+            refundTotal = BigDecimal("-100"),
+            datePaid = "2025-01-01"
+        )
+        val failedOrder = createOrder(orderId = 33L, status = "failed", datePaid = "", refundTotal = BigDecimal.ZERO)
+        whenever(orderStore.getOrdersByIdsAndSite(listOf(11L, 22L, 33L), site))
+            .thenReturn(listOf(failedOrder, paidOrder, refundedOrder))
+
+        // WHEN
+        val result = sut.resolveAll(listOf(11L, 22L, 33L))
+
+        // THEN
+        assertThat(result).isEqualTo(
+            mapOf(
+                11L to PaymentStatus.PAID,
+                22L to PaymentStatus.REFUNDED,
+                33L to PaymentStatus.FAILED
+            )
+        )
+    }
+
+    @Test
+    fun `given order ids with duplicates, when resolve list, then returns status per unique id`() = runTest {
+        // GIVEN
+        val paidOrder = createOrder(orderId = 1L, datePaid = "2025-01-01")
+        val failedOrder = createOrder(orderId = 2L, status = "failed", datePaid = "", refundTotal = BigDecimal.ZERO)
+        whenever(orderStore.getOrdersByIdsAndSite(listOf(1L, 2L), site)).thenReturn(listOf(paidOrder, failedOrder))
+
+        // WHEN
+        val result = sut.resolveAll(listOf(1L, 2L, 1L))
+
+        // THEN
+        assertThat(result).isEqualTo(
+            mapOf(
+                1L to PaymentStatus.PAID,
+                2L to PaymentStatus.FAILED
+            )
+        )
+    }
+
+    @Test
+    fun `given missing orders, when resolveAll is called, then missing ids fallback to UNPAID`() = runTest {
+        // GIVEN
+        val refundedOrder = createOrder(
+            orderId = 3L,
+            total = "100",
+            refundTotal = BigDecimal("-100"),
+            datePaid = "2025-01-01"
+        )
+        whenever(orderStore.getOrdersByIdsAndSite(listOf(3L, 999L), site)).thenReturn(listOf(refundedOrder))
+
+        // WHEN
+        val result = sut.resolveAll(listOf(3L, 999L))
+
+        // THEN
+        assertThat(result).isEqualTo(
+            mapOf(
+                3L to PaymentStatus.REFUNDED,
+                999L to PaymentStatus.UNPAID
+            )
+        )
+    }
+
     private fun createOrder(
+        orderId: Long = 1L,
         status: String = "processing",
         datePaid: String = "",
         refundTotal: BigDecimal = BigDecimal.ZERO,
         total: String = "100",
     ) = OrderEntity(
         localSiteId = LocalId(1),
-        orderId = 1L,
+        orderId = orderId,
         status = status,
         datePaid = datePaid,
         refundTotal = refundTotal,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -27,6 +27,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -70,7 +71,10 @@ class BookingListViewModelTest : BaseUnitTest() {
     }
     private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact = mock()
     private val paymentStatusResolver: PaymentStatusResolver = mock {
-        onBlocking { resolve(any()) } doReturn PaymentStatus.UNPAID
+        onBlocking { resolveAll(any()) } doSuspendableAnswer { invocation ->
+            val orderIds = invocation.getArgument<List<Long>>(0)
+            orderIds.distinct().associateWith { PaymentStatus.UNPAID }
+        }
     }
 
     private lateinit var viewModel: BookingListViewModel

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -27,7 +27,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -71,10 +70,7 @@ class BookingListViewModelTest : BaseUnitTest() {
     }
     private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact = mock()
     private val paymentStatusResolver: PaymentStatusResolver = mock {
-        onBlocking { resolveAll(any()) } doSuspendableAnswer { invocation ->
-            val orderIds = invocation.getArgument<List<Long>>(0)
-            orderIds.distinct().associateWith { PaymentStatus.UNPAID }
-        }
+        onBlocking { resolveAll(any()) } doReturn mapOf(1L to PaymentStatus.UNPAID)
     }
 
     private lateinit var viewModel: BookingListViewModel

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -76,6 +76,7 @@ class WCOrderStore @Inject internal constructor(
 ) : Store(dispatcher) {
     companion object {
         const val NUM_ORDERS_PER_FETCH = 15
+        private const val IDS_QUERY_CHUNK_SIZE = 200
     }
 
     class FetchOrderListPayload(
@@ -434,7 +435,9 @@ class WCOrderStore @Inject internal constructor(
     suspend fun getOrdersByIdsAndSite(orderIds: List<Long>, site: SiteModel): List<OrderEntity> {
         if (orderIds.isEmpty()) return emptyList()
         return coroutineEngine.withDefaultContext(API, this, "getOrdersByIdsAndSite") {
-            ordersDaoDecorator.getOrdersForSiteByRemoteIds(site.localId(), orderIds)
+            orderIds.chunked(IDS_QUERY_CHUNK_SIZE).flatMap { orderIdsChunk ->
+                ordersDaoDecorator.getOrdersForSiteByRemoteIds(site.localId(), orderIdsChunk)
+            }
         }
     }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -431,6 +431,13 @@ class WCOrderStore @Inject internal constructor(
         return ordersDaoDecorator.getOrder(orderId, site.localId())
     }
 
+    suspend fun getOrdersByIdsAndSite(orderIds: List<Long>, site: SiteModel): List<OrderEntity> {
+        if (orderIds.isEmpty()) return emptyList()
+        return coroutineEngine.withDefaultContext(API, this, "getOrdersByIdsAndSite") {
+            ordersDaoDecorator.getOrdersForSiteByRemoteIds(site.localId(), orderIds)
+        }
+    }
+
     /**
      * Given an order id and [SiteModel],
      * returns the metadata from the database for an order


### PR DESCRIPTION
### Description

The Bookings list was resolving payment status with one database call per booking (N calls). This PR refactors that flow to fetch all related orders in a single call via `getOrdersByIdsAndSite`, then resolve statuses in memory.

`BookingListViewModel` now uses `resolveAll`, and the previous behavior is preserved by keeping the fallback in the resolver (`UNPAID` when an order is missing).

**Note:** I could not test on a tablet device locally. Please verify this on a real tablet.

### Test Steps
1. On a real tablet device, open the app and navigate to Bookings from the More menu.
2. Use a store with a high number of bookings and open the Bookings list.
3. Verify payment statuses are displayed correctly (`PAID`, `UNPAID`, `FAILED`, `REFUNDED`).
4. Switch tabs, apply search and filters, and verify statuses remain correct after reloads.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
