### PR TITLE
[WOOMOB-2503][POS] Make Select All row clickable in POS refund dialog

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundDialog.kt
@@ -572,12 +572,23 @@ private fun ItemsHeaderRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(bottom = WooPosSpacing.Medium.value),
+            .padding(bottom = WooPosSpacing.Medium.value)
+            .then(
+                if (enabled) {
+                    Modifier.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onSelectAllToggled
+                    )
+                } else {
+                    Modifier
+                }
+            ),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Checkbox(
             checked = allItemsSelected,
-            onCheckedChange = { onSelectAllToggled() },
+            onCheckedChange = null,
             enabled = enabled,
             modifier = Modifier
                 .size(32.dp)
@@ -619,7 +630,6 @@ private fun RefundableItemRow(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = WooPosSpacing.XSmall.value)
-            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
             .then(
                 if (enabled) {
                     Modifier.clickable(


### PR DESCRIPTION
### Description
Fixes WOOMOB-2503

Makes the entire "Select All" row clickable in the POS refund dialog, instead of only the checkbox. Also removes an unnecessary `.clip()` modifier from `RefundableItemRow` since there is no ripple indication to constrain.

### Test Steps
1. Open a POS order with multiple items
2. Tap "Issue Refund"
3. Verify tapping anywhere on the "Select All" row toggles the checkbox
4. Verify tapping anywhere on individual item rows still toggles their checkboxes

### Images/gif
https://github.com/user-attachments/assets/27d2fe7f-217c-44a7-b935-cf4624c81c52

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.