### PR TITLE
[WOOMOB-2518] Fix crash when rapidly tapping a custom field item

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.SnackbarResult
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleResult
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.base.BaseFragment
@@ -88,6 +89,7 @@ class CustomFieldsFragment : BaseFragment() {
     }
 
     private fun openEditor(field: CustomFieldUiModel?) {
+        if (findNavController().currentDestination?.id != R.id.customFieldsFragment) return
         findNavController().navigate(
             CustomFieldsFragmentDirections.actionCustomFieldsFragmentToCustomFieldsEditorFragment(
                 parentItemId = viewModel.parentItemId,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsFragment.kt
@@ -9,8 +9,8 @@ import androidx.compose.material.SnackbarResult
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import com.woocommerce.android.R
 import com.woocommerce.android.extensions.handleResult
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.common.webview.AuthenticatedWebViewLauncher
@@ -89,8 +89,7 @@ class CustomFieldsFragment : BaseFragment() {
     }
 
     private fun openEditor(field: CustomFieldUiModel?) {
-        if (findNavController().currentDestination?.id != R.id.customFieldsFragment) return
-        findNavController().navigate(
+        findNavController().navigateSafely(
             CustomFieldsFragmentDirections.actionCustomFieldsFragmentToCustomFieldsEditorFragment(
                 parentItemId = viewModel.parentItemId,
                 customField = field


### PR DESCRIPTION
### Description
Fixes WOOMOB-2518

When a user rapidly double-taps a custom field item in the Custom Fields list screen, the `OpenCustomFieldEditor` event fires twice in quick succession. The first tap triggers navigation to `customFieldsEditorFragment`, but before the navigation completes, the second event also calls `openEditor()`. At that point the current destination is already `customFieldsEditorFragment`, not `customFieldsFragment`, so the action `action_customFieldsFragment_to_customFieldsEditorFragment` cannot be found — causing an `IllegalArgumentException` crash.

The fix guards `openEditor()` by checking that the current navigation destination is `customFieldsFragment` before navigating, which is the same pattern used in `OrderListFragment`.

### Reproduce crash steps\
You'll need a real device as that allows for "multi tap". 
1. Open any order or product that has at least one custom field.
2. Navigate to the **Custom Fields** screen.
3. Tap at the same time in 2 different custom field items from the list. Use 2 fingers for that.
4. See the app crash when ran from `trunk`
5. Verify the app no longer crashes after applying this changes 

### Images/gif

https://github.com/user-attachments/assets/cff3bfb4-b467-40ee-87b8-f1c59000a25b
