### PR TITLE
[WOOMOB-2383] Always hide the Bookings toolbar

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -55,12 +55,10 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
                 mode = BookingDetailsFragment.Mode.Empty
             ).toBundle()
         )
+
     override val activityAppBarStatus: AppBarStatus
-        get() = if (navArgs.showBottomNavigation) {
-            AppBarStatus.Hidden
-        } else {
-            AppBarStatus.Visible(hasShadow = false, hasDivider = true)
-        }
+        get() = AppBarStatus.Hidden
+
     override val shouldShowBottomNavigation: Boolean
         get() = navArgs.showBottomNavigation
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListFragment.kt
@@ -135,6 +135,7 @@ class BookingListFragment : TopLevelFragment(), TabletLayoutSetupHelper.Screen {
                     )
                 }
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+                is MultiLiveEvent.Event.Exit -> findNavController().navigateUp()
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -86,7 +86,12 @@ fun BookingListScreen(state: BookingListViewState) {
         topBar = {
             Toolbar(
                 title = state.toolbarTitle.getText(),
-                navigationIcon = null,
+                navigationIcon = if (state.showBackButton) {
+                    ImageVector.vectorResource(R.drawable.ic_back_24dp)
+                } else {
+                    null
+                },
+                onNavigationButtonClick = state.onBackClick,
                 actions = {
                     SearchSection(
                         searchState = state.searchState,
@@ -537,7 +542,9 @@ private fun BookingListPreview() {
                 searchState = BookingListSearchState(
                     query = null,
                     onQueryChanged = {}
-                )
+                ),
+                showBackButton = false,
+                onBackClick = {}
             )
         )
     }
@@ -571,7 +578,9 @@ private fun EmptyViewPreview() {
                 searchState = BookingListSearchState(
                     query = null,
                     onQueryChanged = {}
-                )
+                ),
+                showBackButton = false,
+                onBackClick = {}
             )
         )
     }
@@ -605,7 +614,9 @@ private fun EmptySearchResultsViewPreview() {
                 searchState = BookingListSearchState(
                     query = "Haircut",
                     onQueryChanged = {}
-                )
+                ),
+                showBackButton = false,
+                onBackClick = {}
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListScreen.kt
@@ -86,7 +86,8 @@ fun BookingListScreen(state: BookingListViewState) {
         topBar = {
             Toolbar(
                 title = state.toolbarTitle.getText(),
-                navigationIcon = if (state.showBackButton) {
+                // When search is active, the SearchSection already shows a back button
+                navigationIcon = if (state.showBackButton && !state.searchState.isSearchActive) {
                     ImageVector.vectorResource(R.drawable.ic_back_24dp)
                 } else {
                     null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -23,7 +23,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -59,17 +58,16 @@ class BookingListViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
 
     private val analyticsHelper = BookingAnalyticsHelper()
-    private val stateHandle = savedStateHandle
     private val navArgs: BookingsArgs by savedStateHandle.navArgs()
 
     private val loadingState = MutableStateFlow(BookingListLoadingState.Idle)
 
-    private val selectedTab = savedStateHandle.getStateFlow(viewModelScope, BookingListTab.Today)
+    private val selectedTab = savedState.getStateFlow(viewModelScope, BookingListTab.Today)
     private var didUserSwitchTab: Boolean
-        get() = stateHandle["did_user_switch_tab"] ?: false
-        set(value) = stateHandle.set("did_user_switch_tab", value)
+        get() = savedState["did_user_switch_tab"] ?: false
+        set(value) = savedState.set("did_user_switch_tab", value)
 
-    private val searchQuery = savedStateHandle.getNullableStateFlow(
+    private val searchQuery = savedState.getNullableStateFlow(
         scope = viewModelScope,
         initialValue = null,
         clazz = String::class.java,
@@ -80,14 +78,14 @@ class BookingListViewModel @Inject constructor(
 
     private val refreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
-    private val sortOption = savedStateHandle.getStateFlow(viewModelScope, BookingListSortOption.NewestToOldest)
+    private val sortOption = savedState.getStateFlow(viewModelScope, BookingListSortOption.NewestToOldest)
 
-    private var selectedBookingIdOnBigScreen: Long?
-        get() = stateHandle[KEY_BOOKING_SELECTED_ON_BIG_SCREEN]
-        set(value) = stateHandle.set(KEY_BOOKING_SELECTED_ON_BIG_SCREEN, value)
-
-    private val selectedBookingIdFlow: Flow<Long?> =
-        stateHandle.getStateFlow(KEY_BOOKING_SELECTED_ON_BIG_SCREEN, null)
+    private val selectedBookingIdOnBigScreen = savedState.getNullableStateFlow(
+        scope = viewModelScope,
+        initialValue = null,
+        clazz = Long::class.java,
+        key = KEY_BOOKING_SELECTED_ON_BIG_SCREEN
+    )
 
     private val isSortSheetVisible = MutableStateFlow(false)
 
@@ -109,7 +107,7 @@ class BookingListViewModel @Inject constructor(
     private val contentState = combine(
         bookingListItems,
         loadingState,
-        selectedBookingIdFlow,
+        selectedBookingIdOnBigScreen,
     ) { listItems, loadingState, selectedBookingId ->
         BookingListContentState(
             bookings = listItems,
@@ -290,7 +288,7 @@ class BookingListViewModel @Inject constructor(
             )
         )
         if (isWindowClassLargeThanCompact()) {
-            selectedBookingIdOnBigScreen = bookingId
+            selectedBookingIdOnBigScreen.value = bookingId
         }
         triggerEvent(NavigateToBookingDetails(bookingId))
     }
@@ -338,9 +336,9 @@ class BookingListViewModel @Inject constructor(
     }
 
     private fun openFirstLoadedBookingOnTablet(bookings: List<BookingEntity>) {
-        if (isWindowClassLargeThanCompact() && bookings.isNotEmpty() && selectedBookingIdOnBigScreen == null) {
+        if (isWindowClassLargeThanCompact() && bookings.isNotEmpty() && selectedBookingIdOnBigScreen.value == null) {
             val firstId = bookings.first().id.value
-            selectedBookingIdOnBigScreen = firstId
+            selectedBookingIdOnBigScreen.value = firstId
             triggerEvent(NavigateToBookingDetails(firstId))
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.AppConstants
+import com.woocommerce.android.BookingsArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -17,6 +18,7 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getNullableStateFlow
 import com.woocommerce.android.viewmodel.getStateFlow
+import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -57,8 +59,9 @@ class BookingListViewModel @Inject constructor(
 ) : ScopedViewModel(savedStateHandle) {
 
     private val analyticsHelper = BookingAnalyticsHelper()
-
     private val stateHandle = savedStateHandle
+    private val navArgs: BookingsArgs by savedStateHandle.navArgs()
+
     private val loadingState = MutableStateFlow(BookingListLoadingState.Idle)
 
     private val selectedTab = savedStateHandle.getStateFlow(viewModelScope, BookingListTab.Today)
@@ -169,7 +172,9 @@ class BookingListViewModel @Inject constructor(
             tabState = tabsState,
             controlsState = controlsState,
             sortBottomSheetState = listSortBottomSheetState,
-            searchState = searchState
+            searchState = searchState,
+            showBackButton = !navArgs.showBottomNavigation,
+            onBackClick = ::onBackClick
         )
     }.shareIn(
         scope = viewModelScope,
@@ -326,6 +331,10 @@ class BookingListViewModel @Inject constructor(
         launch {
             bookingFilterRepository.save(BookingFilters.EMPTY)
         }
+    }
+
+    private fun onBackClick() {
+        triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
     private fun openFirstLoadedBookingOnTablet(bookings: List<BookingEntity>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewState.kt
@@ -10,8 +10,9 @@ data class BookingListViewState(
     val controlsState: BookingListControlsState,
     val sortBottomSheetState: BookingListSortBottomSheetState?,
     val searchState: BookingListSearchState,
+    val showBackButton: Boolean,
+    val onBackClick: () -> Unit
 ) {
-
     val toolbarTitle: UiString
         get() = if (searchState.isSearchActive) {
             UiString.UiStringText("")


### PR DESCRIPTION
### Description
Fixes WOOMOB-2383

The Bookings list toolbar was conditionally shown based on whether bottom navigation was visible. This caused two issues:
- A duplicated toolbar appeared when the Bookings screen was displayed in the tablet split view
- A lag/animation glitch during the transition when opening the split view, as the toolbar visibility toggled during navigation (to be confirmed whether this improves it for others)

This change always hides the toolbar and adds a back button to the existing toolbar when needed, eliminating both the duplication and improving the navigation animation.

### Test Steps
1. Open the app on a tablet (or tablet emulator)
2. Navigate to the Bookings section
3. Tap on a booking to open the split view
4. Verify there is no duplicated toolbar.

### Images/gif

| Before | After |
|--------|-------|
| <img width="2560" height="1600" alt="Screenshot_20260313_182846" src="https://github.com/user-attachments/assets/285b7f96-3926-47f5-bf05-6656152c60b1" /> | <img width="2560" height="1600" alt="Screenshot_20260313_182526" src="https://github.com/user-attachments/assets/d5df5d07-907a-45ac-8d7b-226fb93d7fcd" /> |
| <video src="https://github.com/user-attachments/assets/6ff756c4-7ba9-4334-8dc1-e0482acdea8b"> | <video src="https://github.com/user-attachments/assets/0768e3f9-a720-48cf-bdc0-67f742e652d5"> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.