### PR TITLE
[WOOMOB-2628] Prevent bypass after failed role check

### DIFF
--- a/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wp/users_me.json
+++ b/WooCommerce/src/androidTest/assets/mocks/mappings/jetpack-blogs/wp/users_me.json
@@ -7,7 +7,7 @@
         "equalTo": "true"
       },
       "path": {
-        "matches": "wp/v2/users/me(.*)"
+        "matches": "/wp/v2/users/me(.*)"
       },
       "query": {
         "matches": "(.*)context\":\"edit(.*)"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
@@ -72,7 +72,7 @@ class UserEligibilityErrorViewModel @Inject constructor(
                     }
                 },
                 onFailure = {
-                    triggerEvent(ShowSnackbar(R.string.error_generic))
+                    triggerEvent(ShowSnackbar(string.user_role_access_error_fetch_failed))
                 }
             )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModel.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.common
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.R
 import com.woocommerce.android.R.string
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -343,7 +343,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 triggerEvent(LoggedIn(selectedSite.getSelectedSiteId()))
             },
             onFailure = { exception ->
-                triggerEvent(ShowSnackbar(R.string.error_generic))
+                triggerEvent(ShowSnackbar(R.string.user_role_access_error_fetch_failed))
                 when (exception) {
                     is ApplicationPasswordGenerationException -> {
                         trackLoginFailure(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -542,7 +542,7 @@ class SitePickerViewModel @Inject constructor(
                             triggerEvent(SitePickerEvent.NavigateToMainActivityEvent)
                         },
                         onFailure = {
-                            triggerEvent(ShowSnackbar(R.string.error_generic))
+                            triggerEvent(ShowSnackbar(R.string.user_role_access_error_fetch_failed))
                         }
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -534,11 +534,11 @@ class SitePickerViewModel @Inject constructor(
                     userEligibilityFetcher.fetchUserInfo(siteVerificationModel.siteModel).fold(
                         onSuccess = {
                             selectedSite.set(siteVerificationModel.siteModel)
-                            sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = false)
-
                             trackLoginEvent(currentStep = UnifiedLoginTracker.Step.SUCCESS)
                             appPrefsWrapper.removeLoginSiteAddress()
                             registerDevice(RegisterDevice.Mode.IF_NEEDED)
+
+                            sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = false)
                             triggerEvent(SitePickerEvent.NavigateToMainActivityEvent)
                         },
                         onFailure = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -530,10 +530,10 @@ class SitePickerViewModel @Inject constructor(
                 siteVerificationResult.isError -> onSiteVerificationError(siteVerificationResult, selectedSiteModel)
                 siteVerificationModel?.apiVersion == WooCommerceStore.WOO_API_NAMESPACE_V3 -> {
                     experimentTracker.log(ExperimentTracker.SITE_VERIFICATION_SUCCESSFUL_EVENT)
-                    selectedSite.set(siteVerificationModel.siteModel)
                     trackAppPasswordsSupport(siteVerificationModel.siteModel)
-                    userEligibilityFetcher.fetchUserInfo().fold(
+                    userEligibilityFetcher.fetchUserInfo(siteVerificationModel.siteModel).fold(
                         onSuccess = {
+                            selectedSite.set(siteVerificationModel.siteModel)
                             sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = false)
 
                             trackLoginEvent(currentStep = UnifiedLoginTracker.Step.SUCCESS)
@@ -548,10 +548,10 @@ class SitePickerViewModel @Inject constructor(
                 }
 
                 else -> {
-                    sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = false)
                     _isWooUpgradeDialogVisible.value = true
                 }
             }
+            sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = false)
         }
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -248,6 +248,7 @@
     <string name="login_troubleshooting_tips">Read our troubleshooting tips</string>
     <string name="login_no_wpcom_account_found">Your email isn\'t used with a WordPress.com account.</string>
     <string name="user_role_access_error_user_roles_null">This app supports only Administrator and Shop Manager user roles. We were unable to fetch user roles for your account. Please contact support.</string>
+    <string name="user_role_access_error_fetch_failed">We couldn\'t verify your role on this store. Please try again. If the problem persists, contact support.</string>
     <string name="user_role_access_error_msg">This app supports only Administrator and Shop Manager user roles. Please contact your store owner to upgrade your role.</string>
     <string name="user_role_access_error_link">Learn more about roles and permissions</string>
     <string name="user_role_access_error_retry">You don\'t have the correct user role</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
@@ -117,6 +117,30 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `Handles retry button correctly when user roles cannot be fetched`() = testBlocking {
+        whenever(userEligibilityFetcher.fetchUserInfo()).thenReturn(Result.failure(Exception()))
+
+        val isProgressDialogShown = ArrayList<Boolean>()
+        viewModel.viewStateData.observeForever { old, new ->
+            new.isProgressDialogShown?.takeIfNotEqualTo(old?.isProgressDialogShown) {
+                isProgressDialogShown.add(it)
+            }
+        }
+
+        var snackbar: ShowSnackbar? = null
+        viewModel.event.observeForever {
+            if (it is ShowSnackbar) snackbar = it
+        }
+
+        viewModel.onRetryButtonClicked()
+
+        verify(userEligibilityFetcher, times(1)).fetchUserInfo()
+
+        assertThat(snackbar).isEqualTo(ShowSnackbar(string.user_role_access_error_fetch_failed))
+        assertThat(isProgressDialogShown).containsExactly(true, false)
+    }
+
+    @Test
     fun `Handles logout button click correctly`() = testBlocking {
         doReturn(true).whenever(accountRepository).logout()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/common/UserEligibilityErrorViewModelTest.kt
@@ -117,7 +117,7 @@ class UserEligibilityErrorViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Handles retry button correctly when user roles cannot be fetched`() = testBlocking {
+    fun `when user roles cannot be fetched on retry, then show the role verification error`() = testBlocking {
         whenever(userEligibilityFetcher.fetchUserInfo()).thenReturn(Result.failure(Exception()))
 
         val isProgressDialogShown = ArrayList<Boolean>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -273,7 +273,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             viewModel.onContinueClick()
         }
 
-        assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(R.string.error_generic))
+        assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(R.string.user_role_access_error_fetch_failed))
         verify(analyticsTracker).track(
             stat = eq(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_LOGIN_FAILED),
             properties = argThat {
@@ -317,7 +317,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `give user role fetch fails, when submitting login, then show a snackbar`() = testBlocking {
+    fun `given user role fetch fails, when submitting login, then show a snackbar`() = testBlocking {
         setup {
             whenever(wpApiSiteRepository.checkIfUserIsEligible(testSite)).thenReturn(Result.failure(Exception()))
         }
@@ -328,7 +328,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             viewModel.onContinueClick()
         }
 
-        assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(R.string.error_generic))
+        assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(R.string.user_role_access_error_fetch_failed))
         verify(analyticsTracker).track(
             stat = eq(AnalyticsEvent.LOGIN_SITE_CREDENTIALS_LOGIN_FAILED),
             properties = argThat {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -123,7 +123,7 @@ class SitePickerViewModelTest : BaseUnitTest() {
         whenever(repository.verifySiteWooAPIVersion(any())).thenReturn(
             WooResult(SitePickerTestUtils.apiVerificationResponse)
         )
-        whenever(userEligibilityFetcher.fetchUserInfo()).thenReturn(Result.success(SitePickerTestUtils.userModel))
+        whenever(userEligibilityFetcher.fetchUserInfo(any())).thenReturn(Result.success(SitePickerTestUtils.userModel))
     }
 
     private suspend fun whenSitesAreFetched(
@@ -540,13 +540,35 @@ class SitePickerViewModelTest : BaseUnitTest() {
         viewModel.onContinueButtonClick()
 
         verify(repository, times(1)).verifySiteWooAPIVersion(any())
+        verify(userEligibilityFetcher, times(1)).fetchUserInfo(any())
         verify(selectedSite, times(1)).set(any())
-        verify(userEligibilityFetcher, times(1)).fetchUserInfo()
         verify(appPrefsWrapper, times(1)).removeLoginSiteAddress()
 
         assertThat(view).isEqualTo(NavigateToMainActivityEvent)
         assertThat(isProgressShown).containsExactly(false, true, false)
     }
+
+    @Test
+    fun `given eligibility fetch fails after site verification, when continue is tapped, then do not persist selected site`() =
+        testBlocking {
+            whenever(repository.verifySiteWooAPIVersion(any())).thenReturn(
+                WooResult(SitePickerTestUtils.apiVerificationResponse)
+            )
+            whenever(userEligibilityFetcher.fetchUserInfo(any())).thenReturn(Result.failure(Exception()))
+            whenSitesAreFetched()
+            whenViewModelIsCreated()
+
+            val selectedSiteModel = defaultExpectedSiteList[1]
+
+            viewModel.onSiteSelected(selectedSiteModel)
+            viewModel.onContinueButtonClick()
+
+            verify(repository, times(1)).verifySiteWooAPIVersion(any())
+            verify(userEligibilityFetcher, times(1)).fetchUserInfo(any())
+            verify(selectedSite, times(0)).set(any())
+            verify(appPrefsWrapper, times(0)).removeLoginSiteAddress()
+            assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(R.string.error_generic))
+        }
 
     @Test
     fun `given that a site is selected, when verification is initiated, but then returns upgrade error`() =
@@ -569,7 +591,7 @@ class SitePickerViewModelTest : BaseUnitTest() {
 
             verify(repository, times(1)).verifySiteWooAPIVersion(any())
             verify(selectedSite, times(0)).set(any())
-            verify(userEligibilityFetcher, times(0)).fetchUserInfo()
+            verify(userEligibilityFetcher, times(0)).fetchUserInfo(any())
             verify(appPrefsWrapper, times(0)).removeLoginSiteAddress()
 
             assertThat(viewModel.isWooUpgradeDialogVisible.value).isEqualTo(true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -558,6 +558,11 @@ class SitePickerViewModelTest : BaseUnitTest() {
             whenSitesAreFetched()
             whenViewModelIsCreated()
 
+            val isProgressShown = ArrayList<Boolean>()
+            viewModel.sitePickerViewStateData.observeForever { old, new ->
+                new.isProgressDiaLogVisible.takeIfNotEqualTo(old?.isProgressDiaLogVisible) { isProgressShown.add(it) }
+            }
+
             val selectedSiteModel = defaultExpectedSiteList[1]
 
             viewModel.onSiteSelected(selectedSiteModel)
@@ -567,7 +572,8 @@ class SitePickerViewModelTest : BaseUnitTest() {
             verify(userEligibilityFetcher, times(1)).fetchUserInfo(any())
             verify(selectedSite, times(0)).set(any())
             verify(appPrefsWrapper, times(0)).removeLoginSiteAddress()
-            assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(R.string.error_generic))
+            assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(R.string.user_role_access_error_fetch_failed))
+            assertThat(isProgressShown).containsExactly(false, true, false)
         }
 
     @Test

--- a/libs/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPAPIEndpoint.java
+++ b/libs/fluxc-annotations/src/main/java/org/wordpress/android/fluxc/annotations/endpoint/WPAPIEndpoint.java
@@ -2,7 +2,7 @@ package org.wordpress.android.fluxc.annotations.endpoint;
 
 public class WPAPIEndpoint {
     private static final String WPCOM_REST_PREFIX = "https://public-api.wordpress.com";
-    private static final String WPAPI_PREFIX_V2 = "wp/v2";
+    private static final String WPAPI_PREFIX_V2 = "/wp/v2";
     private static final String WPCOM_WPAPI_PREFIX = WPCOM_REST_PREFIX + "/wp/v2/sites/";
 
     private final String mEndpoint;

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/endpoints/WPAPIEndpointTest.java
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/endpoints/WPAPIEndpointTest.java
@@ -38,12 +38,12 @@ public class WPAPIEndpointTest {
 
     @Test
     public void testUrls() {
-        assertEquals("wp/v2/posts/", WPAPI.posts.getUrlV2());
-        assertEquals("wp/v2/pages/", WPAPI.pages.getUrlV2());
-        assertEquals("wp/v2/media/", WPAPI.media.getUrlV2());
-        assertEquals("wp/v2/comments/", WPAPI.comments.getUrlV2());
-        assertEquals("wp/v2/users/", WPAPI.users.getUrlV2());
-        assertEquals("wp/v2/users/me/", WPAPI.users.me.getUrlV2());
-        assertEquals("wp/v2/plugins/", WPAPI.plugins.getUrlV2());
+        assertEquals("/wp/v2/posts/", WPAPI.posts.getUrlV2());
+        assertEquals("/wp/v2/pages/", WPAPI.pages.getUrlV2());
+        assertEquals("/wp/v2/media/", WPAPI.media.getUrlV2());
+        assertEquals("/wp/v2/comments/", WPAPI.comments.getUrlV2());
+        assertEquals("/wp/v2/users/", WPAPI.users.getUrlV2());
+        assertEquals("/wp/v2/users/me/", WPAPI.users.me.getUrlV2());
+        assertEquals("/wp/v2/plugins/", WPAPI.plugins.getUrlV2());
     }
 }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPApiRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/plugin/PluginWPApiRestClientTest.kt
@@ -57,7 +57,7 @@ class PluginWPApiRestClientTest(private val site: SiteModel) {
         val responseModel = restClient.installPlugin(site, installedPluginSlug)
         assertMappedPlugin(responseModel.data!!, testPlugin)
         assertThat(urlCaptor.lastValue)
-            .isEqualTo("wp/v2/plugins/")
+            .isEqualTo("/wp/v2/plugins/")
         assertThat(bodyCaptor.lastValue).isEqualTo(mapOf("slug" to installedPluginSlug))
     }
 
@@ -69,7 +69,7 @@ class PluginWPApiRestClientTest(private val site: SiteModel) {
         val responseModel = restClient.updatePlugin(site, installedPluginSlug, active)
         assertMappedPlugin(responseModel.data!!, testPlugin)
         assertThat(urlCaptor.lastValue)
-            .isEqualTo("wp/v2/plugins/$installedPluginSlug/")
+            .isEqualTo("/wp/v2/plugins/$installedPluginSlug/")
         assertThat(bodyCaptor.lastValue).isEqualTo(mapOf("status" to "active"))
     }
 
@@ -81,7 +81,7 @@ class PluginWPApiRestClientTest(private val site: SiteModel) {
         val responseModel = restClient.updatePlugin(site, installedPluginSlug, active)
         assertMappedPlugin(responseModel.data!!, testPlugin)
         assertThat(urlCaptor.lastValue)
-            .isEqualTo("wp/v2/plugins/$installedPluginSlug/")
+            .isEqualTo("/wp/v2/plugins/$installedPluginSlug/")
         assertThat(bodyCaptor.lastValue).isEqualTo(mapOf("status" to "inactive"))
     }
 


### PR DESCRIPTION
### Description
Fixes WOOMOB-2628
This prevents the app from bypassing a failed role check after restart by only persisting the selected site once user-role verification succeeds. It also aligns WP API v2 endpoint strings with ApiFaker, updates the affected mocks/tests, and replaces the generic role-fetch snackbar with more specific copy.

### Test Steps
1. Simulate a failure for the endpoint `/wp/v2/users/me`.
2. Log in using WordPress.com.
3. Confirm that a Snackbar error is shown on the site picker.
4. Restart the app.
5. Confirm you are still blocked at the site picker level

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.