### PR TITLE
Fix order filter not applied after clear+rotate+reselect flow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -903,7 +903,7 @@ class OrderListFragment :
     }
 
     private fun initializeResultHandlers() {
-        handleResult<String>(FILTER_CHANGE_NOTICE_KEY) {
+        handleResult<String>(FILTER_CHANGE_NOTICE_KEY, R.id.orders) {
             selectedOrder.selectOrder(-1L)
             viewModel.loadOrders()
         }


### PR DESCRIPTION
## Description

Closes: WOOMOB-32

> [!NOTE]
> The original issue from Linear was slightly different, but I couldn't reproduce it anymore. I've noticed a related issue (very similar testing steps) so decided to fix it as part of that issue. 

Fixes order filters not being applied after clearing filters, rotating the device, and reselecting a new filter.

**Root cause:** `handleResult` in `OrderListFragment` registered its observer on `navController.currentBackStackEntry` (the default when no `entryId` is provided). After rotation with a filter dialog on top, `currentBackStackEntry` points to the dialog's entry rather than `R.id.orders`. When filters are later applied and the dialog dismissed, the result is set on the `R.id.orders` entry but the observer watches the wrong entry, so `loadOrders()` never fires.

**Fix:** Pass explicit `R.id.orders` entry ID to `handleResult`, ensuring the observer is always registered on the correct back stack entry regardless of what's on top during rotation.

## Testing instructions

1. Open the Orders tab
2. Tap **Filters** and select a status filter (e.g., "Processing")
3. Tap **Show orders** to apply the filter
4. Tap **Filters** again
5. Tap **Clear** to clear all filters
6. **Rotate the device** (before tapping "Show orders")
7. Tap **Show orders**
8. Verify the order list shows **all orders** (no filter applied)
9. Tap **Filters** again
10. Select a different status (e.g., "Completed")
11. Tap **Show orders**
12. Verify only orders with "Completed" status appear

## Images/gif

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/673d5648-4fd8-410c-a65b-023e2459ad71"/> | <video src="https://github.com/user-attachments/assets/76baf1d8-956d-4b08-848d-82a59d9abd98"/> |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.