### PR TITLE
[WOOMOB-2599] Treat CIAB sites like atomic sites during site connection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,14 +2,11 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final APK before release (e.g. major library or targetSdk updates).
 *** For entries which are touching the Android Wear app's, start entry with `[WEAR]` too.
 
-24.6
+24.5
 -----
 - [*] Fixed shipping address showing billing address data when selecting a registered customer during order creation [https://github.com/woocommerce/woocommerce-android/pull/15575]
 - [Internal] Migrate AccountSettingsScreen, BarcodeScannerScreen, and PrivacySettingsPoliciesScreen from Material 2 to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/15596]
 - [Internal] Treat CIAB sites like atomic sites during site connection [https://github.com/woocommerce/woocommerce-android/pull/15608]
-
-24.5
------
 - [Internal] Unified local and remote feature flag handling [https://github.com/woocommerce/woocommerce-android/pull/15299]
 - [Internal][WEAR] Update watchface complications dependency to 1.3.0 [https://github.com/woocommerce/woocommerce-android/pull/15577]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -----
 - [*] Fixed shipping address showing billing address data when selecting a registered customer during order creation [https://github.com/woocommerce/woocommerce-android/pull/15575]
 - [Internal] Migrate AccountSettingsScreen, BarcodeScannerScreen, and PrivacySettingsPoliciesScreen from Material 2 to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/15596]
+- [Internal] Treat CIAB sites like atomic sites during site connection [https://github.com/woocommerce/woocommerce-android/pull/15608]
 
 24.5
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -358,7 +358,7 @@ class SitePickerViewModel @Inject constructor(
         repository.fetchSiteInfo(url).fold(
             onSuccess = {
                 val primaryButton = when {
-                    it.isWPCom -> AccountMismatchPrimaryButton.CONNECT_WPCOM_SITE
+                    it.isWPCom || it.isCommerceGarden -> AccountMismatchPrimaryButton.CONNECT_WPCOM_SITE
                     else -> AccountMismatchPrimaryButton.CONNECT_JETPACK
                 }
                 if (event.value !is NavigateToAccountMismatchScreen) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitediscovery/SitePickerSiteDiscoveryViewModel.kt
@@ -182,7 +182,7 @@ class SitePickerSiteDiscoveryViewModel @Inject constructor(
                     }
                     !it.exists -> inlineErrorFlow.value = R.string.invalid_site_url_message
                     !it.isWordPress -> stepFlow.value = Step.NotWordpress
-                    !it.isWPCom -> {
+                    !it.isWPCom && !it.isCommerceGarden -> {
                         triggerEvent(
                             StartJetpackActivation(
                                 siteAddress = siteAddress,


### PR DESCRIPTION
### Description
Fixes WOOMOB-2599

CIAB (Commerce in a Box) sites were being incorrectly directed to the Jetpack activation flow during site connection, since they weren't recognized as WPCom sites. This change treats CIAB sites the same as WPCom/atomic sites by checking the `isCommerceGarden` flag alongside `isWPCom` in the site picker connection logic.

> [!NOTE]
> This is for now just a small fix, and follows iOS approach. We need a better UI in the future. 

### Test Steps
1. Have a CIAB site available for testing that's not connected to your account.
2. Make sure you are signed in using WordPress.com.
3. Open the site picker.
4. Tap on "Connect another store"
5. Enter the site of the CIAB site from step 1.
6. Confirm the account mismatch screen is shown with a "Connect to the site" button.
7. Tap on the button and confirms it shows the below screenshot.

### Images/gif
<img width="320" alt="Screenshot_20260402_221358" src="https://github.com/user-attachments/assets/2c978b8a-01fa-448a-901f-f1c7a0977442" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.