### PR TITLE
[WOOMOB-2648] Rethrow CancellationException in POS catalog sync

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncAction.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.localcatalog
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
@@ -34,7 +35,10 @@ class WooPosSyncAction @Inject constructor(
             updateDatabaseWithFetchedItems(site, fetchResults, isFullSync)
         }.fold(
             onSuccess = { result -> result },
-            onFailure = { error -> handleSyncError(error) }
+            onFailure = { error ->
+                if (error is CancellationException) throw error
+                handleSyncError(error)
+            }
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.woopos.localcatalog
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.localcatalog.WooPosLocalCatalogSyncRepository.Companion.PAGE_SIZE
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -624,6 +625,18 @@ class WooPosSyncActionTest {
         assertThat(result).isInstanceOf(WooPosSyncResult.Failed.CatalogTooLarge::class.java)
     }
 
+    @Test(expected = CancellationException::class)
+    fun `when fetch is cancelled, then CancellationException propagates`() = runTest {
+        // GIVEN
+        givenProductFetchThrowsCancellation()
+        mockFetchVariationsSuccess(pages = listOf(0), serverDate = "2024-01-01T12:00:00Z")
+
+        // WHEN
+        sut.syncCatalog(site, null, PAGE_SIZE, 10)
+
+        // THEN — expected CancellationException
+    }
+
     // === EDGE CASE TESTS ===
 
     @Test
@@ -1016,6 +1029,19 @@ class WooPosSyncActionTest {
         whenever(
             posLocalCatalogStore.fetchRecentlyModifiedVariations(eq(site), any(), anyOrNull(), eq(page), any())
         ).thenReturn(KotlinResult.failure(Exception(errorMessage ?: "Generic error")))
+    }
+
+    private fun givenProductFetchThrowsCancellation() = runBlocking {
+        whenever(
+            posLocalCatalogStore.fetchRecentlyModifiedProducts(
+                eq(site),
+                any(),
+                anyOrNull(),
+                eq(1),
+                any(),
+                eq(null)
+            )
+        ).thenReturn(KotlinResult.failure(CancellationException("Worker cancelled")))
     }
 
     private fun givenProductCatalogTooLarge(totalPages: Int) = runBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/localcatalog/WooPosSyncActionTest.kt
@@ -637,6 +637,19 @@ class WooPosSyncActionTest {
         // THEN — expected CancellationException
     }
 
+    @Test(expected = CancellationException::class)
+    fun `when transaction is cancelled, then CancellationException propagates`() = runTest {
+        // GIVEN
+        mockFetchProductsSuccess(pages = listOf(10), serverDate = "2024-01-01T12:00:00Z")
+        mockFetchVariationsSuccess(pages = listOf(5), serverDate = "2024-01-01T12:00:00Z")
+        givenTransactionThrowsCancellation()
+
+        // WHEN
+        sut.syncCatalog(site, null, PAGE_SIZE, 10)
+
+        // THEN — expected CancellationException
+    }
+
     // === EDGE CASE TESTS ===
 
     @Test
@@ -1132,6 +1145,13 @@ class WooPosSyncActionTest {
         whenever(
             posLocalCatalogStore.executeInTransaction(any<suspend () -> KotlinResult<Unit>>())
         ).thenReturn(KotlinResult.failure(Exception(errorMessage)))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun givenTransactionThrowsCancellation() = runBlocking {
+        whenever(
+            posLocalCatalogStore.executeInTransaction(any<suspend () -> KotlinResult<Unit>>())
+        ).thenAnswer { throw CancellationException("Worker cancelled") }
     }
 
     private fun generateProducts(count: Int): List<WooPosProductEntity> {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/pos/localcatalog/WooPosLocalCatalogStore.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.store.pos.localcatalog
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
@@ -246,7 +247,7 @@ class WooPosLocalCatalogStore @Inject constructor(
         block: suspend () -> T
     ): Result<T> =
         coroutineEngine.withDefaultContext(API, this, "executeInTransaction") {
-            runCatching {
+            runCatchingCancellable {
                 database.executeInTransaction(block)
             }
         }
@@ -330,7 +331,7 @@ class WooPosLocalCatalogStore @Inject constructor(
         }
 
     suspend fun upsertProducts(products: List<WooPosProductEntity>): Result<Unit> =
-        runCatching { posProductDao.upsertProducts(products) }
+        runCatchingCancellable { posProductDao.upsertProducts(products) }
 
     suspend fun storeCatalogData(
         localSiteId: LocalOrRemoteId.LocalId,
@@ -356,13 +357,13 @@ class WooPosLocalCatalogStore @Inject constructor(
     suspend fun deleteAllProducts(
         siteId: LocalOrRemoteId.LocalId
     ): Result<Unit> =
-        runCatching { posProductDao.deleteAllProductsForSite(siteId) }
+        runCatchingCancellable { posProductDao.deleteAllProductsForSite(siteId) }
 
     suspend fun deleteProducts(
         siteId: LocalOrRemoteId.LocalId,
         productIds: List<LocalOrRemoteId.RemoteId>
     ): Result<Unit> =
-        runCatching {
+        runCatchingCancellable {
             database.executeInTransaction {
                 posProductDao.deleteProducts(siteId, productIds)
                 posVariationsDao.deleteVariationsForProducts(siteId, productIds)
@@ -373,7 +374,7 @@ class WooPosLocalCatalogStore @Inject constructor(
         siteId: LocalOrRemoteId.LocalId,
         variations: List<Pair<LocalOrRemoteId.RemoteId, LocalOrRemoteId.RemoteId>>
     ): Result<Unit> =
-        runCatching {
+        runCatchingCancellable {
             database.executeInTransaction {
                 val variationIds = variations.map { it.second }
                 posVariationsDao.deleteVariationsByIds(siteId, variationIds)
@@ -381,12 +382,12 @@ class WooPosLocalCatalogStore @Inject constructor(
         }
 
     suspend fun upsertVariations(variations: List<WooPosVariationEntity>): Result<Unit> =
-        runCatching { posVariationsDao.upsertVariations(variations) }
+        runCatchingCancellable { posVariationsDao.upsertVariations(variations) }
 
     suspend fun deleteAllVariations(
         siteId: LocalOrRemoteId.LocalId
     ): Result<Unit> =
-        runCatching { posVariationsDao.deleteAllVariationsForSite(siteId) }
+        runCatchingCancellable { posVariationsDao.deleteAllVariationsForSite(siteId) }
 
     /**
      * Observes all variations for a given product from the local database.
@@ -600,4 +601,10 @@ class WooPosLocalCatalogStore @Inject constructor(
             )
         }
     }
+
+    private inline fun <T> runCatchingCancellable(block: () -> T): Result<T> =
+        runCatching(block).also { result ->
+            val error = result.exceptionOrNull()
+            if (error is CancellationException) throw error
+        }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2648

`WooPosSyncAction.syncCatalog()` wraps a suspending block in `runCatching`, which catches `CancellationException` along with everything else. This is a [documented Kotlin coroutines anti-pattern](https://kotlinlang.org/docs/exception-handling.html#cancellation-exceptions): swallowing `CancellationException` breaks structured concurrency, because the coroutine machinery relies on it to unwind cancelled work cleanly. When something cancels the sync (e.g. WorkManager stopping the worker), the exception ends up routed through `handleSyncError` and reported as a regular failure instead of propagating as a cancellation.

This PR rethrows `CancellationException` before delegating to `handleSyncError`, bringing this code path back in line with the recommended practice. The accompanying unit test pins the behavior so we don't regress.

### Test Steps
Reproducing a real mid-flight cancellation from outside the app is impractical, so the unit test (`when fetch is cancelled, then CancellationException propagates`) is the load-bearing verification. For a manual smoke check:

1. Run `./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "*WooPosSyncActionTest"` and confirm all tests pass.
2. Install the build, open the **Point of Sale** tab on a tablet, and confirm the catalog loads normally with products visible.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.