### PR TITLE
[WOOMOB-2674] Fix push notification gating for Woo and WPCom

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -86,7 +86,6 @@ class NotificationMessageHandler @Inject constructor(
 
         val notification = notificationModel.toAppModel(resourceProvider)
         val notificationSource = messageData.detectNotificationSource(notification.remoteNoteId)
-        val registrationStatusResult = runBlocking { registrationStatus(notification.remoteSiteId) }
         val pushUserId = messageData[PUSH_ARG_USER]
         val hasWpComAccessToken = accountStore.hasAccessToken()
 
@@ -95,13 +94,12 @@ class NotificationMessageHandler @Inject constructor(
             return
         }
 
-        if (notificationSource == NotificationSource.WPCOM && !hasWpComAccessToken) {
-            wooLog.e(NOTIFICATIONS, "User is not logged in!")
-            return
-        }
-
         if (notificationSource == NotificationSource.WPCOM) {
-            // At this point 'note_id' is always available in the notification bundle.
+            if (!hasWpComAccessToken) {
+                wooLog.e(NOTIFICATIONS, "User is not logged in!")
+                return
+            }
+
             if (notification.remoteNoteId == 0L) {
                 wooLog.e(NOTIFICATIONS, "Push notification received without a valid note_id in the payload!")
                 return
@@ -113,6 +111,7 @@ class NotificationMessageHandler @Inject constructor(
                 return
             }
 
+            val registrationStatusResult = runBlocking { registrationStatus(notification.remoteSiteId) }
             if (registrationStatusResult.isWooRegistered) {
                 wooLog.d(NOTIFICATIONS, "Skipping WPCOM notification, already registered with Woo Core")
                 return
@@ -278,10 +277,7 @@ class NotificationMessageHandler @Inject constructor(
 
     private fun Map<String, String>.detectNotificationSource(remoteNoteId: Long): NotificationSource =
         when {
-            this[PUSH_ARG_USER] != null || remoteNoteId != 0L -> {
-                NotificationSource.WPCOM
-            }
-
+            this[PUSH_ARG_USER] != null || remoteNoteId != 0L -> NotificationSource.WPCOM
             else -> NotificationSource.WOO
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -48,6 +48,7 @@ class NotificationMessageHandler @Inject constructor(
         private const val PUSH_NOTIFICATION_ID = 10000
 
         private const val PUSH_ARG_USER = "user"
+
         @VisibleForTesting
         const val MAX_INBOX_ITEMS = 5
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -48,6 +48,7 @@ class NotificationMessageHandler @Inject constructor(
         private const val PUSH_NOTIFICATION_ID = 10000
 
         private const val PUSH_ARG_USER = "user"
+        private const val PUSH_ARG_NOTE_ID = "note_id"
 
         @VisibleForTesting
         const val MAX_INBOX_ITEMS = 5
@@ -86,33 +87,38 @@ class NotificationMessageHandler @Inject constructor(
         }
 
         val notification = notificationModel.toAppModel(resourceProvider)
+        val notificationSource = messageData.source(notification.remoteNoteId)
         val registrationStatusResult = runBlocking { registrationStatus(notification.remoteSiteId) }
-        val isRegisteredForWooPush =
-            registrationStatusResult == PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY ||
-                registrationStatusResult == PushNotificationRegistrationStatus.Status.REGISTERED_BOTH
         val pushUserId = messageData[PUSH_ARG_USER]
+        val hasWpComAccessToken = accountStore.hasAccessToken()
 
-        // We need to filter out duplicate notifications from the WPCOM system
-        if (!isWooSiteVisible(notification.remoteSiteId)) {
+        if (hasWpComAccessToken && !isWooSiteVisible(notification.remoteSiteId)) {
             wooLog.w(NOTIFICATIONS, "Skipping notification, site ${notification.remoteSiteId} is not visible")
             return
         }
-        if (isRegisteredForWooPush) {
-            if (notification.remoteNoteId > 0L) {
+
+        if (notificationSource == NotificationSource.WPCOM && !hasWpComAccessToken) {
+            wooLog.e(NOTIFICATIONS, "User is not logged in!")
+            return
+        }
+
+        if (notificationSource == NotificationSource.WPCOM) {
+            // At this point 'note_id' is always available in the notification bundle.
+            if (notification.remoteNoteId == 0L) {
+                wooLog.e(NOTIFICATIONS, "Push notification received without a valid note_id in the payload!")
+                return
+            }
+
+            // At this point, pushUserId is always set server side, but better to double check it here.
+            if (accountStore.account.userId.toString() != pushUserId) {
+                wooLog.e(NOTIFICATIONS, "WP.com userId found in the app doesn't match with the ID in the PN. Aborting.")
+                return
+            }
+
+            if (registrationStatusResult.isWooRegistered) {
                 wooLog.d(NOTIFICATIONS, "Skipping WPCOM notification, already registered with Woo Core")
                 return
             }
-        } else if (!accountStore.hasAccessToken()) {
-            wooLog.e(NOTIFICATIONS, "User is not logged in!")
-            return
-        } else if (notification.remoteNoteId == 0L) {
-            // At this point 'note_id' is always available in the notification bundle.
-            wooLog.e(NOTIFICATIONS, "Push notification received without a valid note_id in the payload!")
-            return
-        } else if (accountStore.account.userId.toString() != pushUserId) {
-            // At this point, pushUserId is always set server side, but better to double check it here.
-            wooLog.e(NOTIFICATIONS, "WP.com userId found in the app doesn't match with the ID in the PN. Aborting.")
-            return
         }
 
         dispatchBackgroundEvents(notificationModel)
@@ -270,5 +276,17 @@ class NotificationMessageHandler @Inject constructor(
                 .filter { it.channelType == type.name && it.remoteSiteId == remoteSiteId }
                 .forEach { cancelNotification(it.id) }
         }
+    }
+
+    private fun Map<String, String>.source(remoteNoteId: Long): NotificationSource {
+        val isWooNotification = this[PUSH_ARG_USER] == null &&
+            this[PUSH_ARG_NOTE_ID] == null &&
+            remoteNoteId == 0L
+        return if (isWooNotification) NotificationSource.WOO else NotificationSource.WPCOM
+    }
+
+    private enum class NotificationSource {
+        WOO,
+        WPCOM
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -48,8 +48,6 @@ class NotificationMessageHandler @Inject constructor(
         private const val PUSH_NOTIFICATION_ID = 10000
 
         private const val PUSH_ARG_USER = "user"
-        private const val PUSH_ARG_NOTE_ID = "note_id"
-
         @VisibleForTesting
         const val MAX_INBOX_ITEMS = 5
     }
@@ -87,7 +85,7 @@ class NotificationMessageHandler @Inject constructor(
         }
 
         val notification = notificationModel.toAppModel(resourceProvider)
-        val notificationSource = messageData.source(notification.remoteNoteId)
+        val notificationSource = messageData.detectNotificationSource(notification.remoteNoteId)
         val registrationStatusResult = runBlocking { registrationStatus(notification.remoteSiteId) }
         val pushUserId = messageData[PUSH_ARG_USER]
         val hasWpComAccessToken = accountStore.hasAccessToken()
@@ -278,12 +276,14 @@ class NotificationMessageHandler @Inject constructor(
         }
     }
 
-    private fun Map<String, String>.source(remoteNoteId: Long): NotificationSource {
-        val isWooNotification = this[PUSH_ARG_USER] == null &&
-            this[PUSH_ARG_NOTE_ID] == null &&
-            remoteNoteId == 0L
-        return if (isWooNotification) NotificationSource.WOO else NotificationSource.WPCOM
-    }
+    private fun Map<String, String>.detectNotificationSource(remoteNoteId: Long): NotificationSource =
+        when {
+            this[PUSH_ARG_USER] != null || remoteNoteId != 0L -> {
+                NotificationSource.WPCOM
+            }
+
+            else -> NotificationSource.WOO
+        }
 
     private enum class NotificationSource {
         WOO,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -11,6 +11,9 @@ import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_ORD
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_ORDER_NOTE_FULL_DATA_SITE_2
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_REVIEW_NOTE_FULL_DATA_2
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_REVIEW_NOTE_FULL_DATA_SITE_2
+import com.woocommerce.android.notifications.push.PushNotificationRegistrationStatus.Status.REGISTERED_BOTH
+import com.woocommerce.android.notifications.push.PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY
+import com.woocommerce.android.notifications.push.PushNotificationRegistrationStatus.Status.UNREGISTERED
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.sitepicker.sitevisibility.GetWooVisibleSites
 import com.woocommerce.android.util.Base64Decoder
@@ -54,7 +57,9 @@ class NotificationMessageHandlerTest {
     private val accountStore: AccountStore = mock {
         on { account } doReturn accountModel
     }
-    private val registrationStatus: PushNotificationRegistrationStatus = mock()
+    private val registrationStatus: PushNotificationRegistrationStatus = mock {
+        onBlocking { invoke(any()) } doReturn UNREGISTERED
+    }
     private val dispatcher: Dispatcher = mock()
     private val actionCaptor: KArgumentCaptor<Action<*>> = argumentCaptor()
     private val wooLog: WooLog = mock()
@@ -161,7 +166,6 @@ class NotificationMessageHandlerTest {
 
     @Test
     fun `when the user is not logged in, then do not process the incoming notification`() = runTest {
-        whenever(registrationStatus.invoke(any())).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
         doReturn(false).whenever(accountStore).hasAccessToken()
 
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
@@ -191,7 +195,6 @@ class NotificationMessageHandlerTest {
 
     @Test
     fun `when the user id does not match, then do not process the notification`() = runTest {
-        whenever(registrationStatus.invoke(any())).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
         val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload(userId = 67890)
 
         notificationMessageHandler.onNewMessageReceived(payload)
@@ -205,9 +208,6 @@ class NotificationMessageHandlerTest {
     @Test
     fun `given wpcom payload is missing note id, when notification received, then keep legacy note id validation`() =
         runTest {
-            whenever(
-                registrationStatus.invoke(any())
-            ).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
             val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload().minus("note_id")
             createWooNotificationMessageHandler()
 
@@ -223,9 +223,6 @@ class NotificationMessageHandlerTest {
     @Test
     fun `given payload has no wpcom user and parsed note id is zero, when notification received, then treat it as Woo`() =
         runTest {
-            whenever(
-                registrationStatus.invoke(any())
-            ).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
             val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload().minus("user")
             createWooNotificationMessageHandler()
 
@@ -249,7 +246,7 @@ class NotificationMessageHandlerTest {
     @Test
     fun `given site registered in both systems, when wpcom notification received, then skip notification`() = runTest {
         whenever(registrationStatus.invoke(any()))
-            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_BOTH)
+            .thenReturn(REGISTERED_BOTH)
 
         // WPCOM notifications have remoteNoteId > 0
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
@@ -265,7 +262,7 @@ class NotificationMessageHandlerTest {
     fun `given site registered in both systems and user mismatch, when wpcom notification received, then keep legacy validation`() =
         runTest {
             whenever(registrationStatus.invoke(any()))
-                .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_BOTH)
+                .thenReturn(REGISTERED_BOTH)
             val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload(userId = 67890)
 
             notificationMessageHandler.onNewMessageReceived(payload)
@@ -278,19 +275,19 @@ class NotificationMessageHandlerTest {
         }
 
     @Test
-    fun `given site registered only in Woo, when wpcom notification received, then process notification`() = runTest {
+    fun `given site registered only in Woo, when wpcom notification received, then skip notification`() = runTest {
         whenever(registrationStatus.invoke(any()))
-            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY)
+            .thenReturn(REGISTERED_WOO_ONLY)
 
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
 
-        verify(dispatcher, atLeastOnce()).dispatch(any())
+        verify(dispatcher, never()).dispatch(any())
     }
 
     @Test
     fun `given woo push registered and site is visible, when woo notification received, then process it`() = runTest {
         whenever(registrationStatus.invoke(any()))
-            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY)
+            .thenReturn(REGISTERED_WOO_ONLY)
         createWooNotificationMessageHandler()
 
         notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
@@ -301,7 +298,7 @@ class NotificationMessageHandlerTest {
     @Test
     fun `given site registered in both systems, when woo notification received, then process it`() = runTest {
         whenever(registrationStatus.invoke(any()))
-            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_BOTH)
+            .thenReturn(REGISTERED_BOTH)
         createWooNotificationMessageHandler()
 
         notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
@@ -312,8 +309,6 @@ class NotificationMessageHandlerTest {
     @Test
     fun `given user has access token and site is not marked as Woo registered, when woo notification received, then process it`() =
         runTest {
-            whenever(registrationStatus.invoke(any()))
-                .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
             createWooNotificationMessageHandler()
 
             notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
@@ -323,8 +318,6 @@ class NotificationMessageHandlerTest {
 
     @Test
     fun `given user is not logged in, when woo notification received, then process it`() = runTest {
-        whenever(registrationStatus.invoke(any()))
-            .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
         doReturn(false).whenever(accountStore).hasAccessToken()
         createWooNotificationMessageHandler()
 
@@ -335,8 +328,6 @@ class NotificationMessageHandlerTest {
 
     @Test
     fun `given site is hidden, when notification received, then skip it`() = runTest {
-        whenever(registrationStatus.invoke(any()))
-            .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
         createWooNotificationMessageHandler()
         whenever(getWooVisibleSites.invoke()).thenReturn(emptyList())
 
@@ -351,8 +342,6 @@ class NotificationMessageHandlerTest {
 
     @Test
     fun `given wpcom notification site is hidden, when user has access token, then skip it`() = runTest {
-        whenever(registrationStatus.invoke(any()))
-            .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
         whenever(getWooVisibleSites.invoke()).thenReturn(emptyList())
 
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
@@ -366,8 +355,6 @@ class NotificationMessageHandlerTest {
 
     @Test
     fun `given site is hidden and user has no access token, when woo notification received, then process it`() = runTest {
-        whenever(registrationStatus.invoke(any()))
-            .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
         doReturn(false).whenever(accountStore).hasAccessToken()
         createWooNotificationMessageHandler()
         whenever(getWooVisibleSites.invoke()).thenReturn(emptyList())
@@ -453,36 +440,28 @@ class NotificationMessageHandlerTest {
         )
     }
 
-    @Test
-    fun `when two new order notifications are received for the same store, then display correctly`() {
+    private fun verifyGroupedNotificationDisplay(
+        firstPayload: Map<String, String>,
+        firstNotification: Notification,
+        secondPayload: Map<String, String>,
+        simulatedRemoteNoteId: Long
+    ) {
         // First notification
-        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
+        notificationMessageHandler.onNewMessageReceived(firstPayload)
 
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
-            notification = eq(orderNotification),
+            notification = eq(firstNotification),
             isGroupNotification = eq(false)
         )
 
         // Simulate first notification being active before second arrives
-        // Use a DIFFERENT remoteNoteId to ensure second notification is treated as new
-        val firstNotificationData = ActiveNotificationData(
-            id = 10000,
-            remoteNoteId = 999999L, // Different from orderNotification2.remoteNoteId
-            remoteSiteId = orderNotification.remoteSiteId,
-            channelType = orderNotification.channelType.name,
-            noteMessage = orderNotification.noteMessage,
-            noteTypeTrackingValue = orderNotification.noteType.trackingValue,
-            isGroupSummary = false
-        )
+        val firstNotificationData = firstNotification.toActiveNotificationData(10000)
+            .copy(remoteNoteId = simulatedRemoteNoteId)
         doReturn(listOf(firstNotificationData)).whenever(notificationBuilder).getActiveNotifications()
 
         // Second notification
-        val orderNotificationPayload2 = NotificationTestUtils.generateTestNewOrderNotificationPayload(
-            userId = accountModel.userId,
-            noteData = TEST_ORDER_NOTE_FULL_DATA_2
-        )
-        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload2)
+        notificationMessageHandler.onNewMessageReceived(secondPayload)
 
         // Verify second notification is displayed as group notification
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
@@ -496,141 +475,62 @@ class NotificationMessageHandlerTest {
             inboxMessage = any(),
             subject = any(),
             notification = any()
+        )
+    }
+
+    @Test
+    fun `when two new order notifications are received for the same store, then display correctly`() {
+        val orderNotificationPayload2 = NotificationTestUtils.generateTestNewOrderNotificationPayload(
+            userId = accountModel.userId,
+            noteData = TEST_ORDER_NOTE_FULL_DATA_2
+        )
+        verifyGroupedNotificationDisplay(
+            firstPayload = orderNotificationPayload,
+            firstNotification = orderNotification,
+            secondPayload = orderNotificationPayload2,
+            simulatedRemoteNoteId = 999999L
         )
     }
 
     @Test
     fun `when two new review notifications are received for the same store, then display correctly`() {
-        // First notification
-        notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload)
-
-        verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
-            pushId = any(),
-            notification = eq(reviewNotification),
-            isGroupNotification = eq(false)
-        )
-
-        // Simulate first notification being active before second arrives
-        val firstNotificationData = ActiveNotificationData(
-            id = 10000,
-            remoteNoteId = 888888L,
-            remoteSiteId = reviewNotification.remoteSiteId,
-            channelType = reviewNotification.channelType.name,
-            noteMessage = reviewNotification.noteMessage,
-            noteTypeTrackingValue = reviewNotification.noteType.trackingValue,
-            isGroupSummary = false
-        )
-        doReturn(listOf(firstNotificationData)).whenever(notificationBuilder).getActiveNotifications()
-
-        // Second notification
         val reviewNotificationPayload2 = NotificationTestUtils.generateTestNewReviewNotificationPayload(
             userId = accountModel.userId,
             noteData = TEST_REVIEW_NOTE_FULL_DATA_2
         )
-        notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload2)
-
-        // Verify second notification is displayed as group notification
-        verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
-            pushId = any(),
-            notification = any(),
-            isGroupNotification = eq(true)
-        )
-
-        // Verify group notification is displayed
-        verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
-            inboxMessage = any(),
-            subject = any(),
-            notification = any()
+        verifyGroupedNotificationDisplay(
+            firstPayload = reviewNotificationPayload,
+            firstNotification = reviewNotification,
+            secondPayload = reviewNotificationPayload2,
+            simulatedRemoteNoteId = 888888L
         )
     }
 
     @Test
     fun `when two new order notifications are received for different stores, then display correctly`() {
-        // First notification
-        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
-
-        verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
-            pushId = any(),
-            notification = eq(orderNotification),
-            isGroupNotification = eq(false)
-        )
-
-        // Simulate first notification being active before second arrives
-        val firstNotificationData = ActiveNotificationData(
-            id = 10000,
-            remoteNoteId = 777777L,
-            remoteSiteId = orderNotification.remoteSiteId,
-            channelType = orderNotification.channelType.name,
-            noteMessage = orderNotification.noteMessage,
-            noteTypeTrackingValue = orderNotification.noteType.trackingValue,
-            isGroupSummary = false
-        )
-        doReturn(listOf(firstNotificationData)).whenever(notificationBuilder).getActiveNotifications()
-
-        // Second notification for different store
         val orderNotificationPayload2 = NotificationTestUtils.generateTestNewOrderNotificationPayload(
             userId = accountModel.userId,
             noteData = TEST_ORDER_NOTE_FULL_DATA_SITE_2
         )
-        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload2)
-
-        // Verify second notification is displayed as group notification
-        verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
-            pushId = any(),
-            notification = any(),
-            isGroupNotification = eq(true)
-        )
-
-        // Verify group notification is displayed
-        verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
-            inboxMessage = any(),
-            subject = any(),
-            notification = any()
+        verifyGroupedNotificationDisplay(
+            firstPayload = orderNotificationPayload,
+            firstNotification = orderNotification,
+            secondPayload = orderNotificationPayload2,
+            simulatedRemoteNoteId = 777777L
         )
     }
 
     @Test
     fun `when two new review notifications are received for different stores, then display correctly`() {
-        // First notification
-        notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload)
-
-        verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
-            pushId = any(),
-            notification = eq(reviewNotification),
-            isGroupNotification = eq(false)
-        )
-
-        // Simulate first notification being active before second arrives
-        val firstNotificationData = ActiveNotificationData(
-            id = 10000,
-            remoteNoteId = 666666L,
-            remoteSiteId = reviewNotification.remoteSiteId,
-            channelType = reviewNotification.channelType.name,
-            noteMessage = reviewNotification.noteMessage,
-            noteTypeTrackingValue = reviewNotification.noteType.trackingValue,
-            isGroupSummary = false
-        )
-        doReturn(listOf(firstNotificationData)).whenever(notificationBuilder).getActiveNotifications()
-
-        // Second notification for different store
         val reviewNotificationPayload2 = NotificationTestUtils.generateTestNewReviewNotificationPayload(
             userId = accountModel.userId,
             noteData = TEST_REVIEW_NOTE_FULL_DATA_SITE_2
         )
-        notificationMessageHandler.onNewMessageReceived(reviewNotificationPayload2)
-
-        // Verify second notification is displayed as group notification
-        verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
-            pushId = any(),
-            notification = any(),
-            isGroupNotification = eq(true)
-        )
-
-        // Verify group notification is displayed
-        verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
-            inboxMessage = any(),
-            subject = any(),
-            notification = any()
+        verifyGroupedNotificationDisplay(
+            firstPayload = reviewNotificationPayload,
+            firstNotification = reviewNotification,
+            secondPayload = reviewNotificationPayload2,
+            simulatedRemoteNoteId = 666666L
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -103,6 +103,7 @@ class NotificationMessageHandlerTest {
         .buildNotificationModelFromPayloadMap(reviewNotificationSite2Payload)!!.toAppModel(resourceProvider)
 
     private val workManagerScheduler: WorkManagerScheduler = mock()
+    private val wooNotificationPayload = mapOf("type" to "new_order")
 
     private fun createNotificationMessageHandler(
         notificationsParser: NotificationsParser = this.notificationsParser
@@ -189,6 +190,29 @@ class NotificationMessageHandlerTest {
     }
 
     @Test
+    fun `given wpcom payload is missing note id, when notification received, then keep legacy note id validation`() =
+        runTest {
+            whenever(registrationStatus.invoke(any())).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
+            val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload().minus("note_id")
+            val mockNotificationsParser: NotificationsParser = mock {
+                on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
+                    remoteNoteId = 0L,
+                    remoteSiteId = orderNotification.remoteSiteId,
+                    type = NotificationModel.Kind.STORE_ORDER
+                )
+            }
+            createNotificationMessageHandler(mockNotificationsParser)
+
+            notificationMessageHandler.onNewMessageReceived(payload)
+
+            verify(wooLog).e(
+                eq(WooLog.T.NOTIFICATIONS),
+                eq("Push notification received without a valid note_id in the payload!")
+            )
+            verifyNoInteractions(dispatcher)
+        }
+
+    @Test
     fun `when the notification payload is empty then do not process the notification`() {
         notificationMessageHandler.onNewMessageReceived(
             mapOf(
@@ -201,9 +225,9 @@ class NotificationMessageHandlerTest {
     }
 
     @Test
-    fun `given woo push registered, when wpcom notification received, then skip notification`() = runTest {
+    fun `given site registered in both systems, when wpcom notification received, then skip notification`() = runTest {
         whenever(registrationStatus.invoke(any()))
-            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY)
+            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_BOTH)
 
         // WPCOM notifications have remoteNoteId > 0
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
@@ -213,6 +237,32 @@ class NotificationMessageHandlerTest {
             eq("Skipping WPCOM notification, already registered with Woo Core")
         )
         verifyNoInteractions(dispatcher)
+    }
+
+    @Test
+    fun `given site registered in both systems and user mismatch, when wpcom notification received, then keep legacy validation`() =
+        runTest {
+            whenever(registrationStatus.invoke(any()))
+                .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_BOTH)
+            val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload(userId = 67890)
+
+            notificationMessageHandler.onNewMessageReceived(payload)
+
+            verify(wooLog).e(
+                eq(WooLog.T.NOTIFICATIONS),
+                eq("WP.com userId found in the app doesn't match with the ID in the PN. Aborting.")
+            )
+            verifyNoInteractions(dispatcher)
+        }
+
+    @Test
+    fun `given site registered only in Woo, when wpcom notification received, then process notification`() = runTest {
+        whenever(registrationStatus.invoke(any()))
+            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY)
+
+        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
+
+        verify(dispatcher, atLeastOnce()).dispatch(any())
     }
 
     @Test
@@ -228,7 +278,45 @@ class NotificationMessageHandlerTest {
         }
         createNotificationMessageHandler(mockNotificationsParser)
 
-        notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
+        notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
+
+        verify(dispatcher, atLeastOnce()).dispatch(any())
+    }
+
+    @Test
+    fun `given user has access token and site is not marked as Woo registered, when woo notification received, then process it`() =
+        runTest {
+            whenever(registrationStatus.invoke(any()))
+                .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
+            val mockNotificationsParser: NotificationsParser = mock {
+                on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
+                    remoteNoteId = 0L,
+                    remoteSiteId = orderNotification.remoteSiteId,
+                    type = NotificationModel.Kind.STORE_ORDER
+                )
+            }
+            createNotificationMessageHandler(mockNotificationsParser)
+
+            notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
+
+            verify(dispatcher, atLeastOnce()).dispatch(any())
+        }
+
+    @Test
+    fun `given user is not logged in, when woo notification received, then process it`() = runTest {
+        whenever(registrationStatus.invoke(any()))
+            .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
+        doReturn(false).whenever(accountStore).hasAccessToken()
+        val mockNotificationsParser: NotificationsParser = mock {
+            on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
+                remoteNoteId = 0L,
+                remoteSiteId = orderNotification.remoteSiteId,
+                type = NotificationModel.Kind.STORE_ORDER
+            )
+        }
+        createNotificationMessageHandler(mockNotificationsParser)
+
+        notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
 
         verify(dispatcher, atLeastOnce()).dispatch(any())
     }
@@ -247,6 +335,21 @@ class NotificationMessageHandlerTest {
         createNotificationMessageHandler(mockNotificationsParser)
         whenever(getWooVisibleSites.invoke()).thenReturn(emptyList())
 
+        notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
+
+        verify(wooLog).w(
+            eq(WooLog.T.NOTIFICATIONS),
+            eq("Skipping notification, site ${orderNotification.remoteSiteId} is not visible")
+        )
+        verifyNoInteractions(dispatcher)
+    }
+
+    @Test
+    fun `given wpcom notification site is hidden, when user has access token, then skip it`() = runTest {
+        whenever(registrationStatus.invoke(any()))
+            .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
+        whenever(getWooVisibleSites.invoke()).thenReturn(emptyList())
+
         notificationMessageHandler.onNewMessageReceived(orderNotificationPayload)
 
         verify(wooLog).w(
@@ -254,6 +357,26 @@ class NotificationMessageHandlerTest {
             eq("Skipping notification, site ${orderNotification.remoteSiteId} is not visible")
         )
         verifyNoInteractions(dispatcher)
+    }
+
+    @Test
+    fun `given site is hidden and user has no access token, when woo notification received, then process it`() = runTest {
+        whenever(registrationStatus.invoke(any()))
+            .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
+        doReturn(false).whenever(accountStore).hasAccessToken()
+        val mockNotificationsParser: NotificationsParser = mock {
+            on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
+                remoteNoteId = 0L,
+                remoteSiteId = orderNotification.remoteSiteId,
+                type = NotificationModel.Kind.STORE_ORDER
+            )
+        }
+        createNotificationMessageHandler(mockNotificationsParser)
+        whenever(getWooVisibleSites.invoke()).thenReturn(emptyList())
+
+        notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
+
+        verify(dispatcher, atLeastOnce()).dispatch(any())
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -207,10 +207,7 @@ class NotificationMessageHandlerTest {
         runTest {
             whenever(registrationStatus.invoke(any())).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
             val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload().minus("note_id")
-            val mockNotificationsParser: NotificationsParser = mock {
-                on { buildNotificationModelFromPayloadMap(any()) } doReturn wooNotificationModel
-            }
-            createNotificationMessageHandler(mockNotificationsParser)
+            createWooNotificationMessageHandler()
 
             notificationMessageHandler.onNewMessageReceived(payload)
 
@@ -226,10 +223,7 @@ class NotificationMessageHandlerTest {
         runTest {
             whenever(registrationStatus.invoke(any())).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
             val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload().minus("user")
-            val mockNotificationsParser: NotificationsParser = mock {
-                on { buildNotificationModelFromPayloadMap(any()) } doReturn wooNotificationModel
-            }
-            createNotificationMessageHandler(mockNotificationsParser)
+            createWooNotificationMessageHandler()
 
             notificationMessageHandler.onNewMessageReceived(payload)
 
@@ -293,6 +287,17 @@ class NotificationMessageHandlerTest {
     fun `given woo push registered and site is visible, when woo notification received, then process it`() = runTest {
         whenever(registrationStatus.invoke(any()))
             .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY)
+        createWooNotificationMessageHandler()
+
+        notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
+
+        verify(dispatcher, atLeastOnce()).dispatch(any())
+    }
+
+    @Test
+    fun `given site registered in both systems, when woo notification received, then process it`() = runTest {
+        whenever(registrationStatus.invoke(any()))
+            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_BOTH)
         createWooNotificationMessageHandler()
 
         notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -205,7 +205,9 @@ class NotificationMessageHandlerTest {
     @Test
     fun `given wpcom payload is missing note id, when notification received, then keep legacy note id validation`() =
         runTest {
-            whenever(registrationStatus.invoke(any())).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
+            whenever(
+                registrationStatus.invoke(any())
+            ).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
             val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload().minus("note_id")
             createWooNotificationMessageHandler()
 
@@ -221,7 +223,9 @@ class NotificationMessageHandlerTest {
     @Test
     fun `given payload has no wpcom user and parsed note id is zero, when notification received, then treat it as Woo`() =
         runTest {
-            whenever(registrationStatus.invoke(any())).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
+            whenever(
+                registrationStatus.invoke(any())
+            ).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
             val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload().minus("user")
             createWooNotificationMessageHandler()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -104,6 +104,12 @@ class NotificationMessageHandlerTest {
 
     private val workManagerScheduler: WorkManagerScheduler = mock()
     private val wooNotificationPayload = mapOf("type" to "new_order")
+    private val wooNotificationModel
+        get() = NotificationModel(
+            remoteNoteId = 0L,
+            remoteSiteId = orderNotification.remoteSiteId,
+            type = NotificationModel.Kind.STORE_ORDER
+        )
 
     private fun createNotificationMessageHandler(
         notificationsParser: NotificationsParser = this.notificationsParser
@@ -121,6 +127,13 @@ class NotificationMessageHandlerTest {
             selectedSite = selectedSite,
             workManagerScheduler = workManagerScheduler,
         )
+    }
+
+    private fun createWooNotificationMessageHandler() {
+        val mockNotificationsParser: NotificationsParser = mock {
+            on { buildNotificationModelFromPayloadMap(any()) } doReturn wooNotificationModel
+        }
+        createNotificationMessageHandler(mockNotificationsParser)
     }
 
     @Before
@@ -195,11 +208,7 @@ class NotificationMessageHandlerTest {
             whenever(registrationStatus.invoke(any())).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
             val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload().minus("note_id")
             val mockNotificationsParser: NotificationsParser = mock {
-                on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
-                    remoteNoteId = 0L,
-                    remoteSiteId = orderNotification.remoteSiteId,
-                    type = NotificationModel.Kind.STORE_ORDER
-                )
+                on { buildNotificationModelFromPayloadMap(any()) } doReturn wooNotificationModel
             }
             createNotificationMessageHandler(mockNotificationsParser)
 
@@ -210,6 +219,21 @@ class NotificationMessageHandlerTest {
                 eq("Push notification received without a valid note_id in the payload!")
             )
             verifyNoInteractions(dispatcher)
+        }
+
+    @Test
+    fun `given payload has no wpcom user and parsed note id is zero, when notification received, then treat it as Woo`() =
+        runTest {
+            whenever(registrationStatus.invoke(any())).thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
+            val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload().minus("user")
+            val mockNotificationsParser: NotificationsParser = mock {
+                on { buildNotificationModelFromPayloadMap(any()) } doReturn wooNotificationModel
+            }
+            createNotificationMessageHandler(mockNotificationsParser)
+
+            notificationMessageHandler.onNewMessageReceived(payload)
+
+            verify(dispatcher, atLeastOnce()).dispatch(any())
         }
 
     @Test
@@ -269,14 +293,7 @@ class NotificationMessageHandlerTest {
     fun `given woo push registered and site is visible, when woo notification received, then process it`() = runTest {
         whenever(registrationStatus.invoke(any()))
             .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY)
-        val mockNotificationsParser: NotificationsParser = mock {
-            on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
-                remoteNoteId = 0L,
-                remoteSiteId = orderNotification.remoteSiteId,
-                type = NotificationModel.Kind.STORE_ORDER
-            )
-        }
-        createNotificationMessageHandler(mockNotificationsParser)
+        createWooNotificationMessageHandler()
 
         notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
 
@@ -288,14 +305,7 @@ class NotificationMessageHandlerTest {
         runTest {
             whenever(registrationStatus.invoke(any()))
                 .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
-            val mockNotificationsParser: NotificationsParser = mock {
-                on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
-                    remoteNoteId = 0L,
-                    remoteSiteId = orderNotification.remoteSiteId,
-                    type = NotificationModel.Kind.STORE_ORDER
-                )
-            }
-            createNotificationMessageHandler(mockNotificationsParser)
+            createWooNotificationMessageHandler()
 
             notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
 
@@ -307,14 +317,7 @@ class NotificationMessageHandlerTest {
         whenever(registrationStatus.invoke(any()))
             .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
         doReturn(false).whenever(accountStore).hasAccessToken()
-        val mockNotificationsParser: NotificationsParser = mock {
-            on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
-                remoteNoteId = 0L,
-                remoteSiteId = orderNotification.remoteSiteId,
-                type = NotificationModel.Kind.STORE_ORDER
-            )
-        }
-        createNotificationMessageHandler(mockNotificationsParser)
+        createWooNotificationMessageHandler()
 
         notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
 
@@ -325,14 +328,7 @@ class NotificationMessageHandlerTest {
     fun `given site is hidden, when notification received, then skip it`() = runTest {
         whenever(registrationStatus.invoke(any()))
             .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
-        val mockNotificationsParser: NotificationsParser = mock {
-            on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
-                remoteNoteId = 0L,
-                remoteSiteId = orderNotification.remoteSiteId,
-                type = NotificationModel.Kind.STORE_ORDER
-            )
-        }
-        createNotificationMessageHandler(mockNotificationsParser)
+        createWooNotificationMessageHandler()
         whenever(getWooVisibleSites.invoke()).thenReturn(emptyList())
 
         notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
@@ -364,14 +360,7 @@ class NotificationMessageHandlerTest {
         whenever(registrationStatus.invoke(any()))
             .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
         doReturn(false).whenever(accountStore).hasAccessToken()
-        val mockNotificationsParser: NotificationsParser = mock {
-            on { buildNotificationModelFromPayloadMap(any()) } doReturn NotificationModel(
-                remoteNoteId = 0L,
-                remoteSiteId = orderNotification.remoteSiteId,
-                type = NotificationModel.Kind.STORE_ORDER
-            )
-        }
-        createNotificationMessageHandler(mockNotificationsParser)
+        createWooNotificationMessageHandler()
         whenever(getWooVisibleSites.invoke()).thenReturn(emptyList())
 
         notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)


### PR DESCRIPTION
### Description
Fixes WOOMOB-2674

#### Problem

App-password users never received push notifications. The site-visibility check ran unconditionally, but app-password users don't have a WP.com access token, so `getWooVisibleSites()` returns an empty list for them — every notification was silently dropped.

The root cause is that the gating logic did not distinguish between WP.com-delivered and Woo-delivered notifications, so WP.com-specific checks (site visibility, note ID validation, user ID match) were applied to all notifications regardless of their origin.

#### Fix

Introduce a `detectNotificationSource()` function that classifies each incoming notification as either `WPCOM` or `WOO` based on payload signals (presence of the `user` key or a non-zero `note_id`). Then scope each check to the appropriate source:

- **Site-visibility filtering** — only runs when the user has a WP.com access token. App-password users bypass this check entirely, since their sites are not managed through the WP.com visible-sites list.
- **WP.com validation** (note ID presence, user ID match) — only runs for `WPCOM` notifications.
- **Duplicate suppression** — blocks `WPCOM` notifications when the site is already registered for Woo Push (`isWooRegistered`), ensuring we prefer the Woo-delivered notification if both systems might send one. `WOO` notifications are never suppressed by this check.
- **`registrationStatus` call** — deferred into the `WPCOM` branch so Woo-delivered notifications skip the `runBlocking` call entirely.

> [!TIP]
> For an easier code review: check this [code](https://github.com/woocommerce/woocommerce-android/blob/86982b968bc8af35d7418246a654134809962adb/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt#L88-L120) directly, and see if it matches what we expect. 

Additionally, we simplified `NotificationMessageHandlerTest.kt` to reduce boilerplate logic, duplicate setup steps, and redundant mock configurations for group notifications and status checks.

### Test Steps
> [!TIP]
> - For setting up Woo driven notifications, check the last version here paaHJt-9VE-p2, feel free also to ping me for an invite to a test site.
> - For all the test steps, confirm that PN feature flags are enabled.

1. Run `./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "com.woocommerce.android.notifications.push.NotificationMessageHandlerTest"`.
2. Verify WP.com notifications on a Jetpack-connected site with production Woo Core:
   - Install the branch build.
   - Log into the app with the WP.com account connected to the test site.
   - Select the Jetpack-connected site in the app and make sure site notifications are enabled and the site is visible in the site list.
   - From the store backend, create an event that sends a notification (for example, place a new order).
   - Confirm a notification is received on the device.
3. Verify Woo-driven notifications on a Jetpack-connected site running the test version of Woo:
   - Keep using the same app build.
   - Switch the selected site to a Jetpack-connected site that has the test Woo build with Woo-driven push enabled.
   - Trigger a notification from the store (for example, place a new order).
   - Confirm exactly one notification is shown on the device.
   - Confirm there is no duplicate second notification for the same event.
4. Verify Woo-driven notifications on a non-Jetpack-connected site running the test version of Woo:
   - Log into the app using app passwords to a site that use test version of Woo.
   - Trigger a notification from the store (for example, place a new order).
   - Confirm the notification is received on the device.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

