### PR TITLE
[Hack Week] Refactor connection checks to a list-driven architecture

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityCheckCardData.kt
@@ -4,87 +4,64 @@ import android.os.Parcelable
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.NotStarted
-import kotlinx.parcelize.IgnoredOnParcel
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.ui.connectivitytool.useCases.InternetConnectionCheckUseCase
+import com.woocommerce.android.ui.connectivitytool.useCases.StoreConnectionCheckUseCase
+import com.woocommerce.android.ui.connectivitytool.useCases.StoreOrdersCheckUseCase
+import com.woocommerce.android.ui.connectivitytool.useCases.StoreProductsCheckUseCase
+import com.woocommerce.android.ui.connectivitytool.useCases.WPComConnectionCheckUseCase
 import kotlinx.parcelize.Parcelize
 
-typealias OnReadMoreClicked = () -> Unit
-typealias OnRetryConnection = () -> Unit
-
-sealed class ConnectivityCheckCardData(
+@Parcelize
+enum class ConnectivityCheckType(
     @StringRes val title: Int,
     @StringRes val suggestion: Int,
     @DrawableRes val icon: Int,
-    open val connectivityCheckStatus: ConnectivityCheckStatus,
-    @IgnoredOnParcel open val retryConnectionAction: OnRetryConnection? = null,
-    @IgnoredOnParcel open val readMoreAction: OnReadMoreClicked? = null
-) {
-    @Parcelize
-    data class InternetConnectivityCheckData(
-        override val connectivityCheckStatus: ConnectivityCheckStatus = NotStarted,
-        @IgnoredOnParcel override val retryConnectionAction: OnRetryConnection? = null
-    ) : Parcelable, ConnectivityCheckCardData(
+    val analyticsValue: String,
+    val operationName: String
+) : Parcelable {
+    INTERNET(
         title = R.string.orderlist_connectivity_tool_internet_check_title,
         suggestion = R.string.orderlist_connectivity_tool_internet_check_suggestion,
         icon = R.drawable.ic_wifi,
-        connectivityCheckStatus = connectivityCheckStatus,
-        retryConnectionAction = retryConnectionAction
-    )
-
-    @Parcelize
-    data class WPComConnectivityCheckData(
-        override val connectivityCheckStatus: ConnectivityCheckStatus = NotStarted,
-        @IgnoredOnParcel override val retryConnectionAction: OnRetryConnection? = null
-    ) : Parcelable, ConnectivityCheckCardData(
+        analyticsValue = AnalyticsTracker.VALUE_CONNECTIVITY_INTERNET,
+        operationName = InternetConnectionCheckUseCase.OPERATION_NAME
+    ),
+    WP_COM(
         title = R.string.orderlist_connectivity_tool_wordpress_check_title,
         suggestion = R.string.orderlist_connectivity_tool_wordpress_check_suggestion,
         icon = R.drawable.ic_storage,
-        connectivityCheckStatus = connectivityCheckStatus,
-        retryConnectionAction = retryConnectionAction
-    )
-
-    @Parcelize
-    data class StoreConnectivityCheckData(
-        override val connectivityCheckStatus: ConnectivityCheckStatus = NotStarted,
-        @IgnoredOnParcel override val retryConnectionAction: OnRetryConnection? = null,
-        @IgnoredOnParcel override val readMoreAction: OnReadMoreClicked? = null
-    ) : Parcelable, ConnectivityCheckCardData(
+        analyticsValue = AnalyticsTracker.VALUE_CONNECTIVITY_WP_COM,
+        operationName = WPComConnectionCheckUseCase.OPERATION_NAME
+    ),
+    STORE(
         title = R.string.orderlist_connectivity_tool_store_check_title,
         suggestion = R.string.orderlist_connectivity_tool_generic_error_suggestion,
         icon = R.drawable.ic_more_menu_store,
-        connectivityCheckStatus = connectivityCheckStatus,
-        retryConnectionAction = retryConnectionAction,
-        readMoreAction = readMoreAction
-    )
-
-    @Parcelize
-    data class StoreOrdersConnectivityCheckData(
-        override val connectivityCheckStatus: ConnectivityCheckStatus = NotStarted,
-        @IgnoredOnParcel override val retryConnectionAction: OnRetryConnection? = null,
-        @IgnoredOnParcel override val readMoreAction: OnReadMoreClicked? = null
-    ) : Parcelable, ConnectivityCheckCardData(
+        analyticsValue = AnalyticsTracker.VALUE_CONNECTIVITY_SITE,
+        operationName = StoreConnectionCheckUseCase.OPERATION_NAME
+    ),
+    ORDERS(
         title = R.string.orderlist_connectivity_tool_store_orders_check_title,
         suggestion = R.string.orderlist_connectivity_tool_generic_error_suggestion,
         icon = R.drawable.ic_clipboard,
-        connectivityCheckStatus = connectivityCheckStatus,
-        retryConnectionAction = retryConnectionAction,
-        readMoreAction = readMoreAction
-    )
-
-    @Parcelize
-    data class StoreProductsConnectivityCheckData(
-        override val connectivityCheckStatus: ConnectivityCheckStatus = NotStarted,
-        @IgnoredOnParcel override val retryConnectionAction: OnRetryConnection? = null,
-        @IgnoredOnParcel override val readMoreAction: OnReadMoreClicked? = null
-    ) : Parcelable, ConnectivityCheckCardData(
+        analyticsValue = AnalyticsTracker.VALUE_CONNECTIVITY_ORDERS,
+        operationName = StoreOrdersCheckUseCase.OPERATION_NAME
+    ),
+    PRODUCTS(
         title = R.string.orderlist_connectivity_tool_store_products_check_title,
         suggestion = R.string.orderlist_connectivity_tool_generic_error_suggestion,
         icon = R.drawable.ic_product,
-        connectivityCheckStatus = connectivityCheckStatus,
-        retryConnectionAction = retryConnectionAction,
-        readMoreAction = readMoreAction
+        analyticsValue = AnalyticsTracker.VALUE_CONNECTIVITY_PRODUCTS,
+        operationName = StoreProductsCheckUseCase.OPERATION_NAME
     )
 }
+
+@Parcelize
+data class ConnectivityCheckCardData(
+    val type: ConnectivityCheckType,
+    val status: ConnectivityCheckStatus = ConnectivityCheckStatus.NotStarted
+) : Parcelable
 
 @Parcelize
 sealed class ConnectivityCheckStatus : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolScreen.kt
@@ -158,7 +158,9 @@ fun ConnectivityCheckCard(
         onRetryConnectionClicked = onRetryClick,
         shouldDisplayReadMoreButton = shouldDisplayReadMoreButton,
         onViewTechnicalDetailsClicked = failure?.technicalDetails?.let { details ->
-            { onViewTechnicalDetailsClicked(details) }
+            {
+                onViewTechnicalDetailsClicked(details)
+            }
         }
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolScreen.kt
@@ -39,11 +39,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.InternetConnectivityCheckData
-import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreConnectivityCheckData
-import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreOrdersConnectivityCheckData
-import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreProductsConnectivityCheckData
-import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.WPComConnectivityCheckData
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.Failure
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.InProgress
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.NotStarted
@@ -58,14 +53,11 @@ fun ConnectivityToolScreen(viewModel: ConnectivityToolViewModel) {
     ConnectivityToolScreen(
         shouldEnableContactSupportButton = isCheckFinished ?: false,
         shouldDisplaySummarySection = viewState?.shouldDisplaySummary ?: false,
-        internetConnectionCheckData = viewState?.internetCheckData,
-        wpComConnectionCheckData = viewState?.wpComCheckData,
-        storeConnectionCheckData = viewState?.storeCheckData,
-        storeOrdersCheckData = viewState?.ordersCheckData,
-        storeProductsCheckData = viewState?.productsCheckData,
-        isWPComCheckVisible = viewState?.isWPComCheckVisible ?: true,
+        checks = viewState?.checks ?: emptyList(),
         onContactSupportClicked = viewModel::onContactSupportClicked,
         onReturnClick = viewModel::onReturnClicked,
+        onRetryClick = viewModel::onRetryClicked,
+        onReadMoreClick = viewModel::onReadMoreClicked,
         onViewTechnicalDetailsClicked = viewModel::onViewTechnicalDetailsClicked
     )
 
@@ -81,14 +73,11 @@ fun ConnectivityToolScreen(viewModel: ConnectivityToolViewModel) {
 fun ConnectivityToolScreen(
     shouldEnableContactSupportButton: Boolean,
     shouldDisplaySummarySection: Boolean,
-    internetConnectionCheckData: InternetConnectivityCheckData?,
-    wpComConnectionCheckData: WPComConnectivityCheckData?,
-    storeConnectionCheckData: StoreConnectivityCheckData?,
-    storeOrdersCheckData: StoreOrdersConnectivityCheckData?,
-    storeProductsCheckData: StoreProductsConnectivityCheckData?,
-    isWPComCheckVisible: Boolean,
+    checks: List<ConnectivityCheckCardData>,
     onContactSupportClicked: () -> Unit,
     onReturnClick: () -> Unit,
+    onRetryClick: (ConnectivityCheckType) -> Unit,
+    onReadMoreClick: (FailureType) -> Unit,
     onViewTechnicalDetailsClicked: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -112,13 +101,20 @@ fun ConnectivityToolScreen(
             Text(stringResource(id = R.string.orderlist_connectivity_tool_subtitle))
         }
 
-        ConnectivityCheckCard(internetConnectionCheckData, onViewTechnicalDetailsClicked)
-        if (isWPComCheckVisible) {
-            ConnectivityCheckCard(wpComConnectionCheckData, onViewTechnicalDetailsClicked)
+        checks.forEach { checkData ->
+            if (checkData.status !is NotStarted) {
+                ConnectivityCheckCard(
+                    checkData = checkData,
+                    onRetryClick = { onRetryClick(checkData.type) },
+                    onReadMoreClick = { onReadMoreClick((checkData.status as? Failure)?.error ?: FailureType.GENERIC) },
+                    onViewTechnicalDetailsClicked = onViewTechnicalDetailsClicked
+                )
+                Divider(
+                    modifier = Modifier
+                        .padding(start = dimensionResource(id = R.dimen.major_100))
+                )
+            }
         }
-        ConnectivityCheckCard(storeConnectionCheckData, onViewTechnicalDetailsClicked)
-        ConnectivityCheckCard(storeOrdersCheckData, onViewTechnicalDetailsClicked)
-        ConnectivityCheckCard(storeProductsCheckData, onViewTechnicalDetailsClicked)
 
         ConnectivitySummary(
             shouldDisplaySummarySection = shouldDisplaySummarySection,
@@ -141,34 +137,30 @@ fun ConnectivityToolScreen(
 
 @Composable
 fun ConnectivityCheckCard(
-    cardData: ConnectivityCheckCardData?,
+    checkData: ConnectivityCheckCardData,
+    onRetryClick: () -> Unit,
+    onReadMoreClick: () -> Unit,
     onViewTechnicalDetailsClicked: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    cardData
-        ?.takeUnless { it.connectivityCheckStatus is NotStarted }
-        ?.let {
-            val technicalDetails = (it.connectivityCheckStatus as? Failure)?.technicalDetails
-            ConnectivityCheckCard(
-                modifier = modifier,
-                checkTitle = it.title,
-                iconDrawable = it.icon,
-                suggestion = it.suggestion,
-                checkStatus = it.connectivityCheckStatus,
-                onReadMoreClicked = it.readMoreAction ?: {},
-                onRetryConnectionClicked = it.retryConnectionAction ?: {},
-                shouldDisplayReadMoreButton = it.readMoreAction != null,
-                onViewTechnicalDetailsClicked = technicalDetails?.let { details ->
-                    {
-                        onViewTechnicalDetailsClicked(details)
-                    }
-                }
-            )
-            Divider(
-                modifier = Modifier
-                    .padding(start = dimensionResource(id = R.dimen.major_100))
-            )
+    val failure = checkData.status as? Failure
+    val shouldDisplayReadMoreButton = checkData.type != ConnectivityCheckType.INTERNET &&
+        checkData.type != ConnectivityCheckType.WP_COM &&
+        checkData.status is Failure
+
+    ConnectivityCheckCard(
+        modifier = modifier,
+        checkTitle = checkData.type.title,
+        iconDrawable = checkData.type.icon,
+        suggestion = checkData.type.suggestion,
+        checkStatus = checkData.status,
+        onReadMoreClicked = onReadMoreClick,
+        onRetryConnectionClicked = onRetryClick,
+        shouldDisplayReadMoreButton = shouldDisplayReadMoreButton,
+        onViewTechnicalDetailsClicked = failure?.technicalDetails?.let { details ->
+            { onViewTechnicalDetailsClicked(details) }
         }
+    )
 }
 
 @Composable
@@ -349,30 +341,25 @@ fun ConnectivityToolScreenPreview() {
         ConnectivityToolScreen(
             shouldEnableContactSupportButton = true,
             shouldDisplaySummarySection = true,
-            internetConnectionCheckData = InternetConnectivityCheckData(
-                connectivityCheckStatus = NotStarted
-            ),
-            wpComConnectionCheckData = WPComConnectivityCheckData(
-                connectivityCheckStatus = Success()
-            ),
-            storeConnectionCheckData = StoreConnectivityCheckData(
-                connectivityCheckStatus = Failure(
-                    error = FailureType.PARSE,
-                    technicalDetails = "Operation: Site Connection\n" +
-                        "Error Type: INVALID_RESPONSE\n" +
-                        "Description: Parse error"
+            checks = listOf(
+                ConnectivityCheckCardData(ConnectivityCheckType.INTERNET, NotStarted),
+                ConnectivityCheckCardData(ConnectivityCheckType.WP_COM, Success()),
+                ConnectivityCheckCardData(
+                    ConnectivityCheckType.STORE,
+                    Failure(
+                        error = FailureType.PARSE,
+                        technicalDetails = "Operation: Site Connection\n" +
+                            "Error Type: INVALID_RESPONSE\n" +
+                            "Description: Parse error"
+                    )
                 ),
-                readMoreAction = {}
+                ConnectivityCheckCardData(ConnectivityCheckType.ORDERS, InProgress),
+                ConnectivityCheckCardData(ConnectivityCheckType.PRODUCTS, NotStarted)
             ),
-            storeOrdersCheckData = StoreOrdersConnectivityCheckData(
-                connectivityCheckStatus = InProgress
-            ),
-            storeProductsCheckData = StoreProductsConnectivityCheckData(
-                connectivityCheckStatus = NotStarted
-            ),
-            isWPComCheckVisible = true,
             onContactSupportClicked = {},
             onReturnClick = {},
+            onRetryClick = {},
+            onReadMoreClick = {},
             onViewTechnicalDetailsClicked = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -2,33 +2,16 @@ package com.woocommerce.android.ui.connectivitytool
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
-import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_CONNECTIVITY_TEST
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_INTERNET
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_ORDERS
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_PRODUCTS
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_SITE
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_CONNECTIVITY_WP_COM
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
-import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.InternetConnectivityCheckData
-import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreConnectivityCheckData
-import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreOrdersConnectivityCheckData
-import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.StoreProductsConnectivityCheckData
-import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckCardData.WPComConnectivityCheckData
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.Failure
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.InProgress
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.NotStarted
 import com.woocommerce.android.ui.connectivitytool.ConnectivityCheckStatus.Success
-import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.ConnectivityCheckStep.Finished
-import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.ConnectivityCheckStep.InternetCheck
-import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.ConnectivityCheckStep.StoreCheck
-import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.ConnectivityCheckStep.StoreOrdersCheck
-import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.ConnectivityCheckStep.StoreProductsCheck
-import com.woocommerce.android.ui.connectivitytool.ConnectivityToolViewModel.ConnectivityCheckStep.WPComCheck
 import com.woocommerce.android.ui.connectivitytool.useCases.InternetConnectionCheckUseCase
 import com.woocommerce.android.ui.connectivitytool.useCases.StoreConnectionCheckUseCase
 import com.woocommerce.android.ui.connectivitytool.useCases.StoreOrdersCheckUseCase
@@ -40,13 +23,9 @@ import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.getStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -63,64 +42,32 @@ class ConnectivityToolViewModel @Inject constructor(
     private val isAppPasswordSite: Boolean
         get() = selectedSite.connectionType == SiteConnectionType.ApplicationPasswords
 
-    private val stateMachine = savedState.getStateFlow(
+    private val initialChecks = ArrayList<ConnectivityCheckCardData>().apply {
+        add(ConnectivityCheckCardData(ConnectivityCheckType.INTERNET))
+        if (!isAppPasswordSite) {
+            add(ConnectivityCheckCardData(ConnectivityCheckType.WP_COM))
+        }
+        add(ConnectivityCheckCardData(ConnectivityCheckType.STORE))
+        add(ConnectivityCheckCardData(ConnectivityCheckType.ORDERS))
+        add(ConnectivityCheckCardData(ConnectivityCheckType.PRODUCTS))
+    }
+
+    private val checksFlow = savedState.getStateFlow(
         scope = viewModelScope,
-        initialValue = InternetCheck
+        initialValue = initialChecks,
+        key = "checksFlow"
     )
 
-    private val internetCheckFlow = savedState.getStateFlow(
-        scope = viewModelScope,
-        initialValue = InternetConnectivityCheckData(
-            retryConnectionAction = { handleRetryConnectionClick(InternetCheck) }
-        )
-    )
-
-    private val wpComCheckFlow = savedState.getStateFlow(
-        scope = viewModelScope,
-        initialValue = WPComConnectivityCheckData(
-            retryConnectionAction = { handleRetryConnectionClick(WPComCheck) }
-        )
-    )
-
-    private val storeCheckFlow = savedState.getStateFlow(
-        scope = viewModelScope,
-        initialValue = StoreConnectivityCheckData(
-            retryConnectionAction = { handleRetryConnectionClick(StoreCheck) }
-        )
-    )
-
-    private val ordersCheckFlow = savedState.getStateFlow(
-        scope = viewModelScope,
-        initialValue = StoreOrdersConnectivityCheckData(
-            retryConnectionAction = { handleRetryConnectionClick(StoreOrdersCheck) }
-        )
-    )
-
-    private val productsCheckFlow = savedState.getStateFlow(
-        scope = viewModelScope,
-        initialValue = StoreProductsConnectivityCheckData(
-            retryConnectionAction = { handleRetryConnectionClick(StoreProductsCheck) }
-        )
-    )
-
-    val viewState = combine(
-        internetCheckFlow,
-        wpComCheckFlow,
-        storeCheckFlow,
-        ordersCheckFlow,
-        productsCheckFlow
-    ) { internet, wpCom, store, orders, products ->
+    val viewState = checksFlow.map { checks ->
         ViewState(
-            internetCheckData = internet,
-            wpComCheckData = wpCom,
-            storeCheckData = store,
-            ordersCheckData = orders,
-            productsCheckData = products,
-            isWPComCheckVisible = !isAppPasswordSite
+            checks = checks,
+            shouldDisplaySummary = checks.all { it.status is Success }
         )
     }.distinctUntilChanged().asLiveData()
 
-    val isCheckFinished = stateMachine.map { it == Finished }.asLiveData()
+    val isCheckFinished = checksFlow.map { checks ->
+        checks.all { it.status is Success || it.status is Failure }
+    }.distinctUntilChanged().asLiveData()
 
     private val _technicalDetailsToShow = MutableStateFlow<String?>(null)
     val technicalDetailsToShow = _technicalDetailsToShow.asLiveData()
@@ -134,28 +81,9 @@ class ConnectivityToolViewModel @Inject constructor(
         _technicalDetailsToShow.value = null
     }
 
-    private val nextStep
-        get() = when (stateMachine.value) {
-            InternetCheck -> if (isAppPasswordSite) StoreCheck else WPComCheck
-            WPComCheck -> StoreCheck
-            StoreCheck -> StoreOrdersCheck
-            StoreOrdersCheck -> StoreProductsCheck
-            StoreProductsCheck -> Finished
-            Finished -> error("Cannot move to next state from Finished")
-        }
-
     fun startConnectionChecks() {
         launch {
-            stateMachine.collect {
-                when (it) {
-                    InternetCheck -> startInternetCheck()
-                    WPComCheck -> startWPComCheck()
-                    StoreCheck -> startStoreCheck()
-                    StoreOrdersCheck -> startStoreOrdersCheck()
-                    StoreProductsCheck -> startProductsCheck()
-                    Finished -> { /* No-op */ }
-                }
-            }
+            executeNextCheck()
         }
     }
 
@@ -168,19 +96,18 @@ class ConnectivityToolViewModel @Inject constructor(
         triggerEvent(Exit)
     }
 
-    private fun handleRetryConnectionClick(step: ConnectivityCheckStep) {
-        when (step) {
-            InternetCheck -> internetCheckFlow.update { it.copy(connectivityCheckStatus = NotStarted) }
-            WPComCheck -> wpComCheckFlow.update { it.copy(connectivityCheckStatus = NotStarted) }
-            StoreCheck -> storeCheckFlow.update { it.copy(connectivityCheckStatus = NotStarted) }
-            StoreOrdersCheck -> ordersCheckFlow.update { it.copy(connectivityCheckStatus = NotStarted) }
-            StoreProductsCheck -> productsCheckFlow.update { it.copy(connectivityCheckStatus = NotStarted) }
-            Finished -> { /* No-op */ }
+    fun onRetryClicked(type: ConnectivityCheckType) {
+        checksFlow.update { checks ->
+            checks.map {
+                if (it.type == type) it.copy(status = NotStarted) else it
+            }.toCollection(ArrayList())
         }
-        stateMachine.update { step }
+        launch {
+            executeNextCheck()
+        }
     }
 
-    private fun handleReadMoreClick(failureType: FailureType) {
+    fun onReadMoreClicked(failureType: FailureType) {
         analyticsTrackerWrapper.track(AnalyticsEvent.CONNECTIVITY_TOOL_READ_MORE_TAPPED)
         when (failureType) {
             FailureType.JETPACK -> triggerEvent(OpenWebView(jetpackTroubleshootingUrl))
@@ -188,82 +115,32 @@ class ConnectivityToolViewModel @Inject constructor(
         }
     }
 
-    private fun startInternetCheck() {
-        internetConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_INTERNET)
-            status.startNextCheck()
-            internetCheckFlow.update { it.copy(connectivityCheckStatus = status) }
-        }.launchIn(viewModelScope)
-    }
+    private suspend fun executeNextCheck() {
+        val checks = checksFlow.value
+        val nextCheck = checks.firstOrNull { it.status is NotStarted || it.status is InProgress } ?: return
 
-    private fun startWPComCheck() {
-        wpComConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_WP_COM)
-            status.startNextCheck()
-            wpComCheckFlow.update { it.copy(connectivityCheckStatus = status) }
-        }.launchIn(viewModelScope)
-    }
+        val flow = when (nextCheck.type) {
+            ConnectivityCheckType.INTERNET -> internetConnectionCheck()
+            ConnectivityCheckType.WP_COM -> wpComConnectionCheck()
+            ConnectivityCheckType.STORE -> storeConnectionCheck()
+            ConnectivityCheckType.ORDERS -> storeOrdersCheck()
+            ConnectivityCheckType.PRODUCTS -> storeProductsCheck()
+        }
 
-    private fun startStoreCheck() {
-        storeConnectionCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_SITE)
-            status.startNextCheck()
-            storeCheckFlow.update {
-                if (status is Failure) {
-                    it.copy(
-                        connectivityCheckStatus = status,
-                        readMoreAction = { handleReadMoreClick(status.error ?: FailureType.GENERIC) }
-                    )
-                } else {
-                    it.copy(connectivityCheckStatus = status)
-                }
+        flow.collect { status ->
+            trackChanges(status, nextCheck.type.analyticsValue)
+            updateCheckStatus(nextCheck.type, status)
+            if (status is Success) {
+                executeNextCheck()
             }
-        }.launchIn(viewModelScope)
+        }
     }
 
-    private fun startStoreOrdersCheck() {
-        storeOrdersCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_ORDERS)
-            status.startNextCheck()
-            ordersCheckFlow.update {
-                if (status is Failure) {
-                    it.copy(
-                        connectivityCheckStatus = status,
-                        readMoreAction = { handleReadMoreClick(status.error ?: FailureType.GENERIC) }
-                    )
-                } else {
-                    it.copy(connectivityCheckStatus = status)
-                }
-            }
-        }.launchIn(viewModelScope)
-    }
-
-    private fun startProductsCheck() {
-        storeProductsCheck().onEach { status ->
-            trackChanges(status, VALUE_CONNECTIVITY_PRODUCTS)
-            status.startNextCheck()
-            productsCheckFlow.update {
-                if (status is Failure) {
-                    it.copy(
-                        connectivityCheckStatus = status,
-                        readMoreAction = { handleReadMoreClick(status.error ?: FailureType.GENERIC) }
-                    )
-                } else {
-                    it.copy(connectivityCheckStatus = status)
-                }
-            }
-        }.launchIn(viewModelScope)
-    }
-
-    private fun ConnectivityCheckStatus.startNextCheck() {
-        if (stateMachine.value == Finished) return
-
-        stateMachine.update {
-            when (this) {
-                is Success -> nextStep
-                is Failure -> Finished
-                else -> it
-            }
+    private fun updateCheckStatus(type: ConnectivityCheckType, status: ConnectivityCheckStatus) {
+        checksFlow.update { checks ->
+            checks.map {
+                if (it.type == type) it.copy(status = status) else it
+            }.toCollection(ArrayList())
         }
     }
 
@@ -281,24 +158,17 @@ class ConnectivityToolViewModel @Inject constructor(
     }
 
     private fun generateDiagnosticLog(): String? {
-        val currentState = viewState.value ?: return null
-        val checks = buildList {
-            add(InternetConnectionCheckUseCase.OPERATION_NAME to currentState.internetCheckData.connectivityCheckStatus)
-            if (currentState.isWPComCheckVisible) {
-                add(WPComConnectionCheckUseCase.OPERATION_NAME to currentState.wpComCheckData.connectivityCheckStatus)
-            }
-            add(StoreConnectionCheckUseCase.OPERATION_NAME to currentState.storeCheckData.connectivityCheckStatus)
-            add(StoreOrdersCheckUseCase.OPERATION_NAME to currentState.ordersCheckData.connectivityCheckStatus)
-            add(StoreProductsCheckUseCase.OPERATION_NAME to currentState.productsCheckData.connectivityCheckStatus)
-        }.filter { it.second is Success || it.second is Failure }
+        val completedChecks = checksFlow.value.filter {
+            it.status is Success || it.status is Failure
+        }
 
-        if (checks.isEmpty()) return null
+        if (completedChecks.isEmpty()) return null
 
         return buildString {
-            checks.forEachIndexed { index, (name, status) ->
-                appendLine("## ${index + 1}. $name")
-                appendLine("Took: ${status.durationMs}ms")
-                val resultStr = when (status) {
+            completedChecks.forEachIndexed { index, check ->
+                appendLine("## ${index + 1}. ${check.type.operationName}")
+                appendLine("Took: ${check.status.durationMs}ms")
+                val resultStr = when (val status = check.status) {
                     is Success -> "Success"
                     is Failure -> buildString {
                         append(status.error?.name ?: "Failed")
@@ -318,29 +188,9 @@ class ConnectivityToolViewModel @Inject constructor(
     data class OpenWebView(val url: String) : MultiLiveEvent.Event()
 
     data class ViewState(
-        val internetCheckData: InternetConnectivityCheckData,
-        val wpComCheckData: WPComConnectivityCheckData,
-        val storeCheckData: StoreConnectivityCheckData,
-        val ordersCheckData: StoreOrdersConnectivityCheckData,
-        val productsCheckData: StoreProductsConnectivityCheckData,
-        val isWPComCheckVisible: Boolean
-    ) {
+        val checks: List<ConnectivityCheckCardData>,
         val shouldDisplaySummary: Boolean
-            get() = internetCheckData.connectivityCheckStatus is Success &&
-                (wpComCheckData.connectivityCheckStatus is Success || !isWPComCheckVisible) &&
-                storeCheckData.connectivityCheckStatus is Success &&
-                ordersCheckData.connectivityCheckStatus is Success &&
-                productsCheckData.connectivityCheckStatus is Success
-    }
-
-    enum class ConnectivityCheckStep {
-        InternetCheck,
-        WPComCheck,
-        StoreCheck,
-        StoreOrdersCheck,
-        StoreProductsCheck,
-        Finished
-    }
+    )
 
     companion object {
         const val jetpackTroubleshootingUrl =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.connectivitytool
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_CONNECTIVITY_TEST
@@ -26,6 +27,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -66,7 +68,7 @@ class ConnectivityToolViewModel @Inject constructor(
     }.distinctUntilChanged().asLiveData()
 
     val isCheckFinished = checksFlow.map { checks ->
-        checks.all { it.status is Success || it.status is Failure }
+        checks.any { it.status is Failure } || checks.all { it.status is Success }
     }.distinctUntilChanged().asLiveData()
 
     private val _technicalDetailsToShow = MutableStateFlow<String?>(null)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -44,7 +44,7 @@ class ConnectivityToolViewModel @Inject constructor(
     private val isAppPasswordSite: Boolean
         get() = selectedSite.connectionType == SiteConnectionType.ApplicationPasswords
 
-    private val initialChecks = ArrayList<ConnectivityCheckCardData>().apply {
+    private val initialChecks = buildList {
         add(ConnectivityCheckCardData(ConnectivityCheckType.INTERNET))
         if (!isAppPasswordSite) {
             add(ConnectivityCheckCardData(ConnectivityCheckType.WP_COM))
@@ -102,7 +102,7 @@ class ConnectivityToolViewModel @Inject constructor(
         checksFlow.update { checks ->
             checks.map {
                 if (it.type == type) it.copy(status = NotStarted) else it
-            }.toCollection(ArrayList())
+            }
         }
         launch {
             executeNextCheck()
@@ -142,7 +142,7 @@ class ConnectivityToolViewModel @Inject constructor(
         checksFlow.update { checks ->
             checks.map {
                 if (it.type == type) it.copy(status = status) else it
-            }.toCollection(ArrayList())
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -118,23 +118,27 @@ class ConnectivityToolViewModel @Inject constructor(
     }
 
     private suspend fun executeNextCheck() {
-        val checks = checksFlow.value
-        if (checks.any { it.status is Failure }) return
-        val nextCheck = checks.firstOrNull { it.status is NotStarted || it.status is InProgress } ?: return
+        while (true) {
+            val checks = checksFlow.value
+            if (checks.any { it.status is Failure }) return
+            val nextCheck = checks.firstOrNull { it.status is NotStarted || it.status is InProgress } ?: return
 
-        val flow = when (nextCheck.type) {
-            ConnectivityCheckType.INTERNET -> internetConnectionCheck()
-            ConnectivityCheckType.WP_COM -> wpComConnectionCheck()
-            ConnectivityCheckType.STORE -> storeConnectionCheck()
-            ConnectivityCheckType.ORDERS -> storeOrdersCheck()
-            ConnectivityCheckType.PRODUCTS -> storeProductsCheck()
-        }
+            val flow = when (nextCheck.type) {
+                ConnectivityCheckType.INTERNET -> internetConnectionCheck()
+                ConnectivityCheckType.WP_COM -> wpComConnectionCheck()
+                ConnectivityCheckType.STORE -> storeConnectionCheck()
+                ConnectivityCheckType.ORDERS -> storeOrdersCheck()
+                ConnectivityCheckType.PRODUCTS -> storeProductsCheck()
+            }
 
-        flow.collect { status ->
-            trackChanges(status, nextCheck.type.analyticsValue)
-            updateCheckStatus(nextCheck.type, status)
-            if (status is Success) {
-                executeNextCheck()
+            flow.collect { status ->
+                trackChanges(status, nextCheck.type.analyticsValue)
+                updateCheckStatus(nextCheck.type, status)
+            }
+
+            val finalStatus = checksFlow.value.first { it.type == nextCheck.type }.status
+            if (finalStatus !is Success) {
+                return
             }
         }
     }
@@ -173,11 +177,10 @@ class ConnectivityToolViewModel @Inject constructor(
                 appendLine("Took: ${check.status.durationMs}ms")
                 val resultStr = when (val status = check.status) {
                     is Success -> "Success"
-                    is Failure -> buildString {
-                        append(status.error?.name ?: "Failed")
-                        status.technicalDetails?.let { details ->
-                            append("\n$details")
-                        }
+                    is Failure -> {
+                        val errorName = status.error?.name ?: "Failed"
+                        val details = status.technicalDetails?.let { "\n$it" } ?: ""
+                        errorName + details
                     }
                     else -> "Unknown"
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModel.kt
@@ -119,6 +119,7 @@ class ConnectivityToolViewModel @Inject constructor(
 
     private suspend fun executeNextCheck() {
         val checks = checksFlow.value
+        if (checks.any { it.status is Failure }) return
         val nextCheck = checks.firstOrNull { it.status is NotStarted || it.status is InProgress } ?: return
 
         val flow = when (nextCheck.type) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
@@ -79,7 +79,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
             ConnectivityCheckCardData(ConnectivityCheckType.STORE, NotStarted)
         )
         val savedStateHandle = SavedStateHandle(mapOf("checksFlow" to checks))
-        
+
         sut = ConnectivityToolViewModel(
             internetConnectionCheck = internetConnectionCheck,
             wpComConnectionCheck = wpComConnectionCheck,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
@@ -71,6 +71,34 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when a check previously failed, then startConnectionChecks does not execute the next check`() = testBlocking {
+        // Given
+        val checks = listOf(
+            ConnectivityCheckCardData(ConnectivityCheckType.INTERNET, Success()),
+            ConnectivityCheckCardData(ConnectivityCheckType.WP_COM, Failure()),
+            ConnectivityCheckCardData(ConnectivityCheckType.STORE, NotStarted)
+        )
+        val savedStateHandle = SavedStateHandle(mapOf("checksFlow" to checks))
+        
+        sut = ConnectivityToolViewModel(
+            internetConnectionCheck = internetConnectionCheck,
+            wpComConnectionCheck = wpComConnectionCheck,
+            storeConnectionCheck = storeConnectionCheck,
+            storeOrdersCheck = storeOrdersCheck,
+            storeProductsCheck = storeProductsCheck,
+            analyticsTrackerWrapper = analyticsTrackerWrapper,
+            selectedSite = selectedSite,
+            savedState = savedStateHandle
+        )
+
+        // When
+        sut.startConnectionChecks()
+
+        // Then
+        verify(storeConnectionCheck, never()).invoke()
+    }
+
+    @Test
     fun `when internetConnectionCheck use case starts, then internet check status updates as expected`() = testBlocking {
         // Given
         whenever(internetConnectionCheck()).thenReturn(flowOf(Success()))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
@@ -78,7 +78,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // When
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // Then
         val checks = sut.viewState.value!!.checks
@@ -94,7 +93,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // When
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // Then
         val checks = sut.viewState.value!!.checks
@@ -110,7 +108,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // When
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // Then
         val checks = sut.viewState.value!!.checks
@@ -126,7 +123,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // When
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // Then
         val checks = sut.viewState.value!!.checks
@@ -142,7 +138,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // When
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // Then
         val checks = sut.viewState.value!!.checks
@@ -157,7 +152,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // When
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // Then
         assertThat(sut.isCheckFinished.value).isTrue()
@@ -172,7 +166,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // When
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // Then
         assertThat(sut.isCheckFinished.value).isTrue()
@@ -187,7 +180,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // When
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // Then
         assertThat(sut.isCheckFinished.value).isFalse()
@@ -202,7 +194,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // When
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // Then
         assertThat(sut.isCheckFinished.value).isTrue()
@@ -214,7 +205,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
             // Given
             sut.viewState.observeForever {}
             sut.startConnectionChecks()
-            advanceUntilIdle()
             val events = mutableListOf<MultiLiveEvent.Event>()
             sut.event.observeForever { events.add(it) }
 
@@ -237,7 +227,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // WHEN
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // THEN
         verify(wpComConnectionCheck, never()).invoke()
@@ -252,7 +241,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // WHEN
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // THEN
         assertThat(sut.isCheckFinished.value).isTrue()
@@ -267,7 +255,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // WHEN
         sut.startConnectionChecks()
-        advanceUntilIdle()
 
         // THEN
         assertThat(sut.viewState.value?.shouldDisplaySummary).isTrue()
@@ -315,7 +302,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         // GIVEN
         sut.viewState.observeForever {}
         sut.startConnectionChecks()
-        advanceUntilIdle()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }
 
@@ -343,7 +329,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         createViewModel()
         sut.viewState.observeForever {}
         sut.startConnectionChecks()
-        advanceUntilIdle()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }
 
@@ -364,7 +349,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         createViewModel()
         sut.viewState.observeForever {}
         sut.startConnectionChecks()
-        advanceUntilIdle()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }
 
@@ -387,7 +371,6 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         createViewModel()
         sut.viewState.observeForever {}
         sut.startConnectionChecks()
-        advanceUntilIdle()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/connectivitytool/ConnectivityToolViewModelTest.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.ui.connectivitytool
 
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.map
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
@@ -73,150 +71,141 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when internetConnectionCheck use case starts, then update ViewState as expected`() = testBlocking {
+    fun `when internetConnectionCheck use case starts, then internet check status updates as expected`() = testBlocking {
         // Given
-        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
         whenever(internetConnectionCheck()).thenReturn(flowOf(Success()))
-        sut.viewState
-            .map { it.internetCheckData }
-            .distinctUntilChanged()
-            .observeForever { stateEvents.add(it.connectivityCheckStatus) }
+        sut.viewState.observeForever {}
 
         // When
         sut.startConnectionChecks()
+        advanceUntilIdle()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success()))
+        val checks = sut.viewState.value!!.checks
+        val internetCheck = checks.first { it.type == ConnectivityCheckType.INTERNET }
+        assertThat(internetCheck.status).isEqualTo(Success())
     }
 
     @Test
-    fun `when wpComConnectionCheck use case starts, then update ViewState as expected`() = testBlocking {
+    fun `when wpComConnectionCheck use case starts, then wpCom check status updates as expected`() = testBlocking {
         // Given
-        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
         whenever(wpComConnectionCheck()).thenReturn(flowOf(Success()))
-        sut.viewState
-            .map { it.wpComCheckData }
-            .distinctUntilChanged()
-            .observeForever { stateEvents.add(it.connectivityCheckStatus) }
+        sut.viewState.observeForever {}
 
         // When
         sut.startConnectionChecks()
+        advanceUntilIdle()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success()))
+        val checks = sut.viewState.value!!.checks
+        val wpComCheck = checks.first { it.type == ConnectivityCheckType.WP_COM }
+        assertThat(wpComCheck.status).isEqualTo(Success())
     }
 
     @Test
-    fun `when storeConnectionCheck use case starts, then update ViewState as expected`() = testBlocking {
+    fun `when storeConnectionCheck use case starts, then store check status updates as expected`() = testBlocking {
         // Given
-        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
         whenever(storeConnectionCheck()).thenReturn(flowOf(Success()))
-        sut.viewState
-            .map { it.storeCheckData }
-            .distinctUntilChanged()
-            .observeForever { stateEvents.add(it.connectivityCheckStatus) }
+        sut.viewState.observeForever {}
 
         // When
         sut.startConnectionChecks()
+        advanceUntilIdle()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success()))
+        val checks = sut.viewState.value!!.checks
+        val storeCheck = checks.first { it.type == ConnectivityCheckType.STORE }
+        assertThat(storeCheck.status).isEqualTo(Success())
     }
 
     @Test
-    fun `when storeOrdersCheck use case starts, then update ViewState as expected`() = testBlocking {
+    fun `when storeOrdersCheck use case starts, then orders check status updates as expected`() = testBlocking {
         // Given
-        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
         whenever(storeOrdersCheck()).thenReturn(flowOf(Success()))
-        sut.viewState
-            .map { it.ordersCheckData }
-            .distinctUntilChanged()
-            .observeForever { stateEvents.add(it.connectivityCheckStatus) }
+        sut.viewState.observeForever {}
 
         // When
         sut.startConnectionChecks()
+        advanceUntilIdle()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success()))
+        val checks = sut.viewState.value!!.checks
+        val ordersCheck = checks.first { it.type == ConnectivityCheckType.ORDERS }
+        assertThat(ordersCheck.status).isEqualTo(Success())
+    }
+
+    @Test
+    fun `when storeProductsCheck use case starts, then products check status updates as expected`() = testBlocking {
+        // Given
+        whenever(storeProductsCheck()).thenReturn(flowOf(Success()))
+        sut.viewState.observeForever {}
+
+        // When
+        sut.startConnectionChecks()
+        advanceUntilIdle()
+
+        // Then
+        val checks = sut.viewState.value!!.checks
+        val productsCheck = checks.first { it.type == ConnectivityCheckType.PRODUCTS }
+        assertThat(productsCheck.status).isEqualTo(Success())
     }
 
     @Test
     fun `when all checks are finished, then isCheckFinished is true`() = testBlocking {
         // Given
-        val stateEvents = mutableListOf<Boolean>()
-        sut.isCheckFinished.observeForever {
-            stateEvents.add(it)
-        }
+        sut.isCheckFinished.observeForever {}
 
         // When
         sut.startConnectionChecks()
+        advanceUntilIdle()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(false, false, false, false, false, true))
+        assertThat(sut.isCheckFinished.value).isTrue()
     }
 
     @Test
     fun `when one check fails, then isCheckFinished is true`() = testBlocking {
         // Given
-        val stateEvents = mutableListOf<Boolean>()
         whenever(storeConnectionCheck()).thenReturn(flowOf(Failure()))
-        sut.isCheckFinished.observeForever {
-            stateEvents.add(it)
-        }
+        createViewModel()
+        sut.isCheckFinished.observeForever {}
 
         // When
         sut.startConnectionChecks()
+        advanceUntilIdle()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(false, false, false, true))
+        assertThat(sut.isCheckFinished.value).isTrue()
     }
 
     @Test
     fun `when checks are still running, then isCheckFinished is false`() = testBlocking {
         // Given
-        val stateEvents = mutableListOf<Boolean>()
-        whenever(internetConnectionCheck()).thenReturn(flowOf(Success()))
-        whenever(wpComConnectionCheck()).thenReturn(flowOf(InProgress))
-        sut.isCheckFinished.observeForever {
-            stateEvents.add(it)
-        }
+        whenever(internetConnectionCheck()).thenReturn(flowOf(InProgress))
+        createViewModel()
+        sut.isCheckFinished.observeForever {}
 
         // When
         sut.startConnectionChecks()
+        advanceUntilIdle()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(false, false))
-    }
-
-    @Test
-    fun `when storeProductsCheck use case starts, then update ViewState as expected`() = testBlocking {
-        // Given
-        val stateEvents = mutableListOf<ConnectivityCheckStatus>()
-        whenever(storeProductsCheck()).thenReturn(flowOf(Success()))
-        sut.viewState
-            .map { it.productsCheckData }
-            .distinctUntilChanged()
-            .observeForever { stateEvents.add(it.connectivityCheckStatus) }
-
-        // When
-        sut.startConnectionChecks()
-
-        // Then
-        assertThat(stateEvents).isEqualTo(listOf(NotStarted, Success()))
+        assertThat(sut.isCheckFinished.value).isFalse()
     }
 
     @Test
     fun `when storeProductsCheck fails, then isCheckFinished is true`() = testBlocking {
         // Given
-        val stateEvents = mutableListOf<Boolean>()
         whenever(storeProductsCheck()).thenReturn(flowOf(Failure()))
-        sut.isCheckFinished.observeForever { stateEvents.add(it) }
+        createViewModel()
+        sut.isCheckFinished.observeForever {}
 
         // When
         sut.startConnectionChecks()
+        advanceUntilIdle()
 
         // Then
-        assertThat(stateEvents).isEqualTo(listOf(false, false, false, false, false, true))
+        assertThat(sut.isCheckFinished.value).isTrue()
     }
 
     @Test
@@ -225,6 +214,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
             // Given
             sut.viewState.observeForever {}
             sut.startConnectionChecks()
+            advanceUntilIdle()
             val events = mutableListOf<MultiLiveEvent.Event>()
             sut.event.observeForever { events.add(it) }
 
@@ -247,6 +237,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
 
         // WHEN
         sut.startConnectionChecks()
+        advanceUntilIdle()
 
         // THEN
         verify(wpComConnectionCheck, never()).invoke()
@@ -257,14 +248,14 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         // GIVEN
         whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
         createViewModel()
-        val stateEvents = mutableListOf<Boolean>()
-        sut.isCheckFinished.observeForever { stateEvents.add(it) }
+        sut.isCheckFinished.observeForever {}
 
         // WHEN
         sut.startConnectionChecks()
+        advanceUntilIdle()
 
         // THEN
-        assertThat(stateEvents.last()).isTrue()
+        assertThat(sut.isCheckFinished.value).isTrue()
     }
 
     @Test
@@ -272,28 +263,14 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         // GIVEN
         whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
         createViewModel()
-        var latestState: ConnectivityToolViewModel.ViewState? = null
-        sut.viewState.observeForever { latestState = it }
+        sut.viewState.observeForever {}
 
         // WHEN
         sut.startConnectionChecks()
+        advanceUntilIdle()
 
         // THEN
-        assertThat(latestState?.shouldDisplaySummary).isTrue()
-    }
-
-    @Test
-    fun `given app password site, when viewState is observed, then isWPComCheckVisible is false`() = testBlocking {
-        // GIVEN
-        whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
-        createViewModel()
-
-        // WHEN
-        var latestState: ConnectivityToolViewModel.ViewState? = null
-        sut.viewState.observeForever { latestState = it }
-
-        // THEN
-        assertThat(latestState?.isWPComCheckVisible).isFalse()
+        assertThat(sut.viewState.value?.shouldDisplaySummary).isTrue()
     }
 
     @Test
@@ -338,6 +315,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         // GIVEN
         sut.viewState.observeForever {}
         sut.startConnectionChecks()
+        advanceUntilIdle()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }
 
@@ -365,6 +343,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         createViewModel()
         sut.viewState.observeForever {}
         sut.startConnectionChecks()
+        advanceUntilIdle()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }
 
@@ -385,6 +364,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         createViewModel()
         sut.viewState.observeForever {}
         sut.startConnectionChecks()
+        advanceUntilIdle()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }
 
@@ -407,6 +387,7 @@ class ConnectivityToolViewModelTest : BaseUnitTest() {
         createViewModel()
         sut.viewState.observeForever {}
         sut.startConnectionChecks()
+        advanceUntilIdle()
         val events = mutableListOf<MultiLiveEvent.Event>()
         sut.event.observeForever { events.add(it) }
 


### PR DESCRIPTION
### Description
> [!NOTE]
> Depends on #15597 

This PR refactors the connection checks state machine to use a dynamic, list-driven architecture, significantly reducing boilerplate and making the code more scalable for future checks.

**Key Changes:**
*   **Enum Abstraction:** Replaced the verbose `ConnectivityCheckCardData` sealed class with a cleaner `ConnectivityCheckType` enum that encapsulates all UI and analytics constants (title, icon, suggestion, analytics value, operation name).
*   **Unified State Flow:** Consolidated individual `StateFlow`s into a single `checksFlow` representing the sequential list of checks.
*   **Dynamic UI Rendering:** Updated `ConnectivityToolScreen` to iterate over the `checks` list dynamically instead of hardcoding each connectivity card sequentially.
*   **Bug Fix (State Restoration Callbacks):** Fixed a pre-existing issue where, after a process death and restoration, UI callbacks (such as "Retry connection" or "Read More") would stop working. This was previously caused by storing callback lambdas in state classes using `@IgnoredOnParcel`. The new architecture hoists these events to the ViewModel and passes them directly to the Composables, bypassing Parcelable limitations completely.
*   **Test Coverage:** Updated all ViewModel and UI tests to align with the new list-driven architecture.


### Test Steps
1. Navigate to the **Troubleshoot Connection** screen.
2. Simulate a connection failure (e.g., using ApiFaker to timeout the orders or products endpoint).
3. Verify the UI halts at the failed check and displays the error state correctly.
4. Simulate process death (e.g., enable "Don't keep activities" in developer options, background the app, and bring it back to the foreground).
5. Tap the "Retry connection" and "Read More" buttons.
6. Verify that the callbacks trigger correctly after restoration (the check restarts or the troubleshooting web view opens).

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.