### PR TITLE
[WOOMOB-2105] Fix WooPos dialog overlay not covering system bar areas

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -46,9 +47,7 @@ fun WooPosDialogWrapper(
 
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .statusBarsPadding()
-            .navigationBarsPadding()
+        modifier = Modifier.fillMaxSize()
     ) {
         WooPosBackgroundOverlay(
             modifier = Modifier
@@ -73,7 +72,10 @@ fun WooPosDialogWrapper(
                 shape = RoundedCornerShape(WooPosCornerRadius.Large.value),
                 backgroundColor = MaterialTheme.colorScheme.surfaceBright,
                 elevation = WooPosElevation.Medium,
-                modifier = modifier.fillMaxWidth(0.75f),
+                modifier = modifier
+                    .statusBarsPadding()
+                    .navigationBarsPadding()
+                    .fillMaxWidth(0.75f),
             ) {
                 Column(
                     modifier = Modifier.padding(WooPosSpacing.XLarge.value)


### PR DESCRIPTION
### Description
Fixes WOOMOB-2105

The `WooPosBackgroundOverlay` (scrim) was not covering the full screen when a dialog was shown. The outer `Box` in `WooPosDialogWrapper` had `statusBarsPadding()` and `navigationBarsPadding()`, which constrained the overlay to only fill the area between system bars, leaving white strips at the top/bottom edges.

Moved the system bar padding from the outer `Box` to the `WooPosCard` modifier and added `fillMaxSize()` to the outer `Box`. Now the overlay fills the full available area while the dialog card stays within the safe area.

### Test Steps
1. Open POS on a tablet (or emulator in landscape)
2. Go to Settings and open any dialog (e.g. Product Info, Scanning Setup, Sync Error)
3. Verify the dark scrim covers the full screen including behind system bars
4. Also check the Exit Confirmation dialog on the home screen
5. Verify the dialog card itself is properly centered and not overlapping system bars

### Images/gif
before
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/dbe4f07c-fed6-4c47-8ef7-09bc6eaff9ea" />

after
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/b405813e-fde4-41e4-90c7-b3de039d1c0c" />



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.