### PR TITLE
[CIAB] Use _payment_status metadata for payment status resolution

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/PaymentStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/PaymentStatus.kt
@@ -6,4 +6,19 @@ enum class PaymentStatus {
     FAILED,
     REFUNDED,
     PARTIALLY_REFUNDED,
+    AUTHORIZED,
+    AUTHORIZATION_VOIDED;
+
+    companion object {
+        fun fromApiValue(value: String): PaymentStatus = when (value) {
+            "paid" -> PAID
+            "unpaid" -> UNPAID
+            "failed" -> FAILED
+            "refunded" -> REFUNDED
+            "partially_refunded" -> PARTIALLY_REFUNDED
+            "authorized" -> AUTHORIZED
+            "authorization_voided" -> AUTHORIZATION_VOIDED
+            else -> UNPAID
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolver.kt
@@ -1,9 +1,10 @@
 package com.woocommerce.android.ui.bookings
 
 import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.model.metadata.WCMetaData
+import org.wordpress.android.fluxc.model.metadata.get
 import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
-import java.math.BigDecimal
 import javax.inject.Inject
 
 class PaymentStatusResolver @Inject constructor(
@@ -30,26 +31,7 @@ class PaymentStatusResolver @Inject constructor(
     }
 
     private fun statusForOrder(order: OrderEntity): PaymentStatus {
-        val total = order.total.toBigDecimalOrNull() ?: BigDecimal.ZERO
-        return computeStatus(order.refundTotal.abs(), total, order.datePaid, order.status)
-    }
-
-    // Priority chain: refund checks first, then paid, then failed, then default unpaid.
-    private fun computeStatus(
-        refundTotal: BigDecimal,
-        total: BigDecimal,
-        datePaid: String,
-        orderStatus: String,
-    ): PaymentStatus = when {
-        // Full refund: refund amount covers the entire order total
-        refundTotal > BigDecimal.ZERO && total > BigDecimal.ZERO && refundTotal >= total -> PaymentStatus.REFUNDED
-        // Partial refund: some refund issued but less than the order total
-        refundTotal > BigDecimal.ZERO -> PaymentStatus.PARTIALLY_REFUNDED
-        // Paid: the order has a recorded payment date
-        datePaid.isNotEmpty() -> PaymentStatus.PAID
-        // Failed: the linked order was either failed or cancelled
-        orderStatus == "failed" || orderStatus == "cancelled" -> PaymentStatus.FAILED
-        // Default: no payment recorded
-        else -> PaymentStatus.UNPAID
+        val apiValue = order.metaData[WCMetaData.PaymentMetadataKeys.PAYMENT_STATUS]?.valueAsString
+        return PaymentStatus.fromApiValue(apiValue ?: "")
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingStatusTag.kt
@@ -49,14 +49,20 @@ private fun PaymentStatus.text(): String = when (this) {
     PaymentStatus.FAILED -> stringResource(R.string.booking_payment_status_failed)
     PaymentStatus.REFUNDED -> stringResource(R.string.booking_payment_status_refunded)
     PaymentStatus.PARTIALLY_REFUNDED -> stringResource(R.string.booking_payment_status_partially_refunded)
+    PaymentStatus.AUTHORIZED -> stringResource(R.string.booking_payment_status_authorized)
+    PaymentStatus.AUTHORIZATION_VOIDED -> stringResource(R.string.booking_payment_status_authorization_voided)
 }
 
 @Composable
 private fun PaymentStatus.backgroundColor(): Color = when (this) {
-    PaymentStatus.UNPAID -> colorResource(R.color.tag_bg_booking_yellow)
+    PaymentStatus.UNPAID,
+    PaymentStatus.AUTHORIZED -> colorResource(R.color.tag_bg_booking_yellow)
+
     PaymentStatus.PAID,
     PaymentStatus.REFUNDED,
-    PaymentStatus.PARTIALLY_REFUNDED -> Color.Transparent
+    PaymentStatus.PARTIALLY_REFUNDED,
+    PaymentStatus.AUTHORIZATION_VOIDED -> Color.Transparent
+
     PaymentStatus.FAILED -> colorResource(R.color.tagView_bg)
 }
 
@@ -64,8 +70,11 @@ private fun PaymentStatus.backgroundColor(): Color = when (this) {
 private fun PaymentStatus.textColor(): Color = when (this) {
     PaymentStatus.PAID,
     PaymentStatus.REFUNDED,
-    PaymentStatus.PARTIALLY_REFUNDED -> colorResource(R.color.color_on_surface_high)
+    PaymentStatus.PARTIALLY_REFUNDED,
+    PaymentStatus.AUTHORIZATION_VOIDED -> colorResource(R.color.color_on_surface_high)
+
     PaymentStatus.UNPAID,
+    PaymentStatus.AUTHORIZED,
     PaymentStatus.FAILED -> colorResource(R.color.tagView_text)
 }
 
@@ -73,8 +82,11 @@ private fun PaymentStatus.textColor(): Color = when (this) {
 private fun PaymentStatus.border(): BorderStroke? = when (this) {
     PaymentStatus.PAID,
     PaymentStatus.REFUNDED,
-    PaymentStatus.PARTIALLY_REFUNDED -> BorderStroke(1.dp, colorResource(R.color.tag_border_booking_outlined))
+    PaymentStatus.PARTIALLY_REFUNDED,
+    PaymentStatus.AUTHORIZATION_VOIDED -> BorderStroke(1.dp, colorResource(R.color.tag_border_booking_outlined))
+
     PaymentStatus.UNPAID,
+    PaymentStatus.AUTHORIZED,
     PaymentStatus.FAILED -> null
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsBadges.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsBadges.kt
@@ -23,22 +23,30 @@ fun WooPosPaymentStatusBadge(paymentStatus: PaymentStatus) {
         PaymentStatus.FAILED -> stringResource(R.string.woopos_bookings_payment_status_failed)
         PaymentStatus.REFUNDED -> stringResource(R.string.woopos_bookings_payment_status_refunded)
         PaymentStatus.PARTIALLY_REFUNDED -> stringResource(R.string.woopos_bookings_payment_status_partially_refunded)
+        PaymentStatus.AUTHORIZED -> stringResource(R.string.woopos_bookings_payment_status_authorized)
+        PaymentStatus.AUTHORIZATION_VOIDED -> stringResource(
+            R.string.woopos_bookings_payment_status_authorization_voided
+        )
     }
 
     val bgColor = when (paymentStatus) {
         PaymentStatus.UNPAID,
-        PaymentStatus.FAILED -> WooPosTheme.colors.errorLowest
+        PaymentStatus.FAILED,
+        PaymentStatus.AUTHORIZED -> WooPosTheme.colors.errorLowest
         PaymentStatus.PAID,
         PaymentStatus.REFUNDED,
-        PaymentStatus.PARTIALLY_REFUNDED -> WooPosTheme.colors.disabledContainer
+        PaymentStatus.PARTIALLY_REFUNDED,
+        PaymentStatus.AUTHORIZATION_VOIDED -> WooPosTheme.colors.disabledContainer
     }
 
     val textColor = when (paymentStatus) {
         PaymentStatus.UNPAID,
-        PaymentStatus.FAILED -> WooPosTheme.colors.onErrorLowest
+        PaymentStatus.FAILED,
+        PaymentStatus.AUTHORIZED -> WooPosTheme.colors.onErrorLowest
         PaymentStatus.PAID,
         PaymentStatus.REFUNDED,
-        PaymentStatus.PARTIALLY_REFUNDED -> WooPosTheme.colors.onDefault
+        PaymentStatus.PARTIALLY_REFUNDED,
+        PaymentStatus.AUTHORIZATION_VOIDED -> WooPosTheme.colors.onDefault
     }
 
     WooPosText(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3936,6 +3936,8 @@
     <string name="woopos_bookings_payment_status_failed">Failed</string>
     <string name="woopos_bookings_payment_status_refunded">Refunded</string>
     <string name="woopos_bookings_payment_status_partially_refunded">Partially Refunded</string>
+    <string name="woopos_bookings_payment_status_authorized">Authorized</string>
+    <string name="woopos_bookings_payment_status_authorization_voided">Authorization Voided</string>
     <string name="woopos_bookings_status_cancelled">Canceled</string>
     <string name="woopos_bookings_details_attendance_title">Attendance status</string>
     <string name="woopos_bookings_details_attendance_hint">Mark attendance to keep your reports accurate and spot booking trends.</string>
@@ -4412,6 +4414,8 @@
     <string name="booking_payment_status_refunded">Refunded</string>
     <string name="booking_payment_status_partially_refunded">Partially Refunded</string>
     <string name="booking_payment_status_failed">Failed</string>
+    <string name="booking_payment_status_authorized">Authorized</string>
+    <string name="booking_payment_status_authorization_voided">Authorization Voided</string>
     <string name="booking_attendance_status_attended">Attended</string>
     <string name="booking_attendance_status_unattended">Unattended</string>
     <string name="booking_mark_as_attended">Mark as attended</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/PaymentStatusResolverTest.kt
@@ -8,9 +8,9 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.metadata.WCMetaData
 import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
-import java.math.BigDecimal
 
 class PaymentStatusResolverTest {
 
@@ -34,9 +34,9 @@ class PaymentStatusResolverTest {
     }
 
     @Test
-    fun `given order with datePaid, when resolve, then returns PAID`() = runTest {
+    fun `given order with _payment_status paid, when resolve, then returns PAID`() = runTest {
         // GIVEN
-        val order = createOrder(datePaid = "2025-01-01", refundTotal = BigDecimal.ZERO)
+        val order = createOrder(paymentStatus = "paid")
         whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
 
         // WHEN
@@ -47,69 +47,9 @@ class PaymentStatusResolverTest {
     }
 
     @Test
-    fun `given full refund, when resolve, then returns REFUNDED`() = runTest {
+    fun `given order with _payment_status unpaid, when resolve, then returns UNPAID`() = runTest {
         // GIVEN
-        val order = createOrder(
-            total = "100",
-            refundTotal = BigDecimal("-100"),
-            datePaid = "2025-01-01"
-        )
-        whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
-
-        // WHEN
-        val result = sut.resolve(1L)
-
-        // THEN
-        assertThat(result).isEqualTo(PaymentStatus.REFUNDED)
-    }
-
-    @Test
-    fun `given partial refund, when resolve, then returns PARTIALLY_REFUNDED`() = runTest {
-        // GIVEN
-        val order = createOrder(
-            total = "100",
-            refundTotal = BigDecimal("-50"),
-            datePaid = "2025-01-01"
-        )
-        whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
-
-        // WHEN
-        val result = sut.resolve(1L)
-
-        // THEN
-        assertThat(result).isEqualTo(PaymentStatus.PARTIALLY_REFUNDED)
-    }
-
-    @Test
-    fun `given failed order status, when resolve, then returns FAILED`() = runTest {
-        // GIVEN
-        val order = createOrder(status = "failed", datePaid = "", refundTotal = BigDecimal.ZERO)
-        whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
-
-        // WHEN
-        val result = sut.resolve(1L)
-
-        // THEN
-        assertThat(result).isEqualTo(PaymentStatus.FAILED)
-    }
-
-    @Test
-    fun `given cancelled order status, when resolve, then returns FAILED`() = runTest {
-        // GIVEN
-        val order = createOrder(status = "cancelled", datePaid = "", refundTotal = BigDecimal.ZERO)
-        whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
-
-        // WHEN
-        val result = sut.resolve(1L)
-
-        // THEN
-        assertThat(result).isEqualTo(PaymentStatus.FAILED)
-    }
-
-    @Test
-    fun `given unpaid order with no refunds, when resolve, then returns UNPAID`() = runTest {
-        // GIVEN
-        val order = createOrder(datePaid = "", refundTotal = BigDecimal.ZERO, status = "pending")
+        val order = createOrder(paymentStatus = "unpaid")
         whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
 
         // WHEN
@@ -120,16 +60,104 @@ class PaymentStatusResolverTest {
     }
 
     @Test
-    fun `given unique order ids, when resolve list, then returns status for each id`() = runTest {
+    fun `given order with _payment_status refunded, when resolve, then returns REFUNDED`() = runTest {
         // GIVEN
-        val paidOrder = createOrder(orderId = 11L, datePaid = "2025-01-01")
-        val refundedOrder = createOrder(
-            orderId = 22L,
-            total = "100",
-            refundTotal = BigDecimal("-100"),
-            datePaid = "2025-01-01"
-        )
-        val failedOrder = createOrder(orderId = 33L, status = "failed", datePaid = "", refundTotal = BigDecimal.ZERO)
+        val order = createOrder(paymentStatus = "refunded")
+        whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
+
+        // WHEN
+        val result = sut.resolve(1L)
+
+        // THEN
+        assertThat(result).isEqualTo(PaymentStatus.REFUNDED)
+    }
+
+    @Test
+    fun `given order with _payment_status partially_refunded, when resolve, then returns PARTIALLY_REFUNDED`() =
+        runTest {
+            // GIVEN
+            val order = createOrder(paymentStatus = "partially_refunded")
+            whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
+
+            // WHEN
+            val result = sut.resolve(1L)
+
+            // THEN
+            assertThat(result).isEqualTo(PaymentStatus.PARTIALLY_REFUNDED)
+        }
+
+    @Test
+    fun `given order with _payment_status failed, when resolve, then returns FAILED`() = runTest {
+        // GIVEN
+        val order = createOrder(paymentStatus = "failed")
+        whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
+
+        // WHEN
+        val result = sut.resolve(1L)
+
+        // THEN
+        assertThat(result).isEqualTo(PaymentStatus.FAILED)
+    }
+
+    @Test
+    fun `given order with _payment_status authorized, when resolve, then returns AUTHORIZED`() = runTest {
+        // GIVEN
+        val order = createOrder(paymentStatus = "authorized")
+        whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
+
+        // WHEN
+        val result = sut.resolve(1L)
+
+        // THEN
+        assertThat(result).isEqualTo(PaymentStatus.AUTHORIZED)
+    }
+
+    @Test
+    fun `given order with _payment_status authorization_voided, when resolve, then returns AUTHORIZATION_VOIDED`() =
+        runTest {
+            // GIVEN
+            val order = createOrder(paymentStatus = "authorization_voided")
+            whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
+
+            // WHEN
+            val result = sut.resolve(1L)
+
+            // THEN
+            assertThat(result).isEqualTo(PaymentStatus.AUTHORIZATION_VOIDED)
+        }
+
+    @Test
+    fun `given order with unknown _payment_status value, when resolve, then returns UNPAID`() = runTest {
+        // GIVEN
+        val order = createOrder(paymentStatus = "some_future_value")
+        whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
+
+        // WHEN
+        val result = sut.resolve(1L)
+
+        // THEN
+        assertThat(result).isEqualTo(PaymentStatus.UNPAID)
+    }
+
+    @Test
+    fun `given order without _payment_status metadata, when resolve, then returns UNPAID`() = runTest {
+        // GIVEN
+        val order = createOrder(paymentStatus = null)
+        whenever(orderStore.getOrderByIdAndSite(1L, site)).thenReturn(order)
+
+        // WHEN
+        val result = sut.resolve(1L)
+
+        // THEN
+        assertThat(result).isEqualTo(PaymentStatus.UNPAID)
+    }
+
+    @Test
+    fun `given unique order ids, when resolveAll, then returns status for each id`() = runTest {
+        // GIVEN
+        val paidOrder = createOrder(orderId = 11L, paymentStatus = "paid")
+        val refundedOrder = createOrder(orderId = 22L, paymentStatus = "refunded")
+        val failedOrder = createOrder(orderId = 33L, paymentStatus = "failed")
         whenever(orderStore.getOrdersByIdsAndSite(listOf(11L, 22L, 33L), site))
             .thenReturn(listOf(failedOrder, paidOrder, refundedOrder))
 
@@ -147,11 +175,12 @@ class PaymentStatusResolverTest {
     }
 
     @Test
-    fun `given order ids with duplicates, when resolve list, then returns status per unique id`() = runTest {
+    fun `given order ids with duplicates, when resolveAll, then returns status per unique id`() = runTest {
         // GIVEN
-        val paidOrder = createOrder(orderId = 1L, datePaid = "2025-01-01")
-        val failedOrder = createOrder(orderId = 2L, status = "failed", datePaid = "", refundTotal = BigDecimal.ZERO)
-        whenever(orderStore.getOrdersByIdsAndSite(listOf(1L, 2L), site)).thenReturn(listOf(paidOrder, failedOrder))
+        val paidOrder = createOrder(orderId = 1L, paymentStatus = "paid")
+        val failedOrder = createOrder(orderId = 2L, paymentStatus = "failed")
+        whenever(orderStore.getOrdersByIdsAndSite(listOf(1L, 2L), site))
+            .thenReturn(listOf(paidOrder, failedOrder))
 
         // WHEN
         val result = sut.resolveAll(listOf(1L, 2L, 1L))
@@ -166,15 +195,11 @@ class PaymentStatusResolverTest {
     }
 
     @Test
-    fun `given missing orders, when resolveAll is called, then missing ids fallback to UNPAID`() = runTest {
+    fun `given missing orders, when resolveAll, then missing ids fallback to UNPAID`() = runTest {
         // GIVEN
-        val refundedOrder = createOrder(
-            orderId = 3L,
-            total = "100",
-            refundTotal = BigDecimal("-100"),
-            datePaid = "2025-01-01"
-        )
-        whenever(orderStore.getOrdersByIdsAndSite(listOf(3L, 999L), site)).thenReturn(listOf(refundedOrder))
+        val refundedOrder = createOrder(orderId = 3L, paymentStatus = "refunded")
+        whenever(orderStore.getOrdersByIdsAndSite(listOf(3L, 999L), site))
+            .thenReturn(listOf(refundedOrder))
 
         // WHEN
         val result = sut.resolveAll(listOf(3L, 999L))
@@ -190,16 +215,23 @@ class PaymentStatusResolverTest {
 
     private fun createOrder(
         orderId: Long = 1L,
-        status: String = "processing",
-        datePaid: String = "",
-        refundTotal: BigDecimal = BigDecimal.ZERO,
-        total: String = "100",
-    ) = OrderEntity(
-        localSiteId = LocalId(1),
-        orderId = orderId,
-        status = status,
-        datePaid = datePaid,
-        refundTotal = refundTotal,
-        total = total,
-    )
+        paymentStatus: String? = null,
+    ): OrderEntity {
+        val metaData = if (paymentStatus != null) {
+            listOf(
+                WCMetaData(
+                    id = 1L,
+                    key = WCMetaData.PaymentMetadataKeys.PAYMENT_STATUS,
+                    value = paymentStatus
+                )
+            )
+        } else {
+            emptyList()
+        }
+        return OrderEntity(
+            localSiteId = LocalId(1),
+            orderId = orderId,
+            metaData = metaData,
+        )
+    }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/metadata/WCMetaData.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/metadata/WCMetaData.kt
@@ -113,6 +113,10 @@ data class WCMetaData(
     object AddOnsMetadataKeys {
         const val ADDONS_METADATA_KEY = "_product_addons"
     }
+
+    object PaymentMetadataKeys {
+        const val PAYMENT_STATUS = "_payment_status"
+    }
 }
 
 operator fun List<WCMetaData>.get(key: String) = firstOrNull { it.key == key }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -29,7 +29,8 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
                         .filter {
                             it.key == CHARGE_ID_KEY ||
                                     it.key == SHIPPING_PHONE_KEY ||
-                                    it.key == RECEIPT_URL_KEY
+                                    it.key == RECEIPT_URL_KEY ||
+                                    it.key == WCMetaData.PaymentMetadataKeys.PAYMENT_STATUS
                         }
                 )
     }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
@@ -223,7 +223,7 @@ internal class StripOrderTest {
     }
 
     @Test
-    fun `should preserve _payment_status meta data`() = runTest {
+    fun `when stripping order, then _payment_status meta data is preserved`() = runTest {
         // given
         val metaDataFromRemote = listOf(
             WCMetaData(1, redundantMemberKey, "sample value"),

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
@@ -222,6 +222,24 @@ internal class StripOrderTest {
             )
     }
 
+    @Test
+    fun `should preserve _payment_status meta data`() = runTest {
+        // given
+        val metaDataFromRemote = listOf(
+            WCMetaData(1, redundantMemberKey, "sample value"),
+            WCMetaData(2, WCMetaData.PaymentMetadataKeys.PAYMENT_STATUS, "paid")
+        )
+        val fatModel = emptyOrder.copy(metaData = metaDataFromRemote)
+
+        // when
+        val strippedOrder = sut.invoke(fatModel)
+
+        // then
+        assertThat(strippedOrder.metaData.map { it.key })
+            .contains(WCMetaData.PaymentMetadataKeys.PAYMENT_STATUS)
+            .doesNotContain(redundantMemberKey)
+    }
+
     companion object {
         const val redundantMemberKey = "not_needed_parameter"
 


### PR DESCRIPTION
Closes: WOOMOB-2459

### Description

Replace local payment status computation with the `_payment_status` metadata provided by the API. This aligns the mobile app with the CIAB web dashboard, which uses this metadata to determine payment status badges.

#### Changes:
- Add `PaymentMetadataKeys.PAYMENT_STATUS` constant and preserve it in `StripOrder` so it survives persistence
- Add `AUTHORIZED` and `AUTHORIZATION_VOIDED` values to the `PaymentStatus` enum with `fromApiValue` mapper (defaults to `UNPAID` for unknown values, matching web behavior)
- Simplify `PaymentStatusResolver` to read from metadata instead of computing locally
- Add UI support for new statuses in `BookingPaymentStatusTag` and `WooPosPaymentStatusBadge`:
  - `AUTHORIZED` uses the same styling as `UNPAID` (yellow in bookings, red in POS)
  - `AUTHORIZATION_VOIDED` uses the standard outlined style (gray in bookings, gray in POS)

#### Note on Authorized / Authorization Voided

The `authorized` and `authorization_voided` values are defined in the CIAB API enum, and the app maps them correctly when received via `_payment_status`. However, in the current CIAB implementation, these statuses are derived server-side from the `_intention_status` metadata (`requires_capture` → authorized, `canceled` on a cancelled order → authorization voided) rather than being written directly to `_payment_status`.

We are waiting for confirmation on whether:
1. The CIAB API will be updated to write `authorized`/`authorization_voided` directly to `_payment_status`, or
2. The client needs to replicate the `_intention_status` override logic locally

Until then, the enum values and UI support are in place, but the override logic is not implemented on the client side.

### Test Steps
1. Use a CIAB site.
3. Open bookings screen.
4. Force refresh to make sure the orders are fetched, and the metadata is updated.
5. Confirm the payment statuses are shown correctly.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
