### PR TITLE
[WOOMOB-2472] Apply booking filters on Today and Upcoming tabs

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -338,7 +338,7 @@ class BookingListViewModel @Inject constructor(
 
     private fun FetchParams.prepareFilters(): BookingFilters = when (selectedTab) {
         BookingListTab.Today,
-        BookingListTab.Upcoming -> BookingFilters(
+        BookingListTab.Upcoming -> filters.copy(
             dateRange = dateFilterBuilder.prepareDateFilter(selectedTab, filters.dateRange),
             excludedBookingStatuses = ExcludedBookingStatuses(setOf(Cancelled, Complete))
         )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -363,6 +363,54 @@ class BookingListViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given Today tab, when filters are changed, then bookings are refetched with filters`() = testBlocking {
+        // GIVEN
+        setup()
+
+        // WHEN
+        val customerFilter = BookingsFilterOption.Customer(1L, "Customer")
+        bookingFiltersFlow.emit(
+            BookingFilters(customer = customerFilter)
+        )
+        advanceUntilIdle()
+
+        // THEN
+        verify(bookingListHandler).loadBookings(
+            searchQuery = anyOrNull(),
+            filters = argThat { customer == customerFilter },
+            sortBy = any()
+        )
+    }
+
+    @Test
+    fun `given Upcoming tab, when filters are changed, then bookings are refetched with filters`() = testBlocking {
+        // GIVEN
+        setup()
+        val initialState = viewModel.state.getOrAwaitValue()
+        initialState.tabState.onTabChanged(BookingListTab.Upcoming)
+        advanceUntilIdle()
+
+        // WHEN
+        val customerFilter = BookingsFilterOption.Customer(1L, "Customer")
+        bookingFiltersFlow.emit(
+            BookingFilters(customer = customerFilter)
+        )
+        advanceUntilIdle()
+
+        // THEN
+        verify(bookingListHandler).loadBookings(
+            searchQuery = anyOrNull(),
+            filters = argThat {
+                customer == customerFilter &&
+                    excludedBookingStatuses == BookingsFilterOption.ExcludedBookingStatuses(
+                        setOf(BookingEntity.Status.Cancelled, BookingEntity.Status.Complete)
+                    )
+            },
+            sortBy = any()
+        )
+    }
+
+    @Test
     fun `given enabled filters, when controls state is observed, then enabledFiltersCount is correct`() = testBlocking {
         // GIVEN
         setup()


### PR DESCRIPTION
### Description
Fixes WOOMOB-2472

User-selected filters (team members, customer, attendance status, service/events, etc.) were only applied on the **All** tab. The **Today** and **Upcoming** tabs discarded all user-selected filters because `prepareFilters()` was constructing a new `BookingFilters` object instead of copying the existing user filters.

- Changed `BookingFilters(` to `filters.copy(` for Today/Upcoming tabs so user-selected filters are preserved
- Tab-specific overrides (`dateRange` and `excludedBookingStatuses`) are still applied as before

### Test Steps
1. Open the Bookings screen on the **Today** tab
2. Tap the filter button and select a filter (e.g., a specific team member or customer)
3. Verify the booking list is filtered correctly
4. Switch to the **Upcoming** tab
5. Verify the filters are still applied (same filtered results, not all bookings)
6. Switch to the **All** tab and verify filters still work as before
7. Clear filters and verify all tabs show unfiltered results

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.