### PR TITLE
Rename "Net Payment" to "Total Net" in POS order details

### DIFF
--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3901,7 +3901,7 @@
     <string name="woopos_orders_details_refunded_label">Refunded</string>
     <string name="woopos_orders_details_refund_error">Unable to load refund</string>
     <string name="woopos_refund_error_gateway_not_found">Unable to process refund.</string>
-    <string name="woopos_orders_details_net_payment_label">Net Payment</string>
+    <string name="woopos_orders_details_net_payment_label">Total Net</string>
     <string name="woopos_orders_details_products_list_content_description">Order products list</string>
     <string name="woopos_orders_details_totals_card_content_description">Order totals breakdown</string>
     <string name="woopos_orders_details_booking_info">Booking #%1$d · %2$s, %3$s</string>


### PR DESCRIPTION
### Description
Renames the "Net Payment" label to "Total Net" in the POS order details totals card for consistency with iOS and Figma specs: DK955L5K0bTfkjrHTBLmqo-fi-360_19866

### Test Steps
1. Open the POS
2. Complete an order
3. Open the order from the orders list
4. Verify the totals card shows "Total Net" instead of "Net Payment"

### Images/gif
—

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.