### PR TITLE
[WOOMOB-2417] Fix POS items list vertical alignment with cart items

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -71,7 +71,7 @@ fun WooPosItemList(
     WooPosLazyColumn(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),
-        contentPadding = PaddingValues(vertical = WooPosSpacing.XXSmall.value),
+        contentPadding = PaddingValues(top = WooPosSpacing.Small.value, bottom = WooPosSpacing.XXSmall.value),
         state = listState,
     ) {
         items(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.home.items.coupons
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
@@ -21,6 +22,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorS
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreenButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosPaginationErrorIndicator
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIcons
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.home.items.WooPosCouponsViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemList
@@ -72,6 +74,7 @@ private fun WooPosCouponsScreen(
         when (val itemsState = state.value) {
             is WooPosCouponsViewState.Content -> {
                 WooPosItemList(
+                    modifier = Modifier.padding(top = WooPosSpacing.XSmall.value),
                     state = itemsState,
                     listState = listState,
                     onItemClicked = { item -> onUIEvent(WooPosCouponsUIEvent.CouponClicked(item.id, item.name)) },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/search/WooPosCouponsEmptySearchQueryStateScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/search/WooPosCouponsEmptySearchQueryStateScreen.kt
@@ -35,7 +35,8 @@ fun WooPosCouponsEmptySearchQueryStateScreen(
     Column(
         modifier
             .fillMaxHeight()
-            .padding(top = WooPosSpacing.Large.value)
+            .padding(top = WooPosSpacing.Small.value)
+            .padding(top = WooPosSpacing.XSmall.value)
             .verticalScroll(scrollState)
     ) {
         if (state.recentSearches.isNotEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/search/WooPosCouponsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/search/WooPosCouponsSearchScreen.kt
@@ -130,11 +130,13 @@ private fun WooPosCouponsSearchScreen(
 
                 WooPosCouponsSearchViewState.Loading::class.java -> {
                     WooPosItemsLoadingIndicator(
-                        modifier = Modifier.padding(
-                            start = WooPosSpacing.Medium.value,
-                            end = WooPosSpacing.Medium.value,
-                            top = WooPosSpacing.Large.value
-                        ),
+                        modifier = Modifier
+                            .padding(
+                                start = WooPosSpacing.Medium.value,
+                                end = WooPosSpacing.Medium.value,
+                                top = WooPosSpacing.Small.value
+                            )
+                            .padding(top = WooPosSpacing.XSmall.value),
                         itemsCount = 5
                     )
                 }
@@ -161,7 +163,7 @@ private fun WooPosCouponsSearchContent(
     }
 
     WooPosItemList(
-        modifier = modifier.padding(top = WooPosSpacing.Large.value),
+        modifier = modifier.padding(top = WooPosSpacing.XSmall.value),
         state = state,
         listState = listState,
         animateItems = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsScreen.kt
@@ -139,6 +139,7 @@ private fun Content(
     onEndOfItemListReached: () -> Unit
 ) {
     WooPosItemList(
+        modifier = Modifier.padding(top = WooPosSpacing.XSmall.value),
         state = itemsState,
         listState = listState,
         onItemClicked = onItemClicked,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryStateScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsEmptySearchQueryStateScreen.kt
@@ -40,7 +40,8 @@ fun WooPosItemsEmptySearchQueryStateScreen(
     Column(
         modifier
             .fillMaxHeight()
-            .padding(top = WooPosSpacing.Large.value)
+            .padding(top = WooPosSpacing.Small.value)
+            .padding(top = WooPosSpacing.XSmall.value)
             .verticalScroll(scrollState)
     ) {
         if (state.recentSearches.isNotEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchScreen.kt
@@ -149,11 +149,13 @@ private fun WooPosItemsSearchScreen(
 
                 WooPosItemsSearchViewState.Loading::class.java -> {
                     WooPosItemsLoadingIndicator(
-                        modifier = Modifier.padding(
-                            start = WooPosSpacing.Medium.value,
-                            end = WooPosSpacing.Medium.value,
-                            top = WooPosSpacing.Large.value
-                        ),
+                        modifier = Modifier
+                            .padding(
+                                start = WooPosSpacing.Medium.value,
+                                end = WooPosSpacing.Medium.value,
+                                top = WooPosSpacing.Small.value
+                            )
+                            .padding(top = WooPosSpacing.XSmall.value),
                         itemsCount = 5
                     )
                 }
@@ -185,7 +187,7 @@ private fun WooPosItemsSearchContent(
         }
     }
     WooPosItemList(
-        modifier = modifier.padding(top = WooPosSpacing.Large.value),
+        modifier = modifier.padding(top = WooPosSpacing.XSmall.value),
         state = state,
         listState = listState,
         onItemClicked = { onUIEvent(WooPosItemsSearchUiEvent.OnItemClicked(it)) },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/variations/WooPosVariationsScreen.kt
@@ -103,6 +103,7 @@ private fun WooPosVariationsScreens(
         when (val itemsState = itemState.value) {
             is WooPosVariationsViewState.Content -> {
                 WooPosItemList(
+                    modifier = Modifier.padding(top = WooPosSpacing.XSmall.value),
                     state = itemsState,
                     listState = listState,
                     onItemClicked = {


### PR DESCRIPTION
Closes: WOOMOB-2417

## Description

The left-panel content (products, search results, variations, popular items, recent searches) was vertically misaligned with cart items in the right panel. This fixes the top padding across all left-panel content states so the first visible item lines up with the first cart item.

## Changes

- Increased product/coupon list `contentPadding` top from `XXSmall` (2dp) to `Small` (8dp)
- Added `XSmall` (4dp) top modifier padding to product, coupon, and variation list calls
- Reduced search results and loading indicator top padding from `Large` (24dp) to `Small` + `XSmall` (12dp)
- Reduced empty search query (recent searches / popular items) top padding from `Large` (24dp) to `Small` + `XSmall` (12dp)
- Applied same fixes to coupons search screens

## Test Steps

1. Open POS
2. Add items to cart
3. Verify the first product card on the left aligns vertically with the first cart item on the right
4. Open search (empty query) - verify recent searches / popular items align with cart
5. Type a search query - verify search results align with cart
6. Navigate to a variable product's variations - verify variation items align with cart
7. Switch to Coupons tab - verify coupon items align with cart

**Screenshots verified on emulator** - all states (products, search results, empty search, variations) align at same Y coordinate (Y=216px) with cart items.

<img width="2560" height="1600" alt="pos_products_aligned" src="https://github.com/user-attachments/assets/4e129c73-5deb-4d48-8d79-89c1464b4487" />
<img width="2560" height="1600" alt="pos_search_results_aligned" src="https://github.com/user-attachments/assets/dd449e1d-20d3-4747-88dd-3599aac1a017" />

<img width="2560" height="1600" alt="pos_empty_search_aligned" src="https://github.com/user-attachments/assets/8981a13a-766d-4280-8c5f-19534d049092" />


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.