### PR TITLE
[WOOMOB-1438] Migrate media endpoints to app passwords

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,10 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 
+25.1
+-----
+- [Internal] Migrated media upload and media-list endpoints to Application Passwords [https://github.com/woocommerce/woocommerce-android/pull/15550]
+
 25.0
 -----
 - [*] Added age-eligibility verification to comply with Google Play age requirements [https://github.com/woocommerce/woocommerce-android/pull/16048]
@@ -16,12 +20,9 @@
 - [**] Contact support now includes troubleshooting and AI help [https://github.com/woocommerce/woocommerce-android/pull/15979]
 - [*] Fixed USPS shipping label customs handling for US territories and added a 30-character limit on customs item descriptions [https://github.com/woocommerce/woocommerce-android/pull/15999]
 - [Internal] Enabled local flag for self-driven push notifications [https://github.com/woocommerce/woocommerce-android/pull/15997]
-<<<<<<< merge/release-24.9-into-trunk
 - [*] Fixed Woo POS failing to load products on stores whose web server blocks access to the catalog file [https://github.com/woocommerce/woocommerce-android/pull/16059]
-=======
 - [*] Fixed Woo Shipping label "Shipment details" title not expanding the bottom sheet on tap [https://github.com/woocommerce/woocommerce-android/pull/16020]
 - [*] Fixed Shipping Labels Verify button being briefly tappable when the address form input is invalid [https://github.com/woocommerce/woocommerce-android/pull/16021]
->>>>>>> trunk
 
 24.8
 -----

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClient.kt
@@ -5,13 +5,15 @@ import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import org.wordpress.android.fluxc.annotations.endpoint.WPAPIEndpoint
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
-import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordCreationResult.Created
-import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordCreationResult.Existing
-import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordCreationResult.Failure
-import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordCreationResult.NotSupported
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordCreationResult
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsManager
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+import org.wordpress.android.fluxc.store.MediaStore.MediaError
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
 import org.wordpress.android.fluxc.utils.extensions.slashJoin
 import javax.inject.Inject
 import javax.inject.Named
@@ -30,19 +32,22 @@ class ApplicationPasswordsMediaRestClient @Inject constructor(
         return (site.wpApiRestUrl ?: site.url.slashJoin("wp-json")).slashJoin(urlV2)
     }
 
-    override suspend fun getAuthorizationHeader(site: SiteModel): String {
-        val credentials = when (val result = applicationPasswordsManager.getApplicationCredentials(site)) {
-            is Created -> result.credentials
-            is Existing -> result.credentials
-            // If there is no saved password yet or the creation fails, the request will simply fail with a 401 error
-            // This is unlikely to happen though, since media handling happens later in the app
-            is Failure -> null
-            is NotSupported -> null
-        }
+    override suspend fun getAuthorizationHeader(site: SiteModel): AuthorizationHeaderResult {
+        return when (val result = applicationPasswordsManager.getApplicationCredentials(site)) {
+            is ApplicationPasswordCreationResult.Created -> AuthorizationHeaderResult.Success(
+                Credentials.basic(result.credentials.userName, result.credentials.password)
+            )
 
-        return credentials?.let {
-            Credentials.basic(credentials.userName, credentials.password)
-        }.orEmpty()
+            is ApplicationPasswordCreationResult.Existing -> AuthorizationHeaderResult.Success(
+                Credentials.basic(result.credentials.userName, result.credentials.password)
+            )
+
+            is ApplicationPasswordCreationResult.Failure ->
+                AuthorizationHeaderResult.Failure(result.error.toGenerationFailureMediaError())
+
+            is ApplicationPasswordCreationResult.NotSupported ->
+                AuthorizationHeaderResult.Failure(result.originalError.toGenerationFailureMediaError())
+        }
     }
 
     override suspend fun <T : Any> executeGetGsonRequest(
@@ -57,5 +62,21 @@ class ApplicationPasswordsMediaRestClient @Inject constructor(
             clazz = clazz,
             params = params
         )
+    }
+
+    private fun BaseNetworkError.toGenerationFailureMediaError(): MediaError {
+        val originalErrorCode = when (this) {
+            is WPAPINetworkError -> errorCode
+            is WPComGsonNetworkError -> apiError
+            else -> null
+        }
+
+        return MediaError(MediaErrorType.fromBaseNetworkError(this)).apply {
+            statusCode = volleyError?.networkResponse?.statusCode ?: 0
+            apiErrorCode = ApplicationPasswordsNetwork.APP_PASSWORDS_GENERATION_FAILURE_ERROR_CODE_PREFIX +
+                originalErrorCode.orEmpty()
+            message = this@toGenerationFailureMediaError.message
+            logMessage = getCombinedErrorMessage()
+        }
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/BaseWPV2MediaRestClient.kt
@@ -37,7 +37,7 @@ abstract class BaseWPV2MediaRestClient(
 ) {
     protected abstract fun WPAPIEndpoint.getFullUrl(site: SiteModel): String
 
-    protected abstract suspend fun getAuthorizationHeader(site: SiteModel): String
+    protected abstract suspend fun getAuthorizationHeader(site: SiteModel): AuthorizationHeaderResult
 
     protected abstract suspend fun <T : Any> executeGetGsonRequest(
         site: SiteModel,
@@ -55,6 +55,14 @@ abstract class BaseWPV2MediaRestClient(
         }
 
         return callbackFlow {
+            val authorizationHeader = when (val result = getAuthorizationHeader(site)) {
+                is AuthorizationHeaderResult.Success -> result.header
+                is AuthorizationHeaderResult.Failure -> {
+                    handleFailure(media, result.error)
+                    return@callbackFlow
+                }
+            }
+
             val url = WPAPI.media.getFullUrl(site)
             val body = WPRestUploadRequestBody(media) { media, progress ->
                 val payload = ProgressPayload(media, progress, false, null)
@@ -64,7 +72,7 @@ abstract class BaseWPV2MediaRestClient(
             val request = Request.Builder()
                 .url(url)
                 .post(body = body)
-                .header(WPComGsonRequest.REST_AUTHORIZATION_HEADER, getAuthorizationHeader(site))
+                .header(WPComGsonRequest.REST_AUTHORIZATION_HEADER, authorizationHeader)
                 .build()
 
             val call = okHttpClient.newCall(request)
@@ -107,6 +115,11 @@ abstract class BaseWPV2MediaRestClient(
                 call.cancel()
             }
         }
+    }
+
+    protected sealed class AuthorizationHeaderResult {
+        data class Success(val header: String) : AuthorizationHeaderResult()
+        data class Failure(val error: MediaError) : AuthorizationHeaderResult()
     }
 
     suspend fun fetchMedia(site: SiteModel, mediaId: Long): MediaPayload {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
+import org.wordpress.android.fluxc.logging.FluxCCrashLogger
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
@@ -24,6 +25,7 @@ import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.MimeType
 import org.wordpress.android.util.AppLog
 import java.security.GeneralSecurityException
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -36,55 +38,56 @@ class WooMediaNetwork @Inject constructor(
     private val applicationPasswordsMediaRestClient: ApplicationPasswordsMediaRestClient,
     private val wpComV2MediaRestClient: WPComV2MediaRestClient,
     private val jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport,
-    private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler
+    private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler,
+    private val crashLogger: FluxCCrashLogger
 ) {
     private val currentUploads = ConcurrentHashMap<Int, Job>()
 
     fun uploadMedia(site: SiteModel, media: MediaModel) {
-        when (site.origin) {
-            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
-                requireDirectAccessEnabled()
-                launchUpload(site, media)
-            }
-
-            SiteModel.ORIGIN_WPCOM_REST -> {
-                launchUpload(site, media)
-            }
-
-            else -> throw unsupportedOrigin(site)
+        if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
+            launchUpload(site, media, useAppPasswords = false)
+        } else if (site.origin == SiteModel.ORIGIN_WPAPI
+            && applicationPasswordsConfiguration.isEnabledForDirectAccess()
+        ) {
+            launchUpload(site, media, useAppPasswords = true)
+        } else {
+            reportXmlrpcTry()
         }
     }
 
     fun fetchMediaList(site: SiteModel, number: Int, offset: Int, mimeType: MimeType.Type?) {
-        when (site.origin) {
-            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
-                requireDirectAccessEnabled()
-                coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list") {
-                    val payload = applicationPasswordsMediaRestClient.fetchMediaList(
-                        site, number, offset, mimeType
-                    )
-                    dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
-                }
+        if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
+            coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list for Jetpack site") {
+                val payload = fetchMediaListWithJetpackFallback(site, number, offset, mimeType)
+                dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
             }
-
-            SiteModel.ORIGIN_WPCOM_REST -> {
-                coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list for Jetpack site") {
-                    val payload = fetchMediaListWithJetpackFallback(site, number, offset, mimeType)
-                    dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
-                }
+        } else if (site.origin == SiteModel.ORIGIN_WPAPI
+            && applicationPasswordsConfiguration.isEnabledForDirectAccess()
+        ) {
+            coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list") {
+                val payload = applicationPasswordsMediaRestClient.fetchMediaList(
+                    site, number, offset, mimeType
+                )
+                dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
             }
-
-            else -> throw unsupportedOrigin(site)
+        } else {
+            reportXmlrpcTry()
         }
     }
 
     fun cancelUpload(site: SiteModel, media: MediaModel) {
-        when (site.origin) {
-            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> requireDirectAccessEnabled()
-            SiteModel.ORIGIN_WPCOM_REST -> { /* no precondition */ }
-            else -> throw unsupportedOrigin(site)
+        if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
+            performCancelUpload(media)
+        } else if (site.origin == SiteModel.ORIGIN_WPAPI
+            && applicationPasswordsConfiguration.isEnabledForDirectAccess()
+        ) {
+            performCancelUpload(media)
+        } else {
+            reportXmlrpcTry()
         }
+    }
 
+    private fun performCancelUpload(media: MediaModel) {
         val job = currentUploads.remove(media.id)
         if (job != null) {
             job.cancel()
@@ -93,17 +96,13 @@ class WooMediaNetwork @Inject constructor(
         }
     }
 
-    private fun launchUpload(site: SiteModel, media: MediaModel) {
+    private fun launchUpload(site: SiteModel, media: MediaModel, useAppPasswords: Boolean) {
         val uploadJob = coroutineEngine.launch(AppLog.T.MEDIA, this, "Uploading media") {
             try {
-                when (site.origin) {
-                    SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
-                        dispatchUploadFlow(applicationPasswordsMediaRestClient.uploadMedia(site, media))
-                    }
-
-                    SiteModel.ORIGIN_WPCOM_REST -> {
-                        uploadForJetpackSite(site, media)
-                    }
+                if (useAppPasswords) {
+                    dispatchUploadFlow(applicationPasswordsMediaRestClient.uploadMedia(site, media))
+                } else {
+                    uploadForJetpackSite(site, media)
                 }
             } finally {
                 currentUploads.remove(media.id)
@@ -198,14 +197,13 @@ class WooMediaNetwork @Inject constructor(
         }
     }
 
-    private fun requireDirectAccessEnabled() {
-        check(applicationPasswordsConfiguration.isEnabledForDirectAccess()) {
-            "Application Passwords are not enabled for direct access"
-        }
+    private fun reportXmlrpcTry() {
+        crashLogger.sendReport(
+            null,
+            Collections.emptyMap(),
+            "Requested MediaStore XMLRPC connection. This should not happen."
+        )
     }
-
-    private fun unsupportedOrigin(site: SiteModel) =
-        IllegalArgumentException("Unsupported site origin: ${site.origin}")
 
     private fun createKeystoreEncryptionError() = MediaError(MediaErrorType.GENERIC_ERROR).apply {
         apiErrorCode = ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -1,18 +1,29 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.media
 
+import com.android.volley.NetworkResponse
+import com.android.volley.VolleyError
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
-import org.wordpress.android.fluxc.logging.FluxCCrashLogger
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsStore
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsErrorHandler
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsSupport
 import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload
+import org.wordpress.android.fluxc.store.MediaStore.MediaError
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.MimeType
 import org.wordpress.android.util.AppLog
-import java.util.Collections
+import java.security.GeneralSecurityException
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -24,73 +35,56 @@ class WooMediaNetwork @Inject constructor(
     private val applicationPasswordsConfiguration: ApplicationPasswordsConfiguration,
     private val applicationPasswordsMediaRestClient: ApplicationPasswordsMediaRestClient,
     private val wpComV2MediaRestClient: WPComV2MediaRestClient,
-    private val crashLogger: FluxCCrashLogger
+    private val jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport,
+    private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler
 ) {
     private val currentUploads = ConcurrentHashMap<Int, Job>()
 
     fun uploadMedia(site: SiteModel, media: MediaModel) {
-        if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
-            launchUpload(wpComV2MediaRestClient, site, media)
-        } else if (site.origin == SiteModel.ORIGIN_WPAPI
-            && applicationPasswordsConfiguration.isEnabledForDirectAccess()
-        ) {
-            launchUpload(applicationPasswordsMediaRestClient, site, media)
-        } else {
-            reportXmlrpcTry()
+        when (site.origin) {
+            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
+                requireDirectAccessEnabled()
+                launchUpload(site, media)
+            }
+
+            SiteModel.ORIGIN_WPCOM_REST -> {
+                launchUpload(site, media)
+            }
+
+            else -> throw unsupportedOrigin(site)
         }
     }
 
     fun fetchMediaList(site: SiteModel, number: Int, offset: Int, mimeType: MimeType.Type?) {
-        if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
-            launchFetchMediaList(wpComV2MediaRestClient, site, number, offset, mimeType)
-        } else if (site.origin == SiteModel.ORIGIN_WPAPI
-            && applicationPasswordsConfiguration.isEnabledForDirectAccess()
-        ) {
-            launchFetchMediaList(applicationPasswordsMediaRestClient, site, number, offset, mimeType)
-        } else {
-            reportXmlrpcTry()
+        when (site.origin) {
+            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
+                requireDirectAccessEnabled()
+                coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list") {
+                    val payload = applicationPasswordsMediaRestClient.fetchMediaList(
+                        site, number, offset, mimeType
+                    )
+                    dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
+                }
+            }
+
+            SiteModel.ORIGIN_WPCOM_REST -> {
+                coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list for Jetpack site") {
+                    val payload = fetchMediaListWithJetpackFallback(site, number, offset, mimeType)
+                    dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
+                }
+            }
+
+            else -> throw unsupportedOrigin(site)
         }
     }
 
     fun cancelUpload(site: SiteModel, media: MediaModel) {
-        if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
-            performCancelUpload(media)
-        } else if (site.origin == SiteModel.ORIGIN_WPAPI
-            && applicationPasswordsConfiguration.isEnabledForDirectAccess()
-        ) {
-            performCancelUpload(media)
-        } else {
-            reportXmlrpcTry()
+        when (site.origin) {
+            SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> requireDirectAccessEnabled()
+            SiteModel.ORIGIN_WPCOM_REST -> { /* no precondition */ }
+            else -> throw unsupportedOrigin(site)
         }
-    }
 
-    private fun launchUpload(client: BaseWPV2MediaRestClient, site: SiteModel, media: MediaModel) {
-        val uploadJob = coroutineEngine.launch(AppLog.T.MEDIA, this, "Uploading media") {
-            try {
-                client.uploadMedia(site, media).collect { payload ->
-                    dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
-                }
-            } finally {
-                currentUploads.remove(media.id)
-            }
-        }
-        currentUploads[media.id] = uploadJob
-    }
-
-    private fun launchFetchMediaList(
-        client: BaseWPV2MediaRestClient,
-        site: SiteModel,
-        number: Int,
-        offset: Int,
-        mimeType: MimeType.Type?
-    ) {
-        coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list") {
-            val payload = client.fetchMediaList(site, number, offset, mimeType)
-            dispatcher.dispatch(MediaActionBuilder.newFetchedMediaListAction(payload))
-        }
-    }
-
-    private fun performCancelUpload(media: MediaModel) {
         val job = currentUploads.remove(media.id)
         if (job != null) {
             job.cancel()
@@ -99,11 +93,169 @@ class WooMediaNetwork @Inject constructor(
         }
     }
 
-    private fun reportXmlrpcTry() {
-        crashLogger.sendReport(
-            null,
-            Collections.emptyMap(),
-            "Requested MediaStore XMLRPC connection. This should not happen."
+    private fun launchUpload(site: SiteModel, media: MediaModel) {
+        val uploadJob = coroutineEngine.launch(AppLog.T.MEDIA, this, "Uploading media") {
+            try {
+                when (site.origin) {
+                    SiteModel.ORIGIN_WPAPI, SiteModel.ORIGIN_XMLRPC -> {
+                        dispatchUploadFlow(applicationPasswordsMediaRestClient.uploadMedia(site, media))
+                    }
+
+                    SiteModel.ORIGIN_WPCOM_REST -> {
+                        uploadForJetpackSite(site, media)
+                    }
+                }
+            } finally {
+                currentUploads.remove(media.id)
+            }
+        }
+        currentUploads[media.id] = uploadJob
+    }
+
+    private suspend fun uploadForJetpackSite(site: SiteModel, media: MediaModel) {
+        if (!shouldUseAppPasswordsForJetpack(site)) {
+            dispatchUploadFlow(wpComV2MediaRestClient.uploadMedia(site, media))
+            return
+        }
+
+        var appPasswordsError: MediaError? = null
+
+        try {
+            applicationPasswordsMediaRestClient.uploadMedia(site, media).collect { payload ->
+                if (payload.isError) {
+                    appPasswordsError = payload.error
+                } else {
+                    dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
+                }
+            }
+        } catch (e: GeneralSecurityException) {
+            AppLog.e(AppLog.T.MEDIA, "Error setting up Application Passwords encryption", e)
+            appPasswordsError = createKeystoreEncryptionError()
+        }
+
+        if (appPasswordsError == null) return
+
+        logFailedAppPasswordsRequest("upload", site, appPasswordsError)
+
+        var fallbackSucceeded = false
+        wpComV2MediaRestClient.uploadMedia(site, media).collect { payload ->
+            if (payload.completed && !payload.isError && !payload.canceled) {
+                fallbackSucceeded = true
+            }
+            dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
+        }
+
+        if (fallbackSucceeded) {
+            jetpackApplicationPasswordsErrorHandler.handleError(
+                site,
+                appPasswordsError.toWPAPINetworkError()
+            )
+        }
+    }
+
+    private suspend fun fetchMediaListWithJetpackFallback(
+        site: SiteModel,
+        number: Int,
+        offset: Int,
+        mimeType: MimeType.Type?
+    ): FetchMediaListResponsePayload {
+        if (!shouldUseAppPasswordsForJetpack(site)) {
+            return wpComV2MediaRestClient.fetchMediaList(site, number, offset, mimeType)
+        }
+
+        val appPasswordsPayload = try {
+            applicationPasswordsMediaRestClient.fetchMediaList(site, number, offset, mimeType)
+        } catch (e: GeneralSecurityException) {
+            AppLog.e(AppLog.T.MEDIA, "Error setting up Application Passwords encryption", e)
+            FetchMediaListResponsePayload(site, createKeystoreEncryptionError(), mimeType)
+        }
+
+        if (!appPasswordsPayload.isError) {
+            return appPasswordsPayload
+        }
+
+        logFailedAppPasswordsRequest("fetch media list", site, appPasswordsPayload.error)
+
+        val fallbackPayload = wpComV2MediaRestClient.fetchMediaList(site, number, offset, mimeType)
+        if (!fallbackPayload.isError) {
+            jetpackApplicationPasswordsErrorHandler.handleError(
+                site,
+                appPasswordsPayload.error.toWPAPINetworkError()
+            )
+        }
+
+        return fallbackPayload
+    }
+
+    private suspend fun shouldUseAppPasswordsForJetpack(site: SiteModel): Boolean {
+        return applicationPasswordsConfiguration.isEnabledForJetpackAccess() &&
+            jetpackApplicationPasswordsSupport.supportsAppPasswords(site)
+    }
+
+    private suspend fun dispatchUploadFlow(flow: Flow<ProgressPayload>) {
+        flow.collect { payload ->
+            dispatcher.dispatch(MediaActionBuilder.newUploadedMediaAction(payload))
+        }
+    }
+
+    private fun requireDirectAccessEnabled() {
+        check(applicationPasswordsConfiguration.isEnabledForDirectAccess()) {
+            "Application Passwords are not enabled for direct access"
+        }
+    }
+
+    private fun unsupportedOrigin(site: SiteModel) =
+        IllegalArgumentException("Unsupported site origin: ${site.origin}")
+
+    private fun createKeystoreEncryptionError() = MediaError(MediaErrorType.GENERIC_ERROR).apply {
+        apiErrorCode = ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR
+    }
+
+    private fun logFailedAppPasswordsRequest(operation: String, site: SiteModel, error: MediaError?) {
+        AppLog.w(
+            AppLog.T.MEDIA,
+            "Media $operation failed using Application Passwords for Jetpack Site,\n" +
+                "site: ${site.url},\n" +
+                "error: HTTP status code ${error?.statusCode}, " +
+                "error message: ${error?.apiErrorCode?.ifEmpty { null } ?: error?.message}"
         )
+    }
+
+    private fun MediaError?.toWPAPINetworkError(): WPAPINetworkError {
+        requireNotNull(this) { "MediaError is required to build a WPAPINetworkError" }
+
+        val baseError = BaseNetworkError(
+            errorTypeFrom(this),
+            message.orEmpty(),
+            volleyErrorFrom(this)
+        )
+        return WPAPINetworkError(baseError, apiErrorCode)
+    }
+
+    private fun errorTypeFrom(error: MediaError): GenericErrorType {
+        return when (error.statusCode) {
+            401 -> GenericErrorType.NOT_AUTHENTICATED
+            403 -> GenericErrorType.AUTHORIZATION_REQUIRED
+            404 -> GenericErrorType.NOT_FOUND
+            408 -> GenericErrorType.TIMEOUT
+            in 500..599 -> GenericErrorType.SERVER_ERROR
+            else -> when (error.type) {
+                MediaErrorType.NOT_AUTHENTICATED -> GenericErrorType.NOT_AUTHENTICATED
+                MediaErrorType.AUTHORIZATION_REQUIRED -> GenericErrorType.AUTHORIZATION_REQUIRED
+                MediaErrorType.NOT_FOUND -> GenericErrorType.NOT_FOUND
+                MediaErrorType.TIMEOUT -> GenericErrorType.TIMEOUT
+                MediaErrorType.SERVER_ERROR -> GenericErrorType.SERVER_ERROR
+                MediaErrorType.PARSE_ERROR -> GenericErrorType.PARSE_ERROR
+                else -> GenericErrorType.UNKNOWN
+            }
+        }
+    }
+
+    private fun volleyErrorFrom(error: MediaError): VolleyError {
+        return if (error.statusCode > 0) {
+            VolleyError(NetworkResponse(error.statusCode, null, false, 0, emptyList()))
+        } else {
+            VolleyError(error.message)
+        }
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -232,11 +232,11 @@ class WooMediaNetwork @Inject constructor(
 
     private fun errorTypeFrom(error: MediaError): GenericErrorType {
         return when (error.statusCode) {
-            401 -> GenericErrorType.AUTHORIZATION_REQUIRED
-            403 -> GenericErrorType.NOT_AUTHENTICATED
-            404 -> GenericErrorType.NOT_FOUND
-            408 -> GenericErrorType.TIMEOUT
-            in 500..599 -> GenericErrorType.SERVER_ERROR
+            HTTP_STATUS_UNAUTHORIZED -> GenericErrorType.AUTHORIZATION_REQUIRED
+            HTTP_STATUS_FORBIDDEN -> GenericErrorType.NOT_AUTHENTICATED
+            HTTP_STATUS_NOT_FOUND -> GenericErrorType.NOT_FOUND
+            HTTP_STATUS_REQUEST_TIMEOUT -> GenericErrorType.TIMEOUT
+            in HTTP_STATUS_SERVER_ERROR_MIN..HTTP_STATUS_SERVER_ERROR_MAX -> GenericErrorType.SERVER_ERROR
             else -> when (error.type) {
                 MediaErrorType.NOT_AUTHENTICATED -> GenericErrorType.NOT_AUTHENTICATED
                 MediaErrorType.AUTHORIZATION_REQUIRED -> GenericErrorType.AUTHORIZATION_REQUIRED
@@ -255,5 +255,14 @@ class WooMediaNetwork @Inject constructor(
         } else {
             VolleyError(error.message)
         }
+    }
+
+    companion object {
+        private const val HTTP_STATUS_UNAUTHORIZED = 401
+        private const val HTTP_STATUS_FORBIDDEN = 403
+        private const val HTTP_STATUS_NOT_FOUND = 404
+        private const val HTTP_STATUS_REQUEST_TIMEOUT = 408
+        private const val HTTP_STATUS_SERVER_ERROR_MIN = 500
+        private const val HTTP_STATUS_SERVER_ERROR_MAX = 599
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -49,6 +49,7 @@ class WooMediaNetwork @Inject constructor(
         } else if (site.origin == SiteModel.ORIGIN_WPAPI
             && applicationPasswordsConfiguration.isEnabledForDirectAccess()
         ) {
+            AppLog.v(AppLog.T.MEDIA, "Uploading media using Application Passwords for WPAPI Site")
             launchUpload(site, media, useAppPasswords = true)
         } else {
             reportXmlrpcTry()
@@ -65,6 +66,7 @@ class WooMediaNetwork @Inject constructor(
             && applicationPasswordsConfiguration.isEnabledForDirectAccess()
         ) {
             coroutineEngine.launch(AppLog.T.MEDIA, this, "Fetching media list") {
+                AppLog.v(AppLog.T.MEDIA, "Fetching media list using Application Passwords for WPAPI Site")
                 val payload = applicationPasswordsMediaRestClient.fetchMediaList(
                     site, number, offset, mimeType
                 )
@@ -113,6 +115,7 @@ class WooMediaNetwork @Inject constructor(
 
     private suspend fun uploadForJetpackSite(site: SiteModel, media: MediaModel) {
         if (!shouldUseAppPasswordsForJetpack(site)) {
+            AppLog.v(AppLog.T.MEDIA, "Uploading media using WP.com REST for Jetpack Site")
             dispatchUploadFlow(wpComV2MediaRestClient.uploadMedia(site, media))
             return
         }
@@ -120,6 +123,7 @@ class WooMediaNetwork @Inject constructor(
         var appPasswordsError: MediaError? = null
 
         try {
+            AppLog.v(AppLog.T.MEDIA, "Uploading media using Application Passwords for Jetpack Site")
             applicationPasswordsMediaRestClient.uploadMedia(site, media).collect { payload ->
                 if (payload.isError) {
                     appPasswordsError = payload.error
@@ -137,6 +141,7 @@ class WooMediaNetwork @Inject constructor(
         logFailedAppPasswordsRequest("upload", site, appPasswordsError)
 
         var fallbackSucceeded = false
+        AppLog.v(AppLog.T.MEDIA, "Retrying media upload using WP.com REST for Jetpack Site")
         wpComV2MediaRestClient.uploadMedia(site, media).collect { payload ->
             if (payload.completed && !payload.isError && !payload.canceled) {
                 fallbackSucceeded = true
@@ -159,10 +164,12 @@ class WooMediaNetwork @Inject constructor(
         mimeType: MimeType.Type?
     ): FetchMediaListResponsePayload {
         if (!shouldUseAppPasswordsForJetpack(site)) {
+            AppLog.v(AppLog.T.MEDIA, "Fetching media list using WP.com REST for Jetpack Site")
             return wpComV2MediaRestClient.fetchMediaList(site, number, offset, mimeType)
         }
 
         val appPasswordsPayload = try {
+            AppLog.v(AppLog.T.MEDIA, "Fetching media list using Application Passwords for Jetpack Site")
             applicationPasswordsMediaRestClient.fetchMediaList(site, number, offset, mimeType)
         } catch (e: GeneralSecurityException) {
             AppLog.e(AppLog.T.MEDIA, "Error setting up Application Passwords encryption", e)
@@ -175,6 +182,7 @@ class WooMediaNetwork @Inject constructor(
 
         logFailedAppPasswordsRequest("fetch media list", site, appPasswordsPayload.error)
 
+        AppLog.v(AppLog.T.MEDIA, "Retrying media list fetch using WP.com REST for Jetpack Site")
         val fallbackPayload = wpComV2MediaRestClient.fetchMediaList(site, number, offset, mimeType)
         if (!fallbackPayload.isError) {
             jetpackApplicationPasswordsErrorHandler.handleError(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -232,8 +232,8 @@ class WooMediaNetwork @Inject constructor(
 
     private fun errorTypeFrom(error: MediaError): GenericErrorType {
         return when (error.statusCode) {
-            401 -> GenericErrorType.NOT_AUTHENTICATED
-            403 -> GenericErrorType.AUTHORIZATION_REQUIRED
+            401 -> GenericErrorType.AUTHORIZATION_REQUIRED
+            403 -> GenericErrorType.NOT_AUTHENTICATED
             404 -> GenericErrorType.NOT_FOUND
             408 -> GenericErrorType.TIMEOUT
             in 500..599 -> GenericErrorType.SERVER_ERROR

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetwork.kt
@@ -45,12 +45,12 @@ class WooMediaNetwork @Inject constructor(
 
     fun uploadMedia(site: SiteModel, media: MediaModel) {
         if (site.origin == SiteModel.ORIGIN_WPCOM_REST) {
-            launchUpload(site, media, useAppPasswords = false)
+            launchUpload(site, media, isJetpackSite = true)
         } else if (site.origin == SiteModel.ORIGIN_WPAPI
             && applicationPasswordsConfiguration.isEnabledForDirectAccess()
         ) {
             AppLog.v(AppLog.T.MEDIA, "Uploading media using Application Passwords for WPAPI Site")
-            launchUpload(site, media, useAppPasswords = true)
+            launchUpload(site, media, isJetpackSite = false)
         } else {
             reportXmlrpcTry()
         }
@@ -98,13 +98,13 @@ class WooMediaNetwork @Inject constructor(
         }
     }
 
-    private fun launchUpload(site: SiteModel, media: MediaModel, useAppPasswords: Boolean) {
+    private fun launchUpload(site: SiteModel, media: MediaModel, isJetpackSite: Boolean) {
         val uploadJob = coroutineEngine.launch(AppLog.T.MEDIA, this, "Uploading media") {
             try {
-                if (useAppPasswords) {
-                    dispatchUploadFlow(applicationPasswordsMediaRestClient.uploadMedia(site, media))
-                } else {
+                if (isJetpackSite) {
                     uploadForJetpackSite(site, media)
+                } else {
+                    dispatchUploadFlow(applicationPasswordsMediaRestClient.uploadMedia(site, media))
                 }
             } finally {
                 currentUploads.remove(media.id)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/media/wpv2/WPComV2MediaRestClient.kt
@@ -23,7 +23,9 @@ class WPComV2MediaRestClient @Inject constructor(
 ) : BaseWPV2MediaRestClient(okHttpClient, gson) {
     override fun WPAPIEndpoint.getFullUrl(site: SiteModel): String = getWPComUrl(site.siteId)
 
-    override suspend fun getAuthorizationHeader(site: SiteModel): String = "Bearer ${accessToken.get()}"
+    override suspend fun getAuthorizationHeader(site: SiteModel): AuthorizationHeaderResult {
+        return AuthorizationHeaderResult.Success("Bearer ${accessToken.get()}")
+    }
 
     override suspend fun <T : Any> executeGetGsonRequest(
         site: SiteModel,

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClientTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/ApplicationPasswordsMediaRestClientTest.kt
@@ -1,0 +1,115 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.media
+
+import com.android.volley.NetworkResponse
+import com.android.volley.VolleyError
+import com.google.gson.Gson
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordCreationResult
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsManager
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
+
+@ExperimentalCoroutinesApi
+class ApplicationPasswordsMediaRestClientTest {
+    private val okHttpClient: OkHttpClient = mock()
+    private val applicationPasswordsNetwork: ApplicationPasswordsNetwork = mock()
+    private val applicationPasswordsManager: ApplicationPasswordsManager = mock()
+
+    private val site = SiteModel().apply {
+        url = "https://example.com"
+    }
+    private val media = MediaModel(0, null, null, null, null, null).apply {
+        id = 123
+    }
+
+    private lateinit var sut: ApplicationPasswordsMediaRestClient
+
+    @Before
+    fun setup() {
+        sut = ApplicationPasswordsMediaRestClient(
+            okHttpClient = okHttpClient,
+            applicationPasswordsNetwork = applicationPasswordsNetwork,
+            gson = Gson()
+        ).apply {
+            applicationPasswordsManager = this@ApplicationPasswordsMediaRestClientTest.applicationPasswordsManager
+        }
+    }
+
+    @Test
+    fun `given credential generation fails, when uploading media, then emit one prefixed error without request`() =
+        runTest {
+            val networkError = WPAPINetworkError(
+                BaseNetworkError(
+                    GenericErrorType.NOT_AUTHENTICATED,
+                    "Unable to create application password",
+                    VolleyError(NetworkResponse(401, byteArrayOf(), true, 0, emptyList()))
+                ),
+                "incorrect_password"
+            )
+            whenever(applicationPasswordsManager.getApplicationCredentials(site)).thenReturn(
+                ApplicationPasswordCreationResult.Failure(networkError)
+            )
+
+            val payloads = sut.uploadMedia(site, media).toList()
+
+            assertThat(payloads).hasSize(1)
+            val payload = payloads.single()
+            assertThat(payload.media).isSameAs(media)
+            assertThat(payload.progress).isEqualTo(1f)
+            assertThat(payload.completed).isFalse()
+            val error = requireNotNull(payload.error)
+            assertThat(error.statusCode).isEqualTo(401)
+            assertThat(error.apiErrorCode).isEqualTo(
+                ApplicationPasswordsNetwork.APP_PASSWORDS_GENERATION_FAILURE_ERROR_CODE_PREFIX + "incorrect_password"
+            )
+            verify(okHttpClient, never()).newCall(any())
+        }
+
+    @Test
+    fun `given app passwords unsupported, when uploading media, then emit one prefixed error without request`() =
+        runTest {
+            val networkError = WPComGsonNetworkError(
+                BaseNetworkError(
+                    GenericErrorType.SERVER_ERROR,
+                    "Application passwords are disabled",
+                    VolleyError(NetworkResponse(403, byteArrayOf(), true, 0, emptyList()))
+                )
+            ).apply {
+                apiError = "application_passwords_disabled"
+            }
+            whenever(applicationPasswordsManager.getApplicationCredentials(site)).thenReturn(
+                ApplicationPasswordCreationResult.NotSupported(networkError)
+            )
+
+            val payloads = sut.uploadMedia(site, media).toList()
+
+            assertThat(payloads).hasSize(1)
+            val payload = payloads.single()
+            assertThat(payload.media).isSameAs(media)
+            assertThat(payload.progress).isEqualTo(1f)
+            assertThat(payload.completed).isFalse()
+            val error = requireNotNull(payload.error)
+            assertThat(error.statusCode).isEqualTo(403)
+            assertThat(error.apiErrorCode).isEqualTo(
+                ApplicationPasswordsNetwork.APP_PASSWORDS_GENERATION_FAILURE_ERROR_CODE_PREFIX +
+                    "application_passwords_disabled"
+            )
+            verify(okHttpClient, never()).newCall(any())
+        }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
@@ -36,12 +36,13 @@ import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.fluxc.utils.MimeType
 import java.security.GeneralSecurityException
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.fluxc.annotations.action.Action as FluxAction
 
 @RunWith(RobolectricTestRunner::class)
 class WooMediaNetworkTest {
     private val dispatcher: Dispatcher = mock()
-    private val coroutineEngine = CoroutineEngine(Dispatchers.Unconfined, mock<AppLogWrapper>())
+    private val coroutineEngine = initCoroutineEngine()
     private val applicationPasswordsConfiguration = FakeApplicationPasswordsConfiguration()
     private val applicationPasswordsMediaRestClient: ApplicationPasswordsMediaRestClient = mock()
     private val wpComV2MediaRestClient: WPComV2MediaRestClient = mock()

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
@@ -7,9 +7,10 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -19,7 +20,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.annotations.action.Action as FluxAction
+import org.wordpress.android.fluxc.logging.FluxCCrashLogger
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
@@ -35,6 +36,7 @@ import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.fluxc.utils.MimeType
 import java.security.GeneralSecurityException
+import org.wordpress.android.fluxc.annotations.action.Action as FluxAction
 
 @RunWith(RobolectricTestRunner::class)
 class WooMediaNetworkTest {
@@ -45,6 +47,7 @@ class WooMediaNetworkTest {
     private val wpComV2MediaRestClient: WPComV2MediaRestClient = mock()
     private val jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport = mock()
     private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler = mock()
+    private val crashLogger: FluxCCrashLogger = mock()
 
     private val sut = WooMediaNetwork(
         dispatcher = dispatcher,
@@ -53,7 +56,8 @@ class WooMediaNetworkTest {
         applicationPasswordsMediaRestClient = applicationPasswordsMediaRestClient,
         wpComV2MediaRestClient = wpComV2MediaRestClient,
         jetpackApplicationPasswordsSupport = jetpackApplicationPasswordsSupport,
-        jetpackApplicationPasswordsErrorHandler = jetpackApplicationPasswordsErrorHandler
+        jetpackApplicationPasswordsErrorHandler = jetpackApplicationPasswordsErrorHandler,
+        crashLogger = crashLogger
     )
 
     private val jetpackSite = SiteModel().apply {
@@ -208,11 +212,14 @@ class WooMediaNetworkTest {
         verify(wpComV2MediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
     }
 
-    @Test(expected = IllegalStateException::class)
-    fun `given WPAPI site with direct access disabled, when fetching media list, then throw`() {
-        applicationPasswordsConfiguration.directAccessEnabled = false
-        sut.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
-    }
+    @Test
+    fun `given WPAPI site with direct access disabled, when fetching media list, then report xmlrpc try`() =
+        runTest {
+            applicationPasswordsConfiguration.directAccessEnabled = false
+            sut.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+            verify(crashLogger).sendReport(anyOrNull(), any(), any())
+            verify(applicationPasswordsMediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+        }
 
     @Test
     fun `given supported jetpack site, when app passwords upload fails and fallback succeeds, then flag site`() =
@@ -353,33 +360,32 @@ class WooMediaNetworkTest {
         verify(wpComV2MediaRestClient, never()).uploadMedia(any(), any())
     }
 
-    @Test(expected = IllegalStateException::class)
-    fun `given WPAPI site with direct access disabled, when uploading, then throw`() {
+    @Test
+    fun `given WPAPI site with direct access disabled, when uploading, then report xmlrpc try`() = runTest {
         applicationPasswordsConfiguration.directAccessEnabled = false
         val media: MediaModel = mock()
         sut.uploadMedia(wpapiSite, media)
+        verify(crashLogger).sendReport(anyOrNull(), any(), any())
+        verify(applicationPasswordsMediaRestClient, never()).uploadMedia(any(), any())
     }
 
     @Test
-    fun `when cancelling upload, then dispatch cancelled action with zero progress`() {
+    fun `given no active upload, when cancelling upload, then do not dispatch`() {
         val media: MediaModel = mock {
             on { id } doReturn 13
         }
 
         sut.cancelUpload(jetpackSite, media)
 
-        val captor = argumentCaptor<FluxAction<*>>()
-        verify(dispatcher).dispatch(captor.capture())
-        val payload = captor.firstValue.payload as ProgressPayload
-        assertThat(payload.canceled).isTrue()
-        assertThat(payload.progress).isEqualTo(0f)
+        verify(dispatcher, never()).dispatch(any())
     }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun `given unsupported origin, when cancelling upload, then throw`() {
+    @Test
+    fun `given unsupported origin, when cancelling upload, then report xmlrpc try`() {
         val site = SiteModel().apply { origin = 999 }
         val media: MediaModel = mock()
         sut.cancelUpload(site, media)
+        verify(crashLogger).sendReport(anyOrNull(), any(), any())
     }
 
     private fun createMediaError(statusCode: Int, apiErrorCode: String): MediaError {

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
@@ -1,0 +1,400 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.media
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.annotations.action.Action as FluxAction
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsStore
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsErrorHandler
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsSupport
+import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload
+import org.wordpress.android.fluxc.store.MediaStore.MediaError
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
+import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.fluxc.utils.MimeType
+import java.security.GeneralSecurityException
+
+@RunWith(RobolectricTestRunner::class)
+class WooMediaNetworkTest {
+    private val dispatcher: Dispatcher = mock()
+    private val coroutineEngine = CoroutineEngine(Dispatchers.Unconfined, mock<AppLogWrapper>())
+    private val applicationPasswordsConfiguration = FakeApplicationPasswordsConfiguration()
+    private val applicationPasswordsMediaRestClient: ApplicationPasswordsMediaRestClient = mock()
+    private val wpComV2MediaRestClient: WPComV2MediaRestClient = mock()
+    private val jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport = mock()
+    private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler = mock()
+
+    private val sut = WooMediaNetwork(
+        dispatcher = dispatcher,
+        coroutineEngine = coroutineEngine,
+        applicationPasswordsConfiguration = applicationPasswordsConfiguration,
+        applicationPasswordsMediaRestClient = applicationPasswordsMediaRestClient,
+        wpComV2MediaRestClient = wpComV2MediaRestClient,
+        jetpackApplicationPasswordsSupport = jetpackApplicationPasswordsSupport,
+        jetpackApplicationPasswordsErrorHandler = jetpackApplicationPasswordsErrorHandler
+    )
+
+    private val jetpackSite = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPCOM_REST
+        siteId = 123L
+        url = "https://example.com"
+    }
+
+    private val wpapiSite = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPAPI
+        siteId = 456L
+        url = "https://direct.example.com"
+    }
+
+    @Test
+    fun `given supported jetpack site, when fetching media list, then use app passwords first`() = runTest {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+        whenever(
+            applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        verify(wpComV2MediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `given supported jetpack site, when app passwords fetch fails and fallback succeeds, then flag site`() =
+        runTest {
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(
+                applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 20, 5, MimeType.Type.IMAGE)
+            ).thenReturn(
+                FetchMediaListResponsePayload(
+                    jetpackSite,
+                    createMediaError(statusCode = 500, apiErrorCode = "incorrect_password"),
+                    MimeType.Type.IMAGE
+                )
+            )
+            whenever(
+                wpComV2MediaRestClient.fetchMediaList(jetpackSite, 20, 5, MimeType.Type.IMAGE)
+            ).thenReturn(
+                FetchMediaListResponsePayload(jetpackSite, emptyList(), false, true, MimeType.Type.IMAGE)
+            )
+
+            sut.fetchMediaList(jetpackSite, 20, 5, MimeType.Type.IMAGE)
+
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == "incorrect_password" &&
+                        volleyError?.networkResponse?.statusCode == 500
+                }
+            )
+        }
+
+    @Test
+    fun `given unsupported jetpack site, when fetching media list, then skip app passwords`() = runTest {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(false)
+        whenever(
+            wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+        verify(wpComV2MediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+    }
+
+    @Test
+    fun `given jetpack access disabled, when fetching media list, then use wpcom client directly`() = runTest {
+        applicationPasswordsConfiguration.jetpackAccessEnabled = false
+        whenever(
+            wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+        verify(wpComV2MediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+    }
+
+    @Test
+    fun `given supported jetpack site, when app passwords fetch throws GeneralSecurityException, then fallback`() =
+        runTest {
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(
+                applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+            ).thenAnswer { throw GeneralSecurityException("keystore error") }
+            whenever(
+                wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+            ).thenReturn(
+                FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
+            )
+
+            sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+            verify(wpComV2MediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR
+                }
+            )
+        }
+
+    @Test
+    fun `given supported jetpack site, when both fetch paths fail, then do not flag site`() = runTest {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+        whenever(
+            applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(
+                jetpackSite,
+                createMediaError(statusCode = 500, apiErrorCode = "server_error"),
+                MimeType.Type.IMAGE
+            )
+        )
+        whenever(
+            wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(
+                jetpackSite,
+                createMediaError(statusCode = 502, apiErrorCode = "bad_gateway"),
+                MimeType.Type.IMAGE
+            )
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(jetpackApplicationPasswordsErrorHandler, never()).handleError(any(), any())
+    }
+
+    @Test
+    fun `given WPAPI site, when fetching media list, then use app passwords client`() = runTest {
+        whenever(
+            applicationPasswordsMediaRestClient.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(wpapiSite, emptyList(), false, false, MimeType.Type.IMAGE)
+        )
+
+        sut.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient).fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+        verify(wpComV2MediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `given WPAPI site with direct access disabled, when fetching media list, then throw`() {
+        applicationPasswordsConfiguration.directAccessEnabled = false
+        sut.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+    }
+
+    @Test
+    fun `given supported jetpack site, when app passwords upload fails and fallback succeeds, then flag site`() =
+        runTest {
+            val media: MediaModel = mock {
+                on { id } doReturn 7
+            }
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+                flowOf(
+                    ProgressPayload(media, 0.4f, false, null),
+                    ProgressPayload(media, 1f, false, createMediaError(statusCode = 403, apiErrorCode = "forbidden"))
+                )
+            )
+            whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+                flowOf(ProgressPayload(media, 1f, true, false))
+            )
+
+            sut.uploadMedia(jetpackSite, media)
+
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == "forbidden" &&
+                        volleyError?.networkResponse?.statusCode == 403
+                }
+            )
+
+            val dispatchCaptor = argumentCaptor<FluxAction<*>>()
+            verify(dispatcher, times(2)).dispatch(dispatchCaptor.capture())
+            val payloads = dispatchCaptor.allValues.map { it.payload as ProgressPayload }
+            // First dispatch: progress from app passwords attempt
+            assertThat(payloads[0].progress).isEqualTo(0.4f)
+            // Second dispatch: completed from fallback
+            assertThat(payloads[1].progress).isEqualTo(1f)
+            assertThat(payloads[1].completed).isTrue()
+        }
+
+    @Test
+    fun `given supported jetpack site, when app passwords upload succeeds, then dispatch all progress`() =
+        runTest {
+            val media: MediaModel = mock {
+                on { id } doReturn 8
+            }
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+                flowOf(
+                    ProgressPayload(media, 0.4f, false, null),
+                    ProgressPayload(media, 1f, true, false)
+                )
+            )
+
+            sut.uploadMedia(jetpackSite, media)
+
+            val dispatchCaptor = argumentCaptor<FluxAction<*>>()
+            verify(dispatcher, times(2)).dispatch(dispatchCaptor.capture())
+            verify(wpComV2MediaRestClient, never()).uploadMedia(any(), any())
+            verify(jetpackApplicationPasswordsErrorHandler, never()).handleError(any(), any())
+
+            val payloads = dispatchCaptor.allValues.map { it.payload as ProgressPayload }
+            assertThat(payloads).hasSize(2)
+            assertThat(payloads[0].progress).isEqualTo(0.4f)
+            assertThat(payloads[0].completed).isFalse()
+            assertThat(payloads[1].progress).isEqualTo(1f)
+            assertThat(payloads[1].completed).isTrue()
+        }
+
+    @Test
+    fun `given jetpack access disabled, when uploading, then use wpcom client directly`() = runTest {
+        applicationPasswordsConfiguration.jetpackAccessEnabled = false
+        val media: MediaModel = mock {
+            on { id } doReturn 9
+        }
+        whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, true, false))
+        )
+
+        sut.uploadMedia(jetpackSite, media)
+
+        verify(applicationPasswordsMediaRestClient, never()).uploadMedia(any(), any())
+        verify(wpComV2MediaRestClient).uploadMedia(jetpackSite, media)
+    }
+
+    @Test
+    fun `given supported jetpack site, when app passwords upload throws GeneralSecurityException, then fallback`() =
+        runTest {
+            val media: MediaModel = mock {
+                on { id } doReturn 10
+            }
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media))
+                .thenReturn(flow { throw GeneralSecurityException("keystore error") })
+            whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+                flowOf(ProgressPayload(media, 1f, true, false))
+            )
+
+            sut.uploadMedia(jetpackSite, media)
+
+            verify(wpComV2MediaRestClient).uploadMedia(jetpackSite, media)
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR
+                }
+            )
+        }
+
+    @Test
+    fun `given supported jetpack site, when both upload paths fail, then do not flag site`() = runTest {
+        val media: MediaModel = mock {
+            on { id } doReturn 11
+        }
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+        whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, false, createMediaError(statusCode = 500, apiErrorCode = "error")))
+        )
+        whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, false, createMediaError(statusCode = 502, apiErrorCode = "error")))
+        )
+
+        sut.uploadMedia(jetpackSite, media)
+
+        verify(jetpackApplicationPasswordsErrorHandler, never()).handleError(any(), any())
+    }
+
+    @Test
+    fun `given WPAPI site, when uploading media, then use app passwords client`() = runTest {
+        val media: MediaModel = mock {
+            on { id } doReturn 12
+        }
+        whenever(applicationPasswordsMediaRestClient.uploadMedia(wpapiSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, true, false))
+        )
+
+        sut.uploadMedia(wpapiSite, media)
+
+        verify(applicationPasswordsMediaRestClient).uploadMedia(wpapiSite, media)
+        verify(wpComV2MediaRestClient, never()).uploadMedia(any(), any())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `given WPAPI site with direct access disabled, when uploading, then throw`() {
+        applicationPasswordsConfiguration.directAccessEnabled = false
+        val media: MediaModel = mock()
+        sut.uploadMedia(wpapiSite, media)
+    }
+
+    @Test
+    fun `when cancelling upload, then dispatch cancelled action with zero progress`() {
+        val media: MediaModel = mock {
+            on { id } doReturn 13
+        }
+
+        sut.cancelUpload(jetpackSite, media)
+
+        val captor = argumentCaptor<FluxAction<*>>()
+        verify(dispatcher).dispatch(captor.capture())
+        val payload = captor.firstValue.payload as ProgressPayload
+        assertThat(payload.canceled).isTrue()
+        assertThat(payload.progress).isEqualTo(0f)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `given unsupported origin, when cancelling upload, then throw`() {
+        val site = SiteModel().apply { origin = 999 }
+        val media: MediaModel = mock()
+        sut.cancelUpload(site, media)
+    }
+
+    private fun createMediaError(statusCode: Int, apiErrorCode: String): MediaError {
+        return MediaError(MediaErrorType.GENERIC_ERROR).apply {
+            this.statusCode = statusCode
+            this.apiErrorCode = apiErrorCode
+        }
+    }
+
+    private class FakeApplicationPasswordsConfiguration : ApplicationPasswordsConfiguration {
+        override val applicationName: String = "WooCommerce"
+        var directAccessEnabled: Boolean = true
+        var jetpackAccessEnabled: Boolean = true
+
+        override fun isEnabledForDirectAccess(): Boolean = directAccessEnabled
+        override suspend fun isEnabledForJetpackAccess(): Boolean = jetpackAccessEnabled
+    }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.fluxc.network.rest.wpapi.media
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -32,11 +31,9 @@ import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayloa
 import org.wordpress.android.fluxc.store.MediaStore.MediaError
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
 import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
-import org.wordpress.android.fluxc.tools.CoroutineEngine
-import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.fluxc.utils.MimeType
 import java.security.GeneralSecurityException
-import org.wordpress.android.fluxc.tools.initCoroutineEngine
 import org.wordpress.android.fluxc.annotations.action.Action as FluxAction
 
 @RunWith(RobolectricTestRunner::class)

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
@@ -1,0 +1,420 @@
+package org.wordpress.android.fluxc.network.rest.wpapi.media
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.annotations.action.Action as FluxAction
+import org.wordpress.android.fluxc.model.MediaModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsStore
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsErrorHandler
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.JetpackApplicationPasswordsSupport
+import org.wordpress.android.fluxc.network.rest.wpcom.media.wpv2.WPComV2MediaRestClient
+import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListResponsePayload
+import org.wordpress.android.fluxc.store.MediaStore.MediaError
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
+import org.wordpress.android.fluxc.store.MediaStore.ProgressPayload
+import org.wordpress.android.fluxc.tools.CoroutineEngine
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.fluxc.utils.MimeType
+import java.security.GeneralSecurityException
+
+@RunWith(RobolectricTestRunner::class)
+class WooMediaNetworkTest {
+    private val dispatcher: Dispatcher = mock()
+    private val coroutineEngine = CoroutineEngine(Dispatchers.Unconfined, mock<AppLogWrapper>())
+    private val applicationPasswordsConfiguration = FakeApplicationPasswordsConfiguration()
+    private val applicationPasswordsMediaRestClient: ApplicationPasswordsMediaRestClient = mock()
+    private val wpComV2MediaRestClient: WPComV2MediaRestClient = mock()
+    private val jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport = mock()
+    private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler = mock()
+
+    private val sut = WooMediaNetwork(
+        dispatcher = dispatcher,
+        coroutineEngine = coroutineEngine,
+        applicationPasswordsConfiguration = applicationPasswordsConfiguration,
+        applicationPasswordsMediaRestClient = applicationPasswordsMediaRestClient,
+        wpComV2MediaRestClient = wpComV2MediaRestClient,
+        jetpackApplicationPasswordsSupport = jetpackApplicationPasswordsSupport,
+        jetpackApplicationPasswordsErrorHandler = jetpackApplicationPasswordsErrorHandler
+    )
+
+    private val jetpackSite = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPCOM_REST
+        siteId = 123L
+        url = "https://example.com"
+    }
+
+    private val wpapiSite = SiteModel().apply {
+        origin = SiteModel.ORIGIN_WPAPI
+        siteId = 456L
+        url = "https://direct.example.com"
+    }
+
+    // region Fetch media list – Jetpack
+
+    @Test
+    fun `given supported jetpack site, when fetching media list, then use app passwords first`() = runTest {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+        whenever(
+            applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        verify(wpComV2MediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `given supported jetpack site, when app passwords fetch fails and fallback succeeds, then flag site`() =
+        runTest {
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(
+                applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 20, 5, MimeType.Type.IMAGE)
+            ).thenReturn(
+                FetchMediaListResponsePayload(
+                    jetpackSite,
+                    createMediaError(statusCode = 500, apiErrorCode = "incorrect_password"),
+                    MimeType.Type.IMAGE
+                )
+            )
+            whenever(
+                wpComV2MediaRestClient.fetchMediaList(jetpackSite, 20, 5, MimeType.Type.IMAGE)
+            ).thenReturn(
+                FetchMediaListResponsePayload(jetpackSite, emptyList(), false, true, MimeType.Type.IMAGE)
+            )
+
+            sut.fetchMediaList(jetpackSite, 20, 5, MimeType.Type.IMAGE)
+
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == "incorrect_password" &&
+                        volleyError?.networkResponse?.statusCode == 500
+                }
+            )
+        }
+
+    @Test
+    fun `given unsupported jetpack site, when fetching media list, then skip app passwords`() = runTest {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(false)
+        whenever(
+            wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+        verify(wpComV2MediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+    }
+
+    @Test
+    fun `given jetpack access disabled, when fetching media list, then use wpcom client directly`() = runTest {
+        applicationPasswordsConfiguration.jetpackAccessEnabled = false
+        whenever(
+            wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+        verify(wpComV2MediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+    }
+
+    @Test
+    fun `given supported jetpack site, when app passwords fetch throws GeneralSecurityException, then fallback`() =
+        runTest {
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(
+                applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+            ).thenAnswer { throw GeneralSecurityException("keystore error") }
+            whenever(
+                wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+            ).thenReturn(
+                FetchMediaListResponsePayload(jetpackSite, emptyList(), false, false, MimeType.Type.IMAGE)
+            )
+
+            sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+            verify(wpComV2MediaRestClient).fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR
+                }
+            )
+        }
+
+    @Test
+    fun `given supported jetpack site, when both fetch paths fail, then do not flag site`() = runTest {
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+        whenever(
+            applicationPasswordsMediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(
+                jetpackSite,
+                createMediaError(statusCode = 500, apiErrorCode = "server_error"),
+                MimeType.Type.IMAGE
+            )
+        )
+        whenever(
+            wpComV2MediaRestClient.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(
+                jetpackSite,
+                createMediaError(statusCode = 502, apiErrorCode = "bad_gateway"),
+                MimeType.Type.IMAGE
+            )
+        )
+
+        sut.fetchMediaList(jetpackSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(jetpackApplicationPasswordsErrorHandler, never()).handleError(any(), any())
+    }
+
+    // endregion
+
+    // region Fetch media list – WPAPI
+
+    @Test
+    fun `given WPAPI site, when fetching media list, then use app passwords client`() = runTest {
+        whenever(
+            applicationPasswordsMediaRestClient.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+        ).thenReturn(
+            FetchMediaListResponsePayload(wpapiSite, emptyList(), false, false, MimeType.Type.IMAGE)
+        )
+
+        sut.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+
+        verify(applicationPasswordsMediaRestClient).fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+        verify(wpComV2MediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `given WPAPI site with direct access disabled, when fetching media list, then throw`() {
+        applicationPasswordsConfiguration.directAccessEnabled = false
+        sut.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+    }
+
+    // endregion
+
+    // region Upload – Jetpack
+
+    @Test
+    fun `given supported jetpack site, when app passwords upload fails and fallback succeeds, then flag site`() =
+        runTest {
+            val media: MediaModel = mock {
+                on { id } doReturn 7
+            }
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+                flowOf(
+                    ProgressPayload(media, 0.4f, false, null),
+                    ProgressPayload(media, 1f, false, createMediaError(statusCode = 403, apiErrorCode = "forbidden"))
+                )
+            )
+            whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+                flowOf(ProgressPayload(media, 1f, true, false))
+            )
+
+            sut.uploadMedia(jetpackSite, media)
+
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == "forbidden" &&
+                        volleyError?.networkResponse?.statusCode == 403
+                }
+            )
+
+            val dispatchCaptor = argumentCaptor<FluxAction<*>>()
+            verify(dispatcher, times(2)).dispatch(dispatchCaptor.capture())
+            val payloads = dispatchCaptor.allValues.map { it.payload as ProgressPayload }
+            // First dispatch: progress from app passwords attempt
+            assertThat(payloads[0].progress).isEqualTo(0.4f)
+            // Second dispatch: completed from fallback
+            assertThat(payloads[1].progress).isEqualTo(1f)
+            assertThat(payloads[1].completed).isTrue()
+        }
+
+    @Test
+    fun `given supported jetpack site, when app passwords upload succeeds, then dispatch all progress`() =
+        runTest {
+            val media: MediaModel = mock {
+                on { id } doReturn 8
+            }
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+                flowOf(
+                    ProgressPayload(media, 0.4f, false, null),
+                    ProgressPayload(media, 1f, true, false)
+                )
+            )
+
+            sut.uploadMedia(jetpackSite, media)
+
+            val dispatchCaptor = argumentCaptor<FluxAction<*>>()
+            verify(dispatcher, times(2)).dispatch(dispatchCaptor.capture())
+            verify(wpComV2MediaRestClient, never()).uploadMedia(any(), any())
+            verify(jetpackApplicationPasswordsErrorHandler, never()).handleError(any(), any())
+
+            val payloads = dispatchCaptor.allValues.map { it.payload as ProgressPayload }
+            assertThat(payloads).hasSize(2)
+            assertThat(payloads[0].progress).isEqualTo(0.4f)
+            assertThat(payloads[0].completed).isFalse()
+            assertThat(payloads[1].progress).isEqualTo(1f)
+            assertThat(payloads[1].completed).isTrue()
+        }
+
+    @Test
+    fun `given jetpack access disabled, when uploading, then use wpcom client directly`() = runTest {
+        applicationPasswordsConfiguration.jetpackAccessEnabled = false
+        val media: MediaModel = mock {
+            on { id } doReturn 9
+        }
+        whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, true, false))
+        )
+
+        sut.uploadMedia(jetpackSite, media)
+
+        verify(applicationPasswordsMediaRestClient, never()).uploadMedia(any(), any())
+        verify(wpComV2MediaRestClient).uploadMedia(jetpackSite, media)
+    }
+
+    @Test
+    fun `given supported jetpack site, when app passwords upload throws GeneralSecurityException, then fallback`() =
+        runTest {
+            val media: MediaModel = mock {
+                on { id } doReturn 10
+            }
+            whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+            whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media))
+                .thenReturn(flow { throw GeneralSecurityException("keystore error") })
+            whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+                flowOf(ProgressPayload(media, 1f, true, false))
+            )
+
+            sut.uploadMedia(jetpackSite, media)
+
+            verify(wpComV2MediaRestClient).uploadMedia(jetpackSite, media)
+            verify(jetpackApplicationPasswordsErrorHandler).handleError(
+                eq(jetpackSite),
+                argThat {
+                    errorCode == ApplicationPasswordsStore.APPLICATION_PASSWORDS_KEYSTORE_ENCRYPTION_ERROR
+                }
+            )
+        }
+
+    @Test
+    fun `given supported jetpack site, when both upload paths fail, then do not flag site`() = runTest {
+        val media: MediaModel = mock {
+            on { id } doReturn 11
+        }
+        whenever(jetpackApplicationPasswordsSupport.supportsAppPasswords(jetpackSite)).thenReturn(true)
+        whenever(applicationPasswordsMediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, false, createMediaError(statusCode = 500, apiErrorCode = "error")))
+        )
+        whenever(wpComV2MediaRestClient.uploadMedia(jetpackSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, false, createMediaError(statusCode = 502, apiErrorCode = "error")))
+        )
+
+        sut.uploadMedia(jetpackSite, media)
+
+        verify(jetpackApplicationPasswordsErrorHandler, never()).handleError(any(), any())
+    }
+
+    // endregion
+
+    // region Upload – WPAPI
+
+    @Test
+    fun `given WPAPI site, when uploading media, then use app passwords client`() = runTest {
+        val media: MediaModel = mock {
+            on { id } doReturn 12
+        }
+        whenever(applicationPasswordsMediaRestClient.uploadMedia(wpapiSite, media)).thenReturn(
+            flowOf(ProgressPayload(media, 1f, true, false))
+        )
+
+        sut.uploadMedia(wpapiSite, media)
+
+        verify(applicationPasswordsMediaRestClient).uploadMedia(wpapiSite, media)
+        verify(wpComV2MediaRestClient, never()).uploadMedia(any(), any())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `given WPAPI site with direct access disabled, when uploading, then throw`() {
+        applicationPasswordsConfiguration.directAccessEnabled = false
+        val media: MediaModel = mock()
+        sut.uploadMedia(wpapiSite, media)
+    }
+
+    // endregion
+
+    // region Cancel upload
+
+    @Test
+    fun `when cancelling upload, then dispatch cancelled action with zero progress`() {
+        val media: MediaModel = mock {
+            on { id } doReturn 13
+        }
+
+        sut.cancelUpload(jetpackSite, media)
+
+        val captor = argumentCaptor<FluxAction<*>>()
+        verify(dispatcher).dispatch(captor.capture())
+        val payload = captor.firstValue.payload as ProgressPayload
+        assertThat(payload.canceled).isTrue()
+        assertThat(payload.progress).isEqualTo(0f)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `given unsupported origin, when cancelling upload, then throw`() {
+        val site = SiteModel().apply { origin = 999 }
+        val media: MediaModel = mock()
+        sut.cancelUpload(site, media)
+    }
+
+    // endregion
+
+    private fun createMediaError(statusCode: Int, apiErrorCode: String): MediaError {
+        return MediaError(MediaErrorType.GENERIC_ERROR).apply {
+            this.statusCode = statusCode
+            this.apiErrorCode = apiErrorCode
+        }
+    }
+
+    private class FakeApplicationPasswordsConfiguration : ApplicationPasswordsConfiguration {
+        override val applicationName: String = "WooCommerce"
+        var directAccessEnabled: Boolean = true
+        var jetpackAccessEnabled: Boolean = true
+
+        override fun isEnabledForDirectAccess(): Boolean = directAccessEnabled
+        override suspend fun isEnabledForJetpackAccess(): Boolean = jetpackAccessEnabled
+    }
+}

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/media/WooMediaNetworkTest.kt
@@ -7,9 +7,10 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -19,7 +20,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.annotations.action.Action as FluxAction
+import org.wordpress.android.fluxc.logging.FluxCCrashLogger
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.ApplicationPasswordsConfiguration
@@ -35,6 +36,7 @@ import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.fluxc.utils.MimeType
 import java.security.GeneralSecurityException
+import org.wordpress.android.fluxc.annotations.action.Action as FluxAction
 
 @RunWith(RobolectricTestRunner::class)
 class WooMediaNetworkTest {
@@ -45,6 +47,7 @@ class WooMediaNetworkTest {
     private val wpComV2MediaRestClient: WPComV2MediaRestClient = mock()
     private val jetpackApplicationPasswordsSupport: JetpackApplicationPasswordsSupport = mock()
     private val jetpackApplicationPasswordsErrorHandler: JetpackApplicationPasswordsErrorHandler = mock()
+    private val crashLogger: FluxCCrashLogger = mock()
 
     private val sut = WooMediaNetwork(
         dispatcher = dispatcher,
@@ -53,7 +56,8 @@ class WooMediaNetworkTest {
         applicationPasswordsMediaRestClient = applicationPasswordsMediaRestClient,
         wpComV2MediaRestClient = wpComV2MediaRestClient,
         jetpackApplicationPasswordsSupport = jetpackApplicationPasswordsSupport,
-        jetpackApplicationPasswordsErrorHandler = jetpackApplicationPasswordsErrorHandler
+        jetpackApplicationPasswordsErrorHandler = jetpackApplicationPasswordsErrorHandler,
+        crashLogger = crashLogger
     )
 
     private val jetpackSite = SiteModel().apply {
@@ -214,11 +218,14 @@ class WooMediaNetworkTest {
         verify(wpComV2MediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
     }
 
-    @Test(expected = IllegalStateException::class)
-    fun `given WPAPI site with direct access disabled, when fetching media list, then throw`() {
-        applicationPasswordsConfiguration.directAccessEnabled = false
-        sut.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
-    }
+    @Test
+    fun `given WPAPI site with direct access disabled, when fetching media list, then report xmlrpc try`() =
+        runTest {
+            applicationPasswordsConfiguration.directAccessEnabled = false
+            sut.fetchMediaList(wpapiSite, 10, 0, MimeType.Type.IMAGE)
+            verify(crashLogger).sendReport(anyOrNull(), any(), any())
+            verify(applicationPasswordsMediaRestClient, never()).fetchMediaList(any(), any(), any(), any())
+        }
 
     // endregion
 
@@ -367,11 +374,13 @@ class WooMediaNetworkTest {
         verify(wpComV2MediaRestClient, never()).uploadMedia(any(), any())
     }
 
-    @Test(expected = IllegalStateException::class)
-    fun `given WPAPI site with direct access disabled, when uploading, then throw`() {
+    @Test
+    fun `given WPAPI site with direct access disabled, when uploading, then report xmlrpc try`() = runTest {
         applicationPasswordsConfiguration.directAccessEnabled = false
         val media: MediaModel = mock()
         sut.uploadMedia(wpapiSite, media)
+        verify(crashLogger).sendReport(anyOrNull(), any(), any())
+        verify(applicationPasswordsMediaRestClient, never()).uploadMedia(any(), any())
     }
 
     // endregion
@@ -379,25 +388,22 @@ class WooMediaNetworkTest {
     // region Cancel upload
 
     @Test
-    fun `when cancelling upload, then dispatch cancelled action with zero progress`() {
+    fun `given no active upload, when cancelling upload, then do not dispatch`() {
         val media: MediaModel = mock {
             on { id } doReturn 13
         }
 
         sut.cancelUpload(jetpackSite, media)
 
-        val captor = argumentCaptor<FluxAction<*>>()
-        verify(dispatcher).dispatch(captor.capture())
-        val payload = captor.firstValue.payload as ProgressPayload
-        assertThat(payload.canceled).isTrue()
-        assertThat(payload.progress).isEqualTo(0f)
+        verify(dispatcher, never()).dispatch(any())
     }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun `given unsupported origin, when cancelling upload, then throw`() {
+    @Test
+    fun `given unsupported origin, when cancelling upload, then report xmlrpc try`() {
         val site = SiteModel().apply { origin = 999 }
         val media: MediaModel = mock()
         sut.cancelUpload(site, media)
+        verify(crashLogger).sendReport(anyOrNull(), any(), any())
     }
 
     // endregion


### PR DESCRIPTION
> [!NOTE]
> The PR is big, but the big part of the changes is just for unit tests. 

### Description
Fixes WOOMOB-1438

This is the second of two PRs to migrate media endpoints to Application Passwords. It depends on #15549.

For Jetpack (`WPCOM_REST`) sites that support Application Passwords, this updates media upload and media-list fetches to try App Passwords first and fall back to WP.com REST if the App Password request fails. When the fallback succeeds, the original App Password error is reported through `JetpackApplicationPasswordsErrorHandler` so the site support flag can be refreshed.

This keeps the existing routing behavior for WP.com, Jetpack, and WPAPI direct-access sites, and adds safeguards for App Password setup failures:

- `GeneralSecurityException` from keystore encryption is handled as an App Password error before fallback.
- WPAPI sites still require direct access before using WPAPI media endpoints.
- Upload credential-generation failures now emit the same generation-failure-prefixed error shape as fetches instead of sending an unauthenticated upload request and treating the resulting 401/403 as a media API failure.

### Test Steps
1. Using WordPress.com login with a Jetpack site with Application Passwords supported.
2. Clear logcat, then verify the normal upload flow:
   ```bash
   adb logcat -c
   ```
   Products > select a product > Photos > Add photos > Choose from device > select an image. Verify the image uploads, save the product, leave/reopen it, and verify the image persists.

   Check logs:
   ```bash
   adb logcat -d -s WooCommerce-MEDIA WordPress-MEDIA
   ```
   Expected:
   - `Uploading media using Application Passwords for Jetpack Site`
   - `MediaFilesRepository > uploaded media`
3. Clear logcat, then verify the normal media-library flow:
   ```bash
   adb logcat -c
   ```
   Photos > Add photos > WordPress media library. Verify the media grid loads, select an existing image, save the product, and verify there is no error.

   Check logs:
   ```bash
   adb logcat -d -s WooCommerce-MEDIA WordPress-MEDIA
   ```
   Expected:
   - `Fetching media list using Application Passwords for Jetpack Site`
   - `Fetched media list for site with size:`
4. Configure ApiFaker to fail the App Password media requests. Do not add any `wp-com` mocks.
   ```bash
   adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
   adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS

   adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
     --es api_type wp-api \
     --es path /wp/v2/media \
     --es http_method POST \
     --ei response_status_code 500

   adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
     --es api_type wp-api \
     --es path /wp/v2/media \
     --es http_method GET \
     --ei response_status_code 500

   adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
   ```
5. Relaunch the app:
   ```bash
   adb shell am force-stop com.woocommerce.android.dev
   adb shell am start -n com.woocommerce.android.dev/com.woocommerce.android.ui.main.MainActivity
   ```
6. Clear logcat, then repeat the device-image upload flow. Verify the upload still succeeds.
   ```bash
   adb logcat -c
   ```

   Check logs:
   ```bash
   adb logcat -d -s WooCommerce-MEDIA WordPress-MEDIA
   ```
   Expected:
   - `Uploading media using Application Passwords for Jetpack Site`
   - `Media upload failed using Application Passwords for Jetpack Site`
   - `Retrying media upload using WP.com REST for Jetpack Site`
   - `MediaFilesRepository > uploaded media`
7. Clear logcat, then open Photos > Add photos > WordPress media library. Verify the media grid still loads.
   ```bash
   adb logcat -c
   ```

   Check logs:
   ```bash
   adb logcat -d -s WooCommerce-MEDIA WordPress-MEDIA
   ```
   Expected:
   - `Fetching media list using Application Passwords for Jetpack Site`
   - `Media fetch media list failed using Application Passwords for Jetpack Site`
   - `Retrying media list fetch using WP.com REST for Jetpack Site`
   - `Fetched media list for site with size:`
8. Clean up ApiFaker:
   ```bash
   adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
   adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
   ```
9. Using site credentials, repeat the upload and media-library flows. Verify both still succeed.

   Check logs:
   ```bash
   adb logcat -d -s WooCommerce-MEDIA WordPress-MEDIA
   ```
   Expected:
   - `Uploading media using Application Passwords for WPAPI Site`
   - `Fetching media list using Application Passwords for WPAPI Site`

### Images/gif
N/A — no UI changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.