### PR TITLE
Update Claude build analysis prompt and model to Sonnet 4.6

### DIFF
--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -24,7 +24,7 @@ steps:
           build_log_mode: "failed"
           trigger: "on-failure"
           max_log_lines: 1500
-          custom_prompt: >
+          custom_prompt: |
             Ignore these jobs — they are not real failures:
             (1) The "Claude Build Analysis" job itself (uses `exit 1` to trigger this hook).
             (2) The "Danger - PR Check" job (external linter, not indicative of build health).

--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -27,7 +27,8 @@ steps:
           custom_prompt: >
             Ignore these jobs — they are not real failures:
             (1) The "Claude Build Analysis" job itself (uses `exit 1` to trigger this hook).
-            (2) Jobs in "broken" state due to unmet branch conditions — expected skips, not failures.
+            (2) The "Danger - PR Check" job (external linter, not indicative of build health).
+            (3) Jobs in "broken" state due to unmet branch conditions — expected skips, not failures.
 
             Focus on real failures and recovery. Keep the analysis succinct. Do not mention successful jobs.
             Only add a `Root Cause` section when you are confident about the cause.

--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -12,12 +12,18 @@ steps:
     if: build.state == "failing"
     soft_fail: true
     command: "exit 1"
+    artifact_paths:
+      - "/tmp/claude_debug_${BUILDKITE_BUILD_ID}.txt"
+      - "/tmp/claude_response_${BUILDKITE_BUILD_ID}.json"
+      - "/tmp/buildkite_logs_${BUILDKITE_BUILD_ID}.txt"
     plugins:
       - $CLAUDE_PLUGIN:
           api_key: "$ANTHROPIC_API_KEY"
           buildkite_api_token: "$BUILDKITE_TOKEN_FOR_CLAUDE"
           analysis_level: "build"
-          trigger: "always"
+          build_log_mode: "failed"
+          trigger: "on-failure"
+          max_log_lines: 1500
           custom_prompt: >
             Ignore these jobs entirely — they are not real failures:
             (1) The "Claude Build Analysis" job itself (it uses `exit 1` intentionally to trigger this analysis hook).

--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -25,14 +25,12 @@ steps:
           trigger: "on-failure"
           max_log_lines: 1500
           custom_prompt: >
-            Ignore these jobs entirely — they are not real failures:
-            (1) The "Claude Build Analysis" job itself (it uses `exit 1` intentionally to trigger this analysis hook).
-            (2) The "Danger - PR Check" job (external linter, not indicative of build health).
-            (3) Jobs in "broken" state due to unmet `if:` branch conditions — these are expected skips, not failures.
+            Ignore these jobs — they are not real failures:
+            (1) The "Claude Build Analysis" job itself (uses `exit 1` to trigger this hook).
+            (2) Jobs in "broken" state due to unmet branch conditions — expected skips, not failures.
 
-            If, after excluding the above, there are no real failures, respond with a single short sentence confirming the build is healthy. Do not produce a full analysis.
-
-            When there are real failures: focus on failures and recovery to keep the analysis succinct. Do not mention successful jobs. Only add a `Best Practices` section if the PR changes are directly relevant. Only add a `Root Cause` section when you are confident about the cause.
+            Focus on real failures and recovery. Keep the analysis succinct. Do not mention successful jobs.
+            Only add a `Root Cause` section when you are confident about the cause.
           model: "claude-sonnet-4-6"
 
   - label: ":claude: 💬 Comment Claude Analysis"

--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -18,8 +18,16 @@ steps:
           buildkite_api_token: "$BUILDKITE_TOKEN_FOR_CLAUDE"
           analysis_level: "build"
           trigger: "always"
-          custom_prompt: "Do not mention successful points, focus on failures and recovery to keep the analysis succint. Only add the `Best Practices` section if the changes in this PR are directly relevant to it. Only add a `Root Cause` section when you're sure about the issues' causes."
-          model: "claude-sonnet-4-5"
+          custom_prompt: >
+            Ignore these jobs entirely — they are not real failures:
+            (1) The "Claude Build Analysis" job itself (it uses `exit 1` intentionally to trigger this analysis hook).
+            (2) The "Danger - PR Check" job (external linter, not indicative of build health).
+            (3) Jobs in "broken" state due to unmet `if:` branch conditions — these are expected skips, not failures.
+
+            If, after excluding the above, there are no real failures, respond with a single short sentence confirming the build is healthy. Do not produce a full analysis.
+
+            When there are real failures: focus on failures and recovery to keep the analysis succinct. Do not mention successful jobs. Only add a `Best Practices` section if the PR changes are directly relevant. Only add a `Root Cause` section when you are confident about the cause.
+          model: "claude-sonnet-4-6"
 
   - label: ":claude: 💬 Comment Claude Analysis"
     command: .buildkite/commands/comment-claude-analysis.sh

--- a/.buildkite/commands/upload-claude-analysis.sh
+++ b/.buildkite/commands/upload-claude-analysis.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+
+# Uploads the Claude analysis pipeline only when real build/test failures exist.
+# Skips when only non-essential jobs failed (e.g. Danger).
+
+source .buildkite/shared-pipeline-vars
+
+# Non-essential steps whose failure alone should NOT trigger Claude analysis.
+# Add step keys here as needed.
+NON_ESSENTIAL_STEPS="danger"
+
+for step_key in ${NON_ESSENTIAL_STEPS}; do
+  OUTCOME=$(buildkite-agent step get outcome --step "${step_key}" 2>/dev/null || echo "not_run")
+  if [ "${OUTCOME}" = "failed" ]; then
+    echo "Only non-essential job '${step_key}' failed, skipping Claude analysis"
+    exit 0
+  fi
+done
+
+echo "Real failures detected, running Claude analysis"
+buildkite-agent pipeline upload .buildkite/claude-analysis.yml

--- a/.buildkite/commands/upload-claude-analysis.sh
+++ b/.buildkite/commands/upload-claude-analysis.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 # Uploads the Claude analysis pipeline only when real build/test failures exist.
 # Skips when only non-essential jobs failed (e.g. Danger).
@@ -7,15 +9,44 @@ source .buildkite/shared-pipeline-vars
 
 # Non-essential steps whose failure alone should NOT trigger Claude analysis.
 # Add step keys here as needed.
-NON_ESSENTIAL_STEPS="danger"
+NON_ESSENTIAL_STEPS=("danger")
 
-for step_key in ${NON_ESSENTIAL_STEPS}; do
-  OUTCOME=$(buildkite-agent step get outcome --step "${step_key}" 2>/dev/null || echo "not_run")
-  if [ "${OUTCOME}" = "failed" ]; then
-    echo "Only non-essential job '${step_key}' failed, skipping Claude analysis"
-    exit 0
+# Count how many non-essential steps have a "failed" outcome.
+non_essential_failures=0
+for step_key in "${NON_ESSENTIAL_STEPS[@]}"; do
+  outcome=$(buildkite-agent step get outcome --step "${step_key}" 2>/dev/null || echo "not_run")
+  if [ "${outcome}" = "failed" ]; then
+    echo "Non-essential job '${step_key}' failed"
+    non_essential_failures=$((non_essential_failures + 1))
   fi
 done
 
-echo "Real failures detected, running Claude analysis"
+# No non-essential failures means something essential failed — run Claude.
+if [ "${non_essential_failures}" -eq 0 ]; then
+  echo "Real failures detected, running Claude analysis"
+  buildkite-agent pipeline upload .buildkite/claude-analysis.yml
+  exit 0
+fi
+
+# Non-essential jobs did fail. Only skip Claude if they account for ALL failures.
+# Query the Buildkite API to get the total count of failed jobs in this build.
+build_info=$(curl -sf \
+  -H "Authorization: Bearer ${BUILDKITE_TOKEN_FOR_CLAUDE:-}" \
+  "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}" \
+  2>/dev/null || echo "")
+
+if [ -z "${build_info}" ]; then
+  echo "Could not fetch build info; assuming real failures exist, running Claude analysis"
+  buildkite-agent pipeline upload .buildkite/claude-analysis.yml
+  exit 0
+fi
+
+total_failures=$(echo "${build_info}" | jq '[.jobs[] | select(.state == "failed" or .state == "timed_out")] | length' 2>/dev/null || echo "-1")
+
+if [ "${total_failures}" -eq "${non_essential_failures}" ]; then
+  echo "Only non-essential job(s) failed (${non_essential_failures}/${total_failures}), skipping Claude analysis"
+  exit 0
+fi
+
+echo "Real failures detected alongside non-essential failures, running Claude analysis"
 buildkite-agent pipeline upload .buildkite/claude-analysis.yml

--- a/.buildkite/commands/upload-claude-analysis.sh
+++ b/.buildkite/commands/upload-claude-analysis.sh
@@ -3,32 +3,10 @@
 set -eu
 
 # Uploads the Claude analysis pipeline only when real build/test failures exist.
-# Skips when only non-essential jobs failed (e.g. Danger).
+# Skips when only non-essential jobs failed (e.g. Danger) or nothing failed.
 
 source .buildkite/shared-pipeline-vars
 
-# Non-essential steps whose failure alone should NOT trigger Claude analysis.
-# Add step keys here as needed.
-NON_ESSENTIAL_STEPS=("danger")
-
-# Count how many non-essential steps have a "failed" outcome.
-non_essential_failures=0
-for step_key in "${NON_ESSENTIAL_STEPS[@]}"; do
-  outcome=$(buildkite-agent step get outcome --step "${step_key}" 2>/dev/null || echo "not_run")
-  if [ "${outcome}" = "failed" ]; then
-    echo "Non-essential job '${step_key}' failed"
-    non_essential_failures=$((non_essential_failures + 1))
-  fi
-done
-
-# No non-essential failures means something essential failed — run Claude.
-if [ "${non_essential_failures}" -eq 0 ]; then
-  echo "Real failures detected, running Claude analysis"
-  buildkite-agent pipeline upload .buildkite/claude-analysis.yml
-  exit 0
-fi
-
-# Non-essential jobs did fail. Only skip Claude if they account for ALL failures.
 # Query the Buildkite API to get the total count of failed jobs in this build.
 build_info=$(curl -sf \
   -H "Authorization: Bearer ${BUILDKITE_TOKEN_FOR_CLAUDE:-}" \
@@ -43,10 +21,30 @@ fi
 
 total_failures=$(echo "${build_info}" | jq '[.jobs[] | select(.state == "failed" or .state == "timed_out")] | length' 2>/dev/null || echo "-1")
 
+# Nothing failed — skip Claude analysis.
+if [ "${total_failures}" -eq 0 ]; then
+  echo "All steps passed, skipping Claude analysis"
+  exit 0
+fi
+
+# Non-essential steps whose failure alone should NOT trigger Claude analysis.
+# Add step keys here as needed.
+NON_ESSENTIAL_STEPS=("danger")
+
+# Count how many non-essential steps have a "hard_failed" outcome.
+non_essential_failures=0
+for step_key in "${NON_ESSENTIAL_STEPS[@]}"; do
+  outcome=$(buildkite-agent step get outcome --step "${step_key}" 2>/dev/null || echo "not_run")
+  if [ "${outcome}" = "hard_failed" ]; then
+    echo "Non-essential job '${step_key}' failed"
+    non_essential_failures=$((non_essential_failures + 1))
+  fi
+done
+
 if [ "${total_failures}" -eq "${non_essential_failures}" ]; then
   echo "Only non-essential job(s) failed (${non_essential_failures}/${total_failures}), skipping Claude analysis"
   exit 0
 fi
 
-echo "Real failures detected alongside non-essential failures, running Claude analysis"
+echo "Real failures detected, running Claude analysis"
 buildkite-agent pipeline upload .buildkite/claude-analysis.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -129,8 +129,6 @@ steps:
     continue_on_failure: true
 
   - label: ":claude: 🕵️ Build Analysis"
-    command: |
-      source .buildkite/shared-pipeline-vars
-      buildkite-agent pipeline upload .buildkite/claude-analysis.yml
+    command: .buildkite/commands/upload-claude-analysis.sh
     agents:
       queue: upload

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,4 +5,4 @@
 
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.4.0"
 export TEST_COLLECTOR="test-collector#v1.10.1"
-export CLAUDE_PLUGIN="claude-summarize#v1.1.0"
+export CLAUDE_PLUGIN="iangmaia/claude-summarize#iangmaia/add-build-log-mode"


### PR DESCRIPTION
## Description
- Migrate Claude build analysis model from Sonnet 4.5 to Sonnet 4.6
- Switch to `iangmaia/claude-summarize` fork with `build_log_mode: "failed"` and `max_log_lines: 1500` — only feeds failed job logs to Claude for more focused analysis
- Gate Claude analysis on real failures: `upload-claude-analysis.sh` checks non-essential step outcomes (currently Danger) via `buildkite-agent` before uploading the pipeline. When only Danger failed, Claude is skipped entirely — no annotation, no PR comment
- Simplify the custom prompt now that non-essential jobs are filtered upstream

## Test Steps
- Verify the Claude analysis step passes (green) and does not post a PR comment when only Danger fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)