### PR TITLE
[WOOMOB-1438] Route media requests through WooMediaNetwork for app passwords

### DIFF
--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClientTest.kt
@@ -1,34 +1,28 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
 
 import com.google.gson.Gson
+import kotlinx.coroutines.runBlocking
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.IOException
-import org.greenrobot.eventbus.EventBus
-import org.greenrobot.eventbus.Subscribe
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.UnitTestUtils
-import org.wordpress.android.fluxc.action.MediaAction.UPLOADED_MEDIA
-import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.media.MediaTestUtils
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
-import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import java.io.File
 import java.util.concurrent.CountDownLatch
 
@@ -36,30 +30,24 @@ import java.util.concurrent.CountDownLatch
 class WPComV2MediaRestClientTest {
     private val accessToken: AccessToken = mock()
     private val okHttpClient: OkHttpClient = mock()
-    private val dispatcher: Dispatcher = mock()
     private val wpComNetwork: WPComNetwork = mock()
     private val gson: Gson = Gson()
     private val mockedCall: Call = mock()
     private lateinit var countDownLatch: CountDownLatch
     private lateinit var restClient: WPComV2MediaRestClient
 
-    private lateinit var dispatchedPayload: ProgressPayload
-
     @Before
     fun setup() {
         restClient = WPComV2MediaRestClient(
-            dispatcher = dispatcher,
-            coroutineEngine = initCoroutineEngine(),
             okHttpClient = okHttpClient,
             accessToken = accessToken,
             wpComNetwork = wpComNetwork,
             gson = gson
         )
-        EventBus.getDefault().register(this)
     }
 
     @Test
-    fun `emit success action when upload finishes`() {
+    fun `emit success payload when upload finishes`() {
         createFileThenRunTest {
             whenever(okHttpClient.newCall(any())).thenReturn(mockedCall)
             whenever(mockedCall.enqueue(any())).then {
@@ -77,18 +65,21 @@ class WPComV2MediaRestClientTest {
             }
 
             countDownLatch = CountDownLatch(1)
-            restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+            val payloads = runBlocking {
+                val collectedPayloads = mutableListOf<ProgressPayload>()
+                restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+                    .collect(collectedPayloads::add)
+                collectedPayloads
+            }
 
             countDownLatch.await()
 
-            verify(dispatcher).dispatch(argThat {
-                type == UPLOADED_MEDIA && (payload as ProgressPayload).completed
-            })
+            assertThat(payloads.last().completed).isTrue()
         }
     }
 
     @Test
-    fun `emit failure action when upload fails`() {
+    fun `emit failure payload when upload fails`() {
         createFileThenRunTest {
             whenever(okHttpClient.newCall(any())).thenReturn(mockedCall)
             whenever(mockedCall.enqueue(any())).then {
@@ -97,18 +88,21 @@ class WPComV2MediaRestClientTest {
             }
 
             countDownLatch = CountDownLatch(1)
-            restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+            val payloads = runBlocking {
+                val collectedPayloads = mutableListOf<ProgressPayload>()
+                restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+                    .collect(collectedPayloads::add)
+                collectedPayloads
+            }
 
             countDownLatch.await()
 
-            verify(dispatcher).dispatch(argThat {
-                type == UPLOADED_MEDIA && (payload as ProgressPayload).error != null
-            })
+            assertThat(payloads.last().error).isNotNull()
         }
     }
 
     @Test
-    fun `emit failure action when we can't parse the response`() {
+    fun `emit failure payload when we can't parse the response`() {
         createFileThenRunTest {
             whenever(okHttpClient.newCall(any())).thenReturn(mockedCall)
             whenever(mockedCall.enqueue(any())).then {
@@ -123,13 +117,16 @@ class WPComV2MediaRestClientTest {
             }
 
             countDownLatch = CountDownLatch(1)
-            restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+            val payloads = runBlocking {
+                val collectedPayloads = mutableListOf<ProgressPayload>()
+                restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+                    .collect(collectedPayloads::add)
+                collectedPayloads
+            }
 
             countDownLatch.await()
 
-            verify(dispatcher).dispatch(argThat {
-                type == UPLOADED_MEDIA && (payload as ProgressPayload).error != null
-            })
+            assertThat(payloads.last().error).isNotNull()
         }
     }
 
@@ -143,10 +140,4 @@ class WPComV2MediaRestClientTest {
         }
     }
 
-    @Subscribe
-    fun onAction(action: Action<*>) {
-        if (action.type == UPLOADED_MEDIA) {
-            dispatchedPayload = action.payload as ProgressPayload
-        }
-    }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClient.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpapi.media
 import com.google.gson.Gson
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
@@ -13,7 +12,6 @@ import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.Appli
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordCreationResult.NotSupported
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsManager
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
-import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import javax.inject.Inject
 import javax.inject.Named
@@ -21,12 +19,10 @@ import javax.inject.Singleton
 
 @Singleton
 class ApplicationPasswordsMediaRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    coroutineEngine: CoroutineEngine,
     @Named("no-cookies") okHttpClient: OkHttpClient,
     private val applicationPasswordsNetwork: ApplicationPasswordsNetwork,
     gson: Gson
-) : BaseWPV2MediaRestClient(dispatcher, coroutineEngine, okHttpClient, gson) {
+) : BaseWPV2MediaRestClient(okHttpClient, gson) {
     @Inject
     internal lateinit var applicationPasswordsManager: ApplicationPasswordsManager
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -60,7 +60,7 @@ abstract class BaseWPV2MediaRestClient(
 
     fun uploadMedia(site: SiteModel, media: MediaModel) {
         coroutineEngine.launch(MEDIA, this, "Upload Media using WPCom's v2 API") {
-            syncUploadMedia(site, media)
+            getUploadMediaFlow(site, media)
                 .onStart {
                     currentUploads[media.id] = this@launch
                 }
@@ -83,7 +83,7 @@ abstract class BaseWPV2MediaRestClient(
 
     fun fetchMediaList(site: SiteModel, number: Int, offset: Int, mimeType: MimeType.Type?) {
         coroutineEngine.launch(MEDIA, this, "Fetching Media using WPCom's v2 API") {
-            val payload = syncFetchMediaList(site, number, offset, mimeType)
+            val payload = executeFetchMediaList(site, number, offset, mimeType)
             dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
         }
     }
@@ -93,9 +93,26 @@ abstract class BaseWPV2MediaRestClient(
         media: MediaModel
     ) {
         coroutineEngine.launch(MEDIA, this, "Fetching Media using WPCom's v2 API") {
-            val payload = syncFetchMedia(site, media.mediaId)
+            val payload = executeFetchMedia(site, media.mediaId)
             dispatcher.dispatch(MediaActionBuilder.newFetchedMediaAction(payload))
         }
+    }
+
+    internal fun getUploadMediaFlow(site: SiteModel, media: MediaModel): Flow<ProgressPayload> {
+        return syncUploadMedia(site, media)
+    }
+
+    internal suspend fun executeFetchMedia(site: SiteModel, mediaId: Long): MediaPayload {
+        return syncFetchMedia(site, mediaId)
+    }
+
+    internal suspend fun executeFetchMediaList(
+        site: SiteModel,
+        perPage: Int,
+        offset: Int,
+        mimeType: MimeType.Type?
+    ): FetchMediaListResponsePayload {
+        return syncFetchMediaList(site, perPage, offset, mimeType)
     }
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
@@ -175,6 +192,8 @@ abstract class BaseWPV2MediaRestClient(
                 val errorMessage = "Fail to fetch media. Response: $response"
                 AppLog.w(MEDIA, errorMessage)
                 val error = MediaError(MediaErrorType.fromBaseNetworkError(response.error))
+                error.statusCode = response.error.volleyError?.networkResponse?.statusCode ?: 0
+                error.apiErrorCode = response.error.errorCode
                 error.logMessage = errorMessage
                 MediaPayload(site, null, error)
             }
@@ -225,7 +244,9 @@ abstract class BaseWPV2MediaRestClient(
             is WPAPIResponse.Error -> {
                 val errorMessage = "could not parse Fetch all media response: $response"
                 AppLog.w(MEDIA, errorMessage)
-                val error = MediaError(MediaErrorType.PARSE_ERROR)
+                val error = MediaError(MediaErrorType.fromBaseNetworkError(response.error))
+                error.statusCode = response.error.volleyError?.networkResponse?.statusCode ?: 0
+                error.apiErrorCode = response.error.errorCode
                 error.logMessage = errorMessage
                 FetchMediaListResponsePayload(site, error, mimeType)
             }
@@ -260,6 +281,7 @@ abstract class BaseWPV2MediaRestClient(
                 mediaError.message = it
             }
             jsonBody.optString("code").takeIf { it.isNotEmpty() }?.let {
+                mediaError.apiErrorCode = it
                 mediaError.logMessage = it
             }
         } catch (e: JSONException) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -2,15 +2,11 @@ package org.wordpress.android.fluxc.network.rest.wpapi.media
 
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onStart
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.OkHttpClient
@@ -18,9 +14,7 @@ import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONException
 import org.json.JSONObject
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint
-import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -31,22 +25,16 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaError
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
-import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.MimeType
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MEDIA
 import java.io.IOException
-import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Named
 
 abstract class BaseWPV2MediaRestClient(
-    private val dispatcher: Dispatcher,
-    private val coroutineEngine: CoroutineEngine,
     @Named("regular") private val okHttpClient: OkHttpClient,
     private val gson: Gson
 ) {
-    private val currentUploads = ConcurrentHashMap<Int, CoroutineScope>()
-
     protected abstract fun WPAPIEndpoint.getFullUrl(site: SiteModel): String
 
     protected abstract suspend fun getAuthorizationHeader(site: SiteModel): String
@@ -58,65 +46,8 @@ abstract class BaseWPV2MediaRestClient(
         clazz: Class<T>
     ): WPAPIResponse<T>
 
-    fun uploadMedia(site: SiteModel, media: MediaModel) {
-        coroutineEngine.launch(MEDIA, this, "Upload Media using WPCom's v2 API") {
-            getUploadMediaFlow(site, media)
-                .onStart {
-                    currentUploads[media.id] = this@launch
-                }
-                .onCompletion {
-                    currentUploads.remove(media.id)
-                }
-                .collect { payload ->
-                    dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
-                }
-        }
-    }
-
-    fun cancelUpload(media: MediaModel) {
-        currentUploads[media.id]?.let { scope ->
-            scope.cancel()
-            val payload = ProgressPayload(media, 0f, false, true)
-            dispatcher.dispatch(MediaActionBuilder.newCanceledMediaUploadAction(payload))
-        }
-    }
-
-    fun fetchMediaList(site: SiteModel, number: Int, offset: Int, mimeType: MimeType.Type?) {
-        coroutineEngine.launch(MEDIA, this, "Fetching Media using WPCom's v2 API") {
-            val payload = executeFetchMediaList(site, number, offset, mimeType)
-            dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
-        }
-    }
-
-    fun fetchMedia(
-        site: SiteModel,
-        media: MediaModel
-    ) {
-        coroutineEngine.launch(MEDIA, this, "Fetching Media using WPCom's v2 API") {
-            val payload = executeFetchMedia(site, media.mediaId)
-            dispatcher.dispatch(MediaActionBuilder.newFetchedMediaAction(payload))
-        }
-    }
-
-    internal fun getUploadMediaFlow(site: SiteModel, media: MediaModel): Flow<ProgressPayload> {
-        return syncUploadMedia(site, media)
-    }
-
-    internal suspend fun executeFetchMedia(site: SiteModel, mediaId: Long): MediaPayload {
-        return syncFetchMedia(site, mediaId)
-    }
-
-    internal suspend fun executeFetchMediaList(
-        site: SiteModel,
-        perPage: Int,
-        offset: Int,
-        mimeType: MimeType.Type?
-    ): FetchMediaListResponsePayload {
-        return syncFetchMediaList(site, perPage, offset, mimeType)
-    }
-
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    private fun syncUploadMedia(site: SiteModel, media: MediaModel): Flow<ProgressPayload> {
+    fun uploadMedia(site: SiteModel, media: MediaModel): Flow<ProgressPayload> {
         fun ProducerScope<ProgressPayload>.handleFailure(media: MediaModel, error: MediaError) {
             val payload = ProgressPayload(media, 1f, false, error)
             trySendBlocking(payload)
@@ -178,7 +109,7 @@ abstract class BaseWPV2MediaRestClient(
         }
     }
 
-    private suspend fun syncFetchMedia(site: SiteModel, mediaId: Long): MediaPayload {
+    suspend fun fetchMedia(site: SiteModel, mediaId: Long): MediaPayload {
         val url = WPAPI.media.id(mediaId)
         val response = executeGetGsonRequest(
             site,
@@ -218,7 +149,7 @@ abstract class BaseWPV2MediaRestClient(
         }
     }
 
-    private suspend fun syncFetchMediaList(
+    suspend fun fetchMediaList(
         site: SiteModel,
         perPage: Int,
         offset: Int,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.fluxc.network.rest.wpapi.media
 import com.android.volley.NetworkResponse
 import com.android.volley.VolleyError
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.MediaModel
@@ -11,15 +12,18 @@ import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsStore
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsErrorHandler
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsSupport
 import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload
 import org.wordpress.android.fluxc.store.MediaStore.MediaError
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.MimeType
 import org.wordpress.android.util.AppLog
+import java.security.GeneralSecurityException
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -36,71 +40,60 @@ class WooMediaNetwork @Inject constructor(
 ) {
     private val currentUploads = ConcurrentHashMap<Int, Job>()
 
-    fun uploadMedia(site: SiteModel, media: MediaModel): Boolean {
-        return when (site.origin) {
+    fun uploadMedia(site: SiteModel, media: MediaModel) {
+        when (site.origin) {
             SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
-                if (!applicationPasswordsConfiguration.isEnabledForDirectAccess()) {
-                    false
-                } else {
-                    launchUpload(site, media)
-                    true
-                }
+                requireDirectAccessEnabled()
+                launchUpload(site, media)
             }
 
             SiteModel.ORIGIN_WPCOM_REST -> {
                 launchUpload(site, media)
-                true
             }
 
-            else -> false
+            else -> throw unsupportedOrigin(site)
         }
     }
 
-    fun fetchMediaList(site: SiteModel, number: Int, offset: Int, mimeType: MimeType.Type?): Boolean {
-        return when (site.origin) {
+    fun fetchMediaList(site: SiteModel, number: Int, offset: Int, mimeType: MimeType.Type?) {
+        when (site.origin) {
             SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
-                if (!applicationPasswordsConfiguration.isEnabledForDirectAccess()) {
-                    false
-                } else {
-                    coroutineEngine.launch(
-                        AppLog.T.MEDIA,
-                        this,
-                        "Fetching media list via Application Passwords"
-                    ) {
-                        val payload = applicationPasswordsMediaRestClient.fetchMediaList(
-                            site,
-                            number,
-                            offset,
-                            mimeType
-                        )
-                        dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
-                    }
-                    true
+                requireDirectAccessEnabled()
+                coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list") {
+                    val payload = applicationPasswordsMediaRestClient.fetchMediaList(
+                        site, number, offset, mimeType
+                    )
+                    dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
                 }
             }
 
             SiteModel.ORIGIN_WPCOM_REST -> {
                 coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list for Jetpack site") {
-                    val payload = fetchJetpackMediaList(site, number, offset, mimeType)
+                    val payload = fetchMediaListWithJetpackFallback(site, number, offset, mimeType)
                     dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
                 }
-                true
             }
 
-            else -> false
+            else -> throw unsupportedOrigin(site)
         }
     }
 
-    fun cancelUpload(site: SiteModel, media: MediaModel): Boolean {
-        return when (site.origin) {
-            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC, SiteModel.ORIGIN_WPCOM_REST -> {
+    fun cancelUpload(site: SiteModel, media: MediaModel) {
+        when (site.origin) {
+            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
+                requireDirectAccessEnabled()
                 currentUploads.remove(media.id)?.cancel()
                 val payload = ProgressPayload(media, 0f, false, true)
                 dispatcher.dispatch(MediaActionBuilder.newCanceledMediaUploadAction(payload))
-                true
             }
 
-            else -> false
+            SiteModel.ORIGIN_WPCOM_REST -> {
+                currentUploads.remove(media.id)?.cancel()
+                val payload = ProgressPayload(media, 0f, false, true)
+                dispatcher.dispatch(MediaActionBuilder.newCanceledMediaUploadAction(payload))
+            }
+
+            else -> throw unsupportedOrigin(site)
         }
     }
 
@@ -124,25 +117,29 @@ class WooMediaNetwork @Inject constructor(
     }
 
     private suspend fun uploadForJetpackSite(site: SiteModel, media: MediaModel) {
-        if (!applicationPasswordsConfiguration.isEnabledForJetpackAccess() ||
-            !jetpackApplicationPasswordsSupport.supportsAppPasswords(site)
-        ) {
+        if (!shouldUseAppPasswordsForJetpack(site)) {
             dispatchUploadFlow(wpComV2MediaRestClient.uploadMedia(site, media))
             return
         }
 
         var appPasswordsError: MediaError? = null
 
-        applicationPasswordsMediaRestClient.uploadMedia(site, media).collect { payload ->
-            if (payload.isError) {
-                appPasswordsError = payload.error
-            } else {
-                dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
+        try {
+            applicationPasswordsMediaRestClient.uploadMedia(site, media).collect { payload ->
+                if (payload.isError) {
+                    appPasswordsError = payload.error
+                } else {
+                    dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
+                }
             }
+        } catch (e: GeneralSecurityException) {
+            AppLog.e(AppLog.T.MEDIA, "Error setting up Application Passwords encryption", e)
+            appPasswordsError = createKeystoreEncryptionError()
         }
 
-        // if app passwords succeeded, exit
         if (appPasswordsError == null) return
+
+        logFailedAppPasswordsRequest("upload", site, appPasswordsError)
 
         var fallbackSucceeded = false
         wpComV2MediaRestClient.uploadMedia(site, media).collect { payload ->
@@ -160,27 +157,28 @@ class WooMediaNetwork @Inject constructor(
         }
     }
 
-    private suspend fun fetchJetpackMediaList(
+    private suspend fun fetchMediaListWithJetpackFallback(
         site: SiteModel,
         number: Int,
         offset: Int,
         mimeType: MimeType.Type?
     ): FetchMediaListResponsePayload {
-        if (!applicationPasswordsConfiguration.isEnabledForJetpackAccess() ||
-            !jetpackApplicationPasswordsSupport.supportsAppPasswords(site)
-        ) {
+        if (!shouldUseAppPasswordsForJetpack(site)) {
             return wpComV2MediaRestClient.fetchMediaList(site, number, offset, mimeType)
         }
 
-        val appPasswordsPayload = applicationPasswordsMediaRestClient.fetchMediaList(
-            site,
-            number,
-            offset,
-            mimeType
-        )
+        val appPasswordsPayload = try {
+            applicationPasswordsMediaRestClient.fetchMediaList(site, number, offset, mimeType)
+        } catch (e: GeneralSecurityException) {
+            AppLog.e(AppLog.T.MEDIA, "Error setting up Application Passwords encryption", e)
+            FetchMediaListResponsePayload(site, createKeystoreEncryptionError(), mimeType)
+        }
+
         if (!appPasswordsPayload.isError) {
             return appPasswordsPayload
         }
+
+        logFailedAppPasswordsRequest("fetch media list", site, appPasswordsPayload.error)
 
         val fallbackPayload = wpComV2MediaRestClient.fetchMediaList(site, number, offset, mimeType)
         if (!fallbackPayload.isError) {
@@ -193,10 +191,38 @@ class WooMediaNetwork @Inject constructor(
         return fallbackPayload
     }
 
-    private suspend fun dispatchUploadFlow(flow: kotlinx.coroutines.flow.Flow<ProgressPayload>) {
+    private suspend fun shouldUseAppPasswordsForJetpack(site: SiteModel): Boolean {
+        return applicationPasswordsConfiguration.isEnabledForJetpackAccess() &&
+            jetpackApplicationPasswordsSupport.supportsAppPasswords(site)
+    }
+
+    private suspend fun dispatchUploadFlow(flow: Flow<ProgressPayload>) {
         flow.collect { payload ->
             dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
         }
+    }
+
+    private fun requireDirectAccessEnabled() {
+        check(applicationPasswordsConfiguration.isEnabledForDirectAccess()) {
+            "Application Passwords are not enabled for direct access"
+        }
+    }
+
+    private fun unsupportedOrigin(site: SiteModel) =
+        IllegalArgumentException("Unsupported site origin: ${site.origin}")
+
+    private fun createKeystoreEncryptionError() = MediaError(MediaErrorType.GENERIC_ERROR).apply {
+        apiErrorCode = ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR
+    }
+
+    private fun logFailedAppPasswordsRequest(operation: String, site: SiteModel, error: MediaError?) {
+        AppLog.w(
+            AppLog.T.MEDIA,
+            "Media $operation failed using Application Passwords for Jetpack Site,\n" +
+                "site: ${site.url},\n" +
+                "error: HTTP status code ${error?.statusCode}, " +
+                "error message: ${error?.apiErrorCode?.ifEmpty { null } ?: error?.message}"
+        )
     }
 
     private fun MediaError?.toWPAPINetworkError(): WPAPINetworkError {
@@ -218,24 +244,12 @@ class WooMediaNetwork @Inject constructor(
             408 -> GenericErrorType.TIMEOUT
             in 500..599 -> GenericErrorType.SERVER_ERROR
             else -> when (error.type) {
-                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.NOT_AUTHENTICATED ->
-                    GenericErrorType.NOT_AUTHENTICATED
-
-                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.AUTHORIZATION_REQUIRED ->
-                    GenericErrorType.AUTHORIZATION_REQUIRED
-
-                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.NOT_FOUND ->
-                    GenericErrorType.NOT_FOUND
-
-                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.TIMEOUT ->
-                    GenericErrorType.TIMEOUT
-
-                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.SERVER_ERROR ->
-                    GenericErrorType.SERVER_ERROR
-
-                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.PARSE_ERROR ->
-                    GenericErrorType.PARSE_ERROR
-
+                MediaErrorType.NOT_AUTHENTICATED -> GenericErrorType.NOT_AUTHENTICATED
+                MediaErrorType.AUTHORIZATION_REQUIRED -> GenericErrorType.AUTHORIZATION_REQUIRED
+                MediaErrorType.NOT_FOUND -> GenericErrorType.NOT_FOUND
+                MediaErrorType.TIMEOUT -> GenericErrorType.TIMEOUT
+                MediaErrorType.SERVER_ERROR -> GenericErrorType.SERVER_ERROR
+                MediaErrorType.PARSE_ERROR -> GenericErrorType.PARSE_ERROR
                 else -> GenericErrorType.UNKNOWN
             }
         }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -1,0 +1,250 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.media
+
+import com.android.volley.NetworkResponse
+import com.android.volley.VolleyError
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.MediaActionBuilder
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsErrorHandler
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsSupport
+import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload
+import org.wordpress.android.fluxc.store.MediaStore.MediaError
+import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.MimeType
+import org.wordpress.android.util.AppLog
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooMediaNetwork @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val coroutineEngine: CoroutineEngine,
+    private val applicationPasswordsConfiguration: ApplicationPasswordsConfiguration,
+    private val applicationPasswordsMediaRestClient: ApplicationPasswordsMediaRestClient,
+    private val wpComV2MediaRestClient: WPComV2MediaRestClient,
+    private val jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport,
+    private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler
+) {
+    private val currentUploads = ConcurrentHashMap<Int, kotlinx.coroutines.CoroutineScope>()
+
+    fun uploadMedia(site: SiteModel, media: MediaModel): Boolean {
+        return when (site.origin) {
+            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
+                if (!applicationPasswordsConfiguration.isEnabledForDirectAccess()) {
+                    false
+                } else {
+                    launchUpload(site, media)
+                    true
+                }
+            }
+
+            SiteModel.ORIGIN_WPCOM_REST -> {
+                launchUpload(site, media)
+                true
+            }
+
+            else -> false
+        }
+    }
+
+    fun fetchMediaList(site: SiteModel, number: Int, offset: Int, mimeType: MimeType.Type?): Boolean {
+        return when (site.origin) {
+            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
+                if (!applicationPasswordsConfiguration.isEnabledForDirectAccess()) {
+                    false
+                } else {
+                    coroutineEngine.launch(
+                        AppLog.T.MEDIA,
+                        this,
+                        "Fetching media list via Application Passwords"
+                    ) {
+                        val payload = applicationPasswordsMediaRestClient.executeFetchMediaList(
+                            site,
+                            number,
+                            offset,
+                            mimeType
+                        )
+                        dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
+                    }
+                    true
+                }
+            }
+
+            SiteModel.ORIGIN_WPCOM_REST -> {
+                coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list for Jetpack site") {
+                    val payload = fetchJetpackMediaList(site, number, offset, mimeType)
+                    dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
+                }
+                true
+            }
+
+            else -> false
+        }
+    }
+
+    fun cancelUpload(site: SiteModel, media: MediaModel): Boolean {
+        return when (site.origin) {
+            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC, SiteModel.ORIGIN_WPCOM_REST -> {
+                currentUploads.remove(media.id)?.cancel()
+                val payload = ProgressPayload(media, 0f, false, true)
+                dispatcher.dispatch(MediaActionBuilder.newCanceledMediaUploadAction(payload))
+                true
+            }
+
+            else -> false
+        }
+    }
+
+    private fun launchUpload(site: SiteModel, media: MediaModel) {
+        coroutineEngine.launch(AppLog.T.MEDIA, this, "Uploading media") {
+            currentUploads[media.id] = this
+            try {
+                when (site.origin) {
+                    SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
+                        dispatchUploadFlow(applicationPasswordsMediaRestClient.getUploadMediaFlow(site, media))
+                    }
+
+                    SiteModel.ORIGIN_WPCOM_REST -> {
+                        uploadForJetpackSite(site, media)
+                    }
+                }
+            } finally {
+                currentUploads.remove(media.id)
+            }
+        }
+    }
+
+    private suspend fun uploadForJetpackSite(site: SiteModel, media: MediaModel) {
+        if (!applicationPasswordsConfiguration.isEnabledForJetpackAccess() ||
+            !jetpackApplicationPasswordsSupport.supportsAppPasswords(site)
+        ) {
+            dispatchUploadFlow(wpComV2MediaRestClient.getUploadMediaFlow(site, media))
+            return
+        }
+
+        var appPasswordsError: MediaError? = null
+        applicationPasswordsMediaRestClient.getUploadMediaFlow(site, media).collect { payload ->
+            if (payload.isError) {
+                appPasswordsError = payload.error
+            } else {
+                dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
+            }
+        }
+
+        if (appPasswordsError == null) {
+            return
+        }
+
+        var fallbackSucceeded = false
+        wpComV2MediaRestClient.getUploadMediaFlow(site, media).collect { payload ->
+            if (payload.completed && !payload.isError && !payload.canceled) {
+                fallbackSucceeded = true
+            }
+            dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
+        }
+
+        if (fallbackSucceeded) {
+            jetpackApplicationPasswordsErrorHandler.handleError(
+                site,
+                appPasswordsError.toWPAPINetworkError()
+            )
+        }
+    }
+
+    private suspend fun fetchJetpackMediaList(
+        site: SiteModel,
+        number: Int,
+        offset: Int,
+        mimeType: MimeType.Type?
+    ): FetchMediaListResponsePayload {
+        if (!applicationPasswordsConfiguration.isEnabledForJetpackAccess() ||
+            !jetpackApplicationPasswordsSupport.supportsAppPasswords(site)
+        ) {
+            return wpComV2MediaRestClient.executeFetchMediaList(site, number, offset, mimeType)
+        }
+
+        val appPasswordsPayload = applicationPasswordsMediaRestClient.executeFetchMediaList(
+            site,
+            number,
+            offset,
+            mimeType
+        )
+        if (!appPasswordsPayload.isError) {
+            return appPasswordsPayload
+        }
+
+        val fallbackPayload = wpComV2MediaRestClient.executeFetchMediaList(site, number, offset, mimeType)
+        if (!fallbackPayload.isError) {
+            jetpackApplicationPasswordsErrorHandler.handleError(
+                site,
+                appPasswordsPayload.error.toWPAPINetworkError()
+            )
+        }
+
+        return fallbackPayload
+    }
+
+    private suspend fun dispatchUploadFlow(flow: kotlinx.coroutines.flow.Flow<ProgressPayload>) {
+        flow.collect { payload ->
+            dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
+        }
+    }
+
+    private fun MediaError?.toWPAPINetworkError(): WPAPINetworkError {
+        requireNotNull(this) { "MediaError is required to build a WPAPINetworkError" }
+
+        val baseError = BaseNetworkError(
+            errorTypeFrom(this),
+            message.orEmpty(),
+            volleyErrorFrom(this)
+        )
+        return WPAPINetworkError(baseError, apiErrorCode)
+    }
+
+    private fun errorTypeFrom(error: MediaError): GenericErrorType {
+        return when (error.statusCode) {
+            401 -> GenericErrorType.NOT_AUTHENTICATED
+            403 -> GenericErrorType.AUTHORIZATION_REQUIRED
+            404 -> GenericErrorType.NOT_FOUND
+            408 -> GenericErrorType.TIMEOUT
+            in 500..599 -> GenericErrorType.SERVER_ERROR
+            else -> when (error.type) {
+                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.NOT_AUTHENTICATED ->
+                    GenericErrorType.NOT_AUTHENTICATED
+
+                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.AUTHORIZATION_REQUIRED ->
+                    GenericErrorType.AUTHORIZATION_REQUIRED
+
+                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.NOT_FOUND ->
+                    GenericErrorType.NOT_FOUND
+
+                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.TIMEOUT ->
+                    GenericErrorType.TIMEOUT
+
+                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.SERVER_ERROR ->
+                    GenericErrorType.SERVER_ERROR
+
+                org.wordpress.android.fluxc.store.MediaStore.MediaErrorType.PARSE_ERROR ->
+                    GenericErrorType.PARSE_ERROR
+
+                else -> GenericErrorType.UNKNOWN
+            }
+        }
+    }
+
+    private fun volleyErrorFrom(error: MediaError): VolleyError {
+        return if (error.statusCode > 0) {
+            VolleyError(NetworkResponse(error.statusCode, null, true, 0, emptyList()))
+        } else {
+            VolleyError(error.message)
+        }
+    }
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpapi.media
 
 import com.android.volley.NetworkResponse
 import com.android.volley.VolleyError
+import kotlinx.coroutines.Job
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.MediaModel
@@ -33,7 +34,7 @@ class WooMediaNetwork @Inject constructor(
     private val jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport,
     private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler
 ) {
-    private val currentUploads = ConcurrentHashMap<Int, kotlinx.coroutines.CoroutineScope>()
+    private val currentUploads = ConcurrentHashMap<Int, Job>()
 
     fun uploadMedia(site: SiteModel, media: MediaModel): Boolean {
         return when (site.origin) {
@@ -104,8 +105,7 @@ class WooMediaNetwork @Inject constructor(
     }
 
     private fun launchUpload(site: SiteModel, media: MediaModel) {
-        coroutineEngine.launch(AppLog.T.MEDIA, this, "Uploading media") {
-            currentUploads[media.id] = this
+        val uploadJob = coroutineEngine.launch(AppLog.T.MEDIA, this, "Uploading media") {
             try {
                 when (site.origin) {
                     SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
@@ -120,6 +120,7 @@ class WooMediaNetwork @Inject constructor(
                 currentUploads.remove(media.id)
             }
         }
+        currentUploads[media.id] = uploadJob
     }
 
     private suspend fun uploadForJetpackSite(site: SiteModel, media: MediaModel) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -67,7 +67,7 @@ class WooMediaNetwork @Inject constructor(
                         this,
                         "Fetching media list via Application Passwords"
                     ) {
-                        val payload = applicationPasswordsMediaRestClient.executeFetchMediaList(
+                        val payload = applicationPasswordsMediaRestClient.fetchMediaList(
                             site,
                             number,
                             offset,
@@ -109,7 +109,7 @@ class WooMediaNetwork @Inject constructor(
             try {
                 when (site.origin) {
                     SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
-                        dispatchUploadFlow(applicationPasswordsMediaRestClient.getUploadMediaFlow(site, media))
+                        dispatchUploadFlow(applicationPasswordsMediaRestClient.uploadMedia(site, media))
                     }
 
                     SiteModel.ORIGIN_WPCOM_REST -> {
@@ -127,12 +127,13 @@ class WooMediaNetwork @Inject constructor(
         if (!applicationPasswordsConfiguration.isEnabledForJetpackAccess() ||
             !jetpackApplicationPasswordsSupport.supportsAppPasswords(site)
         ) {
-            dispatchUploadFlow(wpComV2MediaRestClient.getUploadMediaFlow(site, media))
+            dispatchUploadFlow(wpComV2MediaRestClient.uploadMedia(site, media))
             return
         }
 
         var appPasswordsError: MediaError? = null
-        applicationPasswordsMediaRestClient.getUploadMediaFlow(site, media).collect { payload ->
+
+        applicationPasswordsMediaRestClient.uploadMedia(site, media).collect { payload ->
             if (payload.isError) {
                 appPasswordsError = payload.error
             } else {
@@ -140,12 +141,11 @@ class WooMediaNetwork @Inject constructor(
             }
         }
 
-        if (appPasswordsError == null) {
-            return
-        }
+        // if app passwords succeeded, exit
+        if (appPasswordsError == null) return
 
         var fallbackSucceeded = false
-        wpComV2MediaRestClient.getUploadMediaFlow(site, media).collect { payload ->
+        wpComV2MediaRestClient.uploadMedia(site, media).collect { payload ->
             if (payload.completed && !payload.isError && !payload.canceled) {
                 fallbackSucceeded = true
             }
@@ -169,10 +169,10 @@ class WooMediaNetwork @Inject constructor(
         if (!applicationPasswordsConfiguration.isEnabledForJetpackAccess() ||
             !jetpackApplicationPasswordsSupport.supportsAppPasswords(site)
         ) {
-            return wpComV2MediaRestClient.executeFetchMediaList(site, number, offset, mimeType)
+            return wpComV2MediaRestClient.fetchMediaList(site, number, offset, mimeType)
         }
 
-        val appPasswordsPayload = applicationPasswordsMediaRestClient.executeFetchMediaList(
+        val appPasswordsPayload = applicationPasswordsMediaRestClient.fetchMediaList(
             site,
             number,
             offset,
@@ -182,7 +182,7 @@ class WooMediaNetwork @Inject constructor(
             return appPasswordsPayload
         }
 
-        val fallbackPayload = wpComV2MediaRestClient.executeFetchMediaList(site, number, offset, mimeType)
+        val fallbackPayload = wpComV2MediaRestClient.fetchMediaList(site, number, offset, mimeType)
         if (!fallbackPayload.isError) {
             jetpackApplicationPasswordsErrorHandler.handleError(
                 site,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClient.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
 
 import com.google.gson.Gson
 import okhttp3.OkHttpClient
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
@@ -11,20 +10,17 @@ import org.wordpress.android.fluxc.network.rest.wpapi.media.BaseWPV2MediaRestCli
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.tools.CoroutineEngine
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
 @Singleton
 class WPComV2MediaRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    coroutineEngine: CoroutineEngine,
     @Named("regular") okHttpClient: OkHttpClient,
     private val accessToken: AccessToken,
     private val wpComNetwork: WPComNetwork,
     gson: Gson
-) : BaseWPV2MediaRestClient(dispatcher, coroutineEngine, okHttpClient, gson) {
+) : BaseWPV2MediaRestClient(okHttpClient, gson) {
     override fun WPAPIEndpoint.getFullUrl(site: SiteModel): String = getWPComUrl(site.siteId)
 
     override suspend fun getAuthorizationHeader(site: SiteModel): String = "Bearer ${accessToken.get()}"

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -163,6 +163,7 @@ public class MediaStore extends Store {
         @NonNull public MediaErrorType type;
         @Nullable public MediaErrorSubType mErrorSubType;
         @Nullable public String message;
+        @Nullable public String apiErrorCode;
         public int statusCode;
         @Nullable public String logMessage;
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -16,9 +16,7 @@ import org.wordpress.android.fluxc.logging.FluxCCrashLogger;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
-import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration;
-import org.wordpress.android.fluxc.network.rest.wpapi.media.ApplicationPasswordsMediaRestClient;
-import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpapi.media.WooMediaNetwork;
 import org.wordpress.android.fluxc.store.media.MediaErrorSubType;
 import org.wordpress.android.fluxc.store.media.MediaErrorSubType.MalformedMediaArgSubType;
 import org.wordpress.android.fluxc.store.media.MediaErrorSubType.MalformedMediaArgSubType.Type;
@@ -405,29 +403,22 @@ public class MediaStore extends Store {
         }
     }
 
-    private final WPComV2MediaRestClient mWPComV2MediaRestClient;
-    private final ApplicationPasswordsMediaRestClient mApplicationPasswordsMediaRestClient;
+    private final WooMediaNetwork mWooMediaNetwork;
     @NonNull private final RemoteMediaCache mRemoteMediaCache;
     @NonNull private final MediaCacheOperations mMediaCacheOperations;
     @NonNull private final MediaIdGenerator mMediaIdGenerator;
-
-    private final ApplicationPasswordsConfiguration mApplicationPasswordsConfiguration;
 
     @NonNull private final FluxCCrashLogger mCrashLogger;
 
     @Inject public MediaStore(
             Dispatcher dispatcher,
-            WPComV2MediaRestClient wpv2MediaRestClient,
-            ApplicationPasswordsMediaRestClient applicationPasswordsMediaRestClient,
-            ApplicationPasswordsConfiguration applicationPasswordsConfiguration,
+            WooMediaNetwork wooMediaNetwork,
             @NonNull FluxCCrashLogger crashLogger,
             @NonNull RemoteMediaCache remoteMediaCache,
             @NonNull MediaCacheOperations mediaCacheOperations,
             @NonNull MediaIdGenerator mediaIdGenerator) {
         super(dispatcher);
-        mWPComV2MediaRestClient = wpv2MediaRestClient;
-        mApplicationPasswordsMediaRestClient = applicationPasswordsMediaRestClient;
-        mApplicationPasswordsConfiguration = applicationPasswordsConfiguration;
+        mWooMediaNetwork = wooMediaNetwork;
         mCrashLogger = crashLogger;
         mRemoteMediaCache = remoteMediaCache;
         mMediaCacheOperations = mediaCacheOperations;
@@ -598,12 +589,7 @@ public class MediaStore extends Store {
             MediaUtils.stripLocation(payload.media.getFilePath());
         }
 
-        if (payload.site.getOrigin() == SiteModel.ORIGIN_WPCOM_REST) {
-            mWPComV2MediaRestClient.uploadMedia(payload.site, payload.media);
-        } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
-                   && mApplicationPasswordsConfiguration.isEnabledForDirectAccess()) {
-            mApplicationPasswordsMediaRestClient.uploadMedia(payload.site, payload.media);
-        } else {
+        if (!mWooMediaNetwork.uploadMedia(payload.site, payload.media)) {
             reportXmlrpcTry();
         }
     }
@@ -614,12 +600,7 @@ public class MediaStore extends Store {
             String mimeTypeValue = payload.mimeType != null ? payload.mimeType.getValue() : null;
             offset = mMediaCacheOperations.getUploadedMediaCount(payload.site.getId(), mimeTypeValue);
         }
-        if (payload.site.getOrigin() == SiteModel.ORIGIN_WPCOM_REST) {
-            mWPComV2MediaRestClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
-        } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
-                   && mApplicationPasswordsConfiguration.isEnabledForDirectAccess()) {
-            mApplicationPasswordsMediaRestClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
-        } else {
+        if (!mWooMediaNetwork.fetchMediaList(payload.site, payload.number, offset, payload.mimeType)) {
             reportXmlrpcTry();
         }
     }
@@ -630,12 +611,7 @@ public class MediaStore extends Store {
             mRemoteMediaCache.remove(payload.site.getId(), media.getMediaId());
         }
 
-        if (payload.site.getOrigin() == SiteModel.ORIGIN_WPCOM_REST) {
-            mWPComV2MediaRestClient.cancelUpload(media);
-        } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
-                   && mApplicationPasswordsConfiguration.isEnabledForDirectAccess()) {
-            mApplicationPasswordsMediaRestClient.cancelUpload(media);
-        } else {
+        if (!mWooMediaNetwork.cancelUpload(payload.site, media)) {
             reportXmlrpcTry();
         }
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -12,7 +12,6 @@ import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
-import org.wordpress.android.fluxc.logging.FluxCCrashLogger;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
@@ -29,7 +28,6 @@ import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -408,18 +406,14 @@ public class MediaStore extends Store {
     @NonNull private final MediaCacheOperations mMediaCacheOperations;
     @NonNull private final MediaIdGenerator mMediaIdGenerator;
 
-    @NonNull private final FluxCCrashLogger mCrashLogger;
-
     @Inject public MediaStore(
             Dispatcher dispatcher,
             WooMediaNetwork wooMediaNetwork,
-            @NonNull FluxCCrashLogger crashLogger,
             @NonNull RemoteMediaCache remoteMediaCache,
             @NonNull MediaCacheOperations mediaCacheOperations,
             @NonNull MediaIdGenerator mediaIdGenerator) {
         super(dispatcher);
         mWooMediaNetwork = wooMediaNetwork;
-        mCrashLogger = crashLogger;
         mRemoteMediaCache = remoteMediaCache;
         mMediaCacheOperations = mediaCacheOperations;
         mMediaIdGenerator = mediaIdGenerator;
@@ -589,9 +583,7 @@ public class MediaStore extends Store {
             MediaUtils.stripLocation(payload.media.getFilePath());
         }
 
-        if (!mWooMediaNetwork.uploadMedia(payload.site, payload.media)) {
-            reportXmlrpcTry();
-        }
+        mWooMediaNetwork.uploadMedia(payload.site, payload.media);
     }
 
     private void performFetchMediaList(@NonNull FetchMediaListPayload payload) {
@@ -600,9 +592,7 @@ public class MediaStore extends Store {
             String mimeTypeValue = payload.mimeType != null ? payload.mimeType.getValue() : null;
             offset = mMediaCacheOperations.getUploadedMediaCount(payload.site.getId(), mimeTypeValue);
         }
-        if (!mWooMediaNetwork.fetchMediaList(payload.site, payload.number, offset, payload.mimeType)) {
-            reportXmlrpcTry();
-        }
+        mWooMediaNetwork.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
     }
 
     private void performCancelUpload(@NonNull CancelMediaPayload payload) {
@@ -611,9 +601,7 @@ public class MediaStore extends Store {
             mRemoteMediaCache.remove(payload.site.getId(), media.getMediaId());
         }
 
-        if (!mWooMediaNetwork.cancelUpload(payload.site, media)) {
-            reportXmlrpcTry();
-        }
+        mWooMediaNetwork.cancelUpload(payload.site, media);
     }
 
     private void handleMediaUploaded(@NonNull ProgressPayload payload) {
@@ -693,7 +681,4 @@ public class MediaStore extends Store {
         emitChange(mediaChange);
     }
 
-    private void reportXmlrpcTry() {
-        mCrashLogger.sendReport(null, Collections.emptyMap(), "Requested MediaStore XMLRPC connection. This should not happen.");
-    }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
@@ -3,19 +3,22 @@ package org.wordpress.android.fluxc.network.rest.wpapi.media
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.annotations.action.Action as FluxAction
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
@@ -178,6 +181,7 @@ class WooMediaNetworkTest {
 
             sut.uploadMedia(jetpackSite, media)
 
+            val dispatchCaptor = argumentCaptor<FluxAction<*>>()
             verify(jetpackApplicationPasswordsErrorHandler).handleError(
                 eq(jetpackSite),
                 argThat {
@@ -185,7 +189,39 @@ class WooMediaNetworkTest {
                         volleyError?.networkResponse?.statusCode == 403
                 }
             )
-            verify(dispatcher, atLeastOnce()).dispatch(any())
+            verify(dispatcher, times(1)).dispatch(dispatchCaptor.capture())
+            val dispatchedPayload = dispatchCaptor.firstValue.payload as ProgressPayload
+            assertThat(dispatchedPayload.progress).isEqualTo(1f)
+            assertThat(dispatchedPayload.completed).isTrue()
+        }
+
+    @Test
+    fun `given supported jetpack site, when app passwords upload succeeds, then dispatch buffered progress`() =
+        runTest {
+            val media: MediaModel = mock {
+                on { id } doReturn 8
+            }
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(applicationPasswordsMediaRestClient.getUploadMediaFlow(jetpackSite, media)).thenReturn(
+                flowOf(
+                    ProgressPayload(media, 0.4f, false, null),
+                    ProgressPayload(media, 1f, true, false)
+                )
+            )
+
+            sut.uploadMedia(jetpackSite, media)
+
+            val dispatchCaptor = argumentCaptor<FluxAction<*>>()
+            verify(dispatcher, times(2)).dispatch(dispatchCaptor.capture())
+            verify(wpComV2MediaRestClient, never()).getUploadMediaFlow(any(), any())
+            verify(jetpackApplicationPasswordsErrorHandler, never()).handleError(any(), any())
+
+            val payloads = dispatchCaptor.allValues.map { it.payload as ProgressPayload }
+            assertThat(payloads).hasSize(2)
+            assertThat(payloads[0].progress).isEqualTo(0.4f)
+            assertThat(payloads[0].completed).isFalse()
+            assertThat(payloads[1].progress).isEqualTo(1f)
+            assertThat(payloads[1].completed).isTrue()
         }
 
     private fun createMediaError(statusCode: Int, apiErrorCode: String): MediaError {

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
@@ -1,0 +1,204 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.media
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsErrorHandler
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsSupport
+import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload
+import org.wordpress.android.fluxc.store.MediaStore.MediaError
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
+import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.fluxc.utils.MimeType
+
+@RunWith(RobolectricTestRunner::class)
+class WooMediaNetworkTest {
+    private val dispatcher: Dispatcher = mock()
+    private val coroutineEngine = CoroutineEngine(Dispatchers.Unconfined, mock<AppLogWrapper>())
+    private val applicationPasswordsConfiguration = FakeApplicationPasswordsConfiguration()
+    private val applicationPasswordsMediaRestClient: ApplicationPasswordsMediaRestClient = mock()
+    private val wpComV2MediaRestClient: WPComV2MediaRestClient = mock()
+    private val jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport = mock()
+    private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler = mock()
+
+    private val sut = WooMediaNetwork(
+        dispatcher = dispatcher,
+        coroutineEngine = coroutineEngine,
+        applicationPasswordsConfiguration = applicationPasswordsConfiguration,
+        applicationPasswordsMediaRestClient = applicationPasswordsMediaRestClient,
+        wpComV2MediaRestClient = wpComV2MediaRestClient,
+        jetpackApplicationPasswordsSupport = jetpackApplicationPasswordsSupport,
+        jetpackApplicationPasswordsErrorHandler = jetpackApplicationPasswordsErrorHandler
+    )
+
+    private val jetpackSite = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPCOM_REST
+        siteId = 123L
+        url = "https://example.com"
+    }
+
+    @Test
+    fun `given supported jetpack site, when fetching media list, then use app passwords first`() = runTest {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+        whenever(
+            applicationPasswordsMediaRestClient.executeFetchMediaList(
+                jetpackSite,
+                10,
+                0,
+                MimeType.Type.IMAGE
+            )
+        ).thenReturn(
+            FetchMediaListResponsePayload(
+                jetpackSite,
+                emptyList(),
+                false,
+                false,
+                MimeType.Type.IMAGE
+            )
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient).executeFetchMediaList(
+            jetpackSite,
+            10,
+            0,
+            MimeType.Type.IMAGE
+        )
+        verify(wpComV2MediaRestClient, never()).executeFetchMediaList(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `given supported jetpack site, when app passwords fetch fails and fallback succeeds, then flag site`() =
+        runTest {
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(
+                applicationPasswordsMediaRestClient.executeFetchMediaList(
+                    jetpackSite,
+                    20,
+                    5,
+                    MimeType.Type.IMAGE
+                )
+            ).thenReturn(
+                FetchMediaListResponsePayload(
+                    jetpackSite,
+                    createMediaError(statusCode = 500, apiErrorCode = "incorrect_password"),
+                    MimeType.Type.IMAGE
+                )
+            )
+            whenever(
+                wpComV2MediaRestClient.executeFetchMediaList(
+                    jetpackSite,
+                    20,
+                    5,
+                    MimeType.Type.IMAGE
+                )
+            ).thenReturn(
+                FetchMediaListResponsePayload(
+                    jetpackSite,
+                    emptyList(),
+                    false,
+                    true,
+                    MimeType.Type.IMAGE
+                )
+            )
+
+            sut.fetchMediaList(jetpackSite, 20, 5, MimeType.Type.IMAGE)
+
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == "incorrect_password" &&
+                        volleyError?.networkResponse?.statusCode == 500
+                }
+            )
+        }
+
+    @Test
+    fun `given unsupported jetpack site, when fetching media list, then skip app passwords`() = runTest {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(false)
+        whenever(
+            wpComV2MediaRestClient.executeFetchMediaList(
+                jetpackSite,
+                10,
+                0,
+                MimeType.Type.IMAGE
+            )
+        ).thenReturn(
+            FetchMediaListResponsePayload(
+                jetpackSite,
+                emptyList(),
+                false,
+                false,
+                MimeType.Type.IMAGE
+            )
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient, never()).executeFetchMediaList(any(), any(), any(), any())
+        verify(wpComV2MediaRestClient).executeFetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+    }
+
+    @Test
+    fun `given supported jetpack site, when app passwords upload fails and fallback succeeds, then flag site`() =
+        runTest {
+            val media: MediaModel = mock {
+                on { id } doReturn 7
+            }
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(applicationPasswordsMediaRestClient.getUploadMediaFlow(jetpackSite, media)).thenReturn(
+                flowOf(
+                    ProgressPayload(media, 0.4f, false, null),
+                    ProgressPayload(media, 1f, false, createMediaError(statusCode = 403, apiErrorCode = "forbidden"))
+                )
+            )
+            whenever(wpComV2MediaRestClient.getUploadMediaFlow(jetpackSite, media)).thenReturn(
+                flowOf(ProgressPayload(media, 1f, true, false))
+            )
+
+            sut.uploadMedia(jetpackSite, media)
+
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == "forbidden" &&
+                        volleyError?.networkResponse?.statusCode == 403
+                }
+            )
+            verify(dispatcher, atLeastOnce()).dispatch(any())
+        }
+
+    private fun createMediaError(statusCode: Int, apiErrorCode: String): MediaError {
+        return MediaError(MediaErrorType.GENERIC_ERROR).apply {
+            this.statusCode = statusCode
+            this.apiErrorCode = apiErrorCode
+        }
+    }
+
+    private class FakeApplicationPasswordsConfiguration : ApplicationPasswordsConfiguration {
+        override val applicationName: String
+            get() = "WooCommerce"
+
+        override suspend fun isEnabledForJetpackAccess(): Boolean = true
+    }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
@@ -63,7 +63,7 @@ class WooMediaNetworkTest {
     fun `given supported jetpack site, when fetching media list, then use app passwords first`() = runTest {
         whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
         whenever(
-            applicationPasswordsMediaRestClient.executeFetchMediaList(
+            applicationPasswordsMediaRestClient.fetchMediaList(
                 jetpackSite,
                 10,
                 0,
@@ -81,13 +81,13 @@ class WooMediaNetworkTest {
 
         sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
 
-        verify(applicationPasswordsMediaRestClient).executeFetchMediaList(
+        verify(applicationPasswordsMediaRestClient).fetchMediaList(
             jetpackSite,
             10,
             0,
             MimeType.Type.IMAGE
         )
-        verify(wpComV2MediaRestClient, never()).executeFetchMediaList(any(), any(), any(), any())
+        verify(wpComV2MediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
     }
 
     @Test
@@ -95,7 +95,7 @@ class WooMediaNetworkTest {
         runTest {
             whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
             whenever(
-                applicationPasswordsMediaRestClient.executeFetchMediaList(
+                applicationPasswordsMediaRestClient.fetchMediaList(
                     jetpackSite,
                     20,
                     5,
@@ -109,7 +109,7 @@ class WooMediaNetworkTest {
                 )
             )
             whenever(
-                wpComV2MediaRestClient.executeFetchMediaList(
+                wpComV2MediaRestClient.fetchMediaList(
                     jetpackSite,
                     20,
                     5,
@@ -140,7 +140,7 @@ class WooMediaNetworkTest {
     fun `given unsupported jetpack site, when fetching media list, then skip app passwords`() = runTest {
         whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(false)
         whenever(
-            wpComV2MediaRestClient.executeFetchMediaList(
+            wpComV2MediaRestClient.fetchMediaList(
                 jetpackSite,
                 10,
                 0,
@@ -158,8 +158,8 @@ class WooMediaNetworkTest {
 
         sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
 
-        verify(applicationPasswordsMediaRestClient, never()).executeFetchMediaList(any(), any(), any(), any())
-        verify(wpComV2MediaRestClient).executeFetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        verify(applicationPasswordsMediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+        verify(wpComV2MediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
     }
 
     @Test
@@ -169,13 +169,13 @@ class WooMediaNetworkTest {
                 on { id } doReturn 7
             }
             whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
-            whenever(applicationPasswordsMediaRestClient.getUploadMediaFlow(jetpackSite, media)).thenReturn(
+            whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
                 flowOf(
                     ProgressPayload(media, 0.4f, false, null),
                     ProgressPayload(media, 1f, false, createMediaError(statusCode = 403, apiErrorCode = "forbidden"))
                 )
             )
-            whenever(wpComV2MediaRestClient.getUploadMediaFlow(jetpackSite, media)).thenReturn(
+            whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
                 flowOf(ProgressPayload(media, 1f, true, false))
             )
 
@@ -202,7 +202,7 @@ class WooMediaNetworkTest {
                 on { id } doReturn 8
             }
             whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
-            whenever(applicationPasswordsMediaRestClient.getUploadMediaFlow(jetpackSite, media)).thenReturn(
+            whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
                 flowOf(
                     ProgressPayload(media, 0.4f, false, null),
                     ProgressPayload(media, 1f, true, false)
@@ -213,7 +213,7 @@ class WooMediaNetworkTest {
 
             val dispatchCaptor = argumentCaptor<FluxAction<*>>()
             verify(dispatcher, times(2)).dispatch(dispatchCaptor.capture())
-            verify(wpComV2MediaRestClient, never()).getUploadMediaFlow(any(), any())
+            verify(wpComV2MediaRestClient, never()).uploadMedia(any(), any())
             verify(jetpackApplicationPasswordsErrorHandler, never()).handleError(any(), any())
 
             val payloads = dispatchCaptor.allValues.map { it.payload as ProgressPayload }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.media
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -22,6 +23,7 @@ import org.wordpress.android.fluxc.annotations.action.Action as FluxAction
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsStore
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsErrorHandler
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsSupport
 import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient
@@ -32,6 +34,7 @@ import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.fluxc.utils.MimeType
+import java.security.GeneralSecurityException
 
 @RunWith(RobolectricTestRunner::class)
 class WooMediaNetworkTest {
@@ -59,34 +62,26 @@ class WooMediaNetworkTest {
         url = "https://example.com"
     }
 
+    private val wpapiSite = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPAPI
+        siteId = 456L
+        url = "https://direct.example.com"
+    }
+
+    // region Fetch media list – Jetpack
+
     @Test
     fun `given supported jetpack site, when fetching media list, then use app passwords first`() = runTest {
         whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
         whenever(
-            applicationPasswordsMediaRestClient.fetchMediaList(
-                jetpackSite,
-                10,
-                0,
-                MimeType.Type.IMAGE
-            )
+            applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
         ).thenReturn(
-            FetchMediaListResponsePayload(
-                jetpackSite,
-                emptyList(),
-                false,
-                false,
-                MimeType.Type.IMAGE
-            )
+            FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
         )
 
         sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
 
-        verify(applicationPasswordsMediaRestClient).fetchMediaList(
-            jetpackSite,
-            10,
-            0,
-            MimeType.Type.IMAGE
-        )
+        verify(applicationPasswordsMediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
         verify(wpComV2MediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
     }
 
@@ -95,12 +90,7 @@ class WooMediaNetworkTest {
         runTest {
             whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
             whenever(
-                applicationPasswordsMediaRestClient.fetchMediaList(
-                    jetpackSite,
-                    20,
-                    5,
-                    MimeType.Type.IMAGE
-                )
+                applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 20, 5, MimeType.Type.IMAGE)
             ).thenReturn(
                 FetchMediaListResponsePayload(
                     jetpackSite,
@@ -109,20 +99,9 @@ class WooMediaNetworkTest {
                 )
             )
             whenever(
-                wpComV2MediaRestClient.fetchMediaList(
-                    jetpackSite,
-                    20,
-                    5,
-                    MimeType.Type.IMAGE
-                )
+                wpComV2MediaRestClient.fetchMediaList(jetpackSite, 20, 5, MimeType.Type.IMAGE)
             ).thenReturn(
-                FetchMediaListResponsePayload(
-                    jetpackSite,
-                    emptyList(),
-                    false,
-                    true,
-                    MimeType.Type.IMAGE
-                )
+                FetchMediaListResponsePayload(jetpackSite, emptyList(), false, true, MimeType.Type.IMAGE)
             )
 
             sut.fetchMediaList(jetpackSite, 20, 5, MimeType.Type.IMAGE)
@@ -140,20 +119,9 @@ class WooMediaNetworkTest {
     fun `given unsupported jetpack site, when fetching media list, then skip app passwords`() = runTest {
         whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(false)
         whenever(
-            wpComV2MediaRestClient.fetchMediaList(
-                jetpackSite,
-                10,
-                0,
-                MimeType.Type.IMAGE
-            )
+            wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
         ).thenReturn(
-            FetchMediaListResponsePayload(
-                jetpackSite,
-                emptyList(),
-                false,
-                false,
-                MimeType.Type.IMAGE
-            )
+            FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
         )
 
         sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
@@ -161,6 +129,100 @@ class WooMediaNetworkTest {
         verify(applicationPasswordsMediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
         verify(wpComV2MediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
     }
+
+    @Test
+    fun `given jetpack access disabled, when fetching media list, then use wpcom client directly`() = runTest {
+        applicationPasswordsConfiguration.jetpackAccessEnabled = false
+        whenever(
+            wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+        verify(wpComV2MediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+    }
+
+    @Test
+    fun `given supported jetpack site, when app passwords fetch throws GeneralSecurityException, then fallback`() =
+        runTest {
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(
+                applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+            ).thenAnswer { throw GeneralSecurityException("keystore error") }
+            whenever(
+                wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+            ).thenReturn(
+                FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
+            )
+
+            sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+            verify(wpComV2MediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR
+                }
+            )
+        }
+
+    @Test
+    fun `given supported jetpack site, when both fetch paths fail, then do not flag site`() = runTest {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+        whenever(
+            applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(
+                jetpackSite,
+                createMediaError(statusCode = 500, apiErrorCode = "server_error"),
+                MimeType.Type.IMAGE
+            )
+        )
+        whenever(
+            wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(
+                jetpackSite,
+                createMediaError(statusCode = 502, apiErrorCode = "bad_gateway"),
+                MimeType.Type.IMAGE
+            )
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(jetpackApplicationPasswordsErrorHandler, never()).handleError(any(), any())
+    }
+
+    // endregion
+
+    // region Fetch media list – WPAPI
+
+    @Test
+    fun `given WPAPI site, when fetching media list, then use app passwords client`() = runTest {
+        whenever(
+            applicationPasswordsMediaRestClient.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(wpapiSite, emptyList(), false, false, MimeType.Type.IMAGE)
+        )
+
+        sut.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient).fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+        verify(wpComV2MediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `given WPAPI site with direct access disabled, when fetching media list, then throw`() {
+        applicationPasswordsConfiguration.directAccessEnabled = false
+        sut.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+    }
+
+    // endregion
+
+    // region Upload – Jetpack
 
     @Test
     fun `given supported jetpack site, when app passwords upload fails and fallback succeeds, then flag site`() =
@@ -181,7 +243,6 @@ class WooMediaNetworkTest {
 
             sut.uploadMedia(jetpackSite, media)
 
-            val dispatchCaptor = argumentCaptor<FluxAction<*>>()
             verify(jetpackApplicationPasswordsErrorHandler).handleError(
                 eq(jetpackSite),
                 argThat {
@@ -189,14 +250,19 @@ class WooMediaNetworkTest {
                         volleyError?.networkResponse?.statusCode == 403
                 }
             )
-            verify(dispatcher, times(1)).dispatch(dispatchCaptor.capture())
-            val dispatchedPayload = dispatchCaptor.firstValue.payload as ProgressPayload
-            assertThat(dispatchedPayload.progress).isEqualTo(1f)
-            assertThat(dispatchedPayload.completed).isTrue()
+
+            val dispatchCaptor = argumentCaptor<FluxAction<*>>()
+            verify(dispatcher, times(2)).dispatch(dispatchCaptor.capture())
+            val payloads = dispatchCaptor.allValues.map { it.payload as ProgressPayload }
+            // First dispatch: progress from app passwords attempt
+            assertThat(payloads[0].progress).isEqualTo(0.4f)
+            // Second dispatch: completed from fallback
+            assertThat(payloads[1].progress).isEqualTo(1f)
+            assertThat(payloads[1].completed).isTrue()
         }
 
     @Test
-    fun `given supported jetpack site, when app passwords upload succeeds, then dispatch buffered progress`() =
+    fun `given supported jetpack site, when app passwords upload succeeds, then dispatch all progress`() =
         runTest {
             val media: MediaModel = mock {
                 on { id } doReturn 8
@@ -224,6 +290,114 @@ class WooMediaNetworkTest {
             assertThat(payloads[1].completed).isTrue()
         }
 
+    @Test
+    fun `given jetpack access disabled, when uploading, then use wpcom client directly`() = runTest {
+        applicationPasswordsConfiguration.jetpackAccessEnabled = false
+        val media: MediaModel = mock {
+            on { id } doReturn 9
+        }
+        whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, true, false))
+        )
+
+        sut.uploadMedia(jetpackSite, media)
+
+        verify(applicationPasswordsMediaRestClient, never()).uploadMedia(any(), any())
+        verify(wpComV2MediaRestClient).uploadMedia(jetpackSite, media)
+    }
+
+    @Test
+    fun `given supported jetpack site, when app passwords upload throws GeneralSecurityException, then fallback`() =
+        runTest {
+            val media: MediaModel = mock {
+                on { id } doReturn 10
+            }
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media))
+                .thenReturn(flow { throw GeneralSecurityException("keystore error") })
+            whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+                flowOf(ProgressPayload(media, 1f, true, false))
+            )
+
+            sut.uploadMedia(jetpackSite, media)
+
+            verify(wpComV2MediaRestClient).uploadMedia(jetpackSite, media)
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR
+                }
+            )
+        }
+
+    @Test
+    fun `given supported jetpack site, when both upload paths fail, then do not flag site`() = runTest {
+        val media: MediaModel = mock {
+            on { id } doReturn 11
+        }
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+        whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, false, createMediaError(statusCode = 500, apiErrorCode = "error")))
+        )
+        whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, false, createMediaError(statusCode = 502, apiErrorCode = "error")))
+        )
+
+        sut.uploadMedia(jetpackSite, media)
+
+        verify(jetpackApplicationPasswordsErrorHandler, never()).handleError(any(), any())
+    }
+
+    // endregion
+
+    // region Upload – WPAPI
+
+    @Test
+    fun `given WPAPI site, when uploading media, then use app passwords client`() = runTest {
+        val media: MediaModel = mock {
+            on { id } doReturn 12
+        }
+        whenever(applicationPasswordsMediaRestClient.uploadMedia(wpapiSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, true, false))
+        )
+
+        sut.uploadMedia(wpapiSite, media)
+
+        verify(applicationPasswordsMediaRestClient).uploadMedia(wpapiSite, media)
+        verify(wpComV2MediaRestClient, never()).uploadMedia(any(), any())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `given WPAPI site with direct access disabled, when uploading, then throw`() {
+        applicationPasswordsConfiguration.directAccessEnabled = false
+        val media: MediaModel = mock()
+        sut.uploadMedia(wpapiSite, media)
+    }
+
+    // endregion
+
+    // region Cancel upload
+
+    @Test
+    fun `when cancelling upload, then dispatch cancelled action`() {
+        val media: MediaModel = mock {
+            on { id } doReturn 13
+        }
+
+        sut.cancelUpload(jetpackSite, media)
+
+        verify(dispatcher).dispatch(any())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `given unsupported origin, when cancelling upload, then throw`() {
+        val site = SiteModel().apply { origin = 999 }
+        val media: MediaModel = mock()
+        sut.cancelUpload(site, media)
+    }
+
+    // endregion
+
     private fun createMediaError(statusCode: Int, apiErrorCode: String): MediaError {
         return MediaError(MediaErrorType.GENERIC_ERROR).apply {
             this.statusCode = statusCode
@@ -232,9 +406,11 @@ class WooMediaNetworkTest {
     }
 
     private class FakeApplicationPasswordsConfiguration : ApplicationPasswordsConfiguration {
-        override val applicationName: String
-            get() = "WooCommerce"
+        override val applicationName: String = "WooCommerce"
+        var directAccessEnabled: Boolean = true
+        var jetpackAccessEnabled: Boolean = true
 
-        override suspend fun isEnabledForJetpackAccess(): Boolean = true
+        override fun isEnabledForDirectAccess(): Boolean = directAccessEnabled
+        override suspend fun isEnabledForJetpackAccess(): Boolean = jetpackAccessEnabled
     }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/MediaStoreTest.java
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/MediaStoreTest.java
@@ -12,19 +12,23 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.MediaAction;
+import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.logging.FakeCrashLogging;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.network.rest.wpapi.media.ApplicationPasswordsMediaRestClient;
-import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpapi.media.WooMediaNetwork;
 import org.wordpress.android.fluxc.utils.MediaUtils;
+import org.wordpress.android.fluxc.utils.MimeType;
 
+import java.io.File;
 import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
 public class MediaStoreTest {
     private final RemoteMediaCache mRemoteMediaCache = new RemoteMediaCache();
     private final MediaCacheOperations mMediaCacheOperations = new MediaCacheOperations(mRemoteMediaCache);
+    private final WooMediaNetwork mWooMediaNetwork = Mockito.mock(WooMediaNetwork.class);
 
     private static class FakeMediaIdGenerator implements MediaIdGenerator {
         private int nextId = 1;
@@ -36,10 +40,7 @@ public class MediaStoreTest {
 
     @SuppressWarnings("KotlinInternalInJava")
     private final MediaStore mMediaStore = new MediaStore(new Dispatcher(),
-            Mockito.mock(WPComV2MediaRestClient.class),
-            Mockito.mock(ApplicationPasswordsMediaRestClient.class),
-            Mockito.mock(org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
-                    .ApplicationPasswordsConfiguration.class),
+            mWooMediaNetwork,
             FakeCrashLogging.INSTANCE,
             mRemoteMediaCache,
             mMediaCacheOperations,
@@ -255,6 +256,59 @@ public class MediaStoreTest {
 
         assertEquals(testSiteId, storeDocuments.get(0).getLocalSiteId());
         assertEquals(testSiteId, storeDocuments.get(1).getLocalSiteId());
+    }
+
+    @Test
+    public void givenUploadAction_whenHandled_thenDelegateToWooMediaNetwork() {
+        SiteModel site = new SiteModel();
+        site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
+        File file = new File("build/test-image.jpg");
+        try {
+            file.getParentFile().mkdirs();
+            file.createNewFile();
+            MediaModel media = generateMediaFromPath(1, 10L, file.getPath());
+            Mockito.when(mWooMediaNetwork.uploadMedia(site, media)).thenReturn(true);
+
+            mMediaStore.onAction(new Action<>(
+                    MediaAction.UPLOAD_MEDIA,
+                    new MediaStore.UploadMediaPayload(site, media, false)
+            ));
+
+            Mockito.verify(mWooMediaNetwork).uploadMedia(site, media);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            file.delete();
+        }
+    }
+
+    @Test
+    public void givenFetchMediaListAction_whenHandled_thenDelegateToWooMediaNetwork() {
+        SiteModel site = getTestSiteWithLocalId(5);
+        site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
+        Mockito.when(mWooMediaNetwork.fetchMediaList(site, 10, 0, MimeType.Type.IMAGE)).thenReturn(true);
+
+        mMediaStore.onAction(new Action<>(
+                MediaAction.FETCH_MEDIA_LIST,
+                new MediaStore.FetchMediaListPayload(site, 10, false, MimeType.Type.IMAGE)
+        ));
+
+        Mockito.verify(mWooMediaNetwork).fetchMediaList(site, 10, 0, MimeType.Type.IMAGE);
+    }
+
+    @Test
+    public void givenCancelUploadAction_whenHandled_thenDelegateToWooMediaNetwork() {
+        SiteModel site = getTestSiteWithLocalId(5);
+        site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
+        MediaModel media = generateMediaFromPath(5, 11L, "/test/test_image.jpg");
+        Mockito.when(mWooMediaNetwork.cancelUpload(site, media)).thenReturn(true);
+
+        mMediaStore.onAction(new Action<>(
+                MediaAction.CANCEL_MEDIA_UPLOAD,
+                new MediaStore.CancelMediaPayload(site, media, false)
+        ));
+
+        Mockito.verify(mWooMediaNetwork).cancelUpload(site, media);
     }
 
     private SiteModel getTestSiteWithLocalId(int localSiteId) {

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/MediaStoreTest.java
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/MediaStoreTest.java
@@ -14,7 +14,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
-import org.wordpress.android.fluxc.logging.FakeCrashLogging;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.rest.wpapi.media.WooMediaNetwork;
@@ -41,7 +40,6 @@ public class MediaStoreTest {
     @SuppressWarnings("KotlinInternalInJava")
     private final MediaStore mMediaStore = new MediaStore(new Dispatcher(),
             mWooMediaNetwork,
-            FakeCrashLogging.INSTANCE,
             mRemoteMediaCache,
             mMediaCacheOperations,
             new FakeMediaIdGenerator()
@@ -267,7 +265,6 @@ public class MediaStoreTest {
             file.getParentFile().mkdirs();
             file.createNewFile();
             MediaModel media = generateMediaFromPath(1, 10L, file.getPath());
-            Mockito.when(mWooMediaNetwork.uploadMedia(site, media)).thenReturn(true);
 
             mMediaStore.onAction(new Action<>(
                     MediaAction.UPLOAD_MEDIA,
@@ -286,8 +283,6 @@ public class MediaStoreTest {
     public void givenFetchMediaListAction_whenHandled_thenDelegateToWooMediaNetwork() {
         SiteModel site = getTestSiteWithLocalId(5);
         site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
-        Mockito.when(mWooMediaNetwork.fetchMediaList(site, 10, 0, MimeType.Type.IMAGE)).thenReturn(true);
-
         mMediaStore.onAction(new Action<>(
                 MediaAction.FETCH_MEDIA_LIST,
                 new MediaStore.FetchMediaListPayload(site, 10, false, MimeType.Type.IMAGE)
@@ -301,8 +296,6 @@ public class MediaStoreTest {
         SiteModel site = getTestSiteWithLocalId(5);
         site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
         MediaModel media = generateMediaFromPath(5, 11L, "/test/test_image.jpg");
-        Mockito.when(mWooMediaNetwork.cancelUpload(site, media)).thenReturn(true);
-
         mMediaStore.onAction(new Action<>(
                 MediaAction.CANCEL_MEDIA_UPLOAD,
                 new MediaStore.CancelMediaPayload(site, media, false)


### PR DESCRIPTION
### Description
Fixes WOOMOB-1438

The `/media` endpoints in FluxC still use old Java code that bypasses `WooNetwork`, so they weren't migrated to application passwords with the rest of the endpoints. This PR introduces `WooMediaNetwork`, a routing layer that:

- Routes media upload, fetch, and cancel requests through application passwords for self-hosted (WPAPI) sites
- For Jetpack (WPCOM_REST) sites, tries application passwords first and falls back to WPCom REST v2 if that fails, reporting the error via `JetpackApplicationPasswordsErrorHandler`
- Simplifies `MediaStore` by replacing direct client references with delegation to `WooMediaNetwork`
- Exposes `statusCode` and `apiErrorCode` on `MediaError` so the fallback logic can reconstruct proper `WPAPINetworkError`s

### Test Steps
1. Connect a self-hosted WooCommerce site using application passwords
2. Navigate to a product and upload a media image — verify it uploads successfully
3. Fetch the media library — verify images load
4. Cancel an in-progress upload — verify it cancels properly
5. Connect a Jetpack site and repeat steps 2-4

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.