### PR TITLE
Move feature flag release note to 24.5

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,8 +4,8 @@
 
 24.5
 -----
+- [Internal] Unified local and remote feature flag handling [https://github.com/woocommerce/woocommerce-android/pull/15299]
 - [Internal][WEAR] Update watchface complications dependency to 1.3.0 [https://github.com/woocommerce/woocommerce-android/pull/15577]
-
 
 24.4
 -----
@@ -15,7 +15,6 @@
 - [Internal] Fixed attendance status filter sending invalid API requests when multiple statuses were selected [https://github.com/woocommerce/woocommerce-android/pull/15504]
 - [**] Display net sales instead of total sales on My Store dashboard to match wp-admin [https://github.com/woocommerce/woocommerce-android/pull/15493]
 - [*] Fixed Woo Shipping label purchase flow when the origin address is missing required details [https://github.com/woocommerce/woocommerce-android/pull/15542]
-- [Internal] Unified local and remote feature flag handling [https://github.com/woocommerce/woocommerce-android/pull/15299]
 
 24.3
 -----


### PR DESCRIPTION
### Description
This moves the internal release note entry for unified local and remote feature flag handling from 24.4 to 24.5 so it appears in the correct release section.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.