### PR TITLE
[WOOMOB-2113] Use visible Woo sites for notification filtering

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.WooNotificationBuilder
 import com.woocommerce.android.notifications.WooNotificationType
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.sitepicker.sitevisibility.GetWooVisibleSites
 import com.woocommerce.android.util.NotificationsParser
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.NOTIFICATIONS
@@ -25,7 +26,6 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.NotificationActionBuilder
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore.FetchNotificationPayload
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -40,7 +40,7 @@ class NotificationMessageHandler @Inject constructor(
     private val wooLog: WooLog,
     private val dispatcher: Dispatcher,
     private val resourceProvider: ResourceProvider,
-    private val siteStore: SiteStore,
+    private val getWooVisibleSites: GetWooVisibleSites,
     private val selectedSite: SelectedSite,
     private val workManagerScheduler: WorkManagerScheduler
 ) {
@@ -98,7 +98,7 @@ class NotificationMessageHandler @Inject constructor(
                 wooLog.d(NOTIFICATIONS, "Skipping WPCOM notification, already registered with Woo Core")
                 return
             }
-            if (siteStore.visibleSites.none { it.siteId == notification.remoteSiteId }) {
+            if (!isWooSiteVisible(notification.remoteSiteId)) {
                 wooLog.w(NOTIFICATIONS, "Skipping notification, site ${notification.remoteSiteId} is not visible")
                 return
             }
@@ -117,6 +117,12 @@ class NotificationMessageHandler @Inject constructor(
 
         dispatchBackgroundEvents(notificationModel)
         handleWooNotification(notification)
+    }
+
+    private fun isWooSiteVisible(siteId: Long): Boolean {
+        return runBlocking {
+            getWooVisibleSites().any { it.siteId == siteId }
+        }
     }
 
     private fun dispatchBackgroundEvents(notificationModel: NotificationModel) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_ORD
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_REVIEW_NOTE_FULL_DATA_2
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_REVIEW_NOTE_FULL_DATA_SITE_2
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.sitepicker.sitevisibility.GetWooVisibleSites
 import com.woocommerce.android.util.Base64Decoder
 import com.woocommerce.android.util.NotificationsParser
 import com.woocommerce.android.util.WooLog
@@ -43,7 +44,6 @@ import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore.FetchNotificationPayload
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -72,7 +72,7 @@ class NotificationMessageHandlerTest {
         }
     }
     private val notificationsParser: NotificationsParser = NotificationsParser(jvmBase64Decoder)
-    private val siteStore: SiteStore = mock()
+    private lateinit var getWooVisibleSites: GetWooVisibleSites
     private val selectedSite: SelectedSite = mock {
         on { exists() }.thenReturn(true)
     }
@@ -92,8 +92,9 @@ class NotificationMessageHandlerTest {
 
     private val workManagerScheduler: WorkManagerScheduler = mock()
 
-    @Before
-    fun setUp() {
+    private fun createNotificationMessageHandler(
+        notificationsParser: NotificationsParser = this.notificationsParser
+    ) {
         notificationMessageHandler = NotificationMessageHandler(
             notificationBuilder = notificationBuilder,
             analyticsTracker = notificationAnalyticsTracker,
@@ -103,24 +104,29 @@ class NotificationMessageHandlerTest {
             wooLog = wooLog,
             dispatcher = dispatcher,
             resourceProvider = resourceProvider,
-            siteStore = siteStore,
+            getWooVisibleSites = getWooVisibleSites,
             selectedSite = selectedSite,
             workManagerScheduler = workManagerScheduler,
         )
+    }
 
-        doReturn(true).whenever(accountStore).hasAccessToken()
-        doReturn(accountModel).whenever(accountStore).account
-        doReturn(true).whenever(notificationBuilder).isNotificationsEnabled()
-        doReturn(emptyList<ActiveNotificationData>()).whenever(notificationBuilder).getActiveNotifications()
-
-        // Mock visibleSites to include both order and review notification site IDs
+    @Before
+    fun setUp() {
         val visibleSite = mock<SiteModel> {
             on { siteId } doReturn orderNotification.remoteSiteId
         }
         val visibleSite2 = mock<SiteModel> {
             on { siteId } doReturn reviewNotification.remoteSiteId
         }
-        doReturn(listOf(visibleSite, visibleSite2)).whenever(siteStore).visibleSites
+        getWooVisibleSites = mock {
+            onBlocking { invoke() } doReturn listOf(visibleSite, visibleSite2)
+        }
+        createNotificationMessageHandler()
+
+        doReturn(true).whenever(accountStore).hasAccessToken()
+        doReturn(accountModel).whenever(accountStore).account
+        doReturn(true).whenever(notificationBuilder).isNotificationsEnabled()
+        doReturn(emptyList<ActiveNotificationData>()).whenever(notificationBuilder).getActiveNotifications()
     }
 
     @Test
@@ -189,6 +195,47 @@ class NotificationMessageHandlerTest {
         verify(wooLog).d(
             eq(WooLog.T.NOTIFICATIONS),
             eq("Skipping WPCOM notification, already registered with Woo Core")
+        )
+        verifyNoInteractions(dispatcher)
+    }
+
+    @Test
+    fun `given woo push registered and site is visible, when woo notification received, then process it`() = runTest {
+        whenever(registrationStatus.invoke(any()))
+            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY)
+        val mockNotificationsParser: NotificationsParser = mock {
+            on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
+                remoteNoteId = 0L,
+                remoteSiteId = orderNotification.remoteSiteId,
+                type = NotificationModel.Kind.STORE_ORDER
+            )
+        }
+        createNotificationMessageHandler(mockNotificationsParser)
+
+        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
+
+        verify(dispatcher, atLeastOnce()).dispatch(any())
+    }
+
+    @Test
+    fun `given woo push registered and site is hidden, when woo notification received, then skip it`() = runTest {
+        whenever(registrationStatus.invoke(any()))
+            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY)
+        val mockNotificationsParser: NotificationsParser = mock {
+            on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
+                remoteNoteId = 0L,
+                remoteSiteId = orderNotification.remoteSiteId,
+                type = NotificationModel.Kind.STORE_ORDER
+            )
+        }
+        createNotificationMessageHandler(mockNotificationsParser)
+        whenever(getWooVisibleSites.invoke()).thenReturn(emptyList())
+
+        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
+
+        verify(wooLog).w(
+            eq(WooLog.T.NOTIFICATIONS),
+            eq("Skipping notification, site ${orderNotification.remoteSiteId} is not visible")
         )
         verifyNoInteractions(dispatcher)
     }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2113
This updates `NotificationMessageHandler` to use the Woo site visibility source when filtering self-driven notifications for hidden stores.
It avoids relying on `SiteStore.visibleSites`, which is based on deprecated WP.com visibility data, and adds coverage for visible and hidden site flows.

### Test Steps
1. Run `./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "*NotificationMessageHandlerTest"`

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
