### PR TITLE
WOOMOB-32: Fix order filter state lost on device rotation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModel.kt
@@ -99,6 +99,8 @@ class OrderFilterCategoriesViewModel @Inject constructor(
 
     fun onShowOrdersClicked() {
         saveFiltersSelection(_categories.list)
+        oldFilterSelection = _categories.list
+        savedState[OLD_FILTER_SELECTION_KEY] = oldFilterSelection
         trackFilterSelection()
         triggerEvent(OnShowOrders)
     }
@@ -116,6 +118,8 @@ class OrderFilterCategoriesViewModel @Inject constructor(
             }
         )
         saveFiltersSelection(_categories.list)
+        oldFilterSelection = _categories.list
+        savedState[OLD_FILTER_SELECTION_KEY] = oldFilterSelection
     }
 
     fun onClearProductFilter() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/filters/OrderFilterCategoriesViewModelTest.kt
@@ -277,6 +277,39 @@ class OrderFilterCategoriesViewModelTest : BaseUnitTest() {
         whenever(resourceProvider.getString(any(), any(), any())).thenReturn("AnyString")
     }
 
+    @Test
+    fun `given filters selected, when clear filters and recreate viewmodel, then filters remain cleared`() =
+        testBlocking {
+            // GIVEN
+            givenAFilterOptionHasBeenSelected(AN_ORDER_STATUS_FILTER_CATEGORY_WITH_SELECTED_FILTER)
+
+            // WHEN
+            viewModel.onClearFilters()
+            initViewModel() // simulate rotation by recreating with same SavedStateHandle
+
+            // THEN
+            val orderStatusFilter = currentCategoryList.find {
+                it.categoryKey == OrderListFilterCategory.ORDER_STATUS
+            }
+            assertThat(orderStatusFilter!!.orderFilterOptions)
+                .noneMatch { it.isSelected && it.key != OrderFilterOptionUiModel.DEFAULT_ALL_KEY }
+        }
+
+    @Test
+    fun `given filters cleared, when back pressed after rotation, then returns true`() =
+        testBlocking {
+            // GIVEN
+            givenAFilterOptionHasBeenSelected(AN_ORDER_STATUS_FILTER_CATEGORY_WITH_SELECTED_FILTER)
+            viewModel.onClearFilters()
+            initViewModel() // simulate rotation
+
+            // WHEN
+            val result = viewModel.onBackPressed()
+
+            // THEN
+            assertTrue(result)
+        }
+
     private companion object {
         const val DEFAULT_FILTER_TITLE = "Title"
         const val ANY_ORDER_STATUS_KEY = "OrderStatusOptionKey"


### PR DESCRIPTION
### Description

Fixes a bug where clearing order filters and rotating the device before tapping "Show orders" caused the cleared state to be lost. The old filter selections were restored because `oldFilterSelection` (stored in `SavedStateHandle`) was never updated when filters were cleared or applied.

- Update `oldFilterSelection` in SavedStateHandle when filters are cleared (`onClearFilters`)
- Update `oldFilterSelection` in SavedStateHandle when filters are applied (`onShowOrdersClicked`)

Closes: https://linear.app/a8c/issue/WOOMOB-32

### Test Steps

1. Navigate to the Orders tab
2. Tap Filters and apply a filter (e.g., filter by customer or order status)
3. Verify orders load with the selected filter
4. Open filters again and tap "Clear filters"
5. **Before tapping "Show orders", rotate the device**
6. Tap "Show orders"
7. Verify the filters are correctly cleared and all orders are shown
8. Repeat with different filter categories to confirm the fix applies broadly

### Images/gif

N/A — behavioral fix with no UI changes.

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary.