### PR TITLE
[WOOMOB-2421] Fix product detail webview URL path

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/webview/ProductDetailWebViewViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/webview/ProductDetailWebViewViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.products.details.webview
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.liveData
@@ -44,7 +45,7 @@ class ProductDetailWebViewViewModel @Inject constructor(
 
     private fun buildProductUrl(product: Product): String {
         val site = selectedSite.get()
-        return site.adminUrlOrDefault.slashJoin("?page=next-admin&p=/woocommerce/products/edit/${product.remoteId}")
+        return site.adminUrlOrDefault.slashJoin(BOOKABLE_SERVICE_PATH).slashJoin("${product.remoteId}")
     }
 
     private fun navigateBack() {
@@ -56,4 +57,9 @@ class ProductDetailWebViewViewModel @Inject constructor(
         val title: String,
         val onBackClick: () -> Unit
     )
+
+    companion object {
+        @VisibleForTesting
+        const val BOOKABLE_SERVICE_PATH = "admin.php?page=next-admin&p=/woocommerce/services/edit"
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/webview/ProductDetailWebViewViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/webview/ProductDetailWebViewViewModelTest.kt
@@ -78,7 +78,8 @@ class ProductDetailWebViewViewModelTest : BaseUnitTest() {
         // THEN
         assertThat(viewState.title).isEqualTo(testProduct.name)
         assertThat(viewState.urlToLoad).isEqualTo(
-            "https://example.com/wp-admin/?page=next-admin&p=/woocommerce/products/edit/${testProduct.remoteId}"
+            "https://example.com/wp-admin/${ProductDetailWebViewViewModel.BOOKABLE_SERVICE_PATH}" +
+                "/${testProduct.remoteId}"
         )
     }
 


### PR DESCRIPTION
Fixes WOOMOB-2421

### Description
Fix the product detail webview URL by adding the missing `admin.php` segment and using the correct `/woocommerce/services/edit/` path instead of `/woocommerce/products/edit/`.

### Test Steps
1. Use a CIAB site.
2. Open a bookable product in the app
3. Verify the webview loads correctly with the proper admin URL
4. Confirm the product edit page renders as expected

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.