### PR TITLE
[WOOMOB-2707] Phone home screen NavHost skeleton

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/designsystem/WooPosSizes.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/designsystem/WooPosSizes.kt
@@ -109,7 +109,7 @@ fun Dp.toAdaptiveIconSize(): Dp = when (rememberWooPosBreakpoint()) {
 fun Modifier.adaptiveContentWidth(): Modifier = when (rememberWooPosBreakpoint()) {
     WooPosBreakpoint.Phone -> this.fillMaxWidth()
     WooPosBreakpoint.SmallTablet -> this.fillMaxWidth(fraction = 2f / 3f)
-    WooPosBreakpoint.Tablet -> this.fillMaxWidth(fraction = 3f / 5f)
+    WooPosBreakpoint.Tablet -> this.fillMaxWidth(fraction = 0.55f)
 }
 
 internal enum class WooPosBreakpoint { Phone, SmallTablet, Tablet }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeContainer.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.ui.woopos.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.woocommerce.android.ui.woopos.common.composeui.modifier.listenForBarcodes
+
+/**
+ * Root modifier for the POS home screen (both tablet and phone layouts).
+ * Fills the viewport, paints the surface background, and forwards barcode events
+ * into the home UI event stream while the user is on a scannable destination.
+ */
+@Composable
+fun Modifier.wooPosHomeRootContainer(
+    state: WooPosHomeState,
+    onHomeUIEvent: (WooPosHomeUIEvent) -> Unit,
+): Modifier = this
+    .fillMaxSize()
+    .background(MaterialTheme.colorScheme.surface)
+    .listenForBarcodes(
+        onBarcodeEvent = { onHomeUIEvent(WooPosHomeUIEvent.OnBarcodeEvent(it)) },
+        enabled = state.isBarcodeListeningEnabled(),
+    )
+
+private fun WooPosHomeState.isBarcodeListeningEnabled(): Boolean {
+    val onScannableDestination =
+        screenPositionState is WooPosHomeState.ScreenPositionState.Cart ||
+            screenPositionState is WooPosHomeState.ScreenPositionState.Checkout.FullScreenTotals
+    return onScannableDestination && dialogState !is WooPosHomeState.DialogState.ScanningSetupDialog
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeDialogs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeDialogs.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.ui.woopos.home
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosExitConfirmationDialog
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
+
+@Composable
+fun WooPosHomeDialogs(
+    dialogState: WooPosHomeState.DialogState,
+    onHomeUIEvent: (WooPosHomeUIEvent) -> Unit,
+) {
+    WooPosScanningSetupDialog(
+        isVisible = dialogState is WooPosHomeState.DialogState.ScanningSetupDialog,
+        onDismissRequest = {
+            onHomeUIEvent(WooPosHomeUIEvent.DismissScanningSetupDialog)
+        }
+    )
+
+    WooPosExitConfirmationDialog(
+        isVisible = dialogState is WooPosHomeState.DialogState.ExitConfirmationDialog,
+        title = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.title),
+        message = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.message),
+        dismissButtonText = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.confirmButton),
+        onDismissRequest = { onHomeUIEvent(WooPosHomeUIEvent.ExitConfirmationDialogDismissed) },
+        onExit = { onHomeUIEvent(WooPosHomeUIEvent.ExitPosClicked) }
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeNavigation.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -12,9 +13,11 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.woocommerce.android.ui.woopos.eligibility.WooPosEligibilityScreen
+import com.woocommerce.android.ui.woopos.home.phone.WooPosHomePhoneScreen
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
+import com.woocommerce.android.ui.woopos.util.ext.isWooPosPhoneLayout
 
 const val HOME_ROUTE = "home"
 const val HOME_PAYMENT_COMPLETED_VIA_CASH_KEY = "home_payment_completed_via_cash_key"
@@ -83,10 +86,17 @@ fun NavGraphBuilder.homeScreen(
             savedStateHandle[HOME_PAYMENT_COMPLETED_VIA_CASH_KEY] = false
         }
 
-        WooPosHomeScreen(
-            isPaymentCompletedViaCash = isPaymentCompletedViaCash,
-            viewModel = homeViewModel,
-        )
+        if (LocalContext.current.isWooPosPhoneLayout()) {
+            WooPosHomePhoneScreen(
+                isPaymentCompletedViaCash = isPaymentCompletedViaCash,
+                viewModel = homeViewModel,
+            )
+        } else {
+            WooPosHomeScreen(
+                isPaymentCompletedViaCash = isPaymentCompletedViaCash,
+                viewModel = homeViewModel,
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomePanes.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomePanes.kt
@@ -1,0 +1,51 @@
+package com.woocommerce.android.ui.woopos.home
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.woocommerce.android.ui.woopos.common.composeui.isPreviewMode
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreen
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreenProductsPreview
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartViewModel
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosItemsScreenPreview
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreenPreview
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewModel
+
+@Composable
+fun WooPosHomeProductsPane(
+    modifier: Modifier = Modifier,
+    viewModel: WooPosItemsViewModel = hiltViewModel(),
+) {
+    if (isPreviewMode()) {
+        WooPosItemsScreenPreview(modifier)
+    } else {
+        WooPosItemsScreen(modifier = modifier, viewModel = viewModel)
+    }
+}
+
+@Composable
+fun WooPosHomeCartPane(
+    modifier: Modifier = Modifier,
+    viewModel: WooPosCartViewModel = hiltViewModel(),
+) {
+    if (isPreviewMode()) {
+        WooPosCartScreenProductsPreview(modifier)
+    } else {
+        WooPosCartScreen(modifier = modifier, viewModel = viewModel)
+    }
+}
+
+@Composable
+fun WooPosHomeTotalsPane(
+    modifier: Modifier = Modifier,
+    viewModel: WooPosTotalsViewModel = hiltViewModel(),
+) {
+    if (isPreviewMode()) {
+        WooPosTotalsScreenPreview(modifier)
+    } else {
+        WooPosTotalsScreen(modifier = modifier, viewModel = viewModel)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -29,7 +28,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.isPreviewMode
-import com.woocommerce.android.ui.woopos.common.composeui.modifier.listenForBarcodes
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreen
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreenProductsPreview
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
@@ -125,18 +123,7 @@ private fun WooPosHomeScreen(
     onHomeUIEvent: (WooPosHomeUIEvent) -> Unit,
 ) {
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.surface)
-            .listenForBarcodes(
-                onBarcodeEvent = { result ->
-                    onHomeUIEvent(WooPosHomeUIEvent.OnBarcodeEvent(result))
-                },
-                enabled = (
-                    state.screenPositionState is WooPosHomeState.ScreenPositionState.Cart ||
-                        state.screenPositionState is WooPosHomeState.ScreenPositionState.Checkout.FullScreenTotals
-                    ) && state.dialogState !is WooPosHomeState.DialogState.ScanningSetupDialog
-            )
+        modifier = Modifier.wooPosHomeRootContainer(state, onHomeUIEvent)
     ) {
         Row(
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -28,14 +28,8 @@ import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.isPreviewMode
-import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreen
-import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreenProductsPreview
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
-import com.woocommerce.android.ui.woopos.home.items.products.WooPosItemsScreenPreview
 import com.woocommerce.android.ui.woopos.home.toolbar.PreviewWooPosFloatingToolbarStatusConnectedWithMenu
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosFloatingToolbar
-import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen
-import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreenPreview
 import org.wordpress.android.util.ToastUtils
 
 @Composable
@@ -130,16 +124,16 @@ private fun WooPosHomeScreen(
                 .horizontalScroll(scrollState, enabled = false)
                 .fillMaxWidth(),
         ) {
-            WooPosHomeScreenProducts(
+            WooPosHomeProductsPane(
                 modifier = Modifier
                     .width(productsWidthDp)
             )
-            WooPosHomeScreenCart(
+            WooPosHomeCartPane(
                 modifier = Modifier
                     .background(MaterialTheme.colorScheme.surfaceBright)
                     .width(cartWidthDp)
             )
-            WooPosHomeScreenTotals(
+            WooPosHomeTotalsPane(
                 modifier = Modifier
                     .width(totalsWidthDp),
             )
@@ -154,33 +148,6 @@ private fun WooPosHomeScreen(
 
             WooPosHomeDialogs(state.dialogState, onHomeUIEvent)
         }
-    }
-}
-
-@Composable
-private fun WooPosHomeScreenProducts(modifier: Modifier) {
-    if (isPreviewMode()) {
-        WooPosItemsScreenPreview(modifier)
-    } else {
-        WooPosItemsScreen(modifier = modifier)
-    }
-}
-
-@Composable
-private fun WooPosHomeScreenCart(modifier: Modifier) {
-    if (isPreviewMode()) {
-        WooPosCartScreenProductsPreview(modifier)
-    } else {
-        WooPosCartScreen(modifier)
-    }
-}
-
-@Composable
-private fun WooPosHomeScreenTotals(modifier: Modifier) {
-    if (isPreviewMode()) {
-        WooPosTotalsScreenPreview(modifier)
-    } else {
-        WooPosTotalsScreen(modifier = modifier)
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -23,11 +23,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosExitConfirmationDialog
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.isPreviewMode
@@ -40,7 +38,6 @@ import com.woocommerce.android.ui.woopos.home.toolbar.PreviewWooPosFloatingToolb
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosFloatingToolbar
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreenPreview
-import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 import org.wordpress.android.util.ToastUtils
 
 @Composable
@@ -168,31 +165,9 @@ private fun WooPosHomeScreen(
                     .align(Alignment.BottomStart),
             )
 
-            Dialogs(state.dialogState, onHomeUIEvent)
+            WooPosHomeDialogs(state.dialogState, onHomeUIEvent)
         }
     }
-}
-
-@Composable
-private fun Dialogs(
-    dialogState: WooPosHomeState.DialogState,
-    onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
-) {
-    WooPosScanningSetupDialog(
-        isVisible = dialogState is WooPosHomeState.DialogState.ScanningSetupDialog,
-        onDismissRequest = {
-            onHomeUIEvent(WooPosHomeUIEvent.DismissScanningSetupDialog)
-        }
-    )
-
-    WooPosExitConfirmationDialog(
-        isVisible = dialogState is WooPosHomeState.DialogState.ExitConfirmationDialog,
-        title = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.title),
-        message = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.message),
-        dismissButtonText = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.confirmButton),
-        onDismissRequest = { onHomeUIEvent(WooPosHomeUIEvent.ExitConfirmationDialogDismissed) },
-        onExit = { onHomeUIEvent(WooPosHomeUIEvent.ExitPosClicked) }
-    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -94,9 +94,10 @@ import com.woocommerce.android.ui.woopos.home.cart.WooPosCartUIEvent.ItemRemoved
 import com.woocommerce.android.ui.woopos.util.WooPosTestTags
 
 @Composable
-fun WooPosCartScreen(modifier: Modifier = Modifier) {
-    val viewModel: WooPosCartViewModel = hiltViewModel()
-
+fun WooPosCartScreen(
+    modifier: Modifier = Modifier,
+    viewModel: WooPosCartViewModel = hiltViewModel(),
+) {
     viewModel.state.observeAsState().value?.let {
         WooPosCartScreen(modifier, it, viewModel::onUIEvent)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -43,17 +43,19 @@ import kotlinx.coroutines.flow.StateFlow
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun WooPosItemsScreen(modifier: Modifier = Modifier) {
+fun WooPosItemsScreen(
+    modifier: Modifier = Modifier,
+    viewModel: WooPosItemsViewModel = hiltViewModel(),
+) {
     val productsViewState = rememberLazyListState()
     val couponsListState = rememberLazyListState()
-    val productsViewModel: WooPosItemsViewModel = hiltViewModel()
     WooPosItemsScreen(
         modifier = modifier,
-        itemsStateFlow = productsViewModel.viewState,
-        bannerStateFlow = productsViewModel.bannerState,
+        itemsStateFlow = viewModel.viewState,
+        bannerStateFlow = viewModel.bannerState,
         productsViewState = productsViewState,
         couponsListState = couponsListState,
-        onUIEvent = { productsViewModel.onUIEvent(it) },
+        onUIEvent = { viewModel.onUIEvent(it) },
     )
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
@@ -1,0 +1,196 @@
+package com.woocommerce.android.ui.woopos.home.phone
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosExitConfirmationDialog
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.common.composeui.modifier.listenForBarcodes
+import com.woocommerce.android.ui.woopos.home.WooPosHomeState
+import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent
+import com.woocommerce.android.ui.woopos.home.WooPosHomeViewModel
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreen
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartViewModel
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen
+import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewModel
+import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
+import com.woocommerce.android.util.PackageUtils
+import org.wordpress.android.util.ToastUtils
+
+private const val PHONE_PRODUCTS_ROUTE = "phone_products"
+private const val PHONE_CART_ROUTE = "phone_cart"
+private const val PHONE_TOTALS_ROUTE = "phone_totals"
+
+@Composable
+fun WooPosHomePhoneScreen(
+    isPaymentCompletedViaCash: Boolean,
+    viewModel: WooPosHomeViewModel,
+) {
+    val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        if (isPaymentCompletedViaCash) {
+            viewModel.onUIEvent(WooPosHomeUIEvent.OnPaymentCompletedViaCash)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.toastEvent.collect { message ->
+            ToastUtils.showToast(context, message, ToastUtils.Duration.LONG)
+        }
+    }
+
+    WooPosHomePhoneContent(
+        state = state,
+        onHomeUIEvent = { viewModel.onUIEvent(it) },
+    )
+}
+
+@Composable
+private fun WooPosHomePhoneContent(
+    state: WooPosHomeState,
+    onHomeUIEvent: (WooPosHomeUIEvent) -> Unit,
+) {
+    val navController = rememberNavController()
+
+    // Acquire the shared ViewModels once at the parent NavBackStackEntry scope so they
+    // stay alive across inner navigation between products / cart / totals. Without this,
+    // hiltViewModel() calls inside each destination would scope to that destination's
+    // inner NavBackStackEntry and be recreated on every navigation.
+    val itemsViewModel: WooPosItemsViewModel = hiltViewModel()
+    val cartViewModel: WooPosCartViewModel = hiltViewModel()
+    val totalsViewModel: WooPosTotalsViewModel = hiltViewModel()
+
+    var previousState by remember {
+        mutableStateOf<WooPosHomeState.ScreenPositionState?>(null)
+    }
+
+    LaunchedEffect(state.screenPositionState) {
+        val currentRoute = navController.currentDestination?.route
+        when (state.screenPositionState) {
+            is WooPosHomeState.ScreenPositionState.Cart -> {
+                when {
+                    currentRoute == PHONE_TOTALS_ROUTE &&
+                        previousState is WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals -> {
+                        navController.popBackStack()
+                    }
+                    currentRoute == PHONE_TOTALS_ROUTE || currentRoute == PHONE_CART_ROUTE -> {
+                        navController.popBackStack(PHONE_PRODUCTS_ROUTE, inclusive = false)
+                    }
+                }
+            }
+            is WooPosHomeState.ScreenPositionState.Checkout -> {
+                if (currentRoute != PHONE_TOTALS_ROUTE) {
+                    navController.navigate(PHONE_TOTALS_ROUTE) {
+                        launchSingleTop = true
+                    }
+                }
+            }
+        }
+        previousState = state.screenPositionState
+    }
+
+    BackHandler {
+        onHomeUIEvent(WooPosHomeUIEvent.SystemBackClicked)
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+            .listenForBarcodes(
+                onBarcodeEvent = { result ->
+                    onHomeUIEvent(WooPosHomeUIEvent.OnBarcodeEvent(result))
+                },
+                enabled = (
+                    state.screenPositionState is WooPosHomeState.ScreenPositionState.Cart ||
+                        state.screenPositionState is WooPosHomeState.ScreenPositionState.Checkout.FullScreenTotals
+                    ) && state.dialogState !is WooPosHomeState.DialogState.ScanningSetupDialog
+            )
+    ) {
+        NavHost(
+            navController = navController,
+            startDestination = PHONE_PRODUCTS_ROUTE,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            composable(PHONE_PRODUCTS_ROUTE) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    WooPosItemsScreen(viewModel = itemsViewModel)
+
+                    if (PackageUtils.isDebugBuild()) {
+                        // Temporary trigger so Cart is reachable until the persistent
+                        // bottom button lands in WOOMOB-2657. Remove with that ticket.
+                        ExtendedFloatingActionButton(
+                            text = { WooPosText(text = "Cart (debug)", style = WooPosTypography.BodyLarge) },
+                            icon = {},
+                            onClick = {
+                                navController.navigate(PHONE_CART_ROUTE) {
+                                    launchSingleTop = true
+                                }
+                            },
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(WooPosSpacing.Medium.value)
+                        )
+                    }
+                }
+            }
+            composable(PHONE_CART_ROUTE) {
+                WooPosCartScreen(viewModel = cartViewModel)
+            }
+            composable(PHONE_TOTALS_ROUTE) {
+                WooPosTotalsScreen(viewModel = totalsViewModel)
+            }
+        }
+
+        PhoneDialogs(state.dialogState, onHomeUIEvent)
+    }
+}
+
+@Composable
+private fun PhoneDialogs(
+    dialogState: WooPosHomeState.DialogState,
+    onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
+) {
+    WooPosScanningSetupDialog(
+        isVisible = dialogState is WooPosHomeState.DialogState.ScanningSetupDialog,
+        onDismissRequest = {
+            onHomeUIEvent(WooPosHomeUIEvent.DismissScanningSetupDialog)
+        }
+    )
+
+    WooPosExitConfirmationDialog(
+        isVisible = dialogState is WooPosHomeState.DialogState.ExitConfirmationDialog,
+        title = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.title),
+        message = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.message),
+        dismissButtonText = stringResource(
+            id = WooPosHomeState.DialogState.ExitConfirmationDialog.confirmButton
+        ),
+        onDismissRequest = { onHomeUIEvent(WooPosHomeUIEvent.ExitConfirmationDialogDismissed) },
+        onExit = { onHomeUIEvent(WooPosHomeUIEvent.ExitPosClicked) }
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
@@ -17,16 +17,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosExitConfirmationDialog
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.listenForBarcodes
+import com.woocommerce.android.ui.woopos.home.WooPosHomeDialogs
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent
 import com.woocommerce.android.ui.woopos.home.WooPosHomeViewModel
@@ -36,7 +35,6 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewModel
-import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 import com.woocommerce.android.util.PackageUtils
 import org.wordpress.android.util.ToastUtils
 
@@ -93,12 +91,13 @@ private fun WooPosHomePhoneContent(
         val currentRoute = navController.currentDestination?.route
         when (state.screenPositionState) {
             is WooPosHomeState.ScreenPositionState.Cart -> {
-                when {
-                    currentRoute == PHONE_TOTALS_ROUTE &&
-                        previousState is WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals -> {
+                val cameFromCartWithTotals =
+                    previousState is WooPosHomeState.ScreenPositionState.Checkout.CartWithTotals
+                when (currentRoute) {
+                    PHONE_TOTALS_ROUTE if cameFromCartWithTotals -> {
                         navController.popBackStack()
                     }
-                    currentRoute == PHONE_TOTALS_ROUTE || currentRoute == PHONE_CART_ROUTE -> {
+                    PHONE_TOTALS_ROUTE, PHONE_CART_ROUTE -> {
                         navController.popBackStack(PHONE_PRODUCTS_ROUTE, inclusive = false)
                     }
                 }
@@ -167,30 +166,6 @@ private fun WooPosHomePhoneContent(
             }
         }
 
-        PhoneDialogs(state.dialogState, onHomeUIEvent)
+        WooPosHomeDialogs(state.dialogState, onHomeUIEvent)
     }
-}
-
-@Composable
-private fun PhoneDialogs(
-    dialogState: WooPosHomeState.DialogState,
-    onHomeUIEvent: (WooPosHomeUIEvent) -> Unit
-) {
-    WooPosScanningSetupDialog(
-        isVisible = dialogState is WooPosHomeState.DialogState.ScanningSetupDialog,
-        onDismissRequest = {
-            onHomeUIEvent(WooPosHomeUIEvent.DismissScanningSetupDialog)
-        }
-    )
-
-    WooPosExitConfirmationDialog(
-        isVisible = dialogState is WooPosHomeState.DialogState.ExitConfirmationDialog,
-        title = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.title),
-        message = stringResource(id = WooPosHomeState.DialogState.ExitConfirmationDialog.message),
-        dismissButtonText = stringResource(
-            id = WooPosHomeState.DialogState.ExitConfirmationDialog.confirmButton
-        ),
-        onDismissRequest = { onHomeUIEvent(WooPosHomeUIEvent.ExitConfirmationDialogDismissed) },
-        onExit = { onHomeUIEvent(WooPosHomeUIEvent.ExitPosClicked) }
-    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
@@ -112,7 +112,9 @@ private fun WooPosHomePhoneContent(
     }
 
     BackHandler {
-        onHomeUIEvent(WooPosHomeUIEvent.SystemBackClicked)
+        if (!navController.popBackStack()) {
+            onHomeUIEvent(WooPosHomeUIEvent.SystemBackClicked)
+        }
     }
 
     Box(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
@@ -22,15 +22,15 @@ import androidx.navigation.compose.rememberNavController
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.home.WooPosHomeCartPane
 import com.woocommerce.android.ui.woopos.home.WooPosHomeDialogs
+import com.woocommerce.android.ui.woopos.home.WooPosHomeProductsPane
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState
+import com.woocommerce.android.ui.woopos.home.WooPosHomeTotalsPane
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent
 import com.woocommerce.android.ui.woopos.home.WooPosHomeViewModel
-import com.woocommerce.android.ui.woopos.home.cart.WooPosCartScreen
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartViewModel
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
-import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewModel
 import com.woocommerce.android.ui.woopos.home.wooPosHomeRootContainer
 import com.woocommerce.android.util.PackageUtils
@@ -125,7 +125,7 @@ private fun WooPosHomePhoneContent(
         ) {
             composable(PHONE_PRODUCTS_ROUTE) {
                 Box(modifier = Modifier.fillMaxSize()) {
-                    WooPosItemsScreen(viewModel = itemsViewModel)
+                    WooPosHomeProductsPane(viewModel = itemsViewModel)
 
                     if (PackageUtils.isDebugBuild()) {
                         // Temporary trigger so Cart is reachable until the persistent
@@ -146,10 +146,10 @@ private fun WooPosHomePhoneContent(
                 }
             }
             composable(PHONE_CART_ROUTE) {
-                WooPosCartScreen(viewModel = cartViewModel)
+                WooPosHomeCartPane(viewModel = cartViewModel)
             }
             composable(PHONE_TOTALS_ROUTE) {
-                WooPosTotalsScreen(viewModel = totalsViewModel)
+                WooPosHomeTotalsPane(viewModel = totalsViewModel)
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
@@ -1,12 +1,10 @@
 package com.woocommerce.android.ui.woopos.home.phone
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -24,7 +22,6 @@ import androidx.navigation.compose.rememberNavController
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
-import com.woocommerce.android.ui.woopos.common.composeui.modifier.listenForBarcodes
 import com.woocommerce.android.ui.woopos.home.WooPosHomeDialogs
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent
@@ -35,6 +32,7 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsScreen
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsScreen
 import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewModel
+import com.woocommerce.android.ui.woopos.home.wooPosHomeRootContainer
 import com.woocommerce.android.util.PackageUtils
 import org.wordpress.android.util.ToastUtils
 
@@ -118,18 +116,7 @@ private fun WooPosHomePhoneContent(
     }
 
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.surface)
-            .listenForBarcodes(
-                onBarcodeEvent = { result ->
-                    onHomeUIEvent(WooPosHomeUIEvent.OnBarcodeEvent(result))
-                },
-                enabled = (
-                    state.screenPositionState is WooPosHomeState.ScreenPositionState.Cart ||
-                        state.screenPositionState is WooPosHomeState.ScreenPositionState.Checkout.FullScreenTotals
-                    ) && state.dialogState !is WooPosHomeState.DialogState.ScanningSetupDialog
-            )
+        modifier = Modifier.wooPosHomeRootContainer(state, onHomeUIEvent)
     ) {
         NavHost(
             navController = navController,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbar.kt
@@ -64,8 +64,10 @@ import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarS
 private val TOOLBAR_ELEVATION = WooPosElevation.Medium
 
 @Composable
-fun WooPosFloatingToolbar(modifier: Modifier = Modifier) {
-    val viewModel: WooPosHomeFloatingToolbarViewModel = hiltViewModel()
+fun WooPosFloatingToolbar(
+    modifier: Modifier = Modifier,
+    viewModel: WooPosHomeFloatingToolbarViewModel = hiltViewModel(),
+) {
     WooPosFloatingToolbar(
         modifier = modifier,
         state = viewModel.state.collectAsState(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -66,8 +66,10 @@ import com.woocommerce.android.ui.woopos.home.totals.payment.success.WooPosPayme
 import com.woocommerce.android.ui.woopos.util.WooPosTestTags
 
 @Composable
-fun WooPosTotalsScreen(modifier: Modifier = Modifier) {
-    val viewModel: WooPosTotalsViewModel = hiltViewModel()
+fun WooPosTotalsScreen(
+    modifier: Modifier = Modifier,
+    viewModel: WooPosTotalsViewModel = hiltViewModel(),
+) {
     val state = viewModel.state.collectAsState().value
     WooPosTotalsScreen(
         modifier = modifier,


### PR DESCRIPTION
### Description

Closes [WOOMOB-2707](https://linear.app/a8c/issue/WOOMOB-2707). Part of [Woo POS on Phones](https://linear.app/a8c/project/woo-pos-on-phones-9a932b9546b8) (parent: [WOOMOB-2656](https://linear.app/a8c/issue/WOOMOB-2656)).

Adds the **phone home screen skeleton**: a new `WooPosHomePhoneScreen` that hosts an inner `NavHost` with three destinations — `phone_products`, `phone_cart`, `phone_totals`. The outer `homeScreen(...)` now branches on `Context.isWooPosPhoneLayout()` and picks phone or tablet.

> [!IMPORTANT]
> The most important review goal is validating there is **no regression on the tablet layout**. All POS screens on tablet should look and behave exactly as before.

### Base branch

Target: **`woomob-2661-woo-pos-phone-adaptive-design-system-with-breakpoint-based`** (PR [#15656](https://github.com/woocommerce/woocommerce-android/pull/15656)) — not `trunk`.

### What changed (6 commits)

1. **Inject POS home ViewModels via composable parameter** — `WooPosItemsScreen`, `WooPosCartScreen`, `WooPosTotalsScreen`, `WooPosFloatingToolbar` now take `viewModel: X = hiltViewModel()`. Tablet call sites unchanged (default preserves old behaviour).
2. **Add `WooPosHomePhoneScreen`** — inner NavHost, `screenPositionState` → route sync for Cart ↔ Totals, barcode listener, debug-only "Cart (debug)" FAB on Products.
3. **Route POS home to phone screen on phone layout** — branch inside `homeScreen(...)` on `isWooPosPhoneLayout()`.
4. **Share POS home dialogs** — new `WooPosHomeDialogs`, used by both tablet and phone.
5. **Extract POS home root container modifier** — `Modifier.wooPosHomeRootContainer(state, onHomeUIEvent)` wraps `fillMaxSize + background + listenForBarcodes` in one place.
6. **Share POS home product/cart/totals panes** — `WooPosHomeProductsPane`, `WooPosHomeCartPane`, `WooPosHomeTotalsPane`. Preview-mode guard baked in; phone previews no longer crash.

### Out of scope (later tickets)

- **WOOMOB-2708** — phone-adapted Products screen wrapper
- **WOOMOB-2709** — phone-adapted Cart / Totals wrappers
- **WOOMOB-2710** — back press handling + empty-cart auto-nav
- **WOOMOB-2657** — persistent bottom "Cart (n) / Checkout / Cash" button (replaces the temporary debug FAB)

### Debug FAB

Phone Products shows a **"Cart (debug)"** `ExtendedFloatingActionButton` in the bottom-right. Only compiled into debug builds (`PackageUtils.isDebugBuild()`). Temporary — lands in trunk with this PR, removed when **WOOMOB-2657** (bottom button) lands.

### Test Steps

> [!TIP]
> Tablet regression check is the priority. Phone is gated by the `WOO_POS_PHONE` feature flag (on by default in debug builds).

**Tablet (Medium Tablet API 33 or any real tablet)**

1. Build and install from this branch.
2. Open POS — products grid on the left, cart in the middle, ability to open totals. Confirm the three-pane layout is unchanged.
3. Add items to the cart, open totals, try cash payment, dismiss dialogs. Nothing should look different from `woomob-2661` baseline.

**Phone (Pixel 9 Pro XL or similar)**

1. Build and install from this branch (WOO_POS_PHONE flag is on by default in debug builds).
2. Open POS — Products is full-screen.
3. Tap the "Cart (debug)" FAB in the bottom-right → Cart full-screen.
4. Tap "Check out" inside Cart → Totals full-screen.
5. Complete cash payment → goes back to Products.

### Images / gif

#### Tablet — no regression (before = [`woomob-2661`](https://github.com/woocommerce/woocommerce-android/pull/15656), after = this PR)

| Screen | Before | After |
| --- | --- | --- |
| Products + empty cart | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-tablet-before_01_products_empty.png) | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-tablet-after_01_products_empty.png) |
| Cart with items | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-tablet-before_02_cart_with_items.png) | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-tablet-after_02_cart_with_items.png) |
| Totals | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-tablet-before_03_totals.png) | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-tablet-after_03_totals.png) |
| Overflow menu | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-tablet-before_04_menu.png) | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-tablet-after_04_menu.png) |

#### Phone — broken 3-pane before, linear flow after

| Screen | Before (tablet layout on phone — unusable) | After (phone NavHost flow) |
| --- | --- | --- |
| POS landing | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-phone-before-01_pos_landing-scaled.png) | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-phone-after-01_pos_landing-scaled.png) |
| After adding items | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-phone-before-02_after_adding_items-scaled.png) | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-phone-after-02_after_adding_items-scaled.png) |
| Cart / Totals | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-phone-before-03_totals_attempt-scaled.png) | ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-phone-after-03_phone_cart-scaled.png) ![](https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2707-phone-after-04_phone_totals-scaled.png) |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
