### PR TITLE
[WOOMOB-2605] Fix POS crash on process death restoration

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 24.6
 -----
+- [Internal] Fixed POS crash when restoring the app after process death [https://github.com/woocommerce/woocommerce-android/pull/15618]
 - [Internal] Added an entry point to the troubleshooting screen from app settings [https://github.com/woocommerce/woocommerce-android/pull/15582]
 
 24.5

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -16,7 +16,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.home.items.coupons.creation.WooPosCouponCreationFacade
 import com.woocommerce.android.ui.woopos.support.WooPosGetSupportFacade
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -30,16 +29,20 @@ class WooPosActivity : AppCompatActivity() {
     lateinit var wooPosGetSupportFacade: WooPosGetSupportFacade
 
     @Inject
-    lateinit var wooPosAnalyticsTracker: WooPosAnalyticsTracker
-
-    @Inject
     lateinit var wooPosCouponCreationFacade: WooPosCouponCreationFacade
 
     @Inject
     lateinit var wooPosPeriodicSyncFacade: WooPosPeriodicSyncFacade
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+        // POS is session-based: cart, product cache, order cache, and data source selection
+        // all live in in-memory singletons. On process death these are lost, but Compose
+        // Navigation restores the back stack to the home screen, skipping the splash flow
+        // that initializes them — causing IllegalStateException in WooPosProductsDataSource.
+        // Passing null forces a fresh start from the splash screen, which re-initializes
+        // everything. On config changes the process stays alive and singletons survive,
+        // so going through splash again is instant (no loading screen).
+        super.onCreate(null)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
 


### PR DESCRIPTION
### Description
Fixes WOOMOB-2605

After process death, Compose Navigation restores the back stack directly to the POS home screen, skipping the splash flow that initializes in-memory singletons (`WooPosProductsDataSource.activeSource`, orders cache, product cache, etc.). This causes `IllegalStateException: FetchFirstPage - Data source not selected` because the singleton is freshly created with `activeSource = null`.

**Fix:** Pass `null` to `super.onCreate()` so the activity always starts fresh from the splash screen, which re-initializes all session state.

**Why this approach:**
- POS is session-based — cart, caches, data source selection all live in in-memory singletons. After process death they're **all** gone, not just `activeSource`. Restoring the nav back stack to a screen that depends on them is broken by design
- Alternatives considered:
  - *Lazy-init `activeSource` in `fetchFirstPage`* — only fixes one singleton, doesn't address missing order cache, popular products, eligibility checks that splash handles
  - *Check `isInitialized` in Activity to conditionally discard state* — couples the Activity to a specific data source; fragile since multiple singletons are in the same situation
  - *Pop splash from back stack on navigation* — doesn't help because `NavHost` restores saved back stack regardless
- **Trade-off:** on configuration changes (locale, dark mode), the activity also starts fresh from splash. In practice this is fine because the process is alive, singletons survive, and splash completes instantly (hits the `NotRequired` sync path with no loading screen). The activity is currently landscape-locked so rotation is not a concern (for now)

### Test Steps

1. Open POS — wait for products to load on the home screen
2. Press the **Home** button to background the app
3. Kill the process: `adb shell am kill com.woocommerce.android.dev`
4. Open **Recent Apps** and tap the WooCommerce card
5. **Before fix:** app crashes with "keeps stopping" dialog
6. **After fix:** app shows the splash screen briefly, then loads the POS home screen with products

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.