### PR TITLE
[WOOMOB-2449] Fix attendance status filter to be single-select

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -----
 
 - [Internal] Add full-text search for POS product search with analytics tracking [https://github.com/woocommerce/woocommerce-android/pull/15484]
+- [Internal] Fixed attendance status filter sending invalid API requests when multiple statuses were selected [https://github.com/woocommerce/woocommerce-android/pull/15504]
 
 24.3
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListScreen.kt
@@ -162,8 +162,8 @@ private fun FiltersNavHost(
         }
         composable(BookingFilterPage.AttendanceStatus.route) {
             BookingAttendanceStatusFilterRoute(
-                initialAttendanceStatuses = state.updatedBookingFilters.attendanceStatuses
-            ) { attendanceStatuses -> state.onUpdateFilterOption(attendanceStatuses) }
+                initialAttendanceStatus = state.updatedBookingFilters.attendanceStatus
+            ) { attendanceStatus -> state.onUpdateFilterOption(attendanceStatus) }
         }
         composable(BookingFilterPage.PaymentStatus.route) {
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListUiState.kt
@@ -69,13 +69,7 @@ data class BookingFilterListUiState(
             }
 
             BookingFilterPage.AttendanceStatus -> {
-                updatedBookingFilters.attendanceStatuses.values.takeIf { it.isNotEmpty() }?.let { list ->
-                    if (list.size > 1) {
-                        UiString.UiStringText(list.size.toString())
-                    } else {
-                        UiString.UiStringRes(list.first().titleRes)
-                    }
-                }
+                updatedBookingFilters.attendanceStatus.value?.let { UiString.UiStringRes(it.titleRes) }
             }
 
             BookingFilterPage.Customer -> updatedBookingFilters.customer?.customerName?.let { name ->
@@ -151,7 +145,7 @@ fun BookingFilters.updateFilterOption(bookingsFilterOption: BookingsFilterOption
         is BookingsFilterOption.DateRange -> copy(dateRange = bookingsFilterOption)
         is BookingsFilterOption.Customer -> copy(customer = bookingsFilterOption)
         is BookingsFilterOption.TeamMembers -> copy(teamMembers = bookingsFilterOption)
-        is BookingsFilterOption.AttendanceStatuses -> copy(attendanceStatuses = bookingsFilterOption)
+        is BookingsFilterOption.AttendanceStatus -> copy(attendanceStatus = bookingsFilterOption)
         is BookingsFilterOption.PaymentStatus -> copy(paymentStatus = bookingsFilterOption)
         is BookingsFilterOption.BookingType -> copy(bookingType = bookingsFilterOption)
         is BookingsFilterOption.Location -> copy(location = bookingsFilterOption)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModel.kt
@@ -151,7 +151,7 @@ class BookingFilterListViewModel @Inject constructor(
         if (teamMembers != BookingsFilterOption.TeamMembers.DEFAULT) add("team_member")
         if (bookingType?.value != null) add("booking_type")
         if (serviceEvents != BookingsFilterOption.ServiceEvents.DEFAULT) add("service_events")
-        if (attendanceStatuses != BookingsFilterOption.AttendanceStatuses.DEFAULT) add("attendance_status")
+        if (attendanceStatus != BookingsFilterOption.AttendanceStatus.DEFAULT) add("attendance_status")
         if (paymentStatus != null) add("payment_status")
         if (customer != null) add("customer")
         if (dateRange != BookingsFilterOption.DateRange.DEFAULT) add("date_time")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterPage.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterPage.kt
@@ -9,13 +9,13 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilter
 
 @Composable
 fun BookingAttendanceStatusFilterRoute(
-    initialAttendanceStatuses: BookingsFilterOption.AttendanceStatuses?,
-    onAttendanceStatusesFilterChanged: (BookingsFilterOption.AttendanceStatuses) -> Unit,
+    initialAttendanceStatus: BookingsFilterOption.AttendanceStatus?,
+    onAttendanceStatusFilterChanged: (BookingsFilterOption.AttendanceStatus) -> Unit,
 ) {
     val viewModel =
         hiltViewModel<BookingAttendanceStatusFilterViewModel, BookingAttendanceStatusFilterViewModel.Factory>
         { factory ->
-            factory.create(initialAttendanceStatuses, onAttendanceStatusesFilterChanged)
+            factory.create(initialAttendanceStatus, onAttendanceStatusFilterChanged)
         }
     val uiState by viewModel.uiState.observeAsState()
     uiState?.let { BookingAttendanceStatusFilterPage(it) }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterUiState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterUiState.kt
@@ -4,11 +4,10 @@ import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.bookings.filter.BookingFilterListItem
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.AttendanceStatuses
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity.AttendanceStatus
 
 data class BookingAttendanceStatusFilterUiState(
-    val selectedStatuses: AttendanceStatuses = AttendanceStatuses.DEFAULT,
+    val selectedStatus: AttendanceStatus? = null,
     val onStatusSelected: (AttendanceStatus?) -> Unit = {},
 ) {
     val items: List<BookingFilterListItem> = availableAttendanceStatuses().map { status ->
@@ -26,9 +25,9 @@ data class BookingAttendanceStatusFilterUiState(
     )
 
     private fun isSelected(status: AttendanceStatus?): Boolean = if (status == AttendanceStatus.any) {
-        selectedStatuses.values.isEmpty()
+        selectedStatus == null
     } else {
-        selectedStatuses.values.contains(status)
+        selectedStatus == status
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterViewModel.kt
@@ -22,7 +22,7 @@ class BookingAttendanceStatusFilterViewModel @AssistedInject constructor(
 
     private val _uiState = MutableStateFlow(
         BookingAttendanceStatusFilterUiState(
-            selectedStatus = initialStatuses?.values?.firstOrNull(),
+            selectedStatus = initialStatuses?.values?.singleOrNull(),
             onStatusSelected = ::onStatusSelected
         )
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterViewModel.kt
@@ -22,27 +22,20 @@ class BookingAttendanceStatusFilterViewModel @AssistedInject constructor(
 
     private val _uiState = MutableStateFlow(
         BookingAttendanceStatusFilterUiState(
-            selectedStatuses = initialStatuses ?: AttendanceStatuses.DEFAULT,
+            selectedStatus = initialStatuses?.values?.firstOrNull(),
             onStatusSelected = ::onStatusSelected
         )
     )
     val uiState: LiveData<BookingAttendanceStatusFilterUiState> = _uiState.asLiveData()
 
     private fun onStatusSelected(status: AttendanceStatus?) {
-        val newSelectedStatusesState = if (status == AttendanceStatus.any) {
-            AttendanceStatuses.DEFAULT
-        } else {
-            val statusSet = _uiState.value.selectedStatuses.values.toMutableSet()
-            if (statusSet.contains(status)) {
-                statusSet.remove(status)
-            } else {
-                status?.let { statusSet.add(it) }
-            }
-            AttendanceStatuses(statusSet)
+        val newSelectedStatus = when {
+            status == AttendanceStatus.any -> null
+            else -> status
         }
 
-        _uiState.update { it.copy(selectedStatuses = newSelectedStatusesState) }
-        onFilterChanged(newSelectedStatusesState)
+        _uiState.update { it.copy(selectedStatus = newSelectedStatus) }
+        onFilterChanged(AttendanceStatuses(setOfNotNull(newSelectedStatus)))
     }
 
     @AssistedFactory

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterViewModel.kt
@@ -10,19 +10,19 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.AttendanceStatuses
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity.AttendanceStatus
 
 @HiltViewModel(assistedFactory = BookingAttendanceStatusFilterViewModel.Factory::class)
 class BookingAttendanceStatusFilterViewModel @AssistedInject constructor(
-    @Assisted private val initialStatuses: AttendanceStatuses?,
-    @Assisted private val onFilterChanged: (AttendanceStatuses) -> Unit,
+    @Assisted private val initialStatus: BookingsFilterOption.AttendanceStatus?,
+    @Assisted private val onFilterChanged: (BookingsFilterOption.AttendanceStatus) -> Unit,
     savedStateHandle: SavedStateHandle,
 ) : ScopedViewModel(savedStateHandle) {
 
     private val _uiState = MutableStateFlow(
         BookingAttendanceStatusFilterUiState(
-            selectedStatus = initialStatuses?.values?.singleOrNull(),
+            selectedStatus = initialStatus?.value,
             onStatusSelected = ::onStatusSelected
         )
     )
@@ -35,14 +35,14 @@ class BookingAttendanceStatusFilterViewModel @AssistedInject constructor(
         }
 
         _uiState.update { it.copy(selectedStatus = newSelectedStatus) }
-        onFilterChanged(AttendanceStatuses(setOfNotNull(newSelectedStatus)))
+        onFilterChanged(BookingsFilterOption.AttendanceStatus(newSelectedStatus))
     }
 
     @AssistedFactory
     interface Factory {
         fun create(
-            initial: AttendanceStatuses?,
-            onFilterChanged: (AttendanceStatuses) -> Unit
+            initial: BookingsFilterOption.AttendanceStatus?,
+            onFilterChanged: (BookingsFilterOption.AttendanceStatus) -> Unit
         ): BookingAttendanceStatusFilterViewModel
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
@@ -143,11 +143,11 @@ class BookingFilterRepository @Inject constructor(
 
     private fun Preferences.getAttendanceStatuses(siteId: Int): BookingsFilterOption.AttendanceStatuses? {
         val stored = this[attendanceStatusesKey(siteId)] ?: return null
-        val status = stored.firstNotNullOfOrNull { key ->
+        val statuses = stored.mapNotNull { key ->
             runCatching { BookingEntity.AttendanceStatus.fromKey(key) }.getOrNull()
                 ?.takeIf { it !is BookingEntity.AttendanceStatus.Unknown }
-        }
-        return status?.let { BookingsFilterOption.AttendanceStatuses(setOf(it)) }
+        }.toSet()
+        return statuses.singleOrNull()?.let { BookingsFilterOption.AttendanceStatuses(setOf(it)) }
     }
 
     private fun Preferences.getCustomerValue(siteId: Int): BookingsFilterOption.Customer? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
@@ -29,7 +29,12 @@ class BookingFilterRepository @Inject constructor(
     // Keys are built per-site to keep selections isolated across sites
     private fun teamMembersKey(siteId: Int) = stringSetPreferencesKey("bfilters_${siteId}_team_members")
     private fun bookingTypeKey(siteId: Int) = stringPreferencesKey("bfilters_${siteId}_booking_type")
-    private fun attendanceStatusesKey(siteId: Int) = stringSetPreferencesKey("bfilters_${siteId}_attendance_statuses")
+    private fun attendanceStatusKey(siteId: Int) = stringPreferencesKey("bfilters_${siteId}_attendance_status")
+
+    @Deprecated("Legacy key for migration")
+    private fun legacyAttendanceStatusesKey(siteId: Int) =
+        stringSetPreferencesKey("bfilters_${siteId}_attendance_statuses")
+
     private fun customerIdKey(siteId: Int) = longPreferencesKey("bfilters_${siteId}_customer_id")
     private fun customerNameKey(siteId: Int) = stringPreferencesKey("bfilters_${siteId}_customer_name")
     private fun dateBeforeKey(siteId: Int) = longPreferencesKey("bfilters_${siteId}_date_before")
@@ -43,8 +48,7 @@ class BookingFilterRepository @Inject constructor(
             BookingFilters(
                 teamMembers = prefs.getTeamMembers(siteId) ?: BookingsFilterOption.TeamMembers.DEFAULT,
                 bookingType = prefs.getBookingType(siteId),
-                attendanceStatuses = prefs.getAttendanceStatuses(siteId)
-                    ?: BookingsFilterOption.AttendanceStatuses.DEFAULT,
+                attendanceStatus = prefs.getAttendanceStatus(siteId),
                 customer = prefs.getCustomerValue(siteId),
                 dateRange = prefs.getDateRangeValue(siteId),
                 serviceEvents = prefs.getServiceEventsValue(siteId)
@@ -56,7 +60,6 @@ class BookingFilterRepository @Inject constructor(
     suspend fun save(bookingFilters: BookingFilters) {
         val siteId = selectedSite.getSelectedSiteId()
         dataStore.edit { prefs ->
-            // Team member
             val teamMembersKey = teamMembersKey(siteId)
             val teamMembersValues = bookingFilters.teamMembers.values
             if (teamMembersValues.isEmpty()) {
@@ -65,34 +68,29 @@ class BookingFilterRepository @Inject constructor(
                 prefs[teamMembersKey] = teamMembersValues.map { it.value.toString() }.toSet()
             }
 
-            // Booking type
             val bookingTypeKey = bookingTypeKey(siteId)
             val bookingTypeValue = bookingFilters.bookingType?.value?.name
             if (bookingTypeValue != null) {
                 prefs[bookingTypeKey] = bookingTypeValue
             } else {
-                // Clear if not provided
                 prefs.remove(bookingTypeKey)
             }
 
-            // Attendance statuses
-            val attendanceStatusesKey = attendanceStatusesKey(siteId)
-            val attendanceStatusesValues = bookingFilters.attendanceStatuses.values
-            if (attendanceStatusesValues.isEmpty()) {
-                prefs.remove(attendanceStatusesKey)
+            val attendanceStatusValue = bookingFilters.attendanceStatus.value?.key
+            if (attendanceStatusValue != null) {
+                prefs[attendanceStatusKey(siteId)] = attendanceStatusValue
             } else {
-                prefs[attendanceStatusesKey] = attendanceStatusesValues.map { it.key }.toSet()
+                prefs.remove(attendanceStatusKey(siteId))
             }
+            @Suppress("DEPRECATION")
+            prefs.remove(legacyAttendanceStatusesKey(siteId))
 
-            // Customer
             val customerIdKey = customerIdKey(siteId)
             val customerNameKey = customerNameKey(siteId)
             val customer = bookingFilters.customer
             if (customer != null) {
-                val id = customer.customerId
-                val name = customer.customerName
-                prefs[customerIdKey] = id
-                prefs[customerNameKey] = name
+                prefs[customerIdKey] = customer.customerId
+                prefs[customerNameKey] = customer.customerName
             } else {
                 // Clear if not provided
                 prefs.remove(customerIdKey)
@@ -124,7 +122,6 @@ class BookingFilterRepository @Inject constructor(
                     .map { "${it.productId}${SERVICE_EVENTS_PRODUCT_DELIMITER}${it.productName}" }
                     .toSet()
             }
-            // Other filters currently have no persisted payload; ignore for now
         }
     }
 
@@ -141,13 +138,23 @@ class BookingFilterRepository @Inject constructor(
         return value?.let { BookingsFilterOption.BookingType(value = it) }
     }
 
-    private fun Preferences.getAttendanceStatuses(siteId: Int): BookingsFilterOption.AttendanceStatuses? {
-        val stored = this[attendanceStatusesKey(siteId)] ?: return null
-        val statuses = stored.mapNotNull { key ->
+    private fun Preferences.getAttendanceStatus(siteId: Int): BookingsFilterOption.AttendanceStatus {
+        val stored = this[attendanceStatusKey(siteId)]
+            ?: return migrateLegacyAttendanceStatus(siteId)
+        val status = runCatching { BookingEntity.AttendanceStatus.fromKey(stored) }.getOrNull()
+            ?.takeIf { it !is BookingEntity.AttendanceStatus.Unknown }
+        return BookingsFilterOption.AttendanceStatus(status)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun Preferences.migrateLegacyAttendanceStatus(siteId: Int): BookingsFilterOption.AttendanceStatus {
+        val legacy = this[legacyAttendanceStatusesKey(siteId)]
+            ?: return BookingsFilterOption.AttendanceStatus.DEFAULT
+        val status = legacy.firstNotNullOfOrNull { key ->
             runCatching { BookingEntity.AttendanceStatus.fromKey(key) }.getOrNull()
                 ?.takeIf { it !is BookingEntity.AttendanceStatus.Unknown }
-        }.toSet()
-        return statuses.singleOrNull()?.let { BookingsFilterOption.AttendanceStatuses(setOf(it)) }
+        }
+        return BookingsFilterOption.AttendanceStatus(status)
     }
 
     private fun Preferences.getCustomerValue(siteId: Int): BookingsFilterOption.Customer? {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepository.kt
@@ -143,10 +143,11 @@ class BookingFilterRepository @Inject constructor(
 
     private fun Preferences.getAttendanceStatuses(siteId: Int): BookingsFilterOption.AttendanceStatuses? {
         val stored = this[attendanceStatusesKey(siteId)] ?: return null
-        val set = stored.mapNotNull { runCatching { BookingEntity.AttendanceStatus.fromKey(it) }.getOrNull() }
-            .filterNot { it is BookingEntity.AttendanceStatus.Unknown }
-            .toSet()
-        return BookingsFilterOption.AttendanceStatuses(set)
+        val status = stored.firstNotNullOfOrNull { key ->
+            runCatching { BookingEntity.AttendanceStatus.fromKey(key) }.getOrNull()
+                ?.takeIf { it !is BookingEntity.AttendanceStatus.Unknown }
+        }
+        return status?.let { BookingsFilterOption.AttendanceStatuses(setOf(it)) }
     }
 
     private fun Preferences.getCustomerValue(siteId: Int): BookingsFilterOption.Customer? {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/BookingFilterListViewModelTest.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.ui.bookings.filter.data.BookingFilterRepository
 import com.woocommerce.android.util.getOrAwaitValue
@@ -221,7 +220,7 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
         val onPage = viewModel.uiState.getOrAwaitValue()
 
         // Select one attendance status (Attended)
-        onPage.onUpdateFilterOption(BookingsFilterOption.AttendanceStatuses(values = setOf(AttendanceStatus.Attended)))
+        onPage.onUpdateFilterOption(BookingsFilterOption.AttendanceStatus(AttendanceStatus.Attended))
 
         // WHEN: leave the page (go back to root list)
         viewModel.uiState.getOrAwaitValue().onClose()
@@ -237,38 +236,11 @@ class BookingFilterListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when two attendance statuses selected and leaving page, then root shows selected both statuses`() {
-        // GIVEN: navigate to Attendance Status page and select two statuses
-        val initial = viewModel.uiState.getOrAwaitValue()
-        initial.openPage(BookingFilterPage.AttendanceStatus)
-        val onPage = viewModel.uiState.getOrAwaitValue()
-
-        // Select two attendance statuses (Attended and Unattended)
-        onPage.onUpdateFilterOption(
-            BookingsFilterOption.AttendanceStatuses(
-                values = setOf(AttendanceStatus.Attended, AttendanceStatus.Unattended)
-            )
-        )
-
-        // WHEN: leave the page (go back to root list)
-        viewModel.uiState.getOrAwaitValue().onClose()
-
-        // THEN: root list shows both selected statuses in subtitle values (order agnostic)
-        val root = viewModel.uiState.getOrAwaitValue()
-
-        val attendanceItem =
-            root.items.first { (it.title as UiStringRes).stringRes == R.string.bookings_filter_title_attendance_status }
-        val value = (attendanceItem.value as UiString.UiStringText).text
-
-        assertThat(value).isEqualTo("2")
-    }
-
-    @Test
     fun `when onShowBookings called with filters, then BOOKING_LIST_APPLY_FILTERS is tracked`() {
         val state = viewModel.uiState.getOrAwaitValue()
         state.onUpdateFilterOption(BookingType(BookingType.Type.SERVICE))
         state.onUpdateFilterOption(
-            BookingsFilterOption.AttendanceStatuses(values = setOf(AttendanceStatus.Attended))
+            BookingsFilterOption.AttendanceStatus(AttendanceStatus.Attended)
         )
 
         viewModel.uiState.getOrAwaitValue().onShowBookings()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterViewModelTest.kt
@@ -6,20 +6,20 @@ import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.AttendanceStatuses
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity.AttendanceStatus
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BookingAttendanceStatusFilterViewModelTest : BaseUnitTest() {
 
-    private var lastFilterResult: AttendanceStatuses? = null
+    private var lastFilterResult: BookingsFilterOption.AttendanceStatus? = null
 
     private fun createViewModel(
-        initialStatuses: AttendanceStatuses? = null
+        initialStatus: BookingsFilterOption.AttendanceStatus? = null
     ): BookingAttendanceStatusFilterViewModel {
         lastFilterResult = null
         return BookingAttendanceStatusFilterViewModel(
-            initialStatuses = initialStatuses,
+            initialStatus = initialStatus,
             onFilterChanged = { lastFilterResult = it },
             savedStateHandle = SavedStateHandle()
         )
@@ -36,14 +36,14 @@ class BookingAttendanceStatusFilterViewModelTest : BaseUnitTest() {
         // THEN
         val state = viewModel.uiState.getOrAwaitValue()
         assertThat(state.selectedStatus).isEqualTo(AttendanceStatus.Attended)
-        assertThat(lastFilterResult).isEqualTo(AttendanceStatuses(setOf(AttendanceStatus.Attended)))
+        assertThat(lastFilterResult).isEqualTo(BookingsFilterOption.AttendanceStatus(AttendanceStatus.Attended))
     }
 
     @Test
     fun `given Attended selected, when Unattended is selected, then only Unattended is in the filter`() =
         testBlocking {
             // GIVEN
-            val viewModel = createViewModel(AttendanceStatuses(setOf(AttendanceStatus.Attended)))
+            val viewModel = createViewModel(BookingsFilterOption.AttendanceStatus(AttendanceStatus.Attended))
 
             // WHEN
             viewModel.uiState.getOrAwaitValue().items[UNATTENDED_INDEX].onClick()
@@ -51,13 +51,13 @@ class BookingAttendanceStatusFilterViewModelTest : BaseUnitTest() {
             // THEN
             val state = viewModel.uiState.getOrAwaitValue()
             assertThat(state.selectedStatus).isEqualTo(AttendanceStatus.Unattended)
-            assertThat(lastFilterResult).isEqualTo(AttendanceStatuses(setOf(AttendanceStatus.Unattended)))
+            assertThat(lastFilterResult).isEqualTo(BookingsFilterOption.AttendanceStatus(AttendanceStatus.Unattended))
         }
 
     @Test
     fun `given Attended selected, when Any is selected, then filter is cleared`() = testBlocking {
         // GIVEN
-        val viewModel = createViewModel(AttendanceStatuses(setOf(AttendanceStatus.Attended)))
+        val viewModel = createViewModel(BookingsFilterOption.AttendanceStatus(AttendanceStatus.Attended))
 
         // WHEN
         viewModel.uiState.getOrAwaitValue().items[ANY_INDEX].onClick()
@@ -65,13 +65,13 @@ class BookingAttendanceStatusFilterViewModelTest : BaseUnitTest() {
         // THEN
         val state = viewModel.uiState.getOrAwaitValue()
         assertThat(state.selectedStatus).isNull()
-        assertThat(lastFilterResult).isEqualTo(AttendanceStatuses(emptySet()))
+        assertThat(lastFilterResult).isEqualTo(BookingsFilterOption.AttendanceStatus(null))
     }
 
     @Test
     fun `given Attended selected, when Attended is selected again, then Attended remains selected`() = testBlocking {
         // GIVEN
-        val viewModel = createViewModel(AttendanceStatuses(setOf(AttendanceStatus.Attended)))
+        val viewModel = createViewModel(BookingsFilterOption.AttendanceStatus(AttendanceStatus.Attended))
 
         // WHEN
         viewModel.uiState.getOrAwaitValue().items[ATTENDED_INDEX].onClick()
@@ -79,7 +79,7 @@ class BookingAttendanceStatusFilterViewModelTest : BaseUnitTest() {
         // THEN
         val state = viewModel.uiState.getOrAwaitValue()
         assertThat(state.selectedStatus).isEqualTo(AttendanceStatus.Attended)
-        assertThat(lastFilterResult).isEqualTo(AttendanceStatuses(setOf(AttendanceStatus.Attended)))
+        assertThat(lastFilterResult).isEqualTo(BookingsFilterOption.AttendanceStatus(AttendanceStatus.Attended))
     }
 
     companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/attendancestatus/BookingAttendanceStatusFilterViewModelTest.kt
@@ -1,0 +1,90 @@
+package com.woocommerce.android.ui.bookings.filter.attendancestatus
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption.AttendanceStatuses
+import org.wordpress.android.fluxc.persistence.entity.BookingEntity.AttendanceStatus
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BookingAttendanceStatusFilterViewModelTest : BaseUnitTest() {
+
+    private var lastFilterResult: AttendanceStatuses? = null
+
+    private fun createViewModel(
+        initialStatuses: AttendanceStatuses? = null
+    ): BookingAttendanceStatusFilterViewModel {
+        lastFilterResult = null
+        return BookingAttendanceStatusFilterViewModel(
+            initialStatuses = initialStatuses,
+            onFilterChanged = { lastFilterResult = it },
+            savedStateHandle = SavedStateHandle()
+        )
+    }
+
+    @Test
+    fun `when Attended is selected, then only Attended is in the filter`() = testBlocking {
+        // GIVEN
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.uiState.getOrAwaitValue().items[ATTENDED_INDEX].onClick()
+
+        // THEN
+        val state = viewModel.uiState.getOrAwaitValue()
+        assertThat(state.selectedStatus).isEqualTo(AttendanceStatus.Attended)
+        assertThat(lastFilterResult).isEqualTo(AttendanceStatuses(setOf(AttendanceStatus.Attended)))
+    }
+
+    @Test
+    fun `given Attended selected, when Unattended is selected, then only Unattended is in the filter`() =
+        testBlocking {
+            // GIVEN
+            val viewModel = createViewModel(AttendanceStatuses(setOf(AttendanceStatus.Attended)))
+
+            // WHEN
+            viewModel.uiState.getOrAwaitValue().items[UNATTENDED_INDEX].onClick()
+
+            // THEN
+            val state = viewModel.uiState.getOrAwaitValue()
+            assertThat(state.selectedStatus).isEqualTo(AttendanceStatus.Unattended)
+            assertThat(lastFilterResult).isEqualTo(AttendanceStatuses(setOf(AttendanceStatus.Unattended)))
+        }
+
+    @Test
+    fun `given Attended selected, when Any is selected, then filter is cleared`() = testBlocking {
+        // GIVEN
+        val viewModel = createViewModel(AttendanceStatuses(setOf(AttendanceStatus.Attended)))
+
+        // WHEN
+        viewModel.uiState.getOrAwaitValue().items[ANY_INDEX].onClick()
+
+        // THEN
+        val state = viewModel.uiState.getOrAwaitValue()
+        assertThat(state.selectedStatus).isNull()
+        assertThat(lastFilterResult).isEqualTo(AttendanceStatuses(emptySet()))
+    }
+
+    @Test
+    fun `given Attended selected, when Attended is selected again, then Attended remains selected`() = testBlocking {
+        // GIVEN
+        val viewModel = createViewModel(AttendanceStatuses(setOf(AttendanceStatus.Attended)))
+
+        // WHEN
+        viewModel.uiState.getOrAwaitValue().items[ATTENDED_INDEX].onClick()
+
+        // THEN
+        val state = viewModel.uiState.getOrAwaitValue()
+        assertThat(state.selectedStatus).isEqualTo(AttendanceStatus.Attended)
+        assertThat(lastFilterResult).isEqualTo(AttendanceStatuses(setOf(AttendanceStatus.Attended)))
+    }
+
+    companion object {
+        private const val ANY_INDEX = 0
+        private const val ATTENDED_INDEX = 1
+        private const val UNATTENDED_INDEX = 2
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepositoryTest.kt
@@ -135,16 +135,15 @@ class BookingFilterRepositoryTest : BaseUnitTest() {
     fun `when single attendance status saved, then flow emits it`() = testBlocking {
         setSite(5)
         val repository = BookingFilterRepository(dataStore, selectedSite)
-        val statuses = setOf(BookingEntity.AttendanceStatus.Attended)
 
         repository.save(
             BookingFilters(
-                attendanceStatuses = BookingsFilterOption.AttendanceStatuses(values = statuses)
+                attendanceStatus = BookingsFilterOption.AttendanceStatus(BookingEntity.AttendanceStatus.Attended)
             )
         )
         val emitted = repository.bookingFiltersFlow.first()
 
-        assertThat(emitted.attendanceStatuses.values).isEqualTo(statuses)
+        assertThat(emitted.attendanceStatus.value).isEqualTo(BookingEntity.AttendanceStatus.Attended)
     }
 
     @Test
@@ -170,32 +169,31 @@ class BookingFilterRepositoryTest : BaseUnitTest() {
     fun `when saving empty attendance and service events, then values are cleared`() = testBlocking {
         setSite(7)
         val repository = BookingFilterRepository(dataStore, selectedSite)
-        val initialStatuses = setOf(BookingEntity.AttendanceStatus.Attended)
         val initialProducts = setOf(
             BookingsFilterOption.ProductInfo(productId = 33L, productName = "Pilates")
         )
         repository.save(
             BookingFilters(
-                attendanceStatuses = BookingsFilterOption.AttendanceStatuses(initialStatuses),
+                attendanceStatus = BookingsFilterOption.AttendanceStatus(BookingEntity.AttendanceStatus.Attended),
                 serviceEvents = BookingsFilterOption.ServiceEvents(initialProducts)
             )
         )
         // Sanity check precondition
         val pre = repository.bookingFiltersFlow.first()
-        assertThat(pre.attendanceStatuses.values).isEqualTo(initialStatuses)
+        assertThat(pre.attendanceStatus.value).isEqualTo(BookingEntity.AttendanceStatus.Attended)
         assertThat(pre.serviceEvents.values).isEqualTo(initialProducts)
 
-        // WHEN clear by saving empty sets
+        // WHEN clear by saving defaults
         repository.save(
             BookingFilters(
-                attendanceStatuses = BookingsFilterOption.AttendanceStatuses(emptySet()),
+                attendanceStatus = BookingsFilterOption.AttendanceStatus.DEFAULT,
                 serviceEvents = BookingsFilterOption.ServiceEvents(emptySet())
             )
         )
         val emitted = repository.bookingFiltersFlow.first()
 
         // THEN
-        assertThat(emitted.attendanceStatuses.values).isEmpty()
+        assertThat(emitted.attendanceStatus.value).isNull()
         assertThat(emitted.serviceEvents.values).isEmpty()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/data/BookingFilterRepositoryTest.kt
@@ -132,13 +132,10 @@ class BookingFilterRepositoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when attendance statuses saved, then flow emits them`() = testBlocking {
+    fun `when single attendance status saved, then flow emits it`() = testBlocking {
         setSite(5)
         val repository = BookingFilterRepository(dataStore, selectedSite)
-        val statuses = setOf(
-            BookingEntity.AttendanceStatus.Attended,
-            BookingEntity.AttendanceStatus.Unattended
-        )
+        val statuses = setOf(BookingEntity.AttendanceStatus.Attended)
 
         repository.save(
             BookingFilters(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsFilterOption.kt
@@ -20,9 +20,9 @@ sealed interface BookingsFilterOption {
         enum class Type { SERVICE, EVENT }
     }
 
-    data class AttendanceStatuses(val values: Set<BookingEntity.AttendanceStatus>) : BookingsFilterOption {
+    data class AttendanceStatus(val value: BookingEntity.AttendanceStatus?) : BookingsFilterOption {
         companion object {
-            val DEFAULT = AttendanceStatuses(emptySet())
+            val DEFAULT = AttendanceStatus(null)
         }
     }
 
@@ -63,7 +63,7 @@ data class BookingFilters(
     val teamMembers: BookingsFilterOption.TeamMembers = BookingsFilterOption.TeamMembers.DEFAULT,
     val bookingType: BookingsFilterOption.BookingType? = null,
     val serviceEvents: BookingsFilterOption.ServiceEvents = BookingsFilterOption.ServiceEvents.DEFAULT,
-    val attendanceStatuses: BookingsFilterOption.AttendanceStatuses = BookingsFilterOption.AttendanceStatuses.DEFAULT,
+    val attendanceStatus: BookingsFilterOption.AttendanceStatus = BookingsFilterOption.AttendanceStatus.DEFAULT,
     val excludedBookingStatuses: BookingsFilterOption.ExcludedBookingStatuses = BookingsFilterOption.ExcludedBookingStatuses.DEFAULT,
     val paymentStatus: BookingsFilterOption.PaymentStatus? = null,
     val customer: BookingsFilterOption.Customer? = null,
@@ -76,7 +76,7 @@ data class BookingFilters(
             if (teamMembers != BookingsFilterOption.TeamMembers.DEFAULT) count++
             if (bookingType?.value != null) count++
             if (serviceEvents != BookingsFilterOption.ServiceEvents.DEFAULT) count++
-            if (attendanceStatuses != BookingsFilterOption.AttendanceStatuses.DEFAULT) count++
+            if (attendanceStatus != BookingsFilterOption.AttendanceStatus.DEFAULT) count++
             if (paymentStatus != null) count++
             if (customer != null) count++
             if (dateRange != BookingsFilterOption.DateRange.DEFAULT) count++

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -149,7 +149,7 @@ class BookingsRestClient @Inject constructor(
             set("product", serviceEvents.values.joinToString(",") { it.productId.toString() })
         }
         if (attendanceStatuses != BookingsFilterOption.AttendanceStatuses.DEFAULT) {
-            attendanceStatuses.values.firstOrNull()?.let {
+            attendanceStatuses.values.singleOrNull()?.let {
                 set("attendance_status", it.key)
             }
         }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -149,9 +149,9 @@ class BookingsRestClient @Inject constructor(
             set("product", serviceEvents.values.joinToString(",") { it.productId.toString() })
         }
         if (attendanceStatuses != BookingsFilterOption.AttendanceStatuses.DEFAULT) {
-            set(
-                "attendance_status",
-                attendanceStatuses.values.joinToString(FILTER_QUERY_PARAMETER_SEPERATOR) { it.key })
+            attendanceStatuses.values.firstOrNull()?.let {
+                set("attendance_status", it.key)
+            }
         }
         if (excludedBookingStatuses != BookingsFilterOption.ExcludedBookingStatuses.DEFAULT) {
             excludedBookingStatuses.values.forEachIndexed { index, status ->

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -148,11 +148,7 @@ class BookingsRestClient @Inject constructor(
         if (serviceEvents != BookingsFilterOption.ServiceEvents.DEFAULT) {
             set("product", serviceEvents.values.joinToString(",") { it.productId.toString() })
         }
-        if (attendanceStatuses != BookingsFilterOption.AttendanceStatuses.DEFAULT) {
-            attendanceStatuses.values.singleOrNull()?.let {
-                set("attendance_status", it.key)
-            }
-        }
+        attendanceStatus.value?.let { set("attendance_status", it.key) }
         if (excludedBookingStatuses != BookingsFilterOption.ExcludedBookingStatuses.DEFAULT) {
             excludedBookingStatuses.values.forEachIndexed { index, status ->
                 set("booking_status_exclude[$index]", status.key)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/BookingsDao.kt
@@ -22,7 +22,7 @@ interface BookingsDao {
             AND (:startDateBefore IS NULL OR start <= :startDateBefore)
             AND (:startDateAfter IS NULL OR start >= :startDateAfter)
             AND (:customerId IS NULL OR customerId = :customerId)
-            AND ((:attendanceStatusesSize = 0) OR attendanceStatus IN (:attendanceStatuses))
+            AND (:attendanceStatus IS NULL OR attendanceStatus = :attendanceStatus)
             AND status NOT IN (:excludedBookingStatuses)
             AND ((:resourceIdsSize = 0) OR resourceId IN (:resourceIds))
             AND ((:productIdsSize = 0) OR productId IN (:productIds))
@@ -45,8 +45,7 @@ interface BookingsDao {
         customerId: Long?,
         resourceIds: List<Long>,
         resourceIdsSize: Int,
-        attendanceStatuses: List<String>,
-        attendanceStatusesSize: Int,
+        attendanceStatus: String?,
         excludedBookingStatuses: List<String>,
         productIds: List<Long>,
         productIdsSize: Int,
@@ -63,8 +62,7 @@ interface BookingsDao {
         customerId: Long?,
         resourceIds: List<Long>,
         resourceIdsSize: Int,
-        attendanceStatuses: List<String>,
-        attendanceStatusesSize: Int,
+        attendanceStatus: String?,
         excludedBookingStatuses: List<String>,
         productIds: List<Long>,
         productIdsSize: Int,
@@ -100,7 +98,7 @@ interface BookingsDao {
             AND (:startDateBefore IS NULL OR start <= :startDateBefore)
             AND (:startDateAfter IS NULL OR start >= :startDateAfter)
             AND (:customerId IS NULL OR customerId = :customerId)
-            AND ((:attendanceStatusesSize = 0) OR attendanceStatus IN (:attendanceStatuses))
+            AND (:attendanceStatus IS NULL OR attendanceStatus = :attendanceStatus)
             AND status NOT IN (:excludedBookingStatuses)
             AND ((:resourceIdsSize = 0) OR resourceId IN (:resourceIds))
             AND ((:productIdsSize = 0) OR productId IN (:productIds))
@@ -114,8 +112,7 @@ interface BookingsDao {
         customerId: Long?,
         resourceIds: List<Long>,
         resourceIdsSize: Int,
-        attendanceStatuses: List<String>,
-        attendanceStatusesSize: Int,
+        attendanceStatus: String?,
         excludedBookingStatuses: List<String>,
         productIds: List<Long>,
         productIdsSize: Int,
@@ -129,7 +126,6 @@ interface BookingsDao {
         keepIds: List<Long>
     ) {
         val resourceIdsKeySet = filters.teamMembers.values.map { it.value }
-        val attendanceStatusKeySet = filters.attendanceStatuses.values.map { it.key }
         val excludedBookingStatusKeySet = filters.excludedBookingStatuses.values.map { it.key }
         val productIds = filters.serviceEvents.values.map { it.productId }
 
@@ -140,8 +136,7 @@ interface BookingsDao {
             customerId = filters.customer?.customerId,
             resourceIds = resourceIdsKeySet.toList(),
             resourceIdsSize = resourceIdsKeySet.size,
-            attendanceStatuses = attendanceStatusKeySet.toList(),
-            attendanceStatusesSize = attendanceStatusKeySet.size,
+            attendanceStatus = filters.attendanceStatus.value?.key,
             excludedBookingStatuses = excludedBookingStatusKeySet.toList(),
             productIds = productIds,
             productIdsSize = productIds.size,
@@ -175,7 +170,6 @@ interface BookingsDao {
         order: BookingsOrderOption
     ): Flow<List<BookingEntity>> {
         val resourceIdsKeySet = filters?.teamMembers?.values?.map { it.value }.orEmpty()
-        val attendanceStatusKeySet = filters?.attendanceStatuses?.values?.map { it.key }.orEmpty()
         val excludedBookingStatusKeySet = filters?.excludedBookingStatuses?.values?.map { it.key }.orEmpty()
         val productIds = filters?.serviceEvents?.values?.map { it.productId }.orEmpty()
         return observeBookings(
@@ -186,8 +180,7 @@ interface BookingsDao {
             customerId = filters?.customer?.customerId,
             resourceIds = resourceIdsKeySet.toList(),
             resourceIdsSize = resourceIdsKeySet.size,
-            attendanceStatuses = attendanceStatusKeySet.toList(),
-            attendanceStatusesSize = attendanceStatusKeySet.size,
+            attendanceStatus = filters?.attendanceStatus?.value?.key,
             excludedBookingStatuses = excludedBookingStatusKeySet.toList(),
             productIds = productIds,
             productIdsSize = productIds.size,
@@ -202,7 +195,6 @@ interface BookingsDao {
         order: BookingsOrderOption
     ): List<BookingEntity> {
         val resourceIdsKeySet = filters?.teamMembers?.values?.map { it.value }.orEmpty()
-        val attendanceStatusKeySet = filters?.attendanceStatuses?.values?.map { it.key }.orEmpty()
         val excludedBookingStatusKeySet = filters?.excludedBookingStatuses?.values?.map { it.key }.orEmpty()
         val productIds = filters?.serviceEvents?.values?.map { it.productId }.orEmpty()
         return getBookings(
@@ -213,8 +205,7 @@ interface BookingsDao {
             customerId = filters?.customer?.customerId,
             resourceIds = resourceIdsKeySet.toList(),
             resourceIdsSize = resourceIdsKeySet.size,
-            attendanceStatuses = attendanceStatusKeySet.toList(),
-            attendanceStatusesSize = attendanceStatusKeySet.size,
+            attendanceStatus = filters?.attendanceStatus?.value?.key,
             excludedBookingStatuses = excludedBookingStatusKeySet.toList(),
             productIds = productIds,
             productIdsSize = productIds.size,


### PR DESCRIPTION
### Description
Fixes WOOMOB-2449

The attendance status filter in the bookings list allowed multi-select, which caused a 400 API error when multiple statuses were sent (`attendance_status is not of type string`). This PR makes the filter single-select so only one attendance status (or "Any") can be active at a time.

Changes:
- Changed `BookingAttendanceStatusFilterUiState` to hold a single `AttendanceStatus?` instead of a `Set`
- Simplified the ViewModel selection logic to replace (not toggle) the selected status
- Updated `BookingFilterRepository` to read only the first stored value from DataStore (backwards compatible with previously stored multi-value data)
- Simplified API serialization in `BookingsRestClient` to send a plain string

Note: I've decided to keep `AttendanceStatuses` since it's heavily used and in case we need to add multiselect again, it should be significanlty easier. 

### Test Steps
1. Open the Bookings list
2. Tap the filter icon and navigate to the Attendance Status filter
3. Select "Attended" — verify the checkmark appears next to "Attended" only
4. Select "Unattended" — verify "Attended" is deselected and "Unattended" is now selected
5. Tap "Unattended" again — verify it stays selected (no toggle-off)
6. Select "Any" — verify the filter is cleared
7. Tap "Show Bookings" — verify no API error occurs

### Images/gif


https://github.com/user-attachments/assets/500c5144-4c8e-4cee-bf89-3f53463c4b25



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.