### PR TITLE
[WOOMOB-2624] Fix POS splash hanging when sync worker is stopped mid-sync

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncAction.kt
@@ -53,6 +53,7 @@ class WooPosFileBasedSyncAction @Inject constructor(
         ) : WooPosFileBasedSyncResult()
     }
 
+    @Suppress("LongMethod")
     suspend fun syncCatalog(site: SiteModel): WooPosFileBasedSyncResult {
         _syncState.value = null
         val startTime = System.currentTimeMillis()
@@ -62,19 +63,22 @@ class WooPosFileBasedSyncAction @Inject constructor(
         val accumulatedPollAttempts = preferencesRepository.getAndClearFileBasedSyncPollAttempts(siteId)
         var lastGenerationState: WooPosGenerateCatalogState? = null
         var failedConsecutiveAttempts = 0
+        var pollsSinceLastStateChange = 0
+        var totalAttempts = 0
 
-        repeat(MAX_POLL_ATTEMPTS) { attemptIndex ->
-            if (attemptIndex > 0) {
-                val delayMs = computeBackoffDelay(attemptIndex)
-                logger.d("WooPosFileBasedSyncAction: Waiting ${delayMs}ms before poll attempt $attemptIndex")
+        while (pollsSinceLastStateChange < MAX_POLL_ATTEMPTS) {
+            if (totalAttempts > 0) {
+                val delayMs = computeBackoffDelay(pollsSinceLastStateChange)
+                logger.d("WooPosFileBasedSyncAction: Waiting ${delayMs}ms before poll attempt $totalAttempts")
                 delay(delayMs)
             }
+            totalAttempts++
 
             val response = posLocalCatalogStore.generateCatalogOrGetStatus(site)
 
             if (response.isFailure) {
                 if (++failedConsecutiveAttempts >= MAX_CONSECUTIVE_FAILED_ATTEMPTS) {
-                    val totalPollAttempts = accumulatedPollAttempts + attemptIndex + 1
+                    val totalPollAttempts = accumulatedPollAttempts + totalAttempts
                     return handleConsecutiveFailures(
                         siteId,
                         totalPollAttempts,
@@ -82,17 +86,19 @@ class WooPosFileBasedSyncAction @Inject constructor(
                         response.exceptionOrNull()
                     )
                 } else {
-                    logger.w("Poll attempt $attemptIndex failed: ${response.exceptionOrNull()?.message}")
-                    return@repeat
+                    logger.w("Poll attempt $totalAttempts failed: ${response.exceptionOrNull()?.message}")
+                    pollsSinceLastStateChange++
+                    continue
                 }
             }
             failedConsecutiveAttempts = 0
 
             val result = response.getOrThrow()
+            pollsSinceLastStateChange = if (result.state != lastGenerationState) 0 else pollsSinceLastStateChange + 1
             lastGenerationState = result.state
-            logger.d("WooPosFileBasedSyncAction: Poll attempt $attemptIndex, state: ${result.state}")
+            logger.d("WooPosFileBasedSyncAction: Poll attempt $totalAttempts, state: ${result.state}")
 
-            val totalPollAttempts = accumulatedPollAttempts + attemptIndex + 1
+            val totalPollAttempts = accumulatedPollAttempts + totalAttempts
             val processedResult = processPollingResult(
                 result,
                 site,
@@ -112,7 +118,7 @@ class WooPosFileBasedSyncAction @Inject constructor(
 
         return handleTimeout(
             siteId = siteId,
-            totalPollAttempts = accumulatedPollAttempts + MAX_POLL_ATTEMPTS,
+            totalPollAttempts = accumulatedPollAttempts + totalAttempts,
             lastGenerationState = lastGenerationState
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncAction.kt
@@ -53,7 +53,6 @@ class WooPosFileBasedSyncAction @Inject constructor(
         ) : WooPosFileBasedSyncResult()
     }
 
-    @Suppress("LongMethod")
     suspend fun syncCatalog(site: SiteModel): WooPosFileBasedSyncResult {
         _syncState.value = null
         val startTime = System.currentTimeMillis()
@@ -67,11 +66,7 @@ class WooPosFileBasedSyncAction @Inject constructor(
         var totalAttempts = 0
 
         while (pollsSinceLastStateChange < MAX_POLL_ATTEMPTS) {
-            if (totalAttempts > 0) {
-                val delayMs = computeBackoffDelay(pollsSinceLastStateChange)
-                logger.d("WooPosFileBasedSyncAction: Waiting ${delayMs}ms before poll attempt $totalAttempts")
-                delay(delayMs)
-            }
+            delayBeforeNextPoll(totalAttempts, pollsSinceLastStateChange)
             totalAttempts++
 
             val response = posLocalCatalogStore.generateCatalogOrGetStatus(site)
@@ -121,6 +116,13 @@ class WooPosFileBasedSyncAction @Inject constructor(
             totalPollAttempts = accumulatedPollAttempts + totalAttempts,
             lastGenerationState = lastGenerationState
         )
+    }
+
+    private suspend fun delayBeforeNextPoll(totalAttempts: Int, pollsSinceLastStateChange: Int) {
+        if (totalAttempts == 0) return
+        val delayMs = computeBackoffDelay(pollsSinceLastStateChange)
+        logger.d("WooPosFileBasedSyncAction: Waiting ${delayMs}ms before poll attempt ${totalAttempts + 1}")
+        delay(delayMs)
     }
 
     private suspend fun handleConsecutiveFailures(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformInstantCatalogFullSync.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformInstantCatalogFullSync.kt
@@ -39,9 +39,13 @@ class WooPosPerformInstantCatalogFullSync @Inject constructor(
         workInfoFlow: Flow<WorkInfo?>,
         workerType: String
     ): Result<Unit> {
+        // WorkManager can stop a RUNNING worker (e.g., when the network constraint is no longer met
+        // during a large catalog sync), transitioning it back to ENQUEUED/BLOCKED without reaching a
+        // finished state. Waiting only for `isFinished` would hang in that case, so we also break out
+        // whenever the worker leaves the RUNNING state.
         val finalWorkInfo = workInfoFlow
             .filter { workInfo ->
-                workInfo?.state?.isFinished == true || workInfo == null
+                workInfo == null || workInfo.state != WorkInfo.State.RUNNING
             }
             .first()
 
@@ -59,6 +63,12 @@ class WooPosPerformInstantCatalogFullSync @Inject constructor(
             WorkInfo.State.FAILED, WorkInfo.State.CANCELLED -> {
                 wooPosLogWrapper.e("$workerType worker failed or cancelled: ${workInfo.state}")
                 Result.failure(Exception("Background sync worker ${workInfo.state}"))
+            }
+            WorkInfo.State.ENQUEUED, WorkInfo.State.BLOCKED -> {
+                wooPosLogWrapper.e(
+                    "$workerType worker was stopped before finishing (state=${workInfo.state})"
+                )
+                Result.failure(Exception("Background sync worker was stopped: ${workInfo.state}"))
             }
             null -> {
                 verifyAndEmitSyncCompletion(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosFileBasedSyncActionTest.kt
@@ -385,11 +385,10 @@ class WooPosFileBasedSyncActionTest {
         whenever(preferencesRepository.getAndClearFileBasedSyncPollAttempts(any())).thenReturn(10)
         givenCatalogGenerationNeverCompletes()
 
-        // WHEN
+        // THEN - 10 accumulated + 1 initial state-change poll + 20 polls without progress = 31
         sut.syncCatalog(site)
 
-        // THEN - 10 accumulated + 20 max attempts = 30
-        verify(preferencesRepository).setFileBasedSyncPollAttempts(site.localId(), 30)
+        verify(preferencesRepository).setFileBasedSyncPollAttempts(site.localId(), 31)
     }
 
     @Test
@@ -429,10 +428,24 @@ class WooPosFileBasedSyncActionTest {
         // WHEN
         val result = sut.syncCatalog(site)
 
-        // THEN - 5 accumulated + 20 max = 25
+        // THEN - 5 accumulated + 1 initial state-change poll + 20 polls without progress = 26
         val timeout = (result as WooPosFileBasedSyncAction.WooPosFileBasedSyncResult.Failure).result
             as PosLocalCatalogSyncResult.Failure.CatalogGenerationTimeout
-        assertThat(timeout.pollAttempts).isEqualTo(25)
+        assertThat(timeout.pollAttempts).isEqualTo(26)
+    }
+
+    @Test
+    fun `given many polls per state, when state advances, then poll budget resets`() = runTest {
+        // GIVEN — 15 polls in SCHEDULED + 15 polls in IN_PROGRESS + COMPLETED. Without the
+        // state-change reset this would exceed MAX_POLL_ATTEMPTS=20 and time out, but each phase
+        // alone is below the budget so the overall sync should succeed.
+        givenCatalogScheduledThenInProgressThenCompleted(scheduledPolls = 15, inProgressPolls = 15)
+
+        // WHEN
+        val result = sut.syncCatalog(site)
+
+        // THEN
+        assertThat(result).isInstanceOf(WooPosFileBasedSyncAction.WooPosFileBasedSyncResult.Success::class.java)
     }
 
     @Test
@@ -654,6 +667,25 @@ class WooPosFileBasedSyncActionTest {
                     )
                 )
             )
+    }
+
+    private suspend fun givenCatalogScheduledThenInProgressThenCompleted(
+        scheduledPolls: Int,
+        inProgressPolls: Int,
+    ) {
+        val scheduled = Result.success(
+            WooPosGenerateCatalogResult(state = WooPosGenerateCatalogState.SCHEDULED)
+        )
+        val inProgress = Result.success(
+            WooPosGenerateCatalogResult(state = WooPosGenerateCatalogState.IN_PROGRESS, progress = 50f, total = 100)
+        )
+        val completed = Result.success(
+            WooPosGenerateCatalogResult(state = WooPosGenerateCatalogState.COMPLETED, url = defaultUrl)
+        )
+        var stub = whenever(posLocalCatalogStore.generateCatalogOrGetStatus(site)).thenReturn(scheduled)
+        repeat(scheduledPolls - 1) { stub = stub.thenReturn(scheduled) }
+        repeat(inProgressPolls) { stub = stub.thenReturn(inProgress) }
+        stub.thenReturn(completed)
     }
 
     private suspend fun givenFileDownloadSuccess() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformInstantCatalogFullSyncTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformInstantCatalogFullSyncTest.kt
@@ -156,6 +156,66 @@ class WooPosPerformInstantCatalogFullSyncTest {
     }
 
     @Test
+    fun `given one time worker is stopped mid sync, when invoke called, then returns failure`() = runTest {
+        // GIVEN
+        val workInfo = mock<WorkInfo>()
+        whenever(workInfo.state).thenReturn(WorkInfo.State.ENQUEUED)
+        val workInfoFlow = MutableStateFlow<WorkInfo?>(workInfo)
+        whenever(syncScheduler.observeOneTimeWorkStatus()).thenReturn(flowOf(true))
+        whenever(syncScheduler.observePeriodicWorkStatus()).thenReturn(flowOf(false))
+        whenever(syncScheduler.observeOneTimeWorkInfo()).thenReturn(workInfoFlow)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()?.message)
+            .isEqualTo("Background sync worker was stopped: ENQUEUED")
+    }
+
+    @Test
+    fun `given periodic worker is stopped mid sync, when invoke called, then returns failure`() = runTest {
+        // GIVEN
+        val workInfo = mock<WorkInfo>()
+        whenever(workInfo.state).thenReturn(WorkInfo.State.BLOCKED)
+        val workInfoFlow = MutableStateFlow<WorkInfo?>(workInfo)
+        whenever(syncScheduler.observeOneTimeWorkStatus()).thenReturn(flowOf(false))
+        whenever(syncScheduler.observePeriodicWorkStatus()).thenReturn(flowOf(true))
+        whenever(syncScheduler.observePeriodicWorkInfo()).thenReturn(workInfoFlow)
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()?.message)
+            .isEqualTo("Background sync worker was stopped: BLOCKED")
+    }
+
+    @Test
+    fun `given worker transitions from running to enqueued, when invoke called, then returns failure`() = runTest {
+        // GIVEN
+        val runningWorkInfo = mock<WorkInfo>().apply {
+            whenever(state).thenReturn(WorkInfo.State.RUNNING)
+        }
+        val stoppedWorkInfo = mock<WorkInfo>().apply {
+            whenever(state).thenReturn(WorkInfo.State.ENQUEUED)
+        }
+        val workInfoFlow = MutableStateFlow<WorkInfo?>(runningWorkInfo)
+        whenever(syncScheduler.observeOneTimeWorkStatus()).thenReturn(flowOf(true))
+        whenever(syncScheduler.observePeriodicWorkStatus()).thenReturn(flowOf(false))
+        whenever(syncScheduler.observeOneTimeWorkInfo()).thenReturn(workInfoFlow)
+
+        // WHEN
+        workInfoFlow.value = stoppedWorkInfo
+        val result = sut()
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+    }
+
+    @Test
     fun `given worker succeeds but no timestamp found, when invoke called, then returns failure`() = runTest {
         // GIVEN
         val workInfo = mock<WorkInfo>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformInstantCatalogFullSyncTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosPerformInstantCatalogFullSyncTest.kt
@@ -194,28 +194,6 @@ class WooPosPerformInstantCatalogFullSyncTest {
     }
 
     @Test
-    fun `given worker transitions from running to enqueued, when invoke called, then returns failure`() = runTest {
-        // GIVEN
-        val runningWorkInfo = mock<WorkInfo>().apply {
-            whenever(state).thenReturn(WorkInfo.State.RUNNING)
-        }
-        val stoppedWorkInfo = mock<WorkInfo>().apply {
-            whenever(state).thenReturn(WorkInfo.State.ENQUEUED)
-        }
-        val workInfoFlow = MutableStateFlow<WorkInfo?>(runningWorkInfo)
-        whenever(syncScheduler.observeOneTimeWorkStatus()).thenReturn(flowOf(true))
-        whenever(syncScheduler.observePeriodicWorkStatus()).thenReturn(flowOf(false))
-        whenever(syncScheduler.observeOneTimeWorkInfo()).thenReturn(workInfoFlow)
-
-        // WHEN
-        workInfoFlow.value = stoppedWorkInfo
-        val result = sut()
-
-        // THEN
-        assertThat(result.isFailure).isTrue()
-    }
-
-    @Test
     fun `given worker succeeds but no timestamp found, when invoke called, then returns failure`() = runTest {
         // GIVEN
         val workInfo = mock<WorkInfo>()


### PR DESCRIPTION
### Description
Fixes WOOMOB-2624

This PR fixes two related bugs that combined to make POS first use sub-optimal for stores with large catalogs:

**1. Splash hanging on `WorkerStoppedException`.** When a sync worker is stopped mid-run (e.g., the user disconnects Wi-Fi), WorkManager transitions it from `RUNNING` back to `ENQUEUED`/`BLOCKED` — it does **not** reach a finished state. The UI in `WooPosPerformInstantCatalogFullSync.monitorWorkerProgress` was waiting on `workInfo.state.isFinished`, so the collector hung indefinitely and the splash kept showing the last sync progress instead of a failure. The filter now breaks whenever the worker leaves `RUNNING` and reports `ENQUEUED`/`BLOCKED` as an interruption failure, propagating through `WooPosProductsDataSource.prepopulateCache()` → `WooPosPrepopulatingDataStatus.Failed` → `WooPosSplashState.SyncFailed`.

**2. Poll budget timing out mid-progress on large catalogs.** `WooPosFileBasedSyncAction.syncCatalog` was capping at `MAX_POLL_ATTEMPTS = 20` *total* polls regardless of state. For a catalog large enough that server-side generation needs more than 20 polls (verified on `largefuntesting.mystagingwebsite.com` with ~17k items), the worker would time out mid-`IN_PROGRESS` even though the server was actively making progress. It would return `Result.retry()`, transition `RUNNING → ENQUEUED`, and trip bug #1 — the user would see meaningful progress (e.g. "8400 of 17433 items") then suddenly the "Unable to sync" error screen, even though nothing was actually wrong. Now the budget counts polls **since the last state change** instead, so a healthy generation that's still progressing through SCHEDULED → IN_PROGRESS → COMPLETED won't trip the cap. A genuinely stuck server still times out after `MAX_POLL_ATTEMPTS` consecutive polls in the same state.

### Test Steps

Reproducing this requires a tablet emulator (POS is tablet-only) and a store with a large enough catalog that the server-side generation takes long enough to observe (`largefuntesting.mystagingwebsite.com` works). Both bugs share most of the setup.

**Scenario A — interruption recovery (bug 1):**
1. Clear app data, log in
2. Wait for the background `WooPosLocalCatalogSyncWorker` to start (observe `WooPosFileBasedSyncAction: Poll attempt` in logcat)
3. Open POS so the splash attaches to the running worker — verify it shows either **"Preparing catalog…"** or **"X of Y items"**
4. Enable airplane mode mid-sync
5. **Expected:** splash transitions to **"Unable to sync — please check your internet connection and retry"** (before the fix it would stay stuck on the last progress value indefinitely)
6. Disable airplane mode and tap **Retry** — sync should resume and land on the POS catalog screen

**Scenario B — large catalog completes without false failure (bug 2):**
1. Clear app data, log in to a store whose catalog is large enough to need >20 server-side polls (the staging store linked in the issue is large enough; you may need to invalidate the server-side cached file once)
2. Wait for the background worker to start, then open POS
3. **Expected:** splash shows progress climbing all the way to 100%, then transitions directly to the POS catalog screen with products visible — no "Unable to sync" interruption, no manual Retry needed (before the fix the splash would jump from a high progress value to the error screen even though the server was healthy)

You can also just run the unit tests:
```
./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "*WooPosFileBasedSyncActionTest*" --tests "*WooPosPerformInstantCatalogFullSyncTest*"
```

### Tests Performed

Verified end-to-end on a tablet emulator with a fresh login to a store with ~17k catalog items.

- ✅ **Interrupt during `SCHEDULED` phase ("Preparing catalog…")** — toggled airplane mode while polling for generation start; logcat confirmed `WorkerStoppedException` and the splash transitioned to the "Unable to sync" error screen.
- ✅ **Interrupt during `IN_PROGRESS` phase ("X of Y items")** — repeated after the splash showed numerical progress (`6500 of 17433 items`, ~37%); same successful transition to the error screen.
- ✅ **Retry recovery** — from the error screen, disabled airplane mode and tapped **Retry**; WorkManager re-ran the worker, splash re-attached, sync completed (`Local catalog FULL sync completed successfully. Products: 4976, Variations: 12457`), POS catalog screen rendered with all products.
- ✅ **Large-catalog happy path (bug 2)** — fresh login + clean server cache. Server-side generation took ~31 minutes across 17 polls (including one ~28 min stall between polls 15 and 17 where the server was visibly slow). With the old code this would have tripped the 20-poll cap; with the fix the worker stayed in the loop the whole time because the state was still progressing, and the splash transitioned directly to the POS catalog screen showing products.
- ✅ **Unit tests** — `./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "*WooPosFileBasedSyncActionTest*" --tests "*WooPosPerformInstantCatalogFullSyncTest*"`

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.