### PR TITLE
Make trunk prototype builds on-demand and add nightly build pipeline

### DIFF
--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -18,5 +18,9 @@ bundle exec fastlane run configure_apply
 APP_TO_BUILD="${1:?Usage: prototype-build.sh <WooCommerce|WooCommerce-Wear>}"
 echo "Selected app: ${APP_TO_BUILD}"
 
-echo "--- :hammer_and_wrench: Building and uploading to Firebase App Distribution"
+if [ "${APP_TO_BUILD}" == "WooCommerce" ]; then
+  echo "--- :hammer_and_wrench: Building and uploading to Firebase App Distribution"
+else
+  echo "--- :hammer_and_wrench: Building and uploading to S3"
+fi
 bundle exec fastlane build_and_upload_prototype_build app:"${APP_TO_BUILD}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -83,7 +83,7 @@ steps:
           - "WooCommerce/build/outputs/apk/**/*"
 
       - input: Create a Wear Prototype Build?
-        prompt: Share a Wear Prototype Build via Firebase App Distribution?
+        prompt: Share a Wear Prototype Build? (it will be uploaded to AWS S3)
         key: wear_prototype_build_triggered
       - label: ":amazon-s3: Wear Prototype Build"
         depends_on: wear_prototype_build_triggered

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,20 +66,27 @@ steps:
 
   ########################################
   - group: "🚀 Prototype Build"
+    # Mobile Prototype Builds are on-demand on `trunk`, but always built on PRs
+    # WearOS Prototype Builds are on-demand both on `trunk` and PRs
     steps:
+      - input: Create a Mobile Prototype Build?
+        prompt: Share a Mobile Prototype Build via Firebase App Distribution?
+        key: mobile_prototype_build_triggered
+        if: build.branch == "trunk"
       - label: ":firebase: Mobile Prototype Build"
+        # Buildkite considers this implicitly satisfied if `depends_on` step is skipped due to `if:` condition, so this will run unconditionally on PRs
+        # https://buildkite.com/docs/pipelines/configure/dependencies#how-skipped-steps-affect-dependencies
+        depends_on: mobile_prototype_build_triggered
         command: .buildkite/commands/prototype-build.sh WooCommerce
         plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "WooCommerce/build/outputs/apk/**/*"
 
-      - block: Build Watch Prototype?
-        prompt: Trigger an on-demand Wear OS prototype build
-        key: watch_prototype_build_triggered
-        depends_on: ~
-
-      - label: ":amazon-s3: Watch Prototype Build"
-        depends_on: watch_prototype_build_triggered
+      - input: Create a Wear Prototype Build?
+        prompt: Share a Wear Prototype Build via Firebase App Distribution?
+        key: wear_prototype_build_triggered
+      - label: ":amazon-s3: Wear Prototype Build"
+        depends_on: wear_prototype_build_triggered
         command: .buildkite/commands/prototype-build.sh WooCommerce-Wear
         plugins: [$CI_TOOLKIT]
         artifact_paths:

--- a/.buildkite/schedules/nightly-prototype-build.yml
+++ b/.buildkite/schedules/nightly-prototype-build.yml
@@ -10,3 +10,9 @@ steps:
     plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "WooCommerce/build/outputs/apk/**/*"
+
+notify:
+  - slack:
+      channels:
+        - "#android-core-notifs"
+      if: "build.state == 'failed'"

--- a/.buildkite/schedules/nightly-prototype-build.yml
+++ b/.buildkite/schedules/nightly-prototype-build.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: "android"
+
+steps:
+  - label: ":firebase: Nightly Mobile Prototype Build"
+    command: .buildkite/commands/prototype-build.sh WooCommerce
+    plugins: [$CI_TOOLKIT]
+    artifact_paths:
+      - "WooCommerce/build/outputs/apk/**/*"


### PR DESCRIPTION
Closes [AINFRA-2170](https://linear.app/a8c/issue/AINFRA-2170/set-up-nightly-trunk-prototype-builds-for-woo-mobile)
iOS counterpart: https://github.com/woocommerce/woocommerce-ios/pull/16818

## Description

 - Mobile Prototype Builds are now on-demand on `trunk` (gated behind an input step) but still built automatically on PRs.
 - But we added a scheduled pipeline for nightly prototype builds, triggered on `trunk` by a Buildkite schedule to run every day at midnight (see https://github.com/Automattic/buildkite-ci/pull/827)
 - Wear OS Prototype Builds remain on-demand on both trunk and PRs. Nightly builds don't build Wear OS at this point since they are tested more rarely, and if one needs one they can still generate it on demand from `trunk`

This was discussed in p1773397624341559/1773394983.779039-slack-CC7L49W13 to align with WCiOS and provide a balance between having builds from `trunk` all while not overwhelming CI usage too much for building unnecessary.

### Before

| Prototype Builds | Mobile app | Wear app |
|---|---|---|
| On PRs | ✅ Always | 🙋 On Demand |
| On `trunk` commits | ✅ Always | 🙋 On Demand |
| Nightly Builds | ❌ N/A | ❌ N/A |

### After

| Prototype Builds | Mobile app | Wear app |
|---|---|---|
| On PRs | ✅ Always | 🙋 On Demand |
| On `trunk` commits | 🙋 On Demand | 🙋 On Demand |
| Nightly Builds | 🕐 [Every day at midnight](https://github.com/Automattic/buildkite-ci/pull/827/changes#diff-3639440759f4caf7238c60efa31dd20ce64b6c08a2c2f25ff01d943e84f5d3cc) | ❌ N/A |

## Testing

 - [x] Verify a Mobile Prototype Build is created on this PR and you get the PR comment for it
 - [x] Verify [the CI build for this PR shows](https://buildkite.com/automattic/woocommerce-android/builds/latest?branch=ainfra-2170%2Fnightly-prototype-builds) a "Create Wear Prototype Build?" input step
    <img width="498" height="169" alt="image" src="https://github.com/user-attachments/assets/d254434b-8860-4764-ac27-ac31d7c2b303" />
 - [x] Click on the "Create Wear Prototype Build?" step, then on the "Continue" button to confirm
    <img width="655" height="282" alt="image" src="https://github.com/user-attachments/assets/b7fa86ca-efc5-4b74-913e-2b9e13246683" />
 - [ ] Validate the Wear Prototype build is generated for Wear and you get the PR comment for it too.

> [!NOTE]
> Unfortunately, it's not going to be possible to test the cases of `trunk` builds nor scheduled nightly builds until after this PR and https://github.com/Automattic/buildkite-ci/pull/827 land.