### PR TITLE
Add Top Categories dashboard card UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -42,6 +42,10 @@ data class DashboardWidget(
             titleResource = R.string.my_store_widget_top_products_title,
             trackingIdentifier = "top_performers"
         ),
+        TOP_CATEGORIES(
+            titleResource = R.string.my_store_widget_top_categories_title,
+            trackingIdentifier = "top_categories"
+        ),
         BLAZE(
             titleResource = R.string.my_store_widget_blaze_title,
             trackingIdentifier = "blaze"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -59,6 +59,7 @@ import com.woocommerce.android.ui.dashboard.pushnotifications.DashboardPushNotif
 import com.woocommerce.android.ui.dashboard.reviews.DashboardReviewsCard
 import com.woocommerce.android.ui.dashboard.stats.DashboardStatsCard
 import com.woocommerce.android.ui.dashboard.stock.DashboardProductStockCard
+import com.woocommerce.android.ui.dashboard.topcategories.DashboardTopCategoriesWidgetCard
 import com.woocommerce.android.ui.dashboard.topperformers.DashboardTopPerformersWidgetCard
 import com.woocommerce.android.ui.main.MainActivityViewModel
 
@@ -265,6 +266,11 @@ private fun ConfigurableWidgetCard(
         }
 
         DashboardWidget.Type.POPULAR_PRODUCTS -> DashboardTopPerformersWidgetCard(
+            parentViewModel = dashboardViewModel,
+            modifier = modifier
+        )
+
+        DashboardWidget.Type.TOP_CATEGORIES -> DashboardTopCategoriesWidgetCard(
             parentViewModel = dashboardViewModel,
             modifier = modifier
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
@@ -134,7 +134,8 @@ class DashboardRepository @Inject constructor(
                 status = when (type) {
                     DashboardWidget.Type.STATS,
                     DashboardWidget.Type.ORDERS,
-                    DashboardWidget.Type.POPULAR_PRODUCTS -> siteOrdersState
+                    DashboardWidget.Type.POPULAR_PRODUCTS,
+                    DashboardWidget.Type.TOP_CATEGORIES -> siteOrdersState
 
                     DashboardWidget.Type.BLAZE -> blazeWidgetStatus
                     DashboardWidget.Type.PUSH_NOTIFICATIONS -> pushNotificationsWidgetStatus

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/DashboardTopCategoriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/DashboardTopCategoriesViewModel.kt
@@ -256,10 +256,7 @@ class DashboardTopCategoriesViewModel @AssistedInject constructor(
             categoryId = categoryId,
             name = StringEscapeUtils.unescapeHtml4(name),
             timesOrdered = FormatUtils.formatDecimal(quantity),
-            netSales = resourceProvider.getString(
-                R.string.dashboard_top_performers_net_sales,
-                getTotalSpendFormatted(total.toBigDecimal(), currency)
-            ),
+            netSales = getTotalSpendFormatted(total.toBigDecimal(), currency),
             onClick = ::onTopCategoryTapped
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/DashboardTopCategoriesViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/DashboardTopCategoriesViewModel.kt
@@ -1,0 +1,335 @@
+package com.woocommerce.android.ui.dashboard.topcategories
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.R
+import com.woocommerce.android.WooException
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore.AnalyticData
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.dashboard.DashboardStatsUsageTracksEventEmitter
+import com.woocommerce.android.ui.dashboard.DashboardViewModel
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.RefreshEvent
+import com.woocommerce.android.ui.dashboard.TopPerformerCategoryUiModel
+import com.woocommerce.android.ui.dashboard.data.TopCategoriesCustomDateRangeDataStore
+import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
+import com.woocommerce.android.ui.dashboard.domain.DashboardDateRangeFormatter
+import com.woocommerce.android.ui.dashboard.domain.GetTopPerformerCategories
+import com.woocommerce.android.ui.dashboard.domain.GetTopPerformerCategories.TopPerformerCategory
+import com.woocommerce.android.ui.dashboard.domain.ObserveLastUpdate
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.commons.stats.StatsTimeRange
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import org.apache.commons.text.StringEscapeUtils
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.util.FormatUtils
+import java.math.BigDecimal
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel(assistedFactory = DashboardTopCategoriesViewModel.Factory::class)
+@Suppress("LongParameterList")
+class DashboardTopCategoriesViewModel @AssistedInject constructor(
+    @Assisted private val parentViewModel: DashboardViewModel,
+    private val selectedSite: SelectedSite,
+    private val networkStatus: NetworkStatus,
+    private val observeLastUpdate: ObserveLastUpdate,
+    private val resourceProvider: ResourceProvider,
+    private val getTopPerformerCategories: GetTopPerformerCategories,
+    private val currencyFormatter: CurrencyFormatter,
+    private val usageTracksEventEmitter: DashboardStatsUsageTracksEventEmitter,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val wooCommerceStore: WooCommerceStore,
+    private val dateUtils: DateUtils,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val customDateRangeDataStore: TopCategoriesCustomDateRangeDataStore,
+    private val dateFormatter: DashboardDateRangeFormatter,
+    getSelectedDateRange: GetSelectedRangeForTopCategories,
+    savedState: SavedStateHandle,
+) : ScopedViewModel(savedState) {
+    private val _selectedDateRange = getSelectedDateRange()
+    val selectedDateRange: LiveData<TopCategoriesDateRange> = combine(
+        _selectedDateRange,
+        customDateRangeDataStore.dateRange
+    ) { selectedRange, customRange ->
+        TopCategoriesDateRange(
+            rangeSelection = selectedRange,
+            customRange = customRange,
+            dateFormatted = dateFormatter.formatRangeDate(selectedRange)
+        )
+    }.asLiveData()
+
+    private var _topCategoriesState = MutableLiveData<TopCategoriesState>()
+    val topCategoriesState: LiveData<TopCategoriesState> = _topCategoriesState
+
+    private var _lastUpdateTopCategories = MutableStateFlow<Long?>(null)
+    val lastUpdateTopCategories: LiveData<String?> = _lastUpdateTopCategories
+        .map { lastUpdateMillis ->
+            if (lastUpdateMillis == null) return@map null
+            String.format(
+                Locale.getDefault(),
+                resourceProvider.getString(R.string.last_update),
+                dateUtils.getDateOrTimeFromMillis(lastUpdateMillis)
+            )
+        }.asLiveData()
+
+    private val refreshTrigger = MutableSharedFlow<RefreshEvent>(extraBufferCapacity = 1)
+
+    init {
+        _topCategoriesState.value = TopCategoriesState(
+            isLoading = true,
+            titleStringRes = DashboardWidget.Type.TOP_CATEGORIES.titleResource,
+            menu = DashboardWidgetMenu(
+                items = listOf(
+                    DashboardWidget.Type.TOP_CATEGORIES.defaultHideMenuEntry {
+                        parentViewModel.onHideWidgetClicked(DashboardWidget.Type.TOP_CATEGORIES)
+                    }
+                )
+            ),
+            onOpenAnalyticsTapped = DashboardWidgetAction(
+                titleResource = R.string.analytics_section_see_all,
+                action = ::onViewAllAnalyticsTapped
+            )
+        )
+
+        viewModelScope.launch {
+            _selectedDateRange.flatMapLatest { selectedRange ->
+                merge(refreshTrigger, parentViewModel.refreshTrigger)
+                    .onStart { emit(RefreshEvent()) }
+                    .map {
+                        Pair(selectedRange, it.isForced)
+                    }
+            }.collectLatest { (selectedRange, isForceRefresh) ->
+                loadTopCategoriesStats(selectedRange, isForceRefresh)
+            }
+        }
+    }
+
+    fun onRangeChanged(selectionType: SelectionType) {
+        usageTracksEventEmitter.interacted()
+        if (selectionType != SelectionType.CUSTOM) {
+            parentViewModel.trackCardInteracted(DashboardWidget.Type.TOP_CATEGORIES.trackingIdentifier)
+            appPrefsWrapper.setActiveTopCategoriesTab(selectionType.name)
+        } else {
+            when {
+                selectedDateRange.value?.customRange == null -> onEditCustomRangeTapped()
+                else -> {
+                    parentViewModel.trackCardInteracted(DashboardWidget.Type.TOP_CATEGORIES.trackingIdentifier)
+                    appPrefsWrapper.setActiveTopCategoriesTab(SelectionType.CUSTOM.name)
+                }
+            }
+        }
+    }
+
+    fun onEditCustomRangeTapped() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.TOP_CATEGORIES.trackingIdentifier)
+        if (selectedDateRange.value?.customRange == null) {
+            analyticsTrackerWrapper.track(AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_ADD_BUTTON_TAPPED)
+        } else {
+            analyticsTrackerWrapper.track(AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_EDIT_BUTTON_TAPPED)
+        }
+
+        triggerEvent(
+            OpenDatePicker(
+                fromDate = selectedDateRange.value?.customRange?.start ?: Date(),
+                toDate = selectedDateRange.value?.customRange?.end ?: Date()
+            )
+        )
+    }
+
+    fun onRefresh() {
+        trackEventForTopCategoriesCard(AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_RETRY_TAPPED)
+        refreshTrigger.tryEmit(RefreshEvent(isForced = true))
+    }
+
+    private fun onTopCategoryTapped(categoryId: Long) {
+        val categoryName = _topCategoriesState.value?.topCategories
+            ?.firstOrNull { it.categoryId == categoryId }?.name.orEmpty()
+        val rangeSelection = selectedDateRange.value?.rangeSelection
+        if (rangeSelection != null) {
+            triggerEvent(OpenCategoryProducts(categoryId, categoryName, rangeSelection))
+        }
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.TOP_CATEGORIES.trackingIdentifier)
+        usageTracksEventEmitter.interacted()
+    }
+
+    private suspend fun loadTopCategoriesStats(selectedRange: StatsTimeRangeSelection, forceRefresh: Boolean) =
+        coroutineScope {
+            if (!networkStatus.isConnected()) {
+                parentViewModel.hideRefreshingIndicator()
+                _topCategoriesState.value = _topCategoriesState.value?.copy(
+                    error = ErrorType.Generic,
+                    isOutdated = false
+                )
+                return@coroutineScope
+            }
+
+            trackEventForTopCategoriesCard(AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_DATA_LOADING_STARTED)
+            getTopPerformerCategories(selectedRange, forceRefresh).collect { result ->
+                when (result) {
+                    is GetTopPerformerCategories.TopPerformerCategoryResult.Error -> {
+                        parentViewModel.hideRefreshingIndicator()
+                        _topCategoriesState.value = _topCategoriesState.value?.copy(
+                            error = if (
+                                (result.exception as? WooException)?.error?.type == WooErrorType.API_NOT_FOUND
+                            ) {
+                                ErrorType.WCAnalyticsInactive
+                            } else {
+                                ErrorType.Generic
+                            },
+                            isLoading = false
+                        )
+                        trackEventForTopCategoriesCard(
+                            AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_DATA_LOADING_FAILED,
+                            properties = mapOf(
+                                AnalyticsTracker.KEY_ERROR to topCategoriesState.value?.error.toString()
+                            )
+                        )
+                    }
+
+                    is GetTopPerformerCategories.TopPerformerCategoryResult.Success -> {
+                        trackEventForTopCategoriesCard(AnalyticsEvent.DYNAMIC_DASHBOARD_CARD_DATA_LOADING_COMPLETED)
+                        if (_topCategoriesState.value?.isOutdated != true && result.topCategories.isOutdated) {
+                            parentViewModel.displayRefreshingIndicator()
+                        } else {
+                            parentViewModel.hideRefreshingIndicator()
+                        }
+                        _topCategoriesState.value = _topCategoriesState.value?.copy(
+                            isLoading = false,
+                            isOutdated = result.topCategories.isOutdated,
+                            topCategories = result.topCategories.value.toTopCategoriesUiList(),
+                        )
+                    }
+
+                    is GetTopPerformerCategories.TopPerformerCategoryResult.Loading -> {
+                        parentViewModel.hideRefreshingIndicator()
+                        _topCategoriesState.value = _topCategoriesState.value?.copy(isLoading = true)
+                    }
+                }
+            }
+
+            launch {
+                observeLastUpdate(
+                    selectedRange,
+                    AnalyticData.TOP_PERFORMER_CATEGORIES
+                ).collect { lastUpdateMillis -> _lastUpdateTopCategories.value = lastUpdateMillis }
+            }
+        }
+
+    private fun List<TopPerformerCategory>.toTopCategoriesUiList() = map { it.toTopCategoriesUiModel() }
+
+    private fun TopPerformerCategory.toTopCategoriesUiModel() =
+        TopPerformerCategoryUiModel(
+            categoryId = categoryId,
+            name = StringEscapeUtils.unescapeHtml4(name),
+            timesOrdered = FormatUtils.formatDecimal(quantity),
+            netSales = resourceProvider.getString(
+                R.string.dashboard_top_performers_net_sales,
+                getTotalSpendFormatted(total.toBigDecimal(), currency)
+            ),
+            onClick = ::onTopCategoryTapped
+        )
+
+    private fun getTotalSpendFormatted(totalSpend: BigDecimal, currency: String) =
+        currencyFormatter.formatCurrency(
+            totalSpend,
+            wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode ?: currency
+        )
+
+    fun onCustomRangeSelected(statsTimeRange: StatsTimeRange) {
+        analyticsTrackerWrapper.track(
+            AnalyticsEvent.DASHBOARD_STATS_CUSTOM_RANGE_CONFIRMED,
+            mapOf(
+                AnalyticsTracker.KEY_IS_EDITING to (selectedDateRange.value?.customRange != null),
+            )
+        )
+        viewModelScope.launch {
+            customDateRangeDataStore.updateDateRange(statsTimeRange)
+            if (selectedDateRange.value?.rangeSelection?.selectionType != SelectionType.CUSTOM) {
+                appPrefsWrapper.setActiveTopCategoriesTab(SelectionType.CUSTOM.name)
+            }
+        }
+    }
+
+    private fun onViewAllAnalyticsTapped() {
+        parentViewModel.trackCardInteracted(DashboardWidget.Type.TOP_CATEGORIES.trackingIdentifier)
+        AnalyticsTracker.track(AnalyticsEvent.DASHBOARD_SEE_MORE_ANALYTICS_TAPPED)
+        selectedDateRange.value?.let {
+            triggerEvent(OpenAnalytics(it.rangeSelection))
+        }
+    }
+
+    private fun trackEventForTopCategoriesCard(event: AnalyticsEvent, properties: Map<String, Any> = emptyMap()) {
+        analyticsTrackerWrapper.track(
+            event,
+            properties + mapOf(AnalyticsTracker.KEY_TYPE to DashboardWidget.Type.TOP_CATEGORIES.trackingIdentifier)
+        )
+    }
+
+    data class TopCategoriesDateRange(
+        val rangeSelection: StatsTimeRangeSelection,
+        val customRange: StatsTimeRange?,
+        val dateFormatted: String
+    )
+
+    data class TopCategoriesState(
+        val isLoading: Boolean = false,
+        val error: ErrorType? = null,
+        @StringRes val titleStringRes: Int,
+        val topCategories: List<TopPerformerCategoryUiModel> = emptyList(),
+        val menu: DashboardWidgetMenu,
+        val onOpenAnalyticsTapped: DashboardWidgetAction,
+        val isOutdated: Boolean = false,
+    )
+
+    enum class ErrorType {
+        Generic, WCAnalyticsInactive
+    }
+
+    data class OpenCategoryProducts(
+        val categoryId: Long,
+        val categoryName: String,
+        val rangeSelection: StatsTimeRangeSelection
+    ) : MultiLiveEvent.Event()
+
+    data class OpenDatePicker(val fromDate: Date, val toDate: Date) : MultiLiveEvent.Event()
+    data class OpenAnalytics(val analyticsPeriod: StatsTimeRangeSelection) : MultiLiveEvent.Event()
+
+    @AssistedFactory
+    interface Factory {
+        fun create(parentViewModel: DashboardViewModel): DashboardTopCategoriesViewModel
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/DashboardTopCategoriesWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/DashboardTopCategoriesWidgetCard.kt
@@ -58,6 +58,8 @@ import java.util.Date
 import java.util.Locale
 
 const val DASHBOARD_TOP_CATEGORIES_CARD = "dashboard_top_categories_card"
+private val ITEMS_SOLD_COLUMN_WIDTH = 72.dp
+private val NET_SALES_COLUMN_WIDTH = 96.dp
 
 @Composable
 fun DashboardTopCategoriesWidgetCard(
@@ -200,17 +202,20 @@ private fun TopCategoriesContent(
                 fontWeight = FontWeight.SemiBold,
             )
             Text(
-                modifier = Modifier.padding(end = 16.dp),
+                modifier = Modifier.width(ITEMS_SOLD_COLUMN_WIDTH),
                 text = stringResource(id = R.string.dashboard_top_categories_items_sold),
                 style = MaterialTheme.typography.body2,
                 color = colorResource(id = R.color.color_on_surface_medium_selector),
                 fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.End,
             )
             Text(
+                modifier = Modifier.width(NET_SALES_COLUMN_WIDTH),
                 text = stringResource(id = R.string.dashboard_top_categories_net_sales),
                 style = MaterialTheme.typography.body2,
                 color = colorResource(id = R.color.color_on_surface_medium_selector),
                 fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.End,
             )
         }
         when {
@@ -315,12 +320,13 @@ private fun TopCategoryCategoryItem(
                 overflow = TextOverflow.Ellipsis
             )
             Text(
-                modifier = Modifier.padding(start = 8.dp, end = 16.dp),
+                modifier = Modifier.width(ITEMS_SOLD_COLUMN_WIDTH),
                 text = topCategory.timesOrdered,
                 style = MaterialTheme.typography.subtitle1,
                 textAlign = TextAlign.End
             )
             Text(
+                modifier = Modifier.width(NET_SALES_COLUMN_WIDTH),
                 text = topCategory.netSales,
                 style = MaterialTheme.typography.subtitle1,
                 textAlign = TextAlign.End

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/DashboardTopCategoriesWidgetCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/DashboardTopCategoriesWidgetCard.kt
@@ -1,0 +1,454 @@
+package com.woocommerce.android.ui.dashboard.topcategories
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.woocommerce.android.R
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.compose.animations.SkeletonView
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.rememberNavController
+import com.woocommerce.android.ui.dashboard.DashboardDateRangeHeader
+import com.woocommerce.android.ui.dashboard.DashboardFragmentDirections
+import com.woocommerce.android.ui.dashboard.DashboardViewModel
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetAction
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetMenu
+import com.woocommerce.android.ui.dashboard.TopPerformerCategoryUiModel
+import com.woocommerce.android.ui.dashboard.WCAnalyticsNotAvailableErrorView
+import com.woocommerce.android.ui.dashboard.WidgetCard
+import com.woocommerce.android.ui.dashboard.WidgetError
+import com.woocommerce.android.ui.dashboard.topcategories.DashboardTopCategoriesViewModel.OpenAnalytics
+import com.woocommerce.android.ui.dashboard.topcategories.DashboardTopCategoriesViewModel.OpenCategoryProducts
+import com.woocommerce.android.ui.dashboard.topcategories.DashboardTopCategoriesViewModel.OpenDatePicker
+import com.woocommerce.android.ui.dashboard.topcategories.DashboardTopCategoriesViewModel.TopCategoriesDateRange
+import com.woocommerce.android.ui.dashboard.topcategories.DashboardTopCategoriesViewModel.TopCategoriesState
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.commons.stats.StatsTimeRange
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+const val DASHBOARD_TOP_CATEGORIES_CARD = "dashboard_top_categories_card"
+
+@Composable
+fun DashboardTopCategoriesWidgetCard(
+    parentViewModel: DashboardViewModel,
+    modifier: Modifier = Modifier,
+    topCategoriesViewModel: DashboardTopCategoriesViewModel = hiltViewModel(
+        creationCallback = { factory: DashboardTopCategoriesViewModel.Factory ->
+            factory.create(parentViewModel)
+        }
+    )
+) {
+    topCategoriesViewModel.topCategoriesState.observeAsState().value?.let { topCategoriesState ->
+        val lastUpdateState by topCategoriesViewModel.lastUpdateTopCategories.observeAsState()
+        val selectedDateRange by topCategoriesViewModel.selectedDateRange.observeAsState()
+        WidgetCard(
+            titleResource = topCategoriesState.titleStringRes,
+            menu = topCategoriesState.menu,
+            button = topCategoriesState.onOpenAnalyticsTapped,
+            modifier = modifier.testTag(DASHBOARD_TOP_CATEGORIES_CARD),
+            isError = topCategoriesState.error != null
+        ) {
+            when {
+                topCategoriesState.error != null -> TopCategoriesErrorView(
+                    errorType = topCategoriesState.error,
+                    onContactSupportClicked = parentViewModel::onContactSupportClicked,
+                    onRetryClicked = topCategoriesViewModel::onRefresh
+                )
+
+                else -> DashboardTopCategoriesContent(
+                    topCategoriesState = topCategoriesState,
+                    selectedDateRange = selectedDateRange,
+                    lastUpdateState = lastUpdateState,
+                    onTabSelected = topCategoriesViewModel::onRangeChanged,
+                    onEditCustomRangeTapped = topCategoriesViewModel::onEditCustomRangeTapped
+                )
+            }
+        }
+    }
+
+    val openDatePicker = { start: Long, end: Long, callback: (Long, Long) -> Unit ->
+        parentViewModel.onDashboardWidgetEvent(
+            OpenRangePicker(start, end, callback)
+        )
+    }
+    HandleEvents(
+        topCategoriesViewModel.event,
+        openDatePicker = { fromDate, toDate ->
+            openDatePicker(fromDate, toDate) { from, to ->
+                topCategoriesViewModel.onCustomRangeSelected(StatsTimeRange(Date(from), Date(to)))
+            }
+        }
+    )
+}
+
+@Composable
+fun DashboardTopCategoriesContent(
+    topCategoriesState: TopCategoriesState?,
+    selectedDateRange: TopCategoriesDateRange?,
+    lastUpdateState: String?,
+    onTabSelected: (SelectionType) -> Unit,
+    onEditCustomRangeTapped: () -> Unit,
+) {
+    Column {
+        selectedDateRange?.let {
+            DashboardDateRangeHeader(
+                rangeSelection = it.rangeSelection,
+                dateFormatted = it.dateFormatted,
+                onCustomRangeClick = onEditCustomRangeTapped,
+                onTabSelected = onTabSelected
+            )
+        }
+        Divider(modifier = Modifier.padding(bottom = 16.dp))
+
+        when {
+            topCategoriesState?.isLoading == true -> TopCategoriesLoading(
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            else -> {
+                TopCategoriesContent(
+                    topCategoriesState = topCategoriesState,
+                    lastUpdateState = lastUpdateState
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HandleEvents(
+    event: LiveData<Event>,
+    openDatePicker: (Long, Long) -> Unit,
+) {
+    val navController = rememberNavController()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(event, navController, lifecycleOwner) {
+        val observer = Observer { event: Event ->
+            when (event) {
+                is OpenCategoryProducts -> {
+                    navController.navigateSafely(
+                        DashboardFragmentDirections.actionDashboardToCategoryProductsFragment(
+                            categoryId = event.categoryId,
+                            categoryName = event.categoryName,
+                            startDateMillis = event.rangeSelection.currentRange.start.time,
+                            endDateMillis = event.rangeSelection.currentRange.end.time
+                        )
+                    )
+                }
+
+                is OpenDatePicker -> openDatePicker(event.fromDate.time, event.toDate.time)
+                is OpenAnalytics -> {
+                    navController.navigateSafely(
+                        DashboardFragmentDirections.actionDashboardToAnalytics(event.analyticsPeriod)
+                    )
+                }
+            }
+        }
+        event.observe(lifecycleOwner, observer)
+        onDispose {
+            event.removeObserver(observer)
+        }
+    }
+}
+
+@Composable
+private fun TopCategoriesContent(
+    topCategoriesState: TopCategoriesState?,
+    lastUpdateState: String?,
+) {
+    Column {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp)
+        ) {
+            Text(
+                modifier = Modifier.weight(1f),
+                text = stringResource(id = R.string.category),
+                style = MaterialTheme.typography.body2,
+                color = colorResource(id = R.color.color_on_surface_medium_selector),
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                modifier = Modifier.padding(end = 16.dp),
+                text = stringResource(id = R.string.dashboard_top_categories_items_sold),
+                style = MaterialTheme.typography.body2,
+                color = colorResource(id = R.color.color_on_surface_medium_selector),
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = stringResource(id = R.string.dashboard_top_categories_net_sales),
+                style = MaterialTheme.typography.body2,
+                color = colorResource(id = R.color.color_on_surface_medium_selector),
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        when {
+            topCategoriesState?.topCategories.isNullOrEmpty() -> TopCategoriesEmptyView()
+            else -> TopCategoryCategoryList(
+                topCategories = topCategoriesState.topCategories,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+        }
+
+        if (!lastUpdateState.isNullOrEmpty()) {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .align(Alignment.CenterHorizontally),
+                text = lastUpdateState,
+                style = MaterialTheme.typography.body2,
+                color = colorResource(id = R.color.color_on_surface_medium_selector),
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun TopCategoryCategoryList(
+    topCategories: List<TopPerformerCategoryUiModel>,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        topCategories.forEachIndexed { index, category ->
+            TopCategoryCategoryItem(
+                topCategory = category,
+                onItemClicked = category.onClick,
+                displayDivider = index != topCategories.size - 1
+            )
+        }
+    }
+}
+
+@Composable
+private fun TopCategoriesLoading(modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        repeat(5) {
+            TopCategorySkeletonItem()
+            Divider()
+        }
+    }
+}
+
+@Composable
+private fun TopCategorySkeletonItem() {
+    Row(
+        modifier = Modifier
+            .padding(top = 16.dp, bottom = 16.dp)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        SkeletonView(
+            modifier = Modifier
+                .height(14.dp)
+                .weight(1f)
+                .padding(end = 16.dp)
+        )
+        SkeletonView(
+            modifier = Modifier
+                .height(14.dp)
+                .width(50.dp)
+                .padding(end = 16.dp)
+        )
+        SkeletonView(
+            modifier = Modifier
+                .height(14.dp)
+                .width(60.dp)
+        )
+    }
+}
+
+@Composable
+private fun TopCategoryCategoryItem(
+    topCategory: TopPerformerCategoryUiModel,
+    onItemClicked: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+    displayDivider: Boolean
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onItemClicked(topCategory.categoryId) }
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                modifier = Modifier.weight(1f),
+                text = topCategory.name,
+                style = MaterialTheme.typography.subtitle1,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                modifier = Modifier.padding(start = 8.dp, end = 16.dp),
+                text = topCategory.timesOrdered,
+                style = MaterialTheme.typography.subtitle1,
+                textAlign = TextAlign.End
+            )
+            Text(
+                text = topCategory.netSales,
+                style = MaterialTheme.typography.subtitle1,
+                textAlign = TextAlign.End
+            )
+        }
+        if (displayDivider) {
+            Divider(modifier = Modifier.padding(top = 8.dp))
+        }
+    }
+}
+
+@Composable
+private fun TopCategoriesEmptyView(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 32.dp, bottom = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.ic_not_found),
+            contentDescription = "",
+        )
+        Text(
+            modifier = Modifier.padding(top = 24.dp),
+            text = stringResource(id = R.string.dashboard_top_categories_empty),
+            style = MaterialTheme.typography.body2,
+        )
+    }
+}
+
+@Composable
+private fun TopCategoriesErrorView(
+    errorType: DashboardTopCategoriesViewModel.ErrorType,
+    onContactSupportClicked: () -> Unit,
+    onRetryClicked: () -> Unit
+) {
+    when (errorType) {
+        DashboardTopCategoriesViewModel.ErrorType.WCAnalyticsInactive -> {
+            WCAnalyticsNotAvailableErrorView(
+                title = stringResource(id = R.string.dashboard_top_performers_wcanalytics_inactive_title),
+                onContactSupportClick = onContactSupportClicked
+            )
+        }
+        else -> {
+            WidgetError(
+                onContactSupportClicked = onContactSupportClicked,
+                onRetryClicked = onRetryClicked
+            )
+        }
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun TopCategoriesWidgetCardPreview() {
+    val selectedDateRange = TopCategoriesDateRange(
+        SelectionType.TODAY.generateSelectionData(
+            referenceStartDate = Date(),
+            referenceEndDate = Date(),
+            calendar = Calendar.getInstance(),
+            locale = Locale.getDefault(),
+        ),
+        customRange = null,
+        dateFormatted = "Today"
+    )
+    val topCategoriesState = TopCategoriesState(
+        topCategories = listOf(
+            TopPerformerCategoryUiModel(
+                categoryId = 1,
+                name = "Category 1",
+                timesOrdered = "10",
+                netSales = "$100",
+                onClick = {}
+            ),
+            TopPerformerCategoryUiModel(
+                categoryId = 2,
+                name = "Category 2",
+                timesOrdered = "20",
+                netSales = "$200",
+                onClick = {}
+            ),
+            TopPerformerCategoryUiModel(
+                categoryId = 3,
+                name = "Category 3",
+                timesOrdered = "30",
+                netSales = "$300",
+                onClick = {}
+            ),
+        ),
+        isLoading = false,
+        titleStringRes = DashboardWidget.Type.TOP_CATEGORIES.titleResource,
+        menu = DashboardWidgetMenu(emptyList()),
+        onOpenAnalyticsTapped = DashboardWidgetAction(
+            titleResource = R.string.analytics_section_see_all,
+            action = {}
+        )
+    )
+    Column {
+        DashboardTopCategoriesContent(
+            topCategoriesState = topCategoriesState,
+            lastUpdateState = "Last update: 8:52 AM",
+            selectedDateRange = selectedDateRange,
+            onTabSelected = {},
+            onEditCustomRangeTapped = {}
+        )
+        DashboardTopCategoriesContent(
+            topCategoriesState = topCategoriesState.copy(isLoading = true),
+            lastUpdateState = "Last update: 8:52 AM",
+            selectedDateRange = selectedDateRange,
+            onTabSelected = {},
+            onEditCustomRangeTapped = {}
+        )
+        DashboardTopCategoriesContent(
+            topCategoriesState = topCategoriesState.copy(
+                error = DashboardTopCategoriesViewModel.ErrorType.Generic
+            ),
+            lastUpdateState = "Last update: 8:52 AM",
+            selectedDateRange = selectedDateRange,
+            onTabSelected = {},
+            onEditCustomRangeTapped = {}
+        )
+        DashboardTopCategoriesContent(
+            topCategoriesState = topCategoriesState.copy(topCategories = emptyList()),
+            lastUpdateState = "Last update: 8:52 AM",
+            selectedDateRange = selectedDateRange,
+            onTabSelected = {},
+            onEditCustomRangeTapped = {}
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/GetSelectedRangeForTopCategories.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/GetSelectedRangeForTopCategories.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.dashboard.topcategories
+
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.dashboard.data.TopCategoriesCustomDateRangeDataStore
+import com.woocommerce.android.ui.dashboard.domain.GetSelectedDateRange
+import com.woocommerce.android.util.DateUtils
+import javax.inject.Inject
+
+class GetSelectedRangeForTopCategories @Inject constructor(
+    private val appPrefs: AppPrefsWrapper,
+    customDateRangeDataStore: TopCategoriesCustomDateRangeDataStore,
+    dateUtils: DateUtils
+) : GetSelectedDateRange(appPrefs, customDateRangeDataStore, dateUtils) {
+    override fun getSelectedRange(): SelectionType =
+        runCatching {
+            SelectionType.valueOf(appPrefs.getActiveTopCategoriesTab())
+        }.getOrDefault(SelectionType.TODAY)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/categoryproducts/CategoryProductsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/categoryproducts/CategoryProductsFragment.kt
@@ -1,0 +1,69 @@
+package com.woocommerce.android.ui.dashboard.topcategories.categoryproducts
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.extensions.navigateSafely
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.ui.products.details.ProductDetailFragment.Mode.ShowProduct
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class CategoryProductsFragment : BaseFragment() {
+    private val viewModel: CategoryProductsViewModel by viewModels()
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Visible(hasShadow = false)
+
+    override fun getFragmentTitle() =
+        viewModel.state.value?.categoryName ?: ""
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(
+                ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+            )
+            setContent {
+                WooThemeWithBackground {
+                    val state = viewModel.state.observeAsState()
+                    state.value?.let {
+                        CategoryProductsScreen(
+                            state = it,
+                            onRetryClicked = viewModel::onRetryClicked
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is CategoryProductsViewModel.OpenProduct -> {
+                    findNavController().navigateSafely(
+                        NavGraphMainDirections.actionGlobalProductDetailFragment(
+                            mode = ShowProduct(event.productId),
+                        )
+                    )
+                }
+                is MultiLiveEvent.Event -> {}
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/categoryproducts/CategoryProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/categoryproducts/CategoryProductsScreen.kt
@@ -1,0 +1,147 @@
+package com.woocommerce.android.ui.dashboard.topcategories.categoryproducts
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.ProductThumbnail
+import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.dashboard.TopPerformerProductUiModel
+import com.woocommerce.android.ui.dashboard.topcategories.categoryproducts.CategoryProductsViewModel.CategoryProductsState
+
+@Composable
+fun CategoryProductsScreen(
+    state: CategoryProductsState,
+    onRetryClicked: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    when {
+        state.isLoading -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+
+        state.isError -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = stringResource(id = R.string.error_generic),
+                        style = MaterialTheme.typography.body1
+                    )
+                    WCTextButton(onClick = onRetryClicked) {
+                        Text(text = stringResource(id = R.string.retry))
+                    }
+                }
+            }
+        }
+
+        state.products.isEmpty() -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(id = R.string.dashboard_top_categories_empty),
+                    style = MaterialTheme.typography.body1
+                )
+            }
+        }
+
+        else -> {
+            LazyColumn(modifier = modifier.fillMaxSize()) {
+                item {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    ) {
+                        Text(
+                            modifier = Modifier.weight(1f),
+                            text = stringResource(id = R.string.product),
+                            style = MaterialTheme.typography.body2,
+                            color = colorResource(id = R.color.color_on_surface_medium_selector),
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            text = stringResource(id = R.string.dashboard_top_performers_items_sold),
+                            style = MaterialTheme.typography.body2,
+                            color = colorResource(id = R.color.color_on_surface_medium_selector),
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                }
+                itemsIndexed(state.products) { index, product ->
+                    CategoryProductItem(
+                        product = product,
+                        displayDivider = index != state.products.size - 1
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryProductItem(
+    product: TopPerformerProductUiModel,
+    modifier: Modifier = Modifier,
+    displayDivider: Boolean
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { product.onClick(product.productId) }
+            .padding(start = 16.dp, end = 16.dp, top = 8.dp),
+    ) {
+        ProductThumbnail(
+            imageUrl = product.imageUrl ?: "",
+            contentDescription = stringResource(id = R.string.product_image_content_description),
+        )
+        Column(modifier = Modifier.padding(start = 8.dp)) {
+            Row(modifier = Modifier.padding(bottom = 4.dp, end = 16.dp)) {
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = product.name,
+                    style = MaterialTheme.typography.subtitle1,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = product.timesOrdered,
+                    style = MaterialTheme.typography.subtitle1,
+                )
+            }
+            Text(
+                text = product.netSales,
+                style = MaterialTheme.typography.body2,
+                color = colorResource(id = R.color.color_on_surface_medium_selector)
+            )
+            if (displayDivider) {
+                Divider(modifier = Modifier.padding(top = 8.dp))
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/categoryproducts/CategoryProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topcategories/categoryproducts/CategoryProductsViewModel.kt
@@ -1,0 +1,126 @@
+package com.woocommerce.android.ui.dashboard.topcategories.categoryproducts
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.dashboard.TopPerformerProductUiModel
+import com.woocommerce.android.ui.dashboard.domain.GetProductsByCategory
+import com.woocommerce.android.ui.dashboard.domain.GetTopPerformers.TopPerformerProduct
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.commons.stats.StatsTimeRange
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.apache.commons.text.StringEscapeUtils
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import org.wordpress.android.util.FormatUtils
+import org.wordpress.android.util.PhotonUtils
+import java.math.BigDecimal
+import java.util.Date
+import javax.inject.Inject
+
+@HiltViewModel
+class CategoryProductsViewModel @Inject constructor(
+    private val getProductsByCategory: GetProductsByCategory,
+    private val networkStatus: NetworkStatus,
+    private val resourceProvider: ResourceProvider,
+    private val currencyFormatter: CurrencyFormatter,
+    private val wooCommerceStore: WooCommerceStore,
+    private val selectedSite: SelectedSite,
+    savedState: SavedStateHandle,
+) : ScopedViewModel(savedState) {
+    private val categoryId: Long = savedState["categoryId"] ?: 0L
+    private val categoryName: String = savedState["categoryName"] ?: ""
+    private val startDateMillis: Long = savedState["startDateMillis"] ?: 0L
+    private val endDateMillis: Long = savedState["endDateMillis"] ?: 0L
+
+    private val _state = MutableStateFlow(
+        CategoryProductsState(
+            categoryName = categoryName,
+            isLoading = true
+        )
+    )
+    val state = _state.asLiveData()
+
+    init {
+        loadProducts()
+    }
+
+    private fun loadProducts() {
+        viewModelScope.launch {
+            if (!networkStatus.isConnected()) {
+                _state.update { it.copy(isLoading = false, isError = true) }
+                return@launch
+            }
+
+            _state.update { it.copy(isLoading = true, isError = false) }
+
+            val range = StatsTimeRange(
+                Date(startDateMillis),
+                Date(endDateMillis)
+            )
+            getProductsByCategory(range, categoryId).fold(
+                onSuccess = { products ->
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            products = products.map { product -> product.toUiModel() }
+                        )
+                    }
+                },
+                onFailure = {
+                    _state.update { it.copy(isLoading = false, isError = true) }
+                }
+            )
+        }
+    }
+
+    fun onRetryClicked() {
+        loadProducts()
+    }
+
+    private fun onProductTapped(productId: Long) {
+        triggerEvent(OpenProduct(productId))
+    }
+
+    private fun TopPerformerProduct.toUiModel() =
+        TopPerformerProductUiModel(
+            productId = productId,
+            name = StringEscapeUtils.unescapeHtml4(name),
+            timesOrdered = FormatUtils.formatDecimal(quantity),
+            netSales = resourceProvider.getString(
+                R.string.dashboard_top_performers_net_sales,
+                getTotalSpendFormatted(total.toBigDecimal(), currency)
+            ),
+            imageUrl = imageUrl?.let {
+                PhotonUtils.getPhotonImageUrl(
+                    it,
+                    resourceProvider.getDimensionPixelSize(R.dimen.image_minor_100),
+                    0
+                )
+            },
+            onClick = ::onProductTapped
+        )
+
+    private fun getTotalSpendFormatted(totalSpend: BigDecimal, currency: String) =
+        currencyFormatter.formatCurrency(
+            totalSpend,
+            wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode ?: currency
+        )
+
+    data class CategoryProductsState(
+        val categoryName: String = "",
+        val isLoading: Boolean = false,
+        val isError: Boolean = false,
+        val products: List<TopPerformerProductUiModel> = emptyList()
+    )
+
+    data class OpenProduct(val productId: Long) : MultiLiveEvent.Event()
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -90,6 +90,9 @@
         <action
             android:id="@+id/action_dashboard_to_wooPushNotificationsIntroductionDialog"
             app:destination="@id/nav_graph_push_notifications" />
+        <action
+            android:id="@+id/action_dashboard_to_categoryProductsFragment"
+            app:destination="@id/categoryProductsFragment" />
     </fragment>
     <fragment
         android:id="@+id/orders"
@@ -639,6 +642,23 @@
         android:id="@+id/inboxFragment"
         android:name="com.woocommerce.android.ui.inbox.InboxFragment"
         android:label="InboxFragment" />
+    <fragment
+        android:id="@+id/categoryProductsFragment"
+        android:name="com.woocommerce.android.ui.dashboard.topcategories.categoryproducts.CategoryProductsFragment"
+        android:label="CategoryProductsFragment">
+        <argument
+            android:name="categoryId"
+            app:argType="long" />
+        <argument
+            android:name="categoryName"
+            app:argType="string" />
+        <argument
+            android:name="startDateMillis"
+            app:argType="long" />
+        <argument
+            android:name="endDateMillis"
+            app:argType="long" />
+    </fragment>
     <fragment
         android:id="@+id/simpleTextEditorFragment"
         android:name="com.woocommerce.android.ui.common.texteditor.SimpleTextEditorFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -360,6 +360,12 @@
     <string name="dashboard_top_performers_net_sales">Net sales: %s</string>
     <string name="dashboard_top_performers_wcanalytics_inactive_title">Unable to load the top performers</string>
 
+    <string name="category">Category</string>
+    <string name="dashboard_top_categories_items_sold">Items sold</string>
+    <string name="dashboard_top_categories_net_sales">Net sales</string>
+    <string name="dashboard_top_categories_empty">No categories found</string>
+    <string name="dashboard_top_categories_products_title">Products in %s</string>
+
     <string name="dashboard_action_view_all_orders">View all orders</string>
 
     <string name="dashboard_action_view_all_messages">View all messages</string>
@@ -383,6 +389,7 @@
     <string name="my_store_widget_onboarding_title">Store setup</string>
     <string name="my_store_widget_stats_title">Performance</string>
     <string name="my_store_widget_top_products_title">Top performers</string>
+    <string name="my_store_widget_top_categories_title">Top categories</string>
     <string name="my_store_widget_blaze_title">Blaze campaigns</string>
     <string name="my_store_widget_orders_title">Most recent orders</string>
     <string name="my_store_widget_reviews_title">Most recent reviews</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/topcategories/DashboardTopCategoriesViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/topcategories/DashboardTopCategoriesViewModelTest.kt
@@ -1,0 +1,277 @@
+package com.woocommerce.android.ui.dashboard.topcategories
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
+import com.woocommerce.android.ui.dashboard.DashboardStatsUsageTracksEventEmitter
+import com.woocommerce.android.ui.dashboard.DashboardViewModel
+import com.woocommerce.android.ui.dashboard.data.TopCategoriesCustomDateRangeDataStore
+import com.woocommerce.android.ui.dashboard.domain.DashboardDateRangeFormatter
+import com.woocommerce.android.ui.dashboard.domain.GetTopPerformerCategories
+import com.woocommerce.android.ui.dashboard.domain.GetTopPerformerCategories.TopPerformerCategory
+import com.woocommerce.android.ui.dashboard.domain.GetTopPerformerCategories.TopPerformerCategoryResult
+import com.woocommerce.android.ui.dashboard.domain.ObserveLastUpdate
+import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.DateUtils
+import com.woocommerce.android.util.ResultWithOutdatedFlag
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.commons.stats.StatsTimeRange
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyVararg
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DashboardTopCategoriesViewModelTest : BaseUnitTest() {
+
+    private val sampleCategories = listOf(
+        TopPerformerCategory(
+            categoryId = 1L,
+            name = "Clothing",
+            quantity = 10,
+            currency = "USD",
+            total = 100.0
+        ),
+        TopPerformerCategory(
+            categoryId = 2L,
+            name = "Electronics",
+            quantity = 5,
+            currency = "USD",
+            total = 250.0
+        )
+    )
+
+    private val parentViewModel: DashboardViewModel = mock {
+        on { refreshTrigger } doReturn MutableSharedFlow()
+    }
+    private val networkStatus: NetworkStatus = mock {
+        on { isConnected() } doReturn true
+    }
+    private val observeLastUpdate: ObserveLastUpdate = mock {
+        on {
+            invoke(any(), any<com.woocommerce.android.ui.analytics.hub.sync.AnalyticsUpdateDataStore.AnalyticData>())
+        } doReturn flowOf(null)
+    }
+    private val resourceProvider: ResourceProvider = mock()
+    private val getTopPerformerCategories: GetTopPerformerCategories = mock()
+    private val currencyFormatter: CurrencyFormatter = mock()
+    private val usageTracksEventEmitter: DashboardStatsUsageTracksEventEmitter = mock()
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val wooCommerceStore: WooCommerceStore = mock()
+    private val dateUtils: DateUtils = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { get() } doReturn SiteModel()
+    }
+    private val appPrefFlow = MutableStateFlow(SelectionType.TODAY.name)
+    private val appPrefsWrapper: AppPrefsWrapper = mock {
+        on { getActiveTopCategoriesTab() } doAnswer { appPrefFlow.value }
+        on { observePrefs() } doAnswer { appPrefFlow.map {} }
+    }
+    private val customRangeFlow = MutableStateFlow<StatsTimeRange?>(null)
+    private val customDateRangeDataStore: TopCategoriesCustomDateRangeDataStore = mock {
+        on { dateRange } doReturn customRangeFlow
+    }
+    private val dateFormatter: DashboardDateRangeFormatter = mock {
+        on { formatRangeDate(any()) } doReturn "Today"
+    }
+
+    private lateinit var viewModel: DashboardTopCategoriesViewModel
+
+    private suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
+        whenever(resourceProvider.getString(any(), anyVararg())).thenReturn("")
+        whenever(currencyFormatter.formatCurrency(any<java.math.BigDecimal>(), any(), any())).thenReturn("$100.00")
+        prepareMocks()
+        val getSelectedDateRange = GetSelectedRangeForTopCategories(
+            appPrefs = appPrefsWrapper,
+            customDateRangeDataStore = customDateRangeDataStore,
+            dateUtils = dateUtils
+        )
+
+        viewModel = DashboardTopCategoriesViewModel(
+            parentViewModel = parentViewModel,
+            selectedSite = selectedSite,
+            networkStatus = networkStatus,
+            observeLastUpdate = observeLastUpdate,
+            resourceProvider = resourceProvider,
+            getTopPerformerCategories = getTopPerformerCategories,
+            currencyFormatter = currencyFormatter,
+            usageTracksEventEmitter = usageTracksEventEmitter,
+            analyticsTrackerWrapper = analyticsTrackerWrapper,
+            wooCommerceStore = wooCommerceStore,
+            dateUtils = dateUtils,
+            appPrefsWrapper = appPrefsWrapper,
+            customDateRangeDataStore = customDateRangeDataStore,
+            dateFormatter = dateFormatter,
+            getSelectedDateRange = getSelectedDateRange,
+            savedState = SavedStateHandle()
+        )
+    }
+
+    @Test
+    fun `when view model is created, then loading state is emitted`() = testBlocking {
+        setup {
+            whenever(getTopPerformerCategories.invoke(any(), any())).thenReturn(
+                flowOf(TopPerformerCategoryResult.Loading)
+            )
+        }
+
+        // WHEN
+        val state = viewModel.topCategoriesState.captureValues().last()
+
+        // THEN
+        assertThat(state.isLoading).isTrue()
+    }
+
+    @Test
+    fun `given network disconnected, when loading, then generic error is shown`() = testBlocking {
+        setup {
+            whenever(networkStatus.isConnected()).thenReturn(false)
+        }
+
+        // WHEN
+        val state = viewModel.topCategoriesState.getOrAwaitValue()
+
+        // THEN
+        assertThat(state.error).isEqualTo(DashboardTopCategoriesViewModel.ErrorType.Generic)
+    }
+
+    @Test
+    fun `given successful data fetch, when loading completes, then categories are displayed`() = testBlocking {
+        setup {
+            whenever(getTopPerformerCategories.invoke(any(), any())).thenReturn(
+                flowOf(
+                    TopPerformerCategoryResult.Success(
+                        ResultWithOutdatedFlag(sampleCategories, false)
+                    )
+                )
+            )
+        }
+
+        // WHEN
+        val state = viewModel.topCategoriesState.captureValues().last()
+
+        // THEN
+        assertThat(state.isLoading).isFalse()
+        assertThat(state.error).isNull()
+        assertThat(state.topCategories).hasSize(2)
+        assertThat(state.topCategories[0].categoryId).isEqualTo(1L)
+        assertThat(state.topCategories[1].categoryId).isEqualTo(2L)
+    }
+
+    @Test
+    fun `given empty data, when loading completes, then empty list is shown`() = testBlocking {
+        setup {
+            whenever(getTopPerformerCategories.invoke(any(), any())).thenReturn(
+                flowOf(
+                    TopPerformerCategoryResult.Success(
+                        ResultWithOutdatedFlag(emptyList(), false)
+                    )
+                )
+            )
+        }
+
+        // WHEN
+        val state = viewModel.topCategoriesState.captureValues().last()
+
+        // THEN
+        assertThat(state.isLoading).isFalse()
+        assertThat(state.error).isNull()
+        assertThat(state.topCategories).isEmpty()
+    }
+
+    @Test
+    fun `when category tapped, then OpenCategoryProducts event is triggered`() = testBlocking {
+        setup {
+            whenever(getTopPerformerCategories.invoke(any(), any())).thenReturn(
+                flowOf(
+                    TopPerformerCategoryResult.Success(
+                        ResultWithOutdatedFlag(sampleCategories, false)
+                    )
+                )
+            )
+        }
+
+        // GIVEN
+        viewModel.selectedDateRange.getOrAwaitValue()
+        val state = viewModel.topCategoriesState.getOrAwaitValue()
+        assertThat(state.topCategories).isNotEmpty()
+
+        // WHEN
+        val event = viewModel.event.runAndCaptureValues {
+            state.topCategories.first().onClick(state.topCategories.first().categoryId)
+        }.last()
+
+        // THEN
+        assertThat(event).isInstanceOf(DashboardTopCategoriesViewModel.OpenCategoryProducts::class.java)
+        val openEvent = event as DashboardTopCategoriesViewModel.OpenCategoryProducts
+        assertThat(openEvent.categoryId).isEqualTo(1L)
+        assertThat(openEvent.categoryName).isEqualTo("Clothing")
+    }
+
+    @Test
+    fun `when retry tapped, then refresh is triggered`() = testBlocking {
+        setup {
+            whenever(getTopPerformerCategories.invoke(any(), any())).thenReturn(
+                flowOf(
+                    TopPerformerCategoryResult.Success(
+                        ResultWithOutdatedFlag(sampleCategories, false)
+                    )
+                )
+            )
+        }
+
+        // WHEN
+        viewModel.topCategoriesState.runAndCaptureValues {
+            viewModel.onRefresh()
+        }
+
+        // THEN
+        // The refresh call should trigger the getTopPerformerCategories to be called again
+        // via the refreshTrigger flow. We verify that the state is still valid after refresh.
+        val state = viewModel.topCategoriesState.getOrAwaitValue()
+        assertThat(state).isNotNull()
+    }
+
+    @Test
+    fun `when view all analytics tapped, then OpenAnalytics event is triggered`() = testBlocking {
+        setup {
+            whenever(getTopPerformerCategories.invoke(any(), any())).thenReturn(
+                flowOf(
+                    TopPerformerCategoryResult.Success(
+                        ResultWithOutdatedFlag(sampleCategories, false)
+                    )
+                )
+            )
+        }
+
+        // GIVEN
+        viewModel.selectedDateRange.getOrAwaitValue()
+        val state = viewModel.topCategoriesState.getOrAwaitValue()
+
+        // WHEN
+        val event = viewModel.event.runAndCaptureValues {
+            state.onOpenAnalyticsTapped.action()
+        }.last()
+
+        // THEN
+        assertThat(event).isInstanceOf(DashboardTopCategoriesViewModel.OpenAnalytics::class.java)
+    }
+}


### PR DESCRIPTION
## Description

Adds the UI for the Top Categories dashboard widget, building on the data layer from #15580. The card displays product categories ranked by items sold and net sales, with date range selection (Today/Week/Month/Year/Custom) and drill-down into products within a selected category.

### UI Components
- `DashboardTopCategoriesViewModel` with date range selection and data loading
- `DashboardTopCategoriesWidgetCard` Compose UI with table layout showing category name, items sold, and net sales
- `GetSelectedRangeForTopCategories` for date range persistence
- `CategoryProductsFragment` / `CategoryProductsScreen` / `CategoryProductsViewModel` for drill-down into products within a selected category

### Widget Registration & Wiring
- `TOP_CATEGORIES` added to `DashboardWidget.Type` enum
- Routing in `DashboardContainer` to the card composable
- `DashboardRepository` status mapping
- Navigation graph entries for category products screen
- String resources for the card UI

### Tests
- Unit tests for `DashboardTopCategoriesViewModel`

## Test Steps

1. Open the app and navigate to the "My Store" dashboard
2. Tap the edit (pencil) icon and enable the "Top categories" card
3. Verify the card shows categories with "Items sold" and "Net sales" columns
4. Switch between date ranges (Today/Week/Month/Year)
5. Tap on a category to see products within that category
6. Verify the "View all store analytics" button works
7. Verify the card can be hidden via the overflow menu

## RELEASE-NOTES.txt

- [ ] I have considered whether this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if so.