### PR TITLE
Handle isCommerceGarden in login flow — hide site credentials for CIAB sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.annotation.VisibleForTesting
 import android.view.MenuItem
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.SystemBarStyle
@@ -1082,8 +1083,9 @@ class LoginActivity :
         show(currentFragment.childFragmentManager, tag)
     }
 
+    @VisibleForTesting
     @Parcelize
-    private data class ConnectSiteInfo(
+    internal data class ConnectSiteInfo(
         val isWPCom: Boolean,
         val isCommerceGarden: Boolean,
         val isJetpackConnected: Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -623,7 +623,7 @@ class LoginActivity :
         val protocolRegex = Regex("^(http[s]?://)", IGNORE_CASE)
         val siteAddressClean = inputSiteAddress.replaceFirst(protocolRegex, "")
         appPrefsWrapper.setLoginSiteAddress(siteAddressClean)
-        if (result.hasJetpack || connectSiteInfo?.isWPCom == true) {
+        if (result.hasJetpack || connectSiteInfo?.shouldUseWPComAuth == true) {
             showEmailLoginScreen(null)
         } else {
             appPrefsWrapper.isSiteWPComSuspended = result.isWPComSuspended
@@ -882,7 +882,7 @@ class LoginActivity :
         } else {
             val loginEmailFragment = getLoginEmailFragment(
                 siteCredsLayout = false
-            ) ?: WooLoginEmailFragment.newInstance(showSiteCredentialsFallback = connectSiteInfo?.isWPCom == false)
+            ) ?: WooLoginEmailFragment.newInstance(showSiteCredentialsFallback = connectSiteInfo?.shouldUseWPComAuth == false)
             changeFragment(loginEmailFragment as Fragment, true, LoginEmailFragment.TAG)
         }
     }
@@ -997,6 +997,7 @@ class LoginActivity :
             event.info.let {
                 ConnectSiteInfo(
                     isWPCom = it.isWPCom,
+                    isCommerceGarden = it.isCommerceGarden,
                     isJetpackConnected = it.isJetpackConnected,
                     isJetpackActive = it.isJetpackActive
                 )
@@ -1084,7 +1085,11 @@ class LoginActivity :
     @Parcelize
     private data class ConnectSiteInfo(
         val isWPCom: Boolean,
+        val isCommerceGarden: Boolean,
         val isJetpackConnected: Boolean,
         val isJetpackActive: Boolean
-    ) : Parcelable
+    ) : Parcelable {
+        val shouldUseWPComAuth: Boolean
+            get() = isWPCom || isCommerceGarden
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/ConnectSiteInfoTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/ConnectSiteInfoTest.kt
@@ -1,0 +1,70 @@
+package com.woocommerce.android.ui.login
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ConnectSiteInfoTest {
+    @Test
+    fun `when site is commerce garden, then should use WPCom auth`() {
+        val siteInfo = LoginActivity.ConnectSiteInfo(
+            isWPCom = false,
+            isCommerceGarden = true,
+            isJetpackConnected = false,
+            isJetpackActive = false
+        )
+
+        assertThat(siteInfo.shouldUseWPComAuth).isTrue
+    }
+
+    @Test
+    fun `when site is WPCom, then should use WPCom auth`() {
+        val siteInfo = LoginActivity.ConnectSiteInfo(
+            isWPCom = true,
+            isCommerceGarden = false,
+            isJetpackConnected = false,
+            isJetpackActive = false
+        )
+
+        assertThat(siteInfo.shouldUseWPComAuth).isTrue
+    }
+
+    @Test
+    fun `when site is self-hosted Jetpack, then should not use WPCom auth`() {
+        val siteInfo = LoginActivity.ConnectSiteInfo(
+            isWPCom = false,
+            isCommerceGarden = false,
+            isJetpackConnected = true,
+            isJetpackActive = true
+        )
+
+        assertThat(siteInfo.shouldUseWPComAuth).isFalse
+    }
+
+    @Test
+    fun `when site is commerce garden, then site credentials fallback is hidden`() {
+        val siteInfo = LoginActivity.ConnectSiteInfo(
+            isWPCom = false,
+            isCommerceGarden = true,
+            isJetpackConnected = false,
+            isJetpackActive = false
+        )
+
+        val showSiteCredentialsFallback = !siteInfo.shouldUseWPComAuth
+
+        assertThat(showSiteCredentialsFallback).isFalse
+    }
+
+    @Test
+    fun `when site is self-hosted Jetpack, then site credentials fallback is shown`() {
+        val siteInfo = LoginActivity.ConnectSiteInfo(
+            isWPCom = false,
+            isCommerceGarden = false,
+            isJetpackConnected = true,
+            isJetpackActive = true
+        )
+
+        val showSiteCredentialsFallback = !siteInfo.shouldUseWPComAuth
+
+        assertThat(showSiteCredentialsFallback).isTrue
+    }
+}

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -606,54 +606,6 @@ class SiteRestClientTest {
     }
 
     @Test
-    fun `given a commerce garden site, when fetching site info, then isCommerceGarden is true`() = test {
-        val urlUtilsMock = mockStatic(UrlUtils::class.java)
-        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
-        val siteInfoResponse = ConnectSiteInfoResponse().apply {
-            exists = true
-            isWordPress = true
-            hasJetpack = true
-            isJetpackActive = true
-            isJetpackConnected = true
-            isWordPressDotCom = false
-            isCommerceGarden = true
-            urlAfterRedirects = "https://example-garden-site.com"
-        }
-        initGetResponse(ConnectSiteInfoResponse::class.java, siteInfoResponse)
-
-        val result = restClient.fetchConnectSiteInfoSync("example-garden-site.com")
-
-        assertThat(result.error).isNull()
-        assertThat(result.isCommerceGarden).isTrue
-        assertThat(result.isWPCom).isFalse
-        urlUtilsMock.close()
-    }
-
-    @Test
-    fun `given a non-commerce-garden site, when fetching site info, then isCommerceGarden is false`() = test {
-        val urlUtilsMock = mockStatic(UrlUtils::class.java)
-        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
-        val siteInfoResponse = ConnectSiteInfoResponse().apply {
-            exists = true
-            isWordPress = true
-            hasJetpack = true
-            isJetpackActive = true
-            isJetpackConnected = true
-            isWordPressDotCom = true
-            isCommerceGarden = false
-            urlAfterRedirects = "https://example.wordpress.com"
-        }
-        initGetResponse(ConnectSiteInfoResponse::class.java, siteInfoResponse)
-
-        val result = restClient.fetchConnectSiteInfoSync("example.wordpress.com")
-
-        assertThat(result.error).isNull()
-        assertThat(result.isCommerceGarden).isFalse
-        assertThat(result.isWPCom).isTrue
-        urlUtilsMock.close()
-    }
-
-    @Test
     fun `given a Jetpack site, when fetching site info, then fetch app passwords url from root endpoint`() = test {
         initSiteResponse(
             SiteWPComRestResponse().apply {

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClientTest.kt
@@ -606,6 +606,54 @@ class SiteRestClientTest {
     }
 
     @Test
+    fun `given a commerce garden site, when fetching site info, then isCommerceGarden is true`() = test {
+        val urlUtilsMock = mockStatic(UrlUtils::class.java)
+        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
+        val siteInfoResponse = ConnectSiteInfoResponse().apply {
+            exists = true
+            isWordPress = true
+            hasJetpack = true
+            isJetpackActive = true
+            isJetpackConnected = true
+            isWordPressDotCom = false
+            isCommerceGarden = true
+            urlAfterRedirects = "https://example-garden-site.com"
+        }
+        initGetResponse(ConnectSiteInfoResponse::class.java, siteInfoResponse)
+
+        val result = restClient.fetchConnectSiteInfoSync("example-garden-site.com")
+
+        assertThat(result.error).isNull()
+        assertThat(result.isCommerceGarden).isTrue
+        assertThat(result.isWPCom).isFalse
+        urlUtilsMock.close()
+    }
+
+    @Test
+    fun `given a non-commerce-garden site, when fetching site info, then isCommerceGarden is false`() = test {
+        val urlUtilsMock = mockStatic(UrlUtils::class.java)
+        whenever(UrlUtils.addUrlSchemeIfNeeded(any(), any())).thenAnswer { it.arguments[0] as String }
+        val siteInfoResponse = ConnectSiteInfoResponse().apply {
+            exists = true
+            isWordPress = true
+            hasJetpack = true
+            isJetpackActive = true
+            isJetpackConnected = true
+            isWordPressDotCom = true
+            isCommerceGarden = false
+            urlAfterRedirects = "https://example.wordpress.com"
+        }
+        initGetResponse(ConnectSiteInfoResponse::class.java, siteInfoResponse)
+
+        val result = restClient.fetchConnectSiteInfoSync("example.wordpress.com")
+
+        assertThat(result.error).isNull()
+        assertThat(result.isCommerceGarden).isFalse
+        assertThat(result.isWPCom).isTrue
+        urlUtilsMock.close()
+    }
+
+    @Test
     fun `given a Jetpack site, when fetching site info, then fetch app passwords url from root endpoint`() = test {
         initSiteResponse(
             SiteWPComRestResponse().apply {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/ConnectSiteInfoResponse.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/ConnectSiteInfoResponse.java
@@ -9,6 +9,6 @@ public class ConnectSiteInfoResponse implements Response {
     public boolean isJetpackActive;
     public boolean isJetpackConnected;
     public boolean isWordPressDotCom; // CHECKSTYLE IGNORE
-    public boolean isCommerceGarden; // CHECKSTYLE IGNORE
+    public boolean isCommerceGarden;
     public String urlAfterRedirects;
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/ConnectSiteInfoResponse.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/ConnectSiteInfoResponse.java
@@ -9,5 +9,6 @@ public class ConnectSiteInfoResponse implements Response {
     public boolean isJetpackActive;
     public boolean isJetpackConnected;
     public boolean isWordPressDotCom; // CHECKSTYLE IGNORE
+    public boolean isCommerceGarden; // CHECKSTYLE IGNORE
     public String urlAfterRedirects;
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -573,6 +573,7 @@ class SiteRestClient @Inject constructor(
                 isJetpackActive,
                 isJetpackConnected,
                 isWordPressDotCom, // CHECKSTYLE IGNORE
+                isCommerceGarden,
                 urlAfterRedirects
             )
         }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -326,6 +326,7 @@ open class SiteStore @Inject constructor(
         @JvmField val isJetpackActive: Boolean = false,
         @JvmField val isJetpackConnected: Boolean = false,
         @JvmField val isWPCom: Boolean = false,
+        @JvmField val isCommerceGarden: Boolean = false,
         @JvmField val urlAfterRedirects: String? = null
     ) : Payload<SiteError>() {
         constructor(url: String, error: SiteError?) : this(url) {


### PR DESCRIPTION
## Description

Commerce Garden (CIAB) sites are not detected as WP.com sites (`isWordPressDotCom: false`), so users were incorrectly offered site credentials login, which would fail. This PR adds support for the new `isCommerceGarden` boolean from the `connect/site-info` API response and treats it the same as `isWordPressDotCom` for login routing.

Closes: WOOMOB-2477

### Changes

- **`ConnectSiteInfoResponse`**: Added `isCommerceGarden` boolean field to the API response DTO
- **`ConnectSiteInfoPayload`** (SiteStore): Added `isCommerceGarden` field to the payload data class
- **`SiteRestClient`**: Maps `isCommerceGarden` from the API response to the payload
- **`LoginActivity`**: 
  - Added `isCommerceGarden` to the `ConnectSiteInfo` parcelable
  - Added `shouldUseWPComAuth` computed property that checks `isWPCom || isCommerceGarden`
  - Updated login routing logic and site credentials fallback visibility to use `shouldUseWPComAuth`

## Test Steps

1. Enter a Commerce Garden site URL → should be routed to WP.com login, site credentials option should be hidden (for example: https://woo-speedily-maximum-connoisseur.wordpress.com/)
2. Enter a regular WP.com site URL → behavior should remain unchanged (for example: https://devotedly-inner-color.commerce-garden.com/)
3. Enter a self-hosted Jetpack site URL → behavior should remain unchanged (site credentials shown). Use for example: https://easyclothes.mystagingwebsite.com

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
