### PR TITLE
[Hack Week] Attach diagnostic log to support requests from troubleshooting tool

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormActivity.kt
@@ -45,6 +45,10 @@ class SupportRequestFormActivity : AppCompatActivity() {
         intent.extras?.getStringArrayList(EXTRA_TAGS_KEY) ?: emptyList()
     }
 
+    private val diagnosticLog by lazy {
+        intent.extras?.getString(DIAGNOSTIC_LOG_KEY)
+    }
+
     private var progressDialog: CustomProgressDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -127,7 +131,8 @@ class SupportRequestFormActivity : AppCompatActivity() {
             viewModel.submitSupportRequest(
                 context = this,
                 helpOrigin = helpOrigin,
-                extraTags = extraTags
+                extraTags = extraTags,
+                diagnosticLog = diagnosticLog
             )
         }
     }
@@ -197,6 +202,7 @@ class SupportRequestFormActivity : AppCompatActivity() {
                 context = this,
                 helpOrigin = helpOrigin,
                 extraTags = extraTags,
+                diagnosticLog = diagnosticLog,
                 selectedEmail = email,
                 selectedName = name
             )
@@ -207,15 +213,18 @@ class SupportRequestFormActivity : AppCompatActivity() {
     companion object {
         private const val ORIGIN_KEY = "ORIGIN_KEY"
         private const val EXTRA_TAGS_KEY = "EXTRA_TAGS_KEY"
+        private const val DIAGNOSTIC_LOG_KEY = "DIAGNOSTIC_LOG_KEY"
 
         @JvmStatic
         fun createIntent(
             context: Context,
             origin: HelpOrigin,
-            extraTags: java.util.ArrayList<String>
+            extraTags: java.util.ArrayList<String>,
+            diagnosticLog: String? = null
         ) = Intent(context, SupportRequestFormActivity::class.java).apply {
             putExtra(ORIGIN_KEY, origin)
             putStringArrayListExtra(EXTRA_TAGS_KEY, ArrayList(extraTags))
+            diagnosticLog?.let { putExtra(DIAGNOSTIC_LOG_KEY, it) }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -68,6 +68,7 @@ class SupportRequestFormViewModel @Inject constructor(
         viewState.update { it.copy(message = message) }
     }
 
+    @Suppress("LongParameterList")
     fun onUserIdentitySet(
         context: Context,
         helpOrigin: HelpOrigin,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModel.kt
@@ -72,19 +72,26 @@ class SupportRequestFormViewModel @Inject constructor(
         context: Context,
         helpOrigin: HelpOrigin,
         extraTags: List<String>,
+        diagnosticLog: String?,
         selectedEmail: String,
         selectedName: String
     ) {
         zendeskSettings.supportEmail = selectedEmail
         zendeskSettings.supportName = selectedName
         tracks.track(AnalyticsEvent.SUPPORT_IDENTITY_SET)
-        submitSupportRequest(context = context, helpOrigin = helpOrigin, extraTags = extraTags)
+        submitSupportRequest(
+            context = context,
+            helpOrigin = helpOrigin,
+            extraTags = extraTags,
+            diagnosticLog = diagnosticLog
+        )
     }
 
     fun submitSupportRequest(
         context: Context,
         helpOrigin: HelpOrigin,
-        extraTags: List<String>
+        extraTags: List<String>,
+        diagnosticLog: String? = null
     ) {
         val ticketType = viewState.value.ticketType ?: return
 
@@ -98,7 +105,8 @@ class SupportRequestFormViewModel @Inject constructor(
                 viewState.value.subject,
                 viewState.value.message,
                 extraTags,
-                viewState.value.siteAddress
+                viewState.value.siteAddress,
+                diagnosticLog
             ).collect { it.handleCreateRequestResult() }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskSettings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskSettings.kt
@@ -32,6 +32,12 @@ class ZendeskSettings @Inject constructor(
             ?.provider()
             ?.requestProvider()
 
+    val uploadProvider
+        get() = Support.INSTANCE
+            .takeIfInitialized()
+            ?.provider()
+            ?.uploadProvider()
+
     /**
      * These two properties are used to keep track of the Zendesk identity set. Since we allow users' to change their
      * supportEmail and reset their identity on logout, we need to ensure that the correct identity is set all times.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
@@ -71,7 +71,7 @@ class ZendeskTicketRepository @Inject constructor(
         val ssr: String? = selectedSite?.let { fetchSSR(it) }
 
         val attachmentTokens = if (diagnosticLog != null) {
-            listOfNotNull(uploadDiagnosticLog(context, diagnosticLog))
+            listOfNotNull(uploadDiagnosticLog(diagnosticLog))
         } else {
             emptyList()
         }
@@ -131,11 +131,10 @@ class ZendeskTicketRepository @Inject constructor(
     }
 
     private suspend fun uploadDiagnosticLog(
-        context: Context,
         diagnosticLog: String
     ): String? {
         val tempFile = withContext(dispatchers.io) {
-            File(context.cacheDir, DIAGNOSTIC_LOG_FILENAME).also {
+            File.createTempFile(DIAGNOSTIC_LOG_FILENAME, null).also {
                 it.writeText(diagnosticLog)
             }
         }
@@ -148,12 +147,16 @@ class ZendeskTicketRepository @Inject constructor(
                     "text/plain",
                     object : ZendeskCallback<UploadResponse>() {
                         override fun onSuccess(result: UploadResponse?) {
-                            continuation.resume(result?.token)
+                            if (continuation.isActive) {
+                                continuation.resume(result?.token)
+                            }
                         }
 
                         override fun onError(error: ErrorResponse?) {
                             wooLog.e(WooLog.T.SUPPORT, "Failed to upload diagnostic log")
-                            continuation.resume(null)
+                            if (continuation.isActive) {
+                                continuation.resume(null)
+                            }
                         }
                     }
                 ) ?: run {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
@@ -43,7 +43,7 @@ class ZendeskTicketRepository @Inject constructor(
      * This function creates a new customer Support Request through the Zendesk API Providers.
      */
     @Suppress("LongParameterList")
-    suspend fun createRequest(
+    fun createRequest(
         context: Context,
         origin: HelpOrigin,
         ticketType: TicketType,
@@ -51,7 +51,8 @@ class ZendeskTicketRepository @Inject constructor(
         subject: String,
         description: String,
         extraTags: List<String>,
-        siteAddress: String
+        siteAddress: String,
+        diagnosticLog: String? = null
     ) = callbackFlow {
         if (zendeskSettings.isIdentitySet.not()) {
             trySend(Result.failure(IdentityNotSetException))
@@ -78,7 +79,11 @@ class ZendeskTicketRepository @Inject constructor(
         CreateRequest().apply {
             this.ticketFormId = ticketType.form
             this.subject = subject
-            this.description = description
+            this.description = if (diagnosticLog != null) {
+                "$description\n\n---\n\n$diagnosticLog"
+            } else {
+                description
+            }
             this.tags = buildZendeskTags(selectedSite, siteStore.sites, origin, tags)
                 .filter { ticketType.excludedTags.contains(it).not() }
             val zendeskCustomFieldsParams = ZendeskCustomFieldsParams(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/zendesk/ZendeskTicketRepository.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import com.woocommerce.android.applicationpasswords.IsAppPasswordsSupportedForJetpackSite
 import com.woocommerce.android.extensions.formatResult
 import com.woocommerce.android.support.help.HelpOrigin
+import com.woocommerce.android.support.zendesk.RequestConstants.DIAGNOSTIC_LOG_FILENAME
 import com.woocommerce.android.support.zendesk.RequestConstants.requestCreationIdentityNotSetErrorMessage
 import com.woocommerce.android.support.zendesk.RequestConstants.requestCreationTimeoutErrorMessage
 import com.woocommerce.android.support.zendesk.ZendeskException.IdentityNotSetException
@@ -22,13 +23,18 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import zendesk.support.CreateRequest
 import zendesk.support.CustomField
 import zendesk.support.Request
+import zendesk.support.UploadResponse
+import java.io.File
 import javax.inject.Inject
+import kotlin.coroutines.resume
 
 class ZendeskTicketRepository @Inject constructor(
     private val zendeskSettings: ZendeskSettings,
@@ -64,6 +70,12 @@ class ZendeskTicketRepository @Inject constructor(
 
         val ssr: String? = selectedSite?.let { fetchSSR(it) }
 
+        val attachmentTokens = if (diagnosticLog != null) {
+            listOfNotNull(uploadDiagnosticLog(context, diagnosticLog))
+        } else {
+            emptyList()
+        }
+
         val requestCallback = object : ZendeskCallback<Request>() {
             override fun onSuccess(result: Request?) {
                 trySend(Result.success(result))
@@ -79,10 +91,9 @@ class ZendeskTicketRepository @Inject constructor(
         CreateRequest().apply {
             this.ticketFormId = ticketType.form
             this.subject = subject
-            this.description = if (diagnosticLog != null) {
-                "$description\n\n---\n\n$diagnosticLog"
-            } else {
-                description
+            this.description = description
+            if (attachmentTokens.isNotEmpty()) {
+                this.attachments = attachmentTokens
             }
             this.tags = buildZendeskTags(selectedSite, siteStore.sites, origin, tags)
                 .filter { ticketType.excludedTags.contains(it).not() }
@@ -117,6 +128,41 @@ class ZendeskTicketRepository @Inject constructor(
             wooLog.i(WooLog.T.SUPPORT, "SSR fetched successfully")
         }
         return result.model?.formatResult()
+    }
+
+    private suspend fun uploadDiagnosticLog(
+        context: Context,
+        diagnosticLog: String
+    ): String? {
+        val tempFile = withContext(dispatchers.io) {
+            File(context.cacheDir, DIAGNOSTIC_LOG_FILENAME).also {
+                it.writeText(diagnosticLog)
+            }
+        }
+
+        return try {
+            suspendCancellableCoroutine { continuation ->
+                zendeskSettings.uploadProvider?.uploadAttachment(
+                    DIAGNOSTIC_LOG_FILENAME,
+                    tempFile,
+                    "text/plain",
+                    object : ZendeskCallback<UploadResponse>() {
+                        override fun onSuccess(result: UploadResponse?) {
+                            continuation.resume(result?.token)
+                        }
+
+                        override fun onError(error: ErrorResponse?) {
+                            wooLog.e(WooLog.T.SUPPORT, "Failed to upload diagnostic log")
+                            continuation.resume(null)
+                        }
+                    }
+                ) ?: run {
+                    continuation.resume(null)
+                }
+            }
+        } finally {
+            tempFile.delete()
+        }
     }
 
     /**
@@ -312,6 +358,7 @@ private object RequestConstants {
     const val requestCreationTimeout = 10000L
     const val requestCreationTimeoutErrorMessage = "Request creation timed out"
     const val requestCreationIdentityNotSetErrorMessage = "Request creation failed: identity not set"
+    const val DIAGNOSTIC_LOG_FILENAME = "connectivitytest_log.txt"
 }
 
 private data class ZendeskCustomFieldsParams(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
@@ -88,16 +88,19 @@ sealed class ConnectivityCheckCardData(
 
 @Parcelize
 sealed class ConnectivityCheckStatus : Parcelable {
+    open val durationMs: Long get() = 0L
+
     data object NotStarted : ConnectivityCheckStatus()
     data object InProgress : ConnectivityCheckStatus()
+
     @Parcelize
-    data class Success(val durationMs: Long = 0L) : ConnectivityCheckStatus(), Parcelable
+    data class Success(override val durationMs: Long = 0L) : ConnectivityCheckStatus(), Parcelable
 
     @Parcelize
     data class Failure(
         val error: FailureType? = null,
         val technicalDetails: String? = null,
-        val durationMs: Long = 0L
+        override val durationMs: Long = 0L
     ) : ConnectivityCheckStatus(), Parcelable
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
@@ -90,12 +90,13 @@ sealed class ConnectivityCheckCardData(
 sealed class ConnectivityCheckStatus : Parcelable {
     data object NotStarted : ConnectivityCheckStatus()
     data object InProgress : ConnectivityCheckStatus()
-    data object Success : ConnectivityCheckStatus()
+    data class Success(val durationMs: Long = 0L) : ConnectivityCheckStatus()
 
     @Parcelize
     data class Failure(
         val error: FailureType? = null,
-        val technicalDetails: String? = null
+        val technicalDetails: String? = null,
+        val durationMs: Long = 0L
     ) : ConnectivityCheckStatus(), Parcelable
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
@@ -93,10 +93,8 @@ sealed class ConnectivityCheckStatus : Parcelable {
     data object NotStarted : ConnectivityCheckStatus()
     data object InProgress : ConnectivityCheckStatus()
 
-    @Parcelize
     data class Success(override val durationMs: Long = 0L) : ConnectivityCheckStatus(), Parcelable
 
-    @Parcelize
     data class Failure(
         val error: FailureType? = null,
         val technicalDetails: String? = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
@@ -90,7 +90,8 @@ sealed class ConnectivityCheckCardData(
 sealed class ConnectivityCheckStatus : Parcelable {
     data object NotStarted : ConnectivityCheckStatus()
     data object InProgress : ConnectivityCheckStatus()
-    data class Success(val durationMs: Long = 0L) : ConnectivityCheckStatus()
+    @Parcelize
+    data class Success(val durationMs: Long = 0L) : ConnectivityCheckStatus(), Parcelable
 
     @Parcelize
     data class Failure(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolFragment.kt
@@ -47,7 +47,7 @@ class ConnectivityToolFragment : BaseFragment() {
 
     override fun getFragmentTitle() = ""
 
-    private fun openSupportRequestScreen(diagnosticLog: String) {
+    private fun openSupportRequestScreen(diagnosticLog: String?) {
         SupportRequestFormActivity.createIntent(
             context = requireContext(),
             origin = HelpOrigin.CONNECTIVITY_TOOL,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolFragment.kt
@@ -37,7 +37,7 @@ class ConnectivityToolFragment : BaseFragment() {
         super.onViewCreated(view, savedInstanceState)
         viewModel.event.observe(viewLifecycleOwner) {
             when (it) {
-                is OpenSupportRequest -> openSupportRequestScreen()
+                is OpenSupportRequest -> openSupportRequestScreen(it.diagnosticLog)
                 is OpenWebView -> openWebView(it.url)
                 is Exit -> findNavController().popBackStack()
             }
@@ -47,11 +47,12 @@ class ConnectivityToolFragment : BaseFragment() {
 
     override fun getFragmentTitle() = ""
 
-    private fun openSupportRequestScreen() {
+    private fun openSupportRequestScreen(diagnosticLog: String) {
         SupportRequestFormActivity.createIntent(
             context = requireContext(),
             origin = HelpOrigin.CONNECTIVITY_TOOL,
-            extraTags = ArrayList()
+            extraTags = ArrayList(),
+            diagnosticLog = diagnosticLog
         ).let { activity?.startActivity(it) }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolScreen.kt
@@ -353,7 +353,7 @@ fun ConnectivityToolScreenPreview() {
                 connectivityCheckStatus = NotStarted
             ),
             wpComConnectionCheckData = WPComConnectivityCheckData(
-                connectivityCheckStatus = Success
+                connectivityCheckStatus = Success()
             ),
             storeConnectionCheckData = StoreConnectivityCheckData(
                 connectivityCheckStatus = Failure(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -63,7 +63,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private val isAppPasswordSite: Boolean
         get() = selectedSite.connectionType == SiteConnectionType.ApplicationPasswords
 
-    private val testResults = mutableListOf<TestResult>()
+    private val testResults = LinkedHashMap<String, TestResult>()
 
     private val stateMachine = savedState.getStateFlow(
         scope = viewModelScope,
@@ -291,14 +291,14 @@ class ConnectivityToolViewModel @Inject constructor(
                 AnalyticsTracker.KEY_TIME_TAKEN to durationMs
             )
         )
-        testResults.add(TestResult(name = displayName, status = status, durationMs = durationMs))
+        testResults[displayName] = TestResult(name = displayName, status = status, durationMs = durationMs)
     }
 
-    fun generateDiagnosticLog(): String = buildString {
+    private fun generateDiagnosticLog(): String = buildString {
         appendLine("Connectivity Test Log")
         appendLine("====================")
         appendLine()
-        testResults.forEachIndexed { index, result ->
+        testResults.values.forEachIndexed { index, result ->
             val statusStr = when (result.status) {
                 is Success -> "SUCCESS"
                 is Failure -> "FAILED"
@@ -357,7 +357,7 @@ class ConnectivityToolViewModel @Inject constructor(
         private const val TEST_NAME_INTERNET = "Internet Connection"
         private const val TEST_NAME_WPCOM = "WordPress.com Servers"
         private const val TEST_NAME_SITE = "Site Connection"
-        private const val TEST_NAME_ORDERS = "Fetching Orders"
-        private const val TEST_NAME_PRODUCTS = "Fetching Products"
+        private const val TEST_NAME_ORDERS = "Fetch Orders"
+        private const val TEST_NAME_PRODUCTS = "Fetch Products"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -270,16 +270,12 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun trackChanges(status: ConnectivityCheckStatus, type: String) {
         if (status is InProgress || status is NotStarted) return
 
-        val durationMs = when (status) {
-            is Success -> status.durationMs
-            is Failure -> status.durationMs
-        }
         analyticsTrackerWrapper.track(
             AnalyticsEvent.CONNECTIVITY_TOOL_REQUEST_RESPONSE,
             mapOf(
                 AnalyticsTracker.KEY_SUCCESS to (status is Success),
                 KEY_CONNECTIVITY_TEST to type,
-                AnalyticsTracker.KEY_TIME_TAKEN to durationMs
+                AnalyticsTracker.KEY_TIME_TAKEN to status.durationMs
             )
         )
     }
@@ -306,12 +302,7 @@ class ConnectivityToolViewModel @Inject constructor(
                     is Failure -> "FAILED"
                     else -> "UNKNOWN"
                 }
-                val durationMs = when (status) {
-                    is Success -> status.durationMs
-                    is Failure -> status.durationMs
-                    else -> 0L
-                }
-                appendLine("${index + 1}. $name: $statusStr (${durationMs}ms)")
+                appendLine("${index + 1}. $name: $statusStr (${status.durationMs}ms)")
                 if (status is Failure) {
                     status.error?.let { appendLine("   Error: ${it.name}") }
                     status.technicalDetails?.let { details ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -292,6 +292,8 @@ class ConnectivityToolViewModel @Inject constructor(
             add(StoreProductsCheckUseCase.OPERATION_NAME to currentState.productsCheckData.connectivityCheckStatus)
         }.filter { it.second is Success || it.second is Failure }
 
+        if (checks.isEmpty()) return null
+
         return buildString {
             checks.forEachIndexed { index, (name, status) ->
                 appendLine("## ${index + 1}. $name")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -293,22 +293,21 @@ class ConnectivityToolViewModel @Inject constructor(
         }.filter { it.second is Success || it.second is Failure }
 
         return buildString {
-            appendLine("Connectivity Test Log")
-            appendLine("====================")
-            appendLine()
             checks.forEachIndexed { index, (name, status) ->
-                val statusStr = when (status) {
-                    is Success -> "SUCCESS"
-                    is Failure -> "FAILED"
-                    else -> "UNKNOWN"
-                }
-                appendLine("${index + 1}. $name: $statusStr (${status.durationMs}ms)")
-                if (status is Failure) {
-                    status.error?.let { appendLine("   Error: ${it.name}") }
-                    status.technicalDetails?.let { details ->
-                        details.lines().forEach { line -> appendLine("   $line") }
+                appendLine("## ${index + 1}. $name")
+                appendLine("Took: ${status.durationMs}ms")
+                val resultStr = when (status) {
+                    is Success -> "Success"
+                    is Failure -> buildString {
+                        append(status.error?.name ?: "Failed")
+                        status.technicalDetails?.let { details ->
+                            append("\n$details")
+                        }
                     }
+                    else -> "Unknown"
                 }
+                appendLine("Result: $resultStr")
+                appendLine()
             }
         }.trimEnd()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -63,8 +63,6 @@ class ConnectivityToolViewModel @Inject constructor(
     private val isAppPasswordSite: Boolean
         get() = selectedSite.connectionType == SiteConnectionType.ApplicationPasswords
 
-    private val testResults = LinkedHashMap<String, TestResult>()
-
     private val stateMachine = savedState.getStateFlow(
         scope = viewModelScope,
         initialValue = InternetCheck
@@ -191,27 +189,24 @@ class ConnectivityToolViewModel @Inject constructor(
     }
 
     private fun startInternetCheck() {
-        val startTime = System.currentTimeMillis()
         internetConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_INTERNET, InternetConnectionCheckUseCase.OPERATION_NAME, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_INTERNET)
             status.startNextCheck()
             internetCheckFlow.update { it.copy(connectivityCheckStatus = status) }
         }.launchIn(viewModelScope)
     }
 
     private fun startWPComCheck() {
-        val startTime = System.currentTimeMillis()
         wpComConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_WP_COM, WPComConnectionCheckUseCase.OPERATION_NAME, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_WP_COM)
             status.startNextCheck()
             wpComCheckFlow.update { it.copy(connectivityCheckStatus = status) }
         }.launchIn(viewModelScope)
     }
 
     private fun startStoreCheck() {
-        val startTime = System.currentTimeMillis()
         storeConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_SITE, StoreConnectionCheckUseCase.OPERATION_NAME, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_SITE)
             status.startNextCheck()
             storeCheckFlow.update {
                 if (status is Failure) {
@@ -227,9 +222,8 @@ class ConnectivityToolViewModel @Inject constructor(
     }
 
     private fun startStoreOrdersCheck() {
-        val startTime = System.currentTimeMillis()
         storeOrdersCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_ORDERS, StoreOrdersCheckUseCase.OPERATION_NAME, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_ORDERS)
             status.startNextCheck()
             ordersCheckFlow.update {
                 if (status is Failure) {
@@ -245,9 +239,8 @@ class ConnectivityToolViewModel @Inject constructor(
     }
 
     private fun startProductsCheck() {
-        val startTime = System.currentTimeMillis()
         storeProductsCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_PRODUCTS, StoreProductsCheckUseCase.OPERATION_NAME, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_PRODUCTS)
             status.startNextCheck()
             productsCheckFlow.update {
                 if (status is Failure) {
@@ -274,15 +267,13 @@ class ConnectivityToolViewModel @Inject constructor(
         }
     }
 
-    private fun trackChanges(
-        status: ConnectivityCheckStatus,
-        type: String,
-        displayName: String,
-        startTime: Long
-    ) {
+    private fun trackChanges(status: ConnectivityCheckStatus, type: String) {
         if (status is InProgress || status is NotStarted) return
 
-        val durationMs = System.currentTimeMillis() - startTime
+        val durationMs = when (status) {
+            is Success -> status.durationMs
+            is Failure -> status.durationMs
+        }
         analyticsTrackerWrapper.track(
             AnalyticsEvent.CONNECTIVITY_TOOL_REQUEST_RESPONSE,
             mapOf(
@@ -291,28 +282,45 @@ class ConnectivityToolViewModel @Inject constructor(
                 AnalyticsTracker.KEY_TIME_TAKEN to durationMs
             )
         )
-        testResults[displayName] = TestResult(name = displayName, status = status, durationMs = durationMs)
     }
 
-    private fun generateDiagnosticLog(): String = buildString {
-        appendLine("Connectivity Test Log")
-        appendLine("====================")
-        appendLine()
-        testResults.values.forEachIndexed { index, result ->
-            val statusStr = when (result.status) {
-                is Success -> "SUCCESS"
-                is Failure -> "FAILED"
-                else -> "UNKNOWN"
+    private fun generateDiagnosticLog(): String {
+        val currentState = viewState.value ?: return ""
+        val checks = buildList {
+            add(InternetConnectionCheckUseCase.OPERATION_NAME to currentState.internetCheckData.connectivityCheckStatus)
+            if (currentState.isWPComCheckVisible) {
+                add(WPComConnectionCheckUseCase.OPERATION_NAME to currentState.wpComCheckData.connectivityCheckStatus)
             }
-            appendLine("${index + 1}. ${result.name}: $statusStr (${result.durationMs}ms)")
-            if (result.status is Failure) {
-                result.status.error?.let { appendLine("   Error: ${it.name}") }
-                result.status.technicalDetails?.let { details ->
-                    details.lines().forEach { line -> appendLine("   $line") }
+            add(StoreConnectionCheckUseCase.OPERATION_NAME to currentState.storeCheckData.connectivityCheckStatus)
+            add(StoreOrdersCheckUseCase.OPERATION_NAME to currentState.ordersCheckData.connectivityCheckStatus)
+            add(StoreProductsCheckUseCase.OPERATION_NAME to currentState.productsCheckData.connectivityCheckStatus)
+        }.filter { it.second is Success || it.second is Failure }
+
+        return buildString {
+            appendLine("Connectivity Test Log")
+            appendLine("====================")
+            appendLine()
+            checks.forEachIndexed { index, (name, status) ->
+                val statusStr = when (status) {
+                    is Success -> "SUCCESS"
+                    is Failure -> "FAILED"
+                    else -> "UNKNOWN"
+                }
+                val durationMs = when (status) {
+                    is Success -> status.durationMs
+                    is Failure -> status.durationMs
+                    else -> 0L
+                }
+                appendLine("${index + 1}. $name: $statusStr (${durationMs}ms)")
+                if (status is Failure) {
+                    status.error?.let { appendLine("   Error: ${it.name}") }
+                    status.technicalDetails?.let { details ->
+                        details.lines().forEach { line -> appendLine("   $line") }
+                    }
                 }
             }
-        }
-    }.trimEnd()
+        }.trimEnd()
+    }
 
     data class OpenSupportRequest(val diagnosticLog: String) : MultiLiveEvent.Event()
     data class OpenWebView(val url: String) : MultiLiveEvent.Event()
@@ -341,12 +349,6 @@ class ConnectivityToolViewModel @Inject constructor(
         StoreProductsCheck,
         Finished
     }
-
-    private data class TestResult(
-        val name: String,
-        val status: ConnectivityCheckStatus,
-        val durationMs: Long
-    )
 
     companion object {
         const val jetpackTroubleshootingUrl =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -280,8 +280,8 @@ class ConnectivityToolViewModel @Inject constructor(
         )
     }
 
-    private fun generateDiagnosticLog(): String {
-        val currentState = viewState.value ?: return ""
+    private fun generateDiagnosticLog(): String? {
+        val currentState = viewState.value ?: return null
         val checks = buildList {
             add(InternetConnectionCheckUseCase.OPERATION_NAME to currentState.internetCheckData.connectivityCheckStatus)
             if (currentState.isWPComCheckVisible) {
@@ -313,7 +313,7 @@ class ConnectivityToolViewModel @Inject constructor(
         }.trimEnd()
     }
 
-    data class OpenSupportRequest(val diagnosticLog: String) : MultiLiveEvent.Event()
+    data class OpenSupportRequest(val diagnosticLog: String?) : MultiLiveEvent.Event()
     data class OpenWebView(val url: String) : MultiLiveEvent.Event()
 
     data class ViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -193,7 +193,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startInternetCheck() {
         val startTime = System.currentTimeMillis()
         internetConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_INTERNET, TEST_NAME_INTERNET, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_INTERNET, InternetConnectionCheckUseCase.OPERATION_NAME, startTime)
             status.startNextCheck()
             internetCheckFlow.update { it.copy(connectivityCheckStatus = status) }
         }.launchIn(viewModelScope)
@@ -202,7 +202,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startWPComCheck() {
         val startTime = System.currentTimeMillis()
         wpComConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_WP_COM, TEST_NAME_WPCOM, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_WP_COM, WPComConnectionCheckUseCase.OPERATION_NAME, startTime)
             status.startNextCheck()
             wpComCheckFlow.update { it.copy(connectivityCheckStatus = status) }
         }.launchIn(viewModelScope)
@@ -211,7 +211,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startStoreCheck() {
         val startTime = System.currentTimeMillis()
         storeConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_SITE, TEST_NAME_SITE, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_SITE, StoreConnectionCheckUseCase.OPERATION_NAME, startTime)
             status.startNextCheck()
             storeCheckFlow.update {
                 if (status is Failure) {
@@ -229,7 +229,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startStoreOrdersCheck() {
         val startTime = System.currentTimeMillis()
         storeOrdersCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_ORDERS, TEST_NAME_ORDERS, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_ORDERS, StoreOrdersCheckUseCase.OPERATION_NAME, startTime)
             status.startNextCheck()
             ordersCheckFlow.update {
                 if (status is Failure) {
@@ -247,7 +247,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startProductsCheck() {
         val startTime = System.currentTimeMillis()
         storeProductsCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_PRODUCTS, TEST_NAME_PRODUCTS, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_PRODUCTS, StoreProductsCheckUseCase.OPERATION_NAME, startTime)
             status.startNextCheck()
             productsCheckFlow.update {
                 if (status is Failure) {
@@ -353,11 +353,5 @@ class ConnectivityToolViewModel @Inject constructor(
             "https://jetpack.com/support/reconnecting-reinstalling-jetpack/"
         const val genericTroubleshootingUrl =
             "https://woocommerce.com/document/android-ios-apps-troubleshooting-error-fetching-orders/"
-
-        private const val TEST_NAME_INTERNET = "Internet Connection"
-        private const val TEST_NAME_WPCOM = "WordPress.com Servers"
-        private const val TEST_NAME_SITE = "Site Connection"
-        private const val TEST_NAME_ORDERS = "Fetch Orders"
-        private const val TEST_NAME_PRODUCTS = "Fetch Products"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -62,6 +62,9 @@ class ConnectivityToolViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
     private val isAppPasswordSite: Boolean
         get() = selectedSite.connectionType == SiteConnectionType.ApplicationPasswords
+
+    private val testResults = mutableListOf<TestResult>()
+
     private val stateMachine = savedState.getStateFlow(
         scope = viewModelScope,
         initialValue = InternetCheck
@@ -160,7 +163,7 @@ class ConnectivityToolViewModel @Inject constructor(
 
     fun onContactSupportClicked() {
         analyticsTrackerWrapper.track(AnalyticsEvent.CONNECTIVITY_TOOL_CONTACT_SUPPORT_TAPPED)
-        triggerEvent(OpenSupportRequest)
+        triggerEvent(OpenSupportRequest(diagnosticLog = generateDiagnosticLog()))
     }
 
     fun onReturnClicked() {
@@ -190,7 +193,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startInternetCheck() {
         val startTime = System.currentTimeMillis()
         internetConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_INTERNET, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_INTERNET, TEST_NAME_INTERNET, startTime)
             status.startNextCheck()
             internetCheckFlow.update { it.copy(connectivityCheckStatus = status) }
         }.launchIn(viewModelScope)
@@ -199,7 +202,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startWPComCheck() {
         val startTime = System.currentTimeMillis()
         wpComConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_WP_COM, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_WP_COM, TEST_NAME_WPCOM, startTime)
             status.startNextCheck()
             wpComCheckFlow.update { it.copy(connectivityCheckStatus = status) }
         }.launchIn(viewModelScope)
@@ -208,7 +211,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startStoreCheck() {
         val startTime = System.currentTimeMillis()
         storeConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_SITE, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_SITE, TEST_NAME_SITE, startTime)
             status.startNextCheck()
             storeCheckFlow.update {
                 if (status is Failure) {
@@ -226,7 +229,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startStoreOrdersCheck() {
         val startTime = System.currentTimeMillis()
         storeOrdersCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_ORDERS, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_ORDERS, TEST_NAME_ORDERS, startTime)
             status.startNextCheck()
             ordersCheckFlow.update {
                 if (status is Failure) {
@@ -244,7 +247,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun startProductsCheck() {
         val startTime = System.currentTimeMillis()
         storeProductsCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_PRODUCTS, startTime)
+            trackChanges(status, VALUE_CONNECTIVITY_PRODUCTS, TEST_NAME_PRODUCTS, startTime)
             status.startNextCheck()
             productsCheckFlow.update {
                 if (status is Failure) {
@@ -274,21 +277,44 @@ class ConnectivityToolViewModel @Inject constructor(
     private fun trackChanges(
         status: ConnectivityCheckStatus,
         type: String,
+        displayName: String,
         startTime: Long
     ) {
         if (status is InProgress || status is NotStarted) return
 
+        val durationMs = System.currentTimeMillis() - startTime
         analyticsTrackerWrapper.track(
             AnalyticsEvent.CONNECTIVITY_TOOL_REQUEST_RESPONSE,
             mapOf(
                 AnalyticsTracker.KEY_SUCCESS to (status is Success),
                 KEY_CONNECTIVITY_TEST to type,
-                AnalyticsTracker.KEY_TIME_TAKEN to (System.currentTimeMillis() - startTime)
+                AnalyticsTracker.KEY_TIME_TAKEN to durationMs
             )
         )
+        testResults.add(TestResult(name = displayName, status = status, durationMs = durationMs))
     }
 
-    object OpenSupportRequest : MultiLiveEvent.Event()
+    fun generateDiagnosticLog(): String = buildString {
+        appendLine("Connectivity Test Log")
+        appendLine("====================")
+        appendLine()
+        testResults.forEachIndexed { index, result ->
+            val statusStr = when (result.status) {
+                is Success -> "SUCCESS"
+                is Failure -> "FAILED"
+                else -> "UNKNOWN"
+            }
+            appendLine("${index + 1}. ${result.name}: $statusStr (${result.durationMs}ms)")
+            if (result.status is Failure) {
+                result.status.error?.let { appendLine("   Error: ${it.name}") }
+                result.status.technicalDetails?.let { details ->
+                    details.lines().forEach { line -> appendLine("   $line") }
+                }
+            }
+        }
+    }.trimEnd()
+
+    data class OpenSupportRequest(val diagnosticLog: String) : MultiLiveEvent.Event()
     data class OpenWebView(val url: String) : MultiLiveEvent.Event()
 
     data class ViewState(
@@ -316,10 +342,22 @@ class ConnectivityToolViewModel @Inject constructor(
         Finished
     }
 
+    private data class TestResult(
+        val name: String,
+        val status: ConnectivityCheckStatus,
+        val durationMs: Long
+    )
+
     companion object {
         const val jetpackTroubleshootingUrl =
             "https://jetpack.com/support/reconnecting-reinstalling-jetpack/"
         const val genericTroubleshootingUrl =
             "https://woocommerce.com/document/android-ios-apps-troubleshooting-error-fetching-orders/"
+
+        private const val TEST_NAME_INTERNET = "Internet Connection"
+        private const val TEST_NAME_WPCOM = "WordPress.com Servers"
+        private const val TEST_NAME_SITE = "Site Connection"
+        private const val TEST_NAME_ORDERS = "Fetching Orders"
+        private const val TEST_NAME_PRODUCTS = "Fetching Products"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/InternetConnectionCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/InternetConnectionCheckUseCase.kt
@@ -20,4 +20,8 @@ class InternetConnectionCheckUseCase @Inject constructor(
             emit(Failure())
         }
     }
+
+    companion object {
+        const val OPERATION_NAME = "Internet Connection"
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/InternetConnectionCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/InternetConnectionCheckUseCase.kt
@@ -14,10 +14,13 @@ class InternetConnectionCheckUseCase @Inject constructor(
 ) {
     operator fun invoke(): Flow<ConnectivityCheckStatus> = flow {
         emit(InProgress)
-        if (networkStatus.isConnected()) {
-            emit(Success)
+        val startTime = System.currentTimeMillis()
+        val isConnected = networkStatus.isConnected()
+        val durationMs = System.currentTimeMillis() - startTime
+        if (isConnected) {
+            emit(Success(durationMs = durationMs))
         } else {
-            emit(Failure())
+            emit(Failure(durationMs = durationMs))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCase.kt
@@ -25,7 +25,7 @@ class StoreConnectionCheckUseCase @Inject constructor(
     operator fun invoke(): Flow<ConnectivityCheckStatus> = flow {
         emit(InProgress)
         val startTime = System.currentTimeMillis()
-        val result = ssrFetcher.load(selectedSite.get())
+        val result = ssrFetcher.load(selectedSite.get(), forceRefresh = true)
         val durationMs = System.currentTimeMillis() - startTime
         if (result.isError) {
             emit(result.parseError(durationMs))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCase.kt
@@ -54,6 +54,6 @@ class StoreConnectionCheckUseCase @Inject constructor(
     }
 
     companion object {
-        const val OPERATION_NAME = "Site Connection"
+        const val OPERATION_NAME = "Connecting to your site"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCase.kt
@@ -24,14 +24,17 @@ class StoreConnectionCheckUseCase @Inject constructor(
 
     operator fun invoke(): Flow<ConnectivityCheckStatus> = flow {
         emit(InProgress)
-        ssrFetcher.load(selectedSite.get())
-            .takeIf { it.isError }
-            ?.parseError()
-            ?.let { emit(it) }
-            ?: emit(Success)
+        val startTime = System.currentTimeMillis()
+        val result = ssrFetcher.load(selectedSite.get())
+        val durationMs = System.currentTimeMillis() - startTime
+        if (result.isError) {
+            emit(result.parseError(durationMs))
+        } else {
+            emit(Success(durationMs = durationMs))
+        }
     }
 
-    private fun WooResult<WCSSRModel>.parseError(): Failure {
+    private fun WooResult<WCSSRModel>.parseError(durationMs: Long): Failure {
         val failureType = when (error.type) {
             WooErrorType.TIMEOUT -> FailureType.TIMEOUT
             WooErrorType.API_NOT_FOUND -> if (isAppPasswordSite) FailureType.GENERIC else FailureType.JETPACK
@@ -45,7 +48,8 @@ class StoreConnectionCheckUseCase @Inject constructor(
                 operation = OPERATION_NAME,
                 errorType = error.type.name,
                 message = error.message
-            )
+            ),
+            durationMs = durationMs
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCase.kt
@@ -42,10 +42,14 @@ class StoreConnectionCheckUseCase @Inject constructor(
         return Failure(
             error = failureType,
             technicalDetails = formatErrorDetails(
-                operation = "Site Connection",
+                operation = OPERATION_NAME,
                 errorType = error.type.name,
                 message = error.message
             )
         )
+    }
+
+    companion object {
+        const val OPERATION_NAME = "Site Connection"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreOrdersCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreOrdersCheckUseCase.kt
@@ -43,10 +43,14 @@ class StoreOrdersCheckUseCase @Inject constructor(
         return Failure(
             error = failureType,
             technicalDetails = formatErrorDetails(
-                operation = "Fetch Orders",
+                operation = OPERATION_NAME,
                 errorType = error.type.name,
                 message = error.message
             )
         )
+    }
+
+    companion object {
+        const val OPERATION_NAME = "Fetch Orders"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreOrdersCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreOrdersCheckUseCase.kt
@@ -56,6 +56,6 @@ class StoreOrdersCheckUseCase @Inject constructor(
     }
 
     companion object {
-        const val OPERATION_NAME = "Fetch Orders"
+        const val OPERATION_NAME = "Fetching your site orders"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreOrdersCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreOrdersCheckUseCase.kt
@@ -25,14 +25,18 @@ class StoreOrdersCheckUseCase @Inject constructor(
 
     operator fun invoke(): Flow<ConnectivityCheckStatus> = flow {
         emit(InProgress)
-        orderStore.fetchHasOrders(selectedSite.get(), null)
-            .run { this as? HasOrdersResult.Failure }
-            ?.parseError()
-            ?.let { emit(it) }
-            ?: emit(Success)
+        val startTime = System.currentTimeMillis()
+        val result = orderStore.fetchHasOrders(selectedSite.get(), null)
+        val durationMs = System.currentTimeMillis() - startTime
+        val failure = (result as? HasOrdersResult.Failure)?.parseError(durationMs)
+        if (failure != null) {
+            emit(failure)
+        } else {
+            emit(Success(durationMs = durationMs))
+        }
     }
 
-    private fun HasOrdersResult.Failure.parseError(): Failure {
+    private fun HasOrdersResult.Failure.parseError(durationMs: Long): Failure {
         val failureType = when (error.type) {
             TIMEOUT_ERROR -> FailureType.TIMEOUT
             PARSE_ERROR -> FailureType.PARSE
@@ -46,7 +50,8 @@ class StoreOrdersCheckUseCase @Inject constructor(
                 operation = OPERATION_NAME,
                 errorType = error.type.name,
                 message = error.message
-            )
+            ),
+            durationMs = durationMs
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCase.kt
@@ -24,14 +24,17 @@ class StoreProductsCheckUseCase @Inject constructor(
 
     operator fun invoke(): Flow<ConnectivityCheckStatus> = flow {
         emit(InProgress)
-        productStore.fetchProducts(selectedSite.get())
-            .takeIf { it.isError }
-            ?.parseError()
-            ?.let { emit(it) }
-            ?: emit(Success)
+        val startTime = System.currentTimeMillis()
+        val result = productStore.fetchProducts(selectedSite.get())
+        val durationMs = System.currentTimeMillis() - startTime
+        if (result.isError) {
+            emit(result.parseError(durationMs))
+        } else {
+            emit(Success(durationMs = durationMs))
+        }
     }
 
-    private fun WooResult<List<WCProductModel>>.parseError(): Failure {
+    private fun WooResult<List<WCProductModel>>.parseError(durationMs: Long): Failure {
         val failureType = when (error.type) {
             WooErrorType.TIMEOUT -> FailureType.TIMEOUT
             WooErrorType.INVALID_RESPONSE -> FailureType.PARSE
@@ -45,7 +48,8 @@ class StoreProductsCheckUseCase @Inject constructor(
                 operation = OPERATION_NAME,
                 errorType = error.type.name,
                 message = error.message
-            )
+            ),
+            durationMs = durationMs
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCase.kt
@@ -42,10 +42,14 @@ class StoreProductsCheckUseCase @Inject constructor(
         return Failure(
             error = failureType,
             technicalDetails = formatErrorDetails(
-                operation = "Fetch Products",
+                operation = OPERATION_NAME,
                 errorType = error.type.name,
                 message = error.message
             )
         )
+    }
+
+    companion object {
+        const val OPERATION_NAME = "Fetch Products"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCase.kt
@@ -54,6 +54,6 @@ class StoreProductsCheckUseCase @Inject constructor(
     }
 
     companion object {
-        const val OPERATION_NAME = "Fetch Products"
+        const val OPERATION_NAME = "Fetching products in your store"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/WPComConnectionCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/WPComConnectionCheckUseCase.kt
@@ -16,11 +16,16 @@ class WPComConnectionCheckUseCase @Inject constructor(
 ) {
     operator fun invoke(): Flow<ConnectivityCheckStatus> = flow {
         emit(InProgress)
-        whatsNewStore.fetchRemoteAnnouncements(
+        val startTime = System.currentTimeMillis()
+        val result = whatsNewStore.fetchRemoteAnnouncements(
             versionName = buildConfigWrapper.versionName
-        ).fetchError?.let {
-            emit(Failure())
-        } ?: emit(Success)
+        )
+        val durationMs = System.currentTimeMillis() - startTime
+        if (result.fetchError != null) {
+            emit(Failure(durationMs = durationMs))
+        } else {
+            emit(Success(durationMs = durationMs))
+        }
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/WPComConnectionCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/WPComConnectionCheckUseCase.kt
@@ -29,6 +29,6 @@ class WPComConnectionCheckUseCase @Inject constructor(
     }
 
     companion object {
-        const val OPERATION_NAME = "WordPress.com Servers"
+        const val OPERATION_NAME = "Connecting to WordPress.com Servers"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/WPComConnectionCheckUseCase.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/WPComConnectionCheckUseCase.kt
@@ -22,4 +22,8 @@ class WPComConnectionCheckUseCase @Inject constructor(
             emit(Failure())
         } ?: emit(Success)
     }
+
+    companion object {
+        const val OPERATION_NAME = "WordPress.com Servers"
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabled.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPOSIsRemotelyEnabled.kt
@@ -14,11 +14,7 @@ class WooPOSIsRemotelyEnabled @Inject constructor(
 ) {
 
     suspend operator fun invoke(forceRefresh: Boolean = false): Result<Boolean> {
-        if (forceRefresh) {
-            ssrFetcher.invalidate()
-        }
-
-        val result = ssrFetcher.load(selectedSite.get())
+        val result = ssrFetcher.load(selectedSite.get(), forceRefresh)
 
         if (!result.isError) {
             result.model?.let { ssr ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WCSSRModelCachingFetcher.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/WCSSRModelCachingFetcher.kt
@@ -28,12 +28,13 @@ class WCSSRModelCachingFetcher @Inject constructor(
     )
 
     suspend fun load(
-        siteModel: SiteModel
+        siteModel: SiteModel,
+        forceRefresh: Boolean = false
     ): WooResult<WCSSRModel> = mutex.withLock {
         val cached = cache[siteModel.siteId]
         val now = System.currentTimeMillis()
 
-        if (cached != null && now - cached.timestamp < cacheTTL) {
+        if (!forceRefresh && cached != null && now - cached.timestamp < cacheTTL) {
             return WooResult(cached.data)
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
@@ -49,7 +49,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
     private lateinit var envDataSource: ZendeskEnvironmentDataSource
     private lateinit var siteStore: SiteStore
     private val ssrFetcher: WCSSRModelCachingFetcher = mock {
-        onBlocking { load(any()) } doReturn WooResult(model = null)
+        onBlocking { load(any(), any()) } doReturn WooResult(model = null)
     }
     private val isAppPasswordsSupportedForJetpackSite: IsAppPasswordsSupportedForJetpackSite = mock()
 
@@ -409,7 +409,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
             val captor = argumentCaptor<CreateRequest>()
 
             ssrFetcher.stub {
-                onBlocking { load(selectedSite) } doReturn WooResult(model = WCSSRModel(123))
+                onBlocking { load(selectedSite, false) } doReturn WooResult(model = WCSSRModel(123))
             }
 
             // When
@@ -573,7 +573,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
         testBlocking {
             // given
             ssrFetcher.stub {
-                onBlocking { load(any()) } doReturn WooResult(model = WCSSRModel(123))
+                onBlocking { load(any(), any()) } doReturn WooResult(model = WCSSRModel(123))
             }
 
             val siteAddress = "www.test.com"
@@ -607,7 +607,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
         testBlocking {
             // given
             ssrFetcher.stub {
-                onBlocking { load(any()) } doReturn WooResult(model = WCSSRModel(123))
+                onBlocking { load(any(), any()) } doReturn WooResult(model = WCSSRModel(123))
             }
             val captor = argumentCaptor<CreateRequest>()
             createSUT()
@@ -666,7 +666,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
         testBlocking {
             // given
             ssrFetcher.stub {
-                onBlocking { load(any()) } doReturn WooResult(
+                onBlocking { load(any(), any()) } doReturn WooResult(
                     WooError(
                         WooErrorType.GENERIC_ERROR,
                         BaseRequest.GenericErrorType.NETWORK_ERROR

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
@@ -20,6 +20,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -122,7 +123,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         assertThat(isRequestLoading[0]).isFalse
         assertThat(isRequestLoading[1]).isTrue
         assertThat(isRequestLoading[2]).isFalse
-        verify(zendeskTicketRepository, times(1)).createRequest(any(), any(), any(), any(), any(), any(), any(), any())
+        verify(zendeskTicketRepository, times(1)).createRequest(any(), any(), any(), any(), any(), any(), any(), any(), anyOrNull())
     }
 
     @Test
@@ -139,7 +140,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         // Then
         assertThat(isRequestLoading).hasSize(1)
         assertThat(isRequestLoading[0]).isFalse
-        verify(zendeskTicketRepository, never()).createRequest(any(), any(), any(), any(), any(), any(), any(), any())
+        verify(zendeskTicketRepository, never()).createRequest(any(), any(), any(), any(), any(), any(), any(), any(), anyOrNull())
     }
 
     @Test
@@ -215,13 +216,13 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
 
         // When
         sut.onHelpOptionSelected(TicketType.MobileApp)
-        sut.onUserIdentitySet(mock(), HelpOrigin.LOGIN_HELP_NOTIFICATION, emptyList(), email, name)
+        sut.onUserIdentitySet(mock(), HelpOrigin.LOGIN_HELP_NOTIFICATION, emptyList(), null, email, name)
 
         // Then
         verify(zendeskSettings).supportEmail = email
         verify(zendeskSettings).supportName = name
         verify(tracks, times(1)).track(AnalyticsEvent.SUPPORT_IDENTITY_SET)
-        verify(zendeskTicketRepository, times(1)).createRequest(any(), any(), any(), any(), any(), any(), any(), any())
+        verify(zendeskTicketRepository, times(1)).createRequest(any(), any(), any(), any(), any(), any(), any(), any(), anyOrNull())
     }
 
     private fun configureMocks(requestResult: Result<Request?>) {
@@ -241,7 +242,8 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
                     any(),
                     any(),
                     any(),
-                    any()
+                    any(),
+                    anyOrNull()
                 )
             } doReturn flowOf(requestResult)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
@@ -123,7 +123,10 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         assertThat(isRequestLoading[0]).isFalse
         assertThat(isRequestLoading[1]).isTrue
         assertThat(isRequestLoading[2]).isFalse
-        verify(zendeskTicketRepository, times(1)).createRequest(any(), any(), any(), any(), any(), any(), any(), any(), anyOrNull())
+        verify(
+            zendeskTicketRepository,
+            times(1)
+        ).createRequest(any(), any(), any(), any(), any(), any(), any(), any(), anyOrNull())
     }
 
     @Test
@@ -140,7 +143,10 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         // Then
         assertThat(isRequestLoading).hasSize(1)
         assertThat(isRequestLoading[0]).isFalse
-        verify(zendeskTicketRepository, never()).createRequest(any(), any(), any(), any(), any(), any(), any(), any(), anyOrNull())
+        verify(
+            zendeskTicketRepository,
+            never()
+        ).createRequest(any(), any(), any(), any(), any(), any(), any(), any(), anyOrNull())
     }
 
     @Test
@@ -222,7 +228,10 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
         verify(zendeskSettings).supportEmail = email
         verify(zendeskSettings).supportName = name
         verify(tracks, times(1)).track(AnalyticsEvent.SUPPORT_IDENTITY_SET)
-        verify(zendeskTicketRepository, times(1)).createRequest(any(), any(), any(), any(), any(), any(), any(), any(), anyOrNull())
+        verify(
+            zendeskTicketRepository,
+            times(1)
+        ).createRequest(any(), any(), any(), any(), any(), any(), any(), any(), anyOrNull())
     }
 
     private fun configureMocks(requestResult: Result<Request?>) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
@@ -50,11 +50,11 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         storeProductsCheck = mock()
         selectedSite = mock()
         analyticsTrackerWrapper = mock()
-        whenever(internetConnectionCheck()).thenReturn(flowOf(Success))
-        whenever(wpComConnectionCheck()).thenReturn(flowOf(Success))
-        whenever(storeConnectionCheck()).thenReturn(flowOf(Success))
-        whenever(storeOrdersCheck()).thenReturn(flowOf(Success))
-        whenever(storeProductsCheck()).thenReturn(flowOf(Success))
+        whenever(internetConnectionCheck()).thenReturn(flowOf(Success()))
+        whenever(wpComConnectionCheck()).thenReturn(flowOf(Success()))
+        whenever(storeConnectionCheck()).thenReturn(flowOf(Success()))
+        whenever(storeOrdersCheck()).thenReturn(flowOf(Success()))
+        whenever(storeProductsCheck()).thenReturn(flowOf(Success()))
         whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.Jetpack)
         createViewModel()
     }
@@ -76,7 +76,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
     fun `when internetConnectionCheck use case starts, then update ViewState as expected`() = testBlocking {
         // Given
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(internetConnectionCheck()).thenReturn(flowOf(Success))
+        whenever(internetConnectionCheck()).thenReturn(flowOf(Success()))
         sut.viewState
             .map { it.internetCheckData }
             .distinctUntilChanged()
@@ -86,14 +86,14 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         sut.startConnectionChecks()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success))
+        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success()))
     }
 
     @Test
     fun `when wpComConnectionCheck use case starts, then update ViewState as expected`() = testBlocking {
         // Given
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(wpComConnectionCheck()).thenReturn(flowOf(Success))
+        whenever(wpComConnectionCheck()).thenReturn(flowOf(Success()))
         sut.viewState
             .map { it.wpComCheckData }
             .distinctUntilChanged()
@@ -103,14 +103,14 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         sut.startConnectionChecks()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success))
+        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success()))
     }
 
     @Test
     fun `when storeConnectionCheck use case starts, then update ViewState as expected`() = testBlocking {
         // Given
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(storeConnectionCheck()).thenReturn(flowOf(Success))
+        whenever(storeConnectionCheck()).thenReturn(flowOf(Success()))
         sut.viewState
             .map { it.storeCheckData }
             .distinctUntilChanged()
@@ -120,14 +120,14 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         sut.startConnectionChecks()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success))
+        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success()))
     }
 
     @Test
     fun `when storeOrdersCheck use case starts, then update ViewState as expected`() = testBlocking {
         // Given
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(storeOrdersCheck()).thenReturn(flowOf(Success))
+        whenever(storeOrdersCheck()).thenReturn(flowOf(Success()))
         sut.viewState
             .map { it.ordersCheckData }
             .distinctUntilChanged()
@@ -137,7 +137,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         sut.startConnectionChecks()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success))
+        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success()))
     }
 
     @Test
@@ -175,7 +175,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
     fun `when checks are still running, then isCheckFinished is false`() = testBlocking {
         // Given
         val stateEvents = mutableListOf<Boolean>()
-        whenever(internetConnectionCheck()).thenReturn(flowOf(Success))
+        whenever(internetConnectionCheck()).thenReturn(flowOf(Success()))
         whenever(wpComConnectionCheck()).thenReturn(flowOf(InProgress))
         sut.isCheckFinished.observeForever {
             stateEvents.add(it)
@@ -192,7 +192,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
     fun `when storeProductsCheck use case starts, then update ViewState as expected`() = testBlocking {
         // Given
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(storeProductsCheck()).thenReturn(flowOf(Success))
+        whenever(storeProductsCheck()).thenReturn(flowOf(Success()))
         sut.viewState
             .map { it.productsCheckData }
             .distinctUntilChanged()
@@ -202,7 +202,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         sut.startConnectionChecks()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success))
+        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success()))
     }
 
     @Test
@@ -223,6 +223,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
     fun `when onContactSupportClicked is called, then trigger OpenSupportRequest event with diagnostic log`() =
         testBlocking {
             // Given
+            sut.viewState.observeForever {}
             sut.startConnectionChecks()
             val events = mutableListOf<MultiLiveEvent.Event>()
             sut.event.observeForever { events.add(it) }
@@ -335,6 +336,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
     @Test
     fun `when all checks succeed, then diagnostic log contains all SUCCESS entries`() = testBlocking {
         // GIVEN
+        sut.viewState.observeForever {}
         sut.startConnectionChecks()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }
@@ -360,6 +362,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         )
         whenever(storeConnectionCheck()).thenReturn(flowOf(failure))
         createViewModel()
+        sut.viewState.observeForever {}
         sut.startConnectionChecks()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }
@@ -379,6 +382,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         // GIVEN
         whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
         createViewModel()
+        sut.viewState.observeForever {}
         sut.startConnectionChecks()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }
@@ -400,6 +404,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         // GIVEN
         whenever(internetConnectionCheck()).thenReturn(flowOf(Failure()))
         createViewModel()
+        sut.viewState.observeForever {}
         sut.startConnectionChecks()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
@@ -220,17 +220,22 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when onContactSupportClicked is called, then trigger OpenSupportRequest event`() {
-        // Given
-        val events = mutableListOf<MultiLiveEvent.Event>()
-        sut.event.observeForever { events.add(it) }
+    fun `when onContactSupportClicked is called, then trigger OpenSupportRequest event with diagnostic log`() =
+        testBlocking {
+            // Given
+            sut.startConnectionChecks()
+            val events = mutableListOf<MultiLiveEvent.Event>()
+            sut.event.observeForever { events.add(it) }
 
-        // When
-        sut.onContactSupportClicked()
+            // When
+            sut.onContactSupportClicked()
 
-        // Then
-        assertThat(events).isEqualTo(listOf(OpenSupportRequest))
-    }
+            // Then
+            assertThat(events).hasSize(1)
+            assertThat(events.first()).isInstanceOf(OpenSupportRequest::class.java)
+            val log = (events.first() as OpenSupportRequest).diagnosticLog
+            assertThat(log).contains("Connectivity Test Log")
+        }
 
     @Test
     fun `given app password site, when checks run, then WPCom check is skipped`() = testBlocking {
@@ -324,5 +329,71 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
             // THEN
             assertThat(sut.technicalDetailsToShow.value).isNull()
         }
+    }
+
+    @Test
+    fun `when all checks succeed, then diagnostic log contains all SUCCESS entries`() = testBlocking {
+        // WHEN
+        sut.startConnectionChecks()
+
+        // THEN
+        val log = sut.generateDiagnosticLog()
+        assertThat(log).contains("1. Internet Connection: SUCCESS")
+        assertThat(log).contains("2. WordPress.com Servers: SUCCESS")
+        assertThat(log).contains("3. Site Connection: SUCCESS")
+        assertThat(log).contains("4. Fetching Orders: SUCCESS")
+        assertThat(log).contains("5. Fetching Products: SUCCESS")
+    }
+
+    @Test
+    fun `when a check fails, then diagnostic log contains FAILED entry with error info`() = testBlocking {
+        // GIVEN
+        val failure = Failure(
+            error = FailureType.TIMEOUT,
+            technicalDetails = "Operation: Site Connection\nError Type: TIMEOUT"
+        )
+        whenever(storeConnectionCheck()).thenReturn(flowOf(failure))
+
+        // WHEN
+        sut.startConnectionChecks()
+
+        // THEN
+        val log = sut.generateDiagnosticLog()
+        assertThat(log).contains("3. Site Connection: FAILED")
+        assertThat(log).contains("Error: TIMEOUT")
+        assertThat(log).contains("Operation: Site Connection")
+    }
+
+    @Test
+    fun `given app password site, when all checks succeed, then diagnostic log skips WPCom entry`() = testBlocking {
+        // GIVEN
+        whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
+        createViewModel()
+
+        // WHEN
+        sut.startConnectionChecks()
+
+        // THEN
+        val log = sut.generateDiagnosticLog()
+        assertThat(log).contains("Internet Connection: SUCCESS")
+        assertThat(log).doesNotContain("WordPress.com Servers")
+        assertThat(log).contains("Site Connection: SUCCESS")
+        assertThat(log).contains("Fetching Orders: SUCCESS")
+        assertThat(log).contains("Fetching Products: SUCCESS")
+    }
+
+    @Test
+    fun `when check fails early, then diagnostic log only contains completed checks`() = testBlocking {
+        // GIVEN
+        whenever(internetConnectionCheck()).thenReturn(flowOf(Failure()))
+
+        // WHEN
+        sut.startConnectionChecks()
+
+        // THEN
+        val log = sut.generateDiagnosticLog()
+        assertThat(log).contains("1. Internet Connection: FAILED")
+        assertThat(log).doesNotContain("WordPress.com Servers")
+        assertThat(log).doesNotContain("Site Connection")
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
@@ -235,8 +235,8 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
             assertThat(events).hasSize(1)
             assertThat(events.first()).isInstanceOf(OpenSupportRequest::class.java)
             val log = (events.first() as OpenSupportRequest).diagnosticLog
-            assertThat(log).contains("Connectivity Test Log")
-            assertThat(log).contains("Internet Connection: SUCCESS")
+            assertThat(log).contains("## 1. Internet Connection")
+            assertThat(log).contains("Result: Success")
         }
 
     @Test
@@ -346,11 +346,12 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // THEN
         val log = (events.first() as OpenSupportRequest).diagnosticLog
-        assertThat(log).contains("1. Internet Connection: SUCCESS")
-        assertThat(log).contains("2. WordPress.com Servers: SUCCESS")
-        assertThat(log).contains("3. Site Connection: SUCCESS")
-        assertThat(log).contains("4. Fetch Orders: SUCCESS")
-        assertThat(log).contains("5. Fetch Products: SUCCESS")
+        assertThat(log).contains("## 1. Internet Connection")
+        assertThat(log).contains("## 2. Connecting to WordPress.com Servers")
+        assertThat(log).contains("## 3. Connecting to your site")
+        assertThat(log).contains("## 4. Fetching your site orders")
+        assertThat(log).contains("## 5. Fetching products in your store")
+        assertThat(log!!.lines().filter { it == "Result: Success" }).hasSize(5)
     }
 
     @Test
@@ -372,8 +373,8 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // THEN
         val log = (events.first() as OpenSupportRequest).diagnosticLog
-        assertThat(log).contains("3. Site Connection: FAILED")
-        assertThat(log).contains("Error: TIMEOUT")
+        assertThat(log).contains("## 3. Connecting to your site")
+        assertThat(log).contains("Result: TIMEOUT")
         assertThat(log).contains("Operation: Site Connection")
     }
 
@@ -392,11 +393,11 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // THEN
         val log = (events.first() as OpenSupportRequest).diagnosticLog
-        assertThat(log).contains("Internet Connection: SUCCESS")
+        assertThat(log).contains("## 1. Internet Connection")
         assertThat(log).doesNotContain("WordPress.com Servers")
-        assertThat(log).contains("Site Connection: SUCCESS")
-        assertThat(log).contains("Fetch Orders: SUCCESS")
-        assertThat(log).contains("Fetch Products: SUCCESS")
+        assertThat(log).contains("## 2. Connecting to your site")
+        assertThat(log).contains("## 3. Fetching your site orders")
+        assertThat(log).contains("## 4. Fetching products in your store")
     }
 
     @Test
@@ -414,8 +415,9 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // THEN
         val log = (events.first() as OpenSupportRequest).diagnosticLog
-        assertThat(log).contains("1. Internet Connection: FAILED")
+        assertThat(log).contains("## 1. Internet Connection")
+        assertThat(log).contains("Result: Failed")
         assertThat(log).doesNotContain("WordPress.com Servers")
-        assertThat(log).doesNotContain("Site Connection")
+        assertThat(log).doesNotContain("Connecting to your site")
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
@@ -235,6 +235,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
             assertThat(events.first()).isInstanceOf(OpenSupportRequest::class.java)
             val log = (events.first() as OpenSupportRequest).diagnosticLog
             assertThat(log).contains("Connectivity Test Log")
+            assertThat(log).contains("Internet Connection: SUCCESS")
         }
 
     @Test
@@ -333,16 +334,21 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when all checks succeed, then diagnostic log contains all SUCCESS entries`() = testBlocking {
-        // WHEN
+        // GIVEN
         sut.startConnectionChecks()
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        sut.event.observeForever { events.add(it) }
+
+        // WHEN
+        sut.onContactSupportClicked()
 
         // THEN
-        val log = sut.generateDiagnosticLog()
+        val log = (events.first() as OpenSupportRequest).diagnosticLog
         assertThat(log).contains("1. Internet Connection: SUCCESS")
         assertThat(log).contains("2. WordPress.com Servers: SUCCESS")
         assertThat(log).contains("3. Site Connection: SUCCESS")
-        assertThat(log).contains("4. Fetching Orders: SUCCESS")
-        assertThat(log).contains("5. Fetching Products: SUCCESS")
+        assertThat(log).contains("4. Fetch Orders: SUCCESS")
+        assertThat(log).contains("5. Fetch Products: SUCCESS")
     }
 
     @Test
@@ -353,12 +359,16 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
             technicalDetails = "Operation: Site Connection\nError Type: TIMEOUT"
         )
         whenever(storeConnectionCheck()).thenReturn(flowOf(failure))
+        createViewModel()
+        sut.startConnectionChecks()
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        sut.event.observeForever { events.add(it) }
 
         // WHEN
-        sut.startConnectionChecks()
+        sut.onContactSupportClicked()
 
         // THEN
-        val log = sut.generateDiagnosticLog()
+        val log = (events.first() as OpenSupportRequest).diagnosticLog
         assertThat(log).contains("3. Site Connection: FAILED")
         assertThat(log).contains("Error: TIMEOUT")
         assertThat(log).contains("Operation: Site Connection")
@@ -369,29 +379,36 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         // GIVEN
         whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
         createViewModel()
+        sut.startConnectionChecks()
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        sut.event.observeForever { events.add(it) }
 
         // WHEN
-        sut.startConnectionChecks()
+        sut.onContactSupportClicked()
 
         // THEN
-        val log = sut.generateDiagnosticLog()
+        val log = (events.first() as OpenSupportRequest).diagnosticLog
         assertThat(log).contains("Internet Connection: SUCCESS")
         assertThat(log).doesNotContain("WordPress.com Servers")
         assertThat(log).contains("Site Connection: SUCCESS")
-        assertThat(log).contains("Fetching Orders: SUCCESS")
-        assertThat(log).contains("Fetching Products: SUCCESS")
+        assertThat(log).contains("Fetch Orders: SUCCESS")
+        assertThat(log).contains("Fetch Products: SUCCESS")
     }
 
     @Test
     fun `when check fails early, then diagnostic log only contains completed checks`() = testBlocking {
         // GIVEN
         whenever(internetConnectionCheck()).thenReturn(flowOf(Failure()))
+        createViewModel()
+        sut.startConnectionChecks()
+        val events = mutableListOf<MultiLiveEvent.Event>()
+        sut.event.observeForever { events.add(it) }
 
         // WHEN
-        sut.startConnectionChecks()
+        sut.onContactSupportClicked()
 
         // THEN
-        val log = sut.generateDiagnosticLog()
+        val log = (events.first() as OpenSupportRequest).diagnosticLog
         assertThat(log).contains("1. Internet Connection: FAILED")
         assertThat(log).doesNotContain("WordPress.com Servers")
         assertThat(log).doesNotContain("Site Connection")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/InternetConnectionCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/InternetConnectionCheckUseCaseTest.kt
@@ -38,7 +38,9 @@ class InternetConnectionCheckUseCaseTest : BaseUnitTest() {
         }.launchIn(this)
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(InProgress, Success))
+        assertThat(stateEvents).hasSize(2)
+        assertThat(stateEvents[0]).isEqualTo(InProgress)
+        assertThat(stateEvents[1]).isInstanceOf(Success::class.java)
     }
 
     @Test
@@ -53,6 +55,8 @@ class InternetConnectionCheckUseCaseTest : BaseUnitTest() {
         }.launchIn(this)
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(InProgress, Failure()))
+        assertThat(stateEvents).hasSize(2)
+        assertThat(stateEvents[0]).isEqualTo(InProgress)
+        assertThat(stateEvents[1]).isInstanceOf(Failure::class.java)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCaseTest.kt
@@ -179,6 +179,8 @@ class StoreConnectionCheckUseCaseTest : BaseUnitTest() {
         }.launchIn(this)
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(InProgress, Success))
+        assertThat(stateEvents).hasSize(2)
+        assertThat(stateEvents[0]).isEqualTo(InProgress)
+        assertThat(stateEvents[1]).isInstanceOf(Success::class.java)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreConnectionCheckUseCaseTest.kt
@@ -49,7 +49,7 @@ class StoreConnectionCheckUseCaseTest : BaseUnitTest() {
                 original = BaseRequest.GenericErrorType.NETWORK_ERROR
             )
         )
-        whenever(ssrFetcher.load(selectedSite.get())).thenReturn(response)
+        whenever(ssrFetcher.load(selectedSite.get(), true)).thenReturn(response)
 
         // When
         sut.invoke().onEach {
@@ -75,7 +75,7 @@ class StoreConnectionCheckUseCaseTest : BaseUnitTest() {
             )
         )
         whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.Jetpack)
-        whenever(ssrFetcher.load(selectedSite.get())).thenReturn(response)
+        whenever(ssrFetcher.load(selectedSite.get(), true)).thenReturn(response)
 
         // When
         sut.invoke().onEach {
@@ -91,30 +91,31 @@ class StoreConnectionCheckUseCaseTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given app-password site, when fetchSSR returns API_NOT_FOUND error, then emit GENERIC Failure`() = testBlocking {
-        // Given
-        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        val response = WooResult<WCSSRModel>(
-            WooError(
-                type = WooErrorType.API_NOT_FOUND,
-                original = BaseRequest.GenericErrorType.NETWORK_ERROR
+    fun `given app-password site, when fetchSSR returns API_NOT_FOUND error, then emit GENERIC Failure`() =
+        testBlocking {
+            // Given
+            val stateEvents = mutableListOf<ConnectivityCheckStatus>()
+            val response = WooResult<WCSSRModel>(
+                WooError(
+                    type = WooErrorType.API_NOT_FOUND,
+                    original = BaseRequest.GenericErrorType.NETWORK_ERROR
+                )
             )
-        )
-        whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
-        whenever(ssrFetcher.load(selectedSite.get())).thenReturn(response)
+            whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
+            whenever(ssrFetcher.load(selectedSite.get(), true)).thenReturn(response)
 
-        // When
-        sut.invoke().onEach {
-            stateEvents.add(it)
-        }.launchIn(this)
+            // When
+            sut.invoke().onEach {
+                stateEvents.add(it)
+            }.launchIn(this)
 
-        // Then
-        assertThat(stateEvents).hasSize(2)
-        assertThat(stateEvents[0]).isEqualTo(InProgress)
-        assertThat(stateEvents[1]).isInstanceOf(Failure::class.java)
-        assertThat((stateEvents[1] as Failure).error).isEqualTo(FailureType.GENERIC)
-        assertThat((stateEvents[1] as Failure).technicalDetails).isNotNull()
-    }
+            // Then
+            assertThat(stateEvents).hasSize(2)
+            assertThat(stateEvents[0]).isEqualTo(InProgress)
+            assertThat(stateEvents[1]).isInstanceOf(Failure::class.java)
+            assertThat((stateEvents[1] as Failure).error).isEqualTo(FailureType.GENERIC)
+            assertThat((stateEvents[1] as Failure).technicalDetails).isNotNull()
+        }
 
     @Test
     fun `when fetchSSR returns an INVALID_RESPONSE error then emit PARSE Failure`() = testBlocking {
@@ -126,7 +127,7 @@ class StoreConnectionCheckUseCaseTest : BaseUnitTest() {
                 original = BaseRequest.GenericErrorType.NETWORK_ERROR
             )
         )
-        whenever(ssrFetcher.load(selectedSite.get())).thenReturn(response)
+        whenever(ssrFetcher.load(selectedSite.get(), true)).thenReturn(response)
 
         // When
         sut.invoke().onEach {
@@ -151,7 +152,7 @@ class StoreConnectionCheckUseCaseTest : BaseUnitTest() {
                 original = BaseRequest.GenericErrorType.NETWORK_ERROR
             )
         )
-        whenever(ssrFetcher.load(selectedSite.get())).thenReturn(response)
+        whenever(ssrFetcher.load(selectedSite.get(), true)).thenReturn(response)
 
         // When
         sut.invoke().onEach {
@@ -171,7 +172,7 @@ class StoreConnectionCheckUseCaseTest : BaseUnitTest() {
         // Given
         val stateEvents = mutableListOf<ConnectivityCheckStatus>()
         val response = WooResult(WCSSRModel(remoteSiteId = 123L))
-        whenever(ssrFetcher.load(selectedSite.get())).thenReturn(response)
+        whenever(ssrFetcher.load(selectedSite.get(), true)).thenReturn(response)
 
         // When
         sut.invoke().onEach {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreOrdersCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreOrdersCheckUseCaseTest.kt
@@ -54,7 +54,9 @@ class StoreOrdersCheckUseCaseTest : BaseUnitTest() {
         }.launchIn(this)
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(InProgress, Success))
+        assertThat(stateEvents).hasSize(2)
+        assertThat(stateEvents[0]).isEqualTo(InProgress)
+        assertThat(stateEvents[1]).isInstanceOf(Success::class.java)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/StoreProductsCheckUseCaseTest.kt
@@ -48,7 +48,9 @@ class StoreProductsCheckUseCaseTest : BaseUnitTest() {
         }.launchIn(this)
 
         // THEN
-        assertThat(stateEvents).isEqualTo(listOf(InProgress, Success))
+        assertThat(stateEvents).hasSize(2)
+        assertThat(stateEvents[0]).isEqualTo(InProgress)
+        assertThat(stateEvents[1]).isInstanceOf(Success::class.java)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/WPComConnectionCheckUseCaseTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/useCases/WPComConnectionCheckUseCaseTest.kt
@@ -51,7 +51,9 @@ class WPComConnectionCheckUseCaseTest : BaseUnitTest() {
         }.launchIn(this)
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(InProgress, Failure()))
+        assertThat(stateEvents).hasSize(2)
+        assertThat(stateEvents[0]).isEqualTo(InProgress)
+        assertThat(stateEvents[1]).isInstanceOf(Failure::class.java)
     }
 
     @Test
@@ -72,6 +74,8 @@ class WPComConnectionCheckUseCaseTest : BaseUnitTest() {
         }.launchIn(this)
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(InProgress, Success))
+        assertThat(stateEvents).hasSize(2)
+        assertThat(stateEvents[0]).isEqualTo(InProgress)
+        assertThat(stateEvents[1]).isInstanceOf(Success::class.java)
     }
 }


### PR DESCRIPTION
### Description
> [!NOTE]
> Depends on #15591

Attaches a diagnostic log as a file (`connectivitytest_log.txt`) to Zendesk support tickets when "Contact Support" is tapped from the troubleshooting screen. The log includes each check's result, timing, and error details — matching iOS's implementation.

**Changes in this PR:**
- Generate a diagnostic log from `viewState` (single source of truth) with check name, result, duration, and error details
- Add `durationMs` to `ConnectivityCheckStatus.Success` and `Failure` (captured in each UseCase)
- Thread `diagnosticLog` through `ConnectivityToolFragment` → `SupportRequestFormActivity` → `SupportRequestFormViewModel` → `ZendeskTicketRepository`
- Upload the diagnostic log via Zendesk's `UploadProvider` and attach the resulting token to the ticket
- Define `OPERATION_NAME` constants at the UseCase level for log labels
- Add unit tests for all diagnostic log scenarios (all success, failure with details, early failure, app-password site)

### Test Steps

**Diagnostic log attached to support request:**
1. Set up ApiFaker to fail the orders endpoint:
```bash
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
  --es api_type "wp-api" \
  --es path "/wc/v3/orders" \
  --es http_method "GET" \
  --ei response_status_code 500 \
  --es response_body '{}'
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
```
2. Navigate to **Settings > Troubleshoot Connection**
3. Wait for checks to complete — Orders check should fail
4. Tap **Contact Support** → fill in the form and submit
5. Open the ticket on [Zendesk](https://woocommerce.zendesk.com/) and verify `connectivitytest_log.txt` appears as an attachment with numbered check results, timing, and error details
6. Close/delete the test ticket on Zendesk to avoid cluttering the queue
7. Clean up ApiFaker:
```bash
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
```

**All checks pass:**
1. Navigate to **Settings > Troubleshoot Connection** with no ApiFaker active
2. Tap **Contact Support** → fill in the form and submit
3. Open the ticket on Zendesk and verify the attached log shows all checks as SUCCESS with timing
4. Close/delete the test ticket on Zendesk

### Images
| Ticket | Log |
| --- | --- |
| <img width="702" height="239" alt="Screenshot 2026-04-02 at 10 55 24" src="https://github.com/user-attachments/assets/e7311c5e-ede4-4c5a-b2f4-f8c370b70bc9" /> | <img width="750" height="296" alt="Screenshot 2026-04-02 at 10 55 39" src="https://github.com/user-attachments/assets/a5074797-718f-4748-ad39-1ac7b4f402c4" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.