### PR TITLE
[WOOMOB-2397][POS Refunds M2] Part 2: Refunded items UI 

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -823,6 +823,7 @@ private fun sampleOrderDetails(
             )
         )
     ),
+    refundedLineItems = WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded(emptyList()),
     breakdown = WooPosOrdersState.OrderDetailsViewState.Computed.Details.TotalsBreakdown(
         products = "$23.00",
         discount = "-$5.00",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGroupRefundedItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGroupRefundedItems.kt
@@ -15,10 +15,12 @@ class WooPosGroupRefundedItems @Inject constructor() {
             .map { (orderItemId, items) ->
                 val quantity = items.sumOf { it.quantity }
                 val total = items.fold(BigDecimal.ZERO) { acc, item -> acc + item.total }
+                val totalTax = items.fold(BigDecimal.ZERO) { acc, item -> acc + item.totalTax }
                 items.first().copy(
                     orderItemId = orderItemId,
                     quantity = quantity,
                     total = total,
+                    totalTax = totalTax,
                     price = if (quantity != 0) {
                         total.divide(BigDecimal.valueOf(quantity.toLong()), total.scale(), RoundingMode.HALF_UP)
                     } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
@@ -91,12 +91,9 @@ fun WooPosOrderDetails(
 
         Spacer(Modifier.height(WooPosSpacing.Large.value))
 
-        val lineItemsState = details.lineItems
-        if (lineItemsState is WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded &&
-            lineItemsState.items.isNotEmpty()
-        ) {
-            OrdersProducts(lineItems = lineItemsState.items)
-        }
+        ProductsSection(lineItems = details.lineItems)
+
+        RefundedProductsSection(refundedLineItems = details.refundedLineItems)
 
         Spacer(Modifier.height(WooPosSpacing.Medium.value))
 
@@ -166,11 +163,56 @@ private fun OrdersHeader(details: WooPosOrdersState.OrderDetailsViewState.Comput
 }
 
 @Composable
-private fun OrdersProducts(lineItems: List<WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow>) {
+private fun ProductsSection(
+    lineItems: WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState
+) {
+    when (lineItems) {
+        is WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loading ->
+            ProductsShimmer(
+                title = stringResource(R.string.woopos_orders_details_products_title)
+            )
+        is WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded ->
+            if (lineItems.items.isNotEmpty()) {
+                OrdersProducts(
+                    title = stringResource(R.string.woopos_orders_details_products_title),
+                    lineItems = lineItems.items
+                )
+            }
+    }
+}
+
+@Composable
+private fun RefundedProductsSection(
+    refundedLineItems: WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState
+) {
+    when (refundedLineItems) {
+        is WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loading -> {
+            Spacer(Modifier.height(WooPosSpacing.Medium.value))
+            ProductsShimmer(
+                title = stringResource(R.string.woopos_orders_details_refunded_products_title)
+            )
+        }
+        is WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded -> {
+            if (refundedLineItems.items.isNotEmpty()) {
+                Spacer(Modifier.height(WooPosSpacing.Medium.value))
+                OrdersProducts(
+                    title = stringResource(R.string.woopos_orders_details_refunded_products_title),
+                    lineItems = refundedLineItems.items
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OrdersProducts(
+    title: String,
+    lineItems: List<WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow>
+) {
     WooPosCard(shadowType = ShadowType.Soft) {
         Column(Modifier.padding(WooPosSpacing.Medium.value)) {
             WooPosText(
-                text = stringResource(R.string.woopos_orders_details_products_title),
+                text = title,
                 style = WooPosTypography.BodyXLarge,
                 fontWeight = FontWeight.SemiBold,
             )
@@ -181,6 +223,55 @@ private fun OrdersProducts(lineItems: List<WooPosOrdersState.OrderDetailsViewSta
                 OrderProductItem(row = item)
 
                 if (ind < lineItems.size - 1) {
+                    DividerWithSpacing()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProductsShimmer(title: String) {
+    WooPosCard(shadowType = ShadowType.Soft) {
+        Column(Modifier.padding(WooPosSpacing.Medium.value)) {
+            WooPosText(
+                text = title,
+                style = WooPosTypography.BodyXLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            Spacer(Modifier.height(WooPosSpacing.Medium.value))
+
+            repeat(2) { index ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = WooPosSpacing.Small.value),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    WooPosShimmerBox(
+                        modifier = Modifier
+                            .size(56.dp)
+                            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
+                    )
+                    Spacer(Modifier.width(WooPosSpacing.Medium.value))
+                    Column(modifier = Modifier.weight(1f)) {
+                        WooPosShimmerBox(
+                            modifier = Modifier
+                                .fillMaxWidth(0.6f)
+                                .height(16.dp)
+                                .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
+                        )
+                        Spacer(Modifier.height(WooPosSpacing.XSmall.value))
+                        WooPosShimmerBox(
+                            modifier = Modifier
+                                .fillMaxWidth(0.3f)
+                                .height(14.dp)
+                                .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
+                        )
+                    }
+                }
+                if (index < 1) {
                     DividerWithSpacing()
                 }
             }
@@ -495,7 +586,7 @@ fun WooPosOrderDetailsPreview() {
                 ),
                 WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
                     id = 103,
-                    name = "A vey tasty coffee that incidentally has a very long name " +
+                    name = "A very tasty coffee that incidentally has a very long name " +
                         "and should go over a few lines without overlapping anything",
                     attributesDescription = "Medium roast, Decaf",
                     qtyAndUnitPrice = "1 x $5.00",
@@ -512,6 +603,18 @@ fun WooPosOrderDetailsPreview() {
                     bookingInfo = WooPosOrdersState.OrderDetailsViewState.Computed.Details.BookingInfo.Loaded(
                         "Booking #33 \u00B7 Jul 5, 2025, 10:00 AM - 10:30 AM"
                     )
+                )
+            )
+        ),
+        refundedLineItems = WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState.Loaded(
+            listOf(
+                WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
+                    id = 101,
+                    name = "Cup",
+                    attributesDescription = null,
+                    qtyAndUnitPrice = "1 x $4.00",
+                    lineTotal = "-$4.00",
+                    imageUrl = null
                 )
             )
         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -73,11 +73,17 @@ class WooPosOrderDetailsMapper @Inject constructor(
         order: Order
     ): WooPosOrdersState.OrderDetailsViewState.Computed.Details = coroutineScope {
         val status = orderStatusMapper.mapOrderStatus(order.status)
-        val mayHaveRefunds = order.refundTotal > BigDecimal.ZERO ||
-            order.status == Order.Status.Refunded
-        val lineItems = if (mayHaveRefunds) LineItemsState.Loading else LineItemsState.Loaded(buildLineItems(order))
-        val refundedLineItems =
-            if (mayHaveRefunds) LineItemsState.Loading else LineItemsState.Loaded(emptyList())
+        val isFullyRefunded = order.status == Order.Status.Refunded
+        val hasPartialRefund = order.refundTotal > BigDecimal.ZERO && !isFullyRefunded
+        val lineItems = when {
+            isFullyRefunded -> LineItemsState.Loaded(emptyList())
+            hasPartialRefund -> LineItemsState.Loading
+            else -> LineItemsState.Loaded(buildLineItems(order))
+        }
+        val refundedLineItems = when {
+            isFullyRefunded || hasPartialRefund -> LineItemsState.Loading
+            else -> LineItemsState.Loaded(emptyList())
+        }
         val refundInfo = RefundInfo(emptyList(), BigDecimal.ZERO)
         val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -125,22 +125,24 @@ class WooPosOrderDetailsMapper @Inject constructor(
                 val orderItem = order.items.find { it.itemId == refundItem.orderItemId }
                 val name = orderItem?.name ?: refundItem.name
                 val attributesDescription = orderItem?.attributesDescription?.takeIf { it.isNotEmpty() }
-                val unitPrice = if (refundItem.quantity != 0) {
-                    refundItem.total.divide(
-                        BigDecimal.valueOf(refundItem.quantity.toLong()),
-                        refundItem.total.scale(),
+                val absQuantity = kotlin.math.abs(refundItem.quantity)
+                val total = refundItem.total
+                val unitPrice = if (absQuantity != 0) {
+                    total.divide(
+                        BigDecimal.valueOf(absQuantity.toLong()),
+                        total.scale(),
                         RoundingMode.HALF_UP
                     )
                 } else {
-                    refundItem.total
+                    total
                 }
                 val product = getProductById(refundItem.productId)
                 LineItemRow(
                     id = refundItem.orderItemId,
                     name = name,
                     attributesDescription = attributesDescription,
-                    qtyAndUnitPrice = "${refundItem.quantity} x ${formatPrice(unitPrice, order.currency)}",
-                    lineTotal = formatPrice(refundItem.total.negate(), order.currency),
+                    qtyAndUnitPrice = "$absQuantity x ${formatPrice(unitPrice.abs(), order.currency)}",
+                    lineTotal = formatPrice(total.abs(), order.currency),
                     imageUrl = product?.firstImageUrl,
                 )
             }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3887,6 +3887,7 @@
     <string name="woopos_orders_details_placeholder_title">Select an order</string>
     <string name="woopos_orders_details_placeholder_message">Choose an order from the list to view details.</string>
     <string name="woopos_orders_details_products_title">Products</string>
+    <string name="woopos_orders_details_refunded_products_title">Refunded Products</string>
     <string name="woopos_orders_details_totals_title">Totals</string>
     <string name="woopos_orders_details_qty_unit_price_format">%1$d x %2$s</string>
     <string name="woopos_orders_details_breakdown_products_label">Products</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGroupRefundedItemsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosGroupRefundedItemsTest.kt
@@ -15,12 +15,14 @@ class WooPosGroupRefundedItemsTest {
         productId: Long = 10L,
         quantity: Int = 1,
         total: BigDecimal = BigDecimal("10.00"),
+        totalTax: BigDecimal = BigDecimal.ZERO,
     ) = Refund.Item(
         productId = productId,
         quantity = quantity,
         orderItemId = orderItemId,
         name = "Refund Product",
         total = total,
+        totalTax = totalTax,
         price = if (quantity > 0) total / quantity.toBigDecimal() else total,
     )
 
@@ -157,5 +159,44 @@ class WooPosGroupRefundedItemsTest {
 
         // THEN
         assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `given multiple refunds with tax, when grouped, then totalTax is aggregated`() {
+        // GIVEN
+        val refunds = listOf(
+            createRefund(
+                id = 1L,
+                items = listOf(
+                    createRefundItem(
+                        orderItemId = 1L,
+                        productId = 10L,
+                        quantity = 1,
+                        total = BigDecimal("4.00"),
+                        totalTax = BigDecimal("0.40"),
+                    )
+                )
+            ),
+            createRefund(
+                id = 2L,
+                items = listOf(
+                    createRefundItem(
+                        orderItemId = 1L,
+                        productId = 10L,
+                        quantity = 2,
+                        total = BigDecimal("8.00"),
+                        totalTax = BigDecimal("0.80"),
+                    )
+                )
+            ),
+        )
+
+        // WHEN
+        val result = sut(refunds)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        assertThat(result.first().totalTax).isEqualByComparingTo(BigDecimal("1.20"))
+        assertThat(result.first().total).isEqualByComparingTo(BigDecimal("12.00"))
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -317,20 +317,41 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given order with refunds, when mapOrderDetailsWithoutActions, then both lineItems are loading`() =
+    fun `given order with partial refund, when mapOrderDetailsWithoutActions, then both lineItems are loading`() =
         testBlocking {
             // GIVEN
             setupDefaults()
             val orderItems = listOf(
                 createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00")),
             )
-            val order = createOrder(orderItems).copy(refundTotal = BigDecimal("4.00"))
+            val order = createOrder(orderItems).copy(refundTotal = BigDecimal("2.00"))
 
             // WHEN
             val result = sut.mapOrderDetailsWithoutActions(order)
 
             // THEN
             assertThat(result.lineItems).isInstanceOf(LineItemsState.Loading::class.java)
+            assertThat(result.refundedLineItems).isInstanceOf(LineItemsState.Loading::class.java)
+        }
+
+    @Test
+    fun `given fully refunded order, when mapOrderDetailsWithoutActions, then lineItems loaded empty and refundedLineItems loading`() =
+        testBlocking {
+            // GIVEN
+            setupDefaults()
+            val orderItems = listOf(
+                createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00")),
+            )
+            val order = createOrder(orderItems).copy(
+                status = Order.Status.Refunded,
+                refundTotal = BigDecimal("4.00")
+            )
+
+            // WHEN
+            val result = sut.mapOrderDetailsWithoutActions(order)
+
+            // THEN
+            assertThat((result.lineItems as LineItemsState.Loaded).items).isEmpty()
             assertThat(result.refundedLineItems).isInstanceOf(LineItemsState.Loading::class.java)
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -121,6 +121,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         productId: Long = 10L,
         quantity: Int = 1,
         total: BigDecimal = BigDecimal("10.00"),
+        totalTax: BigDecimal = BigDecimal.ZERO,
         name: String = "Refund Product",
     ) = Refund.Item(
         productId = productId,
@@ -128,6 +129,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         orderItemId = orderItemId,
         name = name,
         total = total,
+        totalTax = totalTax,
         price = if (quantity > 0) total / quantity.toBigDecimal() else total,
     )
 
@@ -217,7 +219,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         val refundedItem = refundedItems.first()
         assertThat(refundedItem.name).isEqualTo("Cup")
         assertThat(refundedItem.qtyAndUnitPrice).isEqualTo("1 x $4.00")
-        assertThat(refundedItem.lineTotal).isEqualTo("$-4.00")
+        assertThat(refundedItem.lineTotal).isEqualTo("$4.00")
 
         val lineItems = (result.lineItems as LineItemsState.Loaded).items
         assertThat(lineItems).hasSize(1)
@@ -257,7 +259,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         assertThat(refundedItems).hasSize(1)
         val refundedItem = refundedItems.first()
         assertThat(refundedItem.qtyAndUnitPrice).isEqualTo("3 x $4.00")
-        assertThat(refundedItem.lineTotal).isEqualTo("$-12.00")
+        assertThat(refundedItem.lineTotal).isEqualTo("$12.00")
     }
 
     @Test
@@ -381,7 +383,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         val refundedItems = (result.refundedLineItems as LineItemsState.Loaded).items
         assertThat(refundedItems).hasSize(2)
         assertThat(refundedItems.map { it.name }).containsExactly("Cup", "Plate")
-        assertThat(refundedItems.map { it.lineTotal }).containsExactly("$-4.00", "$-6.00")
+        assertThat(refundedItems.map { it.lineTotal }).containsExactly("$4.00", "$6.00")
 
         val lineItems = (result.lineItems as LineItemsState.Loaded).items
         assertThat(lineItems).hasSize(1)
@@ -514,5 +516,76 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
             val refundedItems = (result.refundedLineItems as LineItemsState.Loaded).items
             assertThat(refundedItems).hasSize(1)
             assertThat(refundedItems.first().name).isEqualTo("Cup (Red)")
+        }
+
+    @Test
+    fun `given refund with tax, when buildRefundedLineItems, then prices exclude tax`() = testBlocking {
+        // GIVEN
+        setupDefaults()
+        val orderItems = listOf(
+            createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00"), quantity = 2f),
+        )
+        val order = createOrder(orderItems)
+        val refunds = listOf(
+            createRefund(
+                items = listOf(
+                    createRefundItem(
+                        orderItemId = 1L,
+                        productId = 10L,
+                        quantity = 1,
+                        total = BigDecimal("4.00"),
+                        totalTax = BigDecimal("0.40"),
+                    )
+                )
+            )
+        )
+        val refundResult = RefundsFetchResult.Success(refunds)
+
+        // WHEN
+        val result = sut.buildRefundedLineItems(order, refundResult)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        assertThat(result.first().qtyAndUnitPrice).isEqualTo("1 x $4.00")
+        assertThat(result.first().lineTotal).isEqualTo("$4.00")
+    }
+
+    @Test
+    fun `given refund with negative quantity, when buildRefundedLineItems, then quantity is shown as positive`() =
+        testBlocking {
+            // GIVEN
+            setupDefaults()
+            val orderItems = listOf(
+                createOrderItem(
+                    itemId = 1L,
+                    productId = 10L,
+                    name = "Cup",
+                    price = BigDecimal("4.00"),
+                    quantity = 2f
+                ),
+            )
+            val order = createOrder(orderItems)
+            val refunds = listOf(
+                createRefund(
+                    items = listOf(
+                        createRefundItem(
+                            orderItemId = 1L,
+                            productId = 10L,
+                            quantity = -1,
+                            total = BigDecimal("-4.00"),
+                            totalTax = BigDecimal("-0.40"),
+                        )
+                    )
+                )
+            )
+            val refundResult = RefundsFetchResult.Success(refunds)
+
+            // WHEN
+            val result = sut.buildRefundedLineItems(order, refundResult)
+
+            // THEN
+            assertThat(result).hasSize(1)
+            assertThat(result.first().qtyAndUnitPrice).isEqualTo("1 x $4.00")
+            assertThat(result.first().lineTotal).isEqualTo("$4.00")
         }
 }


### PR DESCRIPTION
## Description

Adds the UI layer for displaying refunded line items in POS order details. This is the second of two PRs for WOOMOB-2397, building on #15488.

**Changes:**
- Add `ProductsSection` composable that handles `LineItemsState` (loading shimmer / loaded items)
- Add `RefundedProductsSection` composable for displaying refunded items
- Add `ProductsShimmer` composable for loading state placeholder
- Extract `title` parameter in `OrdersProducts` for reuse between products and refunded sections
- Update previews with refunded items sample data
- Add "Refunded Products" string resource

## Testing instructions

1. Open POS and complete an order
2. Issue a partial refund for one item
3. Open order details
4. Verify "Products" section shows non-refunded items
5. Verify "Refunded Products" section appears with refunded items
6. Verify shimmer loading state appears briefly while refund data loads

## Images/Gif
<img width="2304" height="1440" alt="image" src="https://github.com/user-attachments/assets/f421de04-3cfe-473b-bf63-fe1a7d8c2cf5" />

https://github.com/user-attachments/assets/eafc4355-508c-43aa-858d-ae7aaea06c41

