### PR TITLE
[WOOMOB-2645] Fix POS sync crash on variations with null description

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,7 @@
 - [Internal] Migrated UpdateProductStockStatusScreen and PlanSubscriptionScreen from Material 2 to Material 3 [https://github.com/woocommerce/woocommerce-android/pull/15601]
 - [Internal] Tag CIAB support tickets with commerce_in_a_box for proper routing [https://github.com/woocommerce/woocommerce-android/pull/15636]
 - [*] Fixed a startup crash that could happen after the selected site was invalidated in the background [https://github.com/woocommerce/woocommerce-android/pull/15626]
+- [*] Fixed POS catalog sync crash on stores with product variations missing a description [https://github.com/woocommerce/woocommerce-android/pull/15653]
 
 24.5
 -----

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosVariationApiResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosVariationApiResponse.kt
@@ -17,31 +17,31 @@ data class WooPosVariationApiResponse(
     val description: String? = null,
 
     @SerializedName("sku")
-    val sku: String = "",
+    val sku: String? = null,
 
     @SerializedName("global_unique_id")
-    val globalUniqueId: String = "",
+    val globalUniqueId: String? = null,
 
     @SerializedName("status")
-    val status: String = "",
+    val status: String? = null,
 
     @SerializedName("price")
-    val price: String = "",
+    val price: String? = null,
 
     @SerializedName("regular_price")
-    val regularPrice: String = "",
+    val regularPrice: String? = null,
 
     @SerializedName("sale_price")
-    val salePrice: String = "",
+    val salePrice: String? = null,
 
     @SerializedName("date_modified")
-    val dateModified: String = "",
+    val dateModified: String? = null,
 
     @SerializedName("stock_quantity")
     val stockQuantity: Double? = null,
 
     @SerializedName("stock_status")
-    val stockStatus: String = "",
+    val stockStatus: String? = null,
 
     @SerializedName("manage_stock")
     val manageStock: Boolean = false,
@@ -59,22 +59,22 @@ data class WooPosVariationApiResponse(
     val downloadable: Boolean = false,
 
     @SerializedName("name")
-    val name: String = "",
+    val name: String? = null,
 
     @SerializedName("type")
-    val type: String = ""
+    val type: String? = null
 ) {
     data class VariationImage(
         @SerializedName("id")
         val id: Long = 0L,
 
         @SerializedName("src")
-        val src: String = "",
+        val src: String? = null,
 
         @SerializedName("name")
-        val name: String = "",
+        val name: String? = null,
 
         @SerializedName("alt")
-        val alt: String = ""
+        val alt: String? = null
     )
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosVariationApiResponse.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/pos/WooPosVariationApiResponse.kt
@@ -14,7 +14,7 @@ data class WooPosVariationApiResponse(
     val productId: Long = 0L,
 
     @SerializedName("description")
-    val description: String = "",
+    val description: String? = null,
 
     @SerializedName("sku")
     val sku: String = "",

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
@@ -38,6 +38,7 @@ fun ProductApiResponse.mapToWooPOSEntity(localSiteId: LocalOrRemoteId.LocalId): 
         attributes = this.attributes?.toString() ?: "",
     )
 
+@Suppress("CyclomaticComplexMethod")
 fun WooPosVariationApiResponse.mapToPosVariationModel(
     localSiteId: LocalOrRemoteId.LocalId
 ): WooPosVariationEntity {
@@ -45,22 +46,22 @@ fun WooPosVariationApiResponse.mapToPosVariationModel(
         localSiteId = localSiteId,
         remoteProductId = LocalOrRemoteId.RemoteId(this.productId),
         remoteVariationId = LocalOrRemoteId.RemoteId(this.id),
-        type = this.type,
-        dateModified = this.dateModified,
-        sku = this.sku,
-        globalUniqueId = this.globalUniqueId,
-        variationName = this.name,
-        price = this.price,
-        regularPrice = this.regularPrice,
-        salePrice = this.salePrice,
+        type = this.type ?: "",
+        dateModified = this.dateModified ?: "",
+        sku = this.sku ?: "",
+        globalUniqueId = this.globalUniqueId ?: "",
+        variationName = this.name ?: "",
+        price = this.price ?: "",
+        regularPrice = this.regularPrice ?: "",
+        salePrice = this.salePrice ?: "",
         description = this.description ?: "",
         stockQuantity = this.stockQuantity ?: 0.0,
-        stockStatus = this.stockStatus,
+        stockStatus = this.stockStatus ?: "",
         manageStock = this.manageStock,
         backordered = this.backordered,
         attributesJson = this.attributesJson?.toString() ?: "[]",
         imageUrl = this.image?.src ?: "",
-        status = this.status,
+        status = this.status ?: "",
         downloadable = this.downloadable
     )
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosProductResponseToEntityMapper.kt
@@ -53,7 +53,7 @@ fun WooPosVariationApiResponse.mapToPosVariationModel(
         price = this.price,
         regularPrice = this.regularPrice,
         salePrice = this.salePrice,
-        description = this.description,
+        description = this.description ?: "",
         stockQuantity = this.stockQuantity ?: 0.0,
         stockStatus = this.stockStatus,
         manageStock = this.manageStock,

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosVariationMapperTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosVariationMapperTest.kt
@@ -98,6 +98,43 @@ class WooPosVariationMapperTest {
     }
 
     @Test
+    fun `given all string fields null, when mapper called, then all string fields default to empty`() {
+        // Given - mirrors the catastrophic case where the API returns null for any
+        // String field that the entity declares as non-null (see WOOMOB-2645)
+        val response = WooPosVariationApiResponse(
+            id = 123L,
+            productId = 456L,
+            description = null,
+            sku = null,
+            globalUniqueId = null,
+            status = null,
+            price = null,
+            regularPrice = null,
+            salePrice = null,
+            dateModified = null,
+            stockStatus = null,
+            name = null,
+            type = null
+        )
+
+        // When
+        val model = response.mapToPosVariationModel(LocalOrRemoteId.LocalId(1))
+
+        // Then
+        assertThat(model.description).isEmpty()
+        assertThat(model.sku).isEmpty()
+        assertThat(model.globalUniqueId).isEmpty()
+        assertThat(model.status).isEmpty()
+        assertThat(model.price).isEmpty()
+        assertThat(model.regularPrice).isEmpty()
+        assertThat(model.salePrice).isEmpty()
+        assertThat(model.dateModified).isEmpty()
+        assertThat(model.stockStatus).isEmpty()
+        assertThat(model.variationName).isEmpty()
+        assertThat(model.type).isEmpty()
+    }
+
+    @Test
     fun `given null image, when mapper called, then image URL is empty`() {
         // Given
         val response = WooPosVariationApiResponse(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosVariationMapperTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/pos/WooPosVariationMapperTest.kt
@@ -82,6 +82,22 @@ class WooPosVariationMapperTest {
     }
 
     @Test
+    fun `given null description, when mapper called, then description defaults to empty string`() {
+        // Given
+        val response = WooPosVariationApiResponse(
+            id = 123L,
+            productId = 456L,
+            description = null
+        )
+
+        // When
+        val model = response.mapToPosVariationModel(LocalOrRemoteId.LocalId(1))
+
+        // Then
+        assertThat(model.description).isEmpty()
+    }
+
+    @Test
     fun `given null image, when mapper called, then image URL is empty`() {
         // Given
         val response = WooPosVariationApiResponse(


### PR DESCRIPTION
### Description
Fixes WOOMOB-2645

The local catalog full sync was crashing with `Parameter specified as non-null is null: ...WooPosVariationEntity.<init> ... description` whenever the WooCommerce REST API returned a product variation with a `null` `description` field. Affected stores were stuck in a state where every sync attempt hit the same variation and POS never loaded.

`WooPosVariationApiResponse.description` was declared as non-null (`String = ""`), but Gson populates fields via reflection (using Unsafe allocation) and bypasses Kotlin's runtime null check. A JSON `null` lands in the field silently; the crash only surfaces later when `mapToPosVariationModel` reads the field and passes it to `WooPosVariationEntity`'s non-null `String` constructor parameter.

This PR makes `description` (and every other non-null `String` field on `WooPosVariationApiResponse` — `sku`, `globalUniqueId`, `status`, `price`, `regularPrice`, `salePrice`, `dateModified`, `stockStatus`, `name`, `type`, plus the inner `VariationImage` strings) nullable, and coalesces them to `""` in `mapToPosVariationModel`. This matches the pattern already used by the sibling `ProductApiResponse.mapToWooPOSEntity` mapper.

Why expand the scope: we just confirmed on real production stores that nominally-required `String` fields *do* come back null from `/wc-analytics/variations`, the failure mode is catastrophic (unrecoverable sync loop, not a missing field), and the fix shape is identical for every field. Hardening only `description` would leave the same latent bug in 10+ other fields.

### Test Steps

End-to-end on-device test with ApiFaker (covers the full fluxc-plugin → mapper → Room insertion path):

ApiFaker as currently shipped doesn't add response headers like `Date` or `X-WP-TotalPages`, which the paginated variations sync path requires before reaching the mapper. To exercise the mapper end-to-end on-device, apply this temporary local patch to `ApiFakerInterceptor` (do NOT commit):

```diff
--- a/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
+++ b/libs/apifaker/src/main/java/com/woocommerce/android/apifaker/ApiFakerInterceptor.kt
@@ -44,6 +44,9 @@ internal class ApiFakerInterceptor @Inject constructor(
                     fakeResponse.body?.toResponseBody("application/json".toMediaType()) ?: ResponseBody.EMPTY
                 )
                 .addHeader("content-type", "application/json")
+                .addHeader("date", "Mon, 13 Apr 2026 13:00:00 GMT")
+                .addHeader("x-wp-totalpages", "1")
+                .addHeader("x-wp-total", "1")
                 .build()
         } else {
             chain.proceed(request)
```

Then:

1. Rebuild and install the debug APK (`./gradlew :WooCommerce:assembleWasabiDebug && adb install -r …`).
2. Open POS in the app, wait for the initial full sync to complete.
3. Configure ApiFaker to mock the variations endpoint with a payload containing all-null string fields:
   ```bash
   adb shell am broadcast -p com.woocommerce.android.dev \
     -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
     --es api_type "wp-api" --es path "/wc/v3/variations/" --es http_method "GET" \
     --ei response_status_code 200 \
     --es response_body '[{"id":999001,"parent_id":999000,"description":null,"sku":null,"global_unique_id":null,"status":null,"price":null,"regular_price":null,"sale_price":null,"date_modified":null,"stock_quantity":null,"stock_status":null,"manage_stock":false,"backordered":false,"attributes":null,"image":null,"downloadable":false,"name":null,"type":null}]'

   adb shell am broadcast -p com.woocommerce.android.dev \
     -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
   ```
4. In POS, pull-to-refresh on the product list to trigger an incremental sync.
5. **Expected result (with the fix):** the sync completes successfully — you'll see `woocommerceandroid_pos_local_catalog_sync_completed` in logcat with `sync_type: incremental, variations_synced: 1`, and the total variations count increments by 1. Querying `PosVariationEntity WHERE remoteVariationId = 999001` shows the row with all string columns as empty strings.
6. **Without the fix**, the same steps crash the app at `WooPosVariationEntity.<init>` with `Parameter specified as non-null is null … parameter description` as soon as the mapper is reached.

Verified locally on a tablet emulator (post-fix: variation persists, total count goes from N to N+1, no crash).

Remember to revert the ApiFakerInterceptor diff and clear ApiFaker state (`… CLEAR_ENDPOINTS`, `SET_STATUS --ez enabled false`) once you're done.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.