### PR TITLE
[WOOMOB-2506] Disable order status editing for CIAB sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
@@ -12,5 +12,6 @@ enum class CIABAffectedFeature {
     GiftCardEditing,
     ProductsStockDashboardCard,
     Onboarding,
+    OrderStatusEditing,
     POS
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -36,6 +36,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreateEditFormBinding
 import com.woocommerce.android.databinding.LayoutOrderCreationCustomerInfoBinding
@@ -130,6 +132,9 @@ class OrderCreateEditFormFragment :
 
     @Inject
     lateinit var uiHelper: OrderCreateEditFormAddInfoButtonsStatusHelper
+
+    @Inject
+    lateinit var ciabSiteGateKeeper: CIABSiteGateKeeper
 
     private var createOrderMenuItem: MenuItem? = null
     private var progressDialog: CustomProgressDialog? = null
@@ -310,8 +315,13 @@ class OrderCreateEditFormFragment :
             }
 
             is Edit -> {
+                val statusMode = if (ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.OrderStatusEditing)) {
+                    OrderDetailOrderStatusView.Mode.OrderEdit
+                } else {
+                    OrderDetailOrderStatusView.Mode.ReadOnly
+                }
                 orderStatusView.initView(
-                    mode = OrderDetailOrderStatusView.Mode.OrderEdit,
+                    mode = statusMode,
                     editOrderStatusClickListener = {
                         viewModel.orderStatusData.value?.let {
                             viewModel.onEditOrderStatusClicked(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -36,9 +36,9 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.R
 import com.woocommerce.android.ciab.CIABAffectedFeature
 import com.woocommerce.android.ciab.CIABSiteGateKeeper
-import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentOrderCreateEditFormBinding
 import com.woocommerce.android.databinding.LayoutOrderCreationCustomerInfoBinding
 import com.woocommerce.android.databinding.OrderCreationAdditionalInfoCollectionSectionBinding

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailFragment.kt
@@ -37,6 +37,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ORDER_ID
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_START_PAYMENT_FLOW
 import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.databinding.FragmentOrderDetailBinding
 import com.woocommerce.android.extensions.WindowSizeClass
 import com.woocommerce.android.extensions.handleDialogNotice
@@ -139,6 +141,9 @@ class OrderDetailFragment :
     @Inject
     lateinit var cardReaderManager: CardReaderManager
 
+    @Inject
+    lateinit var ciabSiteGateKeeper: CIABSiteGateKeeper
+
     private var _binding: FragmentOrderDetailBinding? = null
     private val binding get() = _binding!!
 
@@ -237,7 +242,12 @@ class OrderDetailFragment :
         setupResultHandlers(viewModel)
         setupOrdersCommunicationObservers(communicationViewModel)
 
-        binding.orderDetailOrderStatus.initView(mode = Mode.OrderEdit) {
+        val statusMode = if (ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.OrderStatusEditing)) {
+            Mode.OrderEdit
+        } else {
+            Mode.ReadOnly
+        }
+        binding.orderDetailOrderStatus.initView(mode = statusMode) {
             viewModel.onEditOrderStatusSelected()
         }
         binding.orderRefreshLayout.apply {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -25,8 +25,6 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
 ) : MaterialCardView(ctx, attrs, defStyleAttr) {
     private val binding = OrderDetailOrderStatusBinding.inflate(LayoutInflater.from(ctx), this)
 
-    private var mode: Mode = Mode.OrderEdit
-
     fun updateStatus(orderStatus: OrderStatus) {
         binding.orderStatusOrderTags.contentDescription =
             context.getString(R.string.orderstatus_contentDesc_withStatus, orderStatus.label)
@@ -35,16 +33,8 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
 
     fun updateOrder(order: Order) {
         binding.orderStatusSubtitle.text = getFormattedDate(order.dateCreated)
-
-        when (mode) {
-            Mode.OrderEdit, Mode.ReadOnly -> {
-                binding.orderStatusHeader.text =
-                    order.getBillingName(context.getString(R.string.orderdetail_customer_name_default))
-            }
-            Mode.OrderCreation -> {
-                binding.orderStatusHeader.isVisible = false
-            }
-        }
+        binding.orderStatusHeader.text =
+            order.getBillingName(context.getString(R.string.orderdetail_customer_name_default))
 
         updatePosTag(order)
     }
@@ -59,30 +49,16 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
     }
 
     private fun getFormattedDate(date: Date): String {
-        return when (mode) {
-            Mode.OrderCreation -> {
-                date.getMediumDate(context)
-            }
-            Mode.OrderEdit, Mode.ReadOnly -> {
-                "${date.getMediumDate(context)}, ${date.getTimeString(context)}"
-            }
-        }
+        return "${date.getMediumDate(context)}, ${date.getTimeString(context)}"
     }
 
     fun initView(mode: Mode, editOrderStatusClickListener: EditStatusClickListener = {}) {
-        this.mode = mode
         when (mode) {
             Mode.OrderEdit -> {
                 binding.orderStatusEditImage.isVisible = true
                 with(binding.orderStatusContainer) {
                     isClickable = true
                     isFocusable = true
-                    setOnClickListener(editOrderStatusClickListener)
-                }
-            }
-            Mode.OrderCreation -> {
-                with(binding.orderStatusEditImage) {
-                    isVisible = true
                     setOnClickListener(editOrderStatusClickListener)
                 }
             }
@@ -95,6 +71,6 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
     }
 
     enum class Mode {
-        OrderCreation, OrderEdit, ReadOnly
+        OrderEdit, ReadOnly
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -52,20 +52,26 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
         return "${date.getMediumDate(context)}, ${date.getTimeString(context)}"
     }
 
-    fun initView(mode: Mode, editOrderStatusClickListener: EditStatusClickListener = {}) {
+    fun initView(mode: Mode, editOrderStatusClickListener: EditStatusClickListener? = null) {
         when (mode) {
             Mode.OrderEdit -> {
+                val listener = requireNotNull(editOrderStatusClickListener) {
+                    "editOrderStatusClickListener must be provided when mode is OrderEdit"
+                }
                 binding.orderStatusEditImage.isVisible = true
                 with(binding.orderStatusContainer) {
                     isClickable = true
                     isFocusable = true
-                    setOnClickListener(editOrderStatusClickListener)
+                    setOnClickListener(listener)
                 }
             }
             Mode.ReadOnly -> {
                 binding.orderStatusEditImage.isVisible = false
-                binding.orderStatusContainer.isClickable = false
-                binding.orderStatusContainer.isFocusable = false
+                with(binding.orderStatusContainer) {
+                    isClickable = false
+                    isFocusable = false
+                    setOnClickListener(null)
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/views/OrderDetailOrderStatusView.kt
@@ -37,7 +37,7 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
         binding.orderStatusSubtitle.text = getFormattedDate(order.dateCreated)
 
         when (mode) {
-            Mode.OrderEdit -> {
+            Mode.OrderEdit, Mode.ReadOnly -> {
                 binding.orderStatusHeader.text =
                     order.getBillingName(context.getString(R.string.orderdetail_customer_name_default))
             }
@@ -63,13 +63,13 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
             Mode.OrderCreation -> {
                 date.getMediumDate(context)
             }
-            Mode.OrderEdit -> {
+            Mode.OrderEdit, Mode.ReadOnly -> {
                 "${date.getMediumDate(context)}, ${date.getTimeString(context)}"
             }
         }
     }
 
-    fun initView(mode: Mode, editOrderStatusClickListener: EditStatusClickListener) {
+    fun initView(mode: Mode, editOrderStatusClickListener: EditStatusClickListener = {}) {
         this.mode = mode
         when (mode) {
             Mode.OrderEdit -> {
@@ -86,10 +86,15 @@ class OrderDetailOrderStatusView @JvmOverloads constructor(
                     setOnClickListener(editOrderStatusClickListener)
                 }
             }
+            Mode.ReadOnly -> {
+                binding.orderStatusEditImage.isVisible = false
+                binding.orderStatusContainer.isClickable = false
+                binding.orderStatusContainer.isFocusable = false
+            }
         }
     }
 
     enum class Mode {
-        OrderCreation, OrderEdit
+        OrderCreation, OrderEdit, ReadOnly
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListAdapter.kt
@@ -237,7 +237,7 @@ class OrderListAdapter(
         //  cause the order's onClick listener to gain focus over the selection tracker.
         //  This quick fix will prevent the app from entering an unexpected status when the app is in selection mode.
         private fun shouldPreventDetailNavigation(orderId: Long): Boolean {
-            if (tracker?.selection?.size() != 0) {
+            if (tracker?.hasSelection() == true) {
                 tracker?.let { selectionTracker ->
                     if (selectionTracker.isSelected(orderId)) {
                         selectionTracker.deselect(orderId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -38,6 +38,8 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ORDER_ID
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_START_PAYMENT_FLOW
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.databinding.FragmentOrderListBinding
 import com.woocommerce.android.extensions.handleDialogResult
 import com.woocommerce.android.extensions.handleResult
@@ -120,11 +122,22 @@ class OrderListFragment :
     @Inject
     internal lateinit var customerListRepository: CustomerListRepository
 
+    @Inject
+    internal lateinit var ciabSiteGateKeeper: CIABSiteGateKeeper
+
     private var tracker: SelectionTracker<Long>? = null
     private var actionMode: ActionMode? = null
-    private val selectionPredicate = MutableMultipleSelectionPredicate<Long>(
-        maxSelectionCount = OrderListViewModel.BULK_UPDATE_COUNT_LIMIT
-    )
+    private val selectionPredicate by lazy {
+        MutableMultipleSelectionPredicate<Long>(
+            // The only option we support with multi-select is order status editing, so disable multi-select
+            // if the feature is not supported
+            maxSelectionCount = if (ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.OrderStatusEditing)) {
+                OrderListViewModel.BULK_UPDATE_COUNT_LIMIT
+            } else {
+                0
+            }
+        )
+    }
     private val viewModel: OrderListViewModel by viewModels()
     private val communicationViewModel: OrdersCommunicationViewModel by activityViewModels()
     private var snackBar: Snackbar? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListFragment.kt
@@ -127,17 +127,9 @@ class OrderListFragment :
 
     private var tracker: SelectionTracker<Long>? = null
     private var actionMode: ActionMode? = null
-    private val selectionPredicate by lazy {
-        MutableMultipleSelectionPredicate<Long>(
-            // The only option we support with multi-select is order status editing, so disable multi-select
-            // if the feature is not supported
-            maxSelectionCount = if (ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.OrderStatusEditing)) {
-                OrderListViewModel.BULK_UPDATE_COUNT_LIMIT
-            } else {
-                0
-            }
-        )
-    }
+    private val selectionPredicate = MutableMultipleSelectionPredicate<Long>(
+        maxSelectionCount = OrderListViewModel.BULK_UPDATE_COUNT_LIMIT
+    )
     private val viewModel: OrderListViewModel by viewModels()
     private val communicationViewModel: OrdersCommunicationViewModel by activityViewModels()
     private var snackBar: Snackbar? = null
@@ -258,7 +250,12 @@ class OrderListFragment :
         binding.orderFiltersCard.setClickListener { viewModel.onFiltersButtonTapped() }
         initCreateOrderFAB(binding.createOrderButton)
         initSwipeBehaviour()
-        addSelectionTracker()
+
+        if (ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.OrderStatusEditing)) {
+            // The only option we support with multi-select is order status editing, so disable multi-select
+            // if the feature is not supported
+            addSelectionTracker()
+        }
     }
 
     private fun addSelectionTracker() {

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -50,14 +50,14 @@
             android:layout_height="wrap_content"
             android:focusable="false"
             android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:paddingBottom="@dimen/major_75">
+            android:orientation="horizontal" >
 
             <com.woocommerce.android.widgets.tags.TagView
                 android:id="@+id/orderStatus_orderTags"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/major_100"
+                android:layout_marginVertical="@dimen/major_75"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -72,7 +72,8 @@
                 android:src="@drawable/ic_edit_pencil"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="g"/>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </LinearLayout>
 </merge>

--- a/WooCommerce/src/main/res/layout/order_detail_order_status.xml
+++ b/WooCommerce/src/main/res/layout/order_detail_order_status.xml
@@ -50,7 +50,8 @@
             android:layout_height="wrap_content"
             android:focusable="false"
             android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:paddingBottom="@dimen/major_75">
 
             <com.woocommerce.android.widgets.tags.TagView
                 android:id="@+id/orderStatus_orderTags"


### PR DESCRIPTION
### Description
Fixes WOOMOB-2506

Prevents CIAB site users from changing order status in both the Order Detail Viewer and Order Detail Editor. A new `ReadOnly` mode is added to `OrderDetailOrderStatusView` which hides the edit pencil icon and disables click listeners on the status container. The mode is selected by checking `CIABSiteGateKeeper.isFeatureSupported(OrderStatusEditing)` — CIAB sites get `ReadOnly`, non-CIAB sites retain the existing `OrderEdit` behavior.

Also removes the unused `OrderCreation` mode from `OrderDetailOrderStatusView` — it was never passed to `initView()` since order creation hides the entire status view.

### Test Steps
1. Switch to a **CIAB site**
2. Open an existing order → verify the status tag is visible but there is **no edit pencil icon** and tapping the status area does nothing
3. Tap **Edit** on the order → verify the status section in the editor is also read-only (no pencil icon)
4. Switch to a **non-CIAB site**
5. Open an existing order → verify the **edit pencil icon is visible** and tapping it opens the "Change order status" dialog
6. Tap Edit on the order → verify status editing works as before

### Images/gif
| CIAB | Non-CIAB |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260316_171933" src="https://github.com/user-attachments/assets/17d053d6-911e-462d-8d21-00c03907bc6a" /> | <img width="1080" height="2400" alt="Screenshot_20260316_165537" src="https://github.com/user-attachments/assets/26352783-7adf-45ce-9690-8ec743f6fbf7" /> |
| <img width="1080" height="2400" alt="ciab_order_detail_padding_fix" src="https://github.com/user-attachments/assets/f1af9e83-737a-477d-8fb7-68c6a7cdd754" /> | <img width="1080" height="2400" alt="non_ciab_order_detail_edit_visible" src="https://github.com/user-attachments/assets/fea54f57-0a4e-48bb-b369-f437ac60db52" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.