### PR TITLE
[WOOMOB-2544] Run incremental sync after manual full sync from Settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModel.kt
@@ -138,6 +138,7 @@ class WooPosSettingsLocalCatalogViewModel @Inject constructor(
 
             when (result) {
                 is PosLocalCatalogSyncResult.Success -> {
+                    localCatalogSyncRepository.syncLocalCatalogIncremental(selectedSite.get())
                     loadCatalogStatus()
                 }
                 is PosLocalCatalogSyncResult.Failure -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModel.kt
@@ -140,6 +140,7 @@ class WooPosSettingsLocalCatalogViewModel @Inject constructor(
                 is PosLocalCatalogSyncResult.Success -> {
                     localCatalogSyncRepository.syncLocalCatalogIncremental(selectedSite.get())
                     loadCatalogStatus()
+                    childToParentEventSender.sendToParent(ChildToParentEvent.RefreshProductList)
                 }
                 is PosLocalCatalogSyncResult.Failure -> {
                     backupCatalogData?.let { _state.update { it.copy(catalogStatus = backupCatalogData) } }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModelTest.kt
@@ -68,6 +68,14 @@ class WooPosSettingsLocalCatalogViewModelTest {
                     syncDurationMs = 1000L
                 )
             )
+        whenever(localCatalogSyncRepository.syncLocalCatalogIncremental(any()))
+            .thenReturn(
+                PosLocalCatalogSyncResult.Success(
+                    productsSynced = 0,
+                    variationsSynced = 0,
+                    syncDurationMs = 100L
+                )
+            )
 
         whenever(syncTimestampManager.getProductsLastSyncTimestamp()).thenReturn(1000L)
         whenever(syncTimestampManager.getVariationsLastSyncTimestamp()).thenReturn(1000L)
@@ -312,6 +320,20 @@ class WooPosSettingsLocalCatalogViewModelTest {
         // THEN
         assertThat(sut.state.value.catalogStatus)
             .isInstanceOf(WooPosSettingsLocalCatalogState.CatalogStatus.Available::class.java)
+    }
+
+    @Test
+    fun `given full sync succeeds, when runFullCatalogSync called, then incremental sync is also run`() = runTest {
+        // GIVEN
+        sut = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        sut.runFullCatalogSync()
+        advanceUntilIdle()
+
+        // THEN
+        verify(localCatalogSyncRepository).syncLocalCatalogIncremental(mockSite)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/settings/details/localcatalog/WooPosSettingsLocalCatalogViewModelTest.kt
@@ -323,6 +323,20 @@ class WooPosSettingsLocalCatalogViewModelTest {
     }
 
     @Test
+    fun `given full sync succeeds, when runFullCatalogSync called, then product list refresh is requested`() = runTest {
+        // GIVEN
+        sut = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        sut.runFullCatalogSync()
+        advanceUntilIdle()
+
+        // THEN
+        verify(childToParentEventSender).sendToParent(ChildToParentEvent.RefreshProductList)
+    }
+
+    @Test
     fun `given full sync succeeds, when runFullCatalogSync called, then incremental sync is also run`() = runTest {
         // GIVEN
         sut = createViewModel()


### PR DESCRIPTION
### Description
Fixes WOOMOB-2544

When a user triggers a manual full catalog sync from POS Settings > Local Catalog, newly added products may not appear because:
1. The incremental sync was not run after the full sync
2. The product list was not refreshed after syncing

The background `WooPosLocalCatalogSyncWorker` correctly runs incremental sync after full sync, but the Settings ViewModel did not. This adds the missing incremental sync call after a successful full sync and sends a `RefreshProductList` event so the product list picks up the newly synced products.

**Note:** Long term, the product list should observe the local database directly so manual refresh events won't be necessary. This is currently blocked by the need to support the original paginated API approach, whose architecture isn't compatible with reactive database observation.

### Test Steps
1. Open POS Settings > Local Catalog
2. Add a new product to the store (e.g. via web admin)
3. Trigger a manual full catalog sync from the Settings screen
4. Verify the newly added product appears in the catalog

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.