### PR TITLE
Add feature flag override panel to Help screen for logged-out state

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -149,6 +149,10 @@
             android:theme="@style/Theme.Woo.DayNight"
             android:windowSoftInputMode="adjustResize" />
         <activity
+            android:name=".ui.prefs.developer.DevFeatureFlagsActivity"
+            android:label="@string/dev_feature_flags"
+            android:theme="@style/Theme.Woo.DayNight" />
+        <activity
             android:name="org.wordpress.android.mediapicker.ui.MediaPickerActivity"
             android:theme="@style/Theme.Woo.DayNight"
             android:windowSoftInputMode="adjustResize" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -33,7 +33,10 @@ import com.woocommerce.android.support.zendesk.TicketType
 import com.woocommerce.android.support.zendesk.ZendeskSettings
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.ui.prefs.developer.DevFeatureFlagsActivity
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.PackageUtils
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.fluxc.store.SiteStore
@@ -52,6 +55,8 @@ class HelpActivity : AppCompatActivity() {
     @Inject lateinit var zendeskSettings: ZendeskSettings
 
     @Inject lateinit var selectedSite: SelectedSite
+
+    @Inject lateinit var featureFlagRepository: FeatureFlagRepository
 
     private lateinit var binding: ActivityHelpBinding
 
@@ -102,6 +107,11 @@ class HelpActivity : AppCompatActivity() {
         if (userIsLoggedIn() && selectedSite.exists()) {
             binding.ssrContainer.show()
             binding.ssrContainer.setOnClickListener { showSSR() }
+        }
+
+        if (!userIsLoggedIn() && featureFlagRepository.isEnabled(FeatureFlag.LOGGED_OUT_FF_PANEL)) {
+            binding.developerSection.show()
+            binding.featureFlagsContainer.setOnClickListener { showFeatureFlagsOverride() }
         }
 
         binding.textVersion.text = getString(R.string.version_with_name_param, PackageUtils.getVersionName(this))
@@ -224,6 +234,10 @@ class HelpActivity : AppCompatActivity() {
 
     private fun showSSR() {
         startActivity(Intent(this, SSRActivity::class.java))
+    }
+
+    private fun showFeatureFlagsOverride() {
+        startActivity(DevFeatureFlagsActivity.createIntent(this, skipRemoteLoad = true))
     }
 
     private fun openSupportRequestForm(extraTags: List<String>) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DevFeatureFlagsActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DevFeatureFlagsActivity.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.android.ui.prefs.developer
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.main.MainActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class DevFeatureFlagsActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            WooThemeWithBackground {
+                DevFeatureFlagsScreen(
+                    onBackClick = { onBackPressedDispatcher.onBackPressed() },
+                    onRestartClick = { restartApp() }
+                )
+            }
+        }
+    }
+
+    private fun restartApp() {
+        val intent = Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        }
+        startActivity(intent)
+    }
+
+    companion object {
+        private const val SKIP_REMOTE_LOAD_KEY = DevFeatureFlagsViewModel.SKIP_REMOTE_LOAD_KEY
+
+        fun createIntent(context: Context, skipRemoteLoad: Boolean = false): Intent {
+            return Intent(context, DevFeatureFlagsActivity::class.java).apply {
+                putExtra(SKIP_REMOTE_LOAD_KEY, skipRemoteLoad)
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DevFeatureFlagsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DevFeatureFlagsViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.prefs.developer
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.util.FeatureFlag
@@ -15,8 +16,11 @@ import javax.inject.Inject
 
 @HiltViewModel
 class DevFeatureFlagsViewModel @Inject constructor(
-    private val featureFlagRepository: FeatureFlagRepository
+    private val featureFlagRepository: FeatureFlagRepository,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+
+    private val skipRemoteLoad: Boolean = savedStateHandle[SKIP_REMOTE_LOAD_KEY] ?: false
 
     private val _uiState = MutableStateFlow(UiState())
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
@@ -25,9 +29,15 @@ class DevFeatureFlagsViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            featureFlagRepository.awaitRemoteFlagsLoaded()
+            if (!skipRemoteLoad) {
+                featureFlagRepository.awaitRemoteFlagsLoaded()
+            }
             loadFlagStates()
         }
+    }
+
+    companion object {
+        const val SKIP_REMOTE_LOAD_KEY = "skip_remote_load"
     }
 
     private fun loadFlagStates() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -31,4 +31,5 @@ enum class FeatureFlag(
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1("woo_self_driven_push_notifications_m1", localValue = false),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2("woo_self_driven_push_notifications_m2", localValue = false),
     WOO_SHIPPING_FEDEX("woo_shipping_fedex", localValue = false),
+    LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
 }

--- a/WooCommerce/src/main/res/layout/activity_help.xml
+++ b/WooCommerce/src/main/res/layout/activity_help.xml
@@ -84,6 +84,27 @@
                 app:optionValue="@string/support_system_status_report_detail"
                 android:visibility="gone" />
 
+            <LinearLayout
+                android:id="@+id/developerSection"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="gone">
+
+                <com.woocommerce.android.ui.prefs.WCSettingsCategoryHeaderView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/support_developer_section_title" />
+
+                <com.woocommerce.android.ui.prefs.WCSettingsOptionValueView
+                    android:id="@+id/featureFlagsContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:optionTitle="@string/support_override_feature_flags"
+                    app:optionValue="@string/support_override_feature_flags_detail" />
+
+            </LinearLayout>
+
         </LinearLayout>
     </ScrollView>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2383,9 +2383,9 @@
     <string name="support_system_status_report_copied_to_clipboard">System status report copied to clipboard</string>
     <string name="support_system_status_report_error_copy_to_clipboard">Error copying SSR to clipboard</string>
 
-    <string name="support_developer_section_title">DEVELOPER</string>
-    <string name="support_override_feature_flags">Override Feature Flags</string>
-    <string name="support_override_feature_flags_detail">Toggle feature flags before logging in</string>
+    <string name="support_developer_section_title" translatable="false">DEVELOPER</string>
+    <string name="support_override_feature_flags" translatable="false">Override Feature Flags</string>
+    <string name="support_override_feature_flags_detail" translatable="false">Toggle feature flags before logging in</string>
     <string name="support_system_status_report_share_error">Unable to share System Status Report</string>
     <string name="support_system_status_report_fetch_error">Error fetching SSR. Please check WooCommerce -&gt; Status in wp-admin.</string>
     <string name="help">Help</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2382,6 +2382,10 @@
     <string name="support_system_status_report_share_label">Share system status report</string>
     <string name="support_system_status_report_copied_to_clipboard">System status report copied to clipboard</string>
     <string name="support_system_status_report_error_copy_to_clipboard">Error copying SSR to clipboard</string>
+
+    <string name="support_developer_section_title">DEVELOPER</string>
+    <string name="support_override_feature_flags">Override Feature Flags</string>
+    <string name="support_override_feature_flags_detail">Toggle feature flags before logging in</string>
     <string name="support_system_status_report_share_error">Unable to share System Status Report</string>
     <string name="support_system_status_report_fetch_error">Error fetching SSR. Please check WooCommerce -&gt; Status in wp-admin.</string>
     <string name="help">Help</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2381,6 +2381,10 @@
     <string name="support_system_status_report_share_label">Share system status report</string>
     <string name="support_system_status_report_copied_to_clipboard">System status report copied to clipboard</string>
     <string name="support_system_status_report_error_copy_to_clipboard">Error copying SSR to clipboard</string>
+
+    <string name="support_developer_section_title">DEVELOPER</string>
+    <string name="support_override_feature_flags">Override Feature Flags</string>
+    <string name="support_override_feature_flags_detail">Toggle feature flags before logging in</string>
     <string name="support_system_status_report_share_error">Unable to share System Status Report</string>
     <string name="support_system_status_report_fetch_error">Error fetching SSR. Please check WooCommerce -&gt; Status in wp-admin.</string>
     <string name="help">Help</string>


### PR DESCRIPTION
## Description

Adds a "Developer" section to the Help & Support screen (accessible during the login flow) that lets developers override feature flags **before logging in**. This avoids the painful restart cycle for flags that are read once at app launch.

Android counterpart of woocommerce/woocommerce-ios#16882.

**What changed:**
- New `LOGGED_OUT_FF_PANEL` local feature flag (enabled for debug builds)
- `DevFeatureFlagsViewModel` gains a `skipRemoteLoad` parameter via `SavedStateHandle` — when `true`, it skips `awaitRemoteFlagsLoaded()` which would hang indefinitely without authentication
- New `DevFeatureFlagsActivity` as a standalone entry point for the feature flags screen, launchable from outside the main nav graph
- `HelpActivity` gets a conditional "DEVELOPER" section with an "Override Feature Flags" row

**Behavior details:**
- The developer section **only appears in logged-out state** — when logged in, the FF panel is already accessible via Settings → Developer Options
- All feature flags are shown, but **remote value loading is skipped** in logged-out state (no authenticated network fetch) — rows show "Local: Enabled/Disabled" instead of "Remote: ..."
- Overrides are stored in SharedPreferences and checked before any remote fetch, so they work without authentication context

## Demo

https://github.com/user-attachments/assets/b6f60810-4202-4520-9ff5-ad5e6d43616a

## Test Steps

1. Run a debug build
2. On the login prologue screen, tap "Help"
3. Verify a "DEVELOPER" section appears with "Override Feature Flags" row
4. Tap it → verify all feature flags are listed with their local values
5. Toggle a flag, go back, proceed with login → verify the override persists
6. Open Help from a logged-in state → verify the "DEVELOPER" section is **not** shown
7. Verify the developer section does **not** appear in release builds

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.