### PR TITLE
Fix $0.00 refunds not tracked in POS UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosRetrieveOrderRefunds.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosRetrieveOrderRefunds.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WCRefundStore
-import java.math.BigDecimal
 import javax.inject.Inject
 
 class WooPosRetrieveOrderRefunds @Inject constructor(
@@ -16,10 +15,6 @@ class WooPosRetrieveOrderRefunds @Inject constructor(
 ) {
     suspend operator fun invoke(order: Order, forceRefresh: Boolean = false): Result<List<Refund>> =
         withContext(Dispatchers.IO) {
-            if (order.refundTotal.compareTo(BigDecimal.ZERO) == 0) {
-                return@withContext Result.success(emptyList())
-            }
-
             val site = selectedSite.get()
 
             val refundModels = if (forceRefresh) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosRetrieveOrderRefundsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosRetrieveOrderRefundsTest.kt
@@ -164,9 +164,13 @@ class WooPosRetrieveOrderRefundsTest {
     }
 
     @Test
-    fun `given order refundTotal is zero, when invoke called, then returns empty list and does not hit store`() = runTest {
+    fun `given order refundTotal is zero, when invoke called, then still fetches refunds from store`() = runTest {
         // GIVEN
         val order = OrderTestUtils.generateTestOrder(orderId = 999L, refundTotal = BigDecimal.ZERO)
+        whenever(refundStore.getAllRefunds(site, order.id)).thenReturn(emptyList())
+        whenever(refundStore.fetchAllRefunds(site, order.id)).thenReturn(
+            WooResult(emptyList())
+        )
 
         // WHEN
         val result = sut.invoke(order)
@@ -174,6 +178,8 @@ class WooPosRetrieveOrderRefundsTest {
         // THEN
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrThrow()).isEmpty()
+        verify(refundStore).getAllRefunds(site, order.id)
+        verify(refundStore).fetchAllRefunds(site, order.id)
     }
 
     @Test


### PR DESCRIPTION
Closes WOOMOB-2490

### Description

After refunding a $0.00 item through the POS refund flow, the refund was created successfully in wp-admin but not reflected in the POS UI. Previously refunded $0.00 items still appeared in the refundable items list.

**Root cause:** `WooPosRetrieveOrderRefunds` short-circuited with an empty list when `order.refundTotal == 0`. Since $0.00 refunds don't change the order's `refundTotal`, this optimization incorrectly skipped fetching refunds for orders that only have $0.00 refunds.

**Fix:** Remove the `refundTotal == 0` early return so refunds are always fetched. When `forceRefresh = false`, the local cache is checked first (fast), and an API call only happens if the cache is empty — so the performance impact is minimal.

### Test Steps

1. In POS, create an order containing a $0.00 item
2. Complete the order, then refund the $0.00 item
3. Verify the refund appears in the POS UI and the item no longer appears in the refundable items list

### Images/gif
<img width="2076" height="2152" alt="image" src="https://github.com/user-attachments/assets/7df26b74-237a-4595-9161-6f8d4f1b17fb" />

<img width="2076" height="2152" alt="image" src="https://github.com/user-attachments/assets/a9d73b80-774a-4608-a035-ec66c6f2ceab" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.