### PR TITLE
[WOOMOB-2583] Hide Inbox for CIAB sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] [Woo POS] Added ability to edit receipt information from POS settings [https://github.com/woocommerce/woocommerce-android/pull/15572]
 - [*] Fixed POS "Refresh catalog" banner persisting after manual sync from settings or pull-to-refresh [https://github.com/woocommerce/woocommerce-android/pull/15620]
 - [Internal] Migrate PrivacyBannerScreen, PrivacySettingsScreen, and ChangeDueCalculatorScreen from Material 2 to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/15595]
+- [Internal] Hide Inbox for CIAB sites in menu and dashboard [https://github.com/woocommerce/woocommerce-android/pull/15623]
 - [Internal] Fixed POS crash when restoring the app after process death [https://github.com/woocommerce/woocommerce-android/pull/15618]
 - [Internal] Extract shared WooPosOrderCreatedData to remove duplicated types in POS event communication [https://github.com/woocommerce/woocommerce-android/pull/15604]
 - [Internal] Migrate AccountSettingsScreen, BarcodeScannerScreen, and PrivacySettingsPoliciesScreen from Material 2 to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/15596]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ciab/CIABAffectedFeature.kt
@@ -14,5 +14,6 @@ enum class CIABAffectedFeature {
     Onboarding,
     OrderStatusEditing,
     Plugins,
-    POS
+    POS,
+    Inbox
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
@@ -31,7 +31,8 @@ class DashboardRepository @Inject constructor(
     observePushNotificationsWidgetStatus: ObservePushNotificationsWidgetStatus,
     observeOnboardingWidgetStatus: ObserveOnboardingWidgetStatus,
     observeStockWidgetStatus: ObserveStockWidgetStatus,
-    observeGoogleAdsWidgetStatus: ObserveGoogleAdsWidgetStatus
+    observeGoogleAdsWidgetStatus: ObserveGoogleAdsWidgetStatus,
+    observeInboxWidgetStatus: ObserveInboxWidgetStatus
 ) {
     private val siteCoroutineScopeFlow = selectedSite.observe().map {
         selectedSite.siteComponent?.let { component ->
@@ -62,6 +63,8 @@ class DashboardRepository @Inject constructor(
 
     private val googleAdsWidgetStatus = widgetStatusFlow { observeGoogleAdsWidgetStatus() }
 
+    private val inboxWidgetStatus = widgetStatusFlow { observeInboxWidgetStatus() }
+
     val widgets = combine(
         dashboardDataStore.widgets,
         siteOrdersState,
@@ -69,16 +72,18 @@ class DashboardRepository @Inject constructor(
         pushNotificationsWidgetStatus,
         onboardingWidgetStatus,
         stockWidgetStatus,
-        googleAdsWidgetStatus
+        googleAdsWidgetStatus,
+        inboxWidgetStatus
     ) { widgets, siteOrdersState, blazeWidgetStatus, pushNotificationsWidgetStatus, onboardingWidgetStatus,
-        stockWidgetStatus, googleAdsWidgetStatus ->
+        stockWidgetStatus, googleAdsWidgetStatus, inboxWidgetStatus ->
         widgets.toDomainModel(
             siteOrdersState,
             blazeWidgetStatus,
             pushNotificationsWidgetStatus,
             onboardingWidgetStatus,
             stockWidgetStatus,
-            googleAdsWidgetStatus
+            googleAdsWidgetStatus,
+            inboxWidgetStatus
         )
     }
 
@@ -124,7 +129,8 @@ class DashboardRepository @Inject constructor(
         pushNotificationsWidgetStatus: DashboardWidget.Status,
         onboardingWidgetStatus: DashboardWidget.Status,
         stockWidgetStatus: DashboardWidget.Status,
-        googleAdsWidgetStatus: DashboardWidget.Status
+        googleAdsWidgetStatus: DashboardWidget.Status,
+        inboxWidgetStatus: DashboardWidget.Status
     ): List<DashboardWidget> {
         return map { widget ->
             val type = DashboardWidget.Type.valueOf(widget.type)
@@ -141,6 +147,7 @@ class DashboardRepository @Inject constructor(
                     DashboardWidget.Type.ONBOARDING -> onboardingWidgetStatus
                     DashboardWidget.Type.STOCK -> stockWidgetStatus
                     DashboardWidget.Type.GOOGLE_ADS -> googleAdsWidgetStatus
+                    DashboardWidget.Type.INBOX -> inboxWidgetStatus
 
                     else -> DashboardWidget.Status.Available
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveInboxWidgetStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveInboxWidgetStatus.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+
+class ObserveInboxWidgetStatus @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper
+) {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    operator fun invoke() = selectedSite.observe()
+        .filterNotNull()
+        .flatMapLatest {
+            if (ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.Inbox)) {
+                flowOf(DashboardWidget.Status.Hidden)
+            } else {
+                flowOf(DashboardWidget.Status.Available)
+            }
+        }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepository.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.ui.moremenu.domain
 
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.extensions.isFreeTrial
 import com.woocommerce.android.extensions.semverCompareTo
 import com.woocommerce.android.tools.SelectedSite
@@ -10,7 +12,8 @@ import javax.inject.Inject
 
 class MoreMenuRepository @Inject constructor(
     private val selectedSite: SelectedSite,
-    private val getWooVersion: GetWooCorePluginCachedVersion
+    private val getWooVersion: GetWooCorePluginCachedVersion,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) {
     companion object {
         private const val INBOX_MINIMUM_SUPPORTED_VERSION = "6.4.0"
@@ -19,6 +22,7 @@ class MoreMenuRepository @Inject constructor(
     suspend fun isInboxEnabled(): Boolean =
         withContext(Dispatchers.IO) {
             if (!selectedSite.exists()) return@withContext false
+            if (ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.Inbox)) return@withContext false
 
             val currentWooCoreVersion = getWooVersion() ?: return@withContext false
             currentWooCoreVersion.semverCompareTo(INBOX_MINIMUM_SUPPORTED_VERSION) >= 0

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepositoryTest.kt
@@ -17,6 +17,7 @@ class DashboardRepositoryTest {
     private val observeOnboardingWidgetStatus: ObserveOnboardingWidgetStatus = mock()
     private val observeStockWidgetStatus: ObserveStockWidgetStatus = mock()
     private val observeGoogleAdsWidgetStatus: ObserveGoogleAdsWidgetStatus = mock()
+    private val observeInboxWidgetStatus: ObserveInboxWidgetStatus = mock()
 
     @Test
     fun `given site component is null, when repository is initialized, then it completes without crash`() = runTest {
@@ -34,7 +35,8 @@ class DashboardRepositoryTest {
             observePushNotificationsWidgetStatus,
             observeOnboardingWidgetStatus,
             observeStockWidgetStatus,
-            observeGoogleAdsWidgetStatus
+            observeGoogleAdsWidgetStatus,
+            observeInboxWidgetStatus
         )
 
         // Then

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveInboxWidgetStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveInboxWidgetStatusTest.kt
@@ -1,0 +1,52 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.SiteModel
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObserveInboxWidgetStatusTest : BaseUnitTest() {
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureUnsupported(any()) } doReturn false
+    }
+    private val selectedSite: SelectedSite = mock {
+        on { observe() } doReturn flowOf(SiteModel())
+    }
+
+    private val sut = ObserveInboxWidgetStatus(
+        selectedSite,
+        ciabSiteGateKeeper
+    )
+
+    @Test
+    fun `given CIAB feature unsupported, when observing inbox widget status, then status is Hidden`() = testBlocking {
+        given(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.Inbox))
+            .willReturn(true)
+
+        val status = sut().first()
+
+        assertThat(status).isEqualTo(DashboardWidget.Status.Hidden)
+    }
+
+    @Test
+    fun `given CIAB feature supported, when observing inbox widget status, then status is Available`() = testBlocking {
+        given(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.Inbox))
+            .willReturn(false)
+
+        val status = sut().first()
+
+        assertThat(status).isEqualTo(DashboardWidget.Status.Available)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepositoryTest.kt
@@ -79,7 +79,7 @@ class MoreMenuRepositoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given CIAB site, when checking inbox, then inbox is disabled`() = testBlocking {
+    fun `given Inbox feature is unsupported, when checking inbox, then inbox is disabled`() = testBlocking {
         // GIVEN
         whenever(selectedSite.exists()).thenReturn(true)
         whenever(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.Inbox)).thenReturn(true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/domain/MoreMenuRepositoryTest.kt
@@ -1,25 +1,38 @@
 package com.woocommerce.android.ui.moremenu.domain
 
+import com.woocommerce.android.ciab.CIABAffectedFeature
+import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.GetWooCorePluginCachedVersion
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 
-class MoreMenuRepositoryTest {
+@OptIn(ExperimentalCoroutinesApi::class)
+class MoreMenuRepositoryTest : BaseUnitTest() {
 
     lateinit var sut: MoreMenuRepository
 
     val selectedSite: SelectedSite = mock()
+    val getWooVersion: GetWooCorePluginCachedVersion = mock()
+    val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
+        on { isFeatureUnsupported(any()) } doReturn false
+    }
 
     @Before
     fun setUp() {
         sut = MoreMenuRepository(
             selectedSite,
-            mock(),
+            getWooVersion,
+            ciabSiteGateKeeper,
         )
     }
 
@@ -63,5 +76,18 @@ class MoreMenuRepositoryTest {
 
         // then
         assertThat(isUpgradesEnabled).isFalse
+    }
+
+    @Test
+    fun `given CIAB site, when checking inbox, then inbox is disabled`() = testBlocking {
+        // GIVEN
+        whenever(selectedSite.exists()).thenReturn(true)
+        whenever(ciabSiteGateKeeper.isFeatureUnsupported(CIABAffectedFeature.Inbox)).thenReturn(true)
+
+        // WHEN
+        val isInboxEnabled = sut.isInboxEnabled()
+
+        // THEN
+        assertThat(isInboxEnabled).isFalse
     }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2583

Hides the Inbox feature for CIAB sites in two places:
1. **More Menu** — `MoreMenuRepository.isInboxEnabled()` now returns `false` for CIAB sites via `CIABSiteGateKeeper`
2. **Dashboard** — New `ObserveInboxWidgetStatus` returns `Hidden` for CIAB sites, preventing the Inbox card from appearing or being added

### Test Steps
1. Log in with a CIAB site
2. Open the More Menu → verify Inbox button is not shown
3. Open the Dashboard → verify the Inbox card is not visible
4. Open the Dashboard widget editor → verify the Inbox widget shows as unavailable/hidden
5. Log in with a non-CIAB site → verify Inbox is visible in both the More Menu and Dashboard as before

### Images/gif

| non-CIAB | CIAB |
|---|---|
| <img width="1280" height="2856" alt="Screenshot_20260407_160746" src="https://github.com/user-attachments/assets/6fae689b-c2b2-43e0-9b0d-f89729b2e3e0" /> | <img width="1280" height="2856" alt="Screenshot_20260407_160715" src="https://github.com/user-attachments/assets/6e2ca580-3e3e-4687-9231-dafa09102af1" /> |
| <img width="1280" height="2856" alt="Screenshot_20260407_160740" src="https://github.com/user-attachments/assets/7d70b36e-c425-45a3-9d2a-7e827a080ce3" /> | <img width="1280" height="2856" alt="Screenshot_20260407_160707" src="https://github.com/user-attachments/assets/f6059ec0-8e49-4d0d-941f-472d44369bb8" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.