### PR TITLE
[WOOMOB-2413] Hide push notifications benefit behind flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsScreen.kt
@@ -83,15 +83,17 @@ fun JetpackBenefitsScreen(
             )
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_200)))
 
-            // Push notifications
-            BenefitEntry(
-                icon = R.drawable.ic_alarm_bell_ring,
-                title = R.string.jetpack_benefits_modal_push_notifications_title,
-                subtitle = R.string.jetpack_benefits_modal_push_notifications_subtitle,
-                modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
-            )
+            if (viewState.isPushNotificationsBenefitVisible) {
+                // Push notifications
+                BenefitEntry(
+                    icon = R.drawable.ic_alarm_bell_ring,
+                    title = R.string.jetpack_benefits_modal_push_notifications_title,
+                    subtitle = R.string.jetpack_benefits_modal_push_notifications_subtitle,
+                    modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.major_100))
+                )
 
-            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.major_100)))
+            }
 
             // Analytics
             BenefitEntry(
@@ -182,6 +184,7 @@ private fun JetpackBenefitsScreenPreview() {
             viewState = JetpackBenefitsViewModel.ViewState(
                 isUsingJetpackCP = false,
                 isLoadingDialogShown = false,
+                isPushNotificationsBenefitVisible = true,
             )
         )
     }
@@ -195,6 +198,7 @@ private fun JetpackBenefitsScreenWithoutNativeInstallPreview() {
             viewState = JetpackBenefitsViewModel.ViewState(
                 isUsingJetpackCP = false,
                 isLoadingDialogShown = false,
+                isPushNotificationsBenefitVisible = true,
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.common.UserEligibilityFetcher
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus
 import com.woocommerce.android.ui.jetpack.FetchJetpackStatus.JetpackStatusFetchResponse
+import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
@@ -47,6 +48,7 @@ class JetpackBenefitsViewModel @Inject constructor(
         ViewState(
             isUsingJetpackCP = selectedSite.connectionType == SiteConnectionType.JetpackConnectionPackage,
             isLoadingDialogShown = false,
+            isPushNotificationsBenefitVisible = !FeatureFlag.WOO_PUSH_NOTIFICATIONS_SYSTEM_M2.isEnabled(),
         )
     )
     val viewState = _viewState.asLiveData()
@@ -184,6 +186,7 @@ class JetpackBenefitsViewModel @Inject constructor(
     data class ViewState(
         val isUsingJetpackCP: Boolean,
         val isLoadingDialogShown: Boolean,
+        val isPushNotificationsBenefitVisible: Boolean,
     )
 
     object StartJetpackActivationForJetpackCP : Event()


### PR DESCRIPTION
Fixes WOOMOB-2413

### Description
Hides the Push Notifications benefit from the Jetpack installation dialog when the WOO_PUSH_NOTIFICATIONS_SYSTEM_M2 feature flag is enabled. This ensures users do not see the benefit if the new push notification system is active.

> [!NOTE]
> I didn't add a unit test for the new behavior because it'll require creating a new use case wrapping the WOO_PUSH_NOTIFICATIONS_SYSTEM_M2 feature flag logic, and given there is already some pending work to make feature flags testable without the use cases (#15299), I decided it's not worth to cause more divergence.

### Test Steps
1. Sign in using a Jetpack CP site or using Site credentials.
2. Open the app and navigate to Settings > Developer Options.
3. Enable the WOO_PUSH_NOTIFICATIONS_SYSTEM_M2 flag.
4. Go to Jetpack installation dialog (from Settings > Install Jetpack).
5. Verify that the Push Notifications benefit is hidden.
6. Disable the flag and verify the benefit reappears.

### Images/gif
| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="jetpack-benefits-after-settings" src="https://github.com/user-attachments/assets/16e2a068-7aa9-4cfc-96f4-92cadc4bcfe4" /> | <img width="1080" height="2400" alt="jetpack-benefits-flag-enabled" src="https://github.com/user-attachments/assets/dec8a544-3abc-41f2-86c6-cc6ae7ac9813" /> |

- [x] I have considered if this change warrants release notes and have added them to RELEASE-NOTES.txt if necessary. Use the [Internal] label for non-user-facing changes.
