### PR TITLE
[WOOMOB-2655] Add feature flag to gate POS on phones

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPosIsScreenSizeAllowed.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPosIsScreenSizeAllowed.kt
@@ -23,7 +23,7 @@ class WooPosIsScreenSizeAllowed @Inject constructor(
         val shortSize = min(screenWidthDp, screenHeightDp)
         val longSize = max(screenWidthDp, screenHeightDp)
 
-        val isTabletSize = shortSize >= MIN_SCREEN_SHORT_SIZE_DP && longSize >= MIN_SCREEN_LONG_SIZE_DP
+        val isTabletSize = shortSize >= MIN_TABLET_SHORT_SIZE_DP && longSize >= MIN_TABLET_LONG_SIZE_DP
         if (isTabletSize) return true
 
         val isPhoneWithFlagEnabled = context.isWooPosPhoneLayout() &&
@@ -33,13 +33,13 @@ class WooPosIsScreenSizeAllowed @Inject constructor(
         wooPosLog.i(
             "POS Not allowed reason: Screen size is not allowed. " +
                 "Short size: $shortSize, Long size: $longSize, " +
-                "Minimum short size: $MIN_SCREEN_SHORT_SIZE_DP, Minimum long size: $MIN_SCREEN_LONG_SIZE_DP"
+                "Minimum short size: $MIN_TABLET_SHORT_SIZE_DP, Minimum long size: $MIN_TABLET_LONG_SIZE_DP"
         )
         return false
     }
 
-    private companion object {
-        const val MIN_SCREEN_SHORT_SIZE_DP = 674
-        const val MIN_SCREEN_LONG_SIZE_DP = 800
+    companion object {
+        internal const val MIN_TABLET_SHORT_SIZE_DP = 674
+        internal const val MIN_TABLET_LONG_SIZE_DP = 800
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPosIsScreenSizeAllowed.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPosIsScreenSizeAllowed.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.util.ext.getScreenHeightDp
 import com.woocommerce.android.ui.woopos.util.ext.getScreenWidthDp
-import com.woocommerce.android.ui.woopos.util.ext.isWooPosPhoneLayout
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
 import javax.inject.Inject
@@ -26,9 +25,7 @@ class WooPosIsScreenSizeAllowed @Inject constructor(
         val isTabletSize = shortSize >= MIN_TABLET_SHORT_SIZE_DP && longSize >= MIN_TABLET_LONG_SIZE_DP
         if (isTabletSize) return true
 
-        val isPhoneWithFlagEnabled = context.isWooPosPhoneLayout() &&
-            featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_PHONE)
-        if (isPhoneWithFlagEnabled) return true
+        if (featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_PHONE)) return true
 
         wooPosLog.i(
             "POS Not allowed reason: Screen size is not allowed. " +

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPosIsScreenSizeAllowed.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/WooPosIsScreenSizeAllowed.kt
@@ -4,12 +4,16 @@ import android.content.Context
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.util.ext.getScreenHeightDp
 import com.woocommerce.android.ui.woopos.util.ext.getScreenWidthDp
+import com.woocommerce.android.ui.woopos.util.ext.isWooPosPhoneLayout
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import javax.inject.Inject
 import kotlin.math.max
 import kotlin.math.min
 
 class WooPosIsScreenSizeAllowed @Inject constructor(
     private val context: Context,
+    private val featureFlagRepository: FeatureFlagRepository,
     private val wooPosLog: WooPosLogWrapper,
 ) {
     operator fun invoke(): Boolean {
@@ -19,16 +23,19 @@ class WooPosIsScreenSizeAllowed @Inject constructor(
         val shortSize = min(screenWidthDp, screenHeightDp)
         val longSize = max(screenWidthDp, screenHeightDp)
 
-        val isAllowed = shortSize >= MIN_SCREEN_SHORT_SIZE_DP && longSize >= MIN_SCREEN_LONG_SIZE_DP
-        return isAllowed.also {
-            if (!isAllowed) {
-                wooPosLog.i(
-                    "POS Not allowed reason: Screen size is not allowed. " +
-                        "Short size: $shortSize, Long size: $longSize, " +
-                        "Minimum short size: $MIN_SCREEN_SHORT_SIZE_DP, Minimum long size: $MIN_SCREEN_LONG_SIZE_DP"
-                )
-            }
-        }
+        val isTabletSize = shortSize >= MIN_SCREEN_SHORT_SIZE_DP && longSize >= MIN_SCREEN_LONG_SIZE_DP
+        if (isTabletSize) return true
+
+        val isPhoneWithFlagEnabled = context.isWooPosPhoneLayout() &&
+            featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_PHONE)
+        if (isPhoneWithFlagEnabled) return true
+
+        wooPosLog.i(
+            "POS Not allowed reason: Screen size is not allowed. " +
+                "Short size: $shortSize, Long size: $longSize, " +
+                "Minimum short size: $MIN_SCREEN_SHORT_SIZE_DP, Minimum long size: $MIN_SCREEN_LONG_SIZE_DP"
+        )
+        return false
     }
 
     private companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
@@ -2,15 +2,10 @@ package com.woocommerce.android.ui.woopos.cardreader
 
 import android.content.Context
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.os.Parcelable
-import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updatePadding
 import androidx.navigation.fragment.NavHostFragment
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.adjustActivityTransition
@@ -18,8 +13,8 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowP
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.payments.cardreader.statuschecker.CardReaderStatusCheckerDialogFragmentArgs
 import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateDialogFragment
-import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
-import com.woocommerce.android.ui.woopos.util.ext.isWooPosPhoneLayout
+import com.woocommerce.android.ui.woopos.util.ext.lockWooPosOrientation
+import com.woocommerce.android.ui.woopos.util.ext.setupWooPosTopAndBottomInsets
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.parcelable
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,12 +31,9 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setupTopAndBottomInsets()
-        requestedOrientation = if (isWooPosPhoneLayout()) {
-            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        } else {
-            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-        }
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        setupWooPosTopAndBottomInsets(R.id.snack_root)
+        lockWooPosOrientation()
 
         val navHostFragment = supportFragmentManager.findFragmentById(
             R.id.woopos_card_reader_nav_host_fragment
@@ -54,30 +46,6 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
         }
         setupNavGraph(navHostFragment, flowType)
         observeResult(navHostFragment, flowType)
-    }
-
-    private fun setupTopAndBottomInsets() {
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-        val rootView = findViewById<View>(R.id.snack_root)
-        ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
-            insets.toWindowInsets()?.let { windowInsets ->
-                val insetsCompat = WindowInsetsCompat.toWindowInsetsCompat(windowInsets, view)
-                val isGestureNavigation = insetsCompat.isGestureNavigation(this)
-
-                val topPadding = insetsCompat.getInsets(WindowInsetsCompat.Type.statusBars()).top
-                val bottomPadding = if (isGestureNavigation) {
-                    0
-                } else {
-                    insetsCompat.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
-                }
-                view.updatePadding(
-                    top = topPadding,
-                    bottom = bottomPadding
-                )
-            }
-
-            insets
-        }
     }
 
     override fun finish() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderActivity.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.payments.cardreader.statuschecker.CardReaderStatusCheckerDialogFragmentArgs
 import com.woocommerce.android.ui.payments.cardreader.update.CardReaderUpdateDialogFragment
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
+import com.woocommerce.android.ui.woopos.util.ext.isWooPosPhoneLayout
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.parcelable
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,7 +37,11 @@ class WooPosCardReaderActivity : AppCompatActivity(R.layout.activity_woo_pos_car
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setupTopAndBottomInsets()
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        requestedOrientation = if (isWooPosPhoneLayout()) {
+            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        } else {
+            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        }
 
         val navHostFragment = supportFragmentManager.findFragmentById(
             R.id.woopos_card_reader_nav_host_fragment

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationActivity.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.extensions.adjustActivityTransition
 import com.woocommerce.android.extensions.getColorCompat
 import com.woocommerce.android.ui.coupons.create.CouponTypePickerFragmentArgs
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
+import com.woocommerce.android.ui.woopos.util.ext.isWooPosPhoneLayout
 import com.woocommerce.android.util.WooLog
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -27,7 +28,11 @@ class WooPosCouponCreationActivity : AppCompatActivity(R.layout.activity_woo_pos
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setupTopAndBottomInsets()
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        requestedOrientation = if (isWooPosPhoneLayout()) {
+            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        } else {
+            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        }
 
         val navHostFragment = supportFragmentManager.findFragmentById(
             R.id.woopos_coupon_creation_nav_host_fragment

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/creation/WooPosCouponCreationActivity.kt
@@ -2,24 +2,19 @@ package com.woocommerce.android.ui.woopos.home.items.coupons.creation
 
 import android.content.Context
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.os.Bundle
-import android.view.View
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updatePadding
 import androidx.navigation.NavGraph
 import androidx.navigation.fragment.NavHostFragment
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.adjustActivityTransition
 import com.woocommerce.android.extensions.getColorCompat
 import com.woocommerce.android.ui.coupons.create.CouponTypePickerFragmentArgs
-import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
-import com.woocommerce.android.ui.woopos.util.ext.isWooPosPhoneLayout
+import com.woocommerce.android.ui.woopos.util.ext.lockWooPosOrientation
+import com.woocommerce.android.ui.woopos.util.ext.setupWooPosTopAndBottomInsets
 import com.woocommerce.android.util.WooLog
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -27,12 +22,9 @@ import dagger.hilt.android.AndroidEntryPoint
 class WooPosCouponCreationActivity : AppCompatActivity(R.layout.activity_woo_pos_coupon_creation) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setupTopAndBottomInsets()
-        requestedOrientation = if (isWooPosPhoneLayout()) {
-            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        } else {
-            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-        }
+        applyFixForStatusBarColor()
+        setupWooPosTopAndBottomInsets(R.id.snack_root)
+        lockWooPosOrientation()
 
         val navHostFragment = supportFragmentManager.findFragmentById(
             R.id.woopos_coupon_creation_nav_host_fragment
@@ -40,30 +32,6 @@ class WooPosCouponCreationActivity : AppCompatActivity(R.layout.activity_woo_pos
 
         setupNavGraph(navHostFragment)
         observeResult(navHostFragment)
-    }
-
-    private fun setupTopAndBottomInsets() {
-        applyFixForStatusBarColor()
-        val rootView = findViewById<View>(R.id.snack_root)
-        ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
-            insets.toWindowInsets()?.let { windowInsets ->
-                val insetsCompat = WindowInsetsCompat.toWindowInsetsCompat(windowInsets, view)
-                val isGestureNavigation = insetsCompat.isGestureNavigation(this)
-
-                val topPadding = insetsCompat.getInsets(WindowInsetsCompat.Type.statusBars()).top
-                val bottomPadding = if (isGestureNavigation) {
-                    0
-                } else {
-                    insetsCompat.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
-                }
-                view.updatePadding(
-                    top = topPadding,
-                    bottom = bottomPadding
-                )
-            }
-
-            insets
-        }
     }
 
     private fun applyFixForStatusBarColor() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.home.items.coupons.creation.WooPosCouponCreationFacade
 import com.woocommerce.android.ui.woopos.support.WooPosGetSupportFacade
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
+import com.woocommerce.android.ui.woopos.util.ext.isWooPosPhoneLayout
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -44,7 +45,11 @@ class WooPosActivity : AppCompatActivity() {
         // so going through splash again is instant (no loading screen).
         super.onCreate(null)
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        requestedOrientation = if (isWooPosPhoneLayout()) {
+            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        } else {
+            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        }
 
         lifecycle.addObserver(wooPosCardReaderFacade)
         lifecycle.addObserver(wooPosGetSupportFacade)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.woopos.root
 
-import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
@@ -17,7 +16,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.home.items.coupons.creation.WooPosCouponCreationFacade
 import com.woocommerce.android.ui.woopos.support.WooPosGetSupportFacade
 import com.woocommerce.android.ui.woopos.util.ext.isGestureNavigation
-import com.woocommerce.android.ui.woopos.util.ext.isWooPosPhoneLayout
+import com.woocommerce.android.ui.woopos.util.ext.lockWooPosOrientation
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -45,11 +44,7 @@ class WooPosActivity : AppCompatActivity() {
         // so going through splash again is instant (no loading screen).
         super.onCreate(null)
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        requestedOrientation = if (isWooPosPhoneLayout()) {
-            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        } else {
-            ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-        }
+        lockWooPosOrientation()
 
         lifecycle.addObserver(wooPosCardReaderFacade)
         lifecycle.addObserver(wooPosGetSupportFacade)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/ext/WooPosActivityExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/ext/WooPosActivityExt.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.ui.woopos.util.ext
+
+import android.app.Activity
+import android.content.pm.ActivityInfo
+import android.view.View
+import androidx.annotation.IdRes
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+
+fun Activity.lockWooPosOrientation() {
+    requestedOrientation = if (isWooPosPhoneLayout()) {
+        ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    } else {
+        ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+    }
+}
+
+fun Activity.setupWooPosTopAndBottomInsets(@IdRes rootViewId: Int) {
+    val rootView = findViewById<View>(rootViewId)
+    ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
+        insets.toWindowInsets()?.let { windowInsets ->
+            val insetsCompat = WindowInsetsCompat.toWindowInsetsCompat(windowInsets, view)
+            val isGestureNavigation = insetsCompat.isGestureNavigation(view.context)
+
+            val topPadding = insetsCompat.getInsets(WindowInsetsCompat.Type.statusBars()).top
+            val bottomPadding = if (isGestureNavigation) {
+                0
+            } else {
+                insetsCompat.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
+            }
+            view.updatePadding(
+                top = topPadding,
+                bottom = bottomPadding
+            )
+        }
+        insets
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/ext/WooPosContextExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/ext/WooPosContextExt.kt
@@ -5,8 +5,16 @@ import androidx.compose.ui.unit.dp
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
+import kotlin.math.min
+
+private const val WOO_POS_MIN_TABLET_SHORT_SIZE_DP = 674
 
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "woo_pos_data_store")
+
+fun Context.isWooPosPhoneLayout(): Boolean {
+    val shortSize = min(getScreenWidthDp(), getScreenHeightDp())
+    return shortSize < WOO_POS_MIN_TABLET_SHORT_SIZE_DP
+}
 
 fun Context.getScreenWidthDp(): Int {
     val displayMetrics = resources.displayMetrics

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/ext/WooPosContextExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/ext/WooPosContextExt.kt
@@ -5,15 +5,14 @@ import androidx.compose.ui.unit.dp
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
+import com.woocommerce.android.ui.woopos.WooPosIsScreenSizeAllowed
 import kotlin.math.min
-
-private const val WOO_POS_MIN_TABLET_SHORT_SIZE_DP = 674
 
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "woo_pos_data_store")
 
 fun Context.isWooPosPhoneLayout(): Boolean {
     val shortSize = min(getScreenWidthDp(), getScreenHeightDp())
-    return shortSize < WOO_POS_MIN_TABLET_SHORT_SIZE_DP
+    return shortSize < WooPosIsScreenSizeAllowed.MIN_TABLET_SHORT_SIZE_DP
 }
 
 fun Context.getScreenWidthDp(): Int {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -19,6 +19,7 @@ enum class FeatureFlag(
     LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES("woo_notification_1d_before_free_trial_expires"),
     LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES("woo_notification_1d_after_free_trial_expires"),
     WOO_POS("woo_pos"),
+    WOO_POS_PHONE("woo_pos_phone", localValue = PackageUtils.isDebugBuild()),
     APP_PASSWORDS_FOR_JETPACK_SITES("woo_app_passwords_for_jetpack_sites"),
     WOO_POS_LOCAL_CATALOG_M1("woo_pos_local_catalog_m1"),
     WOO_POS_TABLET_PROMO_BANNER("woo_pos_tablet_promo_banner"),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPosIsScreenSizeAllowedTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPosIsScreenSizeAllowedTest.kt
@@ -1,0 +1,75 @@
+package com.woocommerce.android.ui.woopos
+
+import android.content.Context
+import android.content.res.Resources
+import android.util.DisplayMetrics
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class WooPosIsScreenSizeAllowedTest {
+
+    private val context: Context = mock()
+    private val resources: Resources = mock()
+    private val featureFlagRepository: FeatureFlagRepository = mock()
+    private val displayMetrics = DisplayMetrics().apply { density = 1f }
+
+    private lateinit var sut: WooPosIsScreenSizeAllowed
+
+    @Before
+    fun setup() {
+        whenever(context.resources).thenReturn(resources)
+        whenever(resources.displayMetrics).thenReturn(displayMetrics)
+
+        sut = WooPosIsScreenSizeAllowed(
+            context = context,
+            featureFlagRepository = featureFlagRepository,
+            wooPosLog = mock()
+        )
+    }
+
+    @Test
+    fun `given tablet screen size, when invoked, then return true`() {
+        // GIVEN
+        displayMetrics.widthPixels = 800
+        displayMetrics.heightPixels = 1280
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `given phone screen size and phone flag enabled, when invoked, then return true`() {
+        // GIVEN
+        displayMetrics.widthPixels = 411
+        displayMetrics.heightPixels = 891
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_PHONE)).thenReturn(true)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `given phone screen size and phone flag disabled, when invoked, then return false`() {
+        // GIVEN
+        displayMetrics.widthPixels = 411
+        displayMetrics.heightPixels = 891
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_PHONE)).thenReturn(false)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).isFalse()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPosIsScreenSizeAllowedTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/WooPosIsScreenSizeAllowedTest.kt
@@ -72,4 +72,47 @@ class WooPosIsScreenSizeAllowedTest {
         // THEN
         assertThat(result).isFalse()
     }
+
+    @Test
+    fun `given tablet boundary size 674x800 and flag disabled, when invoked, then return true`() {
+        // GIVEN
+        displayMetrics.widthPixels = 674
+        displayMetrics.heightPixels = 800
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_PHONE)).thenReturn(false)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `given below tablet boundary 673x800 and flag disabled, when invoked, then return false`() {
+        // GIVEN
+        displayMetrics.widthPixels = 673
+        displayMetrics.heightPixels = 800
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_PHONE)).thenReturn(false)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given high density tablet pixels but phone-sized in dp and flag disabled, when invoked, then return false`() {
+        // GIVEN
+        displayMetrics.density = 2f
+        displayMetrics.widthPixels = 800
+        displayMetrics.heightPixels = 1280
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_PHONE)).thenReturn(false)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).isFalse()
+    }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2655

Add a `WOO_POS_PHONE` feature flag that controls whether POS can run on phone-sized devices. When enabled (debug builds by default), phones pass the screen size gate and POS activities lock to portrait orientation. When disabled, phones are blocked from POS as before.

**Changes:**
- New `WOO_POS_PHONE` flag in `FeatureFlag.kt` (debug-enabled, remotely controlled)
- `isWooPosPhoneLayout()` Context extension to detect phone-sized screens (shortest side < 674dp)
- `WooPosIsScreenSizeAllowed` now checks the phone flag for phone-sized devices instead of rejecting them outright (single source of truth)
- All three POS activities (`WooPosActivity`, `WooPosCardReaderActivity`, `WooPosCouponCreationActivity`) lock to portrait on phones, landscape on tablets

### Test Steps
1. On a **phone emulator** (debug build): open the app and verify the POS tab is visible
2. Tap the POS tab and verify the activity opens in **portrait**
3. On a **tablet emulator**: verify POS still works as before in **landscape**
4. Disable the `WOO_POS_PHONE` flag via feature flag overrides: verify the POS tab is **hidden** on the phone

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.