### PR TITLE
[WOOMOB-2116] Increment compile SDK to API 37 (Android 17)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -182,7 +182,7 @@ gradle.ext.mediaPickerBinaryPath = "org.wordpress:mediapicker"
 gradle.ext.mediaPickerSourceCameraBinaryPath = "org.wordpress.mediapicker:source-camera"
 
 gradle.ext {
-    compileSdkVersion = 36
+    compileSdkVersion = 37
     targetSdkVersion = 36
     minSdkVersion = 26
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2116

Increments the compile SDK from 36 to 37 (Android 17) as part of our [process for mobile OS updates](https://woomobilep2.wordpress.com/process-for-mobile-os-and-ide-updates/). This is a **compileSdk-only** change — `targetSdkVersion` remains at 36 and will be updated separately after thorough migration review.

### Android 17 Behavioral Changes Assessment

Reviewed all [behavioral changes for all apps](https://developer.android.com/about/versions/17/behavior-changes-all). None require code changes for a compileSdk-only bump:

| Behavioral Change | Impact | Why it doesn't affect us |
|---|---|---|
| **usesCleartextTraffic deprecation** | None | Already using [`network_security_config.xml`](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/res/xml/network_security_config.xml) (the recommended replacement). Cleartext is only enabled for testing against mock servers. |
| **Implicit URI grants restriction** | None | The app uses `FileProvider` correctly for URI grants (e.g., [`PaymentReceiptShare.kt`](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/receipt/PaymentReceiptShare.kt), [`ActivityUtils.kt`](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/util/ActivityUtils.kt)). Also, the restriction itself takes effect in Android 18, not 17. |
| **Per-app Keystore limits** | None | Minimal AndroidKeyStore usage — only for [`EncryptedSharedPreferences`](https://github.com/woocommerce/woocommerce-android/blob/trunk/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/ApplicationPasswordsStore.kt) (application passwords) and [`MemorizingTrustManager`](https://github.com/woocommerce/woocommerce-android/blob/trunk/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/MemorizingTrustManager.java) (SSL trust). Well under the 200,000 key limit. |
| **IME visibility after rotation** | None | The app uses `adjustResize` on activities ([`AndroidManifest.xml`](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/AndroidManifest.xml)) but doesn't rely on automatic keyboard restoration after rotation. Login flows use explicit `showSoftInput()` calls which are unaffected. |
| **Touchpad relative events** | None | The app doesn't use `View.requestPointerCapture()`. |
| **Background audio hardening** | None | Audio usage is limited to foreground POS sonification sounds ([`WooPosSoundHelper.kt`](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/util/WooPosSoundHelper.kt)). No background audio playback. |
| **Bluetooth autonomous re-pairing** | Beneficial | The card reader library uses Bluetooth ([`cardreader/`](https://github.com/woocommerce/woocommerce-android/tree/trunk/libs/cardreader)), but this change is beneficial — automatic re-pairing of lost bonds means fewer manual reconnection steps. The app doesn't handle `ACTION_KEY_MISSING` or `ACTION_PAIRING_REQUEST` directly. |

### Test Steps
1. Open project in Android Studio, verify sync completes successfully
2. Build the app (`./gradlew assembleWasabiDebug`)
3. Run unit tests (`./gradlew testWasabiDebugUnitTest`)
4. Install on a device/emulator, verify app launches and basic flows work

### Images/gif
N/A — no UI changes

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

This is an internal build configuration change; no release notes entry needed.