### PR TITLE
Fix NPE on back press in missing store address card reader flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
@@ -42,7 +42,11 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
             R.id.woopos_card_reader_nav_host_fragment
         ) as NavHostFragment
 
-        val flowType = intent.parcelable<FlowType>(FLOW_TYPE_KEY)!!
+        val flowType = intent.parcelable<FlowType>(FLOW_TYPE_KEY)
+        if (flowType == null) {
+            finish()
+            return
+        }
         setupNavGraph(navHostFragment, flowType)
         observeResult(navHostFragment, flowType)
     }


### PR DESCRIPTION
WOOMOB-2481

### Description

When navigating back from the "Enter Address" web view during card reader connection with a missing store address, NavController's `navigateUp()` fallback relaunches `WooPosCardReaderActivity` via an implicit deep link intent — without the required `FLOW_TYPE_KEY` extra. The force-unwrap (`!!`) on the missing extra causes an NPE crash.

**Fix:** Replace `!!` with a null check — if `flowType` is null (unexpected relaunch), `finish()` the activity immediately and return.

Note: There is a preexisting issue, where we sometime end up with a transparent overlay when we navigate away from the connection flow, and we need to tap on back again. Considering this has been there since the beginning of the POS and it's edge case which doesn't block users, I wouldn't worry about it for now.

### Test Steps

1. Open POS
2. Open Bokings
3. Open unpaid booking
4. Tap on Collect Payment → trigger card reader connection with a missing store address (you can use the patch below to enforce it)
5. Tap "Enter Address" to navigate to the web view
6. Press back — the app should **not crash** and should return gracefully

```
Index: WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt	(revision 3778c0fdb786dbc59eb0d700128621c97aa41e78)
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt	(date 1773327832739)
@@ -58,6 +58,7 @@
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectViewState.MissingMerchantAddressError
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectViewState.MultipleExternalReadersFoundState
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderConnectViewState.ScanningFailedState
+import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderLocationRepository.LocationIdFetchingResult
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType.BUILT_IN
@@ -438,21 +439,7 @@
     private fun connectToReader(cardReader: CardReader) {
         launch {
             cardReaderTrackingInfoKeeper.setCardReaderModel(cardReader.type)
-            val cardReaderLocationId = cardReader.locationId
-            if (cardReaderLocationId != null) {
-                cardReaderManager.startConnectionToReader(cardReader, cardReaderLocationId)
-            } else {
-                when (val result = locationRepository.getDefaultLocationId(getPaymentPluginType())) {
-                    is CardReaderLocationRepository.LocationIdFetchingResult.Success -> {
-                        tracker.trackFetchingLocationSucceeded()
-                        cardReaderManager.startConnectionToReader(cardReader, result.locationId)
-                    }
-
-                    is CardReaderLocationRepository.LocationIdFetchingResult.Error -> {
-                        handleLocationFetchingError(result)
-                    }
-                }
-            }
+            handleLocationFetchingError(LocationIdFetchingResult.Error.MissingAddress("https://google.com"))
         }
     }
 
@@ -499,8 +486,10 @@
         val hintLabel = when (errorCode) {
             CardReaderStatus.NotConnected.ErrorCode.BATTERY_CRITICALLY_LOW ->
                 R.string.card_reader_connect_failed_battery_low_hint
+
             CardReaderStatus.NotConnected.ErrorCode.BLUETOOTH_PEER_REMOVED_PAIRING ->
                 R.string.card_reader_connect_failed_bluetooth_pairing_removed_hint
+
             CardReaderStatus.NotConnected.ErrorCode.OTHER -> null
             null -> null
         }
```

### Images/gif

N/A — crash fix, no UI changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.