### PR TITLE
[CIAB] Bypass woocommerce_is_active on CIAB sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsEvent.BACK_PRESSED
 import com.woocommerce.android.analytics.AnalyticsEvent.VIEW_SHOWN
-import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.PackageUtils

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeper.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ciab
 
-import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.tools.SelectedSite
 import javax.inject.Inject
 
@@ -22,8 +21,4 @@ class CIABSiteGateKeeper @Inject constructor(private val selectedSite: SelectedS
 
     fun isCurrentSiteCIAB(): Boolean =
         selectedSite.getOrNull()?.isCIABSite() ?: false
-
-    companion object Companion {
-        const val CIAB_GARDEN_NAME = "commerce"
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/SiteModelExt.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.extensions
 
 import android.text.TextUtils
-import com.woocommerce.android.ciab.CIABSiteGateKeeper.Companion.CIAB_GARDEN_NAME
 import com.woocommerce.android.ui.plans.domain.FREE_TRIAL_PLAN_ID
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.fluxc.model.SiteModel
@@ -79,5 +78,3 @@ val SiteModel?.isSitePublic: Boolean
 
 val SiteModel.isEligibleForAI: Boolean
     get() = isWPComAtomic || planActiveFeatures.orEmpty().contains("ai-assistant")
-
-fun SiteModel.isCIABSite() = isGardenSite && gardenName == CIAB_GARDEN_NAME

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -4,7 +4,6 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.tools.SelectedSite
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibility.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibility.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.bookings.tab
 
 import com.woocommerce.android.di.AppCoroutineScope
-import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.extensions.onFirst
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.bookings.BookingsRepository

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel.kt
@@ -24,7 +24,6 @@ import com.woocommerce.android.extensions.clearList
 import com.woocommerce.android.extensions.containsItem
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.getList
-import com.woocommerce.android.extensions.isCIABSite
 import com.woocommerce.android.extensions.isEligibleForAI
 import com.woocommerce.android.extensions.isEmpty
 import com.woocommerce.android.extensions.isSitePublic

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABSiteGateKeeperTest.kt
@@ -28,12 +28,12 @@ class CIABSiteGateKeeperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given current site is CIAB, when checking WooPayments support, then feature is supported`() {
+    fun `when checking WooPayments support, then feature is always supported`() {
         assertTrue(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.WooPayments))
     }
 
     @Test
-    fun `given current site is CIAB, when checking POS support, then feature is supported`() {
+    fun `when checking POS support, then feature is always supported`() {
         assertTrue(ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.POS))
     }
 
@@ -50,7 +50,7 @@ class CIABSiteGateKeeperTest : BaseUnitTest() {
     private fun createSite(isCIAB: Boolean): SiteModel {
         return SiteModel().apply {
             setIsGardenSite(isCIAB)
-            this.gardenName = if (isCIAB) CIABSiteGateKeeper.CIAB_GARDEN_NAME else null
+            this.gardenName = if (isCIAB) SiteModel.CIAB_GARDEN_NAME else null
         }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/tab/ObserveBookingsVisibilityTest.kt
@@ -216,12 +216,12 @@ class ObserveBookingsVisibilityTest : BaseUnitTest() {
 
     private fun ciabSite(): SiteModel = SiteModel().apply {
         setIsGardenSite(true)
-        gardenName = "commerce"
+        gardenName = SiteModel.CIAB_GARDEN_NAME
     }
 
     private fun nonCiabSite(): SiteModel = SiteModel().apply {
         setIsGardenSite(false)
-        gardenName = "commerce"
+        gardenName = SiteModel.CIAB_GARDEN_NAME
     }
 
     private fun nonCommerceGardenSite(): SiteModel = SiteModel().apply {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -5,7 +5,6 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
-import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.media.MediaFilesRepository
 import com.woocommerce.android.media.ProductImagesServiceWrapper
@@ -1515,7 +1514,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         whenever(selectedSite.get()).thenReturn(
             SiteModel().apply {
                 setIsGardenSite(true)
-                gardenName = CIABSiteGateKeeper.CIAB_GARDEN_NAME
+                gardenName = SiteModel.CIAB_GARDEN_NAME
             }
         )
         savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID))
@@ -1545,7 +1544,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
             whenever(selectedSite.get()).thenReturn(
                 SiteModel().apply {
                     setIsGardenSite(true)
-                    gardenName = CIABSiteGateKeeper.CIAB_GARDEN_NAME
+                    gardenName = SiteModel.CIAB_GARDEN_NAME
                 }
             )
             savedState = ProductDetailFragmentArgs(ProductDetailFragment.Mode.ShowProduct(PRODUCT_REMOTE_ID))

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/model/site/SiteModelTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/model/site/SiteModelTest.kt
@@ -172,4 +172,34 @@ class SiteModelTest {
             if (enableShareButtonsSupport) activeModules = SiteModel.ACTIVE_MODULES_KEY_SHARING_BUTTONS
         }
     }
+
+    /* isCIABSite */
+    @Test
+    fun `given commerce garden site, when checking isCIABSite, then returns true`() {
+        val site = SiteModel().apply {
+            setIsGardenSite(true)
+            gardenName = SiteModel.CIAB_GARDEN_NAME
+        }
+
+        assertTrue(site.isCIABSite)
+    }
+
+    @Test
+    fun `given non-commerce garden site, when checking isCIABSite, then returns false`() {
+        val site = SiteModel().apply {
+            setIsGardenSite(true)
+            gardenName = "other"
+        }
+
+        assertFalse(site.isCIABSite)
+    }
+
+    @Test
+    fun `given non-garden site, when checking isCIABSite, then returns false`() {
+        val site = SiteModel().apply {
+            setIsGardenSite(false)
+        }
+
+        assertFalse(site.isCIABSite)
+    }
 }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -701,6 +701,43 @@ class SiteRestClientTest {
         )
     }
 
+    @Test
+    fun `given CIAB site with woocommerce inactive, when fetching site, then hasWooCommerce is true`() = test {
+        val response = SiteWPComRestResponse().apply {
+            ID = siteId
+            URL = "site.com"
+            options = SiteWPComRestResponse.Options().apply {
+                woocommerce_is_active = false
+            }
+            is_garden = true
+            garden_name = SiteModel.CIAB_GARDEN_NAME
+        }
+
+        initSiteResponse(response)
+
+        val responseModel = restClient.fetchSite(site)
+        assertThat(responseModel.hasWooCommerce).isTrue()
+    }
+
+    @Test
+    fun `given non-CIAB garden site with woocommerce inactive, when fetching site, then hasWooCommerce is false`() =
+        test {
+            val response = SiteWPComRestResponse().apply {
+                ID = siteId
+                URL = "site.com"
+                options = SiteWPComRestResponse.Options().apply {
+                    woocommerce_is_active = false
+                }
+                is_garden = true
+                garden_name = "other"
+            }
+
+            initSiteResponse(response)
+
+            val responseModel = restClient.fetchSite(site)
+            assertThat(responseModel.hasWooCommerce).isFalse()
+        }
+
     private suspend fun initSiteResponse(
         data: SiteWPComRestResponse? = null,
         error: WPComGsonNetworkError? = null

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -6,6 +6,12 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.yarolegovich.wellsql.core.Identifiable;
+import com.yarolegovich.wellsql.core.annotation.Column;
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.RawConstraints;
+import com.yarolegovich.wellsql.core.annotation.Table;
+
 import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId;
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId;
@@ -19,12 +25,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Objects;
-
-import com.yarolegovich.wellsql.core.Identifiable;
-import com.yarolegovich.wellsql.core.annotation.Column;
-import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
-import com.yarolegovich.wellsql.core.annotation.RawConstraints;
-import com.yarolegovich.wellsql.core.annotation.Table;
 
 // WARN: This class is used within WordPress-MediaPicker-Android, do not remove!
 @Table
@@ -46,6 +46,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public static final String ACTIVE_MODULES_KEY_PUBLICIZE = "publicize";
     public static final String ACTIVE_MODULES_KEY_SHARING_BUTTONS = "sharedaddy";
+    public static final String CIAB_GARDEN_NAME = "commerce";
 
     @PrimaryKey
     @Column
@@ -1147,6 +1148,10 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
 
     public boolean isGardenSite() {
         return mIsGardenSite;
+    }
+
+    public boolean isCIABSite() {
+        return mIsGardenSite && CIAB_GARDEN_NAME.equals(mGardenName);
     }
 
     public void setIsGardenSite(boolean mIsGardenSite) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1141,6 +1141,11 @@ class SiteRestClient @Inject constructor(
         site.gardenName = from.garden_name
         site.gardenPartner = from.garden_partner
 
+        // CIAB sites always have WooCommerce, even if the API reports otherwise
+        if (from.is_garden && from.garden_name == SiteModel.CIAB_GARDEN_NAME) {
+            site.hasWooCommerce = true
+        }
+
         return site
     }
 


### PR DESCRIPTION
Closes: WOOMOB-2474

## Description

On CIAB (Commerce-in-a-Box) commerce garden sites, the API may report `woocommerce_is_active` as `false` even though WooCommerce is always present. This causes the app to hide these sites from the site picker, block login, or log users out.

**Fix:** At the network parsing layer (`SiteRestClient.responseToSiteModel()`), force `hasWooCommerce = true` when the site is a CIAB commerce garden site (`is_garden == true && garden_name == "commerce"`).

Also consolidates `isCIABSite()` and `CIAB_GARDEN_NAME` into `SiteModel` (FluxC layer), removing the duplicated app-layer extension function and constant.

## Test Steps

1. Use a CIAB commerce garden site where the API returns `woocommerce_is_active = false`
2. Verify the site appears in the site picker and can be selected
3. Verify the dashboard and orders screen load correctly

<details>
<summary>Alternative: simulate woocommerce_is_active = false locally</summary>

If you don't have a CIAB site that returns `woocommerce_is_active = false`, apply this patch to force it:

```diff
diff --git a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1015,1 +1015,1 @@
-            site.hasWooCommerce = from.options.woocommerce_is_active
+            site.hasWooCommerce = false // Force woocommerce_is_active = false for testing
```

With this patch on a CIAB site, verify the site still appears and works. Then remove the patch.

</details>

## Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
