### PR TITLE
[WOOMOB-2466] Fix issues found during FTS call for testing

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemSelectionViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemSelectionViewState.kt
@@ -4,14 +4,6 @@ sealed class WooPosItemSelectionViewState(
     open val id: Long,
     open val name: String
 ) {
-    val uniqueKey: String
-        get() = when (this) {
-            is Product.Simple -> "simple_$id"
-            is Product.Variable -> "variable_$id"
-            is Product.Variation -> "variation_$id"
-            is Product.VariationSearchResult -> "variation_search_$id"
-            is Coupon -> "coupon_$id"
-        }
     sealed class Product(
         override val id: Long,
         override val name: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemSelectionViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemSelectionViewState.kt
@@ -4,6 +4,14 @@ sealed class WooPosItemSelectionViewState(
     open val id: Long,
     open val name: String
 ) {
+    val uniqueKey: String
+        get() = when (this) {
+            is Product.Simple -> "simple_$id"
+            is Product.Variable -> "variable_$id"
+            is Product.Variation -> "variation_$id"
+            is Product.VariationSearchResult -> "variation_search_$id"
+            is Coupon -> "coupon_$id"
+        }
     sealed class Product(
         override val id: Long,
         override val name: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -76,15 +76,7 @@ fun WooPosItemList(
     ) {
         items(
             state.items,
-            key = { item ->
-                when (item) {
-                    is Product.Simple -> "simple_${item.id}"
-                    is Product.Variable -> "variable_${item.id}"
-                    is Product.Variation -> "variation_${item.id}"
-                    is Product.VariationSearchResult -> "variation_search_${item.id}"
-                    is Coupon -> "coupon_${item.id}"
-                }
-            }
+            key = { item -> item.uniqueKey }
         ) { posItem ->
             val itemModifier = Modifier.then(if (animateItems) Modifier.animateItem() else Modifier)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -76,7 +76,15 @@ fun WooPosItemList(
     ) {
         items(
             state.items,
-            key = { product -> product.id }
+            key = { item ->
+                when (item) {
+                    is Product.Simple -> "simple_${item.id}"
+                    is Product.Variable -> "variable_${item.id}"
+                    is Product.Variation -> "variation_${item.id}"
+                    is Product.VariationSearchResult -> "variation_search_${item.id}"
+                    is Coupon -> "coupon_${item.id}"
+                }
+            }
         ) { posItem ->
             val itemModifier = Modifier.then(if (animateItems) Modifier.animateItem() else Modifier)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -76,7 +76,7 @@ fun WooPosItemList(
     ) {
         items(
             state.items,
-            key = { item -> item.uniqueKey }
+            key = { item -> item.id }
         ) { posItem ->
             val itemModifier = Modifier.then(if (animateItems) Modifier.animateItem() else Modifier)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -188,7 +188,6 @@ private fun WooPosItemsSearchContent(
         modifier = modifier.padding(top = WooPosSpacing.Large.value),
         state = state,
         listState = listState,
-        animateItems = false,
         onItemClicked = { onUIEvent(WooPosItemsSearchUiEvent.OnItemClicked(it)) },
         onEndOfProductsListReached = { onUIEvent(WooPosItemsSearchUiEvent.OnNextPageRequested) },
         onErrorWhilePaginating = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -128,12 +128,11 @@ class WooPosItemsSearchViewModel @Inject constructor(
             setEmptySearchQueryState()
         } else {
             searchJob = viewModelScope.launch {
-                if (!skipDebounce) {
+                val isRemoteSearch = dataSource.getCurrentSyncStrategy() == SyncStrategy.REMOTE
+                if (!skipDebounce && isRemoteSearch) {
                     delay(SEARCH_DEBOUNCING_TIME)
                 }
                 if (query != currentQuery.get()) return@launch
-
-                val isRemoteSearch = dataSource.getCurrentSyncStrategy() == SyncStrategy.REMOTE
                 if (showLoadingState && isRemoteSearch &&
                     _viewState.value !is WooPosItemsSearchViewState.Content
                 ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -314,6 +314,8 @@ class WooPosItemsSearchViewModel @Inject constructor(
                         )
                     )
                 }
+
+                storeRecentSearch()
             }
 
             is WooPosItemSelectionViewState.Product.VariationSearchResult -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -127,8 +127,11 @@ class WooPosItemsSearchViewModel @Inject constructor(
         if (query.isEmpty()) {
             setEmptySearchQueryState()
         } else {
+            val isRemoteSearch = dataSource.getCurrentSyncStrategy() == SyncStrategy.REMOTE
             searchJob = viewModelScope.launch {
-                if (showLoadingState) {
+                if (showLoadingState && isRemoteSearch &&
+                    _viewState.value !is WooPosItemsSearchViewState.Content
+                ) {
                     _viewState.value = WooPosItemsSearchViewState.Loading
                 }
                 if (!skipDebounce) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -127,17 +127,18 @@ class WooPosItemsSearchViewModel @Inject constructor(
         if (query.isEmpty()) {
             setEmptySearchQueryState()
         } else {
-            val isRemoteSearch = dataSource.getCurrentSyncStrategy() == SyncStrategy.REMOTE
             searchJob = viewModelScope.launch {
+                if (!skipDebounce) {
+                    delay(SEARCH_DEBOUNCING_TIME)
+                }
+                if (query != currentQuery.get()) return@launch
+
+                val isRemoteSearch = dataSource.getCurrentSyncStrategy() == SyncStrategy.REMOTE
                 if (showLoadingState && isRemoteSearch &&
                     _viewState.value !is WooPosItemsSearchViewState.Content
                 ) {
                     _viewState.value = WooPosItemsSearchViewState.Loading
                 }
-                if (!skipDebounce) {
-                    delay(SEARCH_DEBOUNCING_TIME)
-                }
-                if (query != currentQuery.get()) return@launch
 
                 executeSearch(query, showLoadingState)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWithFts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWithFts.kt
@@ -5,7 +5,6 @@ import com.google.gson.JsonSyntaxException
 import com.google.gson.reflect.TypeToken
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilterConfig
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
-import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
@@ -15,6 +14,7 @@ import org.wordpress.android.fluxc.persistence.dao.pos.WooPosVariationsDao
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosProductEntity
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosSearchableFtsEntity
 import org.wordpress.android.fluxc.persistence.entity.pos.WooPosVariationEntity
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import javax.inject.Inject
 
 class WooPosLocalCatalogSyncWithFts @Inject constructor(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWithFts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWithFts.kt
@@ -3,7 +3,9 @@ package com.woocommerce.android.ui.woopos.localcatalog
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
 import com.google.gson.reflect.TypeToken
+import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilterConfig
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import org.wordpress.android.fluxc.store.WCProductStore.ProductFilterOption
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
@@ -19,6 +21,7 @@ class WooPosLocalCatalogSyncWithFts @Inject constructor(
     private val ftsDao: WooPosSearchableFtsDao,
     private val productsDao: WooPosProductsDao,
     private val variationsDao: WooPosVariationsDao,
+    private val filterConfig: WooPosProductsTypesFilterConfig,
     private val gson: Gson,
     private val logger: WooPosLogWrapper,
 ) {
@@ -132,22 +135,25 @@ class WooPosLocalCatalogSyncWithFts @Inject constructor(
         products: List<WooPosProductEntity>,
         variations: List<WooPosVariationEntity>
     ): List<WooPosSearchableFtsEntity> {
-        val productFtsEntities = products.map { it.toFtsEntity(siteIdString) }
+        val eligibleProducts = products.filter { it.isEligibleForFts() }
+        val eligibleVariations = variations.filter { it.isEligibleForFts() }
 
-        val productNamesMap = products.associate { it.remoteId.value to it.name }.toMutableMap()
+        val productFtsEntities = eligibleProducts.map { it.toFtsEntity(siteIdString) }
 
-        val missingParentIds = variations
+        val productNamesMap = eligibleProducts.associate { it.remoteId.value to it.name }.toMutableMap()
+
+        val missingParentIds = eligibleVariations
             .map { it.remoteProductId }
             .filter { it.value !in productNamesMap.keys }
             .distinct()
 
-        if (missingParentIds.isNotEmpty() && variations.isNotEmpty()) {
-            val localSiteId = variations.first().localSiteId
+        if (missingParentIds.isNotEmpty() && eligibleVariations.isNotEmpty()) {
+            val localSiteId = eligibleVariations.first().localSiteId
             val parentProducts = productsDao.getProductsByIds(localSiteId, missingParentIds)
             parentProducts.forEach { productNamesMap[it.remoteId.value] = it.name }
         }
 
-        val variationFtsEntities = variations.mapNotNull { variation ->
+        val variationFtsEntities = eligibleVariations.mapNotNull { variation ->
             val parentName = productNamesMap[variation.remoteProductId.value]
             if (parentName == null) {
                 logger.w(
@@ -167,13 +173,16 @@ class WooPosLocalCatalogSyncWithFts @Inject constructor(
         products: List<WooPosProductEntity>,
         variations: List<WooPosVariationEntity>
     ): List<WooPosSearchableFtsEntity> {
-        val productFtsEntities = products.map { product ->
+        val eligibleProducts = products.filter { it.isEligibleForFts() }
+        val eligibleVariations = variations.filter { it.isEligibleForFts() }
+
+        val productFtsEntities = eligibleProducts.map { product ->
             product.toFtsEntity(siteIdString)
         }
 
-        val productNamesMap = products.associate { it.remoteId.value to it.name }
+        val productNamesMap = eligibleProducts.associate { it.remoteId.value to it.name }
 
-        val variationFtsEntities = variations.mapNotNull { variation ->
+        val variationFtsEntities = eligibleVariations.mapNotNull { variation ->
             val parentName = productNamesMap[variation.remoteProductId.value]
             if (parentName == null) {
                 logger.w(
@@ -227,6 +236,17 @@ class WooPosLocalCatalogSyncWithFts @Inject constructor(
             ""
         }
     }
+
+    private val allowedStatus = filterConfig.filters[ProductFilterOption.STATUS]
+    private val allowedTypes = filterConfig.includeTypes.map { it.value }.toSet()
+    private val allowedDownloadable =
+        filterConfig.filters[ProductFilterOption.DOWNLOADABLE]?.toBoolean() ?: false
+
+    private fun WooPosProductEntity.isEligibleForFts(): Boolean =
+        status == allowedStatus && type in allowedTypes && downloadable == allowedDownloadable
+
+    private fun WooPosVariationEntity.isEligibleForFts(): Boolean =
+        status == allowedStatus && downloadable == allowedDownloadable
 
     private data class AttributeJson(
         val id: Long? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWithFts.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWithFts.kt
@@ -135,8 +135,12 @@ class WooPosLocalCatalogSyncWithFts @Inject constructor(
         products: List<WooPosProductEntity>,
         variations: List<WooPosVariationEntity>
     ): List<WooPosSearchableFtsEntity> {
-        val eligibleProducts = products.filter { it.isEligibleForFts() }
-        val eligibleVariations = variations.filter { it.isEligibleForFts() }
+        val eligibleProducts = products
+            .filter { it.isEligibleForFts() }
+            .distinctBy { it.remoteId }
+        val eligibleVariations = variations
+            .filter { it.isEligibleForFts() }
+            .distinctBy { it.remoteVariationId }
 
         val productFtsEntities = eligibleProducts.map { it.toFtsEntity(siteIdString) }
 
@@ -173,8 +177,12 @@ class WooPosLocalCatalogSyncWithFts @Inject constructor(
         products: List<WooPosProductEntity>,
         variations: List<WooPosVariationEntity>
     ): List<WooPosSearchableFtsEntity> {
-        val eligibleProducts = products.filter { it.isEligibleForFts() }
-        val eligibleVariations = variations.filter { it.isEligibleForFts() }
+        val eligibleProducts = products
+            .filter { it.isEligibleForFts() }
+            .distinctBy { it.remoteId }
+        val eligibleVariations = variations
+            .filter { it.isEligibleForFts() }
+            .distinctBy { it.remoteVariationId }
 
         val productFtsEntities = eligibleProducts.map { product ->
             product.toFtsEntity(siteIdString)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModelTest.kt
@@ -428,13 +428,11 @@ class WooPosItemsSearchViewModelTest {
 
         // THEN
         viewModel.viewState.test {
-            skipItems(1) // Skip initial EmptySearchQuery state
-
-            advanceUntilIdle()
-
             val cachedState = awaitItem() as WooPosItemsSearchViewState.Content
             assertThat(cachedState.items).hasSize(1)
             assertThat((cachedState.items[0] as Product.Simple).name).isEqualTo("Cached Product")
+
+            advanceUntilIdle()
 
             val remoteState = awaitItem() as WooPosItemsSearchViewState.Content
             assertThat(remoteState.items).hasSize(1)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWithFtsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncWithFtsTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.localcatalog
 
 import com.google.gson.Gson
+import com.woocommerce.android.ui.woopos.common.data.WooPosProductsTypesFilterConfig
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -28,6 +29,7 @@ class WooPosLocalCatalogSyncWithFtsTest : BaseUnitTest() {
     private val ftsDao: WooPosSearchableFtsDao = mock()
     private val productsDao: WooPosProductsDao = mock()
     private val variationsDao: WooPosVariationsDao = mock()
+    private val filterConfig = WooPosProductsTypesFilterConfig()
     private val gson = Gson()
     private val logger: WooPosLogWrapper = mock()
 
@@ -39,6 +41,7 @@ class WooPosLocalCatalogSyncWithFtsTest : BaseUnitTest() {
             ftsDao = ftsDao,
             productsDao = productsDao,
             variationsDao = variationsDao,
+            filterConfig = filterConfig,
             gson = gson,
             logger = logger
         )
@@ -79,7 +82,7 @@ class WooPosLocalCatalogSyncWithFtsTest : BaseUnitTest() {
     fun `given products with variations, when syncFtsForFullSync, then includes parent name and attributes`() =
         testBlocking {
             // GIVEN
-            val products = listOf(createProduct(1, "Gant T-Shirt", "SKU-001", ""))
+            val products = listOf(createProduct(1, "Gant T-Shirt", "SKU-001", "", type = "variable"))
             val variations = listOf(
                 createVariation(
                     variationId = 10,
@@ -368,13 +371,17 @@ class WooPosLocalCatalogSyncWithFtsTest : BaseUnitTest() {
         id: Long,
         name: String,
         sku: String,
-        barcode: String
+        barcode: String,
+        type: String = "simple",
+        status: String = "publish"
     ) = WooPosProductEntity(
         localSiteId = LocalId(1),
         remoteId = RemoteId(id),
         name = name,
         sku = sku,
-        globalUniqueId = barcode
+        globalUniqueId = barcode,
+        type = type,
+        status = status
     )
 
     private fun createVariation(
@@ -382,13 +389,15 @@ class WooPosLocalCatalogSyncWithFtsTest : BaseUnitTest() {
         productId: Long,
         sku: String,
         barcode: String,
-        attributesJson: String
+        attributesJson: String,
+        status: String = "publish"
     ) = WooPosVariationEntity(
         localSiteId = LocalId(1),
         remoteProductId = RemoteId(productId),
         remoteVariationId = RemoteId(variationId),
         sku = sku,
         globalUniqueId = barcode,
-        attributesJson = attributesJson
+        attributesJson = attributesJson,
+        status = status
     )
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2466

Fixes 4 issues found during the pdfdoF-8Nh-p2 for POS FTS search on Android:

1. **Crash: duplicate LazyColumn keys** — search results could contain items with the same numeric ID across different types (e.g. variable product and variation). Fixed by using composite keys with type prefix (`simple_123`, `variation_search_456`) @staskus could you please validate this one? I could not reproduce this as I probably don't have overlaps in the ids in my stores

2. **Search results not filtered by product_type and status** — FTS index included grouped and draft products. Fixed by filtering at index build time, matching iOS approach. Uses `WooPosProductsTypesFilterConfig` as single source of truth.

3. **Recent searches not saved for variable products** — when tapping a variable product in search, the toolbar state switched to VariationList before the search could be saved. Fixed by saving the search at tap time.

4. **Search UX improvements** — skip full-screen loading state for local FTS search (results are fast enough). Skip debounce for FTS. Enable item animations in search results list so items animate in/out as results change. @malinajirka wdyt about that?

### Test Steps
1. Search for a term that returns many results and scroll down — no crash
2. Search for a grouped or draft product — it should not appear in results
3. Search for a product, tap a variable product, go back — the search term should appear in recent searches
4. Type in search — results should appear immediately without loading flicker (local catalog mode)
5. Verify remote search still shows loading state when local cache is empty

### Images/gif

https://github.com/user-attachments/assets/00f8b53d-191c-4aba-9772-91f5aea664d8



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.