### PR TITLE
[WOOMOB-2454] Improve POS catalog syncing loading UX

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt
@@ -120,12 +120,24 @@ private fun SyncingCatalog(
                 )
             }
 
-            Text(
-                text = stringResource(R.string.woopos_home_syncing_catalog_subtitle),
-                style = MaterialTheme.typography.bodySmall,
-                textAlign = TextAlign.Center,
-                color = WooPosTheme.colors.onSurfaceVariantLowest
-            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value),
+            ) {
+                Text(
+                    text = stringResource(R.string.woopos_home_syncing_catalog_hint),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    color = WooPosTheme.colors.onSurfaceVariantLowest,
+                )
+                Text(
+                    text = stringResource(R.string.woopos_home_syncing_catalog_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    color = WooPosTheme.colors.onSurfaceVariantLowest,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -45,11 +45,11 @@ enum class FeatureFlag {
             POS_PRODUCTS_FTS,
             POS_REFUNDS,
             WOO_POS_CLIENT_SIDE_BANNER,
+            WOO_POS_LOCAL_CATALOG_FILE_APPROACH,
             AGE_ELIGIBILITY_CHECKS -> PackageUtils.isDebugBuild()
 
             WOO_PUSH_NOTIFICATIONS_SYSTEM,
-            WOO_PUSH_NOTIFICATIONS_SYSTEM_M2,
-            WOO_POS_LOCAL_CATALOG_FILE_APPROACH -> false
+            WOO_PUSH_NOTIFICATIONS_SYSTEM_M2 -> false
         }
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3628,7 +3628,8 @@
     Woo POS
     -->
     <string name="woopos_home_syncing_catalog_title">Syncing catalog</string>
-    <string name="woopos_home_syncing_catalog_subtitle">Syncing will continue in the background.</string>
+    <string name="woopos_home_syncing_catalog_hint">Catalog syncing may take a few minutes.</string>
+    <string name="woopos_home_syncing_catalog_subtitle">You can leave and syncing will continue in the background.</string>
     <string name="woopos_home_syncing_catalog_exit_button">Exit POS</string>
     <string name="woopos_home_sync_failed_title">Unable to sync</string>
     <string name="woopos_home_sync_failed_message">We are unable to sync your product catalog. Please check your internet connection and retry.</string>


### PR DESCRIPTION
### Description
Fixes WOOMOB-2454

Improves the POS catalog syncing screen UX for large stores where syncing can take several minutes. Adds a hint message below the exit button explaining that syncing may take a few minutes and that users can leave. 

Also enables the file-based local catalog sync feature flag on debug builds.

### Test Steps
1. Open POS on a debug build
2. Observe the syncing screen shows "Syncing catalog" with a spinner (if the POS opens immediately, you might need to delete your data or switch to a store you haven't synced locally yet)
3. Verify the hint text below the Exit POS button reads "Catalog syncing may take a few minutes." and "You can leave and syncing will continue in the background."
4. Tap "Exit POS" and confirm it exits correctly

### Images/gif
<img width="400" alt="Screenshot 2026-03-10 at 15 18 52" src="https://github.com/user-attachments/assets/26f066bb-5a6f-47ba-a4e8-b2071a791a4b" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.