### PR TITLE
WOOMOB-2467: Fix payment flow not navigating back from Bookings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -230,8 +230,11 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                         // We should pop the back stack to show the [OrderDetailsFragment].
                         findNavController().popBackStack()
                     } else {
-                        SelectPaymentMethodFragmentDirections.actionSelectPaymentMethodFragmentToOrderList().run {
-                            findNavController().navigateSafely(this)
+                        val popped = findNavController().popBackStack(R.id.orders, false)
+                        if (!popped) {
+                            // orders destination is not in the backstack (e.g. when navigating
+                            // from Bookings), fall back to popping to OrderDetailFragment
+                            findNavController().popBackStack(R.id.orderDetailFragment, false)
                         }
                     }
                 }

--- a/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
@@ -38,10 +38,6 @@
             app:popUpTo="@+id/paymentsHubFragment"
             app:popUpToInclusive="false" />
         <action
-            android:id="@+id/action_selectPaymentMethodFragment_to_orderList"
-            app:popUpTo="@+id/orders"
-            app:popUpToInclusive="false" />
-        <action
             android:id="@+id/action_selectPaymentMethodFragment_to_orderDetailFragment"
             app:destination="@id/nav_graph_orders"
             app:popUpTo="@+id/tapToPaySummaryFragment"


### PR DESCRIPTION
### Description

Fixes a bug where completing the Collect Payment flow (via Cash) when navigating from Bookings → View Order → Order Details would leave the user stuck on the payment method selection screen instead of navigating back.

**Root cause:** The `NavigateBackToOrderList` handler used a nav action that pops to the `orders` (Order List) destination. When the user entered Order Details from Bookings, the Order List is not in the navigation backstack, so the pop silently failed.

**Fix:** Use `popBackStack` directly instead of the nav action, with a fallback to `orderDetailFragment` when the `orders` destination is not in the backstack.

### Test Steps

1. Open WooPOS Bookings or navigate to a Booking with an unpaid order
2. Tap "View Order" to open Order Details
3. Tap "Collect Payment"
4. Complete the flow via Cash option
5. **Expected:** Payment flow closes and Order Details is shown
6. **Verify the normal flow still works:** From the Orders list, open an unpaid order → Collect Payment → Cash → should return to the Order List

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary.