### PR TITLE
[WOOMOB-2548] Fix back button navigating background behind POS dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.common.composeui.component
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.core.tween
@@ -44,6 +45,8 @@ fun WooPosDialogWrapper(
     content: @Composable AnimatedVisibilityScope.() -> Unit
 ) {
     val closeContentDescription = stringResource(R.string.close)
+
+    BackHandler(enabled = isVisible) { onDismissRequest() }
 
     Box(
         contentAlignment = Alignment.Center,


### PR DESCRIPTION
### Description
Fixes WOOMOB-2548

When the barcode scanner setup dialog (or any POS dialog using `WooPosDialogWrapper`) was visible, pressing the back button navigated the background settings flow instead of dismissing the dialog. Added a `BackHandler` to `WooPosDialogWrapper` that intercepts back presses when the dialog is visible and calls `onDismissRequest`.

### Test Steps
1. Open POS
2. Go to Settings → Hardware → Barcode scanners
3. Tap "Scanner Setup" to open the dialog
4. Press the back button
5. Verify the dialog is dismissed and the background stays on the "Barcode scanners" screen

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.