### PR TITLE
[WOOMOB-2619] Add booking reschedule screen with availability fetching

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -7,12 +7,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingAvailabilityDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingUpdatePayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsOrderOption
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsStore
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
 import org.wordpress.android.fluxc.persistence.entity.BookingResourceEntity
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 class BookingsRepository @Inject constructor(
@@ -191,6 +193,26 @@ class BookingsRepository @Inject constructor(
             Result.success(Unit)
         }
     }.await()
+
+    suspend fun fetchProductAvailability(
+        productId: Long,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime,
+        resourceId: Long,
+    ): Result<BookingAvailabilityDto> {
+        val result = bookingsStore.fetchProductAvailability(
+            site = selectedSite.get(),
+            productId = productId,
+            startDate = startDate,
+            endDate = endDate,
+            resourceId = resourceId,
+        )
+        return if (result.isError) {
+            Result.failure(WooException(result.error))
+        } else {
+            Result.success(result.model!!)
+        }
+    }
 
     suspend fun fetchProductBookingLocation(productId: Long, bookingId: Long? = null): Result<String?> {
         val result = bookingsStore.fetchProductBookingLocation(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/BookingsRepository.kt
@@ -7,6 +7,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingAvailabilityDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingFilters
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingUpdatePayload
@@ -207,10 +210,11 @@ class BookingsRepository @Inject constructor(
             endDate = endDate,
             resourceId = resourceId,
         )
-        return if (result.isError) {
-            Result.failure(WooException(result.error))
-        } else {
-            Result.success(result.model!!)
+        val model = result.model
+        return when {
+            result.isError -> Result.failure(WooException(result.error))
+            model != null -> Result.success(model)
+            else -> Result.failure(WooException(WooError(GENERIC_ERROR, UNKNOWN)))
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsFragment.kt
@@ -66,6 +66,12 @@ class BookingDetailsFragment : BaseFragment() {
                             .actionBookingDetailsFragmentToBookingNoteFragment(event.bookingId)
                     )
                 }
+                is BookingDetailsViewModel.NavigateToRescheduleBooking -> {
+                    findNavController().navigateSafely(
+                        BookingDetailsFragmentDirections
+                            .actionBookingDetailsFragmentToBookingRescheduleFragment(event.bookingId)
+                    )
+                }
                 is BookingDetailsViewModel.NavigateToOrder -> {
                     requireActivity().findNavController(R.id.nav_host_fragment_main).navigate(
                         NavGraphMainDirections.actionGlobalOrderDetailFragment(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModel.kt
@@ -262,9 +262,8 @@ class BookingDetailsViewModel @Inject constructor(
         BookingAttendanceStatus.Unattended -> BookingEntity.AttendanceStatus.Unattended
     }
 
-    @Suppress("ForbiddenComment")
     private fun onRescheduleBooking() {
-        // TODO: Navigate to reschedule screen
+        bookingId?.let { triggerEvent(NavigateToRescheduleBooking(it)) }
     }
 
     private fun onCancelBooking() {
@@ -400,4 +399,5 @@ class BookingDetailsViewModel @Inject constructor(
     data class NavigateToOrder(val orderId: Long) : MultiLiveEvent.Event()
     data class NavigateToIssueRefund(val orderId: Long) : MultiLiveEvent.Event()
     data class NavigateToBookingNote(val bookingId: Long) : MultiLiveEvent.Event()
+    data class NavigateToRescheduleBooking(val bookingId: Long) : MultiLiveEvent.Event()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleFragment.kt
@@ -1,0 +1,51 @@
+package com.woocommerce.android.ui.bookings.reschedule
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
+import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class BookingRescheduleFragment : BaseFragment() {
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
+
+    private val viewModel: BookingRescheduleViewModel by viewModels()
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return composeView {
+            BookingRescheduleScreen(viewModel = viewModel)
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        handleEvents()
+    }
+
+    private fun handleEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.ShowSnackbar -> {
+                    uiMessageResolver.showSnack(event.message)
+                }
+                is MultiLiveEvent.Event.Exit -> {
+                    findNavController().navigateUp()
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleScreen.kt
@@ -1,0 +1,62 @@
+package com.woocommerce.android.ui.bookings.reschedule
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.Toolbar
+
+@Composable
+fun BookingRescheduleScreen(
+    viewModel: BookingRescheduleViewModel,
+) {
+    val state by viewModel.state.observeAsState()
+    BookingRescheduleScreen(
+        state = state,
+        onBackPressed = viewModel::onBackPressed,
+    )
+}
+
+@Composable
+fun BookingRescheduleScreen(
+    state: BookingRescheduleState?,
+    onBackPressed: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            Toolbar(
+                title = stringResource(R.string.booking_reschedule_screen_title),
+                onNavigationButtonClick = onBackPressed,
+            )
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center,
+        ) {
+            when (state) {
+                is BookingRescheduleState.Loading, null -> {
+                    CircularProgressIndicator()
+                }
+                is BookingRescheduleState.Error -> {
+                    // Empty for now — error is shown via snackbar
+                }
+                is BookingRescheduleState.Content -> {
+                    // Availability data loaded — calendar UI will be added here
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
@@ -1,0 +1,104 @@
+package com.woocommerce.android.ui.bookings.reschedule
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.bookings.Booking
+import com.woocommerce.android.ui.bookings.BookingsRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import com.woocommerce.android.viewmodel.navArgs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingAvailabilityDto
+import java.time.Clock
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneOffset
+import javax.inject.Inject
+
+@HiltViewModel
+class BookingRescheduleViewModel @Inject constructor(
+    private val bookingsRepository: BookingsRepository,
+    private val clock: Clock,
+    savedState: SavedStateHandle,
+) : ScopedViewModel(savedState) {
+
+    private val navArgs: BookingRescheduleFragmentArgs by savedState.navArgs()
+
+    private val _state = MutableStateFlow<BookingRescheduleState>(BookingRescheduleState.Loading)
+    val state: LiveData<BookingRescheduleState> = _state.asLiveData()
+
+    init {
+        loadAvailability()
+    }
+
+    fun onBackPressed() {
+        triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+
+    private fun loadAvailability() {
+        launch {
+            _state.update { BookingRescheduleState.Loading }
+
+            val booking = bookingsRepository.getBooking(navArgs.bookingId)
+            if (booking == null) {
+                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.error_generic))
+                triggerEvent(MultiLiveEvent.Event.Exit)
+                return@launch
+            }
+
+            val productId = booking.productId
+            if (productId == 0L) {
+                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.error_generic))
+                triggerEvent(MultiLiveEvent.Event.Exit)
+                return@launch
+            }
+
+            val resourceId = booking.resourceId
+            val (startDate, endDate) = buildDateRange(booking)
+
+            bookingsRepository.fetchProductAvailability(
+                productId = productId,
+                startDate = startDate,
+                endDate = endDate,
+                resourceId = resourceId,
+            ).onSuccess { availability ->
+                _state.update {
+                    BookingRescheduleState.Content(availability = availability)
+                }
+            }.onFailure {
+                _state.update { BookingRescheduleState.Error }
+                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.error_generic))
+            }
+        }
+    }
+
+    private fun buildDateRange(booking: Booking): Pair<LocalDateTime, LocalDateTime> {
+        val today = LocalDate.now(clock)
+        val bookingDate = booking.start.atOffset(ZoneOffset.UTC).toLocalDate()
+        val effectiveDate = maxOf(bookingDate, today)
+        val monthStart = effectiveDate.withDayOfMonth(1)
+        val rangeStartDate = maxOf(monthStart, today)
+        val startDate = if (rangeStartDate == today) {
+            LocalDateTime.now(clock)
+        } else {
+            rangeStartDate.atStartOfDay()
+        }
+        val endDate = effectiveDate.withDayOfMonth(effectiveDate.lengthOfMonth())
+            .atTime(LocalTime.MAX)
+        return startDate to endDate
+    }
+}
+
+sealed interface BookingRescheduleState {
+    data object Loading : BookingRescheduleState
+    data object Error : BookingRescheduleState
+    data class Content(
+        val availability: BookingAvailabilityDto,
+    ) : BookingRescheduleState
+}

--- a/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_bookings_details.xml
@@ -15,6 +15,9 @@
             android:id="@+id/action_bookingDetailsFragment_to_bookingNoteFragment"
             app:destination="@id/bookingNoteFragment" />
         <action
+            android:id="@+id/action_bookingDetailsFragment_to_bookingRescheduleFragment"
+            app:destination="@id/bookingRescheduleFragment" />
+        <action
             android:id="@+id/action_bookingDetailsFragment_to_issueRefund"
             app:destination="@id/nav_graph_refunds">
             <argument
@@ -25,6 +28,16 @@
     </fragment>
 
     <include app:graph="@navigation/nav_graph_refunds" />
+
+    <fragment
+        android:id="@+id/bookingRescheduleFragment"
+        android:name="com.woocommerce.android.ui.bookings.reschedule.BookingRescheduleFragment"
+        android:label="BookingRescheduleFragment">
+        <argument
+            android:name="bookingId"
+            android:defaultValue="-1L"
+            app:argType="long" />
+    </fragment>
 
     <fragment
         android:id="@+id/bookingNoteFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4454,6 +4454,7 @@
     <string name="booking_attendance_status_cancelled">Canceled</string>
     <string name="booking_details_cancel_booking_button">Cancel booking</string>
     <string name="booking_details_reschedule_button">Reschedule</string>
+    <string name="booking_reschedule_screen_title">Reschedule booking</string>
     <string name="booking_customer_details_header">CUSTOMER</string>
     <string name="booking_customer_label_name">Customer name</string>
     <string name="booking_customer_label_email">Email</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModelTest.kt
@@ -1,0 +1,237 @@
+package com.woocommerce.android.ui.bookings.reschedule
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.ui.bookings.BookingsRepository
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingAvailabilityDto
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingOrderInfo
+import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BookingRescheduleViewModelTest : BaseUnitTest() {
+
+    private val bookingsRepository: BookingsRepository = mock()
+
+    private val sampleAvailability = BookingAvailabilityDto(
+        productId = 1L,
+        resourceId = 1L,
+        startDate = "",
+        endDate = "",
+        timezoneOffset = 0,
+        availability = emptyMap(),
+    )
+
+    @Test
+    fun `given upcoming booking next month, when loading, then range is 1st to last day of booking month`() =
+        testBlocking {
+            // GIVEN
+            val now = LocalDateTime.of(2026, 3, 15, 10, 0, 0)
+            val bookingStart = LocalDate.of(2026, 4, 10)
+                .atStartOfDay()
+                .toInstant(ZoneOffset.UTC)
+            val booking = getSampleBooking(bookingStart)
+
+            whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+            whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+                .thenReturn(Result.success(sampleAvailability))
+
+            createViewModel(now)
+
+            // THEN
+            val expectedStart = LocalDate.of(2026, 4, 1).atStartOfDay()
+            val expectedEnd = LocalDate.of(2026, 4, 30).atTime(LocalTime.MAX)
+            verify(bookingsRepository).fetchProductAvailability(
+                productId = eq(PRODUCT_ID),
+                startDate = eq(expectedStart),
+                endDate = eq(expectedEnd),
+                resourceId = eq(RESOURCE_ID),
+            )
+        }
+
+    @Test
+    fun `given booking today, when loading, then start date uses current time`() = testBlocking {
+        // GIVEN
+        val now = LocalDateTime.of(2026, 4, 10, 14, 30, 0)
+        val bookingStart = LocalDate.of(2026, 4, 10)
+            .atTime(16, 0)
+            .toInstant(ZoneOffset.UTC)
+        val booking = getSampleBooking(bookingStart)
+
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        createViewModel(now)
+
+        // THEN
+        val expectedEnd = LocalDate.of(2026, 4, 30).atTime(LocalTime.MAX)
+        verify(bookingsRepository).fetchProductAvailability(
+            productId = eq(PRODUCT_ID),
+            startDate = eq(now),
+            endDate = eq(expectedEnd),
+            resourceId = eq(RESOURCE_ID),
+        )
+    }
+
+    @Test
+    fun `given past booking, when loading, then start date is today with current time`() = testBlocking {
+        // GIVEN
+        val now = LocalDateTime.of(2026, 4, 15, 9, 0, 0)
+        val bookingStart = LocalDate.of(2026, 4, 3)
+            .atStartOfDay()
+            .toInstant(ZoneOffset.UTC)
+        val booking = getSampleBooking(bookingStart)
+
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        createViewModel(now)
+
+        // THEN
+        val expectedEnd = LocalDate.of(2026, 4, 30).atTime(LocalTime.MAX)
+        verify(bookingsRepository).fetchProductAvailability(
+            productId = eq(PRODUCT_ID),
+            startDate = eq(now),
+            endDate = eq(expectedEnd),
+            resourceId = eq(RESOURCE_ID),
+        )
+    }
+
+    @Test
+    fun `given successful fetch, when loading, then state is Content`() = testBlocking {
+        // GIVEN
+        val booking = getSampleBooking(Instant.now())
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        assertThat(viewModel.state.value).isInstanceOf(BookingRescheduleState.Content::class.java)
+    }
+
+    @Test
+    fun `given failed fetch, when loading, then state is Error`() = testBlocking {
+        // GIVEN
+        val booking = getSampleBooking(Instant.now())
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.failure(Exception("Network error")))
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        assertThat(viewModel.state.value).isEqualTo(BookingRescheduleState.Error)
+    }
+
+    @Test
+    fun `given booking not found, when loading, then exits`() = testBlocking {
+        // GIVEN
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(null)
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val event = viewModel.event.getOrAwaitValue()
+        assertThat(event).isEqualTo(MultiLiveEvent.Event.Exit)
+    }
+
+    @Test
+    fun `given booking in past month, when loading, then range uses current month`() = testBlocking {
+        // GIVEN
+        val now = LocalDateTime.of(2026, 5, 10, 9, 0, 0)
+        val bookingStart = LocalDate.of(2026, 3, 15)
+            .atStartOfDay()
+            .toInstant(ZoneOffset.UTC)
+        val booking = getSampleBooking(bookingStart)
+
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        createViewModel(now)
+
+        // THEN
+        val expectedEnd = LocalDate.of(2026, 5, 31).atTime(LocalTime.MAX)
+        verify(bookingsRepository).fetchProductAvailability(
+            productId = eq(PRODUCT_ID),
+            startDate = eq(now),
+            endDate = eq(expectedEnd),
+            resourceId = eq(RESOURCE_ID),
+        )
+    }
+
+    private fun createViewModel(
+        now: LocalDateTime = LocalDateTime.now(),
+    ): BookingRescheduleViewModel {
+        val fixedInstant = now.toInstant(ZoneOffset.UTC)
+        val clock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
+        return BookingRescheduleViewModel(
+            bookingsRepository = bookingsRepository,
+            clock = clock,
+            savedState = SavedStateHandle(mapOf("bookingId" to BOOKING_ID)),
+        ).also {
+            it.state.observeForever { }
+        }
+    }
+
+    private fun getSampleBooking(
+        start: Instant,
+        productId: Long = PRODUCT_ID,
+        resourceId: Long = RESOURCE_ID,
+    ): BookingEntity {
+        return BookingEntity(
+            id = LocalOrRemoteId.RemoteId(BOOKING_ID),
+            localSiteId = LocalOrRemoteId.LocalId(1),
+            start = start,
+            end = start + Duration.ofHours(1),
+            allDay = false,
+            status = BookingEntity.Status.Confirmed,
+            cost = "100.00",
+            currency = "USD",
+            customerId = 1L,
+            productId = productId,
+            resourceId = resourceId,
+            dateCreated = Instant.now(),
+            dateModified = Instant.now(),
+            googleCalendarEventId = "",
+            orderId = 1L,
+            orderItemId = 1L,
+            parentId = 0L,
+            personCounts = listOf(1L),
+            localTimezone = "",
+            attendanceStatus = BookingEntity.AttendanceStatus.Unattended,
+            order = BookingOrderInfo(),
+            customerNote = "",
+        )
+    }
+
+    companion object {
+        private const val BOOKING_ID = 100L
+        private const val PRODUCT_ID = 47L
+        private const val RESOURCE_ID = 13L
+    }
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingAvailabilityDto.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingAvailabilityDto.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * DTO for the response from `GET wc-bookings/v2/products/{id}/availability`.
+ *
+ * The `availability` field contains slots grouped as: month → day → time slot → capacity count.
+ */
+data class BookingAvailabilityDto(
+    @SerializedName("product_id")
+    val productId: Long,
+    @SerializedName("resource_id")
+    val resourceId: Long,
+    @SerializedName("start_date")
+    val startDate: String,
+    @SerializedName("end_date")
+    val endDate: String,
+    @SerializedName("timezone_offset")
+    val timezoneOffset: Int,
+    @SerializedName("availability")
+    val availability: Map<String, Map<String, Map<String, Int>>>,
+)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -10,6 +10,9 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.utils.extensions.filterNotNull
 import org.wordpress.android.fluxc.utils.extensions.putIfNotNull
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -19,6 +22,7 @@ class BookingsRestClient @Inject constructor(
 ) {
     companion object {
         const val DEFAULT_PER_PAGE = 25 // Number of items to fetch in a single request
+        private val DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.ROOT)
     }
 
     suspend fun fetchBooking(
@@ -129,6 +133,30 @@ class BookingsRestClient @Inject constructor(
             path = endpoint,
             clazz = BookingResourceDto::class.java,
             params = emptyMap()
+        )
+        return when (response) {
+            is Success -> WooPayload(response.data)
+            is Error -> WooPayload(response.error.toWooError())
+        }
+    }
+
+    suspend fun fetchProductAvailability(
+        site: SiteModel,
+        productId: Long,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime,
+        resourceId: Long,
+    ): WooPayload<BookingAvailabilityDto> {
+        val endpoint = WOOCOMMERCE.products.id(productId).availability.pathV2Bookings
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = endpoint,
+            clazz = BookingAvailabilityDto::class.java,
+            params = mapOf(
+                "start_date" to startDate.format(DATE_TIME_FORMATTER),
+                "end_date" to endDate.format(DATE_TIME_FORMATTER),
+                "resource_id" to resourceId.toString(),
+            )
         )
         return when (response) {
             is Success -> WooPayload(response.data)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsStore.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.tools.CoroutineEngine
 import org.wordpress.android.fluxc.utils.HeadersParser
 import org.wordpress.android.util.AppLog
+import java.time.LocalDateTime
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -205,6 +206,25 @@ class BookingsStore @Inject internal constructor(
     fun observeResources(
         site: SiteModel
     ): Flow<List<BookingResourceEntity>> = bookingsDao.observeResources(site.localId())
+
+    suspend fun fetchProductAvailability(
+        site: SiteModel,
+        productId: Long,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime,
+        resourceId: Long,
+    ): WooResult<BookingAvailabilityDto> {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "fetchProductAvailability") {
+            val response = bookingsRestClient.fetchProductAvailability(
+                site, productId, startDate, endDate, resourceId
+            )
+            when {
+                response.isError -> WooResult(response.error)
+                response.result != null -> WooResult(response.result)
+                else -> WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            }
+        }
+    }
 
     suspend fun fetchProductBookingLocation(
         site: SiteModel,

--- a/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -11,6 +11,7 @@
 /orders/batch
 
 /products/<id>/
+/products/<id>/availability/
 /products/<id>/variations/
 /products/<id>/variations/<variation_id>
 /products/<id>/variations/batch


### PR DESCRIPTION
### Description
Fixes WOOMOB-2619

Adds the booking reschedule screen accessible from the booking details "Reschedule" button. The screen fetches product availability for the booking's month (clamped to today) and displays a loading state while fetching. The calendar UI for selecting a new date/time will follow in a subsequent PR.

Changes:
- Add `GET wc-bookings/v2/products/{id}/availability` endpoint through RestClient → Store → Repository
- Wire navigation from booking details to the new reschedule fragment via SafeArgs
- Add `BookingRescheduleViewModel` with date range calculation and `Clock` injection for testability
- Add `BookingRescheduleScreen` Compose UI (Scaffold + toolbar + loading spinner)

### Test Steps
1. Open a booking that has the reschedule button visible (confirmed status, with a product)
2. Tap the "Reschedule" button
3. Verify the "Reschedule booking" screen opens with a loading spinner
4. Verify tapping the back arrow returns to booking details

### Images/gif

https://github.com/user-attachments/assets/ea5827ba-a3ae-412a-ac83-1577b9f7dbfd




- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.