### PR TITLE
[WOOMOB-2456] Revert force-enabled coupons on CIAB sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/CachedCouponEnabledChecker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/CachedCouponEnabledChecker.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.woopos.home.items.coupons
 
-import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.tools.SelectedSite
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
@@ -9,17 +8,19 @@ class CachedCouponEnabledChecker @Inject constructor(
     val wooCommerceStore: WooCommerceStore,
     val selectedSite: SelectedSite
 ) {
+    private var cachedSiteId: Int? = null
     private var cachedValue: Boolean? = null
 
     suspend fun isEnabled(): Boolean {
-        cachedValue?.let { return it }
-
-        val enabled = if (selectedSite.get().isCIABSite()) {
-            true
-        } else {
-            wooCommerceStore.getSiteSettingsAsync(selectedSite.get())?.couponsEnabled ?: false
+        val site = selectedSite.get()
+        if (cachedSiteId == site.id) {
+            cachedValue?.let { return it }
         }
-        cachedValue = enabled
-        return enabled
+
+        return (wooCommerceStore.getSiteSettingsAsync(site)?.couponsEnabled ?: false)
+            .also {
+                cachedSiteId = site.id
+                cachedValue = it
+            }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/CachedCouponEnabledCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/CachedCouponEnabledCheckerTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.woopos.home.items.coupons
 
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -36,45 +35,10 @@ class CachedCouponEnabledCheckerTest {
     }
 
     @Test
-    fun `returns false when site settings are null`() = runTest {
-        // GIVEN
-        whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(null)
-
-        // WHEN
-        val result = cachedCouponEnabledChecker.isEnabled()
-
-        // THEN
-        assertThat(result).isFalse()
-    }
-
-    @Test
-    fun `uses cached value on subsequent calls`() = runTest {
+    fun `when coupons are enabled in site settings, then returns true`() = runTest {
         // GIVEN
         val siteSettings = WCSettingsTestUtils.generateSettings(siteModel.localId()).copy(couponsEnabled = true)
         whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(siteSettings)
-
-        // WHEN
-        val firstResult = cachedCouponEnabledChecker.isEnabled()
-
-        val newSettings = WCSettingsTestUtils.generateSettings(siteModel.localId()).copy(couponsEnabled = true)
-        whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(newSettings)
-
-        val secondResult = cachedCouponEnabledChecker.isEnabled()
-
-        // THEN
-        assertThat(firstResult).isTrue()
-        assertThat(secondResult).isTrue() // Still true from cache, not false from new mock
-    }
-
-    @Test
-    fun `given CIAB site, when checking coupons availability, then returns true`() = runTest {
-        // GIVEN
-        val ciabSiteModel = SiteModel().apply {
-            id = 123
-            setIsGardenSite(true)
-            gardenName = CIABSiteGateKeeper.CIAB_GARDEN_NAME
-        }
-        whenever(selectedSite.get()).thenReturn(ciabSiteModel)
 
         // WHEN
         val result = cachedCouponEnabledChecker.isEnabled()
@@ -84,7 +48,7 @@ class CachedCouponEnabledCheckerTest {
     }
 
     @Test
-    fun `given non-CIAB site, when coupons disabled in settings, then returns false`() = runTest {
+    fun `when coupons are disabled in site settings, then returns false`() = runTest {
         // GIVEN
         val siteSettings = WCSettingsTestUtils.generateSettings(siteModel.localId()).copy(couponsEnabled = false)
         whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(siteSettings)
@@ -97,15 +61,52 @@ class CachedCouponEnabledCheckerTest {
     }
 
     @Test
-    fun `given non-CIAB site, when coupons enabled in settings, then returns true`() = runTest {
+    fun `when site settings are null, then returns false`() = runTest {
         // GIVEN
-        val siteSettings = WCSettingsTestUtils.generateSettings(siteModel.localId()).copy(couponsEnabled = true)
-        whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(siteSettings)
+        whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(null)
 
         // WHEN
         val result = cachedCouponEnabledChecker.isEnabled()
 
         // THEN
-        assertThat(result).isTrue()
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given value is already cached, when checking again, then returns cached value`() = runTest {
+        // GIVEN
+        val siteSettings = WCSettingsTestUtils.generateSettings(siteModel.localId()).copy(couponsEnabled = true)
+        whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(siteSettings)
+
+        // WHEN
+        val firstResult = cachedCouponEnabledChecker.isEnabled()
+
+        val newSettings = WCSettingsTestUtils.generateSettings(siteModel.localId()).copy(couponsEnabled = false)
+        whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(newSettings)
+
+        val secondResult = cachedCouponEnabledChecker.isEnabled()
+
+        // THEN
+        assertThat(firstResult).isTrue()
+        assertThat(secondResult).isTrue() // Still true from cache, not false from new mock
+    }
+
+    @Test
+    fun `given value is cached for one site, when site changes, then fetches fresh value`() = runTest {
+        // GIVEN
+        val siteSettings = WCSettingsTestUtils.generateSettings(siteModel.localId()).copy(couponsEnabled = true)
+        whenever(wooCommerceStore.getSiteSettingsAsync(siteModel)).thenReturn(siteSettings)
+        cachedCouponEnabledChecker.isEnabled()
+
+        // WHEN
+        val newSite = SiteModel().apply { id = 456 }
+        val newSiteSettings = WCSettingsTestUtils.generateSettings(newSite.localId()).copy(couponsEnabled = false)
+        whenever(selectedSite.get()).thenReturn(newSite)
+        whenever(wooCommerceStore.getSiteSettingsAsync(newSite)).thenReturn(newSiteSettings)
+
+        val result = cachedCouponEnabledChecker.isEnabled()
+
+        // THEN
+        assertThat(result).isFalse()
     }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2456

Two changes to `CachedCouponEnabledChecker`:

1. **Remove CIAB coupon override**: The API for checking coupon availability has been fixed for CIAB sites. Previously (#15479), we short-circuited CIAB sites to always return `true` for coupons, bypassing the remote settings check. Now that the API works correctly, all sites (including CIAB) rely on the API result again.

2. **Fix cache invalidation on site switch**: The cached coupon-enabled value was not invalidated when the selected site changed, meaning a user switching sites could potentially see stale coupon availability from the previous site (given the same instance of the cache was used). The cache now tracks the site ID and refetches when the site changes.

### Test Steps
1. Open POS on a CIAB site with coupons enabled → verify coupons are available
2. Open POS on a site with coupons disabled → verify coupons are not available
3. Switch between sites → verify coupon availability reflects the current site's settings

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.