### PR TITLE
[WOOMOB-2323] Match CIAB booking badge styles

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusTag.kt
@@ -92,7 +92,11 @@ fun BookingAttendanceStatus.backgroundColor(): Color = if (isOutlined()) {
 }
 
 @Composable
-fun BookingAttendanceStatus.textColor(): Color = colorResource(R.color.tagView_text)
+fun BookingAttendanceStatus.textColor(): Color = if (isOutlined()) {
+    colorResource(R.color.color_on_surface_high)
+} else {
+    colorResource(R.color.tagView_text)
+}
 
 @Composable
 fun BookingAttendanceStatus.border(): BorderStroke? = if (isOutlined()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusTag.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.bookings.compose
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -55,6 +56,7 @@ fun BookingAttendanceStatusTag(
                     text = state.text(),
                     backgroundColor = state.backgroundColor(),
                     textColor = state.textColor(),
+                    border = state.border(),
                     fontWeight = FontWeight.Normal,
                     modifier = Modifier
                         .onSizeChanged {
@@ -83,10 +85,23 @@ fun BookingAttendanceStatus?.text(): String {
 }
 
 @Composable
-fun BookingAttendanceStatus.backgroundColor(): Color = colorResource(R.color.tagView_bg)
+fun BookingAttendanceStatus.backgroundColor(): Color = if (isOutlined()) {
+    Color.Transparent
+} else {
+    colorResource(R.color.tagView_bg)
+}
 
 @Composable
 fun BookingAttendanceStatus.textColor(): Color = colorResource(R.color.tagView_text)
+
+@Composable
+fun BookingAttendanceStatus.border(): BorderStroke? = if (isOutlined()) {
+    BorderStroke(1.dp, colorResource(R.color.tag_border_booking_outlined))
+} else {
+    null
+}
+
+private fun BookingAttendanceStatus.isOutlined(): Boolean = this == BookingAttendanceStatus.Attended
 
 @Preview
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAttendanceStatusTag.kt
@@ -76,7 +76,7 @@ sealed interface BookingAttendanceStatus {
 }
 
 @Composable
-fun BookingAttendanceStatus?.text(): String {
+private fun BookingAttendanceStatus?.text(): String {
     return when (this) {
         BookingAttendanceStatus.Attended -> stringResource(R.string.booking_attendance_status_attended)
         BookingAttendanceStatus.Unattended -> stringResource(R.string.booking_attendance_status_unattended)
@@ -85,21 +85,21 @@ fun BookingAttendanceStatus?.text(): String {
 }
 
 @Composable
-fun BookingAttendanceStatus.backgroundColor(): Color = if (isOutlined()) {
+private fun BookingAttendanceStatus.backgroundColor(): Color = if (isOutlined()) {
     Color.Transparent
 } else {
     colorResource(R.color.tagView_bg)
 }
 
 @Composable
-fun BookingAttendanceStatus.textColor(): Color = if (isOutlined()) {
+private fun BookingAttendanceStatus.textColor(): Color = if (isOutlined()) {
     colorResource(R.color.color_on_surface_high)
 } else {
     colorResource(R.color.tagView_text)
 }
 
 @Composable
-fun BookingAttendanceStatus.border(): BorderStroke? = if (isOutlined()) {
+private fun BookingAttendanceStatus.border(): BorderStroke? = if (isOutlined()) {
     BorderStroke(1.dp, colorResource(R.color.tag_border_booking_outlined))
 } else {
     null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
@@ -1,11 +1,13 @@
 package com.woocommerce.android.ui.bookings.compose
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.PaymentStatus
 import com.woocommerce.android.ui.compose.component.WCTag
@@ -20,7 +22,8 @@ fun BookingPaymentStatusTag(
     WCTag(
         text = paymentStatus.text(),
         backgroundColor = paymentStatus.backgroundColor(),
-        textColor = paymentStatus.textColor(),
+        textColor = colorResource(R.color.tagView_text),
+        border = paymentStatus.border(),
         fontWeight = FontWeight.Normal,
         modifier = modifier
     )
@@ -49,10 +52,22 @@ private fun PaymentStatus.text(): String = when (this) {
 }
 
 @Composable
-private fun PaymentStatus.backgroundColor(): Color = colorResource(R.color.tagView_bg)
+private fun PaymentStatus.backgroundColor(): Color = when (this) {
+    PaymentStatus.UNPAID -> colorResource(R.color.tag_bg_booking_yellow)
+    PaymentStatus.PAID,
+    PaymentStatus.REFUNDED,
+    PaymentStatus.PARTIALLY_REFUNDED -> Color.Transparent
+    PaymentStatus.FAILED -> colorResource(R.color.tagView_bg)
+}
 
 @Composable
-private fun PaymentStatus.textColor(): Color = colorResource(R.color.tagView_text)
+private fun PaymentStatus.border(): BorderStroke? = when (this) {
+    PaymentStatus.PAID,
+    PaymentStatus.REFUNDED,
+    PaymentStatus.PARTIALLY_REFUNDED -> BorderStroke(1.dp, colorResource(R.color.tag_border_booking_outlined))
+    PaymentStatus.UNPAID,
+    PaymentStatus.FAILED -> null
+}
 
 @LightDarkThemePreviews
 @Composable
@@ -70,6 +85,16 @@ private fun PaymentStatusTagRefundedPreview() {
     WooThemeWithBackground {
         BookingPaymentStatusTag(
             paymentStatus = PaymentStatus.REFUNDED
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun PaymentStatusTagUnpaidPreview() {
+    WooThemeWithBackground {
+        BookingPaymentStatusTag(
+            paymentStatus = PaymentStatus.UNPAID
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
@@ -22,7 +22,7 @@ fun BookingPaymentStatusTag(
     WCTag(
         text = paymentStatus.text(),
         backgroundColor = paymentStatus.backgroundColor(),
-        textColor = colorResource(R.color.tagView_text),
+        textColor = paymentStatus.textColor(),
         border = paymentStatus.border(),
         fontWeight = FontWeight.Normal,
         modifier = modifier
@@ -58,6 +58,15 @@ private fun PaymentStatus.backgroundColor(): Color = when (this) {
     PaymentStatus.REFUNDED,
     PaymentStatus.PARTIALLY_REFUNDED -> Color.Transparent
     PaymentStatus.FAILED -> colorResource(R.color.tagView_bg)
+}
+
+@Composable
+private fun PaymentStatus.textColor(): Color = when (this) {
+    PaymentStatus.PAID,
+    PaymentStatus.REFUNDED,
+    PaymentStatus.PARTIALLY_REFUNDED -> colorResource(R.color.color_on_surface_high)
+    PaymentStatus.UNPAID,
+    PaymentStatus.FAILED -> colorResource(R.color.tagView_text)
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Tag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/Tag.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.compose.component
 
 import android.content.res.Configuration
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -26,12 +28,15 @@ fun WCTag(
     textColor: Color = colorResource(id = R.color.tag_text_main),
     backgroundColor: Color = colorResource(R.color.tag_bg_main),
     textStyle: TextStyle = MaterialTheme.typography.caption,
-    fontWeight: FontWeight = FontWeight.Bold
+    fontWeight: FontWeight = FontWeight.Bold,
+    border: BorderStroke? = null,
 ) {
+    val shape = RoundedCornerShape(4.dp)
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(4.dp))
+            .clip(shape)
             .background(backgroundColor)
+            .then(if (border != null) Modifier.border(border = border, shape = shape) else Modifier)
             .padding(
                 horizontal = dimensionResource(id = R.dimen.minor_50),
             )

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -119,6 +119,7 @@
     <color name="tagView_bg">@color/tag_bg_other</color>
     <color name="tagView_text">@color/color_on_surface_high</color>
     <color name="tagView_border_bg">@android:color/transparent</color>
+    <color name="tag_border_booking_outlined">#E5E5EA</color>
     <color name="tag_bg_processing">@color/woo_celadon_5</color>
     <color name="tag_bg_failed">@color/woo_red_5</color>
     <color name="tag_bg_on_hold">@color/woo_orange_5</color>


### PR DESCRIPTION
### Description
Fixes WOOMOB-2323
Updates CIAB bookings badges to match the current design styling in the bookings UI. This doesn't affect POS badges, I'll update those once we approve the styling in this PR.

### Changes

<img width="2060" height="1512" alt="558974309-04823cbe-ab02-4e64-86e5-624a1ea586e8" src="https://github.com/user-attachments/assets/3cfadba5-a604-41b9-a4de-1af22560b8c1" />

### Test Steps
1. Open a CIAB site with bookings
2. Navigate to the bookings list.

### Images/gif
|Before|After|Web|
|-|-|-|
|<img width="360" alt="before" src="https://github.com/user-attachments/assets/66f0fc6c-c268-427e-a198-5896bdda3c6c" />|<img width="360" alt="after" src="https://github.com/user-attachments/assets/e0f5415b-b35a-4fcf-84b0-515761b15428" />|<img width="360" alt="image" src="https://github.com/user-attachments/assets/1a192466-11ed-469e-956e-3ec41aded310" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.