### PR TITLE
[WOOMOB-2590] Open WC Admin in Chrome Custom Tab for CIAB sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -37,6 +37,7 @@ import com.woocommerce.android.ui.moremenu.MoreMenuEvent.ViewInboxEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.ViewPayments
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.ViewReviewsEvent
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -113,6 +114,8 @@ class MoreMenuFragment : TopLevelFragment() {
                 is ViewPayments -> navigateToPayments()
                 is OpenBlazeCampaignCreationEvent -> openBlazeCreationFlow()
                 is OpenBlazeCampaignListEvent -> openBlazeCampaignList()
+                is MultiLiveEvent.Event.LaunchUrlInChromeTab ->
+                    ChromeCustomTabUtils.launchUrl(requireContext(), event.url)
                 is MultiLiveEvent.Event.LaunchUrlInAuthenticatedWebView ->
                     authenticatedWebViewLauncher.showAuthenticatedWebView(event)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -421,12 +421,20 @@ class MoreMenuViewModel @Inject constructor(
 
     private fun onViewAdminButtonClick() {
         trackMoreMenuOptionSelected(VALUE_MORE_MENU_ADMIN_MENU)
-        triggerEvent(
-            MultiLiveEvent.Event.LaunchUrlInAuthenticatedWebView(
-                url = selectedSite.get().adminUrlOrDefault,
-                screenTitle = UiString.UiStringRes(R.string.more_menu_button_wс_admin)
+        val site = selectedSite.get()
+        val adminUrl = site.adminUrlOrDefault
+        if (site.isCIABSite) {
+            // CIAB hides the navigation sidebar when detecting a mobile user agent,
+            // which breaks the WC Admin experience. Open in Chrome Custom Tab instead.
+            triggerEvent(MultiLiveEvent.Event.LaunchUrlInChromeTab(url = adminUrl))
+        } else {
+            triggerEvent(
+                MultiLiveEvent.Event.LaunchUrlInAuthenticatedWebView(
+                    url = adminUrl,
+                    screenTitle = UiString.UiStringRes(R.string.more_menu_button_wс_admin)
+                )
             )
-        )
+        }
     }
 
     private fun onViewStoreButtonClick() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.ui.plans.repository.SitePlanRepository
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -498,6 +499,46 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             .isEqualTo(MoreMenuItemButton.State.Loading)
         assertThat(items.first { it.title == R.string.more_menu_button_inbox }.state)
             .isEqualTo(MoreMenuItemButton.State.Loading)
+    }
+
+    @Test
+    fun `given CIAB site, when admin button clicked, then launch url in chrome tab`() = testBlocking {
+        // GIVEN
+        selectedSiteFlow.update {
+            it.apply {
+                setIsGardenSite(true)
+                gardenName = SiteModel.CIAB_GARDEN_NAME
+            }
+        }
+        setup()
+
+        // WHEN
+        val state = viewModel.moreMenuViewState.captureValues().last()
+        val button = state.menuSections.flatMap { it.items }
+            .first { it.title == R.string.more_menu_button_wс_admin }
+        val event = viewModel.event.runAndCaptureValues {
+            button.onClick()
+        }.last()
+
+        // THEN
+        assertThat(event).isInstanceOf(MultiLiveEvent.Event.LaunchUrlInChromeTab::class.java)
+    }
+
+    @Test
+    fun `given non-CIAB site, when admin button clicked, then launch url in authenticated web view`() = testBlocking {
+        // GIVEN
+        setup()
+
+        // WHEN
+        val state = viewModel.moreMenuViewState.captureValues().last()
+        val button = state.menuSections.flatMap { it.items }
+            .first { it.title == R.string.more_menu_button_wс_admin }
+        val event = viewModel.event.runAndCaptureValues {
+            button.onClick()
+        }.last()
+
+        // THEN
+        assertThat(event).isInstanceOf(MultiLiveEvent.Event.LaunchUrlInAuthenticatedWebView::class.java)
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixes WOOMOB-2590

CIAB hides the navigation sidebar when detecting a mobile user agent, which breaks the WC Admin experience where navigation to other screens is expected. For CIAB sites, WC Admin now opens in a Chrome Custom Tab instead of the in-app authenticated WebView. Non-CIAB sites retain the existing behavior.

### Test Steps
1. Log in to a **CIAB site**
2. Go to More menu → tap **WC Admin**
3. Verify it opens in a **Chrome Custom Tab** (browser overlay with toolbar showing the URL)
4. Verify the WC Admin sidebar navigation is visible and functional
5. Log in to a **non-CIAB site** (self-hosted + Jetpack)
6. Go to More menu → tap **WC Admin**
7. Verify it opens in the **in-app authenticated WebView** (existing behavior)

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.