### PR TITLE
[Hack Week] Add products check to the troubleshooting tool

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -408,9 +408,11 @@ class AnalyticsTracker private constructor(
         const val KEY_DOWNLOADABLE_FILE_ACTION = "action"
 
         // -- Connectivity Tool
-        const val VALUE_INTERNET = "internet"
-        const val VALUE_SITE = "site"
-        const val VALUE_JETPACK_TUNNEL = "jetpack_tunnel"
+        const val KEY_CONNECTIVITY_TEST = "test"
+        const val VALUE_CONNECTIVITY_INTERNET = "internet"
+        const val VALUE_CONNECTIVITY_WP_COM = "wpCom"
+        const val VALUE_CONNECTIVITY_SITE = "site"
+        const val VALUE_CONNECTIVITY_ORDERS = "orders"
         const val VALUE_CONNECTIVITY_PRODUCTS = "products"
 
         enum class DownloadableFileAction(val value: String) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -411,6 +411,7 @@ class AnalyticsTracker private constructor(
         const val VALUE_INTERNET = "internet"
         const val VALUE_SITE = "site"
         const val VALUE_JETPACK_TUNNEL = "jetpack_tunnel"
+        const val VALUE_CONNECTIVITY_PRODUCTS = "products"
 
         enum class DownloadableFileAction(val value: String) {
             ADDED("added"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
@@ -70,6 +70,20 @@ sealed class ConnectivityCheckCardData(
         retryConnectionAction = retryConnectionAction,
         readMoreAction = readMoreAction
     )
+
+    @Parcelize
+    data class StoreProductsConnectivityCheckData(
+        override val connectivityCheckStatus: ConnectivityCheckStatus = NotStarted,
+        @IgnoredOnParcel override val retryConnectionAction: OnRetryConnection? = null,
+        @IgnoredOnParcel override val readMoreAction: OnReadMoreClicked? = null
+    ) : Parcelable, ConnectivityCheckCardData(
+        title = R.string.orderlist_connectivity_tool_store_products_check_title,
+        suggestion = R.string.orderlist_connectivity_tool_generic_error_suggestion,
+        icon = R.drawable.ic_product,
+        connectivityCheckStatus = connectivityCheckStatus,
+        retryConnectionAction = retryConnectionAction,
+        readMoreAction = readMoreAction
+    )
 }
 
 @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolScreen.kt
@@ -42,6 +42,7 @@ import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.InternetConnectivityCheckData
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreConnectivityCheckData
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreOrdersConnectivityCheckData
+import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreProductsConnectivityCheckData
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.WPComConnectivityCheckData
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.Failure
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.InProgress
@@ -60,6 +61,7 @@ fun ConnectivityToolScreen(viewModel: ConnectivityToolViewModel) {
         wpComConnectionCheckData = viewState?.wpComCheckData,
         storeConnectionCheckData = viewState?.storeCheckData,
         storeOrdersCheckData = viewState?.ordersCheckData,
+        storeProductsCheckData = viewState?.productsCheckData,
         isWPComCheckVisible = viewState?.isWPComCheckVisible ?: true,
         onContactSupportClicked = viewModel::onContactSupportClicked,
         onReturnClick = viewModel::onReturnClicked
@@ -74,6 +76,7 @@ fun ConnectivityToolScreen(
     wpComConnectionCheckData: WPComConnectivityCheckData?,
     storeConnectionCheckData: StoreConnectivityCheckData?,
     storeOrdersCheckData: StoreOrdersConnectivityCheckData?,
+    storeProductsCheckData: StoreProductsConnectivityCheckData?,
     isWPComCheckVisible: Boolean,
     onContactSupportClicked: () -> Unit,
     onReturnClick: () -> Unit,
@@ -105,6 +108,7 @@ fun ConnectivityToolScreen(
         }
         ConnectivityCheckCard(storeConnectionCheckData)
         ConnectivityCheckCard(storeOrdersCheckData)
+        ConnectivityCheckCard(storeProductsCheckData)
 
         ConnectivitySummary(
             shouldDisplaySummarySection = shouldDisplaySummarySection,
@@ -323,6 +327,9 @@ fun ConnectivityToolScreenPreview() {
             ),
             storeOrdersCheckData = StoreOrdersConnectivityCheckData(
                 connectivityCheckStatus = InProgress
+            ),
+            storeProductsCheckData = StoreProductsConnectivityCheckData(
+                connectivityCheckStatus = NotStarted
             ),
             isWPComCheckVisible = true,
             onContactSupportClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -229,7 +229,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startProductsCheck() {
         val startTime = System.currentTimeMillis()
         storeProductsCheck().onEach { status ->
-            trackChanges(status, AnalyticsTracker.VALUE_PRODUCTS, startTime)
+            trackChanges(status, AnalyticsTracker.VALUE_CONNECTIVITY_PRODUCTS, startTime)
             status.startNextCheck()
             productsCheckFlow.update {
                 if (status is Failure) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -5,10 +5,12 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_INTERNET
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_JETPACK_TUNNEL
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_SITE
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_WP_COM
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_CONNECTIVITY_TEST
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_ORDERS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_PRODUCTS
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_WP_COM
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_INTERNET
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_SITE
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
@@ -175,7 +177,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startInternetCheck() {
         val startTime = System.currentTimeMillis()
         internetConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_INTERNET, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_INTERNET, startTime)
             status.startNextCheck()
             internetCheckFlow.update { it.copy(connectivityCheckStatus = status) }
         }.launchIn(viewModelScope)
@@ -184,7 +186,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startWPComCheck() {
         val startTime = System.currentTimeMillis()
         wpComConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_WP_COM, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_WP_COM, startTime)
             status.startNextCheck()
             wpComCheckFlow.update { it.copy(connectivityCheckStatus = status) }
         }.launchIn(viewModelScope)
@@ -193,7 +195,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startStoreCheck() {
         val startTime = System.currentTimeMillis()
         storeConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_SITE, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_SITE, startTime)
             status.startNextCheck()
             storeCheckFlow.update {
                 if (status is Failure) {
@@ -211,7 +213,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startStoreOrdersCheck() {
         val startTime = System.currentTimeMillis()
         storeOrdersCheck().onEach { status ->
-            trackChanges(status, VALUE_JETPACK_TUNNEL, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_ORDERS, startTime)
             status.startNextCheck()
             ordersCheckFlow.update {
                 if (status is Failure) {
@@ -229,7 +231,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startProductsCheck() {
         val startTime = System.currentTimeMillis()
         storeProductsCheck().onEach { status ->
-            trackChanges(status, AnalyticsTracker.VALUE_CONNECTIVITY_PRODUCTS, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_PRODUCTS, startTime)
             status.startNextCheck()
             productsCheckFlow.update {
                 if (status is Failure) {
@@ -267,7 +269,7 @@ class ConnectivityToolViewModel @Inject constructor(
             AnalyticsEvent.CONNECTIVITY_TOOL_REQUEST_RESPONSE,
             mapOf(
                 AnalyticsTracker.KEY_SUCCESS to (status is Success),
-                AnalyticsTracker.KEY_TYPE to type,
+                KEY_CONNECTIVITY_TEST to type,
                 AnalyticsTracker.KEY_TIME_TAKEN to (System.currentTimeMillis() - startTime)
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.InternetConnectivityCheckData
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreConnectivityCheckData
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreOrdersConnectivityCheckData
+import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreProductsConnectivityCheckData
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.WPComConnectivityCheckData
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.Failure
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.InProgress
@@ -24,10 +25,12 @@ import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.Con
 import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.ConnectivityCheckStep.InternetCheck
 import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.ConnectivityCheckStep.StoreCheck
 import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.ConnectivityCheckStep.StoreOrdersCheck
+import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.ConnectivityCheckStep.StoreProductsCheck
 import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.ConnectivityCheckStep.WPComCheck
 import com.woocommerce.android.ui.connectivitytool.useCases.InternetConnectionCheckUseCase
 import com.woocommerce.android.ui.connectivitytool.useCases.StoreConnectionCheckUseCase
 import com.woocommerce.android.ui.connectivitytool.useCases.StoreOrdersCheckUseCase
+import com.woocommerce.android.ui.connectivitytool.useCases.StoreProductsCheckUseCase
 import com.woocommerce.android.ui.connectivitytool.useCases.WPComConnectionCheckUseCase
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -49,6 +52,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private val wpComConnectionCheck: WPComConnectionCheckUseCase,
     private val storeConnectionCheck: StoreConnectionCheckUseCase,
     private val storeOrdersCheck: StoreOrdersCheckUseCase,
+    private val storeProductsCheck: StoreProductsCheckUseCase,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val selectedSite: SelectedSite,
     savedState: SavedStateHandle
@@ -88,17 +92,26 @@ class ConnectivityToolViewModel @Inject constructor(
         )
     )
 
+    private val productsCheckFlow = savedState.getStateFlow(
+        scope = viewModelScope,
+        initialValue = StoreProductsConnectivityCheckData(
+            retryConnectionAction = { handleRetryConnectionClick(StoreProductsCheck) }
+        )
+    )
+
     val viewState = combine(
         internetCheckFlow,
         wpComCheckFlow,
         storeCheckFlow,
-        ordersCheckFlow
-    ) { internet, wpCom, store, orders ->
+        ordersCheckFlow,
+        productsCheckFlow
+    ) { internet, wpCom, store, orders, products ->
         ViewState(
             internetCheckData = internet,
             wpComCheckData = wpCom,
             storeCheckData = store,
             ordersCheckData = orders,
+            productsCheckData = products,
             isWPComCheckVisible = !isAppPasswordSite
         )
     }.distinctUntilChanged().asLiveData()
@@ -110,7 +123,8 @@ class ConnectivityToolViewModel @Inject constructor(
             InternetCheck -> if (isAppPasswordSite) StoreCheck else WPComCheck
             WPComCheck -> StoreCheck
             StoreCheck -> StoreOrdersCheck
-            StoreOrdersCheck -> Finished
+            StoreOrdersCheck -> StoreProductsCheck
+            StoreProductsCheck -> Finished
             Finished -> error("Cannot move to next state from Finished")
         }
 
@@ -122,6 +136,7 @@ class ConnectivityToolViewModel @Inject constructor(
                     WPComCheck -> startWPComCheck()
                     StoreCheck -> startStoreCheck()
                     StoreOrdersCheck -> startStoreOrdersCheck()
+                    StoreProductsCheck -> startProductsCheck()
                     Finished -> { /* No-op */ }
                 }
             }
@@ -143,6 +158,7 @@ class ConnectivityToolViewModel @Inject constructor(
             WPComCheck -> wpComCheckFlow.update { it.copy(connectivityCheckStatus = NotStarted) }
             StoreCheck -> storeCheckFlow.update { it.copy(connectivityCheckStatus = NotStarted) }
             StoreOrdersCheck -> ordersCheckFlow.update { it.copy(connectivityCheckStatus = NotStarted) }
+            StoreProductsCheck -> productsCheckFlow.update { it.copy(connectivityCheckStatus = NotStarted) }
             Finished -> { /* No-op */ }
         }
         stateMachine.update { step }
@@ -210,6 +226,24 @@ class ConnectivityToolViewModel @Inject constructor(
         }.launchIn(viewModelScope)
     }
 
+    private fun startProductsCheck() {
+        val startTime = System.currentTimeMillis()
+        storeProductsCheck().onEach { status ->
+            trackChanges(status, AnalyticsTracker.VALUE_PRODUCTS, startTime)
+            status.startNextCheck()
+            productsCheckFlow.update {
+                if (status is Failure) {
+                    it.copy(
+                        connectivityCheckStatus = status,
+                        readMoreAction = { handleReadMoreClick(status.error ?: FailureType.GENERIC) }
+                    )
+                } else {
+                    it.copy(connectivityCheckStatus = status)
+                }
+            }
+        }.launchIn(viewModelScope)
+    }
+
     private fun ConnectivityCheckStatus.startNextCheck() {
         if (stateMachine.value == Finished) return
 
@@ -247,13 +281,15 @@ class ConnectivityToolViewModel @Inject constructor(
         val wpComCheckData: WPComConnectivityCheckData,
         val storeCheckData: StoreConnectivityCheckData,
         val ordersCheckData: StoreOrdersConnectivityCheckData,
+        val productsCheckData: StoreProductsConnectivityCheckData,
         val isWPComCheckVisible: Boolean
     ) {
         val shouldDisplaySummary: Boolean
             get() = internetCheckData.connectivityCheckStatus is Success &&
                 (wpComCheckData.connectivityCheckStatus is Success || !isWPComCheckVisible) &&
                 storeCheckData.connectivityCheckStatus is Success &&
-                ordersCheckData.connectivityCheckStatus is Success
+                ordersCheckData.connectivityCheckStatus is Success &&
+                productsCheckData.connectivityCheckStatus is Success
     }
 
     enum class ConnectivityCheckStep {
@@ -261,6 +297,7 @@ class ConnectivityToolViewModel @Inject constructor(
         WPComCheck,
         StoreCheck,
         StoreOrdersCheck,
+        StoreProductsCheck,
         Finished
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -6,11 +6,11 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_CONNECTIVITY_TEST
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_INTERNET
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_ORDERS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_PRODUCTS
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_WP_COM
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_INTERNET
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_SITE
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_WP_COM
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCase.kt
@@ -1,0 +1,41 @@
+package com.woocommerce.android.ui.connectivitytool.useCases
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus
+import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.Failure
+import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.InProgress
+import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.Success
+import com.woocommerce.android.ui.connectivitytool.FailureType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WCProductStore
+import javax.inject.Inject
+
+class StoreProductsCheckUseCase @Inject constructor(
+    private val productStore: WCProductStore,
+    private val selectedSite: SelectedSite
+) {
+    private val isAppPasswordSite: Boolean
+        get() = selectedSite.connectionType == SiteConnectionType.ApplicationPasswords
+
+    operator fun invoke(): Flow<ConnectivityCheckStatus> = flow {
+        emit(InProgress)
+        productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true)
+            .takeIf { it.isError }
+            ?.parseError()
+            ?.let { emit(it) }
+            ?: emit(Success)
+    }
+
+    private fun WooResult<Boolean>.parseError() =
+        when (error.type) {
+            WooErrorType.TIMEOUT -> Failure(FailureType.TIMEOUT)
+            WooErrorType.INVALID_RESPONSE -> Failure(FailureType.PARSE)
+            WooErrorType.API_NOT_FOUND ->
+                if (isAppPasswordSite) Failure(FailureType.GENERIC) else Failure(FailureType.JETPACK)
+            else -> Failure(FailureType.GENERIC)
+        }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCase.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.Succe
 import com.woocommerce.android.ui.connectivitytool.FailureType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCProductStore
@@ -23,14 +24,14 @@ class StoreProductsCheckUseCase @Inject constructor(
 
     operator fun invoke(): Flow<ConnectivityCheckStatus> = flow {
         emit(InProgress)
-        productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true)
+        productStore.fetchProducts(selectedSite.get())
             .takeIf { it.isError }
             ?.parseError()
             ?.let { emit(it) }
             ?: emit(Success)
     }
 
-    private fun WooResult<Boolean>.parseError() =
+    private fun WooResult<List<WCProductModel>>.parseError() =
         when (error.type) {
             WooErrorType.TIMEOUT -> Failure(FailureType.TIMEOUT)
             WooErrorType.INVALID_RESPONSE -> Failure(FailureType.PARSE)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -526,6 +526,7 @@
     <string name="orderlist_connectivity_tool_wordpress_check_suggestion">We can\'t connect to WordPress.com right now.\n\nTry again in a few minutes, or contact our support team and we will happily assist you.</string>
     <string name="orderlist_connectivity_tool_store_check_title">Connecting to your site</string>
     <string name="orderlist_connectivity_tool_store_orders_check_title">Fetching your site orders</string>
+    <string name="orderlist_connectivity_tool_store_products_check_title">Fetching products in your store</string>
     <string name="orderlist_connectivity_tool_contact_support_action">Contact Support</string>
     <string name="orderlist_connectivity_tool_read_more_action">Read More</string>
     <string name="orderlist_connectivity_tool_retry_action">Retry connection</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
@@ -201,6 +201,20 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when storeProductsCheck fails, then isCheckFinished is true`() = testBlocking {
+        // Given
+        val stateEvents = mutableListOf<Boolean>()
+        whenever(storeProductsCheck()).thenReturn(flowOf(Failure()))
+        sut.isCheckFinished.observeForever { stateEvents.add(it) }
+
+        // When
+        sut.startConnectionChecks()
+
+        // Then
+        assertThat(stateEvents).isEqualTo(listOf(false, false, false, false, false, true))
+    }
+
+    @Test
     fun `when onContactSupportClicked is called, then trigger OpenSupportRequest event`() {
         // Given
         val events = mutableListOf<MultiLiveEvent.Event>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.Ope
 import com.woocommerce.android.ui.connectivitytool.useCases.InternetConnectionCheckUseCase
 import com.woocommerce.android.ui.connectivitytool.useCases.StoreConnectionCheckUseCase
 import com.woocommerce.android.ui.connectivitytool.useCases.StoreOrdersCheckUseCase
+import com.woocommerce.android.ui.connectivitytool.useCases.StoreProductsCheckUseCase
 import com.woocommerce.android.ui.connectivitytool.useCases.WPComConnectionCheckUseCase
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -33,6 +34,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
     private lateinit var wpComConnectionCheck: WPComConnectionCheckUseCase
     private lateinit var storeConnectionCheck: StoreConnectionCheckUseCase
     private lateinit var storeOrdersCheck: StoreOrdersCheckUseCase
+    private lateinit var storeProductsCheck: StoreProductsCheckUseCase
     private lateinit var selectedSite: SelectedSite
 
     @Before
@@ -41,11 +43,13 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         wpComConnectionCheck = mock()
         storeConnectionCheck = mock()
         storeOrdersCheck = mock()
+        storeProductsCheck = mock()
         selectedSite = mock()
         whenever(internetConnectionCheck()).thenReturn(flowOf(Success))
         whenever(wpComConnectionCheck()).thenReturn(flowOf(Success))
         whenever(storeConnectionCheck()).thenReturn(flowOf(Success))
         whenever(storeOrdersCheck()).thenReturn(flowOf(Success))
+        whenever(storeProductsCheck()).thenReturn(flowOf(Success))
         whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.Jetpack)
         createViewModel()
     }
@@ -56,6 +60,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
             wpComConnectionCheck = wpComConnectionCheck,
             storeConnectionCheck = storeConnectionCheck,
             storeOrdersCheck = storeOrdersCheck,
+            storeProductsCheck = storeProductsCheck,
             analyticsTrackerWrapper = mock(),
             selectedSite = selectedSite,
             savedState = SavedStateHandle()
@@ -142,7 +147,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         sut.startConnectionChecks()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(false, false, false, false, true))
+        assertThat(stateEvents).isEqualTo(listOf(false, false, false, false, false, true))
     }
 
     @Test
@@ -176,6 +181,23 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // Then
         assertThat(stateEvents).isEqualTo(listOf(false, false))
+    }
+
+    @Test
+    fun `when storeProductsCheck use case starts, then update ViewState as expected`() = testBlocking {
+        // Given
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        whenever(storeProductsCheck()).thenReturn(flowOf(Success))
+        sut.viewState
+            .map { it.productsCheckData }
+            .distinctUntilChanged()
+            .observeForever { stateEvents.add(it.connectivityCheckStatus) }
+
+        // When
+        sut.startConnectionChecks()
+
+        // Then
+        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCaseTest.kt
@@ -1,0 +1,136 @@
+package com.woocommerce.android.ui.connectivitytool.useCases
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus
+import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.Failure
+import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.InProgress
+import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.Success
+import com.woocommerce.android.ui.connectivitytool.FailureType
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WCProductStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StoreProductsCheckUseCaseTest : BaseUnitTest() {
+    private lateinit var sut: StoreProductsCheckUseCase
+    private lateinit var productStore: WCProductStore
+    private lateinit var selectedSite: SelectedSite
+
+    @Before
+    fun setUp() {
+        productStore = mock()
+        selectedSite = mock()
+        sut = StoreProductsCheckUseCase(productStore, selectedSite)
+    }
+
+    @Test
+    fun `when fetchProducts returns success, then emit Success`() = testBlocking {
+        // GIVEN
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        whenever(
+            productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true)
+        ).thenReturn(WooResult(true))
+
+        // WHEN
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // THEN
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Success))
+    }
+
+    @Test
+    fun `when fetchProducts returns GENERIC_ERROR, then emit GENERIC Failure`() = testBlocking {
+        // GIVEN
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        whenever(productStore.fetchProducts(selectedSite.get()))
+            .thenReturn(WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN)))
+
+        // WHEN
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // THEN
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Failure(FailureType.GENERIC)))
+    }
+
+    @Test
+    fun `when fetchProducts returns TIMEOUT, then emit TIMEOUT Failure`() = testBlocking {
+        // GIVEN
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        whenever(productStore.fetchProducts(selectedSite.get()))
+            .thenReturn(WooResult(WooError(WooErrorType.TIMEOUT, UNKNOWN)))
+
+        // WHEN
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // THEN
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Failure(FailureType.TIMEOUT)))
+    }
+
+    @Test
+    fun `when fetchProducts returns INVALID_RESPONSE, then emit PARSE Failure`() = testBlocking {
+        // GIVEN
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        whenever(productStore.fetchProducts(selectedSite.get()))
+            .thenReturn(WooResult(WooError(WooErrorType.INVALID_RESPONSE, UNKNOWN)))
+
+        // WHEN
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // THEN
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Failure(FailureType.PARSE)))
+    }
+
+    @Test
+    fun `given Jetpack site, when fetchProducts returns API_NOT_FOUND, then emit JETPACK Failure`() = testBlocking {
+        // GIVEN
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.Jetpack)
+        whenever(productStore.fetchProducts(selectedSite.get()))
+            .thenReturn(WooResult(WooError(WooErrorType.API_NOT_FOUND, UNKNOWN)))
+
+        // WHEN
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // THEN
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Failure(FailureType.JETPACK)))
+    }
+
+    @Test
+    fun `given app-password site, when fetchProducts returns API_NOT_FOUND, then emit GENERIC Failure`() = testBlocking {
+        // GIVEN
+        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+        whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
+        whenever(productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true))
+            .thenReturn(WooResult(WooError(WooErrorType.API_NOT_FOUND, UNKNOWN)))
+
+        // WHEN
+        sut.invoke().onEach {
+            stateEvents.add(it)
+        }.launchIn(this)
+
+        // THEN
+        assertThat(stateEvents).isEqualTo(listOf(InProgress, Failure(FailureType.GENERIC)))
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCaseTest.kt
@@ -56,7 +56,7 @@ class StoreProductsCheckUseCaseTest : BaseUnitTest() {
     fun `when fetchProducts returns GENERIC_ERROR, then emit GENERIC Failure`() = testBlocking {
         // GIVEN
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(productStore.fetchProducts(selectedSite.get()))
+        whenever(productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true))
             .thenReturn(WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN)))
 
         // WHEN
@@ -72,7 +72,7 @@ class StoreProductsCheckUseCaseTest : BaseUnitTest() {
     fun `when fetchProducts returns TIMEOUT, then emit TIMEOUT Failure`() = testBlocking {
         // GIVEN
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(productStore.fetchProducts(selectedSite.get()))
+        whenever(productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true))
             .thenReturn(WooResult(WooError(WooErrorType.TIMEOUT, UNKNOWN)))
 
         // WHEN
@@ -88,7 +88,7 @@ class StoreProductsCheckUseCaseTest : BaseUnitTest() {
     fun `when fetchProducts returns INVALID_RESPONSE, then emit PARSE Failure`() = testBlocking {
         // GIVEN
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(productStore.fetchProducts(selectedSite.get()))
+        whenever(productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true))
             .thenReturn(WooResult(WooError(WooErrorType.INVALID_RESPONSE, UNKNOWN)))
 
         // WHEN
@@ -105,7 +105,7 @@ class StoreProductsCheckUseCaseTest : BaseUnitTest() {
         // GIVEN
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
         whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.Jetpack)
-        whenever(productStore.fetchProducts(selectedSite.get()))
+        whenever(productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true))
             .thenReturn(WooResult(WooError(WooErrorType.API_NOT_FOUND, UNKNOWN)))
 
         // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCaseTest.kt
@@ -39,9 +39,8 @@ class StoreProductsCheckUseCaseTest : BaseUnitTest() {
     fun `when fetchProducts returns success, then emit Success`() = testBlocking {
         // GIVEN
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(
-            productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true)
-        ).thenReturn(WooResult(true))
+        whenever(productStore.fetchProducts(selectedSite.get()))
+            .thenReturn(WooResult(emptyList()))
 
         // WHEN
         sut.invoke().onEach {
@@ -56,7 +55,7 @@ class StoreProductsCheckUseCaseTest : BaseUnitTest() {
     fun `when fetchProducts returns GENERIC_ERROR, then emit GENERIC Failure`() = testBlocking {
         // GIVEN
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true))
+        whenever(productStore.fetchProducts(selectedSite.get()))
             .thenReturn(WooResult(WooError(WooErrorType.GENERIC_ERROR, UNKNOWN)))
 
         // WHEN
@@ -72,7 +71,7 @@ class StoreProductsCheckUseCaseTest : BaseUnitTest() {
     fun `when fetchProducts returns TIMEOUT, then emit TIMEOUT Failure`() = testBlocking {
         // GIVEN
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true))
+        whenever(productStore.fetchProducts(selectedSite.get()))
             .thenReturn(WooResult(WooError(WooErrorType.TIMEOUT, UNKNOWN)))
 
         // WHEN
@@ -88,7 +87,7 @@ class StoreProductsCheckUseCaseTest : BaseUnitTest() {
     fun `when fetchProducts returns INVALID_RESPONSE, then emit PARSE Failure`() = testBlocking {
         // GIVEN
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true))
+        whenever(productStore.fetchProducts(selectedSite.get()))
             .thenReturn(WooResult(WooError(WooErrorType.INVALID_RESPONSE, UNKNOWN)))
 
         // WHEN
@@ -105,7 +104,7 @@ class StoreProductsCheckUseCaseTest : BaseUnitTest() {
         // GIVEN
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
         whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.Jetpack)
-        whenever(productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true))
+        whenever(productStore.fetchProducts(selectedSite.get()))
             .thenReturn(WooResult(WooError(WooErrorType.API_NOT_FOUND, UNKNOWN)))
 
         // WHEN
@@ -122,7 +121,7 @@ class StoreProductsCheckUseCaseTest : BaseUnitTest() {
         // GIVEN
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
         whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
-        whenever(productStore.fetchProducts(site = selectedSite.get(), forceRefresh = true))
+        whenever(productStore.fetchProducts(selectedSite.get()))
             .thenReturn(WooResult(WooError(WooErrorType.API_NOT_FOUND, UNKNOWN)))
 
         // WHEN


### PR DESCRIPTION
### Description
> [!NOTE]
> Depends on #15582  

Adds a "Fetching products in your store" connectivity check as the 5th and final test in the Troubleshoot Connection screen (Milestone 2). **Also aligns all connectivity tool analytics event values with iOS for cross-platform consistency.**

### Test Steps

**Happy path:**
1. Open the app and navigate to **Settings > Troubleshoot Connection**
2. Verify all 5 checks run sequentially: Internet → WordPress.com → Store → Orders → Products
3. Confirm each check shows a green checkmark on success
4. Verify the "No connection issues" summary appears at the bottom

**Products failure:**
1. Set up ApiFaker to return an error for the products endpoint:
```bash
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
  --es api_type "wp-api" \
  --es path "/wc/v3/products" \
  --es http_method "GET" \
  --ei response_status_code 500 \
  --es response_body '{}'
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
```
2. Navigate to **Settings > Troubleshoot Connection**
3. Verify the first 4 checks pass (Internet, WordPress.com, Store, Orders)
4. Verify the Products check shows a red error icon with a failure message and retry button
5. Disable ApiFaker:
```bash
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
```
6. Tap **Retry** on the Products check and verify it now succeeds

**Orders failure (products check should not run):**
1. Set up ApiFaker to return an error for the orders endpoint:
```bash
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
  --es api_type "wp-api" \
  --es path "/wc/v3/orders" \
  --es http_method "GET" \
  --ei response_status_code 500 \
  --es response_body '{}'
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
```
2. Navigate to **Settings > Troubleshoot Connection**
3. Verify the Orders check fails and the Products check never starts (sequential check stops on first failure)
4. Clean up:
```bash
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
```

### Images/gif

https://github.com/user-attachments/assets/f77dd117-a419-4a96-b9ec-49f9873ff1c2



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.