### PR TITLE
Suppress noisy ENOSPC error reports during log writing

### DIFF
--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
@@ -126,7 +126,10 @@ class WooFileLogger(
             )
         }.onFailure {
             it.printStackTrace()
-            if (it.message?.contains("ENOSPC") != true) {
+            val isDiskSpaceError = it.message.orEmpty().let { msg ->
+                msg.contains("ENOSPC") || msg.contains("No space left on device", ignoreCase = true)
+            }
+            if (!isDiskSpaceError) {
                 // Report any error that is not due to disk space issues
                 crashLogging?.get()?.sendReport(it, message = "Error writing logs to file")
             }

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
@@ -114,7 +114,10 @@ class WooFileLogger(
                 }
             }.onFailure {
                 it.printStackTrace()
-                crashLogging?.get()?.sendReport(it, message = "Error reading log file: $fileName")
+                if (!it.isDiskSpaceError()) {
+                    // Report any error that is not due to disk space issues
+                    crashLogging?.get()?.sendReport(it, message = "Error writing logs to file")
+                }
             }.getOrNull()
         }
     }
@@ -126,14 +129,15 @@ class WooFileLogger(
             )
         }.onFailure {
             it.printStackTrace()
-            val isDiskSpaceError = it.message.orEmpty().let { msg ->
-                msg.contains("ENOSPC") || msg.contains("No space left on device", ignoreCase = true)
-            }
-            if (!isDiskSpaceError) {
+            if (!it.isDiskSpaceError()) {
                 // Report any error that is not due to disk space issues
                 crashLogging?.get()?.sendReport(it, message = "Error writing logs to file")
             }
         }
+    }
+
+    private fun Throwable.isDiskSpaceError() = message.orEmpty().let { msg ->
+        msg.contains("ENOSPC") || msg.contains("No space left on device", ignoreCase = true)
     }
 
     companion object {

--- a/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
+++ b/libs/commons/src/main/java/com/woocommerce/android/util/logs/WooFileLogger.kt
@@ -126,7 +126,10 @@ class WooFileLogger(
             )
         }.onFailure {
             it.printStackTrace()
-            crashLogging?.get()?.sendReport(it, message = "Error writing logs to file")
+            if (it.message?.contains("ENOSPC") != true) {
+                // Report any error that is not due to disk space issues
+                crashLogging?.get()?.sendReport(it, message = "Error writing logs to file")
+            }
         }
     }
 


### PR DESCRIPTION
### Description

We're receiving multiple error reports about disk space being full when writing logs (https://a8c.sentry.io/issues/6867914245). These reports are noisy and not actionable — when a user's device is out of storage, there's nothing we can do about it from the app side.

Additionally, https://github.com/woocommerce/woocommerce-android/pull/15347 already added defenses to handle low disk space scenarios:
- **Per-file size cap** (2 MB) prevents unbounded log growth
- **Disk space check** before writes — skips writing when free space drops below 10 MB
- **Proactive cleanup** of oldest log files when disk is low
- **Graceful database recovery** when SQLite fails due to disk exhaustion

With a max footprint of ~14 MB (7 files × 2 MB), our logs are not the culprit for filling up disk space. The ENOSPC errors simply mean the device was already out of storage when a log write was attempted.

This PR filters out ENOSPC errors from crash reporting in `WooFileLogger.processLogs()` to reduce noise, while still reporting any other unexpected write errors.

### Test Steps

Nothing to test, code review should be enough.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.