### PR TITLE
[WOOMOB-2586] Fallback to original product image URL when Photon fails

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [Internal] Fixed logout push cleanup sequencing and added a logout loading state in App Settings [https://github.com/woocommerce/woocommerce-android/pull/15667]
 - [Internal] Show the notification permission card for all supported stores on Android 13+ [https://github.com/woocommerce/woocommerce-android/pull/15676/]
 - [*] Stop POS background catalog sync once the initial sync completes for users who never open POS [https://github.com/woocommerce/woocommerce-android/pull/15651]
+- [*] Fixed product images failing to load when the Photon service is unavailable [https://github.com/woocommerce/woocommerce-android/pull/15646]
 
 24.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/GlideExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/GlideExt.kt
@@ -1,0 +1,56 @@
+package com.woocommerce.android.extensions
+
+import android.graphics.drawable.Drawable
+import com.bumptech.glide.RequestBuilder
+import com.bumptech.glide.RequestManager
+import org.wordpress.android.util.PhotonUtils
+
+fun RequestManager.loadPhotonUrlWithFallback(
+    originalUrl: String?,
+    width: Int,
+    height: Int,
+    quality: PhotonUtils.Quality = PhotonUtils.Quality.HIGH
+): RequestBuilder<Drawable> {
+    if (originalUrl.isNullOrEmpty()) {
+        return this.load(originalUrl)
+    }
+    val photonUrl = PhotonUtils.getPhotonImageUrl(originalUrl, width, height, quality)
+    return this.load(photonUrl).error(this.load(originalUrl))
+}
+
+fun RequestManager.loadPhotonUrlWithFallback(
+    originalUrl: String?,
+    width: Int,
+    height: Int
+): RequestBuilder<Drawable> {
+    if (originalUrl.isNullOrEmpty()) {
+        return this.load(originalUrl)
+    }
+    val photonUrl = PhotonUtils.getPhotonImageUrl(originalUrl, width, height)
+    return this.load(photonUrl).error(this.load(originalUrl))
+}
+
+fun <T> RequestBuilder<T>.loadPhotonUrlWithFallback(
+    originalUrl: String?,
+    width: Int,
+    height: Int,
+    quality: PhotonUtils.Quality = PhotonUtils.Quality.HIGH
+): RequestBuilder<T> {
+    if (originalUrl.isNullOrEmpty()) {
+        return this.load(originalUrl)
+    }
+    val photonUrl = PhotonUtils.getPhotonImageUrl(originalUrl, width, height, quality)
+    return this.load(photonUrl).error(this.clone().load(originalUrl))
+}
+
+fun <T> RequestBuilder<T>.loadPhotonUrlWithFallback(
+    originalUrl: String?,
+    width: Int,
+    height: Int
+): RequestBuilder<T> {
+    if (originalUrl.isNullOrEmpty()) {
+        return this.load(originalUrl)
+    }
+    val photonUrl = PhotonUtils.getPhotonImageUrl(originalUrl, width, height)
+    return this.load(photonUrl).error(this.clone().load(originalUrl))
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/PhotonImageExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/PhotonImageExt.kt
@@ -33,7 +33,7 @@ fun rememberPhotonImageRequest(
 
     var currentUrl by remember(originalUrl, photonUrl) { mutableStateOf(photonUrl) }
 
-    return remember(currentUrl, context, configure) {
+    return remember(currentUrl, context) {
         ImageRequest.Builder(context)
             .data(currentUrl)
             .apply(configure)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/PhotonImageExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/PhotonImageExt.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.util.PhotonUtils
 /**
  * Coil/Compose extension for loading a Photon image with a fallback to the original URL.
  * Generates an ImageRequest that tries the Photon URL first, and if it fails, falls back to the original URL.
+ * If the URL is already a Photon URL, no fallback is applied since the "original" would be the same URL.
  */
 @Composable
 fun rememberPhotonImageRequest(
@@ -24,11 +25,7 @@ fun rememberPhotonImageRequest(
 ): ImageRequest {
     val context = LocalContext.current
     val photonUrl = remember(originalUrl, imageSizePx) {
-        if (originalUrl.isNotEmpty()) {
-            PhotonUtils.getPhotonImageUrl(originalUrl, imageSizePx, imageSizePx)
-        } else {
-            originalUrl
-        }
+        PhotonUtils.getPhotonImageUrl(originalUrl, imageSizePx, imageSizePx)
     }
 
     var currentUrl by remember(originalUrl, photonUrl) { mutableStateOf(photonUrl) }
@@ -39,7 +36,7 @@ fun rememberPhotonImageRequest(
             .apply(configure)
             .listener(
                 onError = { _, _ ->
-                    if (currentUrl != originalUrl && originalUrl.isNotEmpty()) {
+                    if (!originalUrl.isPhotonUrl() && currentUrl != originalUrl) {
                         currentUrl = originalUrl
                     }
                 }
@@ -58,6 +55,9 @@ fun RequestManager.loadPhotonUrlWithFallback(
         return this.load(originalUrl)
     }
     val photonUrl = PhotonUtils.getPhotonImageUrl(originalUrl, width, height, quality)
+    if (originalUrl.isPhotonUrl()) {
+        return this.load(photonUrl)
+    }
     return this.load(photonUrl).error(this.load(originalUrl))
 }
 
@@ -71,5 +71,12 @@ fun <T> RequestBuilder<T>.loadPhotonUrlWithFallback(
         return this.load(originalUrl)
     }
     val photonUrl = PhotonUtils.getPhotonImageUrl(originalUrl, width, height, quality)
+    if (originalUrl.isPhotonUrl()) {
+        return this.load(photonUrl)
+    }
     return this.load(photonUrl).error(this.clone().load(originalUrl))
+}
+
+private fun String.isPhotonUrl(): Boolean {
+    return contains("i0.wp.com") || contains("i1.wp.com") || contains("i2.wp.com")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/PhotonImageExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/PhotonImageExt.kt
@@ -1,9 +1,52 @@
 package com.woocommerce.android.extensions
 
 import android.graphics.drawable.Drawable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import coil.request.ImageRequest
 import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.RequestManager
 import org.wordpress.android.util.PhotonUtils
+
+/**
+ * Coil/Compose extension for loading a Photon image with a fallback to the original URL.
+ * Generates an ImageRequest that tries the Photon URL first, and if it fails, falls back to the original URL.
+ */
+@Composable
+fun rememberPhotonImageRequest(
+    originalUrl: String,
+    imageSizePx: Int,
+    configure: ImageRequest.Builder.() -> Unit = {}
+): ImageRequest {
+    val context = LocalContext.current
+    val photonUrl = remember(originalUrl, imageSizePx) {
+        if (originalUrl.isNotEmpty()) {
+            PhotonUtils.getPhotonImageUrl(originalUrl, imageSizePx, imageSizePx)
+        } else {
+            originalUrl
+        }
+    }
+
+    var currentUrl by remember(originalUrl, photonUrl) { mutableStateOf(photonUrl) }
+
+    return remember(currentUrl) {
+        ImageRequest.Builder(context)
+            .data(currentUrl)
+            .apply(configure)
+            .listener(
+                onError = { _, _ ->
+                    if (currentUrl != originalUrl && originalUrl.isNotEmpty()) {
+                        currentUrl = originalUrl
+                    }
+                }
+            )
+            .build()
+    }
+}
 
 fun RequestManager.loadPhotonUrlWithFallback(
     originalUrl: String?,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/PhotonImageExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/PhotonImageExt.kt
@@ -33,7 +33,7 @@ fun rememberPhotonImageRequest(
 
     var currentUrl by remember(originalUrl, photonUrl) { mutableStateOf(photonUrl) }
 
-    return remember(currentUrl) {
+    return remember(currentUrl, context, configure) {
         ImageRequest.Builder(context)
             .data(currentUrl)
             .apply(configure)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/PhotonImageExt.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/extensions/PhotonImageExt.kt
@@ -52,24 +52,12 @@ fun RequestManager.loadPhotonUrlWithFallback(
     originalUrl: String?,
     width: Int,
     height: Int,
-    quality: PhotonUtils.Quality = PhotonUtils.Quality.HIGH
+    quality: PhotonUtils.Quality = PhotonUtils.Quality.MEDIUM
 ): RequestBuilder<Drawable> {
     if (originalUrl.isNullOrEmpty()) {
         return this.load(originalUrl)
     }
     val photonUrl = PhotonUtils.getPhotonImageUrl(originalUrl, width, height, quality)
-    return this.load(photonUrl).error(this.load(originalUrl))
-}
-
-fun RequestManager.loadPhotonUrlWithFallback(
-    originalUrl: String?,
-    width: Int,
-    height: Int
-): RequestBuilder<Drawable> {
-    if (originalUrl.isNullOrEmpty()) {
-        return this.load(originalUrl)
-    }
-    val photonUrl = PhotonUtils.getPhotonImageUrl(originalUrl, width, height)
     return this.load(photonUrl).error(this.load(originalUrl))
 }
 
@@ -77,23 +65,11 @@ fun <T> RequestBuilder<T>.loadPhotonUrlWithFallback(
     originalUrl: String?,
     width: Int,
     height: Int,
-    quality: PhotonUtils.Quality = PhotonUtils.Quality.HIGH
+    quality: PhotonUtils.Quality = PhotonUtils.Quality.MEDIUM
 ): RequestBuilder<T> {
     if (originalUrl.isNullOrEmpty()) {
         return this.load(originalUrl)
     }
     val photonUrl = PhotonUtils.getPhotonImageUrl(originalUrl, width, height, quality)
-    return this.load(photonUrl).error(this.clone().load(originalUrl))
-}
-
-fun <T> RequestBuilder<T>.loadPhotonUrlWithFallback(
-    originalUrl: String?,
-    width: Int,
-    height: Int
-): RequestBuilder<T> {
-    if (originalUrl.isNullOrEmpty()) {
-        return this.load(originalUrl)
-    }
-    val photonUrl = PhotonUtils.getPhotonImageUrl(originalUrl, width, height)
     return this.load(photonUrl).error(this.clone().load(originalUrl))
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
@@ -16,12 +16,12 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import com.bumptech.glide.Glide
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.ui.main.MainActivity
 import com.woocommerce.android.util.SystemVersionUtils
 import com.woocommerce.android.util.WooLog
 import org.wordpress.android.util.ImageUtils
-import org.wordpress.android.util.PhotonUtils
 import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
 import java.util.concurrent.ExecutionException
@@ -245,10 +245,9 @@ class WooNotificationBuilder @Inject constructor(
                 val largeIconSize = context.resources.getDimensionPixelSize(
                     android.R.dimen.notification_large_icon_height
                 )
-                val resizedUrl = PhotonUtils.getPhotonImageUrl(decodedIconUrl, largeIconSize, largeIconSize)
                 val largeIconBitmap = Glide.with(context)
                     .asBitmap()
-                    .load(resizedUrl)
+                    .loadPhotonUrlWithFallback(decodedIconUrl, largeIconSize, largeIconSize)
                     .submit()
                     .get()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/listcard/AnalyticsHubListCardItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/analytics/hub/listcard/AnalyticsHubListCardItemView.kt
@@ -10,8 +10,8 @@ import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.google.android.material.card.MaterialCardView
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.AnalyticsListCardItemViewBinding
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.util.StringUtils
-import org.wordpress.android.util.PhotonUtils
 
 class AnalyticsHubListCardItemView @JvmOverloads constructor(
     ctx: Context,
@@ -38,7 +38,7 @@ class AnalyticsHubListCardItemView @JvmOverloads constructor(
 
         if (viewState.showImage) {
             Glide.with(binding.root.context)
-                .load(PhotonUtils.getPhotonImageUrl(viewState.imageUri, imageSize, imageSize))
+                .loadPhotonUrlWithFallback(viewState.imageUri, imageSize, imageSize)
                 .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
                 .placeholder(R.drawable.ic_product)
                 .into(binding.analyticsCardListItemImage)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ProductThumbnail.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ProductThumbnail.kt
@@ -4,21 +4,15 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import coil.request.ImageRequest.Builder
 import com.woocommerce.android.R
-import org.wordpress.android.util.PhotonUtils
+import com.woocommerce.android.extensions.rememberPhotonImageRequest
 
 @Composable
 fun ProductThumbnail(
@@ -31,31 +25,18 @@ fun ProductThumbnail(
     contentDescription: String = ""
 ) {
     val imageSizePx = with(LocalDensity.current) { imageSize.roundToPx() }
-    val photonUrl = remember(imageUrl, imageSizePx) {
-        if (imageUrl.isNotEmpty()) {
-            PhotonUtils.getPhotonImageUrl(imageUrl, imageSizePx, imageSizePx)
-        } else {
-            imageUrl
-        }
+    val imageRequest = rememberPhotonImageRequest(
+        originalUrl = imageUrl,
+        imageSizePx = imageSizePx
+    ) {
+        crossfade(true)
+        placeholder(placeHolderDrawableId)
+        fallback(fallbackDrawableId)
+        error(errorDrawableId)
     }
 
-    var currentUrl by remember(imageUrl, photonUrl) { mutableStateOf(photonUrl) }
-
     AsyncImage(
-        model = Builder(LocalContext.current)
-            .data(currentUrl)
-            .crossfade(true)
-            .placeholder(placeHolderDrawableId)
-            .fallback(fallbackDrawableId)
-            .error(errorDrawableId)
-            .listener(
-                onError = { _, _ ->
-                    if (currentUrl != imageUrl && imageUrl.isNotEmpty()) {
-                        currentUrl = imageUrl
-                    }
-                }
-            )
-            .build(),
+        model = imageRequest,
         contentDescription = contentDescription,
         contentScale = ContentScale.Crop,
         modifier = modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ProductThumbnail.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/compose/component/ProductThumbnail.kt
@@ -4,36 +4,62 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest.Builder
 import com.woocommerce.android.R
+import org.wordpress.android.util.PhotonUtils
 
 @Composable
 fun ProductThumbnail(
     imageUrl: String,
     modifier: Modifier = Modifier,
+    imageSize: Dp = 42.dp,
     @DrawableRes placeHolderDrawableId: Int = R.drawable.ic_product,
     @DrawableRes fallbackDrawableId: Int = R.drawable.ic_product,
     @DrawableRes errorDrawableId: Int = R.drawable.ic_product,
     contentDescription: String = ""
 ) {
+    val imageSizePx = with(LocalDensity.current) { imageSize.roundToPx() }
+    val photonUrl = remember(imageUrl, imageSizePx) {
+        if (imageUrl.isNotEmpty()) {
+            PhotonUtils.getPhotonImageUrl(imageUrl, imageSizePx, imageSizePx)
+        } else {
+            imageUrl
+        }
+    }
+
+    var currentUrl by remember(imageUrl, photonUrl) { mutableStateOf(photonUrl) }
+
     AsyncImage(
         model = Builder(LocalContext.current)
-            .data(imageUrl)
+            .data(currentUrl)
             .crossfade(true)
             .placeholder(placeHolderDrawableId)
             .fallback(fallbackDrawableId)
             .error(errorDrawableId)
+            .listener(
+                onError = { _, _ ->
+                    if (currentUrl != imageUrl && imageUrl.isNotEmpty()) {
+                        currentUrl = imageUrl
+                    }
+                }
+            )
             .build(),
         contentDescription = contentDescription,
         contentScale = ContentScale.Crop,
         modifier = modifier
-            .size(42.dp)
+            .size(imageSize)
             .clip(shape = RoundedCornerShape(4.dp))
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/topperformers/DashboardTopPerformersViewModel.kt
@@ -56,7 +56,6 @@ import org.apache.commons.text.StringEscapeUtils
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import org.wordpress.android.util.FormatUtils
-import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
 import java.util.Date
 import java.util.Locale
@@ -260,7 +259,7 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
                 R.string.dashboard_top_performers_net_sales,
                 getTotalSpendFormatted(total.toBigDecimal(), currency)
             ),
-            imageUrl = imageUrl?.toImageUrl(),
+            imageUrl = imageUrl,
             onClick = ::onTopPerformerTapped
         )
 
@@ -268,13 +267,6 @@ class DashboardTopPerformersViewModel @AssistedInject constructor(
         currencyFormatter.formatCurrency(
             totalSpend,
             wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode ?: currency
-        )
-
-    private fun String.toImageUrl() =
-        PhotonUtils.getPhotonImageUrl(
-            this,
-            resourceProvider.getDimensionPixelSize(R.dimen.image_minor_100),
-            0
         )
 
     fun onCustomRangeSelected(statsTimeRange: StatsTimeRange) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/OrderDetailProductItemView.kt
@@ -12,9 +12,9 @@ import com.woocommerce.android.AppPrefs
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.OrderDetailProductItemBinding
 import com.woocommerce.android.extensions.formatToString
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.util.StringUtils
-import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
 
 typealias ViewAddonClickListener = (Order.Item) -> Unit
@@ -66,9 +66,8 @@ class OrderDetailProductItemView @JvmOverloads constructor(
         productImage?.let {
             val imageSize = context.resources.getDimensionPixelSize(R.dimen.image_minor_100)
             val imageCornerRadius = context.resources.getDimensionPixelSize(R.dimen.corner_radius_image)
-            val imageUrl = PhotonUtils.getPhotonImageUrl(it, imageSize, imageSize)
             Glide.with(context)
-                .load(imageUrl)
+                .loadPhotonUrlWithFallback(it, imageSize, imageSize)
                 .placeholder(R.drawable.ic_product)
                 .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
                 .into(binding.productInfoIcon)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableGroupedProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableGroupedProductCard.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
@@ -269,8 +268,8 @@ fun ExpandableChildrenProductCard(
                     start.linkTo(parent.start)
                     bottom.linkTo(collapsedStateBottomBarrier)
                 }
-                .padding(start = dimensionResource(id = R.dimen.major_200))
-                .size(dimensionResource(R.dimen.major_250)),
+                .padding(start = dimensionResource(id = R.dimen.major_200)),
+            imageSize = dimensionResource(R.dimen.major_250),
             imageUrl = product.productInfo.imageUrl
         )
         Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/views/ExpandableProductCard.kt
@@ -128,8 +128,8 @@ fun ExpandableProductCard(
                     start.linkTo(parent.start)
                     bottom.linkTo(collapsedStateBottomBarrier)
                 }
-                .padding(dimensionResource(id = R.dimen.major_100))
-                .size(dimensionResource(R.dimen.major_300)),
+                .padding(dimensionResource(id = R.dimen.major_100)),
+            imageSize = dimensionResource(R.dimen.major_300),
             imageUrl = product.productInfo.imageUrl
         )
         Text(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductChildItemListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductChildItemListAdapter.kt
@@ -11,11 +11,11 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.OrderDetailProductChildItemBinding
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.getColorCompat
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.orders.OrderProductActionListener
 import com.woocommerce.android.ui.orders.details.OrderProduct
 import com.woocommerce.android.util.StringUtils
-import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
 
 class OrderDetailProductChildItemListAdapter(
@@ -64,7 +64,7 @@ class OrderDetailProductChildItemListAdapter(
         ) {
             val item = productItem.product
             val imageSize = itemView.resources.getDimensionPixelSize(R.dimen.image_minor_100)
-            val productImage = PhotonUtils.getPhotonImageUrl(productImageMap.get(item.uniqueId), imageSize, imageSize)
+            val productImage = productImageMap.get(item.uniqueId)
 
             binding.productInfoName.text = item.name
             val orderTotal = formatCurrencyForDisplay(item.total)
@@ -87,9 +87,8 @@ class OrderDetailProductChildItemListAdapter(
 
             productImage?.let {
                 val imageCornerRadius = itemView.resources.getDimensionPixelSize(R.dimen.corner_radius_image)
-                val imageUrl = PhotonUtils.getPhotonImageUrl(it, imageSize, imageSize)
                 Glide.with(binding.productInfoIcon)
-                    .load(imageUrl)
+                    .loadPhotonUrlWithFallback(it, imageSize, imageSize)
                     .placeholder(R.drawable.ic_product)
                     .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
                     .into(binding.productInfoIcon)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductItemListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductItemListAdapter.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.ui.orders.OrderDetailProductItemView
 import com.woocommerce.android.ui.orders.OrderProductActionListener
 import com.woocommerce.android.ui.orders.ViewAddonClickListener
 import com.woocommerce.android.ui.orders.details.OrderProduct
-import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
 
 class OrderDetailProductItemListAdapter(
@@ -32,8 +31,7 @@ class OrderDetailProductItemListAdapter(
             onViewAddonsClick: ViewAddonClickListener? = null
         ) {
             val item = productItem.product
-            val imageSize = view.resources.getDimensionPixelSize(R.dimen.image_major_50)
-            val productImage = PhotonUtils.getPhotonImageUrl(productImageMap.get(item.uniqueId), imageSize, imageSize)
+            val productImage = productImageMap.get(item.uniqueId)
             view.initView(item, productImage, formatCurrencyForDisplay, onViewAddonsClick)
             itemView.setOnClickListener {
                 if (item.isVariation) {
@@ -56,8 +54,7 @@ class OrderDetailProductItemListAdapter(
             onViewAddonsClick: ViewAddonClickListener? = null
         ) {
             val item = groupedItem.product
-            val imageSize = itemView.resources.getDimensionPixelSize(R.dimen.image_major_50)
-            val productImage = PhotonUtils.getPhotonImageUrl(productImageMap.get(item.uniqueId), imageSize, imageSize)
+            val productImage = productImageMap.get(item.uniqueId)
 
             binding.productInfoGroupedProduct.initView(item, productImage, formatCurrencyForDisplay, onViewAddonsClick)
             binding.productInfoGroupedProduct.setOnClickListener {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/details/adapter/OrderDetailProductListAdapter.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.orders.OrderDetailProductItemView
 import com.woocommerce.android.ui.orders.OrderProductActionListener
 import com.woocommerce.android.ui.orders.ViewAddonClickListener
-import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
 
 class OrderDetailProductListAdapter(
@@ -30,8 +29,7 @@ class OrderDetailProductListAdapter(
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val item = orderItems[position]
-        val imageSize = holder.itemView.resources.getDimensionPixelSize(R.dimen.image_minor_100)
-        val productImage = PhotonUtils.getPhotonImageUrl(productImageMap.get(item.uniqueId), imageSize, imageSize)
+        val productImage = productImageMap.get(item.uniqueId)
         (holder as ProductViewHolder).view.initView(
             orderItems[position],
             productImage,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundProductListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundProductListAdapter.kt
@@ -19,11 +19,11 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.formatToString
 import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.isEqualTo
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.ProductImageMap
 import com.woocommerce.android.ui.payments.refunds.RefundProductListAdapter.RefundViewHolder
-import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
 
 typealias ViewAddonClickListener = (Order.Item) -> Unit
@@ -115,9 +115,8 @@ class RefundProductListAdapter(
             imageMap.get(item.orderItem.productId)?.let {
                 val imageCornerRadius = itemView.context.resources.getDimensionPixelSize(R.dimen.corner_radius_image)
                 val imageSize = itemView.context.resources.getDimensionPixelSize(R.dimen.image_minor_100)
-                val imageUrl = PhotonUtils.getPhotonImageUrl(it, imageSize, imageSize)
                 Glide.with(itemView.context)
-                    .load(imageUrl)
+                    .loadPhotonUrlWithFallback(it, imageSize, imageSize)
                     .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
                     .placeholder(R.drawable.ic_product)
                     .into(productImageView)
@@ -156,9 +155,8 @@ class RefundProductListAdapter(
             imageMap.get(item.orderItem.productId)?.let {
                 val imageCornerRadius = itemView.context.resources.getDimensionPixelSize(R.dimen.corner_radius_image)
                 val imageSize = itemView.context.resources.getDimensionPixelSize(R.dimen.image_minor_100)
-                val imageUrl = PhotonUtils.getPhotonImageUrl(it, imageSize, imageSize)
                 Glide.with(itemView.context)
-                    .load(imageUrl)
+                    .loadPhotonUrlWithFallback(it, imageSize, imageSize)
                     .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
                     .placeholder(R.drawable.ic_product)
                     .into(productImageView)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/ProductItemView.kt
@@ -13,11 +13,11 @@ import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ProductItemViewBinding
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.util.getStockText
 import org.wordpress.android.util.HtmlUtils
-import org.wordpress.android.util.PhotonUtils
 import java.math.BigDecimal
 
 /**
@@ -85,9 +85,8 @@ class ProductItemView @JvmOverloads constructor(
             }
             else -> {
                 size = imageSize
-                val photonUrl = PhotonUtils.getPhotonImageUrl(imageUrl, imageSize, imageSize)
                 Glide.with(context)
-                    .load(photonUrl)
+                    .loadPhotonUrlWithFallback(imageUrl, imageSize, imageSize)
                     .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
                     .placeholder(R.drawable.ic_product)
                     .into(binding.productImage)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/BundleProductViewHolder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/adapters/BundleProductViewHolder.kt
@@ -8,9 +8,9 @@ import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.BundledProductItemViewBinding
 import com.woocommerce.android.extensions.isNotNullOrEmpty
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.model.BundledProduct
 import com.woocommerce.android.ui.products.ProductStockStatus
-import org.wordpress.android.util.PhotonUtils
 
 class BundleProductViewHolder(val viewBinding: BundledProductItemViewBinding) :
     RecyclerView.ViewHolder(viewBinding.root) {
@@ -32,9 +32,8 @@ class BundleProductViewHolder(val viewBinding: BundledProductItemViewBinding) :
             }
             else -> {
                 size = imageSize
-                val photonUrl = PhotonUtils.getPhotonImageUrl(imageUrl, imageSize, imageSize)
                 Glide.with(viewBinding.productImage)
-                    .load(photonUrl)
+                    .loadPhotonUrlWithFallback(imageUrl, imageSize, imageSize)
                     .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
                     .placeholder(R.drawable.ic_product)
                     .into(viewBinding.productImage)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentDetailsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentDetailsFragment.kt
@@ -12,6 +12,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.FragmentComponentDetailsBinding
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.QueryType
 import com.woocommerce.android.ui.base.BaseFragment
@@ -21,7 +22,6 @@ import com.woocommerce.android.util.setupTabletSecondPaneToolbar
 import com.woocommerce.android.widgets.AlignedDividerDecoration
 import com.woocommerce.android.widgets.SkeletonView
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.util.PhotonUtils
 
 @AndroidEntryPoint
 class ComponentDetailsFragment : BaseFragment(R.layout.fragment_component_details) {
@@ -125,8 +125,7 @@ class ComponentDetailsFragment : BaseFragment(R.layout.fragment_component_detail
             }
             else -> {
                 val imageSize = resources.getDimensionPixelSize(R.dimen.image_major_120)
-                val photonUrl = PhotonUtils.getPhotonImageUrl(imageUrl, imageSize, imageSize)
-                Glide.with(requireContext()).load(photonUrl)
+                Glide.with(requireContext()).loadPhotonUrlWithFallback(imageUrl, imageSize, imageSize)
                     .transform(CenterCrop()).placeholder(R.drawable.ic_product)
                     .into(binding.componentImage)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentOptionsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentOptionsListAdapter.kt
@@ -11,8 +11,8 @@ import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ComponentOptionItemViewBinding
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.ui.products.ComponentOption
-import org.wordpress.android.util.PhotonUtils
 
 class ComponentOptionsListAdapter :
     ListAdapter<ComponentOption, ComponentOptionViewHolder>(ComponentOptionItemDiffCallback) {
@@ -60,8 +60,7 @@ class ComponentOptionViewHolder(val viewBinding: ComponentOptionItemViewBinding)
             }
             else -> {
                 size = imageSize
-                val photonUrl = PhotonUtils.getPhotonImageUrl(imageUrl, imageSize, imageSize)
-                Glide.with(viewBinding.componentOptionImage).load(photonUrl)
+                Glide.with(viewBinding.componentOptionImage).loadPhotonUrlWithFallback(imageUrl, imageSize, imageSize)
                     .transform(CenterCrop(), RoundedCorners(imageCornerRadius)).placeholder(R.drawable.ic_product)
                     .into(viewBinding.componentOptionImage)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentsListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/components/ComponentsListAdapter.kt
@@ -12,8 +12,8 @@ import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ComponentItemViewBinding
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.model.Component
-import org.wordpress.android.util.PhotonUtils
 
 class ComponentsListAdapter(private val clickListener: OnComponentClickListener) :
     ListAdapter<Component, ComponentViewHolder>(ComponentItemDiffCallback) {
@@ -77,8 +77,7 @@ class ComponentViewHolder(val viewBinding: ComponentItemViewBinding) : RecyclerV
             }
             else -> {
                 size = imageSize
-                val photonUrl = PhotonUtils.getPhotonImageUrl(imageUrl, imageSize, imageSize)
-                Glide.with(viewBinding.componentImage).load(photonUrl)
+                Glide.with(viewBinding.componentImage).loadPhotonUrlWithFallback(imageUrl, imageSize, imageSize)
                     .transform(CenterCrop(), RoundedCorners(imageCornerRadius)).placeholder(R.drawable.ic_product)
                     .into(viewBinding.componentImage)
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/QuickInventoryUpdateBottomSheet.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/inventory/QuickInventoryUpdateBottomSheet.kt
@@ -70,8 +70,8 @@ fun QuickInventoryUpdateBottomSheet(
         Divider()
         Spacer(modifier = Modifier.size(dimensionResource(id = R.dimen.major_200)))
         ProductThumbnail(
+            imageSize = 160.dp,
             modifier = Modifier
-                .size(160.dp)
                 .clip(
                     RoundedCornerShape(8.dp)
                 ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListAdapter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/variations/VariationListAdapter.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.databinding.VariationListItemBinding
 import com.woocommerce.android.extensions.appendWithIfNotEmpty
 import com.woocommerce.android.extensions.isSet
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.model.Product
 import com.woocommerce.android.model.ProductVariation
 import com.woocommerce.android.ui.products.OnLoadMoreListener
@@ -25,7 +26,6 @@ import com.woocommerce.android.ui.products.ProductStockStatus.InStock
 import com.woocommerce.android.ui.products.ProductStockStatus.OnBackorder
 import com.woocommerce.android.ui.products.ProductStockStatus.OutOfStock
 import com.woocommerce.android.ui.products.variations.VariationListAdapter.VariationViewHolder
-import org.wordpress.android.util.PhotonUtils
 
 class VariationListAdapter(
     private val context: Context,
@@ -118,8 +118,7 @@ class VariationListAdapter(
             viewBinding.variationOptionImage.clipToOutline = true
 
             variation.image?.let {
-                val imageUrl = PhotonUtils.getPhotonImageUrl(it.source, imageSize, imageSize)
-                glideRequest.load(imageUrl)
+                glideRequest.loadPhotonUrlWithFallback(it.source, imageSize, imageSize)
                     .transform(CenterCrop(), RoundedCorners(imageCornerRadius))
                     .placeholder(R.drawable.ic_product)
                     .into(viewBinding.variationOptionImage)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailFragment.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentReviewDetailBinding
 import com.woocommerce.android.extensions.fastStripHtml
 import com.woocommerce.android.extensions.handleResult
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.takeIfNotEqualTo
 import com.woocommerce.android.model.ProductReview
@@ -46,7 +47,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.HtmlUtils
-import org.wordpress.android.util.PhotonUtils
 import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 
@@ -228,9 +228,8 @@ class ReviewDetailFragment :
         // it from the backend. When the request completes it will be captured by the presenter, which will
         // call this method to show the image for the just-downloaded product model
         productImageMap.get(remoteProductId)?.let { productImage ->
-            val imageUrl = PhotonUtils.getPhotonImageUrl(productImage, productIconSize, productIconSize)
             Glide.with(activity as Context)
-                .load(imageUrl)
+                .loadPhotonUrlWithFallback(productImage, productIconSize, productIconSize)
                 .placeholder(ContextCompat.getDrawable(requireContext(), R.drawable.ic_product))
                 .into(binding.reviewProductIcon)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/widgets/WCProductImageGalleryView.kt
@@ -28,6 +28,7 @@ import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.request.RequestOptions
 import com.woocommerce.android.R
 import com.woocommerce.android.databinding.ImageGalleryItemBinding
+import com.woocommerce.android.extensions.loadPhotonUrlWithFallback
 import com.woocommerce.android.model.Product
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.PhotonUtils
@@ -422,13 +423,12 @@ class WCProductImageGalleryView @JvmOverloads constructor(
             if (viewType == VIEW_TYPE_PLACEHOLDER) {
                 glideRequest.load(Uri.parse(image.source)).apply(glideTransform).into(viewBinding.productImage)
             } else if (viewType == VIEW_TYPE_IMAGE) {
-                val photonUrl = PhotonUtils.getPhotonImageUrl(
+                glideRequest.loadPhotonUrlWithFallback(
                     image.source,
                     0,
                     imageSize,
                     PhotonUtils.Quality.LOW
-                )
-                glideRequest.load(photonUrl).apply(glideTransform).into(viewBinding.productImage)
+                ).apply(glideTransform).into(viewBinding.productImage)
             }
 
             when (viewType) {


### PR DESCRIPTION
### Description
Fixes WOOMOB-2586

This PR fixes an issue where product images would fail to display if Photon-hosted URLs (`i0.wp.com`) were blocked or unavailable. It introduces a robust fallback mechanism so that the app gracefully loads the original image URL whenever the Photon request fails.

For the Compose components, `ProductThumbnail` now handles the fallback logic internally using a custom Coil extension (`rememberPhotonImageRequest`). This required replacing `Modifier.size()` with a direct `imageSize` parameter across all callers so that the exact dimensions can be fetched from the server.

A similar fallback approach was applied to the View system components using new Glide extensions in `PhotonImageExt.kt`.

### Test Steps
1. Open the app and navigate to a screen with product images (e.g., Orders list, Product list, Dashboard top performers).
2. Verify that product images load correctly and appear at the correct dimensions.
3. Simulate a failure for `i0.wp.com` (Photon URL) requests using Android Studio's Network Inspector. (Note: ApiFaker cannot be used for this as it does not intercept these requests).
4. Verify that the images gracefully fall back to the original URL and load successfully despite the Photon failure.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
