### PR TITLE
[WOOMOB-2480] Fix symbol-only FTS search showing error instead of empty results

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -145,9 +145,7 @@ class WooPosLocalCatalogStore @Inject constructor(
         coroutineEngine.withDefaultContext(API, this, "searchProductsFts") {
             val ftsQuery = formatFtsQuery(searchQuery)
             if (ftsQuery.isBlank()) {
-                return@withDefaultContext Result.failure(
-                    IllegalArgumentException("Search query is blank after formatting")
-                )
+                return@withDefaultContext Result.success(emptyList())
             }
 
             val ftsResults = posFtsDao.search(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreFtsTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/pos/WooPosLocalCatalogStoreFtsTest.kt
@@ -69,13 +69,23 @@ class WooPosLocalCatalogStoreFtsTest {
     }
 
     @Test
-    fun `given blank query, when searching fts, then returns failure`() = runTest {
+    fun `given blank query, when searching fts, then returns empty list`() = runTest {
         // WHEN
         val result = store.searchProductsFts(siteId, "  ")
 
         // THEN
-        assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEmpty()
+    }
+
+    @Test
+    fun `given symbol-only query, when searching fts, then returns empty list`() = runTest {
+        // WHEN
+        val result = store.searchProductsFts(siteId, "-!@#$")
+
+        // THEN
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixes WOOMOB-2480

When searching for symbol-only queries (like `-`, `!`, `@`, `#`, `$`) in POS, the UNICODE61 tokenizer strips all non-letter/non-digit characters, producing a blank formatted query. Previously this returned `Result.failure`, which propagated as "Unable to load products" error. Now it returns an empty success so the UI correctly shows "No search results".

### Test Steps
1. Open POS and go to the product search
2. Search for `-` or `!` or `@#$`
3. Verify it shows "No search results" instead of "Unable to load products"
4. Search for `t-shirt` — verify it still finds products as before

### Images/gif

https://github.com/user-attachments/assets/efc2eb4c-29be-4332-b0d2-0de3e1e014b2



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.