### PR TITLE
[WOOMOB-2397][Refunds M2] Add Refunded Products section in POS order details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -823,6 +823,7 @@ private fun sampleOrderDetails(
             )
         )
     ),
+    refundedLineItems = WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded(emptyList()),
     breakdown = WooPosOrdersState.OrderDetailsViewState.Computed.Details.TotalsBreakdown(
         products = "$23.00",
         discount = "-$5.00",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -795,30 +795,32 @@ private fun sampleOrderDetails(
     dateTime = "Aug 28, 2025 at 10:31 AM",
     customerEmail = "johndoe@mail.com",
     status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
-    lineItems = listOf(
-        WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
-            id = 101,
-            name = "Cup",
-            attributesDescription = null,
-            qtyAndUnitPrice = "1 x $8.50",
-            lineTotal = "$15.00",
-            imageUrl = null
-        ),
-        WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
-            id = 102,
-            name = "Coffee Container",
-            attributesDescription = "Blue, Large",
-            qtyAndUnitPrice = "1 x $10.00",
-            lineTotal = "$8.00",
-            imageUrl = null
-        ),
-        WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
-            id = 103,
-            name = "Paper Filter",
-            attributesDescription = null,
-            qtyAndUnitPrice = "1 x $4.50",
-            lineTotal = "$8.00",
-            imageUrl = null
+    lineItems = WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded(
+        listOf(
+            WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
+                id = 101,
+                name = "Cup",
+                attributesDescription = null,
+                qtyAndUnitPrice = "1 x $8.50",
+                lineTotal = "$15.00",
+                imageUrl = null
+            ),
+            WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
+                id = 102,
+                name = "Coffee Container",
+                attributesDescription = "Blue, Large",
+                qtyAndUnitPrice = "1 x $10.00",
+                lineTotal = "$8.00",
+                imageUrl = null
+            ),
+            WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
+                id = 103,
+                name = "Paper Filter",
+                attributesDescription = null,
+                qtyAndUnitPrice = "1 x $4.50",
+                lineTotal = "$8.00",
+                imageUrl = null
+            )
         )
     ),
     breakdown = WooPosOrdersState.OrderDetailsViewState.Computed.Details.TotalsBreakdown(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -56,7 +56,8 @@ sealed class WooPosOrdersState {
                 val customerEmail: String?,
                 val status: PosOrderStatus,
 
-                val lineItems: List<LineItemRow>,
+                val lineItems: List<LineItemRow>? = null,
+                val refundedLineItems: List<LineItemRow>? = null,
                 val breakdown: TotalsBreakdown,
                 val total: String,
                 val totalPaid: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -56,14 +56,23 @@ sealed class WooPosOrdersState {
                 val customerEmail: String?,
                 val status: PosOrderStatus,
 
-                val lineItems: List<LineItemRow>? = null,
-                val refundedLineItems: List<LineItemRow>? = null,
+                val lineItems: LineItemsState = LineItemsState.Loading,
+                val refundedLineItems: LineItemsState = LineItemsState.Loading,
                 val breakdown: TotalsBreakdown,
                 val total: String,
                 val totalPaid: String,
                 val paymentMethodTitle: String?,
                 val actionsState: OrderActionsState
             ) {
+                @Immutable
+                sealed interface LineItemsState {
+                    @Immutable
+                    data object Loading : LineItemsState
+
+                    @Immutable
+                    data class Loaded(val items: List<LineItemRow>) : LineItemsState
+                }
+
                 @Immutable
                 sealed interface BookingInfo {
                     @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -253,6 +253,8 @@ class WooPosOrdersViewModel @Inject constructor(
             val actions = orderActionsProvider.getAvailableActions(order)
             val refundInfo = refundInfoBuilder.buildRefundInfo(order, refundsResult)
             val updatedBreakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
+            val refundedLineItems = orderDetailsMapper.buildRefundedLineItems(order, refundsResult)
+            val nonRefundedLineItems = orderDetailsMapper.buildNonRefundedLineItems(order, refundsResult)
 
             val updatedState = _state.value as? WooPosOrdersState.Content ?: return@launch
             if (updatedState.selectedDetails?.id == orderId &&
@@ -261,7 +263,9 @@ class WooPosOrdersViewModel @Inject constructor(
                 _state.value = updatedState.withUpdatedDetails(orderId) { details ->
                     details.copy(
                         actionsState = WooPosOrdersState.OrderActionsState.Loaded(actions),
-                        breakdown = updatedBreakdown
+                        breakdown = updatedBreakdown,
+                        lineItems = nonRefundedLineItems,
+                        refundedLineItems = refundedLineItems
                     )
                 }
             }
@@ -272,8 +276,8 @@ class WooPosOrdersViewModel @Inject constructor(
         orderId: Long,
         details: WooPosOrdersState.OrderDetailsViewState.Computed.Details
     ) {
-        val loadingItems = details.lineItems.filter { it.bookingInfo is BookingInfo.Loading }
-        if (loadingItems.isEmpty()) return
+        val loadingItems = details.lineItems?.filter { it.bookingInfo is BookingInfo.Loading }
+        if (loadingItems.isNullOrEmpty()) return
 
         viewModelScope.launch {
             val results = coroutineScope {
@@ -290,7 +294,7 @@ class WooPosOrdersViewModel @Inject constructor(
 
             _state.value = currentState.withUpdatedDetails(orderId) { details ->
                 details.copy(
-                    lineItems = details.lineItems.map { lineItem ->
+                    lineItems = details.lineItems?.map { lineItem ->
                         results[lineItem.id]?.let { lineItem.copy(bookingInfo = it) } ?: lineItem
                     }
                 )
@@ -640,20 +644,11 @@ class WooPosOrdersViewModel @Inject constructor(
         val orderDetails = loadedItems.items.values.firstOrNull { it.orderId == orderId }
             ?: error("Order $orderId not found in state")
 
-        return orderDetailsMapper.mapOrderDetails(
-            when (orderDetails) {
-                is WooPosOrdersState.OrderDetailsViewState.Lazy -> orderDetails.order
-                is WooPosOrdersState.OrderDetailsViewState.Computed -> {
-                    loadedItems.items.keys.firstOrNull { it.id == orderId }?.let {
-                        ordersDataSource.getOrderById(it.id).getOrNull()
-                    } ?: error("Order $orderId not found")
-                }
-            },
-            when (orderDetails) {
-                is WooPosOrdersState.OrderDetailsViewState.Lazy -> orderDetails.refundResult
-                is WooPosOrdersState.OrderDetailsViewState.Computed -> RefundsFetchResult.Error
-            }
-        )
+        return when (orderDetails) {
+            is WooPosOrdersState.OrderDetailsViewState.Computed -> orderDetails.details
+            is WooPosOrdersState.OrderDetailsViewState.Lazy ->
+                orderDetailsMapper.mapOrderDetails(orderDetails.order, orderDetails.refundResult)
+        }
     }
 
     private suspend fun getOrComputeDetailsWithoutActions(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModel.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.BookingInfo
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState
 import com.woocommerce.android.ui.woopos.orders.details.WooPosBookingInfoMapper
 import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderDetailsMapper
 import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderItemMapper
@@ -264,8 +265,8 @@ class WooPosOrdersViewModel @Inject constructor(
                     details.copy(
                         actionsState = WooPosOrdersState.OrderActionsState.Loaded(actions),
                         breakdown = updatedBreakdown,
-                        lineItems = nonRefundedLineItems,
-                        refundedLineItems = refundedLineItems
+                        lineItems = LineItemsState.Loaded(nonRefundedLineItems),
+                        refundedLineItems = LineItemsState.Loaded(refundedLineItems)
                     )
                 }
             }
@@ -276,8 +277,9 @@ class WooPosOrdersViewModel @Inject constructor(
         orderId: Long,
         details: WooPosOrdersState.OrderDetailsViewState.Computed.Details
     ) {
-        val loadingItems = details.lineItems?.filter { it.bookingInfo is BookingInfo.Loading }
-        if (loadingItems.isNullOrEmpty()) return
+        val loadedItems = (details.lineItems as? LineItemsState.Loaded)?.items ?: return
+        val loadingItems = loadedItems.filter { it.bookingInfo is BookingInfo.Loading }
+        if (loadingItems.isEmpty()) return
 
         viewModelScope.launch {
             val results = coroutineScope {
@@ -293,10 +295,14 @@ class WooPosOrdersViewModel @Inject constructor(
             if (currentState.selectedDetails?.id != orderId) return@launch
 
             _state.value = currentState.withUpdatedDetails(orderId) { details ->
+                val currentItems = (details.lineItems as? LineItemsState.Loaded)?.items
+                    ?: return@withUpdatedDetails details
                 details.copy(
-                    lineItems = details.lineItems?.map { lineItem ->
-                        results[lineItem.id]?.let { lineItem.copy(bookingInfo = it) } ?: lineItem
-                    }
+                    lineItems = LineItemsState.Loaded(
+                        currentItems.map { lineItem ->
+                            results[lineItem.id]?.let { lineItem.copy(bookingInfo = it) } ?: lineItem
+                        }
+                    )
                 )
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGetNonRefundedItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGetNonRefundedItems.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.ui.woopos.orders.details
+
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.Refund
+import javax.inject.Inject
+import kotlin.math.abs
+
+class WooPosGetNonRefundedItems @Inject constructor() {
+    operator fun invoke(
+        order: Order,
+        refunds: List<Refund>,
+    ): List<Order.Item> {
+        if (refunds.isEmpty()) return order.items
+
+        val refundedByItemId = refunds
+            .flatMap { it.items }
+            .groupingBy { it.orderItemId }
+            .fold(0) { acc, item -> acc + item.quantity }
+
+        return order.items.mapNotNull { item ->
+            val refundedQty = abs(refundedByItemId[item.itemId] ?: 0).toFloat()
+            val remaining = item.quantity - refundedQty
+            when {
+                remaining <= 0f -> null
+                remaining == item.quantity -> item
+                else -> {
+                    val newTotal = item.total * (remaining / item.quantity).toBigDecimal()
+                    item.copy(quantity = remaining, total = newTotal)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGroupRefundedItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGroupRefundedItems.kt
@@ -1,0 +1,22 @@
+package com.woocommerce.android.ui.woopos.orders.details
+
+import com.woocommerce.android.model.Refund
+import java.math.BigDecimal
+import javax.inject.Inject
+
+class WooPosGroupRefundedItems @Inject constructor() {
+    operator fun invoke(refunds: List<Refund>): List<Refund.Item> {
+        val allRefundItems = refunds.flatMap { it.items }
+        if (allRefundItems.isEmpty()) return emptyList()
+
+        return allRefundItems
+            .groupBy { it.orderItemId }
+            .map { (orderItemId, items) ->
+                items.first().copy(
+                    orderItemId = orderItemId,
+                    quantity = items.sumOf { it.quantity },
+                    total = items.fold(BigDecimal.ZERO) { acc, item -> acc + item.total },
+                )
+            }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
@@ -586,7 +586,7 @@ fun WooPosOrderDetailsPreview() {
                 ),
                 WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
                     id = 103,
-                    name = "A vey tasty coffee that incidentally has a very long name " +
+                    name = "A very tasty coffee that incidentally has a very long name " +
                         "and should go over a few lines without overlapping anything",
                     attributesDescription = "Medium roast, Decaf",
                     qtyAndUnitPrice = "1 x $5.00",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
@@ -91,7 +91,9 @@ fun WooPosOrderDetails(
 
         Spacer(Modifier.height(WooPosSpacing.Large.value))
 
-        OrdersProducts(lineItems = details.lineItems)
+        ProductsSection(lineItems = details.lineItems)
+
+        RefundedProductsSection(refundedLineItems = details.refundedLineItems)
 
         Spacer(Modifier.height(WooPosSpacing.Medium.value))
 
@@ -161,11 +163,50 @@ private fun OrdersHeader(details: WooPosOrdersState.OrderDetailsViewState.Comput
 }
 
 @Composable
-private fun OrdersProducts(lineItems: List<WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow>) {
+private fun ProductsSection(
+    lineItems: List<WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow>?
+) {
+    when {
+        lineItems == null -> ProductsShimmer(
+            title = stringResource(R.string.woopos_orders_details_products_title)
+        )
+        lineItems.isNotEmpty() -> OrdersProducts(
+            title = stringResource(R.string.woopos_orders_details_products_title),
+            lineItems = lineItems
+        )
+    }
+}
+
+@Composable
+private fun RefundedProductsSection(
+    refundedLineItems: List<WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow>?
+) {
+    when {
+        refundedLineItems == null -> {
+            Spacer(Modifier.height(WooPosSpacing.Medium.value))
+            ProductsShimmer(
+                title = stringResource(R.string.woopos_orders_details_refunded_products_title)
+            )
+        }
+        refundedLineItems.isNotEmpty() -> {
+            Spacer(Modifier.height(WooPosSpacing.Medium.value))
+            OrdersProducts(
+                title = stringResource(R.string.woopos_orders_details_refunded_products_title),
+                lineItems = refundedLineItems
+            )
+        }
+    }
+}
+
+@Composable
+private fun OrdersProducts(
+    title: String,
+    lineItems: List<WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow>
+) {
     WooPosCard(shadowType = ShadowType.Soft) {
         Column(Modifier.padding(WooPosSpacing.Medium.value)) {
             WooPosText(
-                text = stringResource(R.string.woopos_orders_details_products_title),
+                text = title,
                 style = WooPosTypography.BodyXLarge,
                 fontWeight = FontWeight.SemiBold,
             )
@@ -176,6 +217,55 @@ private fun OrdersProducts(lineItems: List<WooPosOrdersState.OrderDetailsViewSta
                 OrderProductItem(row = item)
 
                 if (ind < lineItems.size - 1) {
+                    DividerWithSpacing()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProductsShimmer(title: String) {
+    WooPosCard(shadowType = ShadowType.Soft) {
+        Column(Modifier.padding(WooPosSpacing.Medium.value)) {
+            WooPosText(
+                text = title,
+                style = WooPosTypography.BodyXLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            Spacer(Modifier.height(WooPosSpacing.Medium.value))
+
+            repeat(2) { index ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = WooPosSpacing.Small.value),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    WooPosShimmerBox(
+                        modifier = Modifier
+                            .size(56.dp)
+                            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
+                    )
+                    Spacer(Modifier.width(WooPosSpacing.Medium.value))
+                    Column(modifier = Modifier.weight(1f)) {
+                        WooPosShimmerBox(
+                            modifier = Modifier
+                                .fillMaxWidth(0.6f)
+                                .height(16.dp)
+                                .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
+                        )
+                        Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                        WooPosShimmerBox(
+                            modifier = Modifier
+                                .fillMaxWidth(0.3f)
+                                .height(14.dp)
+                                .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
+                        )
+                    }
+                }
+                if (index < 1) {
                     DividerWithSpacing()
                 }
             }
@@ -506,6 +596,16 @@ fun WooPosOrderDetailsPreview() {
                 bookingInfo = WooPosOrdersState.OrderDetailsViewState.Computed.Details.BookingInfo.Loaded(
                     "Booking #33 \u00B7 Jul 5, 2025, 10:00 AM - 10:30 AM"
                 )
+            )
+        ),
+        refundedLineItems = listOf(
+            WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
+                id = 101,
+                name = "Cup",
+                attributesDescription = null,
+                qtyAndUnitPrice = "1 x $4.00",
+                lineTotal = "-$4.00",
+                imageUrl = null
             )
         ),
         breakdown = WooPosOrdersState.OrderDetailsViewState.Computed.Details.TotalsBreakdown(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
@@ -164,36 +164,42 @@ private fun OrdersHeader(details: WooPosOrdersState.OrderDetailsViewState.Comput
 
 @Composable
 private fun ProductsSection(
-    lineItems: List<WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow>?
+    lineItems: WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState
 ) {
-    when {
-        lineItems == null -> ProductsShimmer(
-            title = stringResource(R.string.woopos_orders_details_products_title)
-        )
-        lineItems.isNotEmpty() -> OrdersProducts(
-            title = stringResource(R.string.woopos_orders_details_products_title),
-            lineItems = lineItems
-        )
+    when (lineItems) {
+        is WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loading ->
+            ProductsShimmer(
+                title = stringResource(R.string.woopos_orders_details_products_title)
+            )
+        is WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded ->
+            if (lineItems.items.isNotEmpty()) {
+                OrdersProducts(
+                    title = stringResource(R.string.woopos_orders_details_products_title),
+                    lineItems = lineItems.items
+                )
+            }
     }
 }
 
 @Composable
 private fun RefundedProductsSection(
-    refundedLineItems: List<WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow>?
+    refundedLineItems: WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState
 ) {
-    when {
-        refundedLineItems == null -> {
+    when (refundedLineItems) {
+        is WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loading -> {
             Spacer(Modifier.height(WooPosSpacing.Medium.value))
             ProductsShimmer(
                 title = stringResource(R.string.woopos_orders_details_refunded_products_title)
             )
         }
-        refundedLineItems.isNotEmpty() -> {
-            Spacer(Modifier.height(WooPosSpacing.Medium.value))
-            OrdersProducts(
-                title = stringResource(R.string.woopos_orders_details_refunded_products_title),
-                lineItems = refundedLineItems
-            )
+        is WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded -> {
+            if (refundedLineItems.items.isNotEmpty()) {
+                Spacer(Modifier.height(WooPosSpacing.Medium.value))
+                OrdersProducts(
+                    title = stringResource(R.string.woopos_orders_details_refunded_products_title),
+                    lineItems = refundedLineItems.items
+                )
+            }
         }
     }
 }
@@ -560,52 +566,56 @@ fun WooPosOrderDetailsPreview() {
         dateTime = "Aug 28, 2025 at 10:31 AM",
         customerEmail = "johndoe@mail.com",
         status = PosOrderStatus(text = "Completed", colorKey = OrderStatusColorKey.COMPLETED),
-        lineItems = listOf(
-            WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
-                id = 101,
-                name = "Cup",
-                attributesDescription = null,
-                qtyAndUnitPrice = "2 x $4.00",
-                lineTotal = "$8.00",
-                imageUrl = null
-            ),
-            WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
-                id = 102,
-                name = "T-Shirt",
-                attributesDescription = "Blue, Large",
-                qtyAndUnitPrice = "1 x $10.00",
-                lineTotal = "$10.00",
-                imageUrl = null
-            ),
-            WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
-                id = 103,
-                name = "A vey tasty coffee that incidentally has a very long name " +
-                    "and should go over a few lines without overlapping anything",
-                attributesDescription = "Medium roast, Decaf",
-                qtyAndUnitPrice = "1 x $5.00",
-                lineTotal = "$5.00",
-                imageUrl = null
-            ),
-            WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
-                id = 104,
-                name = "Women's Haircut",
-                attributesDescription = null,
-                qtyAndUnitPrice = "1 x $55.00",
-                lineTotal = "$55.00",
-                imageUrl = null,
-                bookingInfo = WooPosOrdersState.OrderDetailsViewState.Computed.Details.BookingInfo.Loaded(
-                    "Booking #33 \u00B7 Jul 5, 2025, 10:00 AM - 10:30 AM"
+        lineItems = WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded(
+            listOf(
+                WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
+                    id = 101,
+                    name = "Cup",
+                    attributesDescription = null,
+                    qtyAndUnitPrice = "2 x $4.00",
+                    lineTotal = "$8.00",
+                    imageUrl = null
+                ),
+                WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
+                    id = 102,
+                    name = "T-Shirt",
+                    attributesDescription = "Blue, Large",
+                    qtyAndUnitPrice = "1 x $10.00",
+                    lineTotal = "$10.00",
+                    imageUrl = null
+                ),
+                WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
+                    id = 103,
+                    name = "A vey tasty coffee that incidentally has a very long name " +
+                        "and should go over a few lines without overlapping anything",
+                    attributesDescription = "Medium roast, Decaf",
+                    qtyAndUnitPrice = "1 x $5.00",
+                    lineTotal = "$5.00",
+                    imageUrl = null
+                ),
+                WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
+                    id = 104,
+                    name = "Women's Haircut",
+                    attributesDescription = null,
+                    qtyAndUnitPrice = "1 x $55.00",
+                    lineTotal = "$55.00",
+                    imageUrl = null,
+                    bookingInfo = WooPosOrdersState.OrderDetailsViewState.Computed.Details.BookingInfo.Loaded(
+                        "Booking #33 \u00B7 Jul 5, 2025, 10:00 AM - 10:30 AM"
+                    )
                 )
             )
         ),
-        refundedLineItems = listOf(
-            WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
-                id = 101,
-                name = "Cup",
-                attributesDescription = null,
-                qtyAndUnitPrice = "1 x $4.00",
-                lineTotal = "-$4.00",
-                imageUrl = null
+        refundedLineItems = WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded(
+            listOf(
+                WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
+                    id = 101,
+                    name = "Cup",
+                    attributesDescription = null,
+                    qtyAndUnitPrice = "1 x $4.00",
+                    lineTotal = "-$4.00",
+                    imageUrl = null
+                )
             )
         ),
         breakdown = WooPosOrdersState.OrderDetailsViewState.Computed.Details.TotalsBreakdown(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.woopos.orders.details
 
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
-import com.woocommerce.android.model.Refund
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
@@ -20,7 +19,6 @@ import kotlinx.coroutines.coroutineScope
 import java.math.BigDecimal
 import java.math.RoundingMode
 import javax.inject.Inject
-import kotlin.math.abs
 
 class WooPosOrderDetailsMapper @Inject constructor(
     private val resourceProvider: ResourceProvider,
@@ -30,13 +28,19 @@ class WooPosOrderDetailsMapper @Inject constructor(
     private val refundInfoBuilder: WooPosRefundInfoBuilder,
     private val orderActionsProvider: WooPosOrderActionsProvider,
     private val bookingInfoMapper: WooPosBookingInfoMapper,
+    private val getNonRefundedItems: WooPosGetNonRefundedItems,
+    private val groupRefundedItems: WooPosGroupRefundedItems,
 ) {
     suspend fun mapOrderDetails(
         order: Order,
         historicalRefundsResult: RefundsFetchResult
     ): WooPosOrdersState.OrderDetailsViewState.Computed.Details = coroutineScope {
         val status = orderStatusMapper.mapOrderStatus(order.status)
-        val nonRefundedItems = getNonRefundedItems(order, historicalRefundsResult)
+        val refunds = when (historicalRefundsResult) {
+            is RefundsFetchResult.Success -> historicalRefundsResult.refunds
+            is RefundsFetchResult.Error -> emptyList()
+        }
+        val nonRefundedItems = getNonRefundedItems(order, refunds)
         val lineItems = buildLineItems(order, nonRefundedItems)
         val refundInfo = refundInfoBuilder.buildRefundInfo(order, historicalRefundsResult)
         val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
@@ -108,31 +112,12 @@ class WooPosOrderDetailsMapper @Inject constructor(
             is RefundsFetchResult.Error -> return@coroutineScope emptyList()
         }
 
-        val allRefundItems = refunds.flatMap { it.items }
-        if (allRefundItems.isEmpty()) return@coroutineScope emptyList()
-
-        data class AggregatedRefundItem(
-            val orderItemId: Long,
-            val quantity: Int,
-            val total: BigDecimal,
-            val refundItem: Refund.Item
-        )
-
-        val aggregated = allRefundItems
-            .groupBy { it.orderItemId }
-            .map { (orderItemId, items) ->
-                AggregatedRefundItem(
-                    orderItemId = orderItemId,
-                    quantity = items.sumOf { it.quantity },
-                    total = items.fold(BigDecimal.ZERO) { acc, item -> acc + item.total },
-                    refundItem = items.first()
-                )
-            }
+        val aggregated = groupRefundedItems(refunds)
 
         aggregated.map { agg ->
             async {
                 val orderItem = order.items.find { it.itemId == agg.orderItemId }
-                val name = orderItem?.name ?: agg.refundItem.name
+                val name = orderItem?.name ?: agg.orderItemId.toString()
                 val attributesDescription = orderItem?.attributesDescription?.takeIf { it.isNotEmpty() }
                 val unitPrice = if (agg.quantity != 0) {
                     agg.total.divide(
@@ -143,7 +128,7 @@ class WooPosOrderDetailsMapper @Inject constructor(
                 } else {
                     agg.total
                 }
-                val product = getProductById(agg.refundItem.productId)
+                val product = getProductById(agg.productId)
                 LineItemRow(
                     id = agg.orderItemId,
                     name = name,
@@ -160,37 +145,12 @@ class WooPosOrderDetailsMapper @Inject constructor(
         order: Order,
         refundResult: RefundsFetchResult
     ): List<LineItemRow> {
-        val items = getNonRefundedItems(order, refundResult)
-        return buildLineItems(order, items)
-    }
-
-    private fun getNonRefundedItems(
-        order: Order,
-        refundResult: RefundsFetchResult
-    ): List<Order.Item> {
         val refunds = when (refundResult) {
             is RefundsFetchResult.Success -> refundResult.refunds
-            is RefundsFetchResult.Error -> return order.items
+            is RefundsFetchResult.Error -> emptyList()
         }
-        if (refunds.isEmpty()) return order.items
-
-        val refundedByItemId = refunds
-            .flatMap { it.items }
-            .groupingBy { it.orderItemId }
-            .fold(0) { acc, item -> acc + item.quantity }
-
-        return order.items.mapNotNull { item ->
-            val refundedQty = abs(refundedByItemId[item.itemId] ?: 0).toFloat()
-            val remaining = item.quantity - refundedQty
-            when {
-                remaining <= 0f -> null
-                remaining == item.quantity -> item
-                else -> {
-                    val newTotal = item.total * (remaining / item.quantity).toBigDecimal()
-                    item.copy(quantity = remaining, total = newTotal)
-                }
-            }
-        }
+        val items = getNonRefundedItems(order, refunds)
+        return buildLineItems(order, items)
     }
 
     private suspend fun buildLineItems(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -168,10 +168,10 @@ class WooPosOrderDetailsMapper @Inject constructor(
         val refundedByItemId = refunds
             .flatMap { it.items }
             .groupingBy { it.orderItemId }
-            .fold(0f) { acc, item -> acc + item.quantity }
+            .fold(0) { acc, item -> acc + item.quantity }
 
         return order.items.mapNotNull { item ->
-            val refundedQty = abs(refundedByItemId[item.itemId] ?: 0f)
+            val refundedQty = abs(refundedByItemId[item.itemId] ?: 0).toFloat()
             val remaining = item.quantity - refundedQty
             when {
                 remaining <= 0f -> null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -3,12 +3,12 @@ package com.woocommerce.android.ui.woopos.orders.details
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
-import kotlin.math.abs
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState
 import com.woocommerce.android.ui.woopos.orders.details.refund.RefundInfo
 import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
 import com.woocommerce.android.ui.woopos.util.ext.formatToMMMddYYYYAtHHmm
@@ -19,6 +19,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import java.math.BigDecimal
 import javax.inject.Inject
+import kotlin.math.abs
 
 class WooPosOrderDetailsMapper @Inject constructor(
     private val resourceProvider: ResourceProvider,
@@ -49,8 +50,8 @@ class WooPosOrderDetailsMapper @Inject constructor(
             ),
             customerEmail = order.customer?.email ?: order.billingAddress.email,
             status = status,
-            lineItems = lineItems,
-            refundedLineItems = refundedLineItems,
+            lineItems = LineItemsState.Loaded(lineItems),
+            refundedLineItems = LineItemsState.Loaded(refundedLineItems),
             breakdown = breakdown,
             total = formatPrice(order.total, order.currency),
             totalPaid = if (order.isOrderPaid) {
@@ -69,7 +70,9 @@ class WooPosOrderDetailsMapper @Inject constructor(
         val status = orderStatusMapper.mapOrderStatus(order.status)
         val mayHaveRefunds = order.refundTotal > BigDecimal.ZERO ||
             order.status == Order.Status.Refunded
-        val lineItems = if (mayHaveRefunds) null else buildLineItems(order)
+        val lineItems = if (mayHaveRefunds) LineItemsState.Loading else LineItemsState.Loaded(buildLineItems(order))
+        val refundedLineItems =
+            if (mayHaveRefunds) LineItemsState.Loading else LineItemsState.Loaded(emptyList())
         val refundInfo = RefundInfo(emptyList(), BigDecimal.ZERO)
         val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
 
@@ -82,6 +85,7 @@ class WooPosOrderDetailsMapper @Inject constructor(
             customerEmail = order.customer?.email ?: order.billingAddress.email,
             status = status,
             lineItems = lineItems,
+            refundedLineItems = refundedLineItems,
             breakdown = breakdown,
             total = formatPrice(order.total),
             totalPaid = if (order.isOrderPaid) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import java.math.BigDecimal
+import java.math.RoundingMode
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -133,14 +134,22 @@ class WooPosOrderDetailsMapper @Inject constructor(
                 val orderItem = order.items.find { it.itemId == agg.orderItemId }
                 val name = orderItem?.name ?: agg.refundItem.name
                 val attributesDescription = orderItem?.attributesDescription?.takeIf { it.isNotEmpty() }
-                val unitPrice = agg.refundItem.price
+                val unitPrice = if (agg.quantity != 0) {
+                    agg.total.divide(
+                        BigDecimal.valueOf(agg.quantity.toLong()),
+                        agg.total.scale(),
+                        RoundingMode.HALF_UP
+                    )
+                } else {
+                    agg.total
+                }
                 val product = getProductById(agg.refundItem.productId)
                 LineItemRow(
                     id = agg.orderItemId,
                     name = name,
                     attributesDescription = attributesDescription,
                     qtyAndUnitPrice = "${agg.quantity} x ${formatPrice(unitPrice, order.currency)}",
-                    lineTotal = "-${formatPrice(agg.total, order.currency)}",
+                    lineTotal = formatPrice(agg.total.negate(), order.currency),
                     imageUrl = product?.firstImageUrl,
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.woopos.orders.details
 
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.Refund
+import com.woocommerce.android.model.getNonRefundedProducts
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
@@ -32,10 +34,12 @@ class WooPosOrderDetailsMapper @Inject constructor(
         historicalRefundsResult: RefundsFetchResult
     ): WooPosOrdersState.OrderDetailsViewState.Computed.Details = coroutineScope {
         val status = orderStatusMapper.mapOrderStatus(order.status)
-        val lineItems = buildLineItems(order)
+        val nonRefundedItems = getNonRefundedItems(order, historicalRefundsResult)
+        val lineItems = buildLineItems(order, nonRefundedItems)
         val refundInfo = refundInfoBuilder.buildRefundInfo(order, historicalRefundsResult)
         val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
         val actions = orderActionsProvider.getAvailableActions(order)
+        val refundedLineItems = buildRefundedLineItems(order, historicalRefundsResult)
 
         WooPosOrdersState.OrderDetailsViewState.Computed.Details(
             id = order.id,
@@ -46,6 +50,7 @@ class WooPosOrderDetailsMapper @Inject constructor(
             customerEmail = order.customer?.email ?: order.billingAddress.email,
             status = status,
             lineItems = lineItems,
+            refundedLineItems = refundedLineItems,
             breakdown = breakdown,
             total = formatPrice(order.total, order.currency),
             totalPaid = if (order.isOrderPaid) {
@@ -62,7 +67,9 @@ class WooPosOrderDetailsMapper @Inject constructor(
         order: Order
     ): WooPosOrdersState.OrderDetailsViewState.Computed.Details = coroutineScope {
         val status = orderStatusMapper.mapOrderStatus(order.status)
-        val lineItems = buildLineItems(order)
+        val mayHaveRefunds = order.refundTotal > BigDecimal.ZERO ||
+            order.status == Order.Status.Refunded
+        val lineItems = if (mayHaveRefunds) null else buildLineItems(order)
         val refundInfo = RefundInfo(emptyList(), BigDecimal.ZERO)
         val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
 
@@ -87,10 +94,84 @@ class WooPosOrderDetailsMapper @Inject constructor(
         )
     }
 
-    private suspend fun buildLineItems(
-        order: Order
+    suspend fun buildRefundedLineItems(
+        order: Order,
+        refundResult: RefundsFetchResult
     ): List<LineItemRow> = coroutineScope {
-        order.items.map { item ->
+        val refunds = when (refundResult) {
+            is RefundsFetchResult.Success -> refundResult.refunds
+            is RefundsFetchResult.Error -> return@coroutineScope emptyList()
+        }
+
+        val allRefundItems = refunds.flatMap { it.items }
+        if (allRefundItems.isEmpty()) return@coroutineScope emptyList()
+
+        data class AggregatedRefundItem(
+            val orderItemId: Long,
+            val quantity: Int,
+            val total: BigDecimal,
+            val refundItem: Refund.Item
+        )
+
+        val aggregated = allRefundItems
+            .groupBy { it.orderItemId }
+            .map { (orderItemId, items) ->
+                AggregatedRefundItem(
+                    orderItemId = orderItemId,
+                    quantity = items.sumOf { it.quantity },
+                    total = items.fold(BigDecimal.ZERO) { acc, item -> acc + item.total },
+                    refundItem = items.first()
+                )
+            }
+
+        aggregated.map { agg ->
+            async {
+                val orderItem = order.items.find { it.itemId == agg.orderItemId }
+                val name = orderItem?.name ?: agg.refundItem.name
+                val attributesDescription = orderItem?.attributesDescription?.takeIf { it.isNotEmpty() }
+                val unitPrice = if (agg.quantity > 0) {
+                    agg.total / agg.quantity.toBigDecimal()
+                } else {
+                    agg.total
+                }
+                val product = getProductById(agg.refundItem.productId)
+                LineItemRow(
+                    id = agg.orderItemId,
+                    name = name,
+                    attributesDescription = attributesDescription,
+                    qtyAndUnitPrice = "${agg.quantity} x ${formatPrice(unitPrice, order.currency)}",
+                    lineTotal = "-${formatPrice(agg.total, order.currency)}",
+                    imageUrl = product?.firstImageUrl,
+                )
+            }
+        }.awaitAll()
+    }
+
+    suspend fun buildNonRefundedLineItems(
+        order: Order,
+        refundResult: RefundsFetchResult
+    ): List<LineItemRow> {
+        val items = getNonRefundedItems(order, refundResult)
+        return buildLineItems(order, items)
+    }
+
+    private fun getNonRefundedItems(
+        order: Order,
+        refundResult: RefundsFetchResult
+    ): List<Order.Item> {
+        val refunds = when (refundResult) {
+            is RefundsFetchResult.Success -> refundResult.refunds
+            is RefundsFetchResult.Error -> return order.items
+        }
+        if (refunds.isEmpty()) return order.items
+        return refunds.getNonRefundedProducts(order.items)
+    }
+
+    private suspend fun buildLineItems(
+        order: Order,
+        items: List<Order.Item> = order.items
+    ): List<LineItemRow> = coroutineScope {
+        items.map { item ->
             async {
                 val unitPrice =
                     if (item.quantity == 0f) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.ui.woopos.orders.details
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
-import com.woocommerce.android.model.getNonRefundedProducts
+import kotlin.math.abs
 import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
@@ -164,7 +164,24 @@ class WooPosOrderDetailsMapper @Inject constructor(
             is RefundsFetchResult.Error -> return order.items
         }
         if (refunds.isEmpty()) return order.items
-        return refunds.getNonRefundedProducts(order.items)
+
+        val refundedByItemId = refunds
+            .flatMap { it.items }
+            .groupingBy { it.orderItemId }
+            .fold(0f) { acc, item -> acc + item.quantity }
+
+        return order.items.mapNotNull { item ->
+            val refundedQty = abs(refundedByItemId[item.itemId] ?: 0f)
+            val remaining = item.quantity - refundedQty
+            when {
+                remaining <= 0f -> null
+                remaining == item.quantity -> item
+                else -> {
+                    val newTotal = item.price * remaining.toBigDecimal()
+                    item.copy(quantity = remaining, total = newTotal)
+                }
+            }
+        }
     }
 
     private suspend fun buildLineItems(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -177,7 +177,7 @@ class WooPosOrderDetailsMapper @Inject constructor(
                 remaining <= 0f -> null
                 remaining == item.quantity -> item
                 else -> {
-                    val newTotal = item.price * remaining.toBigDecimal()
+                    val newTotal = item.total * (remaining / item.quantity).toBigDecimal()
                     item.copy(quantity = remaining, total = newTotal)
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -129,11 +129,7 @@ class WooPosOrderDetailsMapper @Inject constructor(
                 val orderItem = order.items.find { it.itemId == agg.orderItemId }
                 val name = orderItem?.name ?: agg.refundItem.name
                 val attributesDescription = orderItem?.attributesDescription?.takeIf { it.isNotEmpty() }
-                val unitPrice = if (agg.quantity > 0) {
-                    agg.total / agg.quantity.toBigDecimal()
-                } else {
-                    agg.total
-                }
+                val unitPrice = agg.refundItem.price
                 val product = getProductById(agg.refundItem.productId)
                 LineItemRow(
                     id = agg.orderItemId,

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3885,6 +3885,7 @@
     <string name="woopos_orders_details_placeholder_title">Select an order</string>
     <string name="woopos_orders_details_placeholder_message">Choose an order from the list to view details.</string>
     <string name="woopos_orders_details_products_title">Products</string>
+    <string name="woopos_orders_details_refunded_products_title">Refunded Products</string>
     <string name="woopos_orders_details_totals_title">Totals</string>
     <string name="woopos_orders_details_qty_unit_price_format">%1$d x %2$s</string>
     <string name="woopos_orders_details_breakdown_products_label">Products</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -645,7 +645,9 @@ class WooPosOrdersViewModelTest {
         val selectedItemId = loadedItems.items.keys.single { it.isSelected }.id
         assertThat(selectedItemId).isEqualTo(2L)
         assertThat(content.selectedDetails?.id).isEqualTo(2L)
-        assertThat(content.selectedDetails?.lineItems).isNotEmpty
+        assertThat(content.selectedDetails?.lineItems).isInstanceOf(
+            WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded::class.java
+        )
         assertThat(content.selectedDetails?.total).isEqualTo("$106.00")
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersViewModelTest.kt
@@ -13,7 +13,9 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
+import com.woocommerce.android.ui.woopos.orders.details.WooPosGroupRefundedItems
 import com.woocommerce.android.ui.woopos.orders.details.WooPosBookingInfoMapper
+import com.woocommerce.android.ui.woopos.orders.details.WooPosGetNonRefundedItems
 import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderDetailsMapper
 import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderItemMapper
 import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderStatusMapper
@@ -147,6 +149,8 @@ class WooPosOrdersViewModelTest {
             refundInfoBuilder,
             orderActionsProvider,
             bookingInfoMapper,
+            WooPosGetNonRefundedItems(),
+            WooPosGroupRefundedItems(),
         )
         orderItemMapper = WooPosOrderItemMapper(resourceProvider, formatPrice, orderStatusMapper)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGetNonRefundedItemsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGetNonRefundedItemsTest.kt
@@ -1,0 +1,187 @@
+package com.woocommerce.android.ui.woopos.orders.details
+
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.Refund
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.math.BigDecimal
+import java.util.Date
+
+class WooPosGetNonRefundedItemsTest {
+
+    private val sut = WooPosGetNonRefundedItems()
+
+    private fun createOrderItem(
+        itemId: Long,
+        productId: Long = 10L,
+        name: String = "Product $itemId",
+        price: BigDecimal = BigDecimal("10.00"),
+        quantity: Float = 1f,
+    ) = Order.Item(
+        itemId = itemId,
+        productId = productId,
+        name = name,
+        price = price,
+        sku = "",
+        quantity = quantity,
+        subtotal = price * quantity.toBigDecimal(),
+        subtotalTax = BigDecimal.ZERO,
+        totalTax = BigDecimal.ZERO,
+        total = price * quantity.toBigDecimal(),
+        variationId = 0,
+        attributesList = emptyList(),
+    )
+
+    private fun createRefundItem(
+        orderItemId: Long,
+        quantity: Int = 1,
+        total: BigDecimal = BigDecimal("10.00"),
+    ) = Refund.Item(
+        productId = 10L,
+        quantity = quantity,
+        orderItemId = orderItemId,
+        name = "Refund Product",
+        total = total,
+        price = if (quantity > 0) total / quantity.toBigDecimal() else total,
+    )
+
+    private fun createRefund(
+        id: Long = 1L,
+        items: List<Refund.Item>,
+    ) = Refund(
+        id = id,
+        dateCreated = Date(),
+        amount = items.fold(BigDecimal.ZERO) { acc, item -> acc + item.total },
+        reason = null,
+        automaticGatewayRefund = false,
+        items = items,
+        shippingLines = emptyList(),
+        feeLines = emptyList(),
+    )
+
+    private fun createOrder(items: List<Order.Item>): Order {
+        return com.woocommerce.android.ui.orders.OrderTestUtils.generateTestOrder().copy(items = items)
+    }
+
+    @Test
+    fun `given no refunds, when invoked, then all items returned`() {
+        // GIVEN
+        val items = listOf(
+            createOrderItem(itemId = 1L, name = "Cup", price = BigDecimal("4.00"), quantity = 2f),
+        )
+        val order = createOrder(items)
+
+        // WHEN
+        val result = sut(order, emptyList())
+
+        // THEN
+        assertThat(result).hasSize(1)
+        assertThat(result.first().name).isEqualTo("Cup")
+        assertThat(result.first().quantity).isEqualTo(2f)
+    }
+
+    @Test
+    fun `given fully refunded item, when invoked, then item excluded`() {
+        // GIVEN
+        val items = listOf(
+            createOrderItem(itemId = 1L, name = "Cup", price = BigDecimal("4.00"), quantity = 1f),
+            createOrderItem(itemId = 2L, name = "Plate", price = BigDecimal("6.00"), quantity = 1f),
+        )
+        val order = createOrder(items)
+        val refunds = listOf(
+            createRefund(
+                items = listOf(createRefundItem(orderItemId = 1L, quantity = 1, total = BigDecimal("4.00")))
+            )
+        )
+
+        // WHEN
+        val result = sut(order, refunds)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        assertThat(result.first().name).isEqualTo("Plate")
+    }
+
+    @Test
+    fun `given partial refund, when invoked, then item has prorated total`() {
+        // GIVEN
+        val items = listOf(
+            createOrderItem(itemId = 1L, name = "Cup", price = BigDecimal("4.00"), quantity = 3f),
+        )
+        val order = createOrder(items)
+        val refunds = listOf(
+            createRefund(
+                items = listOf(createRefundItem(orderItemId = 1L, quantity = 1, total = BigDecimal("4.00")))
+            )
+        )
+
+        // WHEN
+        val result = sut(order, refunds)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        assertThat(result.first().quantity).isEqualTo(2f)
+        val expectedTotal = BigDecimal("12.00") * (2f / 3f).toBigDecimal()
+        assertThat(result.first().total).isEqualByComparingTo(expectedTotal)
+    }
+
+    @Test
+    fun `given same product in different line items, when one is refunded, then only that line item affected`() {
+        // GIVEN
+        val items = listOf(
+            createOrderItem(
+                itemId = 1L,
+                productId = 10L,
+                name = "Cup (Red)",
+                price = BigDecimal("4.00"),
+                quantity = 1f
+            ),
+            createOrderItem(
+                itemId = 2L,
+                productId = 10L,
+                name = "Cup (Blue)",
+                price = BigDecimal("4.00"),
+                quantity = 1f
+            ),
+        )
+        val order = createOrder(items)
+        val refunds = listOf(
+            createRefund(
+                items = listOf(createRefundItem(orderItemId = 1L, quantity = 1, total = BigDecimal("4.00")))
+            )
+        )
+
+        // WHEN
+        val result = sut(order, refunds)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        assertThat(result.first().name).isEqualTo("Cup (Blue)")
+    }
+
+    @Test
+    fun `given multiple refunds for same item, when invoked, then quantities are folded correctly`() {
+        // GIVEN
+        val items = listOf(
+            createOrderItem(itemId = 1L, name = "Cup", price = BigDecimal("4.00"), quantity = 5f),
+        )
+        val order = createOrder(items)
+        val refunds = listOf(
+            createRefund(
+                id = 1L,
+                items = listOf(createRefundItem(orderItemId = 1L, quantity = 1, total = BigDecimal("4.00")))
+            ),
+            createRefund(
+                id = 2L,
+                items = listOf(createRefundItem(orderItemId = 1L, quantity = 2, total = BigDecimal("8.00")))
+            ),
+        )
+
+        // WHEN
+        val result = sut(order, refunds)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        assertThat(result.first().quantity).isEqualTo(2f)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGroupRefundedItemsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGroupRefundedItemsTest.kt
@@ -1,0 +1,133 @@
+package com.woocommerce.android.ui.woopos.orders.details
+
+import com.woocommerce.android.model.Refund
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.math.BigDecimal
+import java.util.Date
+
+class WooPosGroupRefundedItemsTest {
+
+    private val sut = WooPosGroupRefundedItems()
+
+    private fun createRefundItem(
+        orderItemId: Long,
+        productId: Long = 10L,
+        quantity: Int = 1,
+        total: BigDecimal = BigDecimal("10.00"),
+    ) = Refund.Item(
+        productId = productId,
+        quantity = quantity,
+        orderItemId = orderItemId,
+        name = "Refund Product",
+        total = total,
+        price = if (quantity > 0) total / quantity.toBigDecimal() else total,
+    )
+
+    private fun createRefund(
+        id: Long = 1L,
+        items: List<Refund.Item>,
+    ) = Refund(
+        id = id,
+        dateCreated = Date(),
+        amount = items.fold(BigDecimal.ZERO) { acc, item -> acc + item.total },
+        reason = null,
+        automaticGatewayRefund = false,
+        items = items,
+        shippingLines = emptyList(),
+        feeLines = emptyList(),
+    )
+
+    @Test
+    fun `given single refund with single item, when invoked, then correct grouping`() {
+        // GIVEN
+        val refunds = listOf(
+            createRefund(
+                items = listOf(
+                    createRefundItem(orderItemId = 1L, productId = 10L, quantity = 2, total = BigDecimal("8.00"))
+                )
+            )
+        )
+
+        // WHEN
+        val result = sut(refunds)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        assertThat(result.first().orderItemId).isEqualTo(1L)
+        assertThat(result.first().quantity).isEqualTo(2)
+        assertThat(result.first().total).isEqualByComparingTo(BigDecimal("8.00"))
+        assertThat(result.first().productId).isEqualTo(10L)
+    }
+
+    @Test
+    fun `given multiple refunds for same item, when invoked, then quantities and totals summed`() {
+        // GIVEN
+        val refunds = listOf(
+            createRefund(
+                id = 1L,
+                items = listOf(
+                    createRefundItem(orderItemId = 1L, productId = 10L, quantity = 1, total = BigDecimal("4.00"))
+                )
+            ),
+            createRefund(
+                id = 2L,
+                items = listOf(
+                    createRefundItem(orderItemId = 1L, productId = 10L, quantity = 2, total = BigDecimal("8.00"))
+                )
+            ),
+        )
+
+        // WHEN
+        val result = sut(refunds)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        assertThat(result.first().quantity).isEqualTo(3)
+        assertThat(result.first().total).isEqualByComparingTo(BigDecimal("12.00"))
+    }
+
+    @Test
+    fun `given multiple different items, when invoked, then separate entries`() {
+        // GIVEN
+        val refunds = listOf(
+            createRefund(
+                items = listOf(
+                    createRefundItem(orderItemId = 1L, productId = 10L, quantity = 1, total = BigDecimal("4.00")),
+                    createRefundItem(orderItemId = 2L, productId = 20L, quantity = 1, total = BigDecimal("6.00")),
+                )
+            )
+        )
+
+        // WHEN
+        val result = sut(refunds)
+
+        // THEN
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.orderItemId }).containsExactly(1L, 2L)
+        assertThat(result.map { it.productId }).containsExactly(10L, 20L)
+    }
+
+    @Test
+    fun `given empty refunds, when invoked, then empty result`() {
+        // WHEN
+        val result = sut(emptyList())
+
+        // THEN
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `given refunds with no items, when invoked, then empty result`() {
+        // GIVEN
+        val refunds = listOf(
+            createRefund(items = emptyList())
+        )
+
+        // WHEN
+        val result = sut(refunds)
+
+        // THEN
+        assertThat(result).isEmpty()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.ui.woopos.orders.details
 
+import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.Refund
 import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
 import com.woocommerce.android.ui.woopos.orders.OrderStatusColorKey
 import com.woocommerce.android.ui.woopos.orders.PosOrderStatus
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
@@ -23,12 +26,13 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.util.DateTimeUtils
 import java.math.BigDecimal
+import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     private val resourceProvider: ResourceProvider = mock()
-    private val getProductById: com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById = mock()
+    private val getProductById: WooPosGetProductById = mock()
     private val formatPrice: WooPosFormatPrice = mock()
     private val orderStatusMapper: WooPosOrderStatusMapper = mock()
     private val refundInfoBuilder: WooPosRefundInfoBuilder = mock()
@@ -76,6 +80,71 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         Unit
     }
 
+    private suspend fun setupDefaults() {
+        whenever(formatPrice(any<BigDecimal>(), any())).thenAnswer { invocation ->
+            val amount = invocation.arguments[0] as? BigDecimal
+            amount?.let { "$${it.setScale(2)}" } ?: "$0.00"
+        }
+        whenever(formatPrice(any<BigDecimal>())).thenAnswer { invocation ->
+            val amount = invocation.arguments[0] as? BigDecimal
+            amount?.let { "$${it.setScale(2)}" } ?: "$0.00"
+        }
+    }
+
+    private fun createOrderItem(
+        itemId: Long,
+        productId: Long = 10L,
+        name: String = "Product $itemId",
+        price: BigDecimal = BigDecimal("10.00"),
+        quantity: Float = 1f,
+    ) = Order.Item(
+        itemId = itemId,
+        productId = productId,
+        name = name,
+        price = price,
+        sku = "",
+        quantity = quantity,
+        subtotal = price * quantity.toBigDecimal(),
+        subtotalTax = BigDecimal.ZERO,
+        totalTax = BigDecimal.ZERO,
+        total = price * quantity.toBigDecimal(),
+        variationId = 0,
+        attributesList = emptyList(),
+    )
+
+    private fun createRefundItem(
+        orderItemId: Long,
+        productId: Long = 10L,
+        quantity: Int = 1,
+        total: BigDecimal = BigDecimal("10.00"),
+        name: String = "Refund Product",
+    ) = Refund.Item(
+        productId = productId,
+        quantity = quantity,
+        orderItemId = orderItemId,
+        name = name,
+        total = total,
+        price = if (quantity > 0) total / quantity.toBigDecimal() else total,
+    )
+
+    private fun createRefund(
+        id: Long = 1L,
+        items: List<Refund.Item>,
+        amount: BigDecimal = items.fold(BigDecimal.ZERO) { acc, item -> acc + item.total },
+    ) = Refund(
+        id = id,
+        dateCreated = Date(),
+        amount = amount,
+        reason = null,
+        automaticGatewayRefund = false,
+        items = items,
+        shippingLines = emptyList(),
+        feeLines = emptyList(),
+    )
+
+    private fun createOrder(items: List<Order.Item>) =
+        OrderTestUtils.generateTestOrder().copy(items = items)
+
     @Test
     fun `given order is paid, when mapOrderDetails, then totalPaid equals formatted total`() = testBlocking {
         whenever(formatPrice(paidOrder.total, paidOrder.currency)).thenReturn("$106.00")
@@ -117,4 +186,224 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
             assertThat(result.totalPaid).isEqualTo("$0.00")
         }
+
+    @Test
+    fun `given refunds with items, when mapOrderDetails, then refundedLineItems are populated`() = testBlocking {
+        // GIVEN
+        setupDefaults()
+        val orderItems = listOf(
+            createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00"), quantity = 2f),
+        )
+        val order = createOrder(orderItems)
+        val refunds = listOf(
+            createRefund(
+                items = listOf(
+                    createRefundItem(orderItemId = 1L, productId = 10L, quantity = 1, total = BigDecimal("4.00"))
+                )
+            )
+        )
+        val refundResult = RefundsFetchResult.Success(refunds)
+
+        // WHEN
+        val result = sut.mapOrderDetails(order, refundResult)
+
+        // THEN
+        assertThat(result.refundedLineItems).hasSize(1)
+        val refundedItem = result.refundedLineItems!!.first()
+        assertThat(refundedItem.name).isEqualTo("Cup")
+        assertThat(refundedItem.qtyAndUnitPrice).isEqualTo("1 x $4.00")
+        assertThat(refundedItem.lineTotal).isEqualTo("-$4.00")
+
+        assertThat(result.lineItems).hasSize(1)
+        assertThat(result.lineItems!!.first().name).isEqualTo("Cup")
+        assertThat(result.lineItems.first().qtyAndUnitPrice).isEqualTo("1 x $4.00")
+    }
+
+    @Test
+    fun `given multiple refunds for same item, when mapOrderDetails, then quantities are aggregated`() = testBlocking {
+        // GIVEN
+        setupDefaults()
+        val orderItems = listOf(
+            createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00"), quantity = 3f),
+        )
+        val order = createOrder(orderItems)
+        val refunds = listOf(
+            createRefund(
+                id = 1L,
+                items = listOf(
+                    createRefundItem(orderItemId = 1L, productId = 10L, quantity = 1, total = BigDecimal("4.00"))
+                )
+            ),
+            createRefund(
+                id = 2L,
+                items = listOf(
+                    createRefundItem(orderItemId = 1L, productId = 10L, quantity = 2, total = BigDecimal("8.00"))
+                )
+            )
+        )
+        val refundResult = RefundsFetchResult.Success(refunds)
+
+        // WHEN
+        val result = sut.mapOrderDetails(order, refundResult)
+
+        // THEN
+        assertThat(result.refundedLineItems).hasSize(1)
+        val refundedItem = result.refundedLineItems!!.first()
+        assertThat(refundedItem.qtyAndUnitPrice).isEqualTo("3 x $4.00")
+        assertThat(refundedItem.lineTotal).isEqualTo("-$12.00")
+    }
+
+    @Test
+    fun `given refunds with no items, when mapOrderDetails, then refundedLineItems is empty`() = testBlocking {
+        // GIVEN
+        setupDefaults()
+        val orderItems = listOf(
+            createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00")),
+        )
+        val order = createOrder(orderItems)
+        val refunds = listOf(
+            createRefund(id = 1L, items = emptyList(), amount = BigDecimal("4.00"))
+        )
+        val refundResult = RefundsFetchResult.Success(refunds)
+
+        // WHEN
+        val result = sut.mapOrderDetails(order, refundResult)
+
+        // THEN
+        assertThat(result.refundedLineItems).isEmpty()
+    }
+
+    @Test
+    fun `given refund fetch error, when mapOrderDetails, then refundedLineItems is empty`() = testBlocking {
+        // GIVEN
+        setupDefaults()
+        val orderItems = listOf(
+            createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00")),
+        )
+        val order = createOrder(orderItems)
+        val refundResult = RefundsFetchResult.Error
+
+        // WHEN
+        val result = sut.mapOrderDetails(order, refundResult)
+
+        // THEN
+        assertThat(result.refundedLineItems).isEmpty()
+    }
+
+    @Test
+    fun `given order without refunds, when mapOrderDetailsWithoutActions, then lineItems populated and refunds null`() =
+        testBlocking {
+            // GIVEN
+            setupDefaults()
+            val orderItems = listOf(
+                createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00")),
+            )
+            val order = createOrder(orderItems)
+
+            // WHEN
+            val result = sut.mapOrderDetailsWithoutActions(order)
+
+            // THEN
+            assertThat(result.lineItems).isNotNull
+            assertThat(result.lineItems).hasSize(1)
+            assertThat(result.refundedLineItems).isNull()
+        }
+
+    @Test
+    fun `given order with refunds, when mapOrderDetailsWithoutActions, then both lineItems are null`() =
+        testBlocking {
+            // GIVEN
+            setupDefaults()
+            val orderItems = listOf(
+                createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00")),
+            )
+            val order = createOrder(orderItems).copy(refundTotal = BigDecimal("4.00"))
+
+            // WHEN
+            val result = sut.mapOrderDetailsWithoutActions(order)
+
+            // THEN
+            assertThat(result.lineItems).isNull()
+            assertThat(result.refundedLineItems).isNull()
+        }
+
+    @Test
+    fun `given refunds for multiple items, when mapOrderDetails, then each item has separate entry`() = testBlocking {
+        // GIVEN
+        setupDefaults()
+        val orderItems = listOf(
+            createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00"), quantity = 2f),
+            createOrderItem(itemId = 2L, productId = 20L, name = "Plate", price = BigDecimal("6.00"), quantity = 1f),
+        )
+        val order = createOrder(orderItems)
+        val refunds = listOf(
+            createRefund(
+                items = listOf(
+                    createRefundItem(orderItemId = 1L, productId = 10L, quantity = 1, total = BigDecimal("4.00")),
+                    createRefundItem(orderItemId = 2L, productId = 20L, quantity = 1, total = BigDecimal("6.00")),
+                )
+            )
+        )
+        val refundResult = RefundsFetchResult.Success(refunds)
+
+        // WHEN
+        val result = sut.mapOrderDetails(order, refundResult)
+
+        // THEN
+        assertThat(result.refundedLineItems).hasSize(2)
+        assertThat(result.refundedLineItems!!.map { it.name }).containsExactly("Cup", "Plate")
+        assertThat(result.refundedLineItems.map { it.lineTotal }).containsExactly("-$4.00", "-$6.00")
+
+        assertThat(result.lineItems).hasSize(1)
+        assertThat(result.lineItems!!.first().name).isEqualTo("Cup")
+        assertThat(result.lineItems.first().qtyAndUnitPrice).isEqualTo("1 x $4.00")
+    }
+
+    @Test
+    fun `given fully refunded item, when mapOrderDetails, then item is excluded from lineItems`() = testBlocking {
+        // GIVEN
+        setupDefaults()
+        val orderItems = listOf(
+            createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00"), quantity = 1f),
+            createOrderItem(itemId = 2L, productId = 20L, name = "Plate", price = BigDecimal("6.00"), quantity = 1f),
+        )
+        val order = createOrder(orderItems)
+        val refunds = listOf(
+            createRefund(
+                items = listOf(
+                    createRefundItem(orderItemId = 1L, productId = 10L, quantity = 1, total = BigDecimal("4.00")),
+                )
+            )
+        )
+        val refundResult = RefundsFetchResult.Success(refunds)
+
+        // WHEN
+        val result = sut.mapOrderDetails(order, refundResult)
+
+        // THEN
+        assertThat(result.lineItems).hasSize(1)
+        assertThat(result.lineItems!!.first().name).isEqualTo("Plate")
+        assertThat(result.refundedLineItems).hasSize(1)
+        assertThat(result.refundedLineItems!!.first().name).isEqualTo("Cup")
+    }
+
+    @Test
+    fun `given no refunds, when mapOrderDetails, then all items shown in lineItems`() = testBlocking {
+        // GIVEN
+        setupDefaults()
+        val orderItems = listOf(
+            createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00"), quantity = 2f),
+        )
+        val order = createOrder(orderItems)
+        val refundResult = RefundsFetchResult.Success(emptyList())
+
+        // WHEN
+        val result = sut.mapOrderDetails(order, refundResult)
+
+        // THEN
+        assertThat(result.lineItems).hasSize(1)
+        assertThat(result.lineItems!!.first().name).isEqualTo("Cup")
+        assertThat(result.lineItems.first().qtyAndUnitPrice).isEqualTo("2 x $4.00")
+        assertThat(result.refundedLineItems).isEmpty()
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.woopos.orders.details
 
-import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.ui.orders.OrderTestUtils
@@ -214,7 +213,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         val refundedItem = refundedItems.first()
         assertThat(refundedItem.name).isEqualTo("Cup")
         assertThat(refundedItem.qtyAndUnitPrice).isEqualTo("1 x $4.00")
-        assertThat(refundedItem.lineTotal).isEqualTo("-$4.00")
+        assertThat(refundedItem.lineTotal).isEqualTo("$-4.00")
 
         val lineItems = (result.lineItems as LineItemsState.Loaded).items
         assertThat(lineItems).hasSize(1)
@@ -254,7 +253,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         assertThat(refundedItems).hasSize(1)
         val refundedItem = refundedItems.first()
         assertThat(refundedItem.qtyAndUnitPrice).isEqualTo("3 x $4.00")
-        assertThat(refundedItem.lineTotal).isEqualTo("-$12.00")
+        assertThat(refundedItem.lineTotal).isEqualTo("$-12.00")
     }
 
     @Test
@@ -357,7 +356,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         val refundedItems = (result.refundedLineItems as LineItemsState.Loaded).items
         assertThat(refundedItems).hasSize(2)
         assertThat(refundedItems.map { it.name }).containsExactly("Cup", "Plate")
-        assertThat(refundedItems.map { it.lineTotal }).containsExactly("-$4.00", "-$6.00")
+        assertThat(refundedItems.map { it.lineTotal }).containsExactly("$-4.00", "$-6.00")
 
         val lineItems = (result.lineItems as LineItemsState.Loaded).items
         assertThat(lineItems).hasSize(1)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -38,6 +38,8 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     private val refundInfoBuilder: WooPosRefundInfoBuilder = mock()
     private val orderActionsProvider: WooPosOrderActionsProvider = mock()
     private val bookingInfoMapper: WooPosBookingInfoMapper = mock()
+    private val getNonRefundedItems = WooPosGetNonRefundedItems()
+    private val groupRefundedItems = WooPosGroupRefundedItems()
 
     private val sut = WooPosOrderDetailsMapper(
         resourceProvider = resourceProvider,
@@ -47,6 +49,8 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         refundInfoBuilder = refundInfoBuilder,
         orderActionsProvider = orderActionsProvider,
         bookingInfoMapper = bookingInfoMapper,
+        getNonRefundedItems = getNonRefundedItems,
+        groupRefundedItems = groupRefundedItems,
     )
 
     private val paidOrder: Order = OrderTestUtils.generateTestOrder().copy(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.woopos.orders.OrderStatusColorKey
 import com.woocommerce.android.ui.woopos.orders.PosOrderStatus
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.TotalsBreakdown
 import com.woocommerce.android.ui.woopos.orders.details.refund.RefundInfo
 import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
@@ -208,15 +209,17 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         val result = sut.mapOrderDetails(order, refundResult)
 
         // THEN
-        assertThat(result.refundedLineItems).hasSize(1)
-        val refundedItem = result.refundedLineItems!!.first()
+        val refundedItems = (result.refundedLineItems as LineItemsState.Loaded).items
+        assertThat(refundedItems).hasSize(1)
+        val refundedItem = refundedItems.first()
         assertThat(refundedItem.name).isEqualTo("Cup")
         assertThat(refundedItem.qtyAndUnitPrice).isEqualTo("1 x $4.00")
         assertThat(refundedItem.lineTotal).isEqualTo("-$4.00")
 
-        assertThat(result.lineItems).hasSize(1)
-        assertThat(result.lineItems!!.first().name).isEqualTo("Cup")
-        assertThat(result.lineItems.first().qtyAndUnitPrice).isEqualTo("1 x $4.00")
+        val lineItems = (result.lineItems as LineItemsState.Loaded).items
+        assertThat(lineItems).hasSize(1)
+        assertThat(lineItems.first().name).isEqualTo("Cup")
+        assertThat(lineItems.first().qtyAndUnitPrice).isEqualTo("1 x $4.00")
     }
 
     @Test
@@ -247,8 +250,9 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         val result = sut.mapOrderDetails(order, refundResult)
 
         // THEN
-        assertThat(result.refundedLineItems).hasSize(1)
-        val refundedItem = result.refundedLineItems!!.first()
+        val refundedItems = (result.refundedLineItems as LineItemsState.Loaded).items
+        assertThat(refundedItems).hasSize(1)
+        val refundedItem = refundedItems.first()
         assertThat(refundedItem.qtyAndUnitPrice).isEqualTo("3 x $4.00")
         assertThat(refundedItem.lineTotal).isEqualTo("-$12.00")
     }
@@ -270,7 +274,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         val result = sut.mapOrderDetails(order, refundResult)
 
         // THEN
-        assertThat(result.refundedLineItems).isEmpty()
+        assertThat((result.refundedLineItems as LineItemsState.Loaded).items).isEmpty()
     }
 
     @Test
@@ -287,11 +291,11 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         val result = sut.mapOrderDetails(order, refundResult)
 
         // THEN
-        assertThat(result.refundedLineItems).isEmpty()
+        assertThat((result.refundedLineItems as LineItemsState.Loaded).items).isEmpty()
     }
 
     @Test
-    fun `given order without refunds, when mapOrderDetailsWithoutActions, then lineItems populated and refunds null`() =
+    fun `given order without refunds, when mapOrderDetailsWithoutActions, then lineItems loaded and refunds empty`() =
         testBlocking {
             // GIVEN
             setupDefaults()
@@ -304,13 +308,13 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
             val result = sut.mapOrderDetailsWithoutActions(order)
 
             // THEN
-            assertThat(result.lineItems).isNotNull
-            assertThat(result.lineItems).hasSize(1)
-            assertThat(result.refundedLineItems).isNull()
+            val lineItems = (result.lineItems as LineItemsState.Loaded).items
+            assertThat(lineItems).hasSize(1)
+            assertThat((result.refundedLineItems as LineItemsState.Loaded).items).isEmpty()
         }
 
     @Test
-    fun `given order with refunds, when mapOrderDetailsWithoutActions, then both lineItems are null`() =
+    fun `given order with refunds, when mapOrderDetailsWithoutActions, then both lineItems are loading`() =
         testBlocking {
             // GIVEN
             setupDefaults()
@@ -323,8 +327,8 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
             val result = sut.mapOrderDetailsWithoutActions(order)
 
             // THEN
-            assertThat(result.lineItems).isNull()
-            assertThat(result.refundedLineItems).isNull()
+            assertThat(result.lineItems).isInstanceOf(LineItemsState.Loading::class.java)
+            assertThat(result.refundedLineItems).isInstanceOf(LineItemsState.Loading::class.java)
         }
 
     @Test
@@ -350,13 +354,15 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         val result = sut.mapOrderDetails(order, refundResult)
 
         // THEN
-        assertThat(result.refundedLineItems).hasSize(2)
-        assertThat(result.refundedLineItems!!.map { it.name }).containsExactly("Cup", "Plate")
-        assertThat(result.refundedLineItems.map { it.lineTotal }).containsExactly("-$4.00", "-$6.00")
+        val refundedItems = (result.refundedLineItems as LineItemsState.Loaded).items
+        assertThat(refundedItems).hasSize(2)
+        assertThat(refundedItems.map { it.name }).containsExactly("Cup", "Plate")
+        assertThat(refundedItems.map { it.lineTotal }).containsExactly("-$4.00", "-$6.00")
 
-        assertThat(result.lineItems).hasSize(1)
-        assertThat(result.lineItems!!.first().name).isEqualTo("Cup")
-        assertThat(result.lineItems.first().qtyAndUnitPrice).isEqualTo("1 x $4.00")
+        val lineItems = (result.lineItems as LineItemsState.Loaded).items
+        assertThat(lineItems).hasSize(1)
+        assertThat(lineItems.first().name).isEqualTo("Cup")
+        assertThat(lineItems.first().qtyAndUnitPrice).isEqualTo("1 x $4.00")
     }
 
     @Test
@@ -381,10 +387,12 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         val result = sut.mapOrderDetails(order, refundResult)
 
         // THEN
-        assertThat(result.lineItems).hasSize(1)
-        assertThat(result.lineItems!!.first().name).isEqualTo("Plate")
-        assertThat(result.refundedLineItems).hasSize(1)
-        assertThat(result.refundedLineItems!!.first().name).isEqualTo("Cup")
+        val lineItems = (result.lineItems as LineItemsState.Loaded).items
+        assertThat(lineItems).hasSize(1)
+        assertThat(lineItems.first().name).isEqualTo("Plate")
+        val refundedItems = (result.refundedLineItems as LineItemsState.Loaded).items
+        assertThat(refundedItems).hasSize(1)
+        assertThat(refundedItems.first().name).isEqualTo("Cup")
     }
 
     @Test
@@ -401,10 +409,11 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         val result = sut.mapOrderDetails(order, refundResult)
 
         // THEN
-        assertThat(result.lineItems).hasSize(1)
-        assertThat(result.lineItems!!.first().name).isEqualTo("Cup")
-        assertThat(result.lineItems.first().qtyAndUnitPrice).isEqualTo("2 x $4.00")
-        assertThat(result.refundedLineItems).isEmpty()
+        val lineItems = (result.lineItems as LineItemsState.Loaded).items
+        assertThat(lineItems).hasSize(1)
+        assertThat(lineItems.first().name).isEqualTo("Cup")
+        assertThat(lineItems.first().qtyAndUnitPrice).isEqualTo("2 x $4.00")
+        assertThat((result.refundedLineItems as LineItemsState.Loaded).items).isEmpty()
     }
 
     @Test
@@ -442,10 +451,12 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
             val result = sut.mapOrderDetails(order, refundResult)
 
             // THEN
-            assertThat(result.lineItems).hasSize(1)
-            assertThat(result.lineItems!!.first().name).isEqualTo("Cup (Blue)")
+            val lineItems = (result.lineItems as LineItemsState.Loaded).items
+            assertThat(lineItems).hasSize(1)
+            assertThat(lineItems.first().name).isEqualTo("Cup (Blue)")
 
-            assertThat(result.refundedLineItems).hasSize(1)
-            assertThat(result.refundedLineItems!!.first().name).isEqualTo("Cup (Red)")
+            val refundedItems = (result.refundedLineItems as LineItemsState.Loaded).items
+            assertThat(refundedItems).hasSize(1)
+            assertThat(refundedItems.first().name).isEqualTo("Cup (Red)")
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -406,4 +406,46 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         assertThat(result.lineItems.first().qtyAndUnitPrice).isEqualTo("2 x $4.00")
         assertThat(result.refundedLineItems).isEmpty()
     }
+
+    @Test
+    fun `given same product in different line items, when one is refunded, then only that line item is affected`() =
+        testBlocking {
+            // GIVEN
+            setupDefaults()
+            val orderItems = listOf(
+                createOrderItem(
+                    itemId = 1L,
+                    productId = 10L,
+                    name = "Cup (Red)",
+                    price = BigDecimal("4.00"),
+                    quantity = 1f
+                ),
+                createOrderItem(
+                    itemId = 2L,
+                    productId = 10L,
+                    name = "Cup (Blue)",
+                    price = BigDecimal("4.00"),
+                    quantity = 1f
+                ),
+            )
+            val order = createOrder(orderItems)
+            val refunds = listOf(
+                createRefund(
+                    items = listOf(
+                        createRefundItem(orderItemId = 1L, productId = 10L, quantity = 1, total = BigDecimal("4.00"))
+                    )
+                )
+            )
+            val refundResult = RefundsFetchResult.Success(refunds)
+
+            // WHEN
+            val result = sut.mapOrderDetails(order, refundResult)
+
+            // THEN
+            assertThat(result.lineItems).hasSize(1)
+            assertThat(result.lineItems!!.first().name).isEqualTo("Cup (Blue)")
+
+            assertThat(result.refundedLineItems).hasSize(1)
+            assertThat(result.refundedLineItems!!.first().name).isEqualTo("Cup (Red)")
+        }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2397

Adds a "Refunded Products" section to the POS order details screen. When an order has item-level refunds, the refunded line items are displayed separately below the main products list, showing aggregated quantities, computed unit prices, and negated totals.

Key changes:
- Introduce `LineItemsState` sealed type (`Loading` / `Loaded`) for both `lineItems` and `refundedLineItems`, enabling shimmer placeholders while refund data loads
- Add `buildRefundedLineItems` to the mapper that aggregates refund items by order item ID across multiple refunds
- Adjust `getNonRefundedItems` to exclude fully refunded items and prorate partially refunded ones
- Add "Refunded Products" UI section in `WooPosOrderDetails` with proper theming and layout

### Test Steps
1. Open a POS order that has item-level refunds (partially or fully refunded items)
2. Verify the "Refunded Products" section appears below the main products list
3. Verify refunded items show correct aggregated quantities and negated totals
4. Verify the main products list excludes fully refunded items and adjusts quantities for partially refunded ones
5. Open an order with no refunds and verify no "Refunded Products" section appears

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.