### PR TITLE
[WOOMOB-2681] Fix Woo notification tap routing and cleanup

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
@@ -80,9 +80,7 @@ class WooNotificationBuilder @Inject constructor(
         flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         putExtra(MainActivity.FIELD_OPENED_FROM_PUSH, true)
         putExtra(MainActivity.FIELD_PUSH_ID, pushId)
-        if (notification.remoteNoteId != 0L) {
-            putExtra(MainActivity.FIELD_REMOTE_NOTIFICATION, notification)
-        }
+        putExtra(MainActivity.FIELD_REMOTE_NOTIFICATION, notification)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -268,6 +268,24 @@ class NotificationMessageHandler @Inject constructor(
     }
 
     @Synchronized
+    fun removeTappedNotificationAndSummaryIfNeeded(localPushId: Int, notification: Notification) {
+        with(notificationBuilder) {
+            cancelNotification(localPushId)
+
+            val hasRemainingChildrenInGroup = getActiveNotifications().any {
+                !it.isGroupSummary &&
+                    it.id != localPushId &&
+                    it.channelType == notification.channelType.name &&
+                    it.remoteSiteId == notification.remoteSiteId
+            }
+
+            if (!hasRemainingChildrenInGroup) {
+                cancelNotification(notification.getGroupPushId())
+            }
+        }
+    }
+
+    @Synchronized
     fun removeNotificationsOfTypeFromSystemsBar(type: NotificationChannelType, remoteSiteId: Long) {
         with(notificationBuilder) {
             getActiveNotifications()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -195,7 +195,7 @@ class MainActivityViewModel @Inject constructor(
 
     private fun onSinglePushNotificationOpened(localPushId: Int, notification: Notification) {
         notificationHandler.markNotificationTapped(notification.remoteNoteId)
-        notificationHandler.removeNotificationByNotificationIdFromSystemsBar(localPushId)
+        notificationHandler.removeTappedNotificationAndSummaryIfNeeded(localPushId, notification)
         when (notification.noteType) {
             is WooNotificationType.NewOrder -> {
                 when {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -354,15 +354,16 @@ class NotificationMessageHandlerTest {
     }
 
     @Test
-    fun `given site is hidden and user has no access token, when woo notification received, then process it`() = runTest {
-        doReturn(false).whenever(accountStore).hasAccessToken()
-        createWooNotificationMessageHandler()
-        whenever(getWooVisibleSites.invoke()).thenReturn(emptyList())
+    fun `given site is hidden and user has no access token, when woo notification received, then process it`() =
+        runTest {
+            doReturn(false).whenever(accountStore).hasAccessToken()
+            createWooNotificationMessageHandler()
+            whenever(getWooVisibleSites.invoke()).thenReturn(emptyList())
 
-        notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
+            notificationMessageHandler.onNewMessageReceived(wooNotificationPayload)
 
-        verify(dispatcher, atLeastOnce()).dispatch(any())
-    }
+            verify(dispatcher, atLeastOnce()).dispatch(any())
+        }
 
     @Test
     fun `when an incoming notification is received, then we should update that notification to local cache`() {
@@ -684,7 +685,10 @@ class NotificationMessageHandlerTest {
         }
     }
 
-    private fun Notification.toActiveNotificationData(id: Int, isGroupSummary: Boolean = false) = ActiveNotificationData(
+    private fun Notification.toActiveNotificationData(
+        id: Int,
+        isGroupSummary: Boolean = false
+    ) = ActiveNotificationData(
         id = id,
         remoteNoteId = remoteNoteId,
         remoteSiteId = remoteSiteId,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -600,6 +600,70 @@ class NotificationMessageHandlerTest {
     }
 
     @Test
+    fun `when tapped notification is the last child in its group, then remove child and summary`() {
+        val childNotificationId = 10000
+        val summaryNotificationId = orderNotification.getGroupPushId()
+        doReturn(
+            listOf(
+                orderNotification.toActiveNotificationData(id = childNotificationId),
+                orderNotification.toActiveNotificationData(id = summaryNotificationId, isGroupSummary = true)
+            )
+        ).whenever(notificationBuilder).getActiveNotifications()
+
+        notificationMessageHandler.removeTappedNotificationAndSummaryIfNeeded(
+            localPushId = childNotificationId,
+            notification = orderNotification
+        )
+
+        verify(notificationBuilder).cancelNotification(childNotificationId)
+        verify(notificationBuilder).cancelNotification(summaryNotificationId)
+    }
+
+    @Test
+    fun `when another child in the same group remains, then keep summary notification`() {
+        val tappedNotificationId = 10000
+        val remainingChildId = 10001
+        val summaryNotificationId = orderNotification.getGroupPushId()
+        doReturn(
+            listOf(
+                orderNotification.toActiveNotificationData(id = tappedNotificationId),
+                orderNotification.toActiveNotificationData(id = remainingChildId),
+                orderNotification.toActiveNotificationData(id = summaryNotificationId, isGroupSummary = true)
+            )
+        ).whenever(notificationBuilder).getActiveNotifications()
+
+        notificationMessageHandler.removeTappedNotificationAndSummaryIfNeeded(
+            localPushId = tappedNotificationId,
+            notification = orderNotification
+        )
+
+        verify(notificationBuilder).cancelNotification(tappedNotificationId)
+        verify(notificationBuilder, never()).cancelNotification(summaryNotificationId)
+    }
+
+    @Test
+    fun `when only notifications from another store remain, then remove tapped group summary`() {
+        val tappedNotificationId = 10000
+        val otherStoreChildId = 10001
+        val summaryNotificationId = orderNotification.getGroupPushId()
+        doReturn(
+            listOf(
+                orderNotification.toActiveNotificationData(id = tappedNotificationId),
+                orderNotificationSite2.toActiveNotificationData(id = otherStoreChildId),
+                orderNotification.toActiveNotificationData(id = summaryNotificationId, isGroupSummary = true)
+            )
+        ).whenever(notificationBuilder).getActiveNotifications()
+
+        notificationMessageHandler.removeTappedNotificationAndSummaryIfNeeded(
+            localPushId = tappedNotificationId,
+            notification = orderNotification
+        )
+
+        verify(notificationBuilder).cancelNotification(tappedNotificationId)
+        verify(notificationBuilder).cancelNotification(summaryNotificationId)
+    }
+
+    @Test
     fun `remove notifications concurrently without throwing ConcurrentModificationException`() {
         notificationMessageHandler.removeAllNotificationsFromSystemsBar()
 
@@ -620,13 +684,13 @@ class NotificationMessageHandlerTest {
         }
     }
 
-    private fun Notification.toActiveNotificationData(id: Int) = ActiveNotificationData(
+    private fun Notification.toActiveNotificationData(id: Int, isGroupSummary: Boolean = false) = ActiveNotificationData(
         id = id,
         remoteNoteId = remoteNoteId,
         remoteSiteId = remoteSiteId,
         channelType = channelType.name,
         noteMessage = noteMessage,
         noteTypeTrackingValue = noteType.trackingValue,
-        isGroupSummary = false
+        isGroupSummary = isGroupSummary
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -194,7 +194,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
 
         verify(notificationMessageHandler, atLeastOnce()).markNotificationTapped(eq(testOrderNotification.remoteNoteId))
         verify(notificationMessageHandler, atLeastOnce())
-            .removeNotificationByNotificationIdFromSystemsBar(eq(localPushId))
+            .removeTappedNotificationAndSummaryIfNeeded(eq(localPushId), eq(testOrderNotification))
         assertThat(event).isEqualTo(
             ViewOrderDetail(
                 testOrderNotification.uniqueId,
@@ -217,7 +217,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
 
         verify(notificationMessageHandler, atLeastOnce()).markNotificationTapped(eq(testOrderNotification.remoteNoteId))
         verify(notificationMessageHandler, atLeastOnce())
-            .removeNotificationByNotificationIdFromSystemsBar(eq(localPushId))
+            .removeTappedNotificationAndSummaryIfNeeded(eq(localPushId), eq(testOrderNotification))
         assertThat(event).isEqualTo(ViewOrderList)
     }
 
@@ -234,7 +234,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         verify(notificationMessageHandler, atLeastOnce())
             .markNotificationTapped(eq(testReviewNotification.remoteNoteId))
         verify(notificationMessageHandler, atLeastOnce())
-            .removeNotificationByNotificationIdFromSystemsBar(eq(localPushId))
+            .removeTappedNotificationAndSummaryIfNeeded(eq(localPushId), eq(testReviewNotification))
         assertThat(event).isEqualTo(ViewReviewDetail(testReviewNotification.uniqueId))
     }
 
@@ -575,7 +575,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         verify(notificationMessageHandler, atLeastOnce())
             .markNotificationTapped(eq(testBlazeNotification.remoteNoteId))
         verify(notificationMessageHandler, atLeastOnce())
-            .removeNotificationByNotificationIdFromSystemsBar(eq(localPushId))
+            .removeTappedNotificationAndSummaryIfNeeded(eq(localPushId), eq(testBlazeNotification))
         assertThat(event).isEqualTo(
             ViewBlazeCampaignDetail(
                 testBlazeNotification.uniqueId.toString()


### PR DESCRIPTION
### Description
Fixes WOOMOB-2681

This updates Woo-driven push notifications to always include the notification payload in the tap intent so they route to the correct destination even when they do not have a WP.com `remoteNoteId`.

It also fixes the remaining tray cleanup gap for Woo notifications by removing the tapped child notification and, when that child was the last active notification in its exact group (`channelType + remoteSiteId`), removing the group summary notification as well.

Changes in this PR:
- always include `FIELD_REMOTE_NOTIFICATION` in `WooNotificationBuilder.getResultIntent()`
- add summary-aware cleanup in `NotificationMessageHandler` for single tapped notifications
- remove the group summary only when the tapped child was the last active notification in its exact group
- update `MainActivityViewModel` to use the new cleanup path for single push opens
- add regression tests for last-child summary removal, remaining-sibling behavior, and exact-group scoping by store

### Test Steps
1. Prepare a test site following paaHJt-9VE-p2
2. Trigger a push notification.
3. Tap the notification.
4. Confirm the app opens the expected destination instead of falling back to My Store.
5. Confirm the tapped notification is removed from the tray.
6. Confirm the group summary is also removed when that tapped notification was the last active notification in its group.
7. Trigger two Woo notifications in the same group and tap one of them.
8. Confirm the tapped child is removed but the group summary remains because another child is still active.
9. Trigger notifications for a different store and confirm tapping one group does not incorrectly preserve or remove the other store's summary.
10. Trigger a standard notification with a non-zero `remoteNoteId` and confirm tap routing still works.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.