### PR TITLE
Put Cancelled badge first on booking screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingSummary.kt
@@ -53,6 +53,9 @@ fun BookingSummary(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.padding(top = 6.dp)
         ) {
+            if (model.isCancelled) {
+                BookingCancelledTag()
+            }
             model.attendanceStatus?.let {
                 BookingAttendanceStatusTag(
                     state = it,
@@ -60,9 +63,6 @@ fun BookingSummary(
                 )
             }
             BookingPaymentStatusTag(paymentStatus = model.paymentStatus)
-            if (model.isCancelled) {
-                BookingCancelledTag()
-            }
         }
     }
 }
@@ -145,6 +145,25 @@ private fun BookingSummaryAttendanceUpdatingPreview() {
                 paymentStatus = PaymentStatus.PAID,
                 isCancelled = false,
                 attendanceUpdateStatus = AttendanceUpdateStatus.InProgress,
+            ),
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun BookingSummaryCancelledPreview() {
+    WooThemeWithBackground {
+        BookingSummary(
+            model = BookingSummaryModel(
+                date = "05/07/2025, 11:00 AM",
+                name = "Women's Haircut",
+                customerName = "Margarita Nikolaevna",
+                attendanceStatus = BookingAttendanceStatus.Unattended,
+                paymentStatus = PaymentStatus.UNPAID,
+                isCancelled = true,
+                attendanceUpdateStatus = AttendanceUpdateStatus.Idle,
             ),
             modifier = Modifier.fillMaxWidth()
         )


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/WOOMOB-2393

## Description

Aligns booking badge ordering with web by placing the `Cancelled` badge first on booking screens.

**Before:** Attendance badge → Status badge
**After (when cancelled):** Cancelled badge → Attendance badge

The change applies to both the booking list and booking detail header since they share the `BookingSummary` composable.

## Test Steps

1. Open the app and navigate to the Bookings section
2. Find or create a booking with `Cancelled` status
3. Verify the `Cancelled` badge appears **before** the attendance badge in the booking list
4. Tap on the cancelled booking to open details
5. Verify the `Cancelled` badge appears **before** the attendance badge in the detail header
6. Verify non-cancelled bookings still show badges in the same order as before (attendance → status)

| List  | Detail |
| ------------- | ------------- |
| <img width="300" height="2400" alt="booking_list_cancelled_first" src="https://github.com/user-attachments/assets/4a5d3a61-1a1e-4167-96d5-18cef3f6fda7" />   | <img width="300" height="2400" alt="booking_detail_cancelled_first" src="https://github.com/user-attachments/assets/81f2ef53-4fbc-4956-9aa9-b12956daebe7" />  |
| <img width="300"  src="">  | <img width="300"  src="">  |


- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.