### PR TITLE
Add pagination support for POS local catalog product loading

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -342,7 +342,7 @@ class WooPosProductsInDbDataSource @Inject constructor(
         get() = localCatalogSearchDataSource.hasMorePages
 
     companion object {
-        private const val PAGE_SIZE = 100
+        private const val PAGE_SIZE = 25
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsDataSource.kt
@@ -200,31 +200,56 @@ class WooPosProductsInDbDataSource @Inject constructor(
     private val syncWithFts: WooPosLocalCatalogSyncWithFts,
 ) : WooPosProductsDataSourceInterface {
 
-    private fun getProductsFromDatabaseFlow(): Flow<List<WooPosProductModel>> {
-        val siteModel = selectedSite.getOrNull() ?: return flow { emit(emptyList()) }
-        val siteId = LocalOrRemoteId.LocalId(siteModel.id)
-
-        return posLocalCatalogStore.observeProducts(siteId)
-            .map { result ->
-                result.getOrNull()?.map { entity ->
-                    productMapper.fromEntity(entity)
-                } ?: emptyList()
-            }
-    }
+    private val offset = AtomicInteger(0)
+    private val canLoadMore = AtomicBoolean(false)
+    private val accumulatedProducts = mutableListOf<WooPosProductModel>()
 
     override fun fetchFirstProductsPage(
         forceRefresh: Boolean
-    ): Flow<ProductsResult> = getProductsFromDatabaseFlow()
-        .map { products ->
-            ProductsResult.Remote(Result.success(products))
-        }
-        .flowOn(Dispatchers.IO)
+    ): Flow<ProductsResult> = flow {
+        offset.set(0)
+        canLoadMore.set(false)
+        accumulatedProducts.clear()
+
+        val products = loadNextProductPage()
+        accumulatedProducts.addAll(products)
+
+        emit(ProductsResult.Remote(Result.success(accumulatedProducts.toList())))
+    }.flowOn(Dispatchers.IO)
 
     override suspend fun loadMoreProducts(): Result<List<WooPosProductModel>> = withContext(Dispatchers.IO) {
-        Result.success(emptyList())
+        if (!canLoadMore.get()) {
+            return@withContext Result.success(accumulatedProducts.toList())
+        }
+
+        val products = loadNextProductPage()
+        accumulatedProducts.addAll(products)
+
+        Result.success(accumulatedProducts.toList())
     }
 
-    override val hasMoreProductsPages: Boolean = false
+    override val hasMoreProductsPages: Boolean
+        get() = canLoadMore.get()
+
+    private suspend fun loadNextProductPage(): List<WooPosProductModel> {
+        val siteModel = selectedSite.getOrNull() ?: return emptyList()
+        val siteId = LocalOrRemoteId.LocalId(siteModel.id)
+
+        val result = posLocalCatalogStore.getProducts(
+            siteId = siteId,
+            pageSize = PAGE_SIZE,
+            offset = offset.get()
+        )
+
+        val products: List<WooPosProductModel> = result.getOrNull()?.map { entity ->
+            productMapper.fromEntity(entity)
+        } ?: emptyList()
+
+        canLoadMore.set(products.size == PAGE_SIZE)
+        offset.addAndGet(PAGE_SIZE)
+
+        return products
+    }
 
     override suspend fun getProductById(productId: LocalOrRemoteId.RemoteId): WooPosProductModel? {
         val result = posLocalCatalogStore.getProduct(
@@ -315,6 +340,10 @@ class WooPosProductsInDbDataSource @Inject constructor(
 
     override val hasMoreSearchPages: Boolean
         get() = localCatalogSearchDataSource.hasMorePages
+
+    companion object {
+        private const val PAGE_SIZE = 100
+    }
 }
 
 class WooPosProductsRemoteDataSource @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -282,8 +282,10 @@ class WooPosProductsViewModel @Inject constructor(
         loadMoreProductsJob?.cancel()
         loadMoreProductsJob = viewModelScope.launch {
             val result = dataSource.loadMore()
+            val latestState = _viewState.value
+            if (latestState !is WooPosProductsViewState.Content) return@launch
             _viewState.value = if (result.isSuccess) {
-                appendNewProducts(currentState, result.getOrThrow()).also {
+                appendNewProducts(latestState, result.getOrThrow()).also {
                     analyticsTracker.track(
                         WooPosAnalyticsEvent.Event.ItemsNextPageLoaded(
                             source = WooPosAnalyticsEventConstant.ItemsListSource.PRODUCT,
@@ -292,7 +294,7 @@ class WooPosProductsViewModel @Inject constructor(
                     )
                 }
             } else {
-                currentState.copy(paginationState = WooPosPaginationState.Error)
+                latestState.copy(paginationState = WooPosPaginationState.Error)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -25,7 +25,6 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventCons
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.CoroutineDispatchers
-import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -35,7 +34,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.system.measureTimeMillis
 
 @HiltViewModel
 class WooPosProductsViewModel @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventCons
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -34,6 +35,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.system.measureTimeMillis
 
 @HiltViewModel
 class WooPosProductsViewModel @Inject constructor(
@@ -326,6 +328,7 @@ class WooPosProductsViewModel @Inject constructor(
                         when (syncResult.value) {
                             is PosLocalCatalogSyncResult.Success -> {
                                 _viewState.value = hidePTRIndicator()
+                                loadProducts(forceRefreshProducts = false)
                             }
                             is PosLocalCatalogSyncResult.Failure -> {
                                 handlePTRError(isNetworkError = isNetworkError(syncResult.value))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -283,7 +283,7 @@ class WooPosProductsViewModel @Inject constructor(
         loadMoreProductsJob = viewModelScope.launch {
             val result = dataSource.loadMore()
             _viewState.value = if (result.isSuccess) {
-                result.getOrThrow().toContentState().also {
+                appendNewProducts(currentState, result.getOrThrow()).also {
                     analyticsTracker.track(
                         WooPosAnalyticsEvent.Event.ItemsNextPageLoaded(
                             source = WooPosAnalyticsEventConstant.ItemsListSource.PRODUCT,
@@ -295,6 +295,18 @@ class WooPosProductsViewModel @Inject constructor(
                 currentState.copy(paginationState = WooPosPaginationState.Error)
             }
         }
+    }
+
+    private suspend fun appendNewProducts(
+        currentState: WooPosProductsViewState.Content,
+        allProducts: List<WooPosProductModel>,
+    ): WooPosProductsViewState.Content {
+        val newItems = allProducts.drop(currentState.items.size)
+            .map { it.toItemSelectionViewState() }
+        return currentState.copy(
+            items = currentState.items + newItems,
+            paginationState = WooPosPaginationState.None,
+        )
     }
 
     private fun onSimpleProductClicked(product: WooPosItemSelectionViewState.Product.Simple) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -45,11 +45,11 @@ enum class FeatureFlag {
             POS_PRODUCTS_FTS,
             POS_REFUNDS,
             WOO_POS_CLIENT_SIDE_BANNER,
+            WOO_POS_LOCAL_CATALOG_FILE_APPROACH,
             AGE_ELIGIBILITY_CHECKS -> PackageUtils.isDebugBuild()
 
             WOO_PUSH_NOTIFICATIONS_SYSTEM,
-            WOO_PUSH_NOTIFICATIONS_SYSTEM_M2,
-            WOO_POS_LOCAL_CATALOG_FILE_APPROACH -> false
+            WOO_PUSH_NOTIFICATIONS_SYSTEM_M2 -> false
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsInDbDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsInDbDataSourceTest.kt
@@ -9,13 +9,13 @@ import com.woocommerce.android.ui.woopos.localcatalog.ProductsResult
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosLocalCatalogSyncRepository
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosLocalCatalogSyncWithFts
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosPerformInstantCatalogFullSync
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
@@ -87,8 +87,8 @@ class WooPosProductsInDbDataSourceTest {
         val productEntity = createProductEntity(remoteId = 123L, name = "Test Product")
         val productModel = createProductModel(remoteId = 123L, name = "Test Product")
 
-        whenever(posLocalCatalogStore.observeProducts(any()))
-            .thenReturn(flowOf(Result.success(listOf(productEntity))))
+        whenever(posLocalCatalogStore.getProducts(any(), any(), any()))
+            .thenReturn(Result.success(listOf(productEntity)))
         whenever(mapper.fromEntity(productEntity))
             .thenReturn(productModel)
 
@@ -113,8 +113,8 @@ class WooPosProductsInDbDataSourceTest {
         val model1 = createProductModel(remoteId = 1L, name = "Apple iPhone", sku = "ABC123")
         val model2 = createProductModel(remoteId = 2L, name = "Samsung Galaxy", sku = "XYZ789")
 
-        whenever(posLocalCatalogStore.observeProducts(any()))
-            .thenReturn(flowOf(Result.success(listOf(product1, product2))))
+        whenever(posLocalCatalogStore.getProducts(any(), any(), any()))
+            .thenReturn(Result.success(listOf(product1, product2)))
         whenever(mapper.fromEntity(product1)).thenReturn(model1)
         whenever(mapper.fromEntity(product2)).thenReturn(model2)
 
@@ -152,8 +152,8 @@ class WooPosProductsInDbDataSourceTest {
     @Test
     fun `given db error, when fetchFirstProductsPage called, then returns empty list`() = runTest {
         // Given
-        whenever(posLocalCatalogStore.observeProducts(any()))
-            .thenReturn(flowOf(Result.failure(Exception("DB Error"))))
+        whenever(posLocalCatalogStore.getProducts(any(), any(), any()))
+            .thenReturn(Result.failure(Exception("DB Error")))
 
         // When
         val results = sut.fetchFirstProductsPage(forceRefresh = false).toList()
@@ -169,19 +169,92 @@ class WooPosProductsInDbDataSourceTest {
     }
 
     @Test
-    fun `when loadMore called, then returns empty list`() = runTest {
+    fun `given full first page, when hasMoreProductsPages checked, then returns true`() = runTest {
+        // Given
+        val entities = (1..200).map { createProductEntity(remoteId = it.toLong(), name = "Product $it") }
+        val models = (1..200).map { createProductModel(remoteId = it.toLong(), name = "Product $it") }
+
+        whenever(posLocalCatalogStore.getProducts(any(), any(), any()))
+            .thenReturn(Result.success(entities))
+        entities.zip(models).forEach { (entity, model) ->
+            whenever(mapper.fromEntity(entity)).thenReturn(model)
+        }
+
         // When
+        sut.fetchFirstProductsPage(forceRefresh = false).toList()
+
+        // Then
+        assertThat(sut.hasMoreProductsPages).isTrue()
+    }
+
+    @Test
+    fun `given partial first page, when hasMoreProductsPages checked, then returns false`() = runTest {
+        // Given
+        val entities = (1..10).map { createProductEntity(remoteId = it.toLong(), name = "Product $it") }
+        val models = (1..10).map { createProductModel(remoteId = it.toLong(), name = "Product $it") }
+
+        whenever(posLocalCatalogStore.getProducts(any(), any(), any()))
+            .thenReturn(Result.success(entities))
+        entities.zip(models).forEach { (entity, model) ->
+            whenever(mapper.fromEntity(entity)).thenReturn(model)
+        }
+
+        // When
+        sut.fetchFirstProductsPage(forceRefresh = false).toList()
+
+        // Then
+        assertThat(sut.hasMoreProductsPages).isFalse()
+    }
+
+    @Test
+    fun `given full first page, when loadMoreProducts called, then returns accumulated products`() = runTest {
+        // Given
+        val firstPageEntities = (1..100).map { createProductEntity(remoteId = it.toLong(), name = "Product $it") }
+        val firstPageModels = (1..100).map { createProductModel(remoteId = it.toLong(), name = "Product $it") }
+
+        // Second page partial
+        val secondPageEntities = (101..130).map { createProductEntity(remoteId = it.toLong(), name = "Product $it") }
+        val secondPageModels = (101..130).map { createProductModel(remoteId = it.toLong(), name = "Product $it") }
+
+        whenever(posLocalCatalogStore.getProducts(any(), eq(100), eq(0)))
+            .thenReturn(Result.success(firstPageEntities))
+        whenever(posLocalCatalogStore.getProducts(any(), eq(100), eq(100)))
+            .thenReturn(Result.success(secondPageEntities))
+
+        (firstPageEntities + secondPageEntities).zip(firstPageModels + secondPageModels)
+            .forEach { (entity, model) ->
+                whenever(mapper.fromEntity(entity)).thenReturn(model)
+            }
+
+        // When
+        sut.fetchFirstProductsPage(forceRefresh = false).toList()
         val result = sut.loadMoreProducts()
 
         // Then
         assertThat(result.isSuccess).isTrue()
-        assertThat(result.getOrThrow()).isEmpty()
+        assertThat(result.getOrThrow()).hasSize(130)
+        assertThat(result.getOrThrow()).containsAll(firstPageModels + secondPageModels)
     }
 
     @Test
-    fun `when hasMorePages called, then returns false`() {
+    fun `given no more pages, when loadMoreProducts called, then returns current accumulated products`() = runTest {
+        // Given
+        val entities = (1..10).map { createProductEntity(remoteId = it.toLong(), name = "Product $it") }
+        val models = (1..10).map { createProductModel(remoteId = it.toLong(), name = "Product $it") }
+
+        whenever(posLocalCatalogStore.getProducts(any(), any(), any()))
+            .thenReturn(Result.success(entities))
+        entities.zip(models).forEach { (entity, model) ->
+            whenever(mapper.fromEntity(entity)).thenReturn(model)
+        }
+
+        // When
+        sut.fetchFirstProductsPage(forceRefresh = false).toList()
+        val result = sut.loadMoreProducts()
+
         // Then
-        assertThat(sut.hasMoreProductsPages).isFalse()
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrThrow()).hasSize(10)
     }
 
     private fun createProductEntity(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsInDbDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsInDbDataSourceTest.kt
@@ -171,8 +171,8 @@ class WooPosProductsInDbDataSourceTest {
     @Test
     fun `given full first page, when hasMoreProductsPages checked, then returns true`() = runTest {
         // Given
-        val entities = (1..200).map { createProductEntity(remoteId = it.toLong(), name = "Product $it") }
-        val models = (1..200).map { createProductModel(remoteId = it.toLong(), name = "Product $it") }
+        val entities = (1..25).map { createProductEntity(remoteId = it.toLong(), name = "Product $it") }
+        val models = (1..25).map { createProductModel(remoteId = it.toLong(), name = "Product $it") }
 
         whenever(posLocalCatalogStore.getProducts(any(), any(), any()))
             .thenReturn(Result.success(entities))
@@ -209,16 +209,16 @@ class WooPosProductsInDbDataSourceTest {
     @Test
     fun `given full first page, when loadMoreProducts called, then returns accumulated products`() = runTest {
         // Given
-        val firstPageEntities = (1..100).map { createProductEntity(remoteId = it.toLong(), name = "Product $it") }
-        val firstPageModels = (1..100).map { createProductModel(remoteId = it.toLong(), name = "Product $it") }
+        val firstPageEntities = (1..25).map { createProductEntity(remoteId = it.toLong(), name = "Product $it") }
+        val firstPageModels = (1..25).map { createProductModel(remoteId = it.toLong(), name = "Product $it") }
 
         // Second page partial
-        val secondPageEntities = (101..130).map { createProductEntity(remoteId = it.toLong(), name = "Product $it") }
-        val secondPageModels = (101..130).map { createProductModel(remoteId = it.toLong(), name = "Product $it") }
+        val secondPageEntities = (26..40).map { createProductEntity(remoteId = it.toLong(), name = "Product $it") }
+        val secondPageModels = (26..40).map { createProductModel(remoteId = it.toLong(), name = "Product $it") }
 
-        whenever(posLocalCatalogStore.getProducts(any(), eq(100), eq(0)))
+        whenever(posLocalCatalogStore.getProducts(any(), eq(25), eq(0)))
             .thenReturn(Result.success(firstPageEntities))
-        whenever(posLocalCatalogStore.getProducts(any(), eq(100), eq(100)))
+        whenever(posLocalCatalogStore.getProducts(any(), eq(25), eq(25)))
             .thenReturn(Result.success(secondPageEntities))
 
         (firstPageEntities + secondPageEntities).zip(firstPageModels + secondPageModels)
@@ -232,7 +232,7 @@ class WooPosProductsInDbDataSourceTest {
 
         // Then
         assertThat(result.isSuccess).isTrue()
-        assertThat(result.getOrThrow()).hasSize(130)
+        assertThat(result.getOrThrow()).hasSize(40)
         assertThat(result.getOrThrow()).containsAll(firstPageModels + secondPageModels)
     }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
@@ -27,6 +27,21 @@ abstract class WooPosProductsDao {
     )
     abstract fun observeAllProducts(localSiteId: LocalId): Flow<List<WooPosProductEntity>>
 
+    @Query(
+        "SELECT * FROM PosProductEntity " +
+            "WHERE localSiteId = :localSiteId " +
+            "AND status = '$PRODUCT_STATUS_PUBLISH' " +
+            "AND (type = '$PRODUCT_TYPE_SIMPLE' OR type = '$PRODUCT_TYPE_VARIABLE') " +
+            "AND downloadable = '$DOWNLOADABLE_FALSE' " +
+            "ORDER BY LOWER(name) " +
+            "LIMIT :limit OFFSET :offset"
+    )
+    abstract suspend fun getProducts(
+        localSiteId: LocalId,
+        limit: Int,
+        offset: Int
+    ): List<WooPosProductEntity>
+
     @Query("SELECT * FROM PosProductEntity WHERE localSiteId = :localSiteId AND remoteId = :remoteId")
     abstract suspend fun getProduct(localSiteId: LocalId, remoteId: RemoteId): WooPosProductEntity?
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/dao/pos/WooPosProductsDao.kt
@@ -23,7 +23,7 @@ abstract class WooPosProductsDao {
             "AND status = '$PRODUCT_STATUS_PUBLISH' " +
             "AND (type = '$PRODUCT_TYPE_SIMPLE' OR type = '$PRODUCT_TYPE_VARIABLE') " +
             "AND downloadable = '$DOWNLOADABLE_FALSE' " +
-            "ORDER BY LOWER(name)"
+            "ORDER BY LOWER(name), remoteId"
     )
     abstract fun observeAllProducts(localSiteId: LocalId): Flow<List<WooPosProductEntity>>
 
@@ -33,7 +33,7 @@ abstract class WooPosProductsDao {
             "AND status = '$PRODUCT_STATUS_PUBLISH' " +
             "AND (type = '$PRODUCT_TYPE_SIMPLE' OR type = '$PRODUCT_TYPE_VARIABLE') " +
             "AND downloadable = '$DOWNLOADABLE_FALSE' " +
-            "ORDER BY LOWER(name) " +
+            "ORDER BY LOWER(name), remoteId " +
             "LIMIT :limit OFFSET :offset"
     )
     abstract suspend fun getProducts(
@@ -80,7 +80,7 @@ abstract class WooPosProductsDao {
             "AND (name LIKE '%' || :searchQuery || '%' " +
             "OR sku LIKE '%' || :searchQuery || '%' " +
             "OR globalUniqueId LIKE '%' || :searchQuery || '%') " +
-            "ORDER BY LOWER(name) " +
+            "ORDER BY LOWER(name), remoteId " +
             "LIMIT :limit OFFSET :offset"
     )
     abstract suspend fun searchProducts(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -112,6 +112,28 @@ class WooPosLocalCatalogStore @Inject constructor(
         }
 
     /**
+     * Gets a paginated list of products from the local database.
+     *
+     * @param [siteId] The local site ID
+     * @param [pageSize] The number of results to return
+     * @param [offset] The offset for pagination
+     * @return Result containing the list of products or error
+     */
+    suspend fun getProducts(
+        siteId: LocalOrRemoteId.LocalId,
+        pageSize: Int = DEFAULT_PAGE_SIZE,
+        offset: Int = 0
+    ): Result<List<WooPosProductEntity>> =
+        coroutineEngine.withDefaultContext(API, this, "getProducts") {
+            val products = posProductDao.getProducts(
+                localSiteId = siteId,
+                limit = pageSize.coerceAtMost(MAX_PAGE_SIZE),
+                offset = offset
+            )
+            Result.success(products)
+        }
+
+    /**
      * Searches products in the local database by name, SKU, or global unique ID.
      *
      * @param [siteId] The local site ID

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -127,8 +127,8 @@ class WooPosLocalCatalogStore @Inject constructor(
         coroutineEngine.withDefaultContext(API, this, "getProducts") {
             val products = posProductDao.getProducts(
                 localSiteId = siteId,
-                limit = pageSize.coerceAtMost(MAX_PAGE_SIZE),
-                offset = offset
+                limit = pageSize.coerceIn(1, MAX_PAGE_SIZE),
+                offset = offset.coerceAtLeast(0)
             )
             Result.success(products)
         }


### PR DESCRIPTION
WOOMOB-2453

### Description

On stores with large catalogs, loading all POS products from the local database at once caused a noticable delay when opening the POS. This PR adds pagination support to the local catalog data source so products are loaded in pages of 25, matching the remote data source behavior.

Eventually, when we remove the hybrid/remote sync approach, we can move back to the more reliable room-observable approach. However, at the moment, it'd require significant changes to the shared data source interface which are not worth it, considering we'll remove it in a few months.

Key changes:
- Added a paginated `getProducts` query to `WooPosProductsDao` with `LIMIT`/`OFFSET` support
- Exposed paginated product fetching via `WooPosLocalCatalogStore.getProducts()`
- Refactored `WooPosProductsInDbDataSource` to use page-based loading with accumulated results instead of observing all products at once
- Fixed lag in `WooPosProductsViewModel` by mapping only newly loaded products when appending pages instead of re-mapping all accumulated products
- Enabled `WOO_POS_LOCAL_CATALOG_FILE_APPROACH` feature flag on debug builds
- Triggered product reload after successful pull-to-refresh sync

### Test Steps

1. Enable the local catalog file approach (debug builds only)
2. Open POS on a store with a large product catalog (50+ products)
3. Scroll through the product list — double-check all products load
4. Pull to refresh — products should reload correctly
5. Verify pagination loads more products as you scroll down


Before

https://github.com/user-attachments/assets/32dc90ac-98e2-48e7-a98d-17e00cb42b99

After

https://github.com/user-attachments/assets/3001b8c9-b887-4ada-905a-561e7854c019



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.