### PR TITLE
[WOOMOB-1797] Add Issue Refund button to booking details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -31,12 +31,16 @@ import kotlin.math.abs
  * @param [key] A unique string that is the same as the one used in [handleResult]
  * @param [result] A result value to be returned
  * @param [destinationId] an optional destinationId, that can be used to navigate up to a specified destination
+ * @param [popDestination] whether to pop the destinationId from the back stack when navigating back, used only
+ *        when [destinationId] is specified
+ * @param [navHostId] an optional navHostId, that can be used to navigate up to a specified navHostId
  *
  */
 fun <T> Fragment.navigateBackWithResult(
     key: String,
     result: T,
     @IdRes destinationId: Int? = null,
+    popDestination: Boolean = false,
     @IdRes navHostId: Int? = null,
 ) {
     val navController = if (navHostId != null) findNavController(navHostId) else findNavController()
@@ -49,7 +53,7 @@ fun <T> Fragment.navigateBackWithResult(
     entry?.savedStateHandle?.set(key, result)
 
     if (destinationId != null) {
-        findNavController().popBackStack(destinationId, false)
+        findNavController().popBackStack(destinationId, popDestination)
     } else {
         findNavController().navigateUp()
     }
@@ -63,7 +67,6 @@ fun <T> Fragment.navigateBackWithResult(
  * @param [key] A unique string that is the same as the one used in [handleResult]
  * @param [result] A result value to be returned
  * @param [childId] an destinationId, that used to navigate up from the specified destination
- * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  */
 fun <T> Fragment.navigateToParentWithResult(key: String, result: T, @IdRes childId: Int) {
     if (findNavController().currentDestination?.id != childId) {
@@ -79,14 +82,17 @@ fun <T> Fragment.navigateToParentWithResult(key: String, result: T, @IdRes child
  *
  * @param [key] A unique string that is the same as the one used in [handleNotice]
  * @param [destinationId] an optional destinationId, that can be used to navigating up to a specified destination
+ * @param [popDestination] whether to pop the destinationId from the back stack when navigating back, used only
+ *        when [destinationId] is specified
  * @param [navHostId] An optional ID of the NavHostFragment, it's useful when the fragment is used in two-pane layouts
  */
 fun Fragment.navigateBackWithNotice(
     key: String,
     @IdRes destinationId: Int? = null,
+    popDestination: Boolean = false,
     @IdRes navHostId: Int? = null,
 ) {
-    navigateBackWithResult(key, key, destinationId, navHostId)
+    navigateBackWithResult(key, key, destinationId, popDestination, navHostId)
 }
 
 /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/FragmentExt.kt
@@ -45,17 +45,22 @@ fun <T> Fragment.navigateBackWithResult(
 ) {
     val navController = if (navHostId != null) findNavController(navHostId) else findNavController()
 
-    val entry = if (destinationId != null) {
-        navController.getBackStackEntry(destinationId)
+    if (popDestination && destinationId != null) {
+        navController.popBackStack(destinationId, true)
+        navController.currentBackStackEntry?.savedStateHandle?.set(key, result)
     } else {
-        navController.previousBackStackEntry
-    }
-    entry?.savedStateHandle?.set(key, result)
+        val entry = if (destinationId != null) {
+            navController.getBackStackEntry(destinationId)
+        } else {
+            navController.previousBackStackEntry
+        }
+        entry?.savedStateHandle?.set(key, result)
 
-    if (destinationId != null) {
-        findNavController().popBackStack(destinationId, popDestination)
-    } else {
-        findNavController().navigateUp()
+        if (destinationId != null) {
+            navController.popBackStack(destinationId, false)
+        } else {
+            navController.navigateUp()
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingPaymentSection.kt
@@ -29,6 +29,7 @@ fun BookingPaymentSection(
     model: BookingPaymentDetailsModel,
     onViewOrder: () -> Unit,
     modifier: Modifier = Modifier,
+    onIssueRefund: (() -> Unit)? = null,
 ) {
     Column(modifier = modifier) {
         BookingSectionHeader(R.string.booking_payment_header)
@@ -55,6 +56,19 @@ fun BookingPaymentSection(
                 modifier = Modifier.padding(start = 16.dp)
             )
             Spacer(modifier = Modifier.height(16.dp))
+            if (onIssueRefund != null) {
+                WCOutlinedButton(
+                    onClick = onIssueRefund,
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onSurface
+                    ),
+                    text = stringResource(id = R.string.booking_overflow_refund),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
             WCOutlinedButton(
                 onClick = onViewOrder,
                 colors = ButtonDefaults.outlinedButtonColors(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
@@ -12,12 +12,15 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.handleNotice
 import com.woocommerce.android.extensions.isTwoPanesShouldBeUsed
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.bookings.BookingsCommunicationViewModel
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.payments.refunds.RefundSummaryFragment
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.parcelize.Parcelize
@@ -71,7 +74,20 @@ class BookingDetailsFragment : BaseFragment() {
                         )
                     )
                 }
+                is BookingDetailsViewModel.NavigateToIssueRefund -> {
+                    findNavController().navigateSafely(
+                        BookingDetailsFragmentDirections
+                            .actionBookingDetailsFragmentToIssueRefund(
+                                orderId = event.orderId,
+                                callerDestinationId = R.id.bookingDetailsFragment
+                            )
+                    )
+                }
             }
+        }
+
+        handleNotice(RefundSummaryFragment.REFUND_ORDER_NOTICE_KEY) {
+            viewModel.onRefundCompleted()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
@@ -78,8 +78,7 @@ class BookingDetailsFragment : BaseFragment() {
                     findNavController().navigateSafely(
                         BookingDetailsFragmentDirections
                             .actionBookingDetailsFragmentToIssueRefund(
-                                orderId = event.orderId,
-                                callerDestinationId = R.id.bookingDetailsFragment
+                                orderId = event.orderId
                             )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -158,6 +158,7 @@ private fun BookingDetailsContent(
         BookingPaymentSection(
             model = it,
             onViewOrder = booking.onViewOrderClicked,
+            onIssueRefund = booking.onIssueRefundClicked,
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -15,11 +15,13 @@ import com.woocommerce.android.ui.bookings.BookingAnalyticsHelper
 import com.woocommerce.android.ui.bookings.BookingMapper
 import com.woocommerce.android.ui.bookings.BookingResource
 import com.woocommerce.android.ui.bookings.BookingsRepository
+import com.woocommerce.android.ui.bookings.PaymentStatus
 import com.woocommerce.android.ui.bookings.PaymentStatusResolver
 import com.woocommerce.android.ui.bookings.compose.BookingAttendanceStatus
 import com.woocommerce.android.ui.bookings.compose.BookingLocationStatus
 import com.woocommerce.android.ui.bookings.compose.BookingStaffMemberStatus
 import com.woocommerce.android.ui.compose.DialogState
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -55,6 +57,7 @@ class BookingDetailsViewModel @Inject constructor(
     private val networkStatus: NetworkStatus,
     private val paymentStatusResolver: PaymentStatusResolver,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val orderDetailRepository: OrderDetailRepository,
     @AppCoroutineScope private val appScope: CoroutineScope,
 ) : ScopedViewModel(savedState) {
 
@@ -118,7 +121,7 @@ class BookingDetailsViewModel @Inject constructor(
         attendanceUpdateStatus,
         loadingState,
         resource,
-        cancelStatusState,
+        cancelStatusState
     ) { booking, attendanceUpdate, loadingState, resource, cancelStatus ->
         if (booking != null) {
             bookingMapper.buildBookingUiState(
@@ -285,6 +288,19 @@ class BookingDetailsViewModel @Inject constructor(
         triggerEvent(NavigateToOrder(orderId))
     }
 
+    private fun issueRefund(orderId: Long) {
+        triggerEvent(NavigateToIssueRefund(orderId))
+    }
+
+    fun onRefundCompleted() {
+        bookingId?.let { fetchBooking(it) }
+        launch {
+            val orderId = booking.first()?.orderId?.takeIf { it != 0L } ?: return@launch
+            orderDetailRepository.fetchOrderById(orderId)
+            orderDetailRepository.fetchOrderRefunds(orderId)
+        }
+    }
+
     private suspend fun BookingMapper.buildBookingUiState(
         booking: Booking,
         attendanceUpdateStatus: AttendanceUpdateStatus,
@@ -321,7 +337,15 @@ class BookingDetailsViewModel @Inject constructor(
                 onAttendanceStatusSelected(bookingId, targetStatus)
             },
             onViewOrderClicked = { openOrderDetails(orderId) },
-            onNoteClicked = { openBookingNote(bookingId) }
+            onNoteClicked = { openBookingNote(bookingId) },
+            onIssueRefundClicked = if (
+                (paymentStatus == PaymentStatus.PAID || paymentStatus == PaymentStatus.PARTIALLY_REFUNDED) &&
+                orderId != 0L
+            ) {
+                { issueRefund(orderId) }
+            } else {
+                null
+            },
         )
     }
 
@@ -359,5 +383,6 @@ class BookingDetailsViewModel @Inject constructor(
     }
 
     data class NavigateToOrder(val orderId: Long) : MultiLiveEvent.Event()
+    data class NavigateToIssueRefund(val orderId: Long) : MultiLiveEvent.Event()
     data class NavigateToBookingNote(val bookingId: Long) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -36,6 +36,7 @@ data class BookingUiState(
     val onAttendanceToggle: () -> Unit = {},
     val onNoteClicked: () -> Unit = {},
     val onViewOrderClicked: () -> Unit = {},
+    val onIssueRefundClicked: (() -> Unit)? = null,
 )
 
 sealed interface BookingDetailsLoadingState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
@@ -123,11 +123,11 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.getSnack(event.message, *event.args).show()
                 is Exit -> {
-                    val callerDestId = findNavController()
-                        .getBackStackEntry(R.id.nav_graph_refunds)
-                        .arguments?.getInt("callerDestinationId", 0) ?: 0
-                    val destId = if (callerDestId != 0) callerDestId else R.id.orderDetailFragment
-                    navigateBackWithNotice(REFUND_ORDER_NOTICE_KEY, destId)
+                    navigateBackWithNotice(
+                        key = REFUND_ORDER_NOTICE_KEY,
+                        destinationId = R.id.issueRefundFragment,
+                        popDestination = true
+                    )
                 }
                 is ShowRefundConfirmation -> {
                     val action =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryFragment.kt
@@ -122,7 +122,13 @@ class RefundSummaryFragment : BaseFragment(R.layout.fragment_refund_summary), Ba
         ) { event ->
             when (event) {
                 is ShowSnackbar -> uiMessageResolver.getSnack(event.message, *event.args).show()
-                is Exit -> navigateBackWithNotice(REFUND_ORDER_NOTICE_KEY, R.id.orderDetailFragment)
+                is Exit -> {
+                    val callerDestId = findNavController()
+                        .getBackStackEntry(R.id.nav_graph_refunds)
+                        .arguments?.getInt("callerDestinationId", 0) ?: 0
+                    val destId = if (callerDestId != 0) callerDestId else R.id.orderDetailFragment
+                    navigateBackWithNotice(REFUND_ORDER_NOTICE_KEY, destId)
+                }
                 is ShowRefundConfirmation -> {
                     val action =
                         RefundSummaryFragmentDirections.actionRefundSummaryFragmentToRefundConfirmationDialog(

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
@@ -25,7 +25,6 @@
     </fragment>
 
     <include app:graph="@navigation/nav_graph_refunds" />
-    <include app:graph="@navigation/nav_graph_payment_flow" />
 
     <fragment
         android:id="@+id/bookingNoteFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
@@ -14,7 +14,22 @@
         <action
             android:id="@+id/action_bookingDetailsFragment_to_bookingNoteFragment"
             app:destination="@id/bookingNoteFragment" />
+        <action
+            android:id="@+id/action_bookingDetailsFragment_to_issueRefund"
+            app:destination="@id/nav_graph_refunds">
+            <argument
+                android:name="orderId"
+                android:defaultValue="0L"
+                app:argType="long" />
+            <argument
+                android:name="callerDestinationId"
+                android:defaultValue="0"
+                app:argType="integer" />
+        </action>
     </fragment>
+
+    <include app:graph="@navigation/nav_graph_refunds" />
+    <include app:graph="@navigation/nav_graph_payment_flow" />
 
     <fragment
         android:id="@+id/bookingNoteFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
@@ -21,10 +21,6 @@
                 android:name="orderId"
                 android:defaultValue="0L"
                 app:argType="long" />
-            <argument
-                android:name="callerDestinationId"
-                android:defaultValue="0"
-                app:argType="integer" />
         </action>
     </fragment>
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_refunds.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_refunds.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_refunds"
     app:startDestination="@id/issueRefundFragment" >
+    <include app:graph="@navigation/nav_graph_payment_flow" />
     <fragment
         android:id="@+id/refundSummaryFragment"
         android:name="com.woocommerce.android.ui.payments.refunds.RefundSummaryFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_refunds.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_refunds.xml
@@ -4,6 +4,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_refunds"
     app:startDestination="@id/issueRefundFragment" >
+    <argument
+        android:name="callerDestinationId"
+        android:defaultValue="0"
+        app:argType="integer" />
     <fragment
         android:id="@+id/refundSummaryFragment"
         android:name="com.woocommerce.android.ui.payments.refunds.RefundSummaryFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_refunds.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_refunds.xml
@@ -4,10 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph_refunds"
     app:startDestination="@id/issueRefundFragment" >
-    <argument
-        android:name="callerDestinationId"
-        android:defaultValue="0"
-        app:argType="integer" />
     <fragment
         android:id="@+id/refundSummaryFragment"
         android:name="com.woocommerce.android.ui.payments.refunds.RefundSummaryFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.ui.bookings.PaymentStatus
 import com.woocommerce.android.ui.bookings.PaymentStatusResolver
 import com.woocommerce.android.ui.bookings.compose.BookingLocationStatus
-import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.bookings.compose.BookingStaffMemberStatus
 import com.woocommerce.android.ui.compose.DialogState
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.bookings.PaymentStatusResolver
 import com.woocommerce.android.ui.bookings.compose.BookingLocationStatus
 import com.woocommerce.android.ui.bookings.compose.BookingStaffMemberStatus
 import com.woocommerce.android.ui.compose.DialogState
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateFormatter
 import com.woocommerce.android.util.getOrAwaitValue

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.ui.bookings.PaymentStatus
 import com.woocommerce.android.ui.bookings.PaymentStatusResolver
 import com.woocommerce.android.ui.bookings.compose.BookingLocationStatus
+import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.bookings.compose.BookingStaffMemberStatus
 import com.woocommerce.android.ui.compose.DialogState
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
@@ -73,6 +74,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
         onBlocking { resolve(any()) } doReturn PaymentStatus.UNPAID
     }
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val orderDetailRepository = mock<OrderDetailRepository>()
 
     @Before
     fun setup() {
@@ -486,6 +488,76 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given booking is paid with order, when state observed, then refund callback is present`() = testBlocking {
+        // GIVEN
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
+        val viewModel = createViewModel()
+
+        // WHEN
+        val state = viewModel.state.getOrAwaitValue()
+
+        // THEN
+        assertThat(state.bookingUiState?.onIssueRefundClicked != null).isTrue()
+    }
+
+    @Test
+    fun `given booking is partially refunded with order, when state observed, then refund callback is present`() = testBlocking {
+        // GIVEN
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PARTIALLY_REFUNDED)
+        val viewModel = createViewModel()
+
+        // WHEN
+        val state = viewModel.state.getOrAwaitValue()
+
+        // THEN
+        assertThat(state.bookingUiState?.onIssueRefundClicked != null).isTrue()
+    }
+
+    @Test
+    fun `given booking is unpaid, when state observed, then refund callback is null`() = testBlocking {
+        // GIVEN
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.UNPAID)
+        val viewModel = createViewModel()
+
+        // WHEN
+        val state = viewModel.state.getOrAwaitValue()
+
+        // THEN
+        assertThat(state.bookingUiState?.onIssueRefundClicked == null).isTrue()
+    }
+
+    @Test
+    fun `given booking has no associated order, when state observed, then refund callback is null`() = testBlocking {
+        // GIVEN
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
+        bookingFlow.value = getSampleBooking(bookingId, orderId = 0L)
+        val viewModel = createViewModel()
+
+        // WHEN
+        val state = viewModel.state.getOrAwaitValue()
+
+        // THEN
+        assertThat(state.bookingUiState?.onIssueRefundClicked == null).isTrue()
+    }
+
+    @Test
+    fun `when refund button clicked, then NavigateToIssueRefund event is triggered with orderId`() = testBlocking {
+        // GIVEN
+        val orderId = 99L
+        bookingFlow.value = getSampleBooking(bookingId, orderId = orderId)
+        whenever(paymentStatusResolver.resolve(any())).thenReturn(PaymentStatus.PAID)
+        val viewModel = createViewModel()
+        val state = viewModel.state.getOrAwaitValue()
+
+        // WHEN
+        state.bookingUiState?.onIssueRefundClicked?.invoke()
+
+        // THEN
+        val event = viewModel.event.getOrAwaitValue()
+        assertThat(event).isEqualTo(BookingDetailsViewModel.NavigateToIssueRefund(orderId))
+    }
+
+    @Test
     fun `when onAttendanceToggle called rapidly, then first request error is suppressed by cancellation`() =
         testBlocking {
             // GIVEN
@@ -520,13 +592,14 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
             networkStatus = networkStatus,
             paymentStatusResolver = paymentStatusResolver,
             analyticsTrackerWrapper = analyticsTrackerWrapper,
+            orderDetailRepository = orderDetailRepository,
             appScope = TestScope(coroutinesTestRule.testDispatcher),
         ).apply {
             state.observeForever { }
         }
     }
 
-    private fun getSampleBooking(id: Long, location: String? = null): Booking {
+    private fun getSampleBooking(id: Long, orderId: Long = id, location: String? = null): Booking {
         return BookingEntity(
             id = LocalOrRemoteId.RemoteId(id),
             localSiteId = LocalOrRemoteId.LocalId(1),
@@ -542,7 +615,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
             dateCreated = Instant.now(),
             dateModified = Instant.now(),
             googleCalendarEventId = "",
-            orderId = id,
+            orderId = orderId,
             orderItemId = 1L,
             parentId = 0L,
             personCounts = listOf(1L),


### PR DESCRIPTION
### Description
Fixes WOOMOB-1797

Adds an "Issue Refund" button to the booking details payment section. The button appears for bookings with a **Paid** or **Partially Refunded** payment status and an associated order. Tapping it launches the existing refund flow. After a successful refund, both the booking and order data are refreshed so the UI reflects the updated payment state.

The **Partially Refunded** status is included to align with the behavior in the Order Details screen, where the refund option remains available until the order is fully refunded. It feels like a Booking shouldn't have a **Partially Refunded** status, because you can only have one product per booking, but that's how it work not, and without this, the refunding wouldn't work for orders with multiple bookings.

To support navigation back from `RefundSummaryFragment` to `BookingDetailsFragment`, a `callerDestinationId` argument was added to `nav_graph_refunds`. When non-zero, it overrides the default exit destination (`orderDetailFragment`), so callers outside the orders flow can reuse the refund graph without crashes.

### Test Steps

Refund from Booking
1. Open a booking with **Paid** payment status and an associated order
2. Verify the "Issue Refund" button appears above "View Order"
3. Tap "Issue Refund" → refund flow opens
4. Complete the refund → returns to booking details, button disappears (or stays if partially refunded)
5. Open a booking with **Unpaid** or **Failed** status → no refund button

Refund from Order
1. Open a **Paid** Order
7. Verify the refund works

Order with multiple bookings (to test partially refunded scenario)
1. Create an order with multiple bookings in the cart
2. Mark it as paid
3. Open one of those bookings and issue a refund
4. Go back to the list and refresh 
5. Confirm you see a booking with **Partially Refunded** badge
6. Open it and issue a refund

### Images/gif


https://github.com/user-attachments/assets/ffd5cffb-41b2-48c5-a7c6-85645316d1d8



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.