### PR TITLE
[WOOMOB-2708] Woo POS phone: products screen wrapper

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosSearchInput.kt
@@ -53,6 +53,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.home.items.WOO_POS_ITEMS_TOOLBAR_HEIGHT
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent
 import kotlinx.coroutines.delay
 import kotlinx.parcelize.Parcelize
 
@@ -280,6 +281,16 @@ sealed class WooPosSearchUIEvent {
     object SearchIconClicked : WooPosSearchUIEvent()
     data class Search(val query: String, val cursorPosition: Int) : WooPosSearchUIEvent()
     object Close : WooPosSearchUIEvent()
+}
+
+fun WooPosSearchUIEvent.toItemsUIEvent(): WooPosItemsUIEvent = when (this) {
+    WooPosSearchUIEvent.Clear -> WooPosItemsUIEvent.ClearSearchClicked
+    WooPosSearchUIEvent.Close -> WooPosItemsUIEvent.CloseSearchClicked
+    WooPosSearchUIEvent.SearchIconClicked -> WooPosItemsUIEvent.SearchIconClicked
+    is WooPosSearchUIEvent.Search -> WooPosItemsUIEvent.SearchChanged(
+        query = query,
+        cursorPosition = cursorPosition,
+    )
 }
 
 @WooPosPreview

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/designsystem/WooPosSizes.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/designsystem/WooPosSizes.kt
@@ -109,7 +109,7 @@ fun Dp.toAdaptiveIconSize(): Dp = when (rememberWooPosBreakpoint()) {
 fun Modifier.adaptiveContentWidth(): Modifier = when (rememberWooPosBreakpoint()) {
     WooPosBreakpoint.Phone -> this.fillMaxWidth()
     WooPosBreakpoint.SmallTablet -> this.fillMaxWidth(fraction = 2f / 3f)
-    WooPosBreakpoint.Tablet -> this.fillMaxWidth(fraction = 3f / 5f)
+    WooPosBreakpoint.Tablet -> this.fillMaxWidth(fraction = 0.55f)
 }
 
 internal enum class WooPosBreakpoint { Phone, SmallTablet, Tablet }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsContent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsContent.kt
@@ -1,0 +1,89 @@
+package com.woocommerce.android.ui.woopos.home.items
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.SearchState
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreen
+import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchScreen
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsScreen
+import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
+import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsNavigationData
+import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsScreen
+
+@Composable
+fun WooPosItemsContent(
+    state: WooPosItemsToolbarViewState,
+    onBackFromVariations: () -> Unit,
+    modifier: Modifier = Modifier,
+    productsListState: LazyListState = rememberLazyListState(),
+    couponsListState: LazyListState = rememberLazyListState(),
+    productsContent: @Composable () -> Unit = {
+        WooPosProductsScreen(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+            listState = productsListState,
+        )
+    },
+    couponsContent: @Composable () -> Unit = {
+        WooPosCouponsScreen(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+            listState = couponsListState,
+        )
+    },
+    productsSearchContent: @Composable () -> Unit = { WooPosItemsSearchScreen() },
+    couponsSearchContent: @Composable () -> Unit = { WooPosCouponsSearchScreen() },
+    variationsContent: @Composable (WooPosVariationsNavigationData) -> Unit = { data ->
+        WooPosVariationsScreen(
+            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+            variableProductData = data,
+            onBackClicked = onBackFromVariations,
+        )
+    },
+) {
+    Crossfade(
+        targetState = state.toScreenState(),
+        animationSpec = tween(durationMillis = 300, easing = LinearEasing),
+        modifier = modifier,
+    ) { screenState ->
+        when (screenState) {
+            ItemsScreenState.Products -> productsContent()
+            ItemsScreenState.Coupons -> couponsContent()
+            ItemsScreenState.ProductsSearch -> productsSearchContent()
+            ItemsScreenState.CouponsSearch -> couponsSearchContent()
+            is ItemsScreenState.Variations -> variationsContent(screenState.variableProductData)
+        }
+    }
+}
+
+internal sealed class ItemsScreenState {
+    data object Products : ItemsScreenState()
+    data object Coupons : ItemsScreenState()
+    data object ProductsSearch : ItemsScreenState()
+    data object CouponsSearch : ItemsScreenState()
+    data class Variations(val variableProductData: WooPosVariationsNavigationData) : ItemsScreenState()
+}
+
+internal fun WooPosItemsToolbarViewState.toScreenState(): ItemsScreenState = when (this) {
+    is WooPosItemsToolbarViewState.ProductList -> when (val s = search) {
+        SearchState.Hidden -> ItemsScreenState.Products
+        is SearchState.Visible -> when (s.state) {
+            WooPosSearchInputState.Closed -> ItemsScreenState.Products
+            is WooPosSearchInputState.Open -> ItemsScreenState.ProductsSearch
+        }
+    }
+    is WooPosItemsToolbarViewState.VariationList -> ItemsScreenState.Variations(variableProductData)
+    is WooPosItemsToolbarViewState.CouponList -> when (val s = search) {
+        SearchState.Hidden -> ItemsScreenState.Coupons
+        is SearchState.Visible -> when (s.state) {
+            WooPosSearchInputState.Closed -> ItemsScreenState.Coupons
+            is WooPosSearchInputState.Open -> ItemsScreenState.CouponsSearch
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsContent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsContent.kt
@@ -3,49 +3,21 @@ package com.woocommerce.android.ui.woopos.home.items
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.SearchState
-import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreen
-import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchScreen
-import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsScreen
-import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsNavigationData
-import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsScreen
 
 @Composable
 fun WooPosItemsContent(
     state: WooPosItemsToolbarViewState,
-    onBackFromVariations: () -> Unit,
+    productsContent: @Composable () -> Unit,
+    couponsContent: @Composable () -> Unit,
+    productsSearchContent: @Composable () -> Unit,
+    couponsSearchContent: @Composable () -> Unit,
+    variationsContent: @Composable (WooPosVariationsNavigationData) -> Unit,
     modifier: Modifier = Modifier,
-    productsListState: LazyListState = rememberLazyListState(),
-    couponsListState: LazyListState = rememberLazyListState(),
-    productsContent: @Composable () -> Unit = {
-        WooPosProductsScreen(
-            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
-            listState = productsListState,
-        )
-    },
-    couponsContent: @Composable () -> Unit = {
-        WooPosCouponsScreen(
-            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
-            listState = couponsListState,
-        )
-    },
-    productsSearchContent: @Composable () -> Unit = { WooPosItemsSearchScreen() },
-    couponsSearchContent: @Composable () -> Unit = { WooPosCouponsSearchScreen() },
-    variationsContent: @Composable (WooPosVariationsNavigationData) -> Unit = { data ->
-        WooPosVariationsScreen(
-            modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
-            variableProductData = data,
-            onBackClicked = onBackFromVariations,
-        )
-    },
 ) {
     Crossfade(
         targetState = state.toScreenState(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.woopos.home.items.products.WooPosItemsScreenPr
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsScreen
 import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
 import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreenPreview
+import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsScreen
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -171,13 +172,17 @@ private fun MainItemsList(
 
             WooPosItemsContent(
                 state = state.value,
-                onBackFromVariations = onBackClicked,
-                productsListState = productsViewState,
-                couponsListState = couponsListState,
                 productsContent = productsContent,
                 couponsContent = couponsContent,
                 productsSearchContent = productsSearchContent,
                 couponsSearchContent = couponsSearchContent,
+                variationsContent = { data ->
+                    WooPosVariationsScreen(
+                        modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+                        variableProductData = data,
+                        onBackClicked = onBackClicked,
+                    )
+                },
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -1,8 +1,5 @@
 package com.woocommerce.android.ui.woopos.home.items
 
-import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -22,12 +19,12 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
+import com.woocommerce.android.ui.woopos.common.composeui.component.toItemsUIEvent
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab.Coupons
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab.HighlightLevel
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab.Products
-import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent.SearchChanged
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreen
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreenContentPreview
 import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchContentPreview
@@ -36,8 +33,6 @@ import com.woocommerce.android.ui.woopos.home.items.products.WooPosItemsScreenPr
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsScreen
 import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
 import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreenPreview
-import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsNavigationData
-import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsScreen
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -82,20 +77,7 @@ private fun WooPosItemsScreen(
         bannerState = bannerState,
         productsViewState = productsViewState,
         couponsListState = couponsListState,
-        onSearchEvent = {
-            when (it) {
-                WooPosSearchUIEvent.Clear -> onUIEvent(WooPosItemsUIEvent.ClearSearchClicked)
-                WooPosSearchUIEvent.Close -> onUIEvent(WooPosItemsUIEvent.CloseSearchClicked)
-                is WooPosSearchUIEvent.Search -> onUIEvent(
-                    SearchChanged(
-                        query = it.query,
-                        cursorPosition = it.cursorPosition,
-                    )
-                )
-
-                WooPosSearchUIEvent.SearchIconClicked -> onUIEvent(WooPosItemsUIEvent.SearchIconClicked)
-            }
-        },
+        onSearchEvent = { onUIEvent(it.toItemsUIEvent()) },
         onAddCouponEvent = {
             onUIEvent(WooPosItemsUIEvent.AddCouponIconClicked)
         },
@@ -187,70 +169,16 @@ private fun MainItemsList(
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
 
-            val currentState = state.value
-
-            Crossfade(
-                targetState = getScreenState(currentState),
-                animationSpec = tween(
-                    durationMillis = 300,
-                    easing = LinearEasing,
-                ),
-            ) { screenState ->
-                when (screenState) {
-                    ScreenState.Products -> productsContent()
-                    ScreenState.ProductsSearch -> productsSearchContent()
-                    ScreenState.Coupons -> couponsContent()
-                    is ScreenState.Variations -> {
-                        WooPosVariationsScreen(
-                            modifier = Modifier.padding(
-                                horizontal = WooPosSpacing.Medium.value,
-                            ),
-                            variableProductData = screenState.variableProductData,
-                            onBackClicked = { onBackClicked() },
-                        )
-                    }
-                    ScreenState.CouponsSearch -> couponsSearchContent()
-                }
-            }
-        }
-    }
-}
-
-private sealed class ScreenState {
-    object Products : ScreenState()
-    object Coupons : ScreenState()
-    object ProductsSearch : ScreenState()
-    object CouponsSearch : ScreenState()
-    data class Variations(val variableProductData: WooPosVariationsNavigationData) : ScreenState()
-}
-
-private fun getScreenState(state: WooPosItemsToolbarViewState): ScreenState {
-    return when (state) {
-        is WooPosItemsToolbarViewState.ProductList -> {
-            when (val searchState = state.search) {
-                WooPosItemsToolbarViewState.SearchState.Hidden -> ScreenState.Products
-                is WooPosItemsToolbarViewState.SearchState.Visible -> {
-                    when (searchState.state) {
-                        WooPosSearchInputState.Closed -> ScreenState.Products
-                        is WooPosSearchInputState.Open -> ScreenState.ProductsSearch
-                    }
-                }
-            }
-        }
-
-        is WooPosItemsToolbarViewState.VariationList -> ScreenState.Variations(
-            variableProductData = state.variableProductData
-        )
-        is WooPosItemsToolbarViewState.CouponList -> {
-            when (val searchState = state.search) {
-                WooPosItemsToolbarViewState.SearchState.Hidden -> ScreenState.Coupons
-                is WooPosItemsToolbarViewState.SearchState.Visible -> {
-                    when (searchState.state) {
-                        WooPosSearchInputState.Closed -> ScreenState.Coupons
-                        is WooPosSearchInputState.Open -> ScreenState.CouponsSearch
-                    }
-                }
-            }
+            WooPosItemsContent(
+                state = state.value,
+                onBackFromVariations = onBackClicked,
+                productsListState = productsViewState,
+                couponsListState = couponsListState,
+                productsContent = productsContent,
+                couponsContent = couponsContent,
+                productsSearchContent = productsSearchContent,
+                couponsSearchContent = couponsSearchContent,
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -85,7 +85,8 @@ fun WooPosItemsToolbar(
                     WooPosItemsTabsRow(
                         tabs = state.tabs,
                         onTabClicked = onTabClicked,
-                        modifier = Modifier.weight(1f)
+                        itemSpacing = WooPosSpacing.Large.value,
+                        modifier = Modifier.weight(1f),
                     )
 
                     if (state is WooPosItemsToolbarViewState.CouponList) {
@@ -119,8 +120,8 @@ fun WooPosItemsToolbar(
 fun WooPosItemsTabsRow(
     tabs: List<WooPosItemsToolbarViewState.Tab>,
     onTabClicked: (WooPosItemsToolbarViewState.Tab) -> Unit,
+    itemSpacing: Dp,
     modifier: Modifier = Modifier,
-    itemSpacing: Dp = WooPosSpacing.Large.value,
 ) {
     Row(
         modifier = modifier,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -57,58 +57,53 @@ fun WooPosItemsToolbar(
             .fillMaxWidth()
             .heightIn(min = WOO_POS_ITEMS_TOOLBAR_HEIGHT)
     ) {
-        when {
-            isSearchOpen -> {
-                WooPosSearchInput(
-                    state = (state.search as SearchState.Visible).state,
-                    onEvent = onSearchEvent,
+        when (isSearchOpen) {
+            true -> WooPosSearchInput(
+                state = (state.search as SearchState.Visible).state,
+                onEvent = onSearchEvent,
+            )
+            false -> Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = WOO_POS_ITEMS_TOOLBAR_HEIGHT),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                when {
+                    leadingContent != null -> leadingContent()
+                    state.backNavigation -> {
+                        Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
+                        WooPosBackButton { onBackClicked() }
+                        Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
+                    }
+                    else -> Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+                }
+
+                WooPosItemsTabsRow(
+                    tabs = state.tabs,
+                    onTabClicked = onTabClicked,
+                    itemSpacing = WooPosSpacing.Large.value,
+                    modifier = Modifier.weight(1f),
                 )
-            }
 
-            else -> {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(min = WOO_POS_ITEMS_TOOLBAR_HEIGHT),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    when {
-                        leadingContent != null -> leadingContent()
-                        state.backNavigation -> {
-                            Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
-                            WooPosBackButton { onBackClicked() }
-                            Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
-                        }
-                        else -> Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
-                    }
-
-                    WooPosItemsTabsRow(
-                        tabs = state.tabs,
-                        onTabClicked = onTabClicked,
-                        itemSpacing = WooPosSpacing.Large.value,
-                        modifier = Modifier.weight(1f),
+                if (state is WooPosItemsToolbarViewState.CouponList) {
+                    Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+                    WooPosCircularIconButton(
+                        icon = ImageVector.vectorResource(R.drawable.ic_add),
+                        contentDescription = stringResource(
+                            id = R.string.woopos_coupons_empty_list_create_coupon_label,
+                        ),
+                        onClick = { onAddCouponEvent() }
                     )
+                    Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+                }
 
-                    if (state is WooPosItemsToolbarViewState.CouponList) {
-                        Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
-                        WooPosCircularIconButton(
-                            icon = ImageVector.vectorResource(R.drawable.ic_add),
-                            contentDescription = stringResource(
-                                id = R.string.woopos_coupons_empty_list_create_coupon_label,
-                            ),
-                            onClick = { onAddCouponEvent() }
+                when (val search = state.search) {
+                    SearchState.Hidden -> Unit
+                    is SearchState.Visible -> {
+                        WooPosSearchInput(
+                            state = search.state,
+                            onEvent = onSearchEvent,
                         )
-                        Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
-                    }
-
-                    when (val search = state.search) {
-                        SearchState.Hidden -> Unit
-                        is SearchState.Visible -> {
-                            WooPosSearchInput(
-                                state = search.state,
-                                onEvent = onSearchEvent,
-                            )
-                        }
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbar.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -19,6 +18,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
@@ -45,6 +46,7 @@ fun WooPosItemsToolbar(
     onSearchEvent: (WooPosSearchUIEvent) -> Unit,
     onBackClicked: () -> Unit,
     onAddCouponEvent: () -> Unit,
+    leadingContent: (@Composable () -> Unit)? = null,
 ) {
     val isSearchOpen = (state.search as? SearchState.Visible)?.let {
         it.state is WooPosSearchInputState.Open
@@ -59,39 +61,28 @@ fun WooPosItemsToolbar(
             isSearchOpen -> {
                 WooPosSearchInput(
                     state = (state.search as SearchState.Visible).state,
-                    onEvent = { event ->
-                        onSearchEvent(event)
-                    },
+                    onEvent = onSearchEvent,
                 )
             }
 
-            state.backNavigation -> {
+            else -> {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(min = WOO_POS_ITEMS_TOOLBAR_HEIGHT),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
-                    WooPosBackButton { onBackClicked() }
-                    Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
+                    when {
+                        leadingContent != null -> leadingContent()
+                        state.backNavigation -> {
+                            Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
+                            WooPosBackButton { onBackClicked() }
+                            Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
+                        }
+                        else -> Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+                    }
 
-                    TabsRow(
-                        tabs = state.tabs,
-                        onTabClicked = onTabClicked,
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-            }
-
-            else -> {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
-
-                    TabsRow(
+                    WooPosItemsTabsRow(
                         tabs = state.tabs,
                         onTabClicked = onTabClicked,
                         modifier = Modifier.weight(1f)
@@ -114,9 +105,7 @@ fun WooPosItemsToolbar(
                         is SearchState.Visible -> {
                             WooPosSearchInput(
                                 state = search.state,
-                                onEvent = { event ->
-                                    onSearchEvent(event)
-                                },
+                                onEvent = onSearchEvent,
                             )
                         }
                     }
@@ -127,28 +116,35 @@ fun WooPosItemsToolbar(
 }
 
 @Composable
-private fun TabsRow(
+fun WooPosItemsTabsRow(
     tabs: List<WooPosItemsToolbarViewState.Tab>,
     onTabClicked: (WooPosItemsToolbarViewState.Tab) -> Unit,
     modifier: Modifier = Modifier,
+    itemSpacing: Dp = WooPosSpacing.Large.value,
 ) {
-    LazyRow(
+    Row(
         modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        items(tabs.size) { index ->
-            val tab = tabs[index]
+        tabs.forEachIndexed { index, tab ->
             WooPosText(
                 text = tab.name,
                 style = WooPosTypography.Heading,
                 fontWeight = FontWeight.Bold,
                 color = tab.highlightLevel.titleColor(),
-                modifier = Modifier.clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = { onTabClicked(tab) }
-                )
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = { onTabClicked(tab) }
+                    )
             )
-            Spacer(modifier = Modifier.width(WooPosSpacing.Large.value))
+            if (index < tabs.lastIndex) {
+                Spacer(modifier = Modifier.width(itemSpacing))
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosHomePhoneScreen.kt
@@ -24,7 +24,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpa
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.home.WooPosHomeCartPane
 import com.woocommerce.android.ui.woopos.home.WooPosHomeDialogs
-import com.woocommerce.android.ui.woopos.home.WooPosHomeProductsPane
 import com.woocommerce.android.ui.woopos.home.WooPosHomeState
 import com.woocommerce.android.ui.woopos.home.WooPosHomeTotalsPane
 import com.woocommerce.android.ui.woopos.home.WooPosHomeUIEvent
@@ -125,7 +124,7 @@ private fun WooPosHomePhoneContent(
         ) {
             composable(PHONE_PRODUCTS_ROUTE) {
                 Box(modifier = Modifier.fillMaxSize()) {
-                    WooPosHomeProductsPane(viewModel = itemsViewModel)
+                    WooPosPhoneProductsScreen(itemsViewModel = itemsViewModel)
 
                     if (PackageUtils.isDebugBuild()) {
                         // Temporary trigger so Cart is reachable until the persistent

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosPhoneProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosPhoneProductsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -35,6 +36,11 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.SearchState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreen
+import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchScreen
+import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsScreen
+import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
+import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsScreen
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarState.Menu
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarUIEvent
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarViewModel
@@ -98,10 +104,32 @@ private fun WooPosPhoneProductsContent(
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
 
+            val productsListState = rememberLazyListState()
+            val couponsListState = rememberLazyListState()
             WooPosItemsContent(
                 state = itemsState,
-                onBackFromVariations = {
-                    onItemsUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked)
+                productsContent = {
+                    WooPosProductsScreen(
+                        modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+                        listState = productsListState,
+                    )
+                },
+                couponsContent = {
+                    WooPosCouponsScreen(
+                        modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+                        listState = couponsListState,
+                    )
+                },
+                productsSearchContent = { WooPosItemsSearchScreen() },
+                couponsSearchContent = { WooPosCouponsSearchScreen() },
+                variationsContent = { data ->
+                    WooPosVariationsScreen(
+                        modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
+                        variableProductData = data,
+                        onBackClicked = {
+                            onItemsUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked)
+                        },
+                    )
                 },
                 modifier = Modifier.weight(1f),
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosPhoneProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosPhoneProductsScreen.kt
@@ -1,0 +1,175 @@
+package com.woocommerce.android.ui.woopos.home.phone
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosBackgroundOverlay
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.common.composeui.component.toItemsUIEvent
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIconSize
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+import com.woocommerce.android.ui.woopos.home.items.WOO_POS_ITEMS_TOOLBAR_HEIGHT
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsContent
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbar
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.SearchState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
+import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarState.Menu
+import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarUIEvent
+import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarViewModel
+import com.woocommerce.android.ui.woopos.home.toolbar.WooPosToolbarPopUpMenu
+
+@Composable
+fun WooPosPhoneProductsScreen(
+    modifier: Modifier = Modifier,
+    itemsViewModel: WooPosItemsViewModel = hiltViewModel(),
+    toolbarViewModel: WooPosHomeFloatingToolbarViewModel = hiltViewModel(),
+) {
+    val itemsState by itemsViewModel.viewState.collectAsState()
+    val toolbarState by toolbarViewModel.state.collectAsState()
+
+    WooPosPhoneProductsContent(
+        modifier = modifier,
+        itemsState = itemsState,
+        menu = toolbarState.menu,
+        onMenuClicked = {
+            toolbarViewModel.onUiEvent(WooPosHomeFloatingToolbarUIEvent.OnToolbarMenuClicked)
+        },
+        onMenuDismissed = {
+            toolbarViewModel.onUiEvent(WooPosHomeFloatingToolbarUIEvent.OnOutsideOfToolbarMenuClicked)
+        },
+        onMenuItemClicked = { menuItem ->
+            toolbarViewModel.onUiEvent(WooPosHomeFloatingToolbarUIEvent.MenuItemClicked(menuItem))
+        },
+        onItemsUIEvent = { itemsViewModel.onUIEvent(it) },
+    )
+}
+
+@Composable
+private fun WooPosPhoneProductsContent(
+    itemsState: WooPosItemsToolbarViewState,
+    menu: Menu,
+    onMenuClicked: () -> Unit,
+    onMenuDismissed: () -> Unit,
+    onMenuItemClicked: (Menu.MenuItem) -> Unit,
+    onItemsUIEvent: (WooPosItemsUIEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+        ) {
+            WooPosItemsToolbar(
+                modifier = Modifier.padding(end = WooPosSpacing.Medium.value),
+                state = itemsState,
+                onTabClicked = { onItemsUIEvent(WooPosItemsUIEvent.OnTabClicked(it)) },
+                onSearchEvent = { onItemsUIEvent(it.toItemsUIEvent()) },
+                onBackClicked = { onItemsUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked) },
+                onAddCouponEvent = { onItemsUIEvent(WooPosItemsUIEvent.AddCouponIconClicked) },
+                leadingContent = if (itemsState.backNavigation) {
+                    null
+                } else {
+                    { PhoneMenuButton(onMenuClicked) }
+                },
+            )
+
+            Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
+
+            WooPosItemsContent(
+                state = itemsState,
+                onBackFromVariations = {
+                    onItemsUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked)
+                },
+                modifier = Modifier.weight(1f),
+            )
+        }
+
+        WooPosBackgroundOverlay(
+            modifier = Modifier.fillMaxSize(),
+            isVisible = menu is Menu.Visible,
+            onClick = onMenuDismissed,
+        )
+
+        if (menu is Menu.Visible) {
+            WooPosToolbarPopUpMenu(
+                menuItems = menu.items,
+                onClick = onMenuItemClicked,
+                modifier = Modifier
+                    .statusBarsPadding()
+                    .align(Alignment.TopStart)
+                    .padding(
+                        start = WooPosSpacing.Small.value,
+                        top = WOO_POS_ITEMS_TOOLBAR_HEIGHT,
+                    )
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhoneMenuButton(onClick: () -> Unit) {
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier
+            .padding(horizontal = WooPosSpacing.Small.value)
+            .size(WooPosIconSize.Large.value),
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_menu_more_vert),
+            contentDescription = stringResource(R.string.woopos_menu_toolbar_content_description),
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(WooPosIconSize.Small.value),
+        )
+    }
+}
+
+@Composable
+@WooPosPreview
+fun WooPosPhoneProductsScreenPreview() {
+    val tabs = listOf(
+        WooPosItemsToolbarViewState.Tab.Products(
+            name = "Products",
+            highlightLevel = WooPosItemsToolbarViewState.Tab.HighlightLevel.Full,
+        ),
+        WooPosItemsToolbarViewState.Tab.Coupons(
+            name = "Coupons",
+            highlightLevel = WooPosItemsToolbarViewState.Tab.HighlightLevel.Normal,
+        ),
+    )
+    WooPosTheme {
+        WooPosPhoneProductsContent(
+            itemsState = WooPosItemsToolbarViewState.ProductList(
+                tabs = tabs,
+                search = SearchState.Visible(WooPosSearchInputState.Closed),
+            ),
+            menu = Menu.Hidden,
+            onMenuClicked = {},
+            onMenuDismissed = {},
+            onMenuItemClicked = {},
+            onItemsUIEvent = {},
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbar.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,7 +19,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TextButton
@@ -34,13 +32,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -131,7 +126,7 @@ private fun WooPosFloatingToolbar(
                     )
 
                     val marginBetweenCards = WooPosSpacing.Small.value
-                    PopUpMenu(
+                    WooPosToolbarPopUpMenu(
                         modifier = Modifier
                             .constrainAs(popupMenu) {
                                 bottom.linkTo(toolbar.top, margin = marginBetweenCards)
@@ -239,55 +234,6 @@ private fun MenuButtonWithPopUpMenu(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun PopUpMenu(
-    modifier: Modifier,
-    menuItems: List<Menu.MenuItem>,
-    onClick: (Menu.MenuItem) -> Unit
-) {
-    WooPosCard(
-        modifier = modifier.width(IntrinsicSize.Max),
-        elevation = TOOLBAR_ELEVATION,
-        backgroundColor = MaterialTheme.colorScheme.surfaceContainerLow,
-    ) {
-        Column {
-            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
-            menuItems.forEach { menuItem ->
-                PopUpMenuItem(menuItem, onClick)
-            }
-            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
-        }
-    }
-}
-
-@Composable
-private fun PopUpMenuItem(
-    menuItem: Menu.MenuItem,
-    onClick: (Menu.MenuItem) -> Unit
-) {
-    TextButton(onClick = { onClick(menuItem) }) {
-        Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
-        Icon(
-            imageVector = ImageVector.vectorResource(menuItem.icon),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.size(WooPosIconSize.Small.value)
-        )
-        Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
-        WooPosText(
-            modifier = Modifier
-                .padding(vertical = WooPosSpacing.Small.value)
-                .weight(1f),
-            text = stringResource(id = menuItem.title),
-            style = WooPosTypography.BodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarPopUpMenu.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosToolbarPopUpMenu.kt
@@ -1,0 +1,74 @@
+package com.woocommerce.android.ui.woopos.home.toolbar
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextOverflow
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIconSize
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarState.Menu
+
+@Composable
+fun WooPosToolbarPopUpMenu(
+    menuItems: List<Menu.MenuItem>,
+    onClick: (Menu.MenuItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    WooPosCard(
+        modifier = modifier.width(IntrinsicSize.Max),
+        elevation = WooPosElevation.Medium,
+        backgroundColor = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column {
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+            menuItems.forEach { menuItem ->
+                WooPosToolbarPopUpMenuItem(menuItem, onClick)
+            }
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+        }
+    }
+}
+
+@Composable
+private fun WooPosToolbarPopUpMenuItem(
+    menuItem: Menu.MenuItem,
+    onClick: (Menu.MenuItem) -> Unit,
+) {
+    TextButton(onClick = { onClick(menuItem) }) {
+        Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+        Icon(
+            imageVector = ImageVector.vectorResource(menuItem.icon),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(WooPosIconSize.Small.value),
+        )
+        Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+        WooPosText(
+            modifier = Modifier
+                .padding(vertical = WooPosSpacing.Small.value)
+                .weight(1f),
+            text = stringResource(menuItem.title),
+            style = WooPosTypography.BodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+    }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-2708 — based on [WOOMOB-2707](https://github.com/woocommerce/woocommerce-android/pull/15665).

Phone-adapted Products screen wrapper for Woo POS. Reuses the existing Products / Cart ViewModels and shares as much as possible with the tablet path (`WooPosItemsContent` crossfade, toolbar with `leadingContent` slot, shared `WooPosToolbarPopUpMenu`, shared search event mapping). Phone-specific pieces are just the hamburger button and the scaffold wiring.

### Test Steps
1. On a phone: open POS → Products screen shows hamburger button, "Products / Coupons" tabs, search icon, products grid, and a debug Cart FAB.
2. Tap the hamburger → popup shows Orders / Settings / Exit POS. Tap outside to dismiss.
3. Tap the search icon → search bar opens and filters.
4. Tap a variable product (e.g. "Aerodynamic Leather Computer") → Variations list opens; long title is ellipsized with "…" and the back arrow returns to Products.
5. On a tablet: POS opens to the usual 3-pane layout. Nothing should look different.

### Images/gif

**Phone**

| Products | Menu | Variations (ellipsized) |
| --- | --- | --- |
| <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2708-phone-products-scaled.png" width="240"> | <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2708-phone-menu-scaled.png" width="240"> | <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2708-phone-variations-scaled.png" width="240"> |

**Tablet (unchanged)**

<img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/woomob-2708-tablet-products.png" width="600">

- [ ] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.