### PR TITLE
Omit template_id for WC >= 10.7.0 in POS receipt emails

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepository.kt
@@ -34,11 +34,13 @@ class WooPosEmailReceiptRepository @Inject constructor(
     fun posReceiptsAreEnabled(): Boolean = isWooCoreSupportsPOSReceipts()
 
     private suspend fun sendPOSReceipt(orderId: Long, email: String): Result<Unit> {
+        val templateId = if (supportsAutoTemplateSelection()) null else TEMPLATE_ID_POS_COMPLETED_ORDER
         val sendOrderResult = orderStore.sendOrderPOSSpecificReceipt(
             selectedSite.get(),
             orderId,
             email,
-            forceEmailUpdate = true
+            forceEmailUpdate = true,
+            templateId = templateId
         )
         return if (sendOrderResult.isError) {
             Result.failure(Exception("Failed to send order receipt"))
@@ -66,8 +68,15 @@ class WooPosEmailReceiptRepository @Inject constructor(
         return wooCoreVersion.semverCompareTo(WC_VERSION_SUPPORTS_POS_RECEIPTS) >= 0
     }
 
+    private fun supportsAutoTemplateSelection(): Boolean {
+        val wooCoreVersion = getWooCoreVersion() ?: return false
+        return wooCoreVersion.semverCompareTo(WC_VERSION_SUPPORTS_AUTO_TEMPLATE) >= 0
+    }
+
     private companion object {
         const val WC_VERSION_SUPPORTS_POS_RECEIPTS = "10.0.0"
+        const val WC_VERSION_SUPPORTS_AUTO_TEMPLATE = "10.7.0"
+        const val TEMPLATE_ID_POS_COMPLETED_ORDER = "customer_pos_completed_order"
     }
 
     class WooPosProvideEmailPattern @Inject constructor() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/emailreceipt/WooPosEmailReceiptRepositoryTest.kt
@@ -90,20 +90,22 @@ class WooPosEmailReceiptRepositoryTest {
     }
 
     @Test
-    fun `given WC version 10 or higher, when sendReceiptByEmail, then sends POS receipt with email directly`() = runTest {
+    fun `given WC version 10 or higher, when sendReceiptByEmail, then sends POS receipt with explicit templateId`() = runTest {
         // GIVEN
         val orderId = 1L
         val email = "test@example.com"
 
         whenever(getWooCoreVersion.invoke()).thenReturn("10.0.0")
-        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email, true)).thenReturn(WooPayload(Unit))
+        whenever(
+            orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email, true, "customer_pos_completed_order")
+        ).thenReturn(WooPayload(Unit))
 
         // WHEN
         val result = repository.sendReceiptByEmail(orderId, email)
 
         // THEN
         assertThat(result.isSuccess).isTrue()
-        verify(orderStore).sendOrderPOSSpecificReceipt(siteModel, orderId, email, true)
+        verify(orderStore).sendOrderPOSSpecificReceipt(siteModel, orderId, email, true, "customer_pos_completed_order")
         verify(orderStore, never()).updateOrderBillingEmail(siteModel, orderId, email)
     }
 
@@ -132,7 +134,9 @@ class WooPosEmailReceiptRepositoryTest {
         val email = "test@example.com"
 
         whenever(getWooCoreVersion.invoke()).thenReturn("10.0.0")
-        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email, true)).thenReturn(
+        whenever(
+            orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email, true, "customer_pos_completed_order")
+        ).thenReturn(
             WooPayload(WooError(WooErrorType.GENERIC_ERROR, GenericErrorType.TIMEOUT))
         )
 
@@ -160,6 +164,44 @@ class WooPosEmailReceiptRepositoryTest {
 
         // THEN
         assertThat(result.isFailure).isTrue()
+    }
+
+    @Test
+    fun `given WC 10_7 or higher, when sendReceiptByEmail, then sends POS receipt without templateId`() = runTest {
+        // GIVEN
+        val orderId = 1L
+        val email = "test@example.com"
+
+        whenever(getWooCoreVersion.invoke()).thenReturn("10.7.0")
+        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email, true, null)).thenReturn(
+            WooPayload(Unit)
+        )
+
+        // WHEN
+        val result = repository.sendReceiptByEmail(orderId, email)
+
+        // THEN
+        assertThat(result.isSuccess).isTrue()
+        verify(orderStore).sendOrderPOSSpecificReceipt(siteModel, orderId, email, true, null)
+    }
+
+    @Test
+    fun `given WC 11_0, when sendReceiptByEmail, then sends POS receipt without templateId`() = runTest {
+        // GIVEN
+        val orderId = 1L
+        val email = "test@example.com"
+
+        whenever(getWooCoreVersion.invoke()).thenReturn("11.0.0")
+        whenever(orderStore.sendOrderPOSSpecificReceipt(siteModel, orderId, email, true, null)).thenReturn(
+            WooPayload(Unit)
+        )
+
+        // WHEN
+        val result = repository.sendReceiptByEmail(orderId, email)
+
+        // THEN
+        assertThat(result.isSuccess).isTrue()
+        verify(orderStore).sendOrderPOSSpecificReceipt(siteModel, orderId, email, true, null)
     }
 
     @Test

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -951,7 +951,7 @@ class OrderRestClient @Inject constructor(
         orderId: Long,
         email: String,
         forceEmailUpdate: Boolean,
-        templateId: String? = null
+        templateId: String?
     ): WooPayload<Unit> {
         val response = wooNetwork.executePostGsonRequest(
             site = site,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClient.kt
@@ -950,17 +950,20 @@ class OrderRestClient @Inject constructor(
         site: SiteModel,
         orderId: Long,
         email: String,
-        forceEmailUpdate: Boolean
+        forceEmailUpdate: Boolean,
+        templateId: String? = null
     ): WooPayload<Unit> {
         val response = wooNetwork.executePostGsonRequest(
             site = site,
             path = WOOCOMMERCE.orders.id(orderId).actions.send_email.pathV3,
             clazz = Unit::class.java,
-            body = mapOf(
-                "template_id" to "customer_pos_completed_order",
-                "email" to email,
-                "force_email_update" to forceEmailUpdate
-            )
+            body = buildMap {
+                put("email", email)
+                put("force_email_update", forceEmailUpdate)
+                if (templateId != null) {
+                    put("template_id", templateId)
+                }
+            }
         )
 
         return response.toWooPayload { it }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -711,7 +711,7 @@ class WCOrderStore @Inject internal constructor(
         orderId: Long,
         email: String,
         forceEmailUpdate: Boolean,
-        templateId: String? = null
+        templateId: String?
     ) = wcOrderRestClient.sendOrderPOSSpecificReceipt(
         site,
         orderId,

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCOrderStore.kt
@@ -710,12 +710,14 @@ class WCOrderStore @Inject internal constructor(
         site: SiteModel,
         orderId: Long,
         email: String,
-        forceEmailUpdate: Boolean
+        forceEmailUpdate: Boolean,
+        templateId: String? = null
     ) = wcOrderRestClient.sendOrderPOSSpecificReceipt(
         site,
         orderId,
         email,
-        forceEmailUpdate
+        forceEmailUpdate,
+        templateId
     )
 
     suspend fun updateOrderBillingEmail(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
@@ -371,7 +371,7 @@ class OrderRestClientTest {
         ).thenReturn(mockResponse)
 
         // When
-        orderRestClient.sendOrderPOSSpecificReceipt(testSite, orderId, email, forceEmailUpdate = true)
+        orderRestClient.sendOrderPOSSpecificReceipt(testSite, orderId, email, forceEmailUpdate = true, templateId = null)
 
         // Then
         val bodyCaptor = argumentCaptor<Map<String, Any>>()

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
@@ -333,7 +333,9 @@ class OrderRestClientTest {
         ).thenReturn(mockResponse)
 
         // When
-        orderRestClient.sendOrderPOSSpecificReceipt(testSite, orderId, email, forceEmailUpdate = true, templateId = templateId)
+        orderRestClient.sendOrderPOSSpecificReceipt(
+            testSite, orderId, email, forceEmailUpdate = true, templateId = templateId
+        )
 
         // Then
         val bodyCaptor = argumentCaptor<Map<String, Any>>()

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderRestClientTest.kt
@@ -310,13 +310,50 @@ class OrderRestClientTest {
     }
 
     @Test
-    fun `when sendOrderPOSSpecificReceipt is called, then email and force_email_update are sent in request body`() = runTest {
+    fun `when sendOrderPOSSpecificReceipt is called with templateId, then template_id is included in request body`() = runTest {
+        // Given
+        val orderId = 123L
+        val email = "test@example.com"
+        val templateId = "customer_pos_completed_order"
+        val expectedPath = WOOCOMMERCE.orders.id(orderId).actions.send_email.pathV3
+        val expectedBody = mapOf(
+            "email" to email,
+            "force_email_update" to true,
+            "template_id" to templateId
+        )
+        val mockResponse = WPAPIResponse.Success(Unit, emptyList())
+
+        whenever(
+            wooNetwork.executePostGsonRequest(
+                site = any(),
+                path = any(),
+                clazz = eq(Unit::class.java),
+                body = any()
+            )
+        ).thenReturn(mockResponse)
+
+        // When
+        orderRestClient.sendOrderPOSSpecificReceipt(testSite, orderId, email, forceEmailUpdate = true, templateId = templateId)
+
+        // Then
+        val bodyCaptor = argumentCaptor<Map<String, Any>>()
+        verify(wooNetwork).executePostGsonRequest(
+            site = eq(testSite),
+            path = eq(expectedPath),
+            clazz = eq(Unit::class.java),
+            body = bodyCaptor.capture()
+        )
+
+        assertThat(bodyCaptor.firstValue).isEqualTo(expectedBody)
+    }
+
+    @Test
+    fun `when sendOrderPOSSpecificReceipt is called without templateId, then template_id is not in request body`() = runTest {
         // Given
         val orderId = 123L
         val email = "test@example.com"
         val expectedPath = WOOCOMMERCE.orders.id(orderId).actions.send_email.pathV3
         val expectedBody = mapOf(
-            "template_id" to "customer_pos_completed_order",
             "email" to email,
             "force_email_update" to true
         )
@@ -344,5 +381,6 @@ class OrderRestClientTest {
         )
 
         assertThat(bodyCaptor.firstValue).isEqualTo(expectedBody)
+        assertThat(bodyCaptor.firstValue).doesNotContainKey("template_id")
     }
 }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/order/WCOrderStoreTest.kt
@@ -640,10 +640,10 @@ internal class WCOrderStoreTest {
             val email = "test@example.com"
 
             // WHEN
-            orderStore.sendOrderPOSSpecificReceipt(site, orderId, email, forceEmailUpdate = true)
+            orderStore.sendOrderPOSSpecificReceipt(site, orderId, email, forceEmailUpdate = true, templateId = null)
 
             // THEN
-            verify(orderRestClient).sendOrderPOSSpecificReceipt(site, orderId, email, true)
+            verify(orderRestClient).sendOrderPOSSpecificReceipt(site, orderId, email, true, null)
         }
     }
 


### PR DESCRIPTION
## Description

WC 10.7.0+ supports auto-selecting the best email template when `template_id` is omitted from `POST /orders/{id}/actions/send_email` ([woocommerce/woocommerce#63556](https://github.com/woocommerce/woocommerce/pull/63556)). This fixes receipt emails for bookings and refunded orders where the `customer_pos_completed_order` template is not available.

Mirrors the iOS implementation: [woocommerce-ios#16781](https://github.com/woocommerce/woocommerce-ios/pull/16781).

The change threads an optional `templateId` parameter through `OrderRestClient`, `WCOrderStore`, and `WooPosEmailReceiptRepository`. The repository now checks the WC plugin version and decides:

- **WC < 10.0**: legacy path - update order email, then call `send_order_details`
- **WC 10.0 - 10.6.x**: call `send_email` with `template_id: "customer_pos_completed_order"`
- **WC >= 10.7.0**: call `send_email` without `template_id` (server auto-selects)

## Test Steps

1. Connect to a store running WC >= 10.7.0
2. Complete a POS order and send a receipt email
3. Verify the email is received successfully
4. For bookings: complete a booking order via POS and send receipt - should now work

Automated tests cover all version ranges.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.