### PR TITLE
[WOOMOB-2236] Parse CIAB fulfillment status from order meta

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -71,7 +71,7 @@ data class Order(
                 "fulfilled" -> FULFILLED
                 "partially_fulfilled" -> PARTIALLY_FULFILLED
                 "unfulfilled" -> UNFULFILLED
-                null, "", "no_fulfillments" -> NO_FULFILLMENTS
+                null -> NO_FULFILLMENTS
                 else -> UNKNOWN
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Order.kt
@@ -52,10 +52,29 @@ data class Order(
     val giftCardDiscountedAmount: BigDecimal?,
     val shippingTax: BigDecimal,
     val salesChannel: SalesChannel,
+    val fulfillmentStatus: FulfillmentStatus = FulfillmentStatus.NO_FULFILLMENTS,
 ) : Parcelable {
     enum class SalesChannel {
         POS,
         NON_POS
+    }
+
+    enum class FulfillmentStatus {
+        FULFILLED,
+        PARTIALLY_FULFILLED,
+        UNFULFILLED,
+        NO_FULFILLMENTS,
+        UNKNOWN;
+
+        companion object {
+            fun fromApiValue(value: String?): FulfillmentStatus = when (value) {
+                "fulfilled" -> FULFILLED
+                "partially_fulfilled" -> PARTIALLY_FULFILLED
+                "unfulfilled" -> UNFULFILLED
+                null, "", "no_fulfillments" -> NO_FULFILLMENTS
+                else -> UNKNOWN
+            }
+        }
     }
 
     @IgnoredOnParcel
@@ -393,7 +412,8 @@ data class Order(
                 selectedGiftCard = "",
                 giftCardDiscountedAmount = null,
                 shippingTax = BigDecimal(0),
-                salesChannel = SalesChannel.NON_POS
+                salesChannel = SalesChannel.NON_POS,
+                fulfillmentStatus = FulfillmentStatus.NO_FULFILLMENTS
             )
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/OrderMapper.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.model.Order.Item
 import com.woocommerce.android.util.DateUtils
 import com.woocommerce.android.util.StringUtils
 import org.wordpress.android.fluxc.model.metadata.WCMetaData
+import org.wordpress.android.fluxc.model.metadata.WCMetaData.OrderFulfillmentMetadataKeys.FULFILLMENT_STATUS
 import org.wordpress.android.fluxc.model.metadata.get
 import org.wordpress.android.fluxc.model.order.FeeLineTaxStatus
 import org.wordpress.android.fluxc.model.order.OrderAddress
@@ -73,6 +74,7 @@ class OrderMapper @Inject constructor(
             } else {
                 Order.SalesChannel.NON_POS
             },
+            fulfillmentStatus = Order.FulfillmentStatus.fromApiValue(metaDataList.getOrNull(FULFILLMENT_STATUS)),
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderMapperTest.kt
@@ -133,7 +133,33 @@ class OrderMapperTest {
     }
 
     @Test
-    fun `when fulfillment status is no fulfillments, then map to NO_FULFILLMENTS`() = runTest {
+    fun `when fulfillment status metadata is missing, then map to NO_FULFILLMENTS`() = runTest {
+        val orderEntity = createTestOrderEntity()
+
+        val result = orderMapper.toAppModel(orderEntity)
+
+        assertThat(result.fulfillmentStatus).isEqualTo(Order.FulfillmentStatus.NO_FULFILLMENTS)
+    }
+
+    @Test
+    fun `when fulfillment status is empty, then map to UNKNOWN`() = runTest {
+        val orderEntity = createTestOrderEntity(
+            metaData = listOf(
+                WCMetaData(
+                    id = 1L,
+                    key = WCMetaData.OrderFulfillmentMetadataKeys.FULFILLMENT_STATUS,
+                    value = ""
+                )
+            )
+        )
+
+        val result = orderMapper.toAppModel(orderEntity)
+
+        assertThat(result.fulfillmentStatus).isEqualTo(Order.FulfillmentStatus.UNKNOWN)
+    }
+
+    @Test
+    fun `when fulfillment status is no fulfillments, then map to UNKNOWN`() = runTest {
         val orderEntity = createTestOrderEntity(
             metaData = listOf(
                 WCMetaData(
@@ -146,16 +172,7 @@ class OrderMapperTest {
 
         val result = orderMapper.toAppModel(orderEntity)
 
-        assertThat(result.fulfillmentStatus).isEqualTo(Order.FulfillmentStatus.NO_FULFILLMENTS)
-    }
-
-    @Test
-    fun `when fulfillment status metadata is missing, then map to NO_FULFILLMENTS`() = runTest {
-        val orderEntity = createTestOrderEntity()
-
-        val result = orderMapper.toAppModel(orderEntity)
-
-        assertThat(result.fulfillmentStatus).isEqualTo(Order.FulfillmentStatus.NO_FULFILLMENTS)
+        assertThat(result.fulfillmentStatus).isEqualTo(Order.FulfillmentStatus.UNKNOWN)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/model/OrderMapperTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.model.metadata.WCMetaData
 import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 import java.util.Date
 
@@ -80,7 +81,104 @@ class OrderMapperTest {
         assertThat(result.salesChannel).isEqualTo(Order.SalesChannel.NON_POS)
     }
 
-    private fun createTestOrderEntity(createdVia: String = ""): OrderEntity {
+    @Test
+    fun `when fulfillment status is fulfilled, then map to FULFILLED`() = runTest {
+        val orderEntity = createTestOrderEntity(
+            metaData = listOf(
+                WCMetaData(
+                    id = 1L,
+                    key = WCMetaData.OrderFulfillmentMetadataKeys.FULFILLMENT_STATUS,
+                    value = "fulfilled"
+                )
+            )
+        )
+
+        val result = orderMapper.toAppModel(orderEntity)
+
+        assertThat(result.fulfillmentStatus).isEqualTo(Order.FulfillmentStatus.FULFILLED)
+    }
+
+    @Test
+    fun `when fulfillment status is partially fulfilled, then map to PARTIALLY_FULFILLED`() = runTest {
+        val orderEntity = createTestOrderEntity(
+            metaData = listOf(
+                WCMetaData(
+                    id = 1L,
+                    key = WCMetaData.OrderFulfillmentMetadataKeys.FULFILLMENT_STATUS,
+                    value = "partially_fulfilled"
+                )
+            )
+        )
+
+        val result = orderMapper.toAppModel(orderEntity)
+
+        assertThat(result.fulfillmentStatus).isEqualTo(Order.FulfillmentStatus.PARTIALLY_FULFILLED)
+    }
+
+    @Test
+    fun `when fulfillment status is unfulfilled, then map to UNFULFILLED`() = runTest {
+        val orderEntity = createTestOrderEntity(
+            metaData = listOf(
+                WCMetaData(
+                    id = 1L,
+                    key = WCMetaData.OrderFulfillmentMetadataKeys.FULFILLMENT_STATUS,
+                    value = "unfulfilled"
+                )
+            )
+        )
+
+        val result = orderMapper.toAppModel(orderEntity)
+
+        assertThat(result.fulfillmentStatus).isEqualTo(Order.FulfillmentStatus.UNFULFILLED)
+    }
+
+    @Test
+    fun `when fulfillment status is no fulfillments, then map to NO_FULFILLMENTS`() = runTest {
+        val orderEntity = createTestOrderEntity(
+            metaData = listOf(
+                WCMetaData(
+                    id = 1L,
+                    key = WCMetaData.OrderFulfillmentMetadataKeys.FULFILLMENT_STATUS,
+                    value = "no_fulfillments"
+                )
+            )
+        )
+
+        val result = orderMapper.toAppModel(orderEntity)
+
+        assertThat(result.fulfillmentStatus).isEqualTo(Order.FulfillmentStatus.NO_FULFILLMENTS)
+    }
+
+    @Test
+    fun `when fulfillment status metadata is missing, then map to NO_FULFILLMENTS`() = runTest {
+        val orderEntity = createTestOrderEntity()
+
+        val result = orderMapper.toAppModel(orderEntity)
+
+        assertThat(result.fulfillmentStatus).isEqualTo(Order.FulfillmentStatus.NO_FULFILLMENTS)
+    }
+
+    @Test
+    fun `when fulfillment status is unknown, then map to UNKNOWN`() = runTest {
+        val orderEntity = createTestOrderEntity(
+            metaData = listOf(
+                WCMetaData(
+                    id = 1L,
+                    key = WCMetaData.OrderFulfillmentMetadataKeys.FULFILLMENT_STATUS,
+                    value = "custom_future_status"
+                )
+            )
+        )
+
+        val result = orderMapper.toAppModel(orderEntity)
+
+        assertThat(result.fulfillmentStatus).isEqualTo(Order.FulfillmentStatus.UNKNOWN)
+    }
+
+    private fun createTestOrderEntity(
+        createdVia: String = "",
+        metaData: List<WCMetaData> = emptyList(),
+    ): OrderEntity {
         return OrderEntity(
             localSiteId = localSiteId,
             orderId = 1L,
@@ -90,7 +188,8 @@ class OrderMapperTest {
             dateCreated = "2023-01-01T00:00:00Z",
             dateModified = "2023-01-01T00:00:00Z",
             total = "100.00",
-            createdVia = createdVia
+            createdVia = createdVia,
+            metaData = metaData,
         )
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/metadata/WCMetaData.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/metadata/WCMetaData.kt
@@ -117,6 +117,10 @@ data class WCMetaData(
     object PaymentMetadataKeys {
         const val PAYMENT_STATUS = "_payment_status"
     }
+
+    object OrderFulfillmentMetadataKeys {
+        const val FULFILLMENT_STATUS = "_fulfillment_status"
+    }
 }
 
 operator fun List<WCMetaData>.get(key: String) = firstOrNull { it.key == key }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrder.kt
@@ -30,7 +30,8 @@ internal class StripOrder @Inject constructor(private val gson: Gson) {
                             it.key == CHARGE_ID_KEY ||
                                     it.key == SHIPPING_PHONE_KEY ||
                                     it.key == RECEIPT_URL_KEY ||
-                                    it.key == WCMetaData.PaymentMetadataKeys.PAYMENT_STATUS
+                                    it.key == WCMetaData.PaymentMetadataKeys.PAYMENT_STATUS ||
+                                    it.key == WCMetaData.OrderFulfillmentMetadataKeys.FULFILLMENT_STATUS
                         }
                 )
     }

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/StripOrderTest.kt
@@ -240,6 +240,24 @@ internal class StripOrderTest {
             .doesNotContain(redundantMemberKey)
     }
 
+    @Test
+    fun `when stripping order, then _fulfillment_status meta data is preserved`() = runTest {
+        // given
+        val metaDataFromRemote = listOf(
+            WCMetaData(1, redundantMemberKey, "sample value"),
+            WCMetaData(2, WCMetaData.OrderFulfillmentMetadataKeys.FULFILLMENT_STATUS, "fulfilled")
+        )
+        val fatModel = emptyOrder.copy(metaData = metaDataFromRemote)
+
+        // when
+        val strippedOrder = sut.invoke(fatModel)
+
+        // then
+        assertThat(strippedOrder.metaData.map { it.key })
+            .contains(WCMetaData.OrderFulfillmentMetadataKeys.FULFILLMENT_STATUS)
+            .doesNotContain(redundantMemberKey)
+    }
+
     companion object {
         const val redundantMemberKey = "not_needed_parameter"
 


### PR DESCRIPTION
### Description
Fixes WOOMOB-2236
Parse CIAB fulfillment status from order metadata and expose it on the order model.
This preserves `_fulfillment_status` in cached orders and maps the known Woo values into a dedicated fulfillment status enum with a safe fallback for unknown values.

### Test Steps
1. Fresh install the app.
2. Sign in to a CIAB site.
3. Open the order list.
4. If you are using the optional debug patch below, apply the patch and verify Logcat contains lines like `OrderListItemDataSource > orderId=190 raw_fulfillment_status=unfulfilled mapped_fulfillment_status=UNFULFILLED`.
5. Check the same orders in Woo web and confirm the fulfillment values match what the app reports.

### Images/gif
N/A

### Optional Debug Patch
```diff
diff --git a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
index e147e19c019..b0593a21fa6 100644
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/list/OrderListItemDataSource.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.orders.list
 
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.getBillingName
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.TimeGroup
 import com.woocommerce.android.model.TimeGroup.GROUP_FUTURE
 import com.woocommerce.android.model.TimeGroup.GROUP_OLDER_MONTH
@@ -16,6 +17,7 @@ import com.woocommerce.android.ui.orders.list.OrderListItemUIType.LoadingItem
 import com.woocommerce.android.ui.orders.list.OrderListItemUIType.OrderListItemUI
 import com.woocommerce.android.ui.orders.list.OrderListItemUIType.SectionHeader
 import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.runBlocking
 import org.wordpress.android.fluxc.Dispatcher
@@ -23,6 +25,8 @@ import org.wordpress.android.fluxc.generated.WCOrderActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.model.WCOrderListDescriptor
 import org.wordpress.android.fluxc.model.WCOrderSummaryModel
+import org.wordpress.android.fluxc.model.metadata.WCMetaData.OrderFulfillmentMetadataKeys.FULFILLMENT_STATUS
+import org.wordpress.android.fluxc.model.metadata.get
 import org.wordpress.android.fluxc.model.list.datasource.ListItemDataSourceInterface
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.FetchOrderListPayload
@@ -67,6 +71,13 @@ class OrderListItemDataSource @Inject constructor(
                 if (order == null) {
                     LoadingItem(orderId)
                 } else {
+                    val rawFulfillmentStatus = order.metaData[FULFILLMENT_STATUS]?.valueAsString
+                    val fulfillmentStatus = Order.FulfillmentStatus.fromApiValue(rawFulfillmentStatus)
+                    WooLog.d(
+                        WooLog.T.ORDERS,
+                        "OrderListItemDataSource > orderId=${order.orderId} raw_fulfillment_status=$rawFulfillmentStatus " +
+                            "mapped_fulfillment_status=$fulfillmentStatus"
+                    )
                     @Suppress("DEPRECATION_ERROR")
                     OrderListItemUI(
                         orderId = order.orderId,
```

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
