### PR TITLE
[WOOMOB-2618] Add reschedule button entry point on booking details

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingMapper.kt
@@ -69,6 +69,7 @@ class BookingMapper @Inject constructor(
     fun Booking.toAppointmentDetailsModel(
         staffMemberStatus: BookingStaffMemberStatus?,
         cancelStatus: CancelStatus,
+        rescheduleButtonVisible: Boolean = false,
         attendanceUpdateStatus: AttendanceUpdateStatus = AttendanceUpdateStatus.Idle,
         locationStatus: BookingLocationStatus = BookingLocationStatus.Loading,
     ): BookingAppointmentDetailsModel {
@@ -82,6 +83,7 @@ class BookingMapper @Inject constructor(
             location = locationStatus,
             cancelStatus = cancelStatus,
             cancelButtonVisible = isCancellable,
+            rescheduleButtonVisible = rescheduleButtonVisible,
             duration = duration,
             attendanceStatus = attendanceStatus.toUiModel(),
             isAttendanceStatusEditable = isAttendanceStatusEditable,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
@@ -102,50 +102,51 @@ fun BookingAppointmentDetails(
                 value = model.duration,
                 withDivider = model.anyButtonVisible,
             )
-            AnimatedVisibility(model.rescheduleButtonVisible) {
-                WCOutlinedButton(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
-                    colors = ButtonDefaults.outlinedButtonColors(
-                        contentColor = MaterialTheme.colorScheme.onSurface
-                    ),
-                    onClick = onRescheduleBooking,
-                    text = stringResource(R.string.booking_details_reschedule_button),
-                )
-            }
-            AnimatedVisibility(model.attendanceButtonVisible) {
-                val text = when (model.attendanceStatus) {
-                    BookingAttendanceStatus.Attended ->
-                        stringResource(R.string.booking_mark_as_unattended)
-                    else -> stringResource(R.string.booking_mark_as_attended)
+            AnimatedVisibility(model.anyButtonVisible) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    AnimatedVisibility(model.rescheduleButtonVisible) {
+                        WCOutlinedButton(
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = MaterialTheme.colorScheme.onSurface
+                            ),
+                            onClick = onRescheduleBooking,
+                            text = stringResource(R.string.booking_details_reschedule_button),
+                        )
+                    }
+                    AnimatedVisibility(model.attendanceButtonVisible) {
+                        val text = when (model.attendanceStatus) {
+                            BookingAttendanceStatus.Attended ->
+                                stringResource(R.string.booking_mark_as_unattended)
+                            else -> stringResource(R.string.booking_mark_as_attended)
+                        }
+                        WCOutlinedButton(
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = MaterialTheme.colorScheme.onSurface
+                            ),
+                            onClick = onAttendanceToggle,
+                            enabled = model.attendanceButtonEnabled,
+                            text = text,
+                            loading = model.attendanceInProgressShown,
+                        )
+                    }
+                    AnimatedVisibility(model.cancelButtonVisible) {
+                        WCOutlinedButton(
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = MaterialTheme.colorScheme.onSurface
+                            ),
+                            onClick = onCancelBooking,
+                            enabled = model.cancelButtonEnabled,
+                            text = stringResource(R.string.booking_details_cancel_booking_button),
+                            loading = model.cancelInProgressShown,
+                        )
+                    }
                 }
-                WCOutlinedButton(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
-                    colors = ButtonDefaults.outlinedButtonColors(
-                        contentColor = MaterialTheme.colorScheme.onSurface
-                    ),
-                    onClick = onAttendanceToggle,
-                    enabled = model.attendanceButtonEnabled,
-                    text = text,
-                    loading = model.attendanceInProgressShown,
-                )
-            }
-            AnimatedVisibility(model.cancelButtonVisible) {
-                WCOutlinedButton(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
-                    colors = ButtonDefaults.outlinedButtonColors(
-                        contentColor = MaterialTheme.colorScheme.onSurface
-                    ),
-                    onClick = onCancelBooking,
-                    enabled = model.cancelButtonEnabled,
-                    text = stringResource(R.string.booking_details_cancel_booking_button),
-                    loading = model.cancelInProgressShown,
-                )
             }
             HorizontalDivider(thickness = 0.5.dp)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/compose/BookingAppointmentDetails.kt
@@ -32,6 +32,7 @@ fun BookingAppointmentDetails(
     model: BookingAppointmentDetailsModel,
     onCancelBooking: () -> Unit,
     onAttendanceToggle: () -> Unit,
+    onRescheduleBooking: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -99,11 +100,24 @@ fun BookingAppointmentDetails(
             AppointmentDetailsRow(
                 label = R.string.booking_appointment_label_duration,
                 value = model.duration,
-                withDivider = model.attendanceButtonVisible || model.cancelButtonVisible,
+                withDivider = model.anyButtonVisible,
             )
+            AnimatedVisibility(model.rescheduleButtonVisible) {
+                WCOutlinedButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onSurface
+                    ),
+                    onClick = onRescheduleBooking,
+                    text = stringResource(R.string.booking_details_reschedule_button),
+                )
+            }
             AnimatedVisibility(model.attendanceButtonVisible) {
                 val text = when (model.attendanceStatus) {
-                    BookingAttendanceStatus.Attended -> stringResource(R.string.booking_mark_as_unattended)
+                    BookingAttendanceStatus.Attended ->
+                        stringResource(R.string.booking_mark_as_unattended)
                     else -> stringResource(R.string.booking_mark_as_attended)
                 }
                 WCOutlinedButton(
@@ -190,6 +204,7 @@ data class BookingAppointmentDetailsModel(
     val duration: String,
     val cancelButtonVisible: Boolean,
     val cancelStatus: CancelStatus,
+    val rescheduleButtonVisible: Boolean = false,
     val attendanceStatus: BookingAttendanceStatus? = null,
     val isAttendanceStatusEditable: Boolean = false,
     val attendanceUpdateStatus: AttendanceUpdateStatus = AttendanceUpdateStatus.Idle,
@@ -199,6 +214,7 @@ data class BookingAppointmentDetailsModel(
     val attendanceButtonVisible: Boolean = isAttendanceStatusEditable
     val attendanceButtonEnabled: Boolean = attendanceUpdateStatus != AttendanceUpdateStatus.InProgress
     val attendanceInProgressShown: Boolean = attendanceUpdateStatus == AttendanceUpdateStatus.InProgress
+    val anyButtonVisible: Boolean = rescheduleButtonVisible || attendanceButtonVisible || cancelButtonVisible
 }
 
 sealed interface BookingLocationStatus {
@@ -226,11 +242,13 @@ private fun BookingAppointmentDetailsPreview() {
                 duration = "60 min",
                 cancelButtonVisible = true,
                 cancelStatus = CancelStatus.Idle,
+                rescheduleButtonVisible = true,
                 attendanceStatus = BookingAttendanceStatus.Unattended,
                 isAttendanceStatusEditable = true,
             ),
             onCancelBooking = {},
             onAttendanceToggle = {},
+            onRescheduleBooking = {},
             modifier = Modifier.fillMaxWidth()
         )
     }
@@ -252,6 +270,7 @@ private fun BookingAppointmentDetailsCancelHiddenPreview() {
             ),
             onCancelBooking = {},
             onAttendanceToggle = {},
+            onRescheduleBooking = {},
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsScreen.kt
@@ -121,6 +121,7 @@ fun BookingDetailsScreen(
                                     BookingDetailsContent(
                                         booking = viewState.bookingUiState,
                                         onCancelBooking = viewState.bookingUiState.onCancelBooking,
+                                        onRescheduleBooking = viewState.bookingUiState.onRescheduleBooking,
                                     )
                                 }
                             }
@@ -137,6 +138,7 @@ fun BookingDetailsScreen(
 private fun BookingDetailsContent(
     booking: BookingUiState,
     onCancelBooking: () -> Unit,
+    onRescheduleBooking: () -> Unit,
 ) {
     BookingSummary(
         model = booking.bookingSummary,
@@ -148,6 +150,7 @@ private fun BookingDetailsContent(
         model = booking.bookingsAppointmentDetails,
         onCancelBooking = onCancelBooking,
         onAttendanceToggle = booking.onAttendanceToggle,
+        onRescheduleBooking = onRescheduleBooking,
         modifier = Modifier.fillMaxWidth()
     )
     BookingCustomerDetails(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -22,6 +22,8 @@ import com.woocommerce.android.ui.bookings.compose.BookingLocationStatus
 import com.woocommerce.android.ui.bookings.compose.BookingStaffMemberStatus
 import com.woocommerce.android.ui.compose.DialogState
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -45,6 +47,7 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import org.wordpress.android.fluxc.persistence.entity.isAttendanceStatusEditable
+import org.wordpress.android.fluxc.persistence.entity.isReschedulable
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -58,6 +61,7 @@ class BookingDetailsViewModel @Inject constructor(
     private val paymentStatusResolver: PaymentStatusResolver,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val orderDetailRepository: OrderDetailRepository,
+    private val featureFlagRepository: FeatureFlagRepository,
     @AppCoroutineScope private val appScope: CoroutineScope,
 ) : ScopedViewModel(savedState) {
 
@@ -251,6 +255,11 @@ class BookingDetailsViewModel @Inject constructor(
         BookingAttendanceStatus.Unattended -> BookingEntity.AttendanceStatus.Unattended
     }
 
+    @Suppress("ForbiddenComment")
+    private fun onRescheduleBooking() {
+        // TODO: Navigate to reschedule screen
+    }
+
     private fun onCancelBooking() {
         showCancelBookingDialog.value = true
     }
@@ -321,6 +330,8 @@ class BookingDetailsViewModel @Inject constructor(
                     loadingState = loadingState
                 ),
                 cancelStatus = cancelStatus,
+                rescheduleButtonVisible = featureFlagRepository.isEnabled(FeatureFlag.BOOKINGS_RESCHEDULE) &&
+                    booking.isReschedulable,
                 attendanceUpdateStatus = attendanceUpdateStatus,
                 locationStatus = buildLocationStatus(booking, loadingState),
             ),
@@ -329,6 +340,7 @@ class BookingDetailsViewModel @Inject constructor(
             note = booking.note,
             isAttendanceStatusEditable = booking.isAttendanceStatusEditable,
             onCancelBooking = ::onCancelBooking,
+            onRescheduleBooking = ::onRescheduleBooking,
             onAttendanceToggle = {
                 val targetStatus = when (booking.attendanceStatus) {
                     BookingEntity.AttendanceStatus.Attended -> BookingAttendanceStatus.Unattended

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewState.kt
@@ -33,6 +33,7 @@ data class BookingUiState(
     val note: String,
     val isAttendanceStatusEditable: Boolean,
     val onCancelBooking: () -> Unit = {},
+    val onRescheduleBooking: () -> Unit = {},
     val onAttendanceToggle: () -> Unit = {},
     val onNoteClicked: () -> Unit = {},
     val onViewOrderClicked: () -> Unit = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -28,6 +28,7 @@ enum class FeatureFlag(
     POS_PRODUCTS_FTS("pos_products_fts", localValue = PackageUtils.isDebugBuild()),
     POS_BOOKINGS("pos_bookings", localValue = PackageUtils.isDebugBuild()),
     AGE_ELIGIBILITY_CHECKS("age_eligibility_checks", localValue = PackageUtils.isDebugBuild()),
+    BOOKINGS_RESCHEDULE("bookings_reschedule", localValue = PackageUtils.isDebugBuild()),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1("woo_self_driven_push_notifications_m1", localValue = false),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2("woo_self_driven_push_notifications_m2", localValue = false),
     WOO_SHIPPING_FEDEX("woo_shipping_fedex", localValue = false),

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4448,6 +4448,7 @@
     <string name="booking_mark_as_unattended">Mark as unattended</string>
     <string name="booking_attendance_status_cancelled">Canceled</string>
     <string name="booking_details_cancel_booking_button">Cancel booking</string>
+    <string name="booking_details_reschedule_button">Reschedule</string>
     <string name="booking_customer_details_header">CUSTOMER</string>
     <string name="booking_customer_label_name">Customer name</string>
     <string name="booking_customer_label_email">Email</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -601,7 +601,8 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
     @Test
     fun `given reschedule flag disabled, when state observed, then reschedule button not visible`() =
         testBlocking {
-            // GIVEN — flag defaults to false (not enabled)
+            // GIVEN
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.BOOKINGS_RESCHEDULE)).thenReturn(false)
 
             // WHEN
             val viewModel = createViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -18,6 +18,8 @@ import com.woocommerce.android.ui.compose.DialogState
 import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.DateFormatter
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -74,6 +76,7 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
     }
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val orderDetailRepository = mock<OrderDetailRepository>()
+    private val featureFlagRepository = mock<FeatureFlagRepository>()
 
     @Before
     fun setup() {
@@ -580,6 +583,79 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
                 .hasSize(1)
         }
 
+    @Test
+    fun `given reschedule flag enabled and confirmed booking, when state observed, then reschedule button visible`() =
+        testBlocking {
+            // GIVEN
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.BOOKINGS_RESCHEDULE)).thenReturn(true)
+            bookingFlow.value = getSampleBooking(bookingId, status = BookingEntity.Status.Confirmed)
+
+            // WHEN
+            val viewModel = createViewModel()
+            val state = viewModel.state.getOrAwaitValue()
+
+            // THEN
+            assertThat(state.bookingUiState?.bookingsAppointmentDetails?.rescheduleButtonVisible).isTrue()
+        }
+
+    @Test
+    fun `given reschedule flag disabled, when state observed, then reschedule button not visible`() =
+        testBlocking {
+            // GIVEN — flag defaults to false (not enabled)
+
+            // WHEN
+            val viewModel = createViewModel()
+            val state = viewModel.state.getOrAwaitValue()
+
+            // THEN
+            assertThat(state.bookingUiState?.bookingsAppointmentDetails?.rescheduleButtonVisible).isFalse()
+        }
+
+    @Test
+    fun `given reschedule flag enabled and cancelled booking, when state observed, then reschedule button not visible`() =
+        testBlocking {
+            // GIVEN
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.BOOKINGS_RESCHEDULE)).thenReturn(true)
+            bookingFlow.value = getSampleBooking(bookingId, status = BookingEntity.Status.Cancelled)
+
+            // WHEN
+            val viewModel = createViewModel()
+            val state = viewModel.state.getOrAwaitValue()
+
+            // THEN
+            assertThat(state.bookingUiState?.bookingsAppointmentDetails?.rescheduleButtonVisible).isFalse()
+        }
+
+    @Test
+    fun `given reschedule flag enabled and completed booking, when state observed, then reschedule button not visible`() =
+        testBlocking {
+            // GIVEN
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.BOOKINGS_RESCHEDULE)).thenReturn(true)
+            bookingFlow.value = getSampleBooking(bookingId, status = BookingEntity.Status.Complete)
+
+            // WHEN
+            val viewModel = createViewModel()
+            val state = viewModel.state.getOrAwaitValue()
+
+            // THEN
+            assertThat(state.bookingUiState?.bookingsAppointmentDetails?.rescheduleButtonVisible).isFalse()
+        }
+
+    @Test
+    fun `given reschedule flag enabled and in-cart booking, when state observed, then reschedule button not visible`() =
+        testBlocking {
+            // GIVEN
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.BOOKINGS_RESCHEDULE)).thenReturn(true)
+            bookingFlow.value = getSampleBooking(bookingId, status = BookingEntity.Status.InCart)
+
+            // WHEN
+            val viewModel = createViewModel()
+            val state = viewModel.state.getOrAwaitValue()
+
+            // THEN
+            assertThat(state.bookingUiState?.bookingsAppointmentDetails?.rescheduleButtonVisible).isFalse()
+        }
+
     private fun createViewModel(
         savedState: SavedStateHandle = savedStateHandle,
     ): BookingDetailsViewModel {
@@ -592,20 +668,26 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
             paymentStatusResolver = paymentStatusResolver,
             analyticsTrackerWrapper = analyticsTrackerWrapper,
             orderDetailRepository = orderDetailRepository,
+            featureFlagRepository = featureFlagRepository,
             appScope = TestScope(coroutinesTestRule.testDispatcher),
         ).apply {
             state.observeForever { }
         }
     }
 
-    private fun getSampleBooking(id: Long, orderId: Long = id, location: String? = null): Booking {
+    private fun getSampleBooking(
+        id: Long,
+        orderId: Long = id,
+        location: String? = null,
+        status: BookingEntity.Status = BookingEntity.Status.Confirmed,
+    ): Booking {
         return BookingEntity(
             id = LocalOrRemoteId.RemoteId(id),
             localSiteId = LocalOrRemoteId.LocalId(1),
             start = Instant.now(),
             end = Instant.now() + Duration.ofDays(1),
             allDay = false,
-            status = BookingEntity.Status.Confirmed,
+            status = status,
             cost = "100.00",
             currency = "USD",
             customerId = 1L,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -656,6 +656,21 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
             assertThat(state.bookingUiState?.bookingsAppointmentDetails?.rescheduleButtonVisible).isFalse()
         }
 
+    @Test
+    fun `given reschedule flag enabled and failed booking, when state observed, then reschedule button not visible`() =
+        testBlocking {
+            // GIVEN
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.BOOKINGS_RESCHEDULE)).thenReturn(true)
+            bookingFlow.value = getSampleBooking(bookingId, status = BookingEntity.Status.Failed)
+
+            // WHEN
+            val viewModel = createViewModel()
+            val state = viewModel.state.getOrAwaitValue()
+
+            // THEN
+            assertThat(state.bookingUiState?.bookingsAppointmentDetails?.rescheduleButtonVisible).isFalse()
+        }
+
     private fun createViewModel(
         savedState: SavedStateHandle = savedStateHandle,
     ): BookingDetailsViewModel {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/BookingEntity.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/BookingEntity.kt
@@ -73,6 +73,10 @@ data class BookingEntity(
             override val key = "in-cart"
         }
 
+        data object Failed : Status {
+            override val key = "failed"
+        }
+
         data class Unknown(override val key: String) : Status
 
         companion object Companion {
@@ -85,6 +89,7 @@ data class BookingEntity(
                     Cancelled.key -> Cancelled
                     Complete.key -> Complete
                     InCart.key -> InCart
+                    Failed.key -> Failed
                     else -> Unknown(key)
                 }
             }
@@ -150,7 +155,8 @@ val BookingEntity.isReschedulable: Boolean
         BookingEntity.Status.Cancelled,
         BookingEntity.Status.Complete,
         BookingEntity.Status.InCart,
-    ) && status.key != "failed"
+        BookingEntity.Status.Failed,
+    )
 
 val BookingEntity.isAttendanceStatusEditable: Boolean
     get() = status != BookingEntity.Status.Cancelled

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/BookingEntity.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/entity/BookingEntity.kt
@@ -145,5 +145,12 @@ val BookingEntity.isCancellable: Boolean
         BookingEntity.Status.Complete
     )
 
+val BookingEntity.isReschedulable: Boolean
+    get() = status !in listOf(
+        BookingEntity.Status.Cancelled,
+        BookingEntity.Status.Complete,
+        BookingEntity.Status.InCart,
+    ) && status.key != "failed"
+
 val BookingEntity.isAttendanceStatusEditable: Boolean
     get() = status != BookingEntity.Status.Cancelled


### PR DESCRIPTION
### Description
Fixes WOOMOB-2618

Adds an outlined "Reschedule" button in the appointment details section of the booking details screen, placed above the existing attendance and cancel buttons. The button is gated behind a new `BOOKINGS_RESCHEDULE` feature flag (debug-only) and hidden for bookings with cancelled, completed, in-cart, or failed status.

Also reduced vertical padding on all appointment detail buttons from `8.dp` to `4.dp` to tighten spacing — the actual gap between buttons was larger than `8.dp` because `WCOutlinedButton` enforces a minimum touch target height which adds implicit padding.

### Test Steps

1. Open a booking with status **Confirmed**, **Paid**, **Unpaid**, or **Pending Confirmation**
2. Verify the "Reschedule" outlined button appears as the first button in the Booking Details section
4. Open a booking with status **Cancelled**, **Completed**, or **In Cart**
5. Verify the "Reschedule" button is not visible
6. Disable the `BOOKINGS_RESCHEDULE` feature flag
7. Verify the "Reschedule" button is hidden for all bookings

### Images/gif

<img width="1280" height="2856" alt="Screenshot_20260408_151410" src="https://github.com/user-attachments/assets/8284187e-c0b3-434d-86d4-823f20c050be" />


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.