### PR TITLE
[WOOMOB-2574] Disable FedEx support locally

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/ObserveShippingPackages.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/ObserveShippingPackages.kt
@@ -6,6 +6,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.StoreOptionsForPackages
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.transformLatest
@@ -18,7 +20,8 @@ import javax.inject.Inject
 class ObserveShippingPackages @Inject constructor(
     private val selectedSite: SelectedSite,
     private val packageRepository: WooShippingLabelPackageRepository,
-    private val fetchShippingPackages: FetchShippingPackages
+    private val fetchShippingPackages: FetchShippingPackages,
+    private val featureFlagRepository: FeatureFlagRepository
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
     operator fun invoke(): Flow<PackagesState> = packageRepository.observeShippingPackages(selectedSite.get())
@@ -56,9 +59,11 @@ class ObserveShippingPackages @Inject constructor(
                 .takeIf { it.isNotEmpty() }
                 ?.let { packageGroups -> put(Carrier.USPS, packageGroups) }
 
-            carrierPackageGroups.parseCarrierData(WooShippingPackagesEntity.CarrierType.FEDEX)
-                .takeIf { it.isNotEmpty() }
-                ?.let { packageGroups -> put(Carrier.FEDEX, packageGroups) }
+            if (featureFlagRepository.isEnabled(FeatureFlag.WOO_SHIPPING_FEDEX)) {
+                carrierPackageGroups.parseCarrierData(WooShippingPackagesEntity.CarrierType.FEDEX)
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { packageGroups -> put(Carrier.FEDEX, packageGroups) }
+            }
 
             carrierPackageGroups.parseCarrierData(WooShippingPackagesEntity.CarrierType.DHL)
                 .takeIf { it.isNotEmpty() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapper.kt
@@ -11,19 +11,23 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.CarrierUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateOptionUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateUI
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.ResourceProvider
 import java.math.BigDecimal
 import javax.inject.Inject
 
 class WooShippingRatesDomainMapper @Inject constructor(
     private val resourceProvider: ResourceProvider,
-    private val currencyFormatter: CurrencyFormatter
+    private val currencyFormatter: CurrencyFormatter,
+    private val featureFlagRepository: FeatureFlagRepository
 ) {
     operator fun invoke(
         rates: List<WooShippingRateOptionsModel>,
         currencyCode: String?
     ): Map<CarrierUI, List<ShippingRateUI>> {
         return rates.groupBy { it.defaultRate.carrier }
+            .filterKeys(::isCarrierEnabled)
             .map { (carrier, models) ->
                 getCarrier(carrier) to models
                     .map { getShippingRate(it, resourceProvider, currencyCode) }
@@ -47,6 +51,13 @@ class WooShippingRatesDomainMapper @Inject constructor(
                 selectedRate.options.getValue(it).rate
             }
         )
+    }
+
+    private fun isCarrierEnabled(carrier: WooShippingCarrier): Boolean {
+        return when (carrier) {
+            WooShippingCarrier.FEDEX -> featureFlagRepository.isEnabled(FeatureFlag.WOO_SHIPPING_FEDEX)
+            else -> true
+        }
     }
 
     private fun getCarrier(carrier: WooShippingCarrier): CarrierUI {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -34,4 +34,5 @@ enum class FeatureFlag(
     AGE_ELIGIBILITY_CHECKS("age_eligibility_checks", localValue = PackageUtils.isDebugBuild()),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1("woo_self_driven_push_notifications_m1", localValue = false),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2("woo_self_driven_push_notifications_m2", localValue = false),
+    WOO_SHIPPING_FEDEX("woo_shipping_fedex", localValue = false),
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/ObserveShippingPackagesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/ObserveShippingPackagesTest.kt
@@ -5,6 +5,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingL
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -13,6 +15,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
@@ -25,10 +28,14 @@ class ObserveShippingPackagesTest : BaseUnitTest() {
     private val packageRepository: WooShippingLabelPackageRepository = mock()
     private val fetchShippingPackages: FetchShippingPackages = mock()
     private val selectedSite: SelectedSite = mock()
+    private val featureFlagRepository: FeatureFlagRepository = mock {
+        on { isEnabled(FeatureFlag.WOO_SHIPPING_FEDEX) } doReturn true
+    }
     private val observeShippingPackages = ObserveShippingPackages(
         selectedSite,
         packageRepository,
-        fetchShippingPackages
+        fetchShippingPackages,
+        featureFlagRepository
     )
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapperTest.kt
@@ -4,6 +4,8 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingCar
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateOptionsModel
 import com.woocommerce.android.util.CurrencyFormatter
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import junit.framework.TestCase.assertEquals
@@ -12,6 +14,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.math.BigDecimal
 
@@ -27,10 +30,13 @@ class WooShippingRatesDomainMapperTest : BaseUnitTest() {
         on(it.getQuantityString(any(), anyOrNull(), anyOrNull(), anyOrNull()))
             .thenAnswer { i -> "formatted ${i.arguments[0]}" }
     }
-
+    private val featureFlagRepository: FeatureFlagRepository = mock {
+        on { isEnabled(FeatureFlag.WOO_SHIPPING_FEDEX) } doReturn true
+    }
     private val sut = WooShippingRatesDomainMapper(
         resourceProvider = resourceProvider,
-        currencyFormatter = currencyFormatter
+        currencyFormatter = currencyFormatter,
+        featureFlagRepository = featureFlagRepository
     )
 
     @Test


### PR DESCRIPTION
### Description
Fixes WOOMOB-2574

Disables FedEx in the Android shipping labels flow behind a temporary feature flag.
This hides FedEx in both the package carrier tabs and the shipping rates flow while the mobile support remains turned off.

Slack discussion:

### Test Steps
1. Open an order that can be used to create a shipping label (The site should be connected to staging server).
2. Start the shipping label flow.
3. Go to the package selection screen.
4. Open the `Carrier` tab.
5. Confirm FedEx is not shown in the carrier list.
6. Continue to the shipping rates step.
7. Confirm FedEx rates are not shown.

### Images/gif
|Before|After|
|-|-|
|<img width="300" alt="Screenshot_20260330_232148" src="https://github.com/user-attachments/assets/8b4d0193-3963-426c-9ab7-5a04bb5a298f" />|<img width="300" alt="Screenshot_20260330_232009" src="https://github.com/user-attachments/assets/954fdb86-70b3-4c2d-8b18-fb52ddc99f19" />|

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.