### PR TITLE
[WOOMOB-2646] Add FedEx to supported shipping features

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/networking/WooShippingLabelRestClient.kt
@@ -177,7 +177,7 @@ class WooShippingLabelRestClient @Inject constructor(
                 "hazmat" to mapOf(shipmentKey to hazmat),
                 "customs" to customs?.let { mapOf(shipmentKey to it) }.orEmpty(),
                 "user_meta" to mapOf("last_order_completed" to lastOrderCompleted),
-                "features_supported_by_client" to listOf("upsdap"),
+                "features_supported_by_client" to listOf("upsdap", "fedex"),
             ),
             clazz = PurchasedShippingLabelResponseDTO::class.java,
         ).toWooPayload()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
@@ -14,7 +14,11 @@ class WooShippingLabelPackageRestClient @Inject constructor(
     ): WooPayload<PackageResponse> {
         return wooNetwork.executeGetGsonRequest(
             site = site,
-            path = "$URL?$UPSDAP_FEATURE_QUERY&$FEDEX_FEATURE_QUERY",
+            path = URL,
+            params = mapOf(
+                "features_supported_by_client[0]" to UPSDAP_FEATURE,
+                "features_supported_by_client[1]" to FEDEX_FEATURE,
+            ),
             clazz = PackageResponse::class.java,
         ).toWooPayload()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
@@ -14,8 +14,7 @@ class WooShippingLabelPackageRestClient @Inject constructor(
     ): WooPayload<PackageResponse> {
         return wooNetwork.executeGetGsonRequest(
             site = site,
-            path = URL,
-            params = mapOf("features_supported_by_client[]" to UPSDAP_FEATURE),
+            path = "$URL?$UPSDAP_FEATURE_QUERY&$FEDEX_FEATURE_QUERY",
             clazz = PackageResponse::class.java,
         ).toWooPayload()
     }
@@ -65,7 +64,8 @@ class WooShippingLabelPackageRestClient @Inject constructor(
 
     companion object {
         private const val URL = "/wcshipping/v1/packages"
-        private const val UPSDAP_FEATURE = "upsdap"
+        private const val UPSDAP_FEATURE_QUERY = "features_supported_by_client%5B%5D=upsdap"
+        private const val FEDEX_FEATURE_QUERY = "features_supported_by_client%5B%5D=fedex"
         private const val TYPE_CUSTOM = "custom"
         private const val TYPE_PREDEFINED = "predefined"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/networking/WooShippingLabelPackageRestClient.kt
@@ -68,8 +68,8 @@ class WooShippingLabelPackageRestClient @Inject constructor(
 
     companion object {
         private const val URL = "/wcshipping/v1/packages"
-        private const val UPSDAP_FEATURE_QUERY = "features_supported_by_client%5B%5D=upsdap"
-        private const val FEDEX_FEATURE_QUERY = "features_supported_by_client%5B%5D=fedex"
+        private const val UPSDAP_FEATURE = "upsdap"
+        private const val FEDEX_FEATURE = "fedex"
         private const val TYPE_CUSTOM = "custom"
         private const val TYPE_PREDEFINED = "predefined"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/networking/WooShippingRatesRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/networking/WooShippingRatesRestClient.kt
@@ -27,7 +27,7 @@ class WooShippingRatesRestClient @Inject constructor(
             "origin" to origin,
             "destination" to destination,
             "packages" to packages,
-            "features_supported_by_client" to listOf(UPSDAP_FEATURE)
+            "features_supported_by_client" to listOf(UPSDAP_FEATURE, FEDEX_FEATURE)
         )
 
         return wooNetwork.executePostGsonRequest(
@@ -45,5 +45,6 @@ class WooShippingRatesRestClient @Inject constructor(
     companion object {
         private const val URL = "/wcshipping/v1/label/rate"
         private const val UPSDAP_FEATURE = "upsdap"
+        private const val FEDEX_FEATURE = "fedex"
     }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2646

This PR adds `fedex` to `features_supported_by_client` in Woo Shipping requests for:
- packages
- label rates
- label purchase

This PR intentionally does not remove the local FedEx feature flag yet. It only updates the request payload so backend gating can recognize FedEx support when the feature is enabled locally.

### Test Steps
1. Enable woo_shipping_fedex flag.
2. Log in to a site that can purchase shipping labels and is connected to the staging connect-server with FedEx enabled.
3. Open an order with shippable products.
4. Start the Create Shipping Label flow.
5. Verify the FedEx package section is shown on the package selection step.
6. Continue to the rates step.
7. Verify FedEx rates are shown.

### Images/gif

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
