### PR TITLE
[WOOMOB-1820] Fix pull-to-refresh not working on empty booking list

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -79,6 +79,7 @@ fun BookingListScreen(viewModel: BookingListViewModel) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BookingListScreen(state: BookingListViewState) {
     state.sortBottomSheetState?.let { BookingSortBottomSheet(it) }
@@ -130,12 +131,20 @@ fun BookingListScreen(state: BookingListViewState) {
                 }
 
                 else -> {
-                    EmptyView(
-                        state = state,
-                        modifier = Modifier
-                            .background(MaterialTheme.colorScheme.surface)
-                            .fillMaxSize()
-                    )
+                    WCPullToRefreshBox(
+                        isRefreshing = state.contentState.loadingState ==
+                            BookingListLoadingState.Refreshing,
+                        onRefresh = state.contentState.onRefresh,
+                        state = rememberPullToRefreshState(),
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        EmptyView(
+                            state = state,
+                            modifier = Modifier
+                                .background(MaterialTheme.colorScheme.surface)
+                                .fillMaxSize()
+                        )
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -79,7 +79,6 @@ fun BookingListScreen(viewModel: BookingListViewModel) {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BookingListScreen(state: BookingListViewState) {
     state.sortBottomSheetState?.let { BookingSortBottomSheet(it) }
@@ -135,7 +134,6 @@ fun BookingListScreen(state: BookingListViewState) {
                         isRefreshing = state.contentState.loadingState ==
                             BookingListLoadingState.Refreshing,
                         onRefresh = state.contentState.onRefresh,
-                        state = rememberPullToRefreshState(),
                         modifier = Modifier.fillMaxSize()
                     ) {
                         EmptyView(


### PR DESCRIPTION
### Description
Fixes WOOMOB-1820

The empty state view in the booking list was not wrapped in a pull-to-refresh container, so users couldn't trigger a refresh when there were no bookings. This wraps the `EmptyView` in `WCPullToRefreshBox` to enable pull-to-refresh on the empty state, consistent with the non-empty list behaviour.

### Test Steps
1. Open the app and navigate to the Bookings list.
2. Ensure there are no bookings (or use a store/account with no bookings).
3. Pull down on the empty state screen.
4. Verify that the pull-to-refresh indicator appears and a refresh is triggered.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
