### PR TITLE
[WOOMOB-2405] Show PN setup entry points for Jetpack CP users

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/ShouldShowEnablePushNotificationsUi.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/ShouldShowEnablePushNotificationsUi.kt
@@ -15,7 +15,8 @@ import javax.inject.Inject
 /**
  * Checks whether the "Enable Push Notifications" UI should be shown.
  *
- * This is part of the Woo Core push notifications system for app-password authenticated sites.
+ * This is part of the Woo Core push notifications system for non-Jetpack sites
+ * (app-password authenticated sites and Jetpack Connection Package sites).
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ShouldShowEnablePushNotificationsUi @Inject constructor(
@@ -26,7 +27,7 @@ class ShouldShowEnablePushNotificationsUi @Inject constructor(
         if (!FeatureFlag.WOO_PUSH_NOTIFICATIONS_SYSTEM_M2.isEnabled()) return flowOf(false)
         return selectedSite.observe()
             .flatMapLatest { site ->
-                if (site == null || site.connectionType != SiteConnectionType.ApplicationPasswords) {
+                if (site == null || site.connectionType == SiteConnectionType.Jetpack) {
                     flowOf(false)
                 } else {
                     pushNotificationRegistrationStatus.observe(site.siteId).map { registrationStatus ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -8,6 +8,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.support.help.HelpOrigin
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
 import com.woocommerce.android.ui.pushnotifications.CheckWooPluginPushNotificationsSupport
@@ -48,30 +50,21 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
 
     private fun fetchStatus() {
         launch {
-            val site = selectedSite.get()
-
-            val result = fetchJetpackStatus(
-                site = site,
-                useApplicationPasswords = true
-            )
-
-            result.fold(
-                onSuccess = { response ->
-                    when (response) {
-                        is JetpackStatusFetchResponse.ConnectionForbidden -> {
-                            _viewState.value = ViewState.ForbiddenError
-                        }
-
-                        is JetpackStatusFetchResponse.Success -> {
-                            if (response.status.isSiteConnected) {
-                                checkWCVersion()
-                            } else {
-                                _viewState.value = ViewState.NotConnected
-                            }
-                        }
+            checkIfJetpackIsConnected().fold(
+                onSuccess = { isConnected ->
+                    if (isConnected) {
+                        checkWCVersion()
+                    } else {
+                        _viewState.value = ViewState.NotConnected
                     }
                 },
-                onFailure = { _viewState.value = ViewState.GenericError }
+                onFailure = { exception ->
+                    _viewState.value = if (exception is JetpackForbiddenException) {
+                        ViewState.ForbiddenError
+                    } else {
+                        ViewState.GenericError
+                    }
+                }
             )
 
             when (_viewState.value) {
@@ -86,11 +79,37 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
         }
     }
 
+    private suspend fun checkIfJetpackIsConnected(): Result<Boolean> {
+        val site = selectedSite.get()
+        return when (site.connectionType) {
+            SiteConnectionType.ApplicationPasswords -> fetchJetpackStatus(
+                site = site,
+                useApplicationPasswords = true
+            ).mapCatching { response ->
+                when (response) {
+                    is JetpackStatusFetchResponse.Success -> response.status.isSiteConnected
+                    is JetpackStatusFetchResponse.ConnectionForbidden -> throw JetpackForbiddenException()
+                }
+            }
+
+            SiteConnectionType.JetpackConnectionPackage -> {
+                // The connection type is enough to determine that the site is connected to Jetpack
+                Result.success(true)
+            }
+
+            SiteConnectionType.Jetpack -> error(
+                "Invalid state: WooPushNotificationsIntroductionViewModel should not be instantiated for sites " +
+                    "with SiteConnectionType.Jetpack"
+            )
+        }
+    }
+
     private suspend fun checkWCVersion() {
         when (checkWCPluginSupport()) {
             Compatible -> _viewState.value = ViewState.GenericError
             is CheckWooPluginPushNotificationsSupport.Result.UpdateRequired ->
                 _viewState.value = ViewState.UpdateRequired
+
             CheckWooPluginPushNotificationsSupport.Result.Error -> _viewState.value = ViewState.GenericError
         }
     }
@@ -165,4 +184,5 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
     ) : Event()
 
     data class OpenUrlEvent(val url: String) : Event()
+    private class JetpackForbiddenException : Exception()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModel.kt
@@ -31,14 +31,14 @@ class WooPushNotificationsIntroductionViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
-        const val BUTTON_LABEL_CONTINUE = "continue"
-        const val BUTTON_LABEL_UPDATE_PLUGIN = "update_plugin"
-        const val BUTTON_LABEL_NOT_NOW = "not_now"
-        const val BUTTON_LABEL_SUPPORT = "support"
-        const val STATE_NOT_CONNECTED = "not_connected"
-        const val STATE_UPDATE_REQUIRED = "update_required"
-        const val ERROR_TYPE_NO_PERMISSION = "no_permission"
-        const val ERROR_TYPE_GENERIC = "generic"
+        private const val BUTTON_LABEL_CONTINUE = "continue"
+        private const val BUTTON_LABEL_UPDATE_PLUGIN = "update_plugin"
+        private const val BUTTON_LABEL_NOT_NOW = "not_now"
+        private const val BUTTON_LABEL_SUPPORT = "support"
+        private const val STATE_NOT_CONNECTED = "not_connected"
+        private const val STATE_UPDATE_REQUIRED = "update_required"
+        private const val ERROR_TYPE_NO_PERMISSION = "no_permission"
+        private const val ERROR_TYPE_GENERIC = "generic"
     }
 
     private val _viewState = MutableStateFlow<ViewState>(ViewState.Loading)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -378,7 +378,7 @@
 
     <string name="my_store_widget_push_notifications_title">Never miss a new order</string>
     <string name="my_store_widget_push_notifications_menu_title">Enable push notifications</string>
-    <string name="my_store_widget_push_notifications_description">Connect your store to WordPress.com to get alerts for new orders and reviews.</string>
+    <string name="my_store_widget_push_notifications_description">Enable push notifications to stay on top of new orders and reviews.</string>
 
     <string name="my_store_widget_onboarding_title">Store setup</string>
     <string name="my_store_widget_stats_title">Performance</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -111,25 +111,52 @@ class DashboardViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given a Jetpack CP site, when screen starts, then show the Jetpack Benefits banner`() = testBlocking {
-        setup {
-            whenever(selectedSite.observe()).thenReturn(
-                flowOf(
-                    SiteModel().apply {
-                        origin = SiteModel.ORIGIN_WPCOM_REST
-                        setIsJetpackCPConnected(true)
-                        setIsJetpackConnected(false)
-                    }
+    fun `given a Jetpack CP site with PN setup available, when screen starts, then hide the Jetpack Benefits banner`() =
+        testBlocking {
+            setup {
+                whenever(selectedSite.observe()).thenReturn(
+                    flowOf(
+                        SiteModel().apply {
+                            origin = SiteModel.ORIGIN_WPCOM_REST
+                            setIsJetpackCPConnected(true)
+                            setIsJetpackConnected(false)
+                        }
+                    )
                 )
-            )
-            whenever(pushNotificationRegistrationStatus.observe(any())).thenReturn(flowOf(Status.UNREGISTERED))
+                whenever(pushNotificationRegistrationStatus.observe(any()))
+                    .thenReturn(flowOf(Status.UNREGISTERED))
+                whenever(shouldShowEnablePushNotificationsUi.invoke()).thenReturn(flowOf(true))
+            }
+
+            val jetpackBenefitsBanner = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()
+
+            assertThat(jetpackBenefitsBanner).isNotNull()
+            assertThat(jetpackBenefitsBanner!!.show).isFalse()
         }
 
-        val jetpackBenefitsBanner = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()
+    @Test
+    fun `given a Jetpack CP site with PN setup not available, when screen starts, then show the Jetpack Benefits banner`() =
+        testBlocking {
+            setup {
+                whenever(selectedSite.observe()).thenReturn(
+                    flowOf(
+                        SiteModel().apply {
+                            origin = SiteModel.ORIGIN_WPCOM_REST
+                            setIsJetpackCPConnected(true)
+                            setIsJetpackConnected(false)
+                        }
+                    )
+                )
+                whenever(pushNotificationRegistrationStatus.observe(any()))
+                    .thenReturn(flowOf(Status.UNREGISTERED))
+                whenever(shouldShowEnablePushNotificationsUi.invoke()).thenReturn(flowOf(false))
+            }
 
-        assertThat(jetpackBenefitsBanner).isNotNull()
-        assertThat(jetpackBenefitsBanner!!.show).isTrue()
-    }
+            val jetpackBenefitsBanner = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()
+
+            assertThat(jetpackBenefitsBanner).isNotNull()
+            assertThat(jetpackBenefitsBanner!!.show).isTrue()
+        }
 
     @Test
     fun `given an Application Passwords site, when screen starts, then show the Jetpack Benefits banner`() =
@@ -152,17 +179,16 @@ class DashboardViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given a Jetpack CP site, when jetpack benefits dismissed, then update prefs`() = testBlocking {
+    fun `given an Application Passwords site, when jetpack benefits dismissed, then update prefs`() = testBlocking {
         setup {
             whenever(selectedSite.observe()).thenReturn(
                 flowOf(
                     SiteModel().apply {
-                        origin = SiteModel.ORIGIN_WPCOM_REST
-                        setIsJetpackCPConnected(true)
-                        setIsJetpackConnected(false)
+                        origin = SiteModel.ORIGIN_WPAPI
                     }
                 )
             )
+            whenever(pushNotificationRegistrationStatus.observe(any())).thenReturn(flowOf(Status.UNREGISTERED))
         }
 
         val jetpackBenefitsBanner = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()
@@ -172,25 +198,25 @@ class DashboardViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given a Jetpack CP site, when jetpack benefits dismissed recently, then hide banner`() = testBlocking {
-        setup {
-            whenever(selectedSite.observe()).thenReturn(
-                flowOf(
-                    SiteModel().apply {
-                        origin = SiteModel.ORIGIN_WPCOM_REST
-                        setIsJetpackCPConnected(true)
-                        setIsJetpackConnected(false)
-                    }
+    fun `given an Application Passwords site, when jetpack benefits dismissed recently, then hide banner`() =
+        testBlocking {
+            setup {
+                whenever(selectedSite.observe()).thenReturn(
+                    flowOf(
+                        SiteModel().apply {
+                            origin = SiteModel.ORIGIN_WPAPI
+                        }
+                    )
                 )
-            )
-            whenever(appPrefsWrapper.getJetpackBenefitsDismissalDate())
-                .thenReturn(System.currentTimeMillis() - 1000)
+                whenever(pushNotificationRegistrationStatus.observe(any())).thenReturn(flowOf(Status.UNREGISTERED))
+                whenever(appPrefsWrapper.getJetpackBenefitsDismissalDate())
+                    .thenReturn(System.currentTimeMillis() - 1000)
+            }
+
+            val jetpackBenefitsBanner = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()
+
+            assertThat(jetpackBenefitsBanner!!.show).isFalse()
         }
-
-        val jetpackBenefitsBanner = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()
-
-        assertThat(jetpackBenefitsBanner!!.show).isFalse()
-    }
 
     @Test
     fun `when the stats card is unavailable, then show the share store card`() = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
@@ -26,6 +26,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -383,6 +384,26 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
 
             val viewState = viewModel.viewState.getOrAwaitValue()
             assertThat(viewState).isEqualTo(ViewState.GenericError)
+            verify(analyticsTrackerWrapper).track(
+                eq(AnalyticsEvent.PUSH_NOTIFICATIONS_SETUP_INTRODUCTION_ERROR),
+                eq(mapOf(AnalyticsTracker.KEY_ERROR_TYPE to "generic"))
+            )
+        }
+
+    @Test
+    fun `given a Jetpack CP site with WC plugin check error, when screen opens, then GenericError state is shown`() =
+        testBlocking {
+            whenever(checkWCPluginSupport())
+                .thenReturn(CheckWooPluginPushNotificationsSupport.Result.Error)
+
+            setup(isJetpackCPSite = true)
+
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState).isEqualTo(ViewState.GenericError)
+            verify(analyticsTrackerWrapper).track(
+                eq(AnalyticsEvent.PUSH_NOTIFICATIONS_SETUP_INTRODUCTION_ERROR),
+                eq(mapOf(AnalyticsTracker.KEY_ERROR_TYPE to "generic"))
+            )
         }
 
     @Test
@@ -393,7 +414,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
 
             setup(isJetpackCPSite = true)
 
-            verify(fetchJetpackStatus, org.mockito.kotlin.never()).invoke(any(), any(), anyOrNull())
+            verify(fetchJetpackStatus, never()).invoke(any(), any(), anyOrNull())
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
@@ -276,7 +276,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
             assertThat(event).isEqualTo(
                 WooPushNotificationsIntroductionViewModel.NavigateToConnectionSteps(
                     isSiteConnectedToJetpack = false,
-                    shouldAutoOpenUpdatePlugin = false
+                    shouldAutoOpenUpdatePlugin = true
                 )
             )
             verify(analyticsTrackerWrapper).track(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
@@ -32,13 +32,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
-    private val site = SiteModel().apply {
-        url = "https://example.com"
-    }
-
-    private val selectedSite: SelectedSite = mock {
-        on { get() } doReturn site
-    }
+    private val selectedSite: SelectedSite = mock()
 
     private val fetchJetpackStatus: FetchJetpackStatus = mock {
         onBlocking { invoke(any(), any(), anyOrNull()) } doReturn Result.success(
@@ -58,7 +52,19 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: WooPushNotificationsIntroductionViewModel
 
-    private fun setup() {
+    private fun setup(isJetpackCPSite: Boolean = false) {
+        val site = SiteModel().apply {
+            url = "https://example.com"
+            origin = if (isJetpackCPSite) {
+                SiteModel.ORIGIN_WPCOM_REST
+            } else {
+                SiteModel.ORIGIN_WPAPI
+            }
+            setIsJetpackCPConnected(isJetpackCPSite)
+            setIsJetpackConnected(false)
+        }
+        whenever(selectedSite.get()).thenReturn(site)
+
         viewModel = WooPushNotificationsIntroductionViewModel(
             savedStateHandle = SavedStateHandle(),
             fetchJetpackStatus = fetchJetpackStatus,
@@ -281,7 +287,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
             )
             verify(analyticsTrackerWrapper).track(
                 eq(AnalyticsEvent.PUSH_NOTIFICATIONS_SETUP_INTRODUCTION_BUTTON_TAP),
-                eq(mapOf(AnalyticsTracker.KEY_BUTTON_LABEL to "update_plugin"))
+                eq(mapOf(AnalyticsTracker.KEY_BUTTON_LABEL to "continue"))
             )
         }
 
@@ -350,4 +356,61 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
         assertThat((event as WooPushNotificationsIntroductionViewModel.OpenUrlEvent).url)
             .isEqualTo(AppUrls.LOGIN_WITH_EMAIL_WHAT_IS_WORDPRESS_COM_ACCOUNT)
     }
+
+    @Test
+    fun `given a Jetpack CP site with incompatible WC version, when screen opens, then UpdateRequired state is shown`() =
+        testBlocking {
+            whenever(checkWCPluginSupport())
+                .thenReturn(CheckWooPluginPushNotificationsSupport.Result.UpdateRequired("9.0.0"))
+
+            setup(isJetpackCPSite = true)
+
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState).isEqualTo(ViewState.UpdateRequired)
+            verify(analyticsTrackerWrapper).track(
+                eq(AnalyticsEvent.PUSH_NOTIFICATIONS_SETUP_INTRODUCTION_VIEW),
+                eq(mapOf(AnalyticsTracker.KEY_STATE to "update_required"))
+            )
+        }
+
+    @Test
+    fun `given a Jetpack CP site with compatible WC version, when screen opens, then GenericError state is shown`() =
+        testBlocking {
+            whenever(checkWCPluginSupport())
+                .thenReturn(CheckWooPluginPushNotificationsSupport.Result.Compatible)
+
+            setup(isJetpackCPSite = true)
+
+            val viewState = viewModel.viewState.getOrAwaitValue()
+            assertThat(viewState).isEqualTo(ViewState.GenericError)
+        }
+
+    @Test
+    fun `given a Jetpack CP site, when screen opens, then fetchJetpackStatus is not called`() =
+        testBlocking {
+            whenever(checkWCPluginSupport())
+                .thenReturn(CheckWooPluginPushNotificationsSupport.Result.Compatible)
+
+            setup(isJetpackCPSite = true)
+
+            verify(fetchJetpackStatus, org.mockito.kotlin.never()).invoke(any(), any(), anyOrNull())
+        }
+
+    @Test
+    fun `given a Jetpack CP site, when continue is clicked, then isSiteConnectedToJetpack is true`() =
+        testBlocking {
+            whenever(checkWCPluginSupport())
+                .thenReturn(CheckWooPluginPushNotificationsSupport.Result.UpdateRequired("9.0.0"))
+
+            setup(isJetpackCPSite = true)
+            viewModel.onContinueClick()
+
+            val event = viewModel.event.value
+            assertThat(event).isEqualTo(
+                WooPushNotificationsIntroductionViewModel.NavigateToConnectionSteps(
+                    isSiteConnectedToJetpack = true,
+                    shouldAutoOpenUpdatePlugin = true
+                )
+            )
+        }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2405

Enables push notification setup UI (dashboard card and settings option) for Jetpack Connection Package sites. Previously, these entry points were only shown for Application Password sites. 

Changes:
- Updated `ShouldShowEnablePushNotificationsUi` to show PN setup UI for all non-Jetpack sites (both ApplicationPasswords and JetpackCP)
- Updated dashboard card description to generic wording: "Enable push notifications to stay on top of new orders and reviews."
- Updated `WooPushNotificationsIntroductionViewModel` to handle JetpackCP sites (skips Jetpack status fetch since connection type proves they're already connected)
- Added unit tests for JetpackCP code paths

The Jetpack benefits banner is automatically hidden for JetpackCP users when the PN setup card is visible, via the existing `!enablePnUiAvailable` condition.

### Test Steps
1. Enable the PN feature flags.
2. Log in with a Jetpack CP site that has an outdated WooCommerce plugin
3. Verify the PN setup dashboard card appears with the text "Enable push notifications to stay on top of new orders and reviews."
4. Verify the Jetpack benefits banner is not shown when the PN card is visible
5. Tap the PN setup card and verify the introduction dialog opens
6. Verify the introduction dialog shows "Update Required" state (not "Not Connected")

### Images/gif
https://github.com/user-attachments/assets/a5524514-d23d-4728-b118-474f4fa05214

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.