### PR TITLE
[WOOMOB-2593] Migrate second batch of Compose screens from Material 2 to Material 3

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,10 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 
+24.6
+-----
+- [Internal] Migrate AccountSettingsScreen, BarcodeScannerScreen, and PrivacySettingsPoliciesScreen from Material 2 to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/15596]
+
 24.5
 -----
 - [Internal] Unified local and remote feature flag handling [https://github.com/woocommerce/woocommerce-android/pull/15299]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScannerScreen.kt
@@ -5,10 +5,10 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.ImageProxy
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.AlertDialog
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
@@ -56,7 +56,7 @@ fun BarcodeScannerScreen(
             )
         }
         is BarcodeScanningViewModel.PermissionState.ShouldShowRationale -> {
-            AlertDialog(
+            PermissionAlertDialog(
                 title = stringResource(id = permissionState.title),
                 message = stringResource(id = permissionState.message),
                 ctaLabel = stringResource(id = permissionState.ctaLabel),
@@ -66,7 +66,7 @@ fun BarcodeScannerScreen(
             )
         }
         is BarcodeScanningViewModel.PermissionState.PermanentlyDenied -> {
-            AlertDialog(
+            PermissionAlertDialog(
                 title = stringResource(id = permissionState.title),
                 message = stringResource(id = permissionState.message),
                 ctaLabel = stringResource(id = permissionState.ctaLabel),
@@ -82,7 +82,7 @@ fun BarcodeScannerScreen(
 }
 
 @Composable
-private fun AlertDialog(
+private fun PermissionAlertDialog(
     title: String,
     message: String,
     ctaLabel: String,
@@ -106,7 +106,7 @@ private fun AlertDialog(
             ) {
                 Text(
                     ctaLabel,
-                    color = MaterialTheme.colors.secondary,
+                    color = MaterialTheme.colorScheme.secondary,
                     modifier = Modifier.padding(8.dp)
                 )
             }
@@ -119,7 +119,7 @@ private fun AlertDialog(
             ) {
                 Text(
                     dismissCtaLabel,
-                    color = MaterialTheme.colors.secondary,
+                    color = MaterialTheme.colorScheme.secondary,
                     modifier = Modifier.padding(8.dp)
                 )
             }
@@ -132,7 +132,7 @@ private fun AlertDialog(
 @Composable
 fun DeniedOnceAlertDialog() {
     WooThemeWithBackground {
-        AlertDialog(
+        PermissionAlertDialog(
             title = stringResource(id = R.string.barcode_scanning_alert_dialog_title),
             message = stringResource(id = R.string.barcode_scanning_alert_dialog_rationale_message),
             ctaLabel = stringResource(id = R.string.barcode_scanning_alert_dialog_rationale_cta_label),
@@ -148,7 +148,7 @@ fun DeniedOnceAlertDialog() {
 @Composable
 fun DeniedPermanentlyAlertDialog() {
     WooThemeWithBackground {
-        AlertDialog(
+        PermissionAlertDialog(
             title = stringResource(id = R.string.barcode_scanning_alert_dialog_title),
             message = stringResource(id = R.string.barcode_scanning_alert_dialog_permanently_denied_message),
             ctaLabel = stringResource(id = R.string.barcode_scanning_alert_dialog_permanently_denied_cta_label),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsPoliciesScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsPoliciesScreen.kt
@@ -2,10 +2,10 @@ package com.woocommerce.android.ui.prefs
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -20,7 +20,7 @@ fun PrivacySettingsPolicesScreen(
     onPrivacyPolicyClicked: () -> Unit,
     onCookiePolicyClicked: () -> Unit,
 ) {
-    Scaffold(backgroundColor = MaterialTheme.colors.surface) { paddingValues ->
+    Scaffold(containerColor = MaterialTheme.colorScheme.surface) { paddingValues ->
         Column(
             modifier = Modifier.padding(paddingValues)
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/AccountSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/account/AccountSettingsScreen.kt
@@ -7,11 +7,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.ContentAlpha
-import androidx.compose.material.Divider
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,10 +28,10 @@ fun AccountSettingsScreen(
 ) {
     Column(
         modifier = Modifier
-            .background(MaterialTheme.colors.surface)
+            .background(MaterialTheme.colorScheme.surface)
             .fillMaxSize()
     ) {
-        Divider()
+        HorizontalDivider()
         AccountSettingsItem(
             title = stringResource(id = R.string.settings_close_account).uppercase(),
             onClick = onCloseAccountClick,
@@ -40,7 +39,7 @@ fun AccountSettingsScreen(
             boldText = true,
             modifier = Modifier.fillMaxWidth()
         )
-        Divider()
+        HorizontalDivider()
     }
 }
 
@@ -66,19 +65,19 @@ private fun AccountSettingsItem(
     ) {
         Text(
             text = title,
-            style = MaterialTheme.typography.subtitle1,
+            style = MaterialTheme.typography.titleMedium,
             fontWeight = if (boldText) FontWeight.Medium else null,
             color = textColor.let {
-                if (!enabled) it.copy(alpha = ContentAlpha.disabled) else it
+                if (!enabled) it.copy(alpha = 0.38f) else it
             }
         )
         subtitle?.let {
             Text(
                 text = subtitle,
-                style = MaterialTheme.typography.body2,
+                style = MaterialTheme.typography.bodyMedium,
                 fontWeight = if (boldText) FontWeight.Medium else null,
                 color = textColor.let {
-                    if (!enabled) it.copy(alpha = ContentAlpha.disabled) else it
+                    if (!enabled) it.copy(alpha = 0.38f) else it
                 }
             )
         }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2593

Migrates 3 more Compose screens from Material 2 to Material 3, continuing the effort from #15595.

**Screens migrated:**
- `AccountSettingsScreen` — Divider, ContentAlpha, LocalContentColor, MaterialTheme
- `BarcodeScannerScreen` — AlertDialog, TextButton, MaterialTheme
- `PrivacySettingsPoliciesScreen` — Scaffold, Icon, IconButton, MaterialTheme

**Key M2→M3 changes applied:**
- `Divider` → `HorizontalDivider`
- `ContentAlpha.disabled` → hardcoded `0.38f` (M3 does not have ContentAlpha)
- M2 `LocalContentColor` → M3 `LocalContentColor`
- M2 `AlertDialog` → M3 `AlertDialog` (renamed private wrapper to `PermissionAlertDialog` to avoid import clash)
- `Scaffold(backgroundColor=)` → `Scaffold(containerColor=)`
- `MaterialTheme.colors` → `MaterialTheme.colorScheme`
- `MaterialTheme.typography.subtitle1/body2` → `titleMedium/bodyMedium`

### Test Steps

**AccountSettingsScreen:**
1. Go to Menu → Settings → scroll down to the bottom → Account settings
2. Verify: "CLOSE ACCOUNT" text in pink, dividers above and below
3. Check both light and dark mode

**BarcodeScannerScreen:**
1. Go to Products → tap the barcode scan icon in the search bar
2. If camera permission was denied before, verify the alert dialog appears with title, message, "Cancel" and "Grant" buttons
3. Check both light and dark mode

**PrivacySettingsPoliciesScreen:**
1. Go to Menu → Settings → Privacy settings → tap "Privacy and Cookies Policies"
2. Verify: two rows (Privacy Policy, Cookie Policy) with external link icons and dividers
3. Check both light and dark mode

### Images/gif

#### AccountSettingsScreen
| Before (M2) | After (M3) |
|---|---|
| ![Before](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/b2_m2_account_settings.png) | ![After](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/b2_m3_account_settings.png) |

#### BarcodeScannerScreen
| Before (M2) | After (M3) |
|---|---|
| ![Before](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/b2_m2_barcode_scanner.png) | ![After](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/b2_m3_barcode_scanner.png) |

#### PrivacySettingsPoliciesScreen
| Before (M2) | After (M3) |
|---|---|
| ![Before](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/b2_m2_privacy_policies.png) | ![After](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/b2_m3_privacy_policies.png) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.