### PR TITLE
[WOOMOB-2467] Fix payment flow not navigating back from Bookings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -230,8 +230,11 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                         // We should pop the back stack to show the [OrderDetailsFragment].
                         findNavController().popBackStack()
                     } else {
-                        SelectPaymentMethodFragmentDirections.actionSelectPaymentMethodFragmentToOrderList().run {
-                            findNavController().navigateSafely(this)
+                        val popped = findNavController().popBackStack(R.id.orders, false)
+                        if (!popped) {
+                            // orders destination is not in the backstack (e.g. when navigating
+                            // from Bookings), fall back to popping to OrderDetailFragment
+                            findNavController().popBackStack(R.id.orderDetailFragment, false)
                         }
                     }
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/methodselection/SelectPaymentMethodFragment.kt
@@ -230,12 +230,7 @@ class SelectPaymentMethodFragment : BaseFragment(R.layout.fragment_select_paymen
                         // We should pop the back stack to show the [OrderDetailsFragment].
                         findNavController().popBackStack()
                     } else {
-                        val popped = findNavController().popBackStack(R.id.orders, false)
-                        if (!popped) {
-                            // orders destination is not in the backstack (e.g. when navigating
-                            // from Bookings), fall back to popping to OrderDetailFragment
-                            findNavController().popBackStack(R.id.orderDetailFragment, false)
-                        }
+                        findNavController().popBackStack(R.id.orderDetailFragment, true)
                     }
                 }
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_payment_flow.xml
@@ -38,10 +38,6 @@
             app:popUpTo="@+id/paymentsHubFragment"
             app:popUpToInclusive="false" />
         <action
-            android:id="@+id/action_selectPaymentMethodFragment_to_orderList"
-            app:popUpTo="@+id/orders"
-            app:popUpToInclusive="false" />
-        <action
             android:id="@+id/action_selectPaymentMethodFragment_to_orderDetailFragment"
             app:destination="@id/nav_graph_orders"
             app:popUpTo="@+id/tapToPaySummaryFragment"


### PR DESCRIPTION
### Description
Fixes WOOMOB-2467

When completing the Collect Payment flow (via Cash) after navigating from Bookings → View Order → Order Details, the user gets stuck on the payment method selection screen instead of navigating back.

**Root cause:** The `NavigateBackToOrderList` handler used a nav action with `popUpTo="@+id/orders"`. When the user entered Order Details from Bookings, the Order List destination is not in the navigation backstack, so the pop silently failed.

**Fix:** Replace the nav action with `popBackStack(R.id.orders)`, falling back to `popBackStack(R.id.orderDetailFragment)` when the orders destination is not found. Also removed the now-unused nav action from `nav_graph_payment_flow.xml`.

### Test Steps

**From Booking Details (phone):**
1. On a phone, open WooPOS Bookings and select an unpaid booking
2. Tap "View Order" to open Order Details
3. Tap "Collect Payment" → complete via Cash
4. Verify: payment flow closes and Order Details is shown

**From Booking Details (tablet):**
5. On a tablet, repeat steps 1-3
6. Verify: payment flow closes and Order Details is shown

**From Order Details (phone):**
7. On a phone, open the Orders list and select an unpaid order
8. Tap "Collect Payment" → complete via Cash
9. Verify: payment flow closes and the Order List is shown

**From Order Details (tablet):**
10. On a tablet, repeat steps 7-8
11. Verify: payment flow closes and Order Details is shown in the detail pane

### Images/gif

https://github.com/user-attachments/assets/8e5c1331-3c58-4a28-b663-6347f0f23a8b



- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.