### PR TITLE
[WOOMOB-2395] Enable POS coupons for CIAB sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModel.kt
@@ -44,6 +44,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
 
+@Suppress("LargeClass")
 @HiltViewModel
 class WooPosBookingsViewModel @Inject constructor(
     private val bookingListHandler: BookingListHandler,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/CachedCouponEnabledChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/CachedCouponEnabledChecker.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.items.coupons
 
+import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.tools.SelectedSite
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
@@ -13,8 +14,12 @@ class CachedCouponEnabledChecker @Inject constructor(
     suspend fun isEnabled(): Boolean {
         cachedValue?.let { return it }
 
-        val result = wooCommerceStore.getSiteSettingsAsync(selectedSite.get())?.couponsEnabled ?: false
-        cachedValue = result
-        return result
+        val enabled = if (selectedSite.get().isCIABSite()) {
+            true
+        } else {
+            wooCommerceStore.getSiteSettingsAsync(selectedSite.get())?.couponsEnabled ?: false
+        }
+        cachedValue = enabled
+        return enabled
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -355,7 +356,8 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
             bookingsRepository = bookingsRepository,
             bookingMapper = bookingMapper,
             networkStatus = networkStatus,
-            paymentStatusResolver = paymentStatusResolver
+            paymentStatusResolver = paymentStatusResolver,
+            appScope = TestScope(coroutinesTestRule.testDispatcher),
         ).apply {
             state.observeForever { }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/CachedCouponEnabledCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/CachedCouponEnabledCheckerTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.items.coupons
 
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,32 +36,6 @@ class CachedCouponEnabledCheckerTest {
     }
 
     @Test
-    fun `returns true when coupons are enabled in site settings`() = runTest {
-        // GIVEN
-        val siteSettings = WCSettingsTestUtils.generateSettings(siteModel.localId()).copy(couponsEnabled = true)
-        whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(siteSettings)
-
-        // WHEN
-        val result = cachedCouponEnabledChecker.isEnabled()
-
-        // THEN
-        assertThat(result).isTrue()
-    }
-
-    @Test
-    fun `returns false when coupons are disabled in site settings`() = runTest {
-        // GIVEN
-        val siteSettings = WCSettingsTestUtils.generateSettings(siteModel.localId()).copy(couponsEnabled = false)
-        whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(siteSettings)
-
-        // WHEN
-        val result = cachedCouponEnabledChecker.isEnabled()
-
-        // THEN
-        assertThat(result).isFalse()
-    }
-
-    @Test
     fun `returns false when site settings are null`() = runTest {
         // GIVEN
         whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(null)
@@ -89,5 +64,48 @@ class CachedCouponEnabledCheckerTest {
         // THEN
         assertThat(firstResult).isTrue()
         assertThat(secondResult).isTrue() // Still true from cache, not false from new mock
+    }
+
+    @Test
+    fun `given CIAB site, when checking coupons availability, then returns true`() = runTest {
+        // GIVEN
+        val ciabSiteModel = SiteModel().apply {
+            id = 123
+            setIsGardenSite(true)
+            gardenName = CIABSiteGateKeeper.CIAB_GARDEN_NAME
+        }
+        whenever(selectedSite.get()).thenReturn(ciabSiteModel)
+
+        // WHEN
+        val result = cachedCouponEnabledChecker.isEnabled()
+
+        // THEN
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `given non-CIAB site, when coupons disabled in settings, then returns false`() = runTest {
+        // GIVEN
+        val siteSettings = WCSettingsTestUtils.generateSettings(siteModel.localId()).copy(couponsEnabled = false)
+        whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(siteSettings)
+
+        // WHEN
+        val result = cachedCouponEnabledChecker.isEnabled()
+
+        // THEN
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given non-CIAB site, when coupons enabled in settings, then returns true`() = runTest {
+        // GIVEN
+        val siteSettings = WCSettingsTestUtils.generateSettings(siteModel.localId()).copy(couponsEnabled = true)
+        whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(siteSettings)
+
+        // WHEN
+        val result = cachedCouponEnabledChecker.isEnabled()
+
+        // THEN
+        assertThat(result).isTrue()
     }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2395

Enables coupons on POS for CIAB sites regardless of site settings. CIAB sites short-circuit to enabled without making the remote settings request. Non-CIAB sites continue to respect the site settings as before.

### Test Steps
1. Open POS on a CIAB site
2. Verify coupons tab is available and functional

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.