### PR TITLE
[WOOMOB-2672] Fix resource and product param encoding to use bracket notation

### DIFF
--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClient.kt
@@ -19,7 +19,6 @@ class BookingsRestClient @Inject constructor(
 ) {
     companion object {
         const val DEFAULT_PER_PAGE = 25 // Number of items to fetch in a single request
-        private const val FILTER_QUERY_PARAMETER_SEPERATOR = ","
     }
 
     suspend fun fetchBooking(
@@ -139,14 +138,15 @@ class BookingsRestClient @Inject constructor(
 
     private fun BookingFilters.toQueryParams(): Map<String, String> = buildMap {
         if (teamMembers != BookingsFilterOption.TeamMembers.DEFAULT) {
-            set(
-                "resource",
-                teamMembers.values.joinToString(FILTER_QUERY_PARAMETER_SEPERATOR) { it.value.toString() }
-            )
+            teamMembers.values.forEachIndexed { index, resource ->
+                set("resource[$index]", resource.value.toString())
+            }
         }
         if (bookingType != null) TODO()
         if (serviceEvents != BookingsFilterOption.ServiceEvents.DEFAULT) {
-            set("product", serviceEvents.values.joinToString(",") { it.productId.toString() })
+            serviceEvents.values.forEachIndexed { index, event ->
+                set("product[$index]", event.productId.toString())
+            }
         }
         attendanceStatus.value?.let { set("attendance_status", it.key) }
         if (excludedBookingStatuses != BookingsFilterOption.ExcludedBookingStatuses.DEFAULT) {

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/bookings/BookingsRestClientTest.kt
@@ -1,0 +1,110 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+
+class BookingsRestClientTest {
+
+    private val wooNetwork: WooNetwork = mock()
+    private lateinit var sut: BookingsRestClient
+
+    @Before
+    fun setUp() {
+        sut = BookingsRestClient(wooNetwork)
+    }
+
+    @Test
+    fun `when teamMembers filter has values, then resource params use bracket notation`(): Unit = runBlocking {
+        // GIVEN
+        val site = SiteModel()
+        val filters = BookingFilters(
+            teamMembers = BookingsFilterOption.TeamMembers(setOf(RemoteId(239L), RemoteId(13L)))
+        )
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        whenever(
+            wooNetwork.executeGetGsonRequest(
+                site = any(),
+                path = any(),
+                clazz = any<Class<Array<BookingDto>>>(),
+                params = paramsCaptor.capture(),
+                enableCaching = any(),
+                cacheTimeToLive = any(),
+                forced = any(),
+                requestTimeout = any(),
+                retries = any()
+            )
+        ).thenReturn(WPAPIResponse.Success(emptyArray(), emptyList()))
+
+        // WHEN
+        sut.fetchBookings(
+            site = site,
+            perPage = 25,
+            page = 1,
+            query = null,
+            filters = filters,
+            order = BookingsOrderOption.DESC
+        )
+
+        // THEN
+        val params = paramsCaptor.firstValue
+        assertThat(params).doesNotContainKey("resource")
+        assertThat(params.keys.filter { it.startsWith("resource[") }).hasSize(2)
+        assertThat(params).containsEntry("resource[0]", "239")
+        assertThat(params).containsEntry("resource[1]", "13")
+    }
+
+    @Test
+    fun `when serviceEvents filter has values, then product params use bracket notation`(): Unit = runBlocking {
+        // GIVEN
+        val site = SiteModel()
+        val filters = BookingFilters(
+            serviceEvents = BookingsFilterOption.ServiceEvents(
+                setOf(
+                    BookingsFilterOption.ProductInfo(47L, "Product A"),
+                    BookingsFilterOption.ProductInfo(49L, "Product B")
+                )
+            )
+        )
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        whenever(
+            wooNetwork.executeGetGsonRequest(
+                site = any(),
+                path = any(),
+                clazz = any<Class<Array<BookingDto>>>(),
+                params = paramsCaptor.capture(),
+                enableCaching = any(),
+                cacheTimeToLive = any(),
+                forced = any(),
+                requestTimeout = any(),
+                retries = any()
+            )
+        ).thenReturn(WPAPIResponse.Success(emptyArray(), emptyList()))
+
+        // WHEN
+        sut.fetchBookings(
+            site = site,
+            perPage = 25,
+            page = 1,
+            query = null,
+            filters = filters,
+            order = BookingsOrderOption.DESC
+        )
+
+        // THEN
+        val params = paramsCaptor.firstValue
+        assertThat(params).doesNotContainKey("product")
+        assertThat(params.keys.filter { it.startsWith("product[") }).hasSize(2)
+        assertThat(params).containsEntry("product[0]", "47")
+        assertThat(params).containsEntry("product[1]", "49")
+    }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-2672

The Android app sends booking `resource` and `product` filter params as comma-separated strings (e.g., `resource=239,13`), but the WooCommerce Bookings PHP REST API expects PHP bracket notation (`resource[0]=239&resource[1]=13`). This applies the same bracket notation pattern already used for `booking_status_exclude` in the same function.

### Test Steps
1. Open bookings list with team member filters applied (multiple resources selected)
2. Observe the network request — `resource` params should use bracket notation: `resource[0]=X&resource[1]=Y`
3. Repeat with service event filters — `product` params should use bracket notation: `product[0]=X&product[1]=Y`
4. Verify bookings are correctly filtered server-side

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.