### PR TITLE
[WOOMOB-2620] Add team member row

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleScreen.kt
@@ -46,14 +46,14 @@ fun BookingRescheduleScreen(
                 .padding(innerPadding),
             contentAlignment = Alignment.Center,
         ) {
-            when (state) {
-                is BookingRescheduleState.Loading, null -> {
+            when (state?.availabilityState) {
+                is BookingRescheduleState.AvailabilityState.Loading, null -> {
                     CircularProgressIndicator()
                 }
-                is BookingRescheduleState.Error -> {
+                is BookingRescheduleState.AvailabilityState.Error -> {
                     // Empty for now — error is shown via snackbar
                 }
-                is BookingRescheduleState.Content -> {
+                is BookingRescheduleState.AvailabilityState.Loaded -> {
                     // Availability data loaded — calendar UI will be added here
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleScreen.kt
@@ -1,17 +1,33 @@
 package com.woocommerce.android.ui.bookings.reschedule
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.bookings.compose.BookingLabel
+import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.component.Toolbar
 
 @Composable
@@ -19,14 +35,14 @@ fun BookingRescheduleScreen(
     viewModel: BookingRescheduleViewModel,
 ) {
     val state by viewModel.state.observeAsState()
-    BookingRescheduleScreen(
+    RescheduleContent(
         state = state,
         onBackPressed = viewModel::onBackPressed,
     )
 }
 
 @Composable
-fun BookingRescheduleScreen(
+fun RescheduleContent(
     state: BookingRescheduleState?,
     onBackPressed: () -> Unit,
     modifier: Modifier = Modifier,
@@ -37,26 +53,87 @@ fun BookingRescheduleScreen(
             Toolbar(
                 title = stringResource(R.string.booking_reschedule_screen_title),
                 onNavigationButtonClick = onBackPressed,
+                modifier = Modifier.shadow(4.dp),
             )
         }
     ) { innerPadding ->
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding),
-            contentAlignment = Alignment.Center,
         ) {
-            when (state?.availabilityState) {
-                is BookingRescheduleState.AvailabilityState.Loading, null -> {
-                    CircularProgressIndicator()
-                }
-                is BookingRescheduleState.AvailabilityState.Error -> {
-                    // Empty for now — error is shown via snackbar
-                }
-                is BookingRescheduleState.AvailabilityState.Loaded -> {
-                    // Availability data loaded — calendar UI will be added here
+            if (state != null && state.teamMemberId != 0L) {
+                TeamMemberSelectorRow(
+                    teamMemberName = state.teamMemberName,
+                )
+            }
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                when (state?.availabilityState) {
+                    is BookingRescheduleState.AvailabilityState.Loading, null -> {
+                        CircularProgressIndicator()
+                    }
+                    is BookingRescheduleState.AvailabilityState.Error -> {
+                        // Empty for now — error is shown via snackbar
+                    }
+                    is BookingRescheduleState.AvailabilityState.Loaded -> {
+                        // Availability data loaded — calendar UI will be added here
+                    }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun TeamMemberSelectorRow(
+    teamMemberName: String?,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surface,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column {
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp)
+            ) {
+                BookingLabel(R.string.booking_appointment_label_team_member)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (teamMemberName != null) {
+                        Text(
+                            text = teamMemberName,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    } else {
+                        SkeletonView(
+                            width = 80.dp,
+                            height = with(LocalDensity.current) {
+                                MaterialTheme.typography.bodyMedium.fontSize.toDp()
+                            },
+                        )
+                    }
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_arrow_right),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+            }
+            HorizontalDivider(
+                modifier = Modifier.padding(start = 16.dp),
+                thickness = 0.5.dp,
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
@@ -3,14 +3,28 @@ package com.woocommerce.android.ui.bookings.reschedule
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.bookings.Booking
+import com.woocommerce.android.ui.bookings.BookingResource
 import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import com.woocommerce.android.viewmodel.navArgs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingAvailabilityDto
@@ -21,6 +35,7 @@ import java.time.LocalTime
 import java.time.ZoneOffset
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class BookingRescheduleViewModel @Inject constructor(
     private val bookingsRepository: BookingsRepository,
@@ -30,51 +45,72 @@ class BookingRescheduleViewModel @Inject constructor(
 
     private val navArgs: BookingRescheduleFragmentArgs by savedState.navArgs()
 
-    private val _state = MutableStateFlow<BookingRescheduleState>(BookingRescheduleState.Loading)
+    private val _state = MutableStateFlow(BookingRescheduleState())
     val state: LiveData<BookingRescheduleState> = _state.asLiveData()
 
+    private val teamMemberIdOverride = MutableStateFlow<Long?>(null)
+
+    private val booking: Flow<Booking> = flow {
+        emit(bookingsRepository.getBooking(navArgs.bookingId))
+    }.onEach { booking ->
+        if (booking == null || booking.productId == 0L) {
+            triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.error_generic))
+            triggerEvent(MultiLiveEvent.Event.Exit)
+        }
+    }.filterNotNull()
+        .filter { it.productId != 0L }
+        .shareIn(viewModelScope, SharingStarted.Lazily, replay = 1)
+
+    private val effectiveResourceId: Flow<Long> = combine(
+        booking,
+        teamMemberIdOverride
+    ) { booking, override ->
+        override ?: booking.resourceId
+    }.distinctUntilChanged()
+
+    private val teamMember: Flow<BookingResource?> = effectiveResourceId
+        .flatMapLatest { bookingsRepository.observeResource(it) }
+
     init {
-        loadAvailability()
+        launch {
+            combine(booking, effectiveResourceId) { booking, resourceId ->
+                AvailabilityFetchParams(
+                    productId = booking.productId,
+                    resourceId = resourceId,
+                    dateRange = buildDateRange(booking),
+                )
+            }.collectLatest { params ->
+                _state.update {
+                    it.copy(teamMemberId = params.resourceId, productId = params.productId)
+                }
+                loadAvailability(params)
+            }
+        }
+        launch {
+            teamMember.collect { member ->
+                _state.update { it.copy(teamMemberName = member?.name) }
+            }
+        }
     }
 
     fun onBackPressed() {
         triggerEvent(MultiLiveEvent.Event.Exit)
     }
 
-    private fun loadAvailability() {
-        launch {
-            _state.update { BookingRescheduleState.Loading }
-
-            val booking = bookingsRepository.getBooking(navArgs.bookingId)
-            if (booking == null) {
-                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.error_generic))
-                triggerEvent(MultiLiveEvent.Event.Exit)
-                return@launch
+    private suspend fun loadAvailability(params: AvailabilityFetchParams) {
+        _state.update { it.copy(availabilityState = BookingRescheduleState.AvailabilityState.Loading) }
+        bookingsRepository.fetchProductAvailability(
+            productId = params.productId,
+            startDate = params.dateRange.first,
+            endDate = params.dateRange.second,
+            resourceId = params.resourceId,
+        ).onSuccess { availability ->
+            _state.update {
+                it.copy(availabilityState = BookingRescheduleState.AvailabilityState.Loaded(availability))
             }
-
-            val productId = booking.productId
-            if (productId == 0L) {
-                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.error_generic))
-                triggerEvent(MultiLiveEvent.Event.Exit)
-                return@launch
-            }
-
-            val resourceId = booking.resourceId
-            val (startDate, endDate) = buildDateRange(booking)
-
-            bookingsRepository.fetchProductAvailability(
-                productId = productId,
-                startDate = startDate,
-                endDate = endDate,
-                resourceId = resourceId,
-            ).onSuccess { availability ->
-                _state.update {
-                    BookingRescheduleState.Content(availability = availability)
-                }
-            }.onFailure {
-                _state.update { BookingRescheduleState.Error }
-                triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.error_generic))
-            }
+        }.onFailure {
+            _state.update { it.copy(availabilityState = BookingRescheduleState.AvailabilityState.Error) }
+            triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.error_generic))
         }
     }
 
@@ -93,12 +129,23 @@ class BookingRescheduleViewModel @Inject constructor(
             .atTime(LocalTime.MAX)
         return startDate to endDate
     }
+
+    private data class AvailabilityFetchParams(
+        val productId: Long,
+        val resourceId: Long,
+        val dateRange: Pair<LocalDateTime, LocalDateTime>,
+    )
 }
 
-sealed interface BookingRescheduleState {
-    data object Loading : BookingRescheduleState
-    data object Error : BookingRescheduleState
-    data class Content(
-        val availability: BookingAvailabilityDto,
-    ) : BookingRescheduleState
+data class BookingRescheduleState(
+    val teamMemberId: Long = 0L,
+    val teamMemberName: String? = null,
+    val productId: Long = 0L,
+    val availabilityState: AvailabilityState = AvailabilityState.Loading,
+) {
+    sealed interface AvailabilityState {
+        data object Loading : AvailabilityState
+        data object Error : AvailabilityState
+        data class Loaded(val availability: BookingAvailabilityDto) : AvailabilityState
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModelTest.kt
@@ -6,16 +6,21 @@ import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingAvailabilityDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingOrderInfo
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
+import org.wordpress.android.fluxc.persistence.entity.BookingResourceEntity
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -28,7 +33,22 @@ import kotlin.test.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class BookingRescheduleViewModelTest : BaseUnitTest() {
 
-    private val bookingsRepository: BookingsRepository = mock()
+    private val sampleResource = BookingResourceEntity(
+        id = LocalOrRemoteId.RemoteId(RESOURCE_ID),
+        localSiteId = LocalOrRemoteId.LocalId(1),
+        name = "Jane Doe",
+        qty = 1,
+        role = null,
+        email = null,
+        phoneNumber = null,
+        imageId = 0,
+        imageUrl = null,
+        description = null,
+    )
+
+    private val bookingsRepository: BookingsRepository = mock {
+        on { observeResource(eq(RESOURCE_ID)) } doReturn flowOf(sampleResource)
+    }
 
     private val sampleAvailability = BookingAvailabilityDto(
         productId = 1L,
@@ -117,49 +137,6 @@ class BookingRescheduleViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given successful fetch, when loading, then state is Content`() = testBlocking {
-        // GIVEN
-        val booking = getSampleBooking(Instant.now())
-        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
-        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
-            .thenReturn(Result.success(sampleAvailability))
-
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        assertThat(viewModel.state.value).isInstanceOf(BookingRescheduleState.Content::class.java)
-    }
-
-    @Test
-    fun `given failed fetch, when loading, then state is Error`() = testBlocking {
-        // GIVEN
-        val booking = getSampleBooking(Instant.now())
-        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
-        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
-            .thenReturn(Result.failure(Exception("Network error")))
-
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        assertThat(viewModel.state.value).isEqualTo(BookingRescheduleState.Error)
-    }
-
-    @Test
-    fun `given booking not found, when loading, then exits`() = testBlocking {
-        // GIVEN
-        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(null)
-
-        // WHEN
-        val viewModel = createViewModel()
-
-        // THEN
-        val event = viewModel.event.getOrAwaitValue()
-        assertThat(event).isEqualTo(MultiLiveEvent.Event.Exit)
-    }
-
-    @Test
     fun `given booking in past month, when loading, then range uses current month`() = testBlocking {
         // GIVEN
         val now = LocalDateTime.of(2026, 5, 10, 9, 0, 0)
@@ -184,15 +161,117 @@ class BookingRescheduleViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Test
+    fun `given successful fetch, when loading, then availability is Loaded`() = testBlocking {
+        // GIVEN
+        val booking = getSampleBooking(Instant.now())
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val state = viewModel.state.value!!
+        assertThat(state.availabilityState).isInstanceOf(BookingRescheduleState.AvailabilityState.Loaded::class.java)
+    }
+
+    @Test
+    fun `when team member loads after init, then availability is fetched only once`() = testBlocking {
+        // GIVEN
+        val resourceFlow = MutableStateFlow<BookingResourceEntity?>(null)
+        val repository = mock<BookingsRepository> {
+            on { observeResource(eq(RESOURCE_ID)) } doReturn resourceFlow
+        }
+        val booking = getSampleBooking(Instant.now())
+        whenever(repository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(repository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        // WHEN
+        createViewModel(repository = repository)
+        resourceFlow.value = sampleResource
+
+        // THEN
+        verify(repository, times(1)).fetchProductAvailability(
+            productId = any(),
+            startDate = any(),
+            endDate = any(),
+            resourceId = any(),
+        )
+    }
+
+    @Test
+    fun `given successful fetch, when loading, then state has correct team member`() = testBlocking {
+        // GIVEN
+        val booking = getSampleBooking(Instant.now())
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val state = viewModel.state.value!!
+        assertThat(state.teamMemberId).isEqualTo(RESOURCE_ID)
+        assertThat(state.teamMemberName).isEqualTo("Jane Doe")
+    }
+
+    @Test
+    fun `given failed fetch, when loading, then availability is Error`() = testBlocking {
+        // GIVEN
+        val booking = getSampleBooking(Instant.now())
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.failure(Exception("Network error")))
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val state = viewModel.state.value!!
+        assertThat(state.availabilityState).isEqualTo(BookingRescheduleState.AvailabilityState.Error)
+    }
+
+    @Test
+    fun `given booking not found, when loading, then shows error and exits`() = testBlocking {
+        // GIVEN
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(null)
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val event = viewModel.event.getOrAwaitValue()
+        assertThat(event).isInstanceOf(MultiLiveEvent.Event.Exit::class.java)
+    }
+
+    @Test
+    fun `given booking with zero productId, when loading, then shows error and exits`() = testBlocking {
+        // GIVEN
+        val booking = getSampleBooking(Instant.now(), productId = 0L)
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val event = viewModel.event.getOrAwaitValue()
+        assertThat(event).isInstanceOf(MultiLiveEvent.Event.Exit::class.java)
+    }
+
     private fun createViewModel(
         now: LocalDateTime = LocalDateTime.now(),
+        repository: BookingsRepository = bookingsRepository,
     ): BookingRescheduleViewModel {
         val fixedInstant = now.toInstant(ZoneOffset.UTC)
         val clock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
         return BookingRescheduleViewModel(
-            bookingsRepository = bookingsRepository,
-            clock = clock,
             savedState = SavedStateHandle(mapOf("bookingId" to BOOKING_ID)),
+            bookingsRepository = repository,
+            clock = clock,
         ).also {
             it.state.observeForever { }
         }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2620

Add a `TeamMemberSelectorRow` composable to the reschedule screen that shows the assigned team member name (with a skeleton placeholder while loading), and add toolbar shadow to match the booking details screen.

Additionally, this PR refactors `BookingRescheduleViewModel` from imperative `loadAvailability()` to a reactive pipeline (`booking → effectiveResourceId → teamMember`) using `combine` + `collectLatest`, so availability is automatically re-fetched when inputs change. 

### Test Steps
1. Open a booking with an assigned team member and tap "Reschedule"
2. Verify the team member row appears at the top with the correct name
3. Verify the availability loading spinner shows below the team member row


### Images/gif
<img width="1280" height="2856" alt="Screenshot_20260410_141636" src="https://github.com/user-attachments/assets/540e89be-eb96-46c1-8d78-5389f31e4d1b" />


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.