### PR TITLE
[WOOMOB-2442] Fix incremental sync missing product updates for sites with negative UTC offsets

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -10,6 +10,10 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import javax.inject.Inject
 
 class WooPosProductRestClient @Inject constructor(
@@ -24,6 +28,11 @@ class WooPosProductRestClient @Inject constructor(
         private const val VARIATIONS_FIELDS = "id,parent_id,description,sku,global_unique_id,status,price," +
             "regular_price,sale_price,date_modified,stock_quantity,stock_status,manage_stock," +
             "backordered,attributes,image,downloadable,name,type"
+
+        private const val SECONDS_PER_HOUR = 3600
+
+        private val API_DATE_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
     }
 
     suspend fun fetchProducts(
@@ -38,7 +47,7 @@ class WooPosProductRestClient @Inject constructor(
         val params = buildBaseParams(
             pageSize = pageSize,
             page = page,
-            modifiedAfter = modifiedAfter,
+            modifiedAfter = modifiedAfter?.let { adjustUtcToSiteLocalTime(it, site.timezone) },
             fields = PRODUCT_FIELDS,
             includeStatus = includeStatus,
             posProductsOnly = posProductsOnly
@@ -74,7 +83,7 @@ class WooPosProductRestClient @Inject constructor(
             pageSize = pageSize,
             page = page,
             fields = VARIATIONS_FIELDS,
-            modifiedAfter = modifiedAfter,
+            modifiedAfter = modifiedAfter?.let { adjustUtcToSiteLocalTime(it, site.timezone) },
             posProductsOnly = posProductsOnly
         )
 
@@ -150,5 +159,23 @@ class WooPosProductRestClient @Inject constructor(
 
     private fun statusListToString(statuses: List<CoreProductStatus>): String {
         return statuses.joinToString(",") { it.value }
+    }
+
+    /**
+     * The WooCommerce REST API compares `modified_after` against `date_modified`, which is stored
+     * in the site's local timezone. Since our stored timestamps are in UTC (from server response
+     * headers), we must convert to site-local time before sending. Without this, sites with
+     * negative UTC offsets will miss recently modified products because the UTC value is always
+     * ahead of their local `date_modified`.
+     */
+    internal fun adjustUtcToSiteLocalTime(utcDateString: String, siteGmtOffset: String?): String {
+        val offsetHours = siteGmtOffset?.toDoubleOrNull() ?: return utcDateString
+        if (offsetHours == 0.0) return utcDateString
+
+        val offsetSeconds = (offsetHours * SECONDS_PER_HOUR).toInt()
+        val zoneOffset = ZoneOffset.ofTotalSeconds(offsetSeconds)
+        val utcInstant = LocalDateTime.parse(utcDateString, API_DATE_FORMATTER)
+            .toInstant(ZoneOffset.UTC)
+        return API_DATE_FORMATTER.withZone(zoneOffset).format(utcInstant)
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -10,6 +10,8 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.CoreProductStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.product.ProductApiResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
+import org.wordpress.android.util.AppLog
+import java.time.DateTimeException
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -172,10 +174,15 @@ class WooPosProductRestClient @Inject constructor(
         val offsetHours = siteGmtOffset?.toDoubleOrNull() ?: return utcDateString
         if (offsetHours == 0.0) return utcDateString
 
-        val offsetSeconds = (offsetHours * SECONDS_PER_HOUR).toInt()
-        val zoneOffset = ZoneOffset.ofTotalSeconds(offsetSeconds)
-        val utcInstant = LocalDateTime.parse(utcDateString, API_DATE_FORMATTER)
-            .toInstant(ZoneOffset.UTC)
-        return API_DATE_FORMATTER.withZone(zoneOffset).format(utcInstant)
+        return try {
+            val offsetSeconds = (offsetHours * SECONDS_PER_HOUR).toInt()
+            val zoneOffset = ZoneOffset.ofTotalSeconds(offsetSeconds)
+            val utcInstant = LocalDateTime.parse(utcDateString, API_DATE_FORMATTER)
+                .toInstant(ZoneOffset.UTC)
+            API_DATE_FORMATTER.withZone(zoneOffset).format(utcInstant)
+        } catch (e: DateTimeException) {
+            AppLog.e(AppLog.T.API, "Error adjusting UTC to site-local time- falling back to UTC.", e)
+            utcDateString
+        }
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClient.kt
@@ -17,6 +17,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.hours
 
 class WooPosProductRestClient @Inject constructor(
     private val wooNetwork: WooNetwork,
@@ -31,7 +32,7 @@ class WooPosProductRestClient @Inject constructor(
             "regular_price,sale_price,date_modified,stock_quantity,stock_status,manage_stock," +
             "backordered,attributes,image,downloadable,name,type"
 
-        private const val SECONDS_PER_HOUR = 3600
+        private val SECONDS_PER_HOUR = 1.hours.inWholeSeconds
 
         private val API_DATE_FORMATTER = DateTimeFormatter
             .ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.US)

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductRestClientTest.kt
@@ -1,0 +1,74 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.product.pos
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+
+class WooPosProductRestClientTest {
+    private val wooNetwork: WooNetwork = mock()
+    private val sut = WooPosProductRestClient(wooNetwork)
+
+    @Test
+    fun `given site is in -6 timezone, when adjusting timestamp, then time is shifted backwards`() {
+        // WHEN
+        val result = sut.adjustUtcToSiteLocalTime("2024-01-15T06:30:00", "-6")
+
+        // THEN
+        assertThat(result).isEqualTo("2024-01-15T00:30:00")
+    }
+
+    @Test
+    fun `given site is in +5,5 timezone, when adjusting timestamp, then time is shifted forward`() {
+        // WHEN
+        val result = sut.adjustUtcToSiteLocalTime("2024-01-15T06:30:00", "5.5")
+
+        // THEN
+        assertThat(result).isEqualTo("2024-01-15T12:00:00")
+    }
+
+    @Test
+    fun `given zero UTC offset, when adjusting timestamp, then time is unchanged`() {
+        // WHEN
+        val result = sut.adjustUtcToSiteLocalTime("2024-01-15T06:30:00", "0")
+
+        // THEN
+        assertThat(result).isEqualTo("2024-01-15T06:30:00")
+    }
+
+    @Test
+    fun `given null offset, when adjusting timestamp, then time is unchanged`() {
+        // WHEN
+        val result = sut.adjustUtcToSiteLocalTime("2024-01-15T06:30:00", null)
+
+        // THEN
+        assertThat(result).isEqualTo("2024-01-15T06:30:00")
+    }
+
+    @Test
+    fun `given non-numeric offset, when adjusting timestamp, then time is unchanged`() {
+        // WHEN
+        val result = sut.adjustUtcToSiteLocalTime("2024-01-15T06:30:00", "America/Chicago")
+
+        // THEN
+        assertThat(result).isEqualTo("2024-01-15T06:30:00")
+    }
+
+    @Test
+    fun `given negative offset causing date rollback, when adjusting timestamp, then date changes correctly`() {
+        // WHEN
+        val result = sut.adjustUtcToSiteLocalTime("2024-01-15T02:00:00", "-6")
+
+        // THEN
+        assertThat(result).isEqualTo("2024-01-14T20:00:00")
+    }
+
+    @Test
+    fun `given positive offset causing date rollforward, when adjusting timestamp, then date changes correctly`() {
+        // WHEN
+        val result = sut.adjustUtcToSiteLocalTime("2024-01-15T22:00:00", "5.5")
+
+        // THEN
+        assertThat(result).isEqualTo("2024-01-16T03:30:00")
+    }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-2442

During incremental sync, the POS sends a `modified_after` parameter to filter products changed since the last sync. The stored timestamp comes from the server's response header and is always in **UTC**. However, the WooCommerce REST API compares `modified_after` against `date_modified`, which is stored in the **site's local timezone**. For sites with negative UTC offsets, the UTC value is always ahead of the local `date_modified`, causing recently modified products to be excluded from the sync response.

This fix converts the UTC timestamp to site-local time (using `SiteModel.timezone`) at the REST client level before sending the `modified_after` parameter, so all callers (products, variations, catalog size check) automatically get the correction.

### Test Steps
1. Configure a WooCommerce site with a negative UTC offset (e.g., UTC-6, America/Chicago)
2. Open the POS and wait for the initial full sync to complete
3. On the site's admin, modify a product (e.g., change the price)
4. Return to the POS and trigger an incremental sync (pull to refresh or wait for periodic sync)
5. Verify the modified product is updated in the POS catalog
6. Repeat with a site in a positive UTC offset (e.g., UTC+5:30) and a UTC+0 site to confirm no regressions

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.