### PR TITLE
[WOOMOB-2601] Exclude FluxC preferences from Android auto backup

### DIFF
--- a/WooCommerce/src/main/res/xml/backup_scheme.xml
+++ b/WooCommerce/src/main/res/xml/backup_scheme.xml
@@ -9,10 +9,16 @@
         <exclude
             domain="sharedpref"
             path="com.woocommerce.android_deletable_preferences.xml" />
+        <exclude
+            domain="sharedpref"
+            path="com.woocommerce.android_fluxc-preferences.xml" />
     </cloud-backup>
     <device-transfer>
         <exclude
             domain="sharedpref"
             path="com.woocommerce.android_deletable_preferences.xml" />
+        <exclude
+            domain="sharedpref"
+            path="com.woocommerce.android_fluxc-preferences.xml" />
     </device-transfer>
 </data-extraction-rules>

--- a/WooCommerce/src/main/res/xml/legacy_backup_scheme.xml
+++ b/WooCommerce/src/main/res/xml/legacy_backup_scheme.xml
@@ -6,4 +6,5 @@
    Reference: https://developer.android.com/guide/topics/data/autobackup#define-device-conditions
    -->
   <exclude domain="sharedpref" path="com.woocommerce.android_deletable_preferences.xml"/>
+  <exclude domain="sharedpref" path="com.woocommerce.android_fluxc-preferences.xml"/>
 </full-backup-content>


### PR DESCRIPTION
### Description
Fixes WOOMOB-2601


P2 post about the issue p91TBi-dNL-p2

The FluxC SharedPreferences file (`com.woocommerce.android_fluxc-preferences`) contains the OAuth access token. Android Auto Backup snapshots this file to Google Cloud while the user is logged in. After logout and app reinstall, the backup restores the stale token, causing the app to treat the user as logged in.

This PR adds an `<exclude>` rule for the FluxC preferences file to both `backup_scheme.xml` (Android 12+) and `legacy_backup_scheme.xml` (pre-Android 12), preventing the access token from being backed up.

### Test Steps

Note, you need a prod version; the dev has a different application ID, so this won't work.

1. Log in to the WooCommerce app with a WordPress.com account
2. Trigger Android Auto Backup (`adb shell bmgr backupnow com.woocommerce.android`)
3. Log out from Settings
4. Uninstall and reinstall the app
5. Open the app — verify the user sees the **login screen**, not the dashboard

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.