### PR TITLE
Migrate media endpoints to app passwords: extract routing into WooMediaNetwork

### DIFF
--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClientTest.kt
@@ -1,65 +1,51 @@
 package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
 
 import com.google.gson.Gson
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.IOException
-import org.greenrobot.eventbus.EventBus
-import org.greenrobot.eventbus.Subscribe
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.UnitTestUtils
-import org.wordpress.android.fluxc.action.MediaAction.UPLOADED_MEDIA
-import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.media.MediaTestUtils
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
-import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import java.io.File
-import java.util.concurrent.CountDownLatch
 
 @RunWith(RobolectricTestRunner::class)
 class WPComV2MediaRestClientTest {
     private val accessToken: AccessToken = mock()
     private val okHttpClient: OkHttpClient = mock()
-    private val dispatcher: Dispatcher = mock()
     private val wpComNetwork: WPComNetwork = mock()
     private val gson: Gson = Gson()
     private val mockedCall: Call = mock()
-    private lateinit var countDownLatch: CountDownLatch
     private lateinit var restClient: WPComV2MediaRestClient
-
-    private lateinit var dispatchedPayload: ProgressPayload
 
     @Before
     fun setup() {
         restClient = WPComV2MediaRestClient(
-            dispatcher = dispatcher,
-            coroutineEngine = initCoroutineEngine(),
             okHttpClient = okHttpClient,
             accessToken = accessToken,
             wpComNetwork = wpComNetwork,
             gson = gson
         )
-        EventBus.getDefault().register(this)
     }
 
     @Test
-    fun `emit success action when upload finishes`() {
+    fun `when upload finishes, then emit success payload`() {
         createFileThenRunTest {
             whenever(okHttpClient.newCall(any())).thenReturn(mockedCall)
             whenever(mockedCall.enqueue(any())).then {
@@ -73,42 +59,40 @@ class WPComV2MediaRestClientTest {
                         on { isSuccessful } doReturn true
                     }
                 )
-                countDownLatch.countDown()
             }
 
-            countDownLatch = CountDownLatch(1)
-            restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+            val payloads = runBlocking {
+                restClient.uploadMedia(
+                    SiteModel(),
+                    MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg")
+                ).toList()
+            }
 
-            countDownLatch.await()
-
-            verify(dispatcher).dispatch(argThat {
-                type == UPLOADED_MEDIA && (payload as ProgressPayload).completed
-            })
+            assertThat(payloads.last().completed).isTrue()
         }
     }
 
     @Test
-    fun `emit failure action when upload fails`() {
+    fun `when upload fails, then emit failure payload`() {
         createFileThenRunTest {
             whenever(okHttpClient.newCall(any())).thenReturn(mockedCall)
             whenever(mockedCall.enqueue(any())).then {
                 (it.arguments.first() as Callback).onFailure(mock(), IOException())
-                countDownLatch.countDown()
             }
 
-            countDownLatch = CountDownLatch(1)
-            restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+            val payloads = runBlocking {
+                restClient.uploadMedia(
+                    SiteModel(),
+                    MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg")
+                ).toList()
+            }
 
-            countDownLatch.await()
-
-            verify(dispatcher).dispatch(argThat {
-                type == UPLOADED_MEDIA && (payload as ProgressPayload).error != null
-            })
+            assertThat(payloads.last().error).isNotNull()
         }
     }
 
     @Test
-    fun `emit failure action when we can't parse the response`() {
+    fun `when response cannot be parsed, then emit failure payload`() {
         createFileThenRunTest {
             whenever(okHttpClient.newCall(any())).thenReturn(mockedCall)
             whenever(mockedCall.enqueue(any())).then {
@@ -119,17 +103,16 @@ class WPComV2MediaRestClientTest {
                         on { isSuccessful } doReturn true
                     }
                 )
-                countDownLatch.countDown()
             }
 
-            countDownLatch = CountDownLatch(1)
-            restClient.uploadMedia(SiteModel(), MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg"))
+            val payloads = runBlocking {
+                restClient.uploadMedia(
+                    SiteModel(),
+                    MediaTestUtils.generateMediaFromPath(0, 0L, "./image.jpg")
+                ).toList()
+            }
 
-            countDownLatch.await()
-
-            verify(dispatcher).dispatch(argThat {
-                type == UPLOADED_MEDIA && (payload as ProgressPayload).error != null
-            })
+            assertThat(payloads.last().error).isNotNull()
         }
     }
 
@@ -140,13 +123,6 @@ class WPComV2MediaRestClientTest {
             test()
         } finally {
             file.delete()
-        }
-    }
-
-    @Subscribe
-    fun onAction(action: Action<*>) {
-        if (action.type == UPLOADED_MEDIA) {
-            dispatchedPayload = action.payload as ProgressPayload
         }
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClient.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.fluxc.network.rest.wpapi.media
 import com.google.gson.Gson
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
@@ -13,7 +12,6 @@ import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.Appli
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordCreationResult.NotSupported
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsManager
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
-import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import javax.inject.Inject
 import javax.inject.Named
@@ -21,12 +19,10 @@ import javax.inject.Singleton
 
 @Singleton
 class ApplicationPasswordsMediaRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    coroutineEngine: CoroutineEngine,
     @Named("no-cookies") okHttpClient: OkHttpClient,
     private val applicationPasswordsNetwork: ApplicationPasswordsNetwork,
     gson: Gson
-) : BaseWPV2MediaRestClient(dispatcher, coroutineEngine, okHttpClient, gson) {
+) : BaseWPV2MediaRestClient(okHttpClient, gson) {
     @Inject
     internal lateinit var applicationPasswordsManager: ApplicationPasswordsManager
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -2,15 +2,11 @@ package org.wordpress.android.fluxc.network.rest.wpapi.media
 
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onStart
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.OkHttpClient
@@ -18,9 +14,7 @@ import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONException
 import org.json.JSONObject
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint
-import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.generated.endpoint.WPAPI
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -31,22 +25,16 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaError
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
-import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.MimeType
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MEDIA
 import java.io.IOException
-import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Named
 
 abstract class BaseWPV2MediaRestClient(
-    private val dispatcher: Dispatcher,
-    private val coroutineEngine: CoroutineEngine,
     @Named("regular") private val okHttpClient: OkHttpClient,
     private val gson: Gson
 ) {
-    private val currentUploads = ConcurrentHashMap<Int, CoroutineScope>()
-
     protected abstract fun WPAPIEndpoint.getFullUrl(site: SiteModel): String
 
     protected abstract suspend fun getAuthorizationHeader(site: SiteModel): String
@@ -58,48 +46,8 @@ abstract class BaseWPV2MediaRestClient(
         clazz: Class<T>
     ): WPAPIResponse<T>
 
-    fun uploadMedia(site: SiteModel, media: MediaModel) {
-        coroutineEngine.launch(MEDIA, this, "Upload Media using WPCom's v2 API") {
-            syncUploadMedia(site, media)
-                .onStart {
-                    currentUploads[media.id] = this@launch
-                }
-                .onCompletion {
-                    currentUploads.remove(media.id)
-                }
-                .collect { payload ->
-                    dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
-                }
-        }
-    }
-
-    fun cancelUpload(media: MediaModel) {
-        currentUploads[media.id]?.let { scope ->
-            scope.cancel()
-            val payload = ProgressPayload(media, 0f, false, true)
-            dispatcher.dispatch(MediaActionBuilder.newCanceledMediaUploadAction(payload))
-        }
-    }
-
-    fun fetchMediaList(site: SiteModel, number: Int, offset: Int, mimeType: MimeType.Type?) {
-        coroutineEngine.launch(MEDIA, this, "Fetching Media using WPCom's v2 API") {
-            val payload = syncFetchMediaList(site, number, offset, mimeType)
-            dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
-        }
-    }
-
-    fun fetchMedia(
-        site: SiteModel,
-        media: MediaModel
-    ) {
-        coroutineEngine.launch(MEDIA, this, "Fetching Media using WPCom's v2 API") {
-            val payload = syncFetchMedia(site, media.mediaId)
-            dispatcher.dispatch(MediaActionBuilder.newFetchedMediaAction(payload))
-        }
-    }
-
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    private fun syncUploadMedia(site: SiteModel, media: MediaModel): Flow<ProgressPayload> {
+    fun uploadMedia(site: SiteModel, media: MediaModel): Flow<ProgressPayload> {
         fun ProducerScope<ProgressPayload>.handleFailure(media: MediaModel, error: MediaError) {
             val payload = ProgressPayload(media, 1f, false, error)
             trySendBlocking(payload)
@@ -161,7 +109,7 @@ abstract class BaseWPV2MediaRestClient(
         }
     }
 
-    private suspend fun syncFetchMedia(site: SiteModel, mediaId: Long): MediaPayload {
+    suspend fun fetchMedia(site: SiteModel, mediaId: Long): MediaPayload {
         val url = WPAPI.media.id(mediaId)
         val response = executeGetGsonRequest(
             site,
@@ -201,7 +149,7 @@ abstract class BaseWPV2MediaRestClient(
         }
     }
 
-    private suspend fun syncFetchMediaList(
+    suspend fun fetchMediaList(
         site: SiteModel,
         perPage: Int,
         offset: Int,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -120,7 +120,7 @@ abstract class BaseWPV2MediaRestClient(
 
         return when (response) {
             is WPAPIResponse.Error -> {
-                val errorMessage = "Fail to fetch media. Response: $response"
+                val errorMessage = "Failed to fetch media. Response: $response"
                 AppLog.w(MEDIA, errorMessage)
                 val error = MediaError(MediaErrorType.fromBaseNetworkError(response.error))
                 error.statusCode = response.error.volleyError?.networkResponse?.statusCode ?: 0
@@ -173,7 +173,7 @@ abstract class BaseWPV2MediaRestClient(
 
         return when (response) {
             is WPAPIResponse.Error -> {
-                val errorMessage = "could not parse Fetch all media response: $response"
+                val errorMessage = "Failed to fetch media list. Response: $response"
                 AppLog.w(MEDIA, errorMessage)
                 val error = MediaError(MediaErrorType.fromBaseNetworkError(response.error))
                 error.statusCode = response.error.volleyError?.networkResponse?.statusCode ?: 0

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -175,6 +175,8 @@ abstract class BaseWPV2MediaRestClient(
                 val errorMessage = "Fail to fetch media. Response: $response"
                 AppLog.w(MEDIA, errorMessage)
                 val error = MediaError(MediaErrorType.fromBaseNetworkError(response.error))
+                error.statusCode = response.error.volleyError?.networkResponse?.statusCode ?: 0
+                error.apiErrorCode = response.error.errorCode
                 error.logMessage = errorMessage
                 MediaPayload(site, null, error)
             }
@@ -225,7 +227,9 @@ abstract class BaseWPV2MediaRestClient(
             is WPAPIResponse.Error -> {
                 val errorMessage = "could not parse Fetch all media response: $response"
                 AppLog.w(MEDIA, errorMessage)
-                val error = MediaError(MediaErrorType.PARSE_ERROR)
+                val error = MediaError(MediaErrorType.fromBaseNetworkError(response.error))
+                error.statusCode = response.error.volleyError?.networkResponse?.statusCode ?: 0
+                error.apiErrorCode = response.error.errorCode
                 error.logMessage = errorMessage
                 FetchMediaListResponsePayload(site, error, mimeType)
             }
@@ -260,6 +264,7 @@ abstract class BaseWPV2MediaRestClient(
                 mediaError.message = it
             }
             jsonBody.optString("code").takeIf { it.isNotEmpty() }?.let {
+                mediaError.apiErrorCode = it
                 mediaError.logMessage = it
             }
         } catch (e: JSONException) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -1,29 +1,40 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.media
 
+import kotlinx.coroutines.Job
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.logging.FluxCCrashLogger
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
 import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient
+import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
+import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.MimeType
+import org.wordpress.android.util.AppLog
 import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class WooMediaNetwork @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val coroutineEngine: CoroutineEngine,
     private val applicationPasswordsConfiguration: ApplicationPasswordsConfiguration,
     private val applicationPasswordsMediaRestClient: ApplicationPasswordsMediaRestClient,
     private val wpComV2MediaRestClient: WPComV2MediaRestClient,
     private val crashLogger: FluxCCrashLogger
 ) {
+    private val currentUploads = ConcurrentHashMap<Int, Job>()
+
     fun uploadMedia(site: SiteModel, media: MediaModel) {
         if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
-            wpComV2MediaRestClient.uploadMedia(site, media)
+            launchUpload(wpComV2MediaRestClient, site, media)
         } else if (site.origin == SiteModel.ORIGIN_WPAPI
             && applicationPasswordsConfiguration.isEnabledForDirectAccess()
         ) {
-            applicationPasswordsMediaRestClient.uploadMedia(site, media)
+            launchUpload(applicationPasswordsMediaRestClient, site, media)
         } else {
             reportXmlrpcTry()
         }
@@ -31,11 +42,11 @@ class WooMediaNetwork @Inject constructor(
 
     fun fetchMediaList(site: SiteModel, number: Int, offset: Int, mimeType: MimeType.Type?) {
         if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
-            wpComV2MediaRestClient.fetchMediaList(site, number, offset, mimeType)
+            launchFetchMediaList(wpComV2MediaRestClient, site, number, offset, mimeType)
         } else if (site.origin == SiteModel.ORIGIN_WPAPI
             && applicationPasswordsConfiguration.isEnabledForDirectAccess()
         ) {
-            applicationPasswordsMediaRestClient.fetchMediaList(site, number, offset, mimeType)
+            launchFetchMediaList(applicationPasswordsMediaRestClient, site, number, offset, mimeType)
         } else {
             reportXmlrpcTry()
         }
@@ -43,14 +54,46 @@ class WooMediaNetwork @Inject constructor(
 
     fun cancelUpload(site: SiteModel, media: MediaModel) {
         if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
-            wpComV2MediaRestClient.cancelUpload(media)
+            performCancelUpload(media)
         } else if (site.origin == SiteModel.ORIGIN_WPAPI
             && applicationPasswordsConfiguration.isEnabledForDirectAccess()
         ) {
-            applicationPasswordsMediaRestClient.cancelUpload(media)
+            performCancelUpload(media)
         } else {
             reportXmlrpcTry()
         }
+    }
+
+    private fun launchUpload(client: BaseWPV2MediaRestClient, site: SiteModel, media: MediaModel) {
+        val uploadJob = coroutineEngine.launch(AppLog.T.MEDIA, this, "Uploading media") {
+            try {
+                client.uploadMedia(site, media).collect { payload ->
+                    dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
+                }
+            } finally {
+                currentUploads.remove(media.id)
+            }
+        }
+        currentUploads[media.id] = uploadJob
+    }
+
+    private fun launchFetchMediaList(
+        client: BaseWPV2MediaRestClient,
+        site: SiteModel,
+        number: Int,
+        offset: Int,
+        mimeType: MimeType.Type?
+    ) {
+        coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list") {
+            val payload = client.fetchMediaList(site, number, offset, mimeType)
+            dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
+        }
+    }
+
+    private fun performCancelUpload(media: MediaModel) {
+        currentUploads.remove(media.id)?.cancel()
+        val payload = ProgressPayload(media, 0f, false, true)
+        dispatcher.dispatch(MediaActionBuilder.newCanceledMediaUploadAction(payload))
     }
 
     private fun reportXmlrpcTry() {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -91,9 +91,12 @@ class WooMediaNetwork @Inject constructor(
     }
 
     private fun performCancelUpload(media: MediaModel) {
-        currentUploads.remove(media.id)?.cancel()
-        val payload = ProgressPayload(media, 0f, false, true)
-        dispatcher.dispatch(MediaActionBuilder.newCanceledMediaUploadAction(payload))
+        val job = currentUploads.remove(media.id)
+        if (job != null) {
+            job.cancel()
+            val payload = ProgressPayload(media, 0f, false, true)
+            dispatcher.dispatch(MediaActionBuilder.newCanceledMediaUploadAction(payload))
+        }
     }
 
     private fun reportXmlrpcTry() {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -1,0 +1,63 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.media
+
+import org.wordpress.android.fluxc.logging.FluxCCrashLogger
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
+import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient
+import org.wordpress.android.fluxc.utils.MimeType
+import java.util.Collections
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooMediaNetwork @Inject constructor(
+    private val applicationPasswordsConfiguration: ApplicationPasswordsConfiguration,
+    private val applicationPasswordsMediaRestClient: ApplicationPasswordsMediaRestClient,
+    private val wpComV2MediaRestClient: WPComV2MediaRestClient,
+    private val crashLogger: FluxCCrashLogger
+) {
+    fun uploadMedia(site: SiteModel, media: MediaModel) {
+        if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
+            wpComV2MediaRestClient.uploadMedia(site, media)
+        } else if (site.origin == SiteModel.ORIGIN_WPAPI
+            && applicationPasswordsConfiguration.isEnabledForDirectAccess()
+        ) {
+            applicationPasswordsMediaRestClient.uploadMedia(site, media)
+        } else {
+            reportXmlrpcTry()
+        }
+    }
+
+    fun fetchMediaList(site: SiteModel, number: Int, offset: Int, mimeType: MimeType.Type?) {
+        if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
+            wpComV2MediaRestClient.fetchMediaList(site, number, offset, mimeType)
+        } else if (site.origin == SiteModel.ORIGIN_WPAPI
+            && applicationPasswordsConfiguration.isEnabledForDirectAccess()
+        ) {
+            applicationPasswordsMediaRestClient.fetchMediaList(site, number, offset, mimeType)
+        } else {
+            reportXmlrpcTry()
+        }
+    }
+
+    fun cancelUpload(site: SiteModel, media: MediaModel) {
+        if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
+            wpComV2MediaRestClient.cancelUpload(media)
+        } else if (site.origin == SiteModel.ORIGIN_WPAPI
+            && applicationPasswordsConfiguration.isEnabledForDirectAccess()
+        ) {
+            applicationPasswordsMediaRestClient.cancelUpload(media)
+        } else {
+            reportXmlrpcTry()
+        }
+    }
+
+    private fun reportXmlrpcTry() {
+        crashLogger.sendReport(
+            null,
+            Collections.emptyMap(),
+            "Requested MediaStore XMLRPC connection. This should not happen."
+        )
+    }
+}

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClient.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2
 
 import com.google.gson.Gson
 import okhttp3.OkHttpClient
-import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
@@ -11,20 +10,17 @@ import org.wordpress.android.fluxc.network.rest.wpapi.media.BaseWPV2MediaRestCli
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequestBuilder
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AccessToken
-import org.wordpress.android.fluxc.tools.CoroutineEngine
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
 @Singleton
 class WPComV2MediaRestClient @Inject constructor(
-    dispatcher: Dispatcher,
-    coroutineEngine: CoroutineEngine,
     @Named("regular") okHttpClient: OkHttpClient,
     private val accessToken: AccessToken,
     private val wpComNetwork: WPComNetwork,
     gson: Gson
-) : BaseWPV2MediaRestClient(dispatcher, coroutineEngine, okHttpClient, gson) {
+) : BaseWPV2MediaRestClient(okHttpClient, gson) {
     override fun WPAPIEndpoint.getFullUrl(site: SiteModel): String = getWPComUrl(site.siteId)
 
     override suspend fun getAuthorizationHeader(site: SiteModel): String = "Bearer ${accessToken.get()}"

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -163,6 +163,7 @@ public class MediaStore extends Store {
         @NonNull public MediaErrorType type;
         @Nullable public MediaErrorSubType mErrorSubType;
         @Nullable public String message;
+        @Nullable public String apiErrorCode;
         public int statusCode;
         @Nullable public String logMessage;
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/MediaStore.java
@@ -12,13 +12,10 @@ import org.wordpress.android.fluxc.Payload;
 import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.annotations.action.IAction;
-import org.wordpress.android.fluxc.logging.FluxCCrashLogger;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError;
-import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration;
-import org.wordpress.android.fluxc.network.rest.wpapi.media.ApplicationPasswordsMediaRestClient;
-import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpapi.media.WooMediaNetwork;
 import org.wordpress.android.fluxc.store.media.MediaErrorSubType;
 import org.wordpress.android.fluxc.store.media.MediaErrorSubType.MalformedMediaArgSubType;
 import org.wordpress.android.fluxc.store.media.MediaErrorSubType.MalformedMediaArgSubType.Type;
@@ -31,7 +28,6 @@ import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -405,30 +401,19 @@ public class MediaStore extends Store {
         }
     }
 
-    private final WPComV2MediaRestClient mWPComV2MediaRestClient;
-    private final ApplicationPasswordsMediaRestClient mApplicationPasswordsMediaRestClient;
+    private final WooMediaNetwork mWooMediaNetwork;
     @NonNull private final RemoteMediaCache mRemoteMediaCache;
     @NonNull private final MediaCacheOperations mMediaCacheOperations;
     @NonNull private final MediaIdGenerator mMediaIdGenerator;
 
-    private final ApplicationPasswordsConfiguration mApplicationPasswordsConfiguration;
-
-    @NonNull private final FluxCCrashLogger mCrashLogger;
-
     @Inject public MediaStore(
             Dispatcher dispatcher,
-            WPComV2MediaRestClient wpv2MediaRestClient,
-            ApplicationPasswordsMediaRestClient applicationPasswordsMediaRestClient,
-            ApplicationPasswordsConfiguration applicationPasswordsConfiguration,
-            @NonNull FluxCCrashLogger crashLogger,
+            WooMediaNetwork wooMediaNetwork,
             @NonNull RemoteMediaCache remoteMediaCache,
             @NonNull MediaCacheOperations mediaCacheOperations,
             @NonNull MediaIdGenerator mediaIdGenerator) {
         super(dispatcher);
-        mWPComV2MediaRestClient = wpv2MediaRestClient;
-        mApplicationPasswordsMediaRestClient = applicationPasswordsMediaRestClient;
-        mApplicationPasswordsConfiguration = applicationPasswordsConfiguration;
-        mCrashLogger = crashLogger;
+        mWooMediaNetwork = wooMediaNetwork;
         mRemoteMediaCache = remoteMediaCache;
         mMediaCacheOperations = mediaCacheOperations;
         mMediaIdGenerator = mediaIdGenerator;
@@ -598,14 +583,7 @@ public class MediaStore extends Store {
             MediaUtils.stripLocation(payload.media.getFilePath());
         }
 
-        if (payload.site.getOrigin() == SiteModel.ORIGIN_WPCOM_REST) {
-            mWPComV2MediaRestClient.uploadMedia(payload.site, payload.media);
-        } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
-                   && mApplicationPasswordsConfiguration.isEnabledForDirectAccess()) {
-            mApplicationPasswordsMediaRestClient.uploadMedia(payload.site, payload.media);
-        } else {
-            reportXmlrpcTry();
-        }
+        mWooMediaNetwork.uploadMedia(payload.site, payload.media);
     }
 
     private void performFetchMediaList(@NonNull FetchMediaListPayload payload) {
@@ -614,14 +592,7 @@ public class MediaStore extends Store {
             String mimeTypeValue = payload.mimeType != null ? payload.mimeType.getValue() : null;
             offset = mMediaCacheOperations.getUploadedMediaCount(payload.site.getId(), mimeTypeValue);
         }
-        if (payload.site.getOrigin() == SiteModel.ORIGIN_WPCOM_REST) {
-            mWPComV2MediaRestClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
-        } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
-                   && mApplicationPasswordsConfiguration.isEnabledForDirectAccess()) {
-            mApplicationPasswordsMediaRestClient.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
-        } else {
-            reportXmlrpcTry();
-        }
+        mWooMediaNetwork.fetchMediaList(payload.site, payload.number, offset, payload.mimeType);
     }
 
     private void performCancelUpload(@NonNull CancelMediaPayload payload) {
@@ -630,14 +601,7 @@ public class MediaStore extends Store {
             mRemoteMediaCache.remove(payload.site.getId(), media.getMediaId());
         }
 
-        if (payload.site.getOrigin() == SiteModel.ORIGIN_WPCOM_REST) {
-            mWPComV2MediaRestClient.cancelUpload(media);
-        } else if (payload.site.getOrigin() == SiteModel.ORIGIN_WPAPI
-                   && mApplicationPasswordsConfiguration.isEnabledForDirectAccess()) {
-            mApplicationPasswordsMediaRestClient.cancelUpload(media);
-        } else {
-            reportXmlrpcTry();
-        }
+        mWooMediaNetwork.cancelUpload(payload.site, media);
     }
 
     private void handleMediaUploaded(@NonNull ProgressPayload payload) {
@@ -717,7 +681,4 @@ public class MediaStore extends Store {
         emitChange(mediaChange);
     }
 
-    private void reportXmlrpcTry() {
-        mCrashLogger.sendReport(null, Collections.emptyMap(), "Requested MediaStore XMLRPC connection. This should not happen.");
-    }
 }

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/MediaStoreTest.java
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/MediaStoreTest.java
@@ -1,13 +1,13 @@
 package org.wordpress.android.fluxc.store;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.*;
 import static org.wordpress.android.fluxc.media.MediaTestUtils.generateMediaFromPath;
 import static org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId;
 
 import org.jetbrains.annotations.NotNull;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
@@ -25,6 +25,9 @@ import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
 public class MediaStoreTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     private final RemoteMediaCache mRemoteMediaCache = new RemoteMediaCache();
     private final MediaCacheOperations mMediaCacheOperations = new MediaCacheOperations(mRemoteMediaCache);
     private final WooMediaNetwork mWooMediaNetwork = Mockito.mock(WooMediaNetwork.class);
@@ -257,26 +260,18 @@ public class MediaStoreTest {
     }
 
     @Test
-    public void givenUploadAction_whenHandled_thenDelegateToWooMediaNetwork() {
+    public void givenUploadAction_whenHandled_thenDelegateToWooMediaNetwork() throws Exception {
         SiteModel site = new SiteModel();
         site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
-        File file = new File("build/test-image.jpg");
-        try {
-            file.getParentFile().mkdirs();
-            file.createNewFile();
-            MediaModel media = generateMediaFromPath(1, 10L, file.getPath());
+        File file = temporaryFolder.newFile("test-image.jpg");
+        MediaModel media = generateMediaFromPath(1, 10L, file.getPath());
 
-            mMediaStore.onAction(new Action<>(
-                    MediaAction.UPLOAD_MEDIA,
-                    new MediaStore.UploadMediaPayload(site, media, false)
-            ));
+        mMediaStore.onAction(new Action<>(
+                MediaAction.UPLOAD_MEDIA,
+                new MediaStore.UploadMediaPayload(site, media, false)
+        ));
 
-            Mockito.verify(mWooMediaNetwork).uploadMedia(site, media);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        } finally {
-            file.delete();
-        }
+        Mockito.verify(mWooMediaNetwork).uploadMedia(site, media);
     }
 
     @Test

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/MediaStoreTest.java
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/MediaStoreTest.java
@@ -12,17 +12,22 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.MediaAction;
+import org.wordpress.android.fluxc.annotations.action.Action;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.rest.wpapi.media.WooMediaNetwork;
 import org.wordpress.android.fluxc.utils.MediaUtils;
+import org.wordpress.android.fluxc.utils.MimeType;
 
+import java.io.File;
 import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
 public class MediaStoreTest {
     private final RemoteMediaCache mRemoteMediaCache = new RemoteMediaCache();
     private final MediaCacheOperations mMediaCacheOperations = new MediaCacheOperations(mRemoteMediaCache);
+    private final WooMediaNetwork mWooMediaNetwork = Mockito.mock(WooMediaNetwork.class);
 
     private static class FakeMediaIdGenerator implements MediaIdGenerator {
         private int nextId = 1;
@@ -34,7 +39,7 @@ public class MediaStoreTest {
 
     @SuppressWarnings("KotlinInternalInJava")
     private final MediaStore mMediaStore = new MediaStore(new Dispatcher(),
-            Mockito.mock(WooMediaNetwork.class),
+            mWooMediaNetwork,
             mRemoteMediaCache,
             mMediaCacheOperations,
             new FakeMediaIdGenerator()
@@ -249,6 +254,54 @@ public class MediaStoreTest {
 
         assertEquals(testSiteId, storeDocuments.get(0).getLocalSiteId());
         assertEquals(testSiteId, storeDocuments.get(1).getLocalSiteId());
+    }
+
+    @Test
+    public void givenUploadAction_whenHandled_thenDelegateToWooMediaNetwork() {
+        SiteModel site = new SiteModel();
+        site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
+        File file = new File("build/test-image.jpg");
+        try {
+            file.getParentFile().mkdirs();
+            file.createNewFile();
+            MediaModel media = generateMediaFromPath(1, 10L, file.getPath());
+
+            mMediaStore.onAction(new Action<>(
+                    MediaAction.UPLOAD_MEDIA,
+                    new MediaStore.UploadMediaPayload(site, media, false)
+            ));
+
+            Mockito.verify(mWooMediaNetwork).uploadMedia(site, media);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            file.delete();
+        }
+    }
+
+    @Test
+    public void givenFetchMediaListAction_whenHandled_thenDelegateToWooMediaNetwork() {
+        SiteModel site = getTestSiteWithLocalId(5);
+        site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
+        mMediaStore.onAction(new Action<>(
+                MediaAction.FETCH_MEDIA_LIST,
+                new MediaStore.FetchMediaListPayload(site, 10, false, MimeType.Type.IMAGE)
+        ));
+
+        Mockito.verify(mWooMediaNetwork).fetchMediaList(site, 10, 0, MimeType.Type.IMAGE);
+    }
+
+    @Test
+    public void givenCancelUploadAction_whenHandled_thenDelegateToWooMediaNetwork() {
+        SiteModel site = getTestSiteWithLocalId(5);
+        site.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
+        MediaModel media = generateMediaFromPath(5, 11L, "/test/test_image.jpg");
+        mMediaStore.onAction(new Action<>(
+                MediaAction.CANCEL_MEDIA_UPLOAD,
+                new MediaStore.CancelMediaPayload(site, media, false)
+        ));
+
+        Mockito.verify(mWooMediaNetwork).cancelUpload(site, media);
     }
 
     private SiteModel getTestSiteWithLocalId(int localSiteId) {

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/MediaStoreTest.java
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/store/MediaStoreTest.java
@@ -12,11 +12,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.wordpress.android.fluxc.Dispatcher;
-import org.wordpress.android.fluxc.logging.FakeCrashLogging;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.network.rest.wpapi.media.ApplicationPasswordsMediaRestClient;
-import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient;
+import org.wordpress.android.fluxc.network.rest.wpapi.media.WooMediaNetwork;
 import org.wordpress.android.fluxc.utils.MediaUtils;
 
 import java.util.List;
@@ -36,11 +34,7 @@ public class MediaStoreTest {
 
     @SuppressWarnings("KotlinInternalInJava")
     private final MediaStore mMediaStore = new MediaStore(new Dispatcher(),
-            Mockito.mock(WPComV2MediaRestClient.class),
-            Mockito.mock(ApplicationPasswordsMediaRestClient.class),
-            Mockito.mock(org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords
-                    .ApplicationPasswordsConfiguration.class),
-            FakeCrashLogging.INSTANCE,
+            Mockito.mock(WooMediaNetwork.class),
             mRemoteMediaCache,
             mMediaCacheOperations,
             new FakeMediaIdGenerator()


### PR DESCRIPTION
Part of WOOMOB-1438

### Description
First of two PRs to migrate media endpoints to Application Passwords.

This PR is a pure structural refactor with no behavior change:
- Adds `apiErrorCode` field to `MediaError` and propagates it in fetch/upload error paths
- Extracts site-origin routing logic from `MediaStore` into a new `WooMediaNetwork` class
- Simplifies `BaseWPV2MediaRestClient` API: removes `Dispatcher`/`CoroutineEngine` dependencies, exposes `uploadMedia` (Flow), `fetchMedia` and `fetchMediaList` (suspend) as public methods
- Moves coroutine launching and action dispatching into `WooMediaNetwork`

The routing logic in `WooMediaNetwork` mirrors exactly what `MediaStore` did before, and the goal is add app passwords handling for Jetpack sites in next PR.

### Test Steps
For tests, please open product and details, and add new media, you can then test upload, or fetch using the WordPress Media Library option.

1. Upload media on a Jetpack site and verify it succeeds
2. Fetch media list on a Jetpack site and verify it loads
3. Upload media on a site with app passwords and verify it succeeds
4. Fetch media list on a site with app passwords and verify it loads

### Images/gif
N/A — no UI changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.