### PR TITLE
POS: Fix empty error_description in local_catalog_sync_failed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,9 +6,12 @@
 -----
 
 
-24.5
+24.5.1
 -----
 - [Internal] POS: Improved error descriptions in catalog sync failure analytics [https://github.com/woocommerce/woocommerce-android/pull/15643]
+
+24.5
+-----
 - [Internal] Hide settings plugins section for CIAB sites [https://github.com/woocommerce/woocommerce-android/pull/15594]
 - [*] Fixed shipping address showing billing address data when selecting a registered customer during order creation [https://github.com/woocommerce/woocommerce-android/pull/15575]
 - [Internal] Migrate AccountSettingsScreen, BarcodeScannerScreen, and PrivacySettingsPoliciesScreen from Material 2 to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/15596]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 
 24.5
 -----
+- [Internal] POS: Improved error descriptions in catalog sync failure analytics [https://github.com/woocommerce/woocommerce-android/pull/15643]
 - [Internal] Hide settings plugins section for CIAB sites [https://github.com/woocommerce/woocommerce-android/pull/15594]
 - [*] Fixed shipping address showing billing address data when selecting a registered customer during order creation [https://github.com/woocommerce/woocommerce-android/pull/15575]
 - [Internal] Migrate AccountSettingsScreen, BarcodeScannerScreen, and PrivacySettingsPoliciesScreen from Material 2 to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/15596]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncAction.kt
@@ -119,7 +119,8 @@ class WooPosFileBasedSyncAction @Inject constructor(
         )
         return WooPosFileBasedSyncResult.Failure(
             PosLocalCatalogSyncResult.Failure.NetworkError(
-                error = error?.message ?: "API error during catalog sync",
+                error = error?.message?.takeIf { it.isNotBlank() }
+                    ?: "API error during catalog sync (${error?.let { it::class.simpleName } ?: "unknown"})",
                 pollAttempts = totalPollAttempts,
                 lastGenerationState = lastGenerationState?.rawValue
             )
@@ -187,7 +188,8 @@ class WooPosFileBasedSyncAction @Inject constructor(
             .getOrElse {
                 return WooPosFileBasedSyncResult.Failure(
                     PosLocalCatalogSyncResult.Failure.NetworkError(
-                        error = it.message ?: "Failed to download catalog file"
+                        error = it.message?.takeIf { msg -> msg.isNotBlank() }
+                            ?: "Failed to download catalog file (${it::class.simpleName})"
                     )
                 )
             }
@@ -197,7 +199,8 @@ class WooPosFileBasedSyncAction @Inject constructor(
             .getOrElse {
                 return WooPosFileBasedSyncResult.Failure(
                     PosLocalCatalogSyncResult.Failure.InvalidResponse(
-                        error = it.message ?: "Failed to parse catalog file"
+                        error = it.message?.takeIf { msg -> msg.isNotBlank() }
+                            ?: "Failed to parse catalog file (${it::class.simpleName})"
                     )
                 )
             }
@@ -210,7 +213,8 @@ class WooPosFileBasedSyncAction @Inject constructor(
             .getOrElse {
                 return WooPosFileBasedSyncResult.Failure(
                     PosLocalCatalogSyncResult.Failure.DatabaseError(
-                        error = it.message ?: "Failed to store catalog data"
+                        error = it.message?.takeIf { msg -> msg.isNotBlank() }
+                            ?: "Failed to store catalog data (${it::class.simpleName})"
                     )
                 )
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosLocalCatalogSyncRepository.kt
@@ -137,7 +137,7 @@ class WooPosLocalCatalogSyncRepository @Inject constructor(
                 syncType = syncType,
                 errorContext = "WooPosLocalCatalogSyncRepository",
                 errorType = errorType,
-                errorDescription = result.error,
+                errorDescription = result.error.ifBlank { "Unknown error (${result::class.simpleName})" },
                 lastGenerationState = result.lastGenerationState,
                 pollAttempts = result.pollAttempts
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
@@ -179,16 +179,20 @@ class WooPosSyncAction @Inject constructor(
             )
 
             is WooPosLocalCatalogError.NetworkError -> WooPosSyncResult.Failed.NetworkError(
-                errorMessage = error.errorMessage
+                errorMessage = error.errorMessage.ifBlank {
+                    "Network error${error.code?.let { " (code: $it)" } ?: ""}"
+                }
             )
 
             is WooPosLocalCatalogError.DatabaseError -> WooPosSyncResult.Failed.DatabaseError(
-                errorMessage = error.errorMessage,
+                errorMessage = error.errorMessage.ifBlank {
+                    "Database error (${error.throwable?.let { it::class.simpleName } ?: "unknown"})"
+                },
                 throwable = error.throwable
             )
 
             is WooPosLocalCatalogError.InvalidResponse -> WooPosSyncResult.Failed.InvalidResponse(
-                errorMessage = error.errorMessage
+                errorMessage = error.errorMessage.ifBlank { "Invalid response" }
             )
 
             is WooPosLocalCatalogError.EmptyResponse -> WooPosSyncResult.Failed.InvalidResponse(
@@ -196,7 +200,8 @@ class WooPosSyncAction @Inject constructor(
             )
 
             else -> WooPosSyncResult.Failed.UnexpectedError(
-                error.message ?: "Failed to sync catalog"
+                error.message?.takeIf { it.isNotBlank() }
+                    ?: "Failed to sync catalog (${error::class.simpleName})"
             )
         }
     }
@@ -303,7 +308,9 @@ class WooPosSyncAction @Inject constructor(
             is WooPosLocalCatalogError.DatabaseError -> {
                 logger.e("Local Catalog Transaction failed and was rolled back: ${error.message}")
                 WooPosSyncResult.Failed.DatabaseError(
-                    errorMessage = error.errorMessage,
+                    errorMessage = error.errorMessage.ifBlank {
+                        "Transaction database error (${error.throwable?.let { it::class.simpleName } ?: "unknown"})"
+                    },
                     throwable = error.throwable
                 )
             }
@@ -311,7 +318,8 @@ class WooPosSyncAction @Inject constructor(
             else -> {
                 logger.e("Local Catalog Transaction failed and was rolled back: ${error.message}")
                 WooPosSyncResult.Failed.UnexpectedError(
-                    error.message ?: "Local Catalog Transaction failed and was rolled back"
+                    error.message?.takeIf { it.isNotBlank() }
+                        ?: "Transaction failed and was rolled back (${error::class.simpleName})"
                 )
             }
         }


### PR DESCRIPTION
WOOMOB-2639

### Description

The `local_catalog_sync_failed` analytics event frequently ships with an empty `error_description` property, making it impossible to distinguish root causes (timeout vs. connectivity loss vs. parse failure, etc.).

**Root cause:** The `?.message ?: "fallback"` elvis pattern only catches `null`, not empty strings. When HTTP/network exceptions produce an empty `.message`, the empty string passes straight through to the analytics event.

**Fix:** At every emission site, treat blank/empty strings the same as null and fall back to a descriptive string that includes the exception class name for debuggability:
- `WooPosFileBasedSyncAction` — 4 sites: consecutive failures, download/parse/store error paths
- `WooPosSyncAction` — 6 sites: `handleSyncError` and `handleTransactionError` error mapping
- `WooPosLocalCatalogSyncRepository` — safety guard in `trackSyncFailed` so analytics never receives a blank string

No behavior change to the sync flow itself — purely an analytics quality fix.

### Test Steps

1. Smoke test

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.