### PR TITLE
[WOOMOB-2621] Add date selector to booking reschedule screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.bookings.reschedule
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -35,7 +36,9 @@ import com.woocommerce.android.ui.bookings.reschedule.teammember.RescheduleTeamM
 import com.woocommerce.android.ui.compose.animations.SkeletonView
 import com.woocommerce.android.ui.compose.animations.slideInNavTransition
 import com.woocommerce.android.ui.compose.animations.slideOutNavTransition
+import com.woocommerce.android.ui.compose.component.DatePickerDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
+import java.util.Calendar
 
 @Composable
 fun BookingRescheduleScreen(
@@ -59,6 +62,7 @@ fun BookingRescheduleScreen(
                 state = state,
                 onBackPressed = viewModel::onBackPressed,
                 onTeamMemberRowClicked = { navController.navigate(ReschedulePage.TeamMemberSelector.route) },
+                onDateRowClicked = viewModel::onDateRowClicked,
             )
         }
         composable(ReschedulePage.TeamMemberSelector.route) {
@@ -90,6 +94,7 @@ private fun RescheduleContent(
     state: BookingRescheduleState?,
     onBackPressed: () -> Unit,
     onTeamMemberRowClicked: () -> Unit,
+    onDateRowClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -113,6 +118,14 @@ private fun RescheduleContent(
                     onClick = onTeamMemberRowClicked,
                 )
             }
+            if (state != null && state.formattedDate.isNotEmpty()) {
+                RescheduleRow(
+                    labelRes = R.string.booking_appointment_label_date,
+                    onClick = onDateRowClicked,
+                ) {
+                    RescheduleRowValue(state.formattedDate)
+                }
+            }
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,
@@ -131,6 +144,21 @@ private fun RescheduleContent(
             }
         }
     }
+
+    state?.datePickerState?.let { pickerState ->
+        DatePickerDialog(
+            currentDate = pickerState.currentDateMillis?.let { millis ->
+                Calendar.getInstance().apply { timeInMillis = millis }
+            },
+            minDate = pickerState.minDateMillis?.let { millis ->
+                Calendar.getInstance().apply { timeInMillis = millis }
+            },
+            onDateSelected = { calendar ->
+                pickerState.onDateSelected(calendar.timeInMillis)
+            },
+            onDismissRequest = pickerState.onDismiss,
+        )
+    }
 }
 
 @Composable
@@ -138,6 +166,42 @@ private fun TeamMemberSelectorRow(
     teamMemberName: String?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+) {
+    RescheduleRow(
+        labelRes = R.string.booking_appointment_label_team_member,
+        onClick = onClick,
+        modifier = modifier,
+    ) {
+        if (teamMemberName != null) {
+            RescheduleRowValue(teamMemberName)
+        } else {
+            SkeletonView(
+                width = 80.dp,
+                height = with(LocalDensity.current) {
+                    MaterialTheme.typography.bodyMedium.fontSize.toDp()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun RescheduleRowValue(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
+}
+
+@Composable
+private fun RescheduleRow(
+    @StringRes labelRes: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    value: @Composable () -> Unit,
 ) {
     Surface(
         color = MaterialTheme.colorScheme.surface,
@@ -152,24 +216,9 @@ private fun TeamMemberSelectorRow(
                     .clickable(onClick = onClick)
                     .padding(horizontal = 16.dp, vertical = 12.dp)
             ) {
-                BookingLabel(R.string.booking_appointment_label_team_member)
+                BookingLabel(labelRes)
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    if (teamMemberName != null) {
-                        Text(
-                            text = teamMemberName,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    } else {
-                        SkeletonView(
-                            width = 80.dp,
-                            height = with(LocalDensity.current) {
-                                MaterialTheme.typography.bodyMedium.fontSize.toDp()
-                            },
-                        )
-                    }
+                    value()
                     Icon(
                         painter = painterResource(id = R.drawable.ic_arrow_right),
                         contentDescription = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleScreen.kt
@@ -39,6 +39,7 @@ import com.woocommerce.android.ui.compose.animations.slideOutNavTransition
 import com.woocommerce.android.ui.compose.component.DatePickerDialog
 import com.woocommerce.android.ui.compose.component.Toolbar
 import java.util.Calendar
+import java.util.TimeZone
 
 @Composable
 fun BookingRescheduleScreen(
@@ -146,12 +147,13 @@ private fun RescheduleContent(
     }
 
     state?.datePickerState?.let { pickerState ->
+        val utcTimeZone = TimeZone.getTimeZone("UTC")
         DatePickerDialog(
             currentDate = pickerState.currentDateMillis?.let { millis ->
-                Calendar.getInstance().apply { timeInMillis = millis }
+                Calendar.getInstance(utcTimeZone).apply { timeInMillis = millis }
             },
             minDate = pickerState.minDateMillis?.let { millis ->
-                Calendar.getInstance().apply { timeInMillis = millis }
+                Calendar.getInstance(utcTimeZone).apply { timeInMillis = millis }
             },
             onDateSelected = { calendar ->
                 pickerState.onDateSelected(calendar.timeInMillis)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.clock
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.bookings.Booking
 import com.woocommerce.android.ui.bookings.BookingResource
 import com.woocommerce.android.ui.bookings.BookingsRepository
@@ -44,8 +46,11 @@ import javax.inject.Inject
 class BookingRescheduleViewModel @Inject constructor(
     private val bookingsRepository: BookingsRepository,
     private val clock: Clock,
+    selectedSite: SelectedSite,
     savedState: SavedStateHandle,
 ) : ScopedViewModel(savedState) {
+
+    private val storeZoneId = selectedSite.get().clock.zone
 
     private val navArgs: BookingRescheduleFragmentArgs by savedState.navArgs()
 
@@ -111,7 +116,6 @@ class BookingRescheduleViewModel @Inject constructor(
         )
     }.asLiveData()
 
-
     init {
         launch {
             combine(
@@ -163,8 +167,12 @@ class BookingRescheduleViewModel @Inject constructor(
         datePickerState.value = null
     }
 
+    private fun storeToday(): LocalDate = Instant.now(clock).atZone(storeZoneId).toLocalDate()
+
+    private fun storeNow(): LocalDateTime = Instant.now(clock).atZone(storeZoneId).toLocalDateTime()
+
     private fun buildDatePickerState(currentDate: LocalDate?): BookingRescheduleState.DatePickerState {
-        val today = LocalDate.now(clock)
+        val today = storeToday()
         return BookingRescheduleState.DatePickerState(
             currentDateMillis = currentDate?.toStartOfDayUtcMillis(),
             minDateMillis = today.toStartOfDayUtcMillis(),
@@ -204,11 +212,11 @@ class BookingRescheduleViewModel @Inject constructor(
     }
 
     private fun buildDateRange(month: YearMonth): Pair<LocalDateTime, LocalDateTime> {
-        val today = LocalDate.now(clock)
+        val today = storeToday()
         val effectiveMonth = maxOf(month, YearMonth.from(today))
         val rangeStartDate = maxOf(effectiveMonth.atDay(1), today)
         val startDate = if (rangeStartDate == today) {
-            LocalDateTime.now(clock)
+            storeNow()
         } else {
             rangeStartDate.atStartOfDay()
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
@@ -33,6 +34,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.YearMonth
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -57,6 +59,7 @@ class BookingRescheduleViewModel @Inject constructor(
     val state: LiveData<BookingRescheduleState> = _state.asLiveData()
 
     private val teamMemberIdOverride = MutableStateFlow<Long?>(null)
+    private val selectedDate = MutableStateFlow<LocalDate?>(null)
 
     private val booking: Flow<Booking> = flow {
         emit(bookingsRepository.getBooking(navArgs.bookingId))
@@ -79,20 +82,36 @@ class BookingRescheduleViewModel @Inject constructor(
     private val teamMember: Flow<BookingResource?> = effectiveResourceId
         .flatMapLatest { bookingsRepository.observeResource(it) }
 
+    private val effectiveDate: Flow<LocalDate> = combine(
+        booking,
+        selectedDate,
+    ) { booking, override ->
+        override ?: booking.start.atOffset(ZoneOffset.UTC).toLocalDate()
+    }.distinctUntilChanged()
+
     init {
         launch {
-            combine(booking, effectiveResourceId) { booking, resourceId ->
-                AvailabilityFetchParams(
-                    productId = booking.productId,
+            combine(
+                booking.map { it.productId },
+                effectiveResourceId,
+                effectiveDate,
+            ) { productId, resourceId, date ->
+                AvailabilityFetchKey(
+                    productId = productId,
                     resourceId = resourceId,
-                    dateRange = buildDateRange(booking),
+                    month = YearMonth.from(date),
                 )
-            }.collectLatest { params ->
-                _state.update {
-                    it.copy(teamMemberId = params.resourceId, productId = params.productId)
+            }.distinctUntilChanged()
+                .collectLatest { key ->
+                    _state.update {
+                        it.copy(teamMemberId = key.resourceId, productId = key.productId)
+                    }
+                    loadAvailability(
+                        productId = key.productId,
+                        resourceId = key.resourceId,
+                        dateRange = buildDateRange(key.month),
+                    )
                 }
-                loadAvailability(params)
-            }
         }
         launch {
             teamMember.collect { member ->
@@ -136,6 +155,9 @@ class BookingRescheduleViewModel @Inject constructor(
                 datePickerState = null,
             )
         }
+        selectedDate.value = Instant.ofEpochMilli(dateMillis)
+            .atOffset(ZoneOffset.UTC)
+            .toLocalDate()
     }
 
     private fun onDatePickerDismissed() {
@@ -163,13 +185,17 @@ class BookingRescheduleViewModel @Inject constructor(
         teamMemberIdOverride.value = newResourceId
     }
 
-    private suspend fun loadAvailability(params: AvailabilityFetchParams) {
+    private suspend fun loadAvailability(
+        productId: Long,
+        resourceId: Long,
+        dateRange: Pair<LocalDateTime, LocalDateTime>,
+    ) {
         _state.update { it.copy(availabilityState = BookingRescheduleState.AvailabilityState.Loading) }
         bookingsRepository.fetchProductAvailability(
-            productId = params.productId,
-            startDate = params.dateRange.first,
-            endDate = params.dateRange.second,
-            resourceId = params.resourceId,
+            productId = productId,
+            startDate = dateRange.first,
+            endDate = dateRange.second,
+            resourceId = resourceId,
         ).onSuccess { availability ->
             _state.update {
                 it.copy(availabilityState = BookingRescheduleState.AvailabilityState.Loaded(availability))
@@ -180,26 +206,23 @@ class BookingRescheduleViewModel @Inject constructor(
         }
     }
 
-    private fun buildDateRange(booking: Booking): Pair<LocalDateTime, LocalDateTime> {
+    private fun buildDateRange(month: YearMonth): Pair<LocalDateTime, LocalDateTime> {
         val today = LocalDate.now(clock)
-        val bookingDate = booking.start.atOffset(ZoneOffset.UTC).toLocalDate()
-        val effectiveDate = maxOf(bookingDate, today)
-        val monthStart = effectiveDate.withDayOfMonth(1)
-        val rangeStartDate = maxOf(monthStart, today)
+        val effectiveMonth = maxOf(month, YearMonth.from(today))
+        val rangeStartDate = maxOf(effectiveMonth.atDay(1), today)
         val startDate = if (rangeStartDate == today) {
             LocalDateTime.now(clock)
         } else {
             rangeStartDate.atStartOfDay()
         }
-        val endDate = effectiveDate.withDayOfMonth(effectiveDate.lengthOfMonth())
-            .atTime(LocalTime.MAX)
+        val endDate = effectiveMonth.atEndOfMonth().atTime(LocalTime.MAX)
         return startDate to endDate
     }
 
-    private data class AvailabilityFetchParams(
+    private data class AvailabilityFetchKey(
         val productId: Long,
         val resourceId: Long,
-        val dateRange: Pair<LocalDateTime, LocalDateTime>,
+        val month: YearMonth,
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingAvailabilityDto
 import java.time.Clock
@@ -53,13 +52,12 @@ class BookingRescheduleViewModel @Inject constructor(
     private val dateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
         .withZone(ZoneOffset.UTC)
 
-    private var currentSelectedDate: LocalDate? = null
-
-    private val _state = MutableStateFlow(BookingRescheduleState())
-    val state: LiveData<BookingRescheduleState> = _state.asLiveData()
-
     private val teamMemberIdOverride = MutableStateFlow<Long?>(null)
     private val selectedDate = MutableStateFlow<LocalDate?>(null)
+    private val availabilityState = MutableStateFlow<BookingRescheduleState.AvailabilityState>(
+        BookingRescheduleState.AvailabilityState.Loading
+    )
+    private val datePickerState = MutableStateFlow<BookingRescheduleState.DatePickerState?>(null)
 
     private val booking: Flow<Booking> = flow {
         emit(bookingsRepository.getBooking(navArgs.bookingId))
@@ -89,6 +87,31 @@ class BookingRescheduleViewModel @Inject constructor(
         override ?: booking.start.atOffset(ZoneOffset.UTC).toLocalDate()
     }.distinctUntilChanged()
 
+    private val dateUiState = combine(
+        effectiveDate,
+        datePickerState,
+    ) { date, picker ->
+        date to picker
+    }
+
+    val state: LiveData<BookingRescheduleState> = combine(
+        booking.map { it.productId }.distinctUntilChanged(),
+        effectiveResourceId,
+        teamMember,
+        availabilityState,
+        dateUiState,
+    ) { productId, resourceId, member, availability, (date, picker) ->
+        BookingRescheduleState(
+            teamMemberId = resourceId,
+            teamMemberName = member?.name,
+            productId = productId,
+            availabilityState = availability,
+            formattedDate = formatDate(date),
+            datePickerState = picker,
+        )
+    }.asLiveData()
+
+
     init {
         launch {
             combine(
@@ -103,9 +126,6 @@ class BookingRescheduleViewModel @Inject constructor(
                 )
             }.distinctUntilChanged()
                 .collectLatest { key ->
-                    _state.update {
-                        it.copy(teamMemberId = key.resourceId, productId = key.productId)
-                    }
                     loadAvailability(
                         productId = key.productId,
                         resourceId = key.resourceId,
@@ -114,21 +134,11 @@ class BookingRescheduleViewModel @Inject constructor(
                 }
         }
         launch {
-            teamMember.collect { member ->
-                _state.update { it.copy(teamMemberName = member?.name) }
-            }
-        }
-        launch {
             booking.collect { booking ->
-                if (currentSelectedDate == null) {
+                if (selectedDate.value == null) {
                     val initialDate = booking.start.atOffset(ZoneOffset.UTC).toLocalDate()
-                    currentSelectedDate = initialDate
-                    _state.update {
-                        it.copy(
-                            formattedDate = formatDate(initialDate),
-                            datePickerState = buildDatePickerState(initialDate),
-                        )
-                    }
+                    selectedDate.value = initialDate
+                    datePickerState.value = buildDatePickerState(initialDate)
                 }
             }
         }
@@ -139,29 +149,18 @@ class BookingRescheduleViewModel @Inject constructor(
     }
 
     fun onDateRowClicked() {
-        _state.update {
-            it.copy(datePickerState = buildDatePickerState(currentSelectedDate))
-        }
+        datePickerState.value = buildDatePickerState(selectedDate.value)
     }
 
     private fun onDateSelected(dateMillis: Long) {
-        val date = Instant.ofEpochMilli(dateMillis)
-            .atOffset(ZoneOffset.UTC)
-            .toLocalDate()
-        currentSelectedDate = date
-        _state.update {
-            it.copy(
-                formattedDate = formatDate(date),
-                datePickerState = null,
-            )
-        }
+        datePickerState.value = null
         selectedDate.value = Instant.ofEpochMilli(dateMillis)
             .atOffset(ZoneOffset.UTC)
             .toLocalDate()
     }
 
     private fun onDatePickerDismissed() {
-        _state.update { it.copy(datePickerState = null) }
+        datePickerState.value = null
     }
 
     private fun buildDatePickerState(currentDate: LocalDate?): BookingRescheduleState.DatePickerState {
@@ -190,18 +189,16 @@ class BookingRescheduleViewModel @Inject constructor(
         resourceId: Long,
         dateRange: Pair<LocalDateTime, LocalDateTime>,
     ) {
-        _state.update { it.copy(availabilityState = BookingRescheduleState.AvailabilityState.Loading) }
+        availabilityState.value = BookingRescheduleState.AvailabilityState.Loading
         bookingsRepository.fetchProductAvailability(
             productId = productId,
             startDate = dateRange.first,
             endDate = dateRange.second,
             resourceId = resourceId,
         ).onSuccess { availability ->
-            _state.update {
-                it.copy(availabilityState = BookingRescheduleState.AvailabilityState.Loaded(availability))
-            }
+            availabilityState.value = BookingRescheduleState.AvailabilityState.Loaded(availability)
         }.onFailure {
-            _state.update { it.copy(availabilityState = BookingRescheduleState.AvailabilityState.Error) }
+            availabilityState.value = BookingRescheduleState.AvailabilityState.Error
             triggerEvent(MultiLiveEvent.Event.ShowSnackbar(R.string.error_generic))
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModel.kt
@@ -29,10 +29,13 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingAvailabilityDto
 import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -44,6 +47,11 @@ class BookingRescheduleViewModel @Inject constructor(
 ) : ScopedViewModel(savedState) {
 
     private val navArgs: BookingRescheduleFragmentArgs by savedState.navArgs()
+
+    private val dateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
+        .withZone(ZoneOffset.UTC)
+
+    private var currentSelectedDate: LocalDate? = null
 
     private val _state = MutableStateFlow(BookingRescheduleState())
     val state: LiveData<BookingRescheduleState> = _state.asLiveData()
@@ -91,10 +99,64 @@ class BookingRescheduleViewModel @Inject constructor(
                 _state.update { it.copy(teamMemberName = member?.name) }
             }
         }
+        launch {
+            booking.collect { booking ->
+                if (currentSelectedDate == null) {
+                    val initialDate = booking.start.atOffset(ZoneOffset.UTC).toLocalDate()
+                    currentSelectedDate = initialDate
+                    _state.update {
+                        it.copy(
+                            formattedDate = formatDate(initialDate),
+                            datePickerState = buildDatePickerState(initialDate),
+                        )
+                    }
+                }
+            }
+        }
     }
 
     fun onBackPressed() {
         triggerEvent(MultiLiveEvent.Event.Exit)
+    }
+
+    fun onDateRowClicked() {
+        _state.update {
+            it.copy(datePickerState = buildDatePickerState(currentSelectedDate))
+        }
+    }
+
+    private fun onDateSelected(dateMillis: Long) {
+        val date = Instant.ofEpochMilli(dateMillis)
+            .atOffset(ZoneOffset.UTC)
+            .toLocalDate()
+        currentSelectedDate = date
+        _state.update {
+            it.copy(
+                formattedDate = formatDate(date),
+                datePickerState = null,
+            )
+        }
+    }
+
+    private fun onDatePickerDismissed() {
+        _state.update { it.copy(datePickerState = null) }
+    }
+
+    private fun buildDatePickerState(currentDate: LocalDate?): BookingRescheduleState.DatePickerState {
+        val today = LocalDate.now(clock)
+        return BookingRescheduleState.DatePickerState(
+            currentDateMillis = currentDate?.toStartOfDayUtcMillis(),
+            minDateMillis = today.toStartOfDayUtcMillis(),
+            onDateSelected = ::onDateSelected,
+            onDismiss = ::onDatePickerDismissed,
+        )
+    }
+
+    private fun LocalDate.toStartOfDayUtcMillis(): Long =
+        atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+
+    private fun formatDate(date: LocalDate): String {
+        return dateFormatter.format(date.atStartOfDay(ZoneOffset.UTC).toInstant())
     }
 
     fun onTeamMemberChanged(newResourceId: Long) {
@@ -146,10 +208,19 @@ data class BookingRescheduleState(
     val teamMemberName: String? = null,
     val productId: Long = 0L,
     val availabilityState: AvailabilityState = AvailabilityState.Loading,
+    val formattedDate: String = "",
+    val datePickerState: DatePickerState? = null,
 ) {
     sealed interface AvailabilityState {
         data object Loading : AvailabilityState
         data object Error : AvailabilityState
         data class Loaded(val availability: BookingAvailabilityDto) : AvailabilityState
     }
+
+    data class DatePickerState(
+        val currentDateMillis: Long?,
+        val minDateMillis: Long?,
+        val onDateSelected: (Long) -> Unit,
+        val onDismiss: () -> Unit,
+    )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModelTest.kt
@@ -276,6 +276,116 @@ class BookingRescheduleViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when booking loaded, then initial date matches booking start`() = testBlocking {
+        // GIVEN
+        val now = LocalDateTime.of(2026, 4, 10, 10, 0, 0)
+        val bookingStart = LocalDate.of(2026, 4, 16)
+            .atStartOfDay()
+            .toInstant(ZoneOffset.UTC)
+        val booking = getSampleBooking(bookingStart)
+
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        // WHEN
+        val viewModel = createViewModel(now)
+
+        // THEN
+        val state = viewModel.state.value!!
+        assertThat(state.formattedDate).isNotEmpty()
+    }
+
+    @Test
+    fun `when booking loaded, then date picker is initially visible`() = testBlocking {
+        // GIVEN
+        val booking = getSampleBooking(Instant.now())
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        val state = viewModel.state.value!!
+        assertThat(state.datePickerState).isNotNull()
+    }
+
+    @Test
+    fun `when date selected, then formatted date updates and picker is dismissed`() = testBlocking {
+        // GIVEN
+        val now = LocalDateTime.of(2026, 4, 10, 10, 0, 0)
+        val bookingStart = LocalDate.of(2026, 4, 16)
+            .atStartOfDay()
+            .toInstant(ZoneOffset.UTC)
+        val booking = getSampleBooking(bookingStart)
+
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        val viewModel = createViewModel(now)
+        val pickerState = viewModel.state.value!!.datePickerState!!
+
+        // WHEN
+        val newDateMillis = LocalDate.of(2026, 4, 20)
+            .atStartOfDay(ZoneOffset.UTC)
+            .toInstant()
+            .toEpochMilli()
+        pickerState.onDateSelected(newDateMillis)
+
+        // THEN
+        val state = viewModel.state.value!!
+        assertThat(state.formattedDate).isNotEmpty()
+        assertThat(state.datePickerState).isNull()
+    }
+
+    @Test
+    fun `when date picker dismissed, then picker state is null`() = testBlocking {
+        // GIVEN
+        val booking = getSampleBooking(Instant.now())
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        val viewModel = createViewModel()
+        assertThat(viewModel.state.value!!.datePickerState).isNotNull()
+
+        // WHEN
+        viewModel.state.value!!.datePickerState!!.onDismiss()
+
+        // THEN
+        assertThat(viewModel.state.value!!.datePickerState).isNull()
+    }
+
+    @Test
+    fun `when date row clicked, then date picker becomes visible with minDate as today`() = testBlocking {
+        // GIVEN
+        val now = LocalDateTime.of(2026, 4, 10, 10, 0, 0)
+        val booking = getSampleBooking(Instant.now())
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        val viewModel = createViewModel(now)
+        viewModel.state.value!!.datePickerState!!.onDismiss()
+        assertThat(viewModel.state.value!!.datePickerState).isNull()
+
+        // WHEN
+        viewModel.onDateRowClicked()
+
+        // THEN
+        val pickerState = viewModel.state.value!!.datePickerState
+        assertThat(pickerState).isNotNull()
+        val todayMillis = LocalDate.of(2026, 4, 10)
+            .atStartOfDay(ZoneOffset.UTC)
+            .toInstant()
+            .toEpochMilli()
+        assertThat(pickerState!!.minDateMillis).isEqualTo(todayMillis)
+    }
+
+    @Test
     fun `given booking not found, when loading, then shows error and exits`() = testBlocking {
         // GIVEN
         whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(null)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModelTest.kt
@@ -386,6 +386,70 @@ class BookingRescheduleViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when date in different month selected, then availability is re-fetched`() = testBlocking {
+        // GIVEN
+        val now = LocalDateTime.of(2026, 4, 10, 10, 0, 0)
+        val bookingStart = LocalDate.of(2026, 4, 16)
+            .atStartOfDay()
+            .toInstant(ZoneOffset.UTC)
+        val booking = getSampleBooking(bookingStart)
+
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        val viewModel = createViewModel(now)
+
+        // WHEN — select a date in May
+        val mayDateMillis = LocalDate.of(2026, 5, 15)
+            .atStartOfDay(ZoneOffset.UTC)
+            .toInstant()
+            .toEpochMilli()
+        viewModel.state.value!!.datePickerState!!.onDateSelected(mayDateMillis)
+
+        // THEN — availability fetched for May
+        val expectedStart = LocalDate.of(2026, 5, 1).atStartOfDay()
+        val expectedEnd = LocalDate.of(2026, 5, 31).atTime(LocalTime.MAX)
+        verify(bookingsRepository).fetchProductAvailability(
+            productId = eq(PRODUCT_ID),
+            startDate = eq(expectedStart),
+            endDate = eq(expectedEnd),
+            resourceId = eq(RESOURCE_ID),
+        )
+    }
+
+    @Test
+    fun `when date in same month selected, then availability is not re-fetched`() = testBlocking {
+        // GIVEN
+        val now = LocalDateTime.of(2026, 4, 10, 10, 0, 0)
+        val bookingStart = LocalDate.of(2026, 4, 16)
+            .atStartOfDay()
+            .toInstant(ZoneOffset.UTC)
+        val booking = getSampleBooking(bookingStart)
+
+        whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(booking)
+        whenever(bookingsRepository.fetchProductAvailability(any(), any(), any(), any()))
+            .thenReturn(Result.success(sampleAvailability))
+
+        val viewModel = createViewModel(now)
+
+        // WHEN — select a different date in April
+        val aprilDateMillis = LocalDate.of(2026, 4, 20)
+            .atStartOfDay(ZoneOffset.UTC)
+            .toInstant()
+            .toEpochMilli()
+        viewModel.state.value!!.datePickerState!!.onDateSelected(aprilDateMillis)
+
+        // THEN — availability fetched only once (initial load)
+        verify(bookingsRepository, times(1)).fetchProductAvailability(
+            productId = any(),
+            startDate = any(),
+            endDate = any(),
+            resourceId = any(),
+        )
+    }
+
+    @Test
     fun `given booking not found, when loading, then shows error and exits`() = testBlocking {
         // GIVEN
         whenever(bookingsRepository.getBooking(BOOKING_ID)).thenReturn(null)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/reschedule/BookingRescheduleViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.bookings.reschedule
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -17,6 +18,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingAvailabilityDto
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingOrderInfo
 import org.wordpress.android.fluxc.persistence.entity.BookingEntity
@@ -482,10 +484,15 @@ class BookingRescheduleViewModelTest : BaseUnitTest() {
     ): BookingRescheduleViewModel {
         val fixedInstant = now.toInstant(ZoneOffset.UTC)
         val clock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
+        val siteModel = SiteModel().apply { timezone = "0" }
+        val selectedSite: SelectedSite = mock {
+            on { get() } doReturn siteModel
+        }
         return BookingRescheduleViewModel(
             savedState = SavedStateHandle(mapOf("bookingId" to BOOKING_ID)),
             bookingsRepository = repository,
             clock = clock,
+            selectedSite = selectedSite,
         ).also {
             it.state.observeForever { }
         }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2621

Adds a date selector row and picker dialog to the booking reschedule screen. Selecting a date in a different month triggers an availability refresh; same-month selections are deduplicated via a custom `AvailabilityFetchKey` that compares only month/year.

The selected date is wired into the availability refresh as an `effectiveDate` flow — combined with `productId` and `effectiveResourceId` to form the fetch key. `distinctUntilChanged` on this key ensures we only re-fetch when the month actually changes.

The final ViewModel state is derived reactively from a single `combine` of all individual flows (`booking`, `effectiveResourceId`, `teamMember`, `availabilityState`, `dateUiState`), following the `BookingDetailsViewModel` pattern. This replaces manual `_state.update` calls and makes the state derivation declarative.

<details>
<summary><strong>Store timezone fix</strong></summary>

The DatePicker minimum selectable date ("today") was previously computed using `LocalDate.now(clock)` where `clock` is `Clock.systemDefaultZone()` — the **device** timezone. When the device timezone differs significantly from the store timezone (e.g., device in Auckland UTC+12, store in UTC-8), the device can be a full day ahead of the store. This caused "today" from the store perspective to be unselectable in the picker.

**ViewModel fix**: Introduced `storeZoneId` from `SelectedSite.get().clock.zone` and two helpers:
- `storeToday()` = `Instant.now(clock).atZone(storeZoneId).toLocalDate()` — the current instant interpreted in the store timezone
- `storeNow()` = `Instant.now(clock).atZone(storeZoneId).toLocalDateTime()`

These replace all `LocalDate.now(clock)` / `LocalDateTime.now(clock)` calls in `buildDatePickerState()` and `buildDateRange()`, so date boundaries are always from the store perspective. The injected `Clock` is kept for testability (fixed clock in tests), while `storeZoneId` provides the correct timezone.



</details>

### Test Steps
1. Open a booking that has rescheduling enabled
2. Tap "Reschedule" — verify the date row shows the booking start date in full format and the date picker opens automatically
3. Dismiss the picker — verify it closes
4. Tap the date row — verify the picker reopens with today as the minimum selectable date
5. Select a date in a different month — verify the availability reloads
6. Select a different date in the same month — verify no additional availability fetch occurs
7. Change device timezone to one far from the store timezone (e.g., Auckland UTC+12) — verify the store "today" is still selectable in the picker

### Images/gif


https://github.com/user-attachments/assets/e18167b3-f7a7-4858-a9b7-a760fbe58f59



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.