### PR TITLE
[Woo POS][Refunds] Fix refund time showing 12:00 AM instead of actual time

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/RefundMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/RefundMapperTest.kt
@@ -1,13 +1,64 @@
 package com.woocommerce.android.model
 
+import com.google.gson.Gson
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.wordpress.android.fluxc.model.metadata.WCMetaData
 import org.wordpress.android.fluxc.model.metadata.WCMetaDataValue
+import org.wordpress.android.fluxc.model.refunds.RefundMapper
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient.RefundResponse
 import java.math.BigDecimal
+import java.util.Calendar
 
 class RefundMapperTest {
+    private val refundMapper = RefundMapper(Gson())
+
+    @Test
+    fun `when mapping refund response with datetime, then dateCreated preserves the time`() {
+        val response = RefundResponse(
+            refundId = 1L,
+            dateCreated = "2024-01-15T14:30:00",
+            amount = "10.00",
+            reason = "test",
+            refundedPayment = false,
+            items = null,
+            shippingLineItems = null,
+            feeLineItems = null
+        )
+
+        val model = refundMapper.toModel(response)
+
+        val calendar = Calendar.getInstance().apply {
+            time = model.dateCreated
+        }
+        assertEquals(14, calendar.get(Calendar.HOUR_OF_DAY))
+        assertEquals(30, calendar.get(Calendar.MINUTE))
+    }
+
+    @Test
+    fun `when mapping refund response with date only, then dateCreated is parsed correctly`() {
+        val response = RefundResponse(
+            refundId = 1L,
+            dateCreated = "2024-01-15",
+            amount = "10.00",
+            reason = "test",
+            refundedPayment = false,
+            items = null,
+            shippingLineItems = null,
+            feeLineItems = null
+        )
+
+        val model = refundMapper.toModel(response)
+
+        val calendar = Calendar.getInstance().apply {
+            time = model.dateCreated
+        }
+        assertEquals(2024, calendar.get(Calendar.YEAR))
+        assertEquals(Calendar.JANUARY, calendar.get(Calendar.MONTH))
+        assertEquals(15, calendar.get(Calendar.DAY_OF_MONTH))
+    }
+
     @Test
     fun `when mapping refund item from domain model, then extract its properties correctly`() {
         val domainModel = WCRefundModel.WCRefundItem(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/RefundMapper.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/RefundMapper.kt
@@ -13,6 +13,7 @@ import java.util.Locale
 import javax.inject.Inject
 
 const val DATE_FORMAT_DAY = "yyyy-MM-dd"
+private const val DATE_FORMAT_DATE_TIME = "yyyy-MM-dd'T'HH:mm:ss"
 
 class RefundMapper @Inject constructor(private val gson: Gson) {
 
@@ -68,7 +69,12 @@ class RefundMapper @Inject constructor(private val gson: Gson) {
         if (date.isEmpty()) {
             return null
         }
-        val dateFormat = SimpleDateFormat(DATE_FORMAT_DAY, Locale.ROOT)
-        return dateFormat.parse(date)
+        val dateTimeFormat = SimpleDateFormat(DATE_FORMAT_DATE_TIME, Locale.ROOT)
+        return try {
+            dateTimeFormat.parse(date)
+        } catch (_: java.text.ParseException) {
+            val dateFormat = SimpleDateFormat(DATE_FORMAT_DAY, Locale.ROOT)
+            dateFormat.parse(date)
+        }
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/RefundMapper.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/refunds/RefundMapper.kt
@@ -6,14 +6,14 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel.WCRefundItem
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.refunds.RefundRestClient.RefundResponse
 import org.wordpress.android.fluxc.persistence.entity.RefundEntity
+import org.wordpress.android.fluxc.utils.DateUtils
 import java.math.BigDecimal
-import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeParseException
 import java.util.Date
-import java.util.Locale
 import javax.inject.Inject
-
-const val DATE_FORMAT_DAY = "yyyy-MM-dd"
-private const val DATE_FORMAT_DATE_TIME = "yyyy-MM-dd'T'HH:mm:ss"
 
 class RefundMapper @Inject constructor(private val gson: Gson) {
 
@@ -66,15 +66,13 @@ class RefundMapper @Inject constructor(private val gson: Gson) {
     }
 
     private fun fromFormattedDate(date: String): Date? {
-        if (date.isEmpty()) {
-            return null
-        }
-        val dateTimeFormat = SimpleDateFormat(DATE_FORMAT_DATE_TIME, Locale.ROOT)
+        if (date.isEmpty()) return null
         return try {
-            dateTimeFormat.parse(date)
-        } catch (_: java.text.ParseException) {
-            val dateFormat = SimpleDateFormat(DATE_FORMAT_DAY, Locale.ROOT)
-            dateFormat.parse(date)
+            val localDateTime = LocalDateTime.parse(date, DateUtils.DATE_TIME_FORMATTER)
+            Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant())
+        } catch (_: DateTimeParseException) {
+            val localDate = LocalDate.parse(date, DateUtils.DATE_FORMATTER)
+            Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant())
         }
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/utils/DateUtils.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.utils
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
 import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
@@ -11,6 +12,9 @@ object DateUtils {
     private const val DATE_FORMAT_DEFAULT = "yyyy-MM-dd"
     private const val DATE_TIME_FORMAT_START = "yyyy-MM-dd'T'00:00:00"
     private const val DATE_TIME_FORMAT_END = "yyyy-MM-dd'T'23:59:59"
+
+    val DATE_TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT)
+    val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT)
 
     private const val ONE_WEEK_IN_DAYS = 7
     private const val ONE_DAY_IN_HOURS = 24


### PR DESCRIPTION
WOOMOB-2488

### Description

In POS > Orders > Order details, refund rows in the totals section always showed "12:00 AM" instead of the actual refund time.

**Root cause:** `RefundMapper.fromFormattedDate()` used a date-only format (`yyyy-MM-dd`) to parse the API's ISO 8601 datetime string (`2024-01-15T14:30:00`), discarding the time portion and defaulting to midnight.

**Fix:** Try parsing with `yyyy-MM-dd'T'HH:mm:ss` first, falling back to the date-only format for backward compatibility.

### Test Steps

1. Open POS and create an order
2. Complete the order, then issue a refund
3. Navigate to Orders > tap the order > scroll to the totals section
4. Verify the refund row shows the correct time (not "12:00 AM")

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.