### PR TITLE
Use WP.com analytics proxy for revenue stats to align with wp-admin

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -55,12 +55,12 @@ class OrderStatsRestClient @Inject constructor(
     /**
      * Fetches revenue stats for the given WooCommerce [SiteModel].
      *
-     * Tries the WP.com analytics proxy endpoint first (`/wc/v3/woocommerce-analytics/proxy/...`)
-     * with `date_type=created`, which aligns the data with what wp-admin (CIAB) shows — including
-     * all order statuses (pending, checkout-draft, etc.) in the aggregation.
+     * For CIAB (Creator in a Box) sites, tries the WP.com analytics proxy endpoint first
+     * (`/wc/v3/woocommerce-analytics/proxy/...`) with `date_type=created`, which aligns the data
+     * with what wp-admin shows — including all order statuses (pending, checkout-draft, etc.)
+     * in the aggregation. Falls back to the local API if the proxy is unavailable.
      *
-     * Falls back to the local `/wc-analytics/reports/revenue/stats` endpoint if the proxy is
-     * unavailable (e.g., the `woocommerce-analytics` plugin is not active on the store).
+     * For all other stores, uses the local `/wc-analytics/reports/revenue/stats` endpoint directly.
      *
      * @param[site] the site to fetch stats data for
      * @param[granularity] one of 'hour', 'day', 'week', 'month', or 'year'
@@ -83,18 +83,22 @@ class OrderStatsRestClient @Inject constructor(
         forceRefresh: Boolean = false,
         revenueRangeId: String,
     ): FetchRevenueStatsResponsePayload {
-        val proxyResult = tryFetchFromProxy(
-            site, granularity, startDate, endDate, revenueRangeId, forceRefresh
-        )
-        if (proxyResult != null) return proxyResult
+        if (site.isCIABSite()) {
+            val proxyResult = tryFetchFromProxy(
+                site, granularity, startDate, endDate, revenueRangeId, forceRefresh
+            )
+            if (proxyResult != null) return proxyResult
+        }
 
         return fetchFromLocalApi(
             site, granularity, startDate, endDate, perPage, forceRefresh, revenueRangeId
         )
     }
 
+    private fun SiteModel.isCIABSite() = isGardenSite && gardenName == CIAB_GARDEN_NAME
+
     /**
-     * Attempts to fetch revenue stats from the WP.com analytics proxy endpoint.
+     * Attempts to fetch revenue stats from the WP.com analytics proxy endpoint for CIAB sites.
      * Uses `date_type=created` to match the wp-admin CIAB dashboard behavior, which
      * includes all order statuses (pending, checkout-draft, etc.) in the aggregation.
      *
@@ -411,6 +415,8 @@ class OrderStatsRestClient @Inject constructor(
     }
 
     companion object {
+        private const val CIAB_GARDEN_NAME = "commerce"
+
         // WP.com analytics proxy endpoint used by the wp-admin CIAB dashboard.
         // Available on stores with the woocommerce-analytics plugin active.
         private const val PROXY_STATS_PATH =

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats
 
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.WCStatsActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
@@ -51,12 +53,14 @@ class OrderStatsRestClient @Inject constructor(
     }
 
     /**
-     * Makes a GET call to `/wc-analytics/reports/revenue/stats`, retrieving data for the given
-     * WooCommerce [SiteModel].
+     * Fetches revenue stats for the given WooCommerce [SiteModel].
      *
-     * Does not send a `date_type` parameter, allowing the server to use the store's configured
-     * `woocommerce_date_type` setting (default: `date_paid`). This matches the behavior of the
-     * wp-admin Analytics dashboard, which also relies on the server-side default.
+     * Tries the WP.com analytics proxy endpoint first (`/wc/v3/woocommerce-analytics/proxy/...`)
+     * with `date_type=created`, which aligns the data with what wp-admin (CIAB) shows — including
+     * all order statuses (pending, checkout-draft, etc.) in the aggregation.
+     *
+     * Falls back to the local `/wc-analytics/reports/revenue/stats` endpoint if the proxy is
+     * unavailable (e.g., the `woocommerce-analytics` plugin is not active on the store).
      *
      * @param[site] the site to fetch stats data for
      * @param[granularity] one of 'hour', 'day', 'week', 'month', or 'year'
@@ -77,6 +81,80 @@ class OrderStatsRestClient @Inject constructor(
         endDate: String,
         perPage: Int,
         forceRefresh: Boolean = false,
+        revenueRangeId: String,
+    ): FetchRevenueStatsResponsePayload {
+        val proxyResult = tryFetchFromProxy(
+            site, granularity, startDate, endDate, revenueRangeId, forceRefresh
+        )
+        if (proxyResult != null) return proxyResult
+
+        return fetchFromLocalApi(
+            site, granularity, startDate, endDate, perPage, forceRefresh, revenueRangeId
+        )
+    }
+
+    /**
+     * Attempts to fetch revenue stats from the WP.com analytics proxy endpoint.
+     * Uses `date_type=created` to match the wp-admin CIAB dashboard behavior, which
+     * includes all order statuses (pending, checkout-draft, etc.) in the aggregation.
+     *
+     * Returns `null` if the proxy endpoint is unavailable so the caller can fall back.
+     */
+    @Suppress("LongParameterList")
+    private suspend fun tryFetchFromProxy(
+        site: SiteModel,
+        granularity: StatsGranularity,
+        startDate: String,
+        endDate: String,
+        revenueRangeId: String,
+        forceRefresh: Boolean,
+    ): FetchRevenueStatsResponsePayload? {
+        val params = mapOf(
+            "from" to startDate,
+            "to" to endDate,
+            "interval" to OrderStatsApiUnit.fromStatsGranularity(granularity).toString(),
+            "date_type" to "created",
+        )
+
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = PROXY_STATS_PATH,
+            params = params,
+            clazz = ProxyRevenueStatsApiResponse::class.java,
+            enableCaching = true,
+            forced = forceRefresh
+        )
+
+        return when (response) {
+            is WPAPIResponse.Success -> {
+                try {
+                    response.data?.let {
+                        val model = mapProxyResponseToModel(
+                            it, site, granularity, startDate, endDate, revenueRangeId
+                        )
+                        FetchRevenueStatsResponsePayload(site, granularity, model)
+                    }
+                } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                    AppLog.e(AppLog.T.API, "Failed to parse proxy stats response, falling back", e)
+                    null
+                }
+            }
+            is WPAPIResponse.Error -> null
+        }
+    }
+
+    /**
+     * Fetches revenue stats from the local `/wc-analytics/reports/revenue/stats` endpoint.
+     * This is the original data source that queries the `wc_order_stats` table directly.
+     */
+    @Suppress("LongParameterList")
+    private suspend fun fetchFromLocalApi(
+        site: SiteModel,
+        granularity: StatsGranularity,
+        startDate: String,
+        endDate: String,
+        perPage: Int,
+        forceRefresh: Boolean,
         revenueRangeId: String,
     ): FetchRevenueStatsResponsePayload {
         val url = WOOCOMMERCE.reports.revenue.stats.pathV4Analytics
@@ -101,23 +179,24 @@ class OrderStatsRestClient @Inject constructor(
         return when (response) {
             is WPAPIResponse.Success -> {
                 response.data?.let {
-                        val model = WCRevenueStatsModel(
-                            localSiteId = site.localId(),
-                            interval = granularity.toString(),
-                            data = it.intervals.toString(),
-                            total = it.totals.toString(),
-                            startDate = startDate,
-                            endDate = endDate,
-                            rangeId = revenueRangeId,
-                        )
+                    val model = WCRevenueStatsModel(
+                        localSiteId = site.localId(),
+                        interval = granularity.toString(),
+                        data = it.intervals.toString(),
+                        total = it.totals.toString(),
+                        startDate = startDate,
+                        endDate = endDate,
+                        rangeId = revenueRangeId,
+                    )
 
                     FetchRevenueStatsResponsePayload(site, granularity, model)
                 } ?: FetchRevenueStatsResponsePayload(
-                        OrderStatsError(type = OrderStatsErrorType.GENERIC_ERROR,
-                                message = "Success response with empty data"
-                        ),
-                        site,
-                        granularity
+                    OrderStatsError(
+                        type = OrderStatsErrorType.GENERIC_ERROR,
+                        message = "Success response with empty data"
+                    ),
+                    site,
+                    granularity
                 )
             }
 
@@ -126,6 +205,79 @@ class OrderStatsRestClient @Inject constructor(
                 FetchRevenueStatsResponsePayload(orderError, site, granularity)
             }
         }
+    }
+
+    /**
+     * Maps the WP.com analytics proxy response to the same [WCRevenueStatsModel] format used
+     * by the local API, so the rest of the data pipeline remains unchanged.
+     *
+     * The proxy uses different field names and string values:
+     * - `orders_no` (string) → `orders_count` (int)
+     * - `orders_value_net` (string) → `net_revenue` (double)
+     * - `time_interval` (string) → `interval` (string)
+     * - `average_order_value` (string) → `avg_order_value` (double)
+     * - `total_items` (string) → `num_items_sold` (int)
+     */
+    @Suppress("LongParameterList")
+    private fun mapProxyResponseToModel(
+        proxyResponse: ProxyRevenueStatsApiResponse,
+        site: SiteModel,
+        granularity: StatsGranularity,
+        startDate: String,
+        endDate: String,
+        revenueRangeId: String,
+    ): WCRevenueStatsModel {
+        val totalsJson = proxyResponse.summary?.let {
+            mapProxySummaryToTotals(it.asJsonObject)
+        } ?: JsonObject()
+
+        val intervalsJson = proxyResponse.data?.let {
+            mapProxyDataToIntervals(it.asJsonArray)
+        } ?: JsonArray()
+
+        return WCRevenueStatsModel(
+            localSiteId = site.localId(),
+            interval = granularity.toString(),
+            data = intervalsJson.toString(),
+            total = totalsJson.toString(),
+            startDate = startDate,
+            endDate = endDate,
+            rangeId = revenueRangeId,
+        )
+    }
+
+    private fun mapProxySummaryToTotals(summary: JsonObject): JsonObject {
+        return JsonObject().apply {
+            addProperty("orders_count", summary.getAsString("orders_no").toIntOrNull() ?: 0)
+            addProperty("net_revenue", summary.getAsString("orders_value_net").toDoubleOrNull() ?: 0.0)
+            addProperty("total_sales", summary.getAsString("total_sales").toDoubleOrNull() ?: 0.0)
+            addProperty("avg_order_value", summary.getAsString("average_order_value").toDoubleOrNull() ?: 0.0)
+            addProperty("num_items_sold", summary.getAsString("total_items").toIntOrNull() ?: 0)
+        }
+    }
+
+    private fun mapProxyDataToIntervals(data: JsonArray): JsonArray {
+        return JsonArray().apply {
+            data.forEach { element ->
+                val item = element.asJsonObject
+                add(JsonObject().apply {
+                    addProperty("interval", item.getAsString("time_interval"))
+                    add("subtotals", JsonObject().apply {
+                        addProperty("orders_count", item.getAsString("orders_no").toLongOrNull() ?: 0L)
+                        addProperty("net_revenue", item.getAsString("orders_value_net").toDoubleOrNull() ?: 0.0)
+                        addProperty("total_sales", item.getAsString("total_sales").toDoubleOrNull() ?: 0.0)
+                        addProperty(
+                            "avg_order_value",
+                            item.getAsString("average_order_value").toDoubleOrNull() ?: 0.0
+                        )
+                    })
+                })
+            }
+        }
+    }
+
+    private fun JsonObject.getAsString(key: String): String {
+        return get(key)?.let { if (it.isJsonNull) "" else it.asString } ?: ""
     }
 
     /**
@@ -256,5 +408,12 @@ class OrderStatsRestClient @Inject constructor(
             else -> OrderStatsErrorType.fromString(errorCode.orEmpty())
         }
         return OrderStatsError(orderStatsErrorType, message.orEmpty())
+    }
+
+    companion object {
+        // WP.com analytics proxy endpoint used by the wp-admin CIAB dashboard.
+        // Available on stores with the woocommerce-analytics plugin active.
+        private const val PROXY_STATS_PATH =
+            "/wc/v3/woocommerce-analytics/proxy/reports/orders/by-date"
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/ProxyRevenueStatsApiResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/ProxyRevenueStatsApiResponse.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats
+
+import com.google.gson.JsonElement
+import org.wordpress.android.fluxc.network.Response
+
+/**
+ * Response model for the WP.com analytics proxy endpoint:
+ * `/wc/v3/woocommerce-analytics/proxy/reports/orders/by-date`
+ *
+ * This endpoint returns a different JSON structure than the local
+ * `/wc-analytics/reports/revenue/stats` endpoint:
+ * - `summary` (object with string values) instead of `totals` (object with numeric values)
+ * - `data` (array with flat objects) instead of `intervals` (array with nested `subtotals`)
+ *
+ * Field names also differ:
+ * - `orders_no` instead of `orders_count`
+ * - `orders_value_net` instead of `net_revenue`
+ * - `time_interval` instead of `interval`
+ * - `average_order_value` instead of `avg_order_value`
+ * - `total_items` instead of `num_items_sold`
+ */
+class ProxyRevenueStatsApiResponse : Response {
+    val summary: JsonElement? = null
+    val data: JsonElement? = null
+}


### PR DESCRIPTION
Closes: WOOMOB-2452

## Description

This PR addresses the **third root cause** of analytics inconsistencies between the Android app and the wp-admin (CIAB) dashboard.

### Problem

The Android app was using the local `/wc-analytics/reports/revenue/stats` endpoint, which queries the `wc_order_stats` table with `date_type=date_paid` (default) and excludes orders in `pending`, `failed`, `cancelled`, `auto-draft`, `trash`, and `checkout-draft` statuses via `get_excluded_report_order_statuses()`.

The wp-admin CIAB dashboard uses a different data source: the WP.com analytics proxy (`/wc/v3/woocommerce-analytics/proxy/reports/orders/by-date`) with `date_type=created`, which includes all order statuses. This causes discrepancies in order counts and revenue totals.

### Solution

`OrderStatsRestClient.fetchRevenueStats()` now uses the WP.com analytics proxy **only for CIAB sites**, with a fallback to the local API:

1. **For CIAB sites**: Try the WP.com analytics proxy first, using `date_type=created` to match what wp-admin shows. Fall back to the local API if the proxy is unavailable (e.g., the `woocommerce-analytics` plugin is not active).
2. **For all other stores**: Use the local `/wc-analytics/reports/revenue/stats` endpoint directly (no proxy attempt).

CIAB sites are identified by `SiteModel.isGardenSite && gardenName == "commerce"`, matching the existing detection logic in the app layer.

The proxy response has a different JSON structure and field names (strings instead of numbers, different key names), so a mapping layer transforms the proxy format into the existing `WCRevenueStatsModel` format, keeping all downstream code (store, repository, ViewModel, UI) completely unchanged.

### Key field mappings (proxy → local):
| Proxy field | Local field |
|---|---|
| `orders_no` (string) | `orders_count` (int) |
| `orders_value_net` (string) | `net_revenue` (double) |
| `time_interval` | `interval` |
| `average_order_value` (string) | `avg_order_value` (double) |
| `total_items` (string) | `num_items_sold` (int) |
| `from` / `to` (params) | `after` / `before` (params) |

### Files changed:
- **`OrderStatsRestClient.kt`** — Refactored `fetchRevenueStats()` to only use the proxy for CIAB sites, with `tryFetchFromProxy()` + `fetchFromLocalApi()`. Added CIAB detection and JSON mapping methods.
- **`ProxyRevenueStatsApiResponse.kt`** — New response model for the proxy endpoint (`summary` + `data` fields).

## Testing instructions

### Prerequisites
- A CIAB WooCommerce store (garden site with `commerce` garden name)
- A non-CIAB WooCommerce store for comparison
- Orders in various statuses (pending, processing, completed) for a visible date range

### Steps — CIAB site

1. Install the app from this branch
2. Log in with a **CIAB site**
3. Navigate to the **My Store** dashboard
4. Select a date range that includes orders in **pending** or **checkout-draft** status
5. Verify the order count and net revenue shown in the Android app **match** what the wp-admin CIAB dashboard shows for the same date range
6. Check the app logs (`AppLog.T.API`) to confirm the proxy endpoint is being hit

### Steps — Non-CIAB site

1. Switch to a **non-CIAB store** (self-hosted + Jetpack, or standard WP.com store)
2. Navigate to the **My Store** dashboard
3. Verify stats load correctly via the local API (proxy should NOT be attempted)
4. Check logs to confirm no proxy request is made

### Fallback verification (CIAB site)
1. If possible, test with a CIAB store that does **not** have `woocommerce-analytics` active
2. Verify the app still loads stats correctly via the local API fallback
3. Check logs for the "Failed to parse proxy stats response, falling back" message (should only appear if proxy fails)

### Edge cases
- [ ] Empty date range (no orders) — should show $0 / 0 orders
- [ ] Different granularities (day, week, month) work correctly
- [ ] Pull-to-refresh triggers a fresh fetch
- [ ] Non-CIAB sites never hit the proxy endpoint
- [ ] CIAB site handles graceful fallback when proxy returns an error

RELEASE-NOTES: not included