### PR TITLE
Document cross-tool local agent notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Cross-Tool Instructions
 
-- Use `LOCAL_AGENT_NOTES.md` for repository-local AI preferences when present
-- `CLAUDE.local.md` may point to `LOCAL_AGENT_NOTES.md` for backward compatibility
+- Use `LOCAL_AGENT_NOTES.md` or `CLAUDE.local.md` for repository-local AI preferences when present
+- `CLAUDE.local.md` is supported for backward compatibility
 
 ## Repository Layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to AI agents when working with code in this repository.
 
+## Cross-Tool Instructions
+
+- `AGENTS.md` is the canonical shared instruction file for AI agents in this repository
+- `LOCAL_AGENT_NOTES.md` is the neutral shared file for repository-local AI preferences
+- If `LOCAL_AGENT_NOTES.md` exists, treat it as additional repository-local preferences and follow it unless it conflicts with higher-priority system, developer, or user instructions
+- When a tool does not auto-load `LOCAL_AGENT_NOTES.md`, agents should read it explicitly before doing substantial work
+
 ## Repository Layout
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 - `AGENTS.md` is the canonical shared instruction file for AI agents in this repository
 - `LOCAL_AGENT_NOTES.md` is the neutral shared file for repository-local AI preferences
+- `CLAUDE.local.md` may point to `LOCAL_AGENT_NOTES.md` for backward compatibility with Claude-compatible tooling
 - If `LOCAL_AGENT_NOTES.md` exists, treat it as additional repository-local preferences and follow it unless it conflicts with higher-priority system, developer, or user instructions
 - When a tool does not auto-load `LOCAL_AGENT_NOTES.md`, agents should read it explicitly before doing substantial work
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,8 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Cross-Tool Instructions
 
-- `AGENTS.md` is the canonical shared instruction file for AI agents in this repository
-- `LOCAL_AGENT_NOTES.md` is the neutral shared file for repository-local AI preferences
-- `CLAUDE.local.md` may point to `LOCAL_AGENT_NOTES.md` for backward compatibility with Claude-compatible tooling
-- If `LOCAL_AGENT_NOTES.md` exists, treat it as additional repository-local preferences and follow it unless it conflicts with higher-priority system, developer, or user instructions
-- When a tool does not auto-load `LOCAL_AGENT_NOTES.md`, agents should read it explicitly before doing substantial work
+- Use `LOCAL_AGENT_NOTES.md` for repository-local AI preferences when present
+- `CLAUDE.local.md` may point to `LOCAL_AGENT_NOTES.md` for backward compatibility
 
 ## Repository Layout
 


### PR DESCRIPTION
### Description
Document that `AGENTS.md` is the shared agent instruction file for Codex and other agentic AI tools, and that `LOCAL_AGENT_NOTES.md` can be used for repository-local preferences when present.

### Test Steps
1. Open `AGENTS.md`.
2. Confirm the new Cross-Tool Instructions section explains the shared role of `AGENTS.md` and `LOCAL_AGENT_NOTES.md`.
3. Confirm no code or runtime behavior changed.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.