### PR TITLE
[CIAB] Add CIAB order status mapping for display and filters

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapper.kt
@@ -1,0 +1,80 @@
+package com.woocommerce.android.ciab
+
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order.OrderStatus
+import com.woocommerce.android.ui.orders.filters.data.OrderStatusOption
+import com.woocommerce.android.viewmodel.ResourceProvider
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
+import javax.inject.Inject
+
+class CIABOrderStatusMapper @Inject constructor(
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
+    private val resourceProvider: ResourceProvider
+) {
+    fun mapOrderStatusOptionsList(
+        statusMap: Map<String, WCOrderStatusModel>
+    ): Map<String, WCOrderStatusModel> {
+        if (!ciabSiteGateKeeper.isCurrentSiteCIAB()) return statusMap
+
+        val openLabel = resourceProvider.getString(R.string.ciab_order_status_open)
+        return statusMap.mapValues { (key, model) ->
+            if (key in OPEN_CORE_KEYS) {
+                WCOrderStatusModel(statusKey = OPEN_KEY, label = openLabel)
+            } else {
+                model
+            }
+        }
+    }
+
+    fun mapOrderStatus(orderStatus: OrderStatus): OrderStatus {
+        if (!ciabSiteGateKeeper.isCurrentSiteCIAB()) return orderStatus
+
+        return if (orderStatus.statusKey in OPEN_CORE_KEYS) {
+            OrderStatus(
+                statusKey = OPEN_KEY,
+                label = resourceProvider.getString(R.string.ciab_order_status_open)
+            )
+        } else {
+            orderStatus
+        }
+    }
+
+    fun mapFilterOptions(options: List<OrderStatusOption>): List<OrderStatusOption> {
+        if (!ciabSiteGateKeeper.isCurrentSiteCIAB()) return options
+
+        val openOptions = options.filter { it.key in OPEN_CORE_KEYS }
+        val otherOptions = options.filter { it.key !in OPEN_CORE_KEYS }
+
+        if (openOptions.isEmpty()) return otherOptions
+
+        val openLabel = resourceProvider.getString(R.string.ciab_order_status_open)
+        val groupedOpen = OrderStatusOption(
+            key = OPEN_KEY,
+            label = openLabel,
+            statusCount = openOptions.sumOf { it.statusCount },
+            isSelected = openOptions.any { it.isSelected }
+        )
+
+        return listOf(groupedOpen) + otherOptions
+    }
+
+    fun resolveFilterKeys(selectedKeys: List<String>): List<String> {
+        if (!ciabSiteGateKeeper.isCurrentSiteCIAB()) return selectedKeys
+
+        return selectedKeys.flatMap { key ->
+            if (key == OPEN_KEY) OPEN_CORE_KEYS.toList() else listOf(key)
+        }
+    }
+
+    companion object {
+        const val OPEN_KEY = "open"
+
+        val OPEN_CORE_KEYS = setOf(
+            CoreOrderStatus.PENDING.value,
+            CoreOrderStatus.PROCESSING.value,
+            CoreOrderStatus.ON_HOLD.value,
+            CoreOrderStatus.FAILED.value
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapper.kt
@@ -21,7 +21,7 @@ class CIABOrderStatusMapper @Inject constructor(
         val openLabel = resourceProvider.getString(R.string.ciab_order_status_open)
         return statusMap.mapValues { (key, model) ->
             if (key in OPEN_CORE_KEYS) {
-                WCOrderStatusModel(statusKey = OPEN_KEY, label = openLabel)
+                model.copy(statusKey = OPEN_KEY, label = openLabel)
             } else {
                 model
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapper.kt
@@ -45,7 +45,7 @@ class CIABOrderStatusMapper @Inject constructor(
         if (!ciabSiteGateKeeper.isCurrentSiteCIAB()) return options
 
         val openOptions = options.filter { it.key in OPEN_CORE_KEYS }
-        val otherOptions = options.filter { it.key !in OPEN_CORE_KEYS }
+        val otherOptions = options.filter { it.key !in OPEN_CORE_KEYS && it.key !in HIDDEN_KEYS }
 
         if (openOptions.isEmpty()) return otherOptions
 
@@ -70,6 +70,7 @@ class CIABOrderStatusMapper @Inject constructor(
 
     companion object {
         const val OPEN_KEY = "open"
+        private const val CHECKOUT_DRAFT_KEY = "checkout-draft"
 
         @VisibleForTesting
         val OPEN_CORE_KEYS = setOf(
@@ -78,5 +79,8 @@ class CIABOrderStatusMapper @Inject constructor(
             CoreOrderStatus.ON_HOLD.value,
             CoreOrderStatus.FAILED.value
         )
+
+        @VisibleForTesting
+        val HIDDEN_KEYS = setOf(CHECKOUT_DRAFT_KEY)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapper.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ciab
 
+import androidx.annotation.VisibleForTesting
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.ui.orders.filters.data.OrderStatusOption
@@ -70,6 +71,7 @@ class CIABOrderStatusMapper @Inject constructor(
     companion object {
         const val OPEN_KEY = "open"
 
+        @VisibleForTesting
         val OPEN_CORE_KEYS = setOf(
             CoreOrderStatus.PENDING.value,
             CoreOrderStatus.PROCESSING.value,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.model.DashboardWidget.Type.ORDERS
@@ -53,7 +54,8 @@ class DashboardOrdersViewModel @AssistedInject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val currencyFormatter: CurrencyFormatter,
     private val resourceProvider: ResourceProvider,
-    private val getOrderStatusFilterOptions: GetOrderStatusFilterOptions
+    private val getOrderStatusFilterOptions: GetOrderStatusFilterOptions,
+    private val ciabOrderStatusMapper: CIABOrderStatusMapper
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         const val MAX_NUMBER_OF_ORDERS_TO_DISPLAY_IN_CARD = 3
@@ -115,9 +117,16 @@ class DashboardOrdersViewModel @AssistedInject constructor(
                         trackEventForOrderCard(AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_DATA_LOADING_COMPLETED)
                         Content(
                             orders = orders.map { order ->
+                                val mappedStatus = ciabOrderStatusMapper.mapOrderStatus(
+                                    Order.OrderStatus(
+                                        statusKey = order.status.value,
+                                        label = order.status.value
+                                    )
+                                )
                                 val status = statusOptions
-                                    .firstOrNull { option -> option.key == order.status.value }?.label
-                                    ?: order.status.value
+                                    .firstOrNull { option ->
+                                        option.key == mappedStatus.statusKey
+                                    }?.label ?: order.status.value
 
                                 ViewState.OrderItem(
                                     id = order.id,
@@ -127,8 +136,13 @@ class DashboardOrdersViewModel @AssistedInject constructor(
                                         resourceProvider.getString(R.string.orderdetail_customer_name_default)
                                     },
                                     status = status,
-                                    statusColor = order.status.color,
-                                    totalPrice = currencyFormatter.formatCurrency(order.total, order.currency),
+                                    statusColor = Order.Status.fromValue(
+                                        mappedStatus.statusKey
+                                    ).color,
+                                    totalPrice = currencyFormatter.formatCurrency(
+                                        order.total,
+                                        order.currency
+                                    ),
                                     isPosOrder = order.salesChannel == Order.SalesChannel.POS
                                 )
                             },
@@ -165,6 +179,11 @@ class DashboardOrdersViewModel @AssistedInject constructor(
                 is Order.Status.Completed -> R.color.tag_bg_completed
                 is Order.Status.Failed -> R.color.tag_bg_failed
                 is Order.Status.OnHold -> R.color.tag_bg_on_hold
+                is Order.Status.Custom -> if (value == CIABOrderStatusMapper.OPEN_KEY) {
+                    R.color.tag_bg_processing
+                } else {
+                    R.color.tag_bg_other
+                }
                 else -> R.color.tag_bg_other
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModel.kt
@@ -95,10 +95,12 @@ class DashboardOrdersViewModel @AssistedInject constructor(
     val viewState = selectedFilter.flatMapLatest { status ->
         refreshTrigger.map { Pair(status, it) }
     }.transformLatest { (filterStatus, refresh) ->
-        val statusFilter = filterStatus
+        val statusFilters = filterStatus
             .takeIf { it != DEFAULT_FILTER_OPTION_STATUS }
-            ?.let { Order.Status.fromValue(it) }
-        val hasOrders = orderListRepository.hasOrdersLocally(statusFilter)
+            ?.let { ciabOrderStatusMapper.resolveFilterKeys(listOf(it)) }
+            ?.map { Order.Status.fromValue(it) }
+            ?: emptyList()
+        val hasOrders = orderListRepository.hasOrdersLocally(statusFilters)
         if (refresh.isForced || !hasOrders) {
             emit(ViewState.Loading)
             trackEventForOrderCard(AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_DATA_LOADING_STARTED)
@@ -108,7 +110,7 @@ class DashboardOrdersViewModel @AssistedInject constructor(
                 orderListRepository.observeTopOrders(
                     count = MAX_NUMBER_OF_ORDERS_TO_DISPLAY_IN_CARD,
                     isForced = refresh.isForced,
-                    statusFilter = statusFilter
+                    statusFilters = statusFilters
                 ),
                 statusOptions
             ) { result, statusOptions ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusTag.kt
@@ -3,10 +3,10 @@ package com.woocommerce.android.ui.orders
 import android.content.Context
 import androidx.core.content.ContextCompat
 import com.woocommerce.android.R
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.widgets.tags.ITag
 import com.woocommerce.android.widgets.tags.TagConfig
-import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import java.util.Locale
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusTag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderStatusTag.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.Order.OrderStatus
 import com.woocommerce.android.widgets.tags.ITag
 import com.woocommerce.android.widgets.tags.TagConfig
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import java.util.Locale
 
@@ -37,6 +38,9 @@ class OrderStatusTag(private val orderStatus: OrderStatus) : ITag(orderStatus.st
             }
             CoreOrderStatus.REFUNDED.value -> {
                 config.bgColor = ContextCompat.getColor(context, R.color.tag_bg_other)
+            }
+            CIABOrderStatusMapper.OPEN_KEY -> {
+                config.bgColor = ContextCompat.getColor(context, R.color.tag_bg_processing)
             }
             else -> {
                 config.bgColor = ContextCompat.getColor(context, R.color.tagView_bg)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditViewModel.kt
@@ -80,6 +80,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUC
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.analytics.IsScreenInTwoPaneLayout
 import com.woocommerce.android.analytics.deviceTypeToAnalyticsString
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.extensions.runWithContext
 import com.woocommerce.android.model.Address
@@ -212,6 +213,7 @@ class OrderCreateEditViewModel @Inject constructor(
     private val feedbackRepository: FeedbackRepository,
     private val fetchProductByIdentifier: FetchProductByIdentifier,
     private val wooPosSurveysNotificationScheduler: WooPosSurveysNotificationScheduler,
+    private val ciabOrderStatusMapper: CIABOrderStatusMapper,
     dateUtils: DateUtils,
     autoSyncOrder: AutoSyncOrder,
     autoSyncPriceModifier: AutoSyncPriceModifier,
@@ -281,7 +283,9 @@ class OrderCreateEditViewModel @Inject constructor(
         .distinctUntilChanged()
         .map { status ->
             withContext(dispatchers.io) {
-                orderDetailRepository.getOrderStatus(status.value)
+                ciabOrderStatusMapper.mapOrderStatus(
+                    orderDetailRepository.getOrderStatus(status.value)
+                )
             }
         }.asLiveData()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SHIPPING_LINES_COUNT
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -124,7 +125,8 @@ class OrderDetailViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val refreshShippingMethods: RefreshShippingMethods,
     private val isStoreCurrencyMatch: IsStoreCurrencyMatch,
-    getShippingMethodsWithOtherValue: GetShippingMethodsWithOtherValue
+    getShippingMethodsWithOtherValue: GetShippingMethodsWithOtherValue,
+    private val ciabOrderStatusMapper: CIABOrderStatusMapper
 ) : ScopedViewModel(savedState), OnProductFetchedListener {
     private val navArgs: OrderDetailFragmentArgs by savedState.navArgs()
 
@@ -753,7 +755,9 @@ class OrderDetailViewModel @Inject constructor(
 
     private suspend fun updateOrderState() {
         val order = awaitOrder()
-        val orderStatus = orderDetailRepository.getOrderStatus(order.status.value)
+        val orderStatus = ciabOrderStatusMapper.mapOrderStatus(
+            orderDetailRepository.getOrderStatus(order.status.value)
+        )
         viewState = viewState.copy(
             orderInfo = OrderDetailViewState.OrderInfo(
                 order = order,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/OrderDetailViewModel.kt
@@ -12,12 +12,12 @@ import androidx.lifecycle.viewModelScope
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
-import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SHIPPING_LINES_COUNT
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.analytics.IsScreenInTwoPaneLayout
 import com.woocommerce.android.analytics.deviceTypeToAnalyticsString
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.extensions.whenNotNullNorEmpty
 import com.woocommerce.android.model.GiftCardSummary
 import com.woocommerce.android.model.Order

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetOrderStatusFilterOptions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetOrderStatusFilterOptions.kt
@@ -23,6 +23,10 @@ class GetOrderStatusFilterOptions @Inject constructor(
                 }
             }
         }
+        val selectedFilterKeys = ciabOrderStatusMapper.resolveFilterKeys(
+            orderFiltersRepository.getCurrentFilterSelection(OrderListFilterCategory.ORDER_STATUS)
+        )
+
         val options = orderStatus.values
             .toList()
             .map {
@@ -30,16 +34,9 @@ class GetOrderStatusFilterOptions @Inject constructor(
                     key = it.statusKey,
                     label = it.label,
                     statusCount = it.statusCount,
-                    isSelected = checkIfSelected(it.statusKey)
+                    isSelected = it.statusKey in selectedFilterKeys
                 )
             }
         return ciabOrderStatusMapper.mapFilterOptions(options)
-    }
-
-    private fun checkIfSelected(filterKey: String): Boolean {
-        val savedKeys = orderFiltersRepository
-            .getCurrentFilterSelection(OrderListFilterCategory.ORDER_STATUS)
-        if (filterKey in savedKeys) return true
-        return filterKey in ciabOrderStatusMapper.resolveFilterKeys(savedKeys)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetOrderStatusFilterOptions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetOrderStatusFilterOptions.kt
@@ -36,8 +36,10 @@ class GetOrderStatusFilterOptions @Inject constructor(
         return ciabOrderStatusMapper.mapFilterOptions(options)
     }
 
-    private fun checkIfSelected(filterKey: String): Boolean =
-        orderFiltersRepository
+    private fun checkIfSelected(filterKey: String): Boolean {
+        val savedKeys = orderFiltersRepository
             .getCurrentFilterSelection(OrderListFilterCategory.ORDER_STATUS)
-            .contains(filterKey)
+        if (filterKey in savedKeys) return true
+        return filterKey in ciabOrderStatusMapper.resolveFilterKeys(savedKeys)
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetOrderStatusFilterOptions.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetOrderStatusFilterOptions.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.filters.domain
 
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.ui.orders.filters.data.OrderFiltersRepository
 import com.woocommerce.android.ui.orders.filters.data.OrderListFilterCategory
@@ -9,7 +10,8 @@ import javax.inject.Inject
 
 class GetOrderStatusFilterOptions @Inject constructor(
     private val orderListRepository: OrderListRepository,
-    private val orderFiltersRepository: OrderFiltersRepository
+    private val orderFiltersRepository: OrderFiltersRepository,
+    private val ciabOrderStatusMapper: CIABOrderStatusMapper
 ) {
     suspend operator fun invoke(): List<OrderStatusOption> {
         var orderStatus = orderListRepository.getCachedOrderStatusOptions()
@@ -21,7 +23,7 @@ class GetOrderStatusFilterOptions @Inject constructor(
                 }
             }
         }
-        return orderStatus.values
+        val options = orderStatus.values
             .toList()
             .map {
                 OrderStatusOption(
@@ -31,6 +33,7 @@ class GetOrderStatusFilterOptions @Inject constructor(
                     isSelected = checkIfSelected(it.statusKey)
                 )
             }
+        return ciabOrderStatusMapper.mapFilterOptions(options)
     }
 
     private fun checkIfSelected(filterKey: String): Boolean =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetWCOrderListDescriptorWithFilters.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/filters/domain/GetWCOrderListDescriptorWithFilters.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.filters.domain
 
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.filters.data.DateRange
 import com.woocommerce.android.ui.orders.filters.data.DateRange.CUSTOM_RANGE
@@ -19,7 +20,8 @@ import javax.inject.Inject
 class GetWCOrderListDescriptorWithFilters @Inject constructor(
     private val orderFiltersRepository: OrderFiltersRepository,
     private val selectedSite: SelectedSite,
-    private val dateUtils: DateUtils
+    private val dateUtils: DateUtils,
+    private val ciabOrderStatusMapper: CIABOrderStatusMapper
 ) {
     operator fun invoke(): WCOrderListDescriptor {
         val selectedDateRange = orderFiltersRepository.getCurrentFilterSelection(DATE_RANGE)
@@ -27,8 +29,9 @@ class GetWCOrderListDescriptorWithFilters @Inject constructor(
             .firstOrNull()
         val rangeStartAndEnd = selectedDateRange.getBeforeAndAfterFrom(orderFiltersRepository, dateUtils)
 
-        val orderStatusFilters = orderFiltersRepository.getCurrentFilterSelection(OrderListFilterCategory.ORDER_STATUS)
-            .joinToString(separator = ",")
+        val orderStatusFilters = ciabOrderStatusMapper.resolveFilterKeys(
+            orderFiltersRepository.getCurrentFilterSelection(OrderListFilterCategory.ORDER_STATUS)
+        ).joinToString(separator = ",")
 
         val salesChannelFilters = orderFiltersRepository.getCurrentFilterSelection(SALES_CHANNEL)
         val createdViaFilter = salesChannelFilters

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/GetWCOrderListDescriptorWithFiltersBySiteId.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/GetWCOrderListDescriptorWithFiltersBySiteId.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.orders.list
 
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.ui.orders.filters.data.DateRange
 import com.woocommerce.android.ui.orders.filters.data.OrderFiltersRepository
 import com.woocommerce.android.ui.orders.filters.data.OrderListFilterCategory
@@ -12,7 +13,8 @@ import javax.inject.Inject
 class GetWCOrderListDescriptorWithFiltersBySiteId @Inject constructor(
     private val orderFiltersRepository: OrderFiltersRepository,
     private val dateUtils: DateUtils,
-    private val siteStore: SiteStore
+    private val siteStore: SiteStore,
+    private val ciabOrderStatusMapper: CIABOrderStatusMapper
 ) {
     operator fun invoke(siteId: Long): WCOrderListDescriptor? {
         val selectedDateRange = orderFiltersRepository.getCurrentFilterSelection(OrderListFilterCategory.DATE_RANGE)
@@ -20,8 +22,9 @@ class GetWCOrderListDescriptorWithFiltersBySiteId @Inject constructor(
             .firstOrNull()
         val rangeStartAndEnd = selectedDateRange.getBeforeAndAfterFrom(orderFiltersRepository, dateUtils)
 
-        val orderStatusFilters = orderFiltersRepository.getCurrentFilterSelection(OrderListFilterCategory.ORDER_STATUS)
-            .joinToString(separator = ",")
+        val orderStatusFilters = ciabOrderStatusMapper.resolveFilterKeys(
+            orderFiltersRepository.getCurrentFilterSelection(OrderListFilterCategory.ORDER_STATUS)
+        ).joinToString(separator = ",")
 
         val site = siteStore.getSiteBySiteId(siteId) ?: return null
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListRepository.kt
@@ -128,15 +128,19 @@ class OrderListRepository @Inject constructor(
         }
     }
 
-    suspend fun hasOrdersLocally(statusFilter: Order.Status? = null) =
+    suspend fun hasOrdersLocally(statusFilters: List<Order.Status> = emptyList()) =
         orderStore.getOrdersForSite(selectedSite.get())
-            .any { statusFilter == null || it.status == statusFilter.value }
+            .any { statusFilters.isEmpty() || it.status in statusFilters.map { s -> s.value } }
 
-    fun observeTopOrders(count: Int, isForced: Boolean, statusFilter: Order.Status? = null) = flow {
+    fun observeTopOrders(count: Int, isForced: Boolean, statusFilters: List<Order.Status> = emptyList()) = flow {
+        val statusFilterValues = statusFilters.map { it.value }.toSet()
         if (!isForced) {
             val cachedOrders = orderStore.getOrdersForSite(selectedSite.get())
                 .asSequence()
-                .filter { it.status != ORDER_STATUS_TRASH && (statusFilter == null || it.status == statusFilter.value) }
+                .filter {
+                    it.status != ORDER_STATUS_TRASH &&
+                        (statusFilterValues.isEmpty() || it.status in statusFilterValues)
+                }
                 .sortedByDescending { it.dateCreated }
                 .take(count)
                 .toList()
@@ -149,7 +153,7 @@ class OrderListRepository @Inject constructor(
         val result = orderStore.fetchOrders(
             site = selectedSite.get(),
             count = count,
-            statusFilter = statusFilter?.value,
+            statusFilter = statusFilterValues.joinToString(",").ifEmpty { null },
             deleteOldData = false
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -20,7 +20,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
-import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDERS_LIST_AUTOMATIC_TIMEOUT_RETRY
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDERS_LIST_TOP_BANNER_TROUBLESHOOT_TAPPED
@@ -30,6 +29,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_HORIZONT
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.analytics.IsScreenInTwoPaneLayout
 import com.woocommerce.android.analytics.deviceTypeToAnalyticsString
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.extensions.NotificationReceivedEvent
 import com.woocommerce.android.extensions.drop
 import com.woocommerce.android.extensions.filter

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListViewModel.kt
@@ -20,6 +20,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDERS_LIST_AUTOMATIC_TIMEOUT_RETRY
 import com.woocommerce.android.analytics.AnalyticsEvent.ORDERS_LIST_TOP_BANNER_TROUBLESHOOT_TAPPED
@@ -120,6 +121,7 @@ class OrderListViewModel @Inject constructor(
     private val shouldUpdateOrdersList: ShouldUpdateOrdersList,
     private val observeOrdersListLastUpdate: ObserveOrdersListLastUpdate,
     private val dataSourceLazyProvider: Lazy<OrderListItemDataSource>,
+    private val ciabOrderStatusMapper: CIABOrderStatusMapper,
 ) : ScopedViewModel(savedState), LifecycleOwner {
     companion object {
         const val BULK_UPDATE_COUNT_LIMIT = 100
@@ -212,7 +214,9 @@ class OrderListViewModel @Inject constructor(
         launch {
             // Populate any cached order status options immediately since we use this
             // value in many different places in the order list view.
-            _orderStatusOptions.value = orderListRepository.getCachedOrderStatusOptions()
+            _orderStatusOptions.value = ciabOrderStatusMapper.mapOrderStatusOptionsList(
+                orderListRepository.getCachedOrderStatusOptions()
+            )
 
             _emptyViewType.postValue(EmptyViewType.ORDER_LIST_LOADING)
             if (selectedSite.exists()) {
@@ -335,7 +339,9 @@ class OrderListViewModel @Inject constructor(
         launch(dispatchers.main) {
             // Fetch and load order status options
             when (orderListRepository.fetchOrderStatusOptionsFromApi()) {
-                SUCCESS -> _orderStatusOptions.value = orderListRepository.getCachedOrderStatusOptions()
+                SUCCESS -> _orderStatusOptions.value = ciabOrderStatusMapper.mapOrderStatusOptionsList(
+                    orderListRepository.getCachedOrderStatusOptions()
+                )
                 else -> {
                     /* do nothing */
                 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -894,6 +894,7 @@
     <string name="order_mark_complete">Mark order complete</string>
     <string name="order_fulfill_completed">🎉 Order completed!</string>
     <string name="order_status_updated">Order status updated</string>
+    <string name="ciab_order_status_open">Open</string>
     <string name="order_error_fetch_notes_generic">Error fetching notes</string>
     <string name="order_error_update_general">Error changing order</string>
     <string name="order_error_update_empty_mail">Unable to update address with empty email. Make sure you are running the latest version of WooCommerce.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapperTest.kt
@@ -1,0 +1,212 @@
+package com.woocommerce.android.ciab
+
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order.OrderStatus
+import com.woocommerce.android.ui.orders.filters.data.OrderStatusOption
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.given
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CIABOrderStatusMapperTest : BaseUnitTest() {
+
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock()
+    private val resourceProvider: ResourceProvider = mock()
+
+    private lateinit var sut: CIABOrderStatusMapper
+
+    private val openLabel = "Open"
+
+    private val defaultStatusMap = mapOf(
+        CoreOrderStatus.PENDING.value to WCOrderStatusModel(statusKey = "pending", label = "Pending"),
+        CoreOrderStatus.PROCESSING.value to WCOrderStatusModel(statusKey = "processing", label = "Processing"),
+        CoreOrderStatus.ON_HOLD.value to WCOrderStatusModel(statusKey = "on-hold", label = "On hold"),
+        CoreOrderStatus.COMPLETED.value to WCOrderStatusModel(statusKey = "completed", label = "Completed"),
+        CoreOrderStatus.CANCELLED.value to WCOrderStatusModel(statusKey = "cancelled", label = "Cancelled"),
+        CoreOrderStatus.REFUNDED.value to WCOrderStatusModel(statusKey = "refunded", label = "Refunded"),
+        CoreOrderStatus.FAILED.value to WCOrderStatusModel(statusKey = "failed", label = "Failed"),
+    )
+
+    private val defaultFilterOptions = listOf(
+        OrderStatusOption(key = "pending", label = "Pending", statusCount = 3, isSelected = false),
+        OrderStatusOption(key = "processing", label = "Processing", statusCount = 5, isSelected = false),
+        OrderStatusOption(key = "on-hold", label = "On hold", statusCount = 2, isSelected = false),
+        OrderStatusOption(key = "failed", label = "Failed", statusCount = 1, isSelected = false),
+        OrderStatusOption(key = "completed", label = "Completed", statusCount = 10, isSelected = false),
+        OrderStatusOption(key = "cancelled", label = "Cancelled", statusCount = 4, isSelected = false),
+    )
+
+    @Before
+    fun setUp() {
+        given(ciabSiteGateKeeper.isCurrentSiteCIAB()).willReturn(true)
+        given(resourceProvider.getString(R.string.ciab_order_status_open)).willReturn(openLabel)
+
+        sut = CIABOrderStatusMapper(ciabSiteGateKeeper, resourceProvider)
+    }
+
+    // region mapOrderStatusOptionsList
+
+    @Test
+    fun `given site is not CIAB, when mapOrderStatusOptionsList, then returns input unchanged`() {
+        // GIVEN
+        given(ciabSiteGateKeeper.isCurrentSiteCIAB()).willReturn(false)
+
+        // WHEN
+        val result = sut.mapOrderStatusOptionsList(defaultStatusMap)
+
+        // THEN
+        assertThat(result).isEqualTo(defaultStatusMap)
+    }
+
+    @Test
+    fun `given site is CIAB, when mapOrderStatusOptionsList, then remaps open statuses to open`() {
+        // WHEN
+        val result = sut.mapOrderStatusOptionsList(defaultStatusMap)
+
+        // THEN
+        val expectedOpenModel = WCOrderStatusModel(statusKey = "open", label = openLabel)
+        assertThat(result["pending"]).isEqualTo(expectedOpenModel)
+        assertThat(result["processing"]).isEqualTo(expectedOpenModel)
+        assertThat(result["on-hold"]).isEqualTo(expectedOpenModel)
+        assertThat(result["failed"]).isEqualTo(expectedOpenModel)
+    }
+
+    @Test
+    fun `given site is CIAB, when mapOrderStatusOptionsList, then leaves non-open statuses unchanged`() {
+        // WHEN
+        val result = sut.mapOrderStatusOptionsList(defaultStatusMap)
+
+        // THEN
+        assertThat(result["completed"]).isEqualTo(defaultStatusMap["completed"])
+        assertThat(result["cancelled"]).isEqualTo(defaultStatusMap["cancelled"])
+        assertThat(result["refunded"]).isEqualTo(defaultStatusMap["refunded"])
+    }
+
+    // endregion
+
+    // region mapOrderStatus
+
+    @Test
+    fun `given site is not CIAB, when mapOrderStatus, then returns input unchanged`() {
+        // GIVEN
+        given(ciabSiteGateKeeper.isCurrentSiteCIAB()).willReturn(false)
+        val status = OrderStatus(statusKey = "pending", label = "Pending")
+
+        // WHEN
+        val result = sut.mapOrderStatus(status)
+
+        // THEN
+        assertThat(result).isEqualTo(status)
+    }
+
+    @Test
+    fun `given site is CIAB, when mapOrderStatus with pending status, then maps to Open`() {
+        // GIVEN
+        val status = OrderStatus(statusKey = "pending", label = "Pending")
+
+        // WHEN
+        val result = sut.mapOrderStatus(status)
+
+        // THEN
+        assertThat(result).isEqualTo(OrderStatus(statusKey = "open", label = openLabel))
+    }
+
+    @Test
+    fun `given site is CIAB, when mapOrderStatus with completed status, then returns unchanged`() {
+        // GIVEN
+        val status = OrderStatus(statusKey = "completed", label = "Completed")
+
+        // WHEN
+        val result = sut.mapOrderStatus(status)
+
+        // THEN
+        assertThat(result).isEqualTo(status)
+    }
+
+    // endregion
+
+    // region mapFilterOptions
+
+    @Test
+    fun `given site is not CIAB, when mapFilterOptions, then returns input unchanged`() {
+        // GIVEN
+        given(ciabSiteGateKeeper.isCurrentSiteCIAB()).willReturn(false)
+
+        // WHEN
+        val result = sut.mapFilterOptions(defaultFilterOptions)
+
+        // THEN
+        assertThat(result).isEqualTo(defaultFilterOptions)
+    }
+
+    @Test
+    fun `given site is CIAB, when mapFilterOptions, then groups open statuses with summed counts`() {
+        // WHEN
+        val result = sut.mapFilterOptions(defaultFilterOptions)
+
+        // THEN
+        val openOption = result.first { it.key == "open" }
+        assertThat(openOption.label).isEqualTo(openLabel)
+        assertThat(openOption.statusCount).isEqualTo(3 + 5 + 2 + 1)
+        assertThat(result.none { it.key in CIABOrderStatusMapper.OPEN_CORE_KEYS }).isTrue()
+    }
+
+    @Test
+    fun `given site is CIAB and one open status is selected, when mapFilterOptions, then grouped option is selected`() {
+        // GIVEN
+        val options = defaultFilterOptions.map {
+            if (it.key == "processing") it.copy(isSelected = true) else it
+        }
+
+        // WHEN
+        val result = sut.mapFilterOptions(options)
+
+        // THEN
+        val openOption = result.first { it.key == "open" }
+        assertThat(openOption.isSelected).isTrue()
+    }
+
+    // endregion
+
+    // region resolveFilterKeys
+
+    @Test
+    fun `given site is not CIAB, when resolveFilterKeys, then returns input unchanged`() {
+        // GIVEN
+        given(ciabSiteGateKeeper.isCurrentSiteCIAB()).willReturn(false)
+        val keys = listOf("open", "completed")
+
+        // WHEN
+        val result = sut.resolveFilterKeys(keys)
+
+        // THEN
+        assertThat(result).isEqualTo(keys)
+    }
+
+    @Test
+    fun `given site is CIAB, when resolveFilterKeys with open key, then expands to core keys`() {
+        // WHEN
+        val result = sut.resolveFilterKeys(listOf("open"))
+
+        // THEN
+        assertThat(result).containsExactlyInAnyOrder("pending", "processing", "on-hold", "failed")
+    }
+
+    @Test
+    fun `given site is CIAB, when resolveFilterKeys with non-open keys, then passes them through unchanged`() {
+        // WHEN
+        val result = sut.resolveFilterKeys(listOf("completed", "cancelled"))
+
+        // THEN
+        assertThat(result).containsExactly("completed", "cancelled")
+    }
+
+    // endregion
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapperTest.kt
@@ -51,8 +51,6 @@ class CIABOrderStatusMapperTest : BaseUnitTest() {
         sut = CIABOrderStatusMapper(ciabSiteGateKeeper, resourceProvider)
     }
 
-    // region mapOrderStatusOptionsList
-
     @Test
     fun `given site is not CIAB, when mapOrderStatusOptionsList, then returns input unchanged`() {
         // GIVEN
@@ -88,10 +86,6 @@ class CIABOrderStatusMapperTest : BaseUnitTest() {
         assertThat(result["cancelled"]).isEqualTo(defaultStatusMap["cancelled"])
         assertThat(result["refunded"]).isEqualTo(defaultStatusMap["refunded"])
     }
-
-    // endregion
-
-    // region mapOrderStatus
 
     @Test
     fun `given site is not CIAB, when mapOrderStatus, then returns input unchanged`() {
@@ -129,10 +123,6 @@ class CIABOrderStatusMapperTest : BaseUnitTest() {
         // THEN
         assertThat(result).isEqualTo(status)
     }
-
-    // endregion
-
-    // region mapFilterOptions
 
     @Test
     fun `given site is not CIAB, when mapFilterOptions, then returns input unchanged`() {
@@ -173,9 +163,40 @@ class CIABOrderStatusMapperTest : BaseUnitTest() {
         assertThat(openOption.isSelected).isTrue()
     }
 
-    // endregion
+    @Test
+    fun `given site is CIAB, when mapFilterOptions with checkout-draft, then excludes checkout-draft`() {
+        // GIVEN
+        val optionsWithDraft = defaultFilterOptions + OrderStatusOption(
+            key = "checkout-draft",
+            label = "Draft",
+            statusCount = 2,
+            isSelected = false
+        )
 
-    // region resolveFilterKeys
+        // WHEN
+        val result = sut.mapFilterOptions(optionsWithDraft)
+
+        // THEN
+        assertThat(result.none { it.key == "checkout-draft" }).isTrue()
+    }
+
+    @Test
+    fun `given site is not CIAB, when mapFilterOptions with checkout-draft, then keeps checkout-draft`() {
+        // GIVEN
+        given(ciabSiteGateKeeper.isCurrentSiteCIAB()).willReturn(false)
+        val optionsWithDraft = defaultFilterOptions + OrderStatusOption(
+            key = "checkout-draft",
+            label = "Draft",
+            statusCount = 2,
+            isSelected = false
+        )
+
+        // WHEN
+        val result = sut.mapFilterOptions(optionsWithDraft)
+
+        // THEN
+        assertThat(result.any { it.key == "checkout-draft" }).isTrue()
+    }
 
     @Test
     fun `given site is not CIAB, when resolveFilterKeys, then returns input unchanged`() {
@@ -207,6 +228,4 @@ class CIABOrderStatusMapperTest : BaseUnitTest() {
         // THEN
         assertThat(result).containsExactly("completed", "cancelled")
     }
-
-    // endregion
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ciab/CIABOrderStatusMapperTest.kt
@@ -69,11 +69,12 @@ class CIABOrderStatusMapperTest : BaseUnitTest() {
         val result = sut.mapOrderStatusOptionsList(defaultStatusMap)
 
         // THEN
-        val expectedOpenModel = WCOrderStatusModel(statusKey = "open", label = openLabel)
-        assertThat(result["pending"]).isEqualTo(expectedOpenModel)
-        assertThat(result["processing"]).isEqualTo(expectedOpenModel)
-        assertThat(result["on-hold"]).isEqualTo(expectedOpenModel)
-        assertThat(result["failed"]).isEqualTo(expectedOpenModel)
+        for (key in CIABOrderStatusMapper.OPEN_CORE_KEYS) {
+            val original = defaultStatusMap[key]!!
+            assertThat(result[key]).isEqualTo(
+                original.copy(statusKey = "open", label = openLabel)
+            )
+        }
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModelTest.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
@@ -40,8 +39,8 @@ class DashboardOrdersViewModelTest : BaseUnitTest() {
         on { refreshTrigger } doReturn emptyFlow()
     }
     private val orderListRepository: OrderListRepository = mock {
-        onBlocking { hasOrdersLocally(anyOrNull()) } doReturn false
-        on { observeTopOrders(any(), any(), anyOrNull()) } doReturn flowOf(Result.success(sampleOrders))
+        onBlocking { hasOrdersLocally(any()) } doReturn false
+        on { observeTopOrders(any(), any(), any()) } doReturn flowOf(Result.success(sampleOrders))
     }
     private val getOrderStatusFilterOptions: GetOrderStatusFilterOptions = mock {
         onBlocking { invoke() } doReturn emptyList()
@@ -55,6 +54,7 @@ class DashboardOrdersViewModelTest : BaseUnitTest() {
     }
     private val ciabOrderStatusMapper: CIABOrderStatusMapper = mock {
         on { mapOrderStatus(any()) } doAnswer { it.getArgument(0) }
+        on { resolveFilterKeys(any()) } doAnswer { it.getArgument(0) }
     }
     private lateinit var viewModel: DashboardOrdersViewModel
 
@@ -113,7 +113,7 @@ class DashboardOrdersViewModelTest : BaseUnitTest() {
     @Test
     fun `given failure when loading orders, when card is loaded, then show error`() = testBlocking {
         setup {
-            whenever(orderListRepository.observeTopOrders(any(), any(), anyOrNull()))
+            whenever(orderListRepository.observeTopOrders(any(), any(), any()))
                 .thenReturn(flowOf(Result.failure(Exception("Error"))))
         }
 
@@ -125,7 +125,7 @@ class DashboardOrdersViewModelTest : BaseUnitTest() {
     @Test
     fun `given failure when loading orders, when retry is clicked, then reload orders`() = testBlocking {
         setup {
-            whenever(orderListRepository.observeTopOrders(any(), any(), anyOrNull()))
+            whenever(orderListRepository.observeTopOrders(any(), any(), any()))
                 .thenReturn(flowOf(Result.failure(Exception("Error"))))
                 .thenReturn(flowOf(Result.success(sampleOrders)))
         }
@@ -177,10 +177,15 @@ class DashboardOrdersViewModelTest : BaseUnitTest() {
         )
         setup {
             whenever(getOrderStatusFilterOptions.invoke()) doReturn listOf(newFilter)
-            whenever(orderListRepository.observeTopOrders(any(), any(), eq(null)))
+            whenever(orderListRepository.observeTopOrders(any(), any(), eq(emptyList())))
                 .thenReturn(flowOf(Result.success(sampleOrders)))
-            whenever(orderListRepository.observeTopOrders(any(), any(), argThat { this.value == newFilter.key }))
-                .thenReturn(flowOf(Result.success(sampleOrders.take(2))))
+            whenever(
+                orderListRepository.observeTopOrders(
+                    any(),
+                    any(),
+                    argThat { any { it.value == newFilter.key } }
+                )
+            ).thenReturn(flowOf(Result.success(sampleOrders.take(2))))
         }
 
         val viewState = viewModel.viewState.runAndCaptureValues {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.dashboard.orders
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
 import com.woocommerce.android.ui.dashboard.orders.DashboardOrdersViewModel.Companion.DEFAULT_FILTER_OPTION_STATUS
@@ -52,6 +53,9 @@ class DashboardOrdersViewModelTest : BaseUnitTest() {
     private val currencyFormatter: CurrencyFormatter = mock {
         on { formatCurrency(amount = any(), any(), any()) } doAnswer { it.arguments[0].toString() }
     }
+    private val ciabOrderStatusMapper: CIABOrderStatusMapper = mock {
+        on { mapOrderStatus(any()) } doAnswer { it.getArgument(0) }
+    }
     private lateinit var viewModel: DashboardOrdersViewModel
 
     suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
@@ -64,6 +68,7 @@ class DashboardOrdersViewModelTest : BaseUnitTest() {
             currencyFormatter = currencyFormatter,
             getOrderStatusFilterOptions = getOrderStatusFilterOptions,
             analyticsTrackerWrapper = analyticsTracker,
+            ciabOrderStatusMapper = ciabOrderStatusMapper,
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -227,6 +227,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 refreshShippingMethods,
                 isStoreCurrencyMatch,
                 getShippingMethodsWithOtherValue,
+                ciabOrderStatusMapper = mock(),
             )
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -194,6 +195,9 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     private val getShippingMethodsWithOtherValue: GetShippingMethodsWithOtherValue = mock()
     private val refreshShippingMethods: RefreshShippingMethods = mock()
     private val isStoreCurrencyMatch: IsStoreCurrencyMatch = mock()
+    private val ciabOrderStatusMapper: CIABOrderStatusMapper = mock {
+        on { mapOrderStatus(any()) } doAnswer { it.arguments[0] as OrderStatus }
+    }
 
     private fun createViewModel() {
         createViewModel(newSavedState = savedState)
@@ -227,7 +231,7 @@ class OrderDetailViewModelTest : BaseUnitTest() {
                 refreshShippingMethods,
                 isStoreCurrencyMatch,
                 getShippingMethodsWithOtherValue,
-                ciabOrderStatusMapper = mock(),
+                ciabOrderStatusMapper = ciabOrderStatusMapper,
             )
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -5,10 +5,10 @@ import android.content.SharedPreferences
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R.string
-import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.GiftCardSummary
 import com.woocommerce.android.model.Order

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -5,9 +5,9 @@ import androidx.paging.PagedList
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
-import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.extensions.NotificationReceivedEvent
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.Order

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -173,7 +173,8 @@ class OrderListViewModelTest : BaseUnitTest() {
         dateUtils = mock(),
         shouldUpdateOrdersList = shouldUpdateOrdersList,
         observeOrdersListLastUpdate = observeOrdersListLastUpdate,
-        dataSourceLazyProvider = { orderListItemDataSource }
+        dataSourceLazyProvider = { orderListItemDataSource },
+        ciabOrderStatusMapper = mock(),
     )
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -124,9 +124,8 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val observeOrdersListLastUpdate = mock<ObserveOrdersListLastUpdate>()
     private val orderListItemDataSource = mock<OrderListItemDataSource>()
     private val ciabOrderStatusMapper: CIABOrderStatusMapper = mock {
-        @Suppress("UNCHECKED_CAST")
         on { mapOrderStatusOptionsList(any()) } doAnswer {
-            it.arguments[0] as Map<String, WCOrderStatusModel>
+            it.getArgument<Map<String, WCOrderStatusModel>>(0)
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagedList
 import com.google.android.material.snackbar.Snackbar
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.extensions.NotificationReceivedEvent
@@ -78,6 +79,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.model.list.PagedListWrapper
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.order.CoreOrderStatus
 import org.wordpress.android.fluxc.store.ListStore
@@ -121,6 +123,12 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val shouldUpdateOrdersList = mock<ShouldUpdateOrdersList>()
     private val observeOrdersListLastUpdate = mock<ObserveOrdersListLastUpdate>()
     private val orderListItemDataSource = mock<OrderListItemDataSource>()
+    private val ciabOrderStatusMapper: CIABOrderStatusMapper = mock {
+        @Suppress("UNCHECKED_CAST")
+        on { mapOrderStatusOptionsList(any()) } doAnswer {
+            it.arguments[0] as Map<String, WCOrderStatusModel>
+        }
+    }
 
     @Before
     fun setup() = testBlocking {
@@ -174,7 +182,7 @@ class OrderListViewModelTest : BaseUnitTest() {
         shouldUpdateOrdersList = shouldUpdateOrdersList,
         observeOrdersListLastUpdate = observeOrdersListLastUpdate,
         dataSourceLazyProvider = { orderListItemDataSource },
-        ciabOrderStatusMapper = mock(),
+        ciabOrderStatusMapper = ciabOrderStatusMapper,
     )
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SCANNING
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SCANNING_FAILURE_REASON
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SCANNING_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.FeatureFeedbackSettings
 import com.woocommerce.android.model.Order
@@ -108,6 +109,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
     protected lateinit var feedbackRepository: FeedbackRepository
     protected lateinit var fetchProductByIdentifier: FetchProductByIdentifier
     private lateinit var wooPosSurveysNotificationScheduler: WooPosSurveysNotificationScheduler
+    private lateinit var ciabOrderStatusMapper: CIABOrderStatusMapper
 
     protected val defaultOrderValue = Order.getEmptyOrder(Date(), Date()).copy(id = 123)
 
@@ -222,6 +224,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         }
         fetchProductByIdentifier = mock()
         wooPosSurveysNotificationScheduler = mock()
+        ciabOrderStatusMapper = mock()
     }
 
     protected abstract val tracksFlow: String
@@ -2179,6 +2182,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             feedbackRepository = feedbackRepository,
             fetchProductByIdentifier = fetchProductByIdentifier,
             wooPosSurveysNotificationScheduler = wooPosSurveysNotificationScheduler,
+            ciabOrderStatusMapper = ciabOrderStatusMapper,
         )
     }
 


### PR DESCRIPTION
Closes WOOMOB-2515

> [!NOTE]
> This PR handles the mapping only for store management screens, POS is not touched.
> For POS, getting an "open" order is an edge case, given it shows only orders that were created on POS itself, which are paid directly on the flow. But if we want to apply the same flow, I think we can reuse the component `CIABOrderStatusMapper`. 

### Description
CIAB sites use a simplified set of order statuses instead of the full WooCommerce Core set. This PR maps between them for display and filtering:

| CIAB Status | Core Statuses |
|-------------|--------------|
| Open | pending, processing, on-hold, failed |
| Completed | completed (1:1, no mapping needed) |
| Canceled | cancelled (1:1, no mapping needed) |
| Refunded | refunded (1:1, no mapping needed) |

Since only "Open" requires actual mapping (the rest are 1:1), the implementation focuses on that single group.

A new `CIABOrderStatusMapper` centralizes all mapping logic with four methods:
- `mapOrderStatusOptionsList` — remaps status labels for the order list adapter
- `mapOrderStatus` — remaps a single status for order detail display
- `mapFilterOptions` — groups 4 open statuses into one "Open" filter option
- `resolveFilterKeys` — expands "open" back to 4 core keys for API requests

### Test Steps
1. On a CIAB site, open the order list and verify pending/processing/on-hold/failed orders show "Open" status tag
2. Tap an order with one of those statuses and verify the detail screen also shows "Open"
3. Open the order filter screen and verify "Open" appears as a single filter option (not 4 separate ones)
4. Select the "Open" filter and verify orders with all 4 core statuses are returned
5. Close and reopen the filter screen — verify "Open" is still selected
6. On a non-CIAB site, verify all order status behavior is unchanged

### Images/gif
<img width="320" alt="01_order_list_ciab_statuses" src="https://github.com/user-attachments/assets/e8e69bdd-c4ab-43f3-bb26-187cebb16ad8" />
</br></br>
<img width="320" alt="02_order_detail_open_status" src="https://github.com/user-attachments/assets/bc316cd2-a460-4617-a0ce-de61dd7c94a8" />
</br></br>
<img width="320" alt="Screenshot_20260318_225627" src="https://github.com/user-attachments/assets/1d3ef213-4db6-417b-b0c5-9a775af1b532" />


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.