### PR TITLE
[Woo PN] Refactor push notification registration into a trigger-based orchestrator

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppInitializer.kt
@@ -27,7 +27,7 @@ import com.woocommerce.android.network.ConnectionChangeReceiver
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.push.FCMRefreshWorker
 import com.woocommerce.android.notifications.push.RegisterDevice
-import com.woocommerce.android.notifications.push.RegisterDevice.Mode.IF_NEEDED
+import com.woocommerce.android.notifications.push.RegisterDevice.Trigger.APP_FOREGROUND
 import com.woocommerce.android.support.zendesk.ZendeskSettings
 import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.tools.RateLimitedTask
@@ -282,9 +282,7 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
         if (networkStatus.isConnected()) {
             updateSelectedSite.runIfNotLimited()
 
-            appCoroutineScope.launch {
-                registerDevice(IF_NEEDED)
-            }
+            registerDevice.kickoff(APP_FOREGROUND)
         }
     }
 
@@ -444,16 +442,8 @@ class AppInitializer @Inject constructor() : ApplicationLifecycleListener {
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAccountChanged(event: OnAccountChanged) {
-        val isLoggedOut = event.causeOfChange == AccountAction.SIGN_OUT && event.error == null
         if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
             analyticsTracker.sendUsageStats = !accountStore.account.tracksOptOut
-        }
-
-        val userAccountFetched = !isLoggedOut && event.causeOfChange == AccountAction.FETCH_ACCOUNT
-        if (userAccountFetched) {
-            appCoroutineScope.launch {
-                registerDevice(IF_NEEDED)
-            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/FCMMessageService.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/FCMMessageService.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.notifications.push
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.notifications.push.RegisterDevice.Mode.FORCEFULLY
+import com.woocommerce.android.notifications.push.RegisterDevice.Trigger.TOKEN_REFRESH
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T
 import dagger.hilt.android.AndroidEntryPoint
@@ -31,7 +31,7 @@ class FCMMessageService : FirebaseMessagingService() {
         appPrefsWrapper.setFCMToken(newToken)
         serviceScope.launch {
             invalidateDeviceRegistration()
-            registerDevice(FORCEFULLY)
+            registerDevice(TOKEN_REFRESH)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/FCMRefreshWorker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/FCMRefreshWorker.kt
@@ -43,7 +43,7 @@ class FCMRefreshWorker @AssistedInject constructor(
                 onSuccess = { token ->
                     WooLog.d(WooLog.T.NOTIFICATIONS, "FCM token retrieved")
                     appPrefs.setFCMToken(token)
-                    registerDevice(RegisterDevice.Mode.FORCEFULLY)
+                    registerDevice(RegisterDevice.Trigger.TOKEN_REFRESH)
                     Result.success()
                 },
                 onFailure = { e ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -173,21 +173,17 @@ class PushNotificationRepository @Inject constructor(
         remove(getPushLocaleKeyForSite(siteId))
     }
 
-    private fun getPushTokenIdKeyForSite(siteId: Long): Preferences.Key<String> {
-        return stringPreferencesKey("$PUSH_TOKEN_KEY_PREFIX$siteId")
-    }
+    private fun getPushTokenIdKeyForSite(siteId: Long): Preferences.Key<String> =
+        stringPreferencesKey("$PUSH_TOKEN_KEY_PREFIX$siteId")
 
-    private fun getPushTokenValueKeyForSite(siteId: Long): Preferences.Key<String> {
-        return stringPreferencesKey("$PUSH_TOKEN_VALUE_KEY_PREFIX$siteId")
-    }
+    private fun getPushTokenValueKeyForSite(siteId: Long): Preferences.Key<String> =
+        stringPreferencesKey("$PUSH_TOKEN_VALUE_KEY_PREFIX$siteId")
 
-    private fun getPushLocaleKeyForSite(siteId: Long): Preferences.Key<String> {
-        return stringPreferencesKey("$PUSH_LOCALE_KEY_PREFIX$siteId")
-    }
+    private fun getPushLocaleKeyForSite(siteId: Long): Preferences.Key<String> =
+        stringPreferencesKey("$PUSH_LOCALE_KEY_PREFIX$siteId")
 
-    suspend fun isWooPushTokenRegisteredForSite(siteId: Long): Boolean {
-        return observeWooPushTokenRegisteredForSite(siteId).first()
-    }
+    suspend fun isWooPushTokenRegisteredForSite(siteId: Long): Boolean =
+        observeWooPushTokenRegisteredForSite(siteId).first()
 
     suspend fun shouldRegisterWooPushForSite(currentToken: String, siteId: Long): Boolean {
         val preferences = pushNotificationsDataStore.data.first()
@@ -198,11 +194,10 @@ class PushNotificationRepository @Inject constructor(
             registration.locale != getDeviceLocale()
     }
 
-    fun isWpComPushRegistered(): Boolean {
-        val wpComPushServerId = prefsWrapper.getFluxCPreferences()
+    fun isWpComPushRegistered(): Boolean =
+        prefsWrapper.getFluxCPreferences()
             .getString(WpComPushNotificationStore.WPCOM_PUSH_DEVICE_SERVER_ID, null)
-        return wpComPushServerId.isNotNullOrEmpty()
-    }
+            .isNotNullOrEmpty()
 
     fun observeWooPushTokenRegisteredForSite(siteId: Long): Flow<Boolean> {
         val tokenKey = getPushTokenIdKeyForSite(siteId)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.notifications.push
 
 import android.os.Build
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -50,10 +51,17 @@ class PushNotificationRepository @Inject constructor(
             tag = WooLog.T.NOTIFICATIONS,
             message = "Registering FCM token in WPCOM instance${if (BuildConfig.DEBUG) ": $token" else ""}"
         )
-        wpComPushNotificationStore.registerDevice(token, WpComPushNotificationStore.NotificationAppKey.WOOCOMMERCE)
+        wpComPushNotificationStore.registerDevice(
+            token,
+            WpComPushNotificationStore.NotificationAppKey.WOOCOMMERCE
+        )
     }
 
-    suspend fun registerPushTokenInWooCoreSystem(token: String, selectedSite: SiteModel): Result<Unit> {
+    suspend fun registerPushTokenInWooCoreSystem(
+        token: String,
+        selectedSite: SiteModel,
+        allowWpComFallback: Boolean = true
+    ): Result<Unit> {
         WooLog.d(
             tag = WooLog.T.NOTIFICATIONS,
             message = "Registering FCM token in Woo Core instance${if (BuildConfig.DEBUG) ": $token" else ""}"
@@ -70,12 +78,12 @@ class PushNotificationRepository @Inject constructor(
             metadata = metadata
         )
         return if (!result.isError) {
-            result.model?.let { pushToken ->
+            result.model?.let { tokenId ->
                 notificationAnalyticsTracker.track(
                     stat = AnalyticsEvent.WOO_PUSH_TOKEN_REGISTER_SUCCESS,
                     siteId = selectedSite.siteId
                 )
-                savePushTokenForSite(selectedSite.siteId, pushToken)
+                savePushTokenForSite(selectedSite.siteId, WooPushRegistrationData(tokenId, token, deviceLocale))
                 disableWpComNotificationsForSite(selectedSite.siteId)
                 Result.success(Unit)
             } ?: run {
@@ -101,7 +109,7 @@ class PushNotificationRepository @Inject constructor(
                 WooLog.T.NOTIFICATIONS,
                 "Woo Core push token registration failed:${result.error?.message}, fallback to WPCom"
             )
-            if (!isWpComPushRegistered()) {
+            if (allowWpComFallback && !isWpComPushRegistered()) {
                 registerPushTokenInWpComSystem(token)
             }
             Result.failure(WooException(result.error))
@@ -140,24 +148,66 @@ class PushNotificationRepository @Inject constructor(
         }
     }
 
-    private suspend fun savePushTokenForSite(siteId: Long, token: String) {
+    private suspend fun savePushTokenForSite(siteId: Long, registration: WooPushRegistrationData) {
         pushNotificationsDataStore.edit { preferences ->
-            preferences[getPushTokenKeyForSite(siteId)] = token
+            preferences.savePushRegistration(siteId, registration)
         }
     }
 
-    private fun getPushTokenKeyForSite(siteId: Long): Preferences.Key<String> {
+    private fun Preferences.getPushRegistration(siteId: Long): WooPushRegistrationData? {
+        val tokenId = this[getPushTokenIdKeyForSite(siteId)] ?: return null
+        val token = this[getPushTokenValueKeyForSite(siteId)] ?: return null
+        val locale = this[getPushLocaleKeyForSite(siteId)] ?: return null
+        return WooPushRegistrationData(tokenId, token, locale)
+    }
+
+    private fun MutablePreferences.savePushRegistration(siteId: Long, registration: WooPushRegistrationData) {
+        this[getPushTokenIdKeyForSite(siteId)] = registration.tokenId
+        this[getPushTokenValueKeyForSite(siteId)] = registration.token
+        this[getPushLocaleKeyForSite(siteId)] = registration.locale
+    }
+
+    private fun MutablePreferences.clearPushRegistration(siteId: Long) {
+        remove(getPushTokenIdKeyForSite(siteId))
+        remove(getPushTokenValueKeyForSite(siteId))
+        remove(getPushLocaleKeyForSite(siteId))
+    }
+
+    private fun getPushTokenIdKeyForSite(siteId: Long): Preferences.Key<String> {
         return stringPreferencesKey("$PUSH_TOKEN_KEY_PREFIX$siteId")
+    }
+
+    private fun getPushTokenValueKeyForSite(siteId: Long): Preferences.Key<String> {
+        return stringPreferencesKey("$PUSH_TOKEN_VALUE_KEY_PREFIX$siteId")
+    }
+
+    private fun getPushLocaleKeyForSite(siteId: Long): Preferences.Key<String> {
+        return stringPreferencesKey("$PUSH_LOCALE_KEY_PREFIX$siteId")
     }
 
     suspend fun isWooPushTokenRegisteredForSite(siteId: Long): Boolean {
         return observeWooPushTokenRegisteredForSite(siteId).first()
     }
 
+    suspend fun shouldRegisterWooPushForSite(currentToken: String, siteId: Long): Boolean {
+        val preferences = pushNotificationsDataStore.data.first()
+        val registration = preferences.getPushRegistration(siteId)
+
+        return registration == null ||
+            registration.token != currentToken ||
+            registration.locale != getDeviceLocale()
+    }
+
+    fun isWpComPushRegistered(): Boolean {
+        val wpComPushServerId = prefsWrapper.getFluxCPreferences()
+            .getString(WpComPushNotificationStore.WPCOM_PUSH_DEVICE_SERVER_ID, null)
+        return wpComPushServerId.isNotNullOrEmpty()
+    }
+
     fun observeWooPushTokenRegisteredForSite(siteId: Long): Flow<Boolean> {
-        val tokenKey = getPushTokenKeyForSite(siteId)
+        val tokenKey = getPushTokenIdKeyForSite(siteId)
         return pushNotificationsDataStore.data.map { preferences ->
-            val isTokenStored = preferences[tokenKey] != null
+            val isTokenStored = preferences[tokenKey].isNotNullOrEmpty()
             val supportResult = checkWooPluginPushNotificationsSupport(forceRefresh = false)
             // Treat errors as "compatible" to avoid hiding entry points during temporary failures
             val isPluginCompatible = when (supportResult) {
@@ -191,17 +241,18 @@ class PushNotificationRepository @Inject constructor(
         val sites = wooCommerceStore.getWooCommerceSites()
 
         val deleteJobs = sites.mapNotNull { site ->
-            val tokenKey = getPushTokenKeyForSite(site.siteId)
-            val pushTokenId = preferences[tokenKey] ?: return@mapNotNull null
+            val registration = preferences.getPushRegistration(site.siteId) ?: return@mapNotNull null
             async {
-                val result = wooPushNotificationsStore.deletePushToken(site, pushTokenId)
+                val result = wooPushNotificationsStore.deletePushToken(site, registration.tokenId)
                 if (result.isError) {
                     WooLog.w(
                         WooLog.T.NOTIFICATIONS,
                         "Failed to delete push token for site ${site.siteId}: ${result.error?.message}"
                     )
                 } else {
-                    pushNotificationsDataStore.edit { it.remove(tokenKey) }
+                    pushNotificationsDataStore.edit {
+                        it.clearPushRegistration(site.siteId)
+                    }
                     WooLog.d(WooLog.T.NOTIFICATIONS, "Woo Core push token deleted for site ${site.siteId}")
                 }
             }
@@ -214,12 +265,6 @@ class PushNotificationRepository @Inject constructor(
         return UUID.randomUUID().toString().also {
             appPrefsWrapper.wooCorePushDeviceUUID = it
         }
-    }
-
-    private fun isWpComPushRegistered(): Boolean {
-        val wpComPushServerId = prefsWrapper.getFluxCPreferences()
-            .getString(WpComPushNotificationStore.WPCOM_PUSH_DEVICE_SERVER_ID, null)
-        return wpComPushServerId.isNotNullOrEmpty()
     }
 
     private fun getDeviceLocale(): String {
@@ -240,8 +285,16 @@ class PushNotificationRepository @Inject constructor(
         "os_version" to Build.VERSION.RELEASE
     )
 
+    private data class WooPushRegistrationData(
+        val tokenId: String,
+        val token: String,
+        val locale: String
+    )
+
     companion object {
         private const val PUSH_TOKEN_KEY_PREFIX = "push_token_"
+        private const val PUSH_TOKEN_VALUE_KEY_PREFIX = "push_token_value_"
+        private const val PUSH_LOCALE_KEY_PREFIX = "push_locale_"
         private const val WPCOM_UNREGISTERED_DEVICE_ERROR_CODE = "unregistered_device"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
@@ -1,66 +1,115 @@
 package com.woocommerce.android.notifications.push
 
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.notifications.push.PushNotificationRegistrationStatus.Status
-import com.woocommerce.android.notifications.push.RegisterDevice.Mode.FORCEFULLY
-import com.woocommerce.android.notifications.push.RegisterDevice.Mode.IF_NEEDED
+import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.sitepicker.sitevisibility.GetWooVisibleSites
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.wordpress.android.fluxc.store.AccountStore
 import javax.inject.Inject
 
 class RegisterDevice @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val accountStore: AccountStore,
-    private val pushNotificationRegistrationStatus: PushNotificationRegistrationStatus,
     private val pushNotificationRepository: PushNotificationRepository,
     private val featureFlagRepository: FeatureFlagRepository,
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    private val getWooVisibleSites: GetWooVisibleSites,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) {
-    suspend operator fun invoke(mode: Mode) {
-        val pushRegistrationStatus = pushNotificationRegistrationStatus(selectedSite.getIfExists()?.siteId)
-        WooLog.d(WooLog.T.NOTIFICATIONS, "Current PN registration status: $pushRegistrationStatus")
-        when (mode) {
-            IF_NEEDED -> {
-                when (pushRegistrationStatus) {
-                    Status.UNREGISTERED -> sendToken()
-                    Status.REGISTERED_WPCOM_ONLY -> {
-                        if (featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)) {
-                            sendToken()
+    private val orchestrationMutex = Mutex()
+    @Volatile
+    private var activeJob: Job? = null
+
+    fun kickoff(trigger: Trigger) {
+        appCoroutineScope.launch {
+            invoke(trigger)
+        }
+    }
+
+    suspend operator fun invoke(trigger: Trigger) {
+        if (trigger == Trigger.TOKEN_REFRESH) {
+            activeJob?.cancel()
+        }
+
+        coroutineScope {
+            orchestrationMutex.withLock {
+                val registrationJob = launch {
+                    try {
+                        register(trigger)
+                    } catch (cancellationException: CancellationException) {
+                        throw cancellationException
+                    } catch (throwable: Throwable) {
+                        WooLog.e(WooLog.T.NOTIFICATIONS, "Push registration kickoff failed for $trigger", throwable)
+                    }
+                }
+
+                activeJob = registrationJob
+                try {
+                    registrationJob.join()
+                } finally {
+                    if (activeJob === registrationJob) {
+                        activeJob = null
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun register(trigger: Trigger) {
+        val token = appPrefsWrapper.getFCMToken()
+        if (token.isEmpty()) return
+
+        val shouldForce = trigger == Trigger.TOKEN_REFRESH
+        val shouldEvaluateWpCom = trigger != Trigger.SITE_SWITCH
+        val sites = when (trigger) {
+            Trigger.LOGIN_SUCCESS,
+            Trigger.APP_FOREGROUND,
+            Trigger.TOKEN_REFRESH -> getWooVisibleSites()
+
+            Trigger.SITE_SWITCH -> listOfNotNull(selectedSite.getIfExists())
+        }
+
+        if (featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)) {
+            coroutineScope {
+                sites.map { site ->
+                    async {
+                        if (shouldForce || pushNotificationRepository.shouldRegisterWooPushForSite(token, site.siteId)) {
+                            pushNotificationRepository.registerPushTokenInWooCoreSystem(
+                                token = token,
+                                selectedSite = site,
+                                allowWpComFallback = trigger != Trigger.SITE_SWITCH
+                            )
                         }
                     }
-
-                    Status.REGISTERED_WOO_ONLY,
-                    Status.REGISTERED_BOTH -> {
-                    }
-                }
+                }.awaitAll()
             }
+        }
 
-            FORCEFULLY -> sendToken()
+        if (
+            shouldEvaluateWpCom &&
+            accountStore.hasAccessToken() &&
+            (shouldForce || pushNotificationRepository.isWpComPushRegistered())
+        ) {
+            pushNotificationRepository.registerPushTokenInWpComSystem(token)
         }
     }
 
-    private suspend fun sendToken() {
-        val token = appPrefsWrapper.getFCMToken()
-        if (token.isNotEmpty()) {
-            if (featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)) {
-                selectedSite.getIfExists()?.let { site ->
-                    pushNotificationRepository.registerPushTokenInWooCoreSystem(token, site)
-                }
-            } else if (accountStore.hasAccessToken()) {
-                pushNotificationRepository.registerPushTokenInWpComSystem(token)
-            }
-            WooLog.d(
-                WooLog.T.NOTIFICATIONS,
-                "Updated push notification registration status: " +
-                    "${pushNotificationRegistrationStatus(selectedSite.getIfExists()?.siteId)}"
-            )
-        }
-    }
-
-    enum class Mode {
-        IF_NEEDED, FORCEFULLY
+    enum class Trigger {
+        LOGIN_SUCCESS,
+        APP_FOREGROUND,
+        SITE_SWITCH,
+        TOKEN_REFRESH
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.wordpress.android.fluxc.store.AccountStore
@@ -80,16 +81,15 @@ class RegisterDevice @Inject constructor(
 
         val shouldForce = trigger == Trigger.TOKEN_REFRESH
 
-        val sites = when (trigger) {
-            Trigger.LOGIN_SUCCESS,
-            Trigger.APP_FOREGROUND,
-            Trigger.TOKEN_REFRESH -> getWooVisibleSites()
-
-            Trigger.SITE_SWITCH -> listOfNotNull(selectedSite.getIfExists())
-        }
-
         if (featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)) {
-            coroutineScope {
+            val sites = when (trigger) {
+                Trigger.LOGIN_SUCCESS,
+                Trigger.APP_FOREGROUND,
+                Trigger.TOKEN_REFRESH -> getWooVisibleSites()
+
+                Trigger.SITE_SWITCH -> listOfNotNull(selectedSite.getIfExists())
+            }
+            supervisorScope {
                 sites.map { site ->
                     async {
                         val shouldRegisterSite = shouldForce ||

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
@@ -29,6 +29,7 @@ class RegisterDevice @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope
 ) {
     private val orchestrationMutex = Mutex()
+
     @Volatile
     private var activeJob: Job? = null
 
@@ -38,6 +39,7 @@ class RegisterDevice @Inject constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     suspend operator fun invoke(trigger: Trigger) {
         if (trigger == Trigger.TOKEN_REFRESH) {
             activeJob?.cancel()
@@ -72,7 +74,7 @@ class RegisterDevice @Inject constructor(
         if (token.isEmpty()) return
 
         val shouldForce = trigger == Trigger.TOKEN_REFRESH
-        val shouldEvaluateWpCom = trigger != Trigger.SITE_SWITCH
+
         val sites = when (trigger) {
             Trigger.LOGIN_SUCCESS,
             Trigger.APP_FOREGROUND,
@@ -85,7 +87,9 @@ class RegisterDevice @Inject constructor(
             coroutineScope {
                 sites.map { site ->
                     async {
-                        if (shouldForce || pushNotificationRepository.shouldRegisterWooPushForSite(token, site.siteId)) {
+                        if (shouldForce ||
+                            pushNotificationRepository.shouldRegisterWooPushForSite(token, site.siteId)
+                        ) {
                             pushNotificationRepository.registerPushTokenInWooCoreSystem(
                                 token = token,
                                 selectedSite = site,
@@ -97,10 +101,12 @@ class RegisterDevice @Inject constructor(
             }
         }
 
-        if (
-            shouldEvaluateWpCom &&
-            accountStore.hasAccessToken() &&
+        // For WPCom, site switching doesn't affect registration
+        val shouldEvaluateWpCom = trigger != Trigger.SITE_SWITCH &&
             (shouldForce || pushNotificationRepository.isWpComPushRegistered())
+
+        if (shouldEvaluateWpCom &&
+            accountStore.hasAccessToken()
         ) {
             pushNotificationRepository.registerPushTokenInWpComSystem(token)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
@@ -41,12 +41,14 @@ class RegisterDevice @Inject constructor(
 
     @Suppress("TooGenericExceptionCaught")
     suspend operator fun invoke(trigger: Trigger) {
-        if (trigger == Trigger.TOKEN_REFRESH) {
+        if (trigger == Trigger.TOKEN_REFRESH && activeJob != null) {
+            WooLog.d(WooLog.T.NOTIFICATIONS, "Cancelling in-progress push registration before $trigger")
             activeJob?.cancel()
         }
 
         coroutineScope {
             orchestrationMutex.withLock {
+                WooLog.d(WooLog.T.NOTIFICATIONS, "Starting push registration for $trigger")
                 val registrationJob = launch {
                     try {
                         register(trigger)
@@ -71,7 +73,10 @@ class RegisterDevice @Inject constructor(
 
     private suspend fun register(trigger: Trigger) {
         val token = appPrefsWrapper.getFCMToken()
-        if (token.isEmpty()) return
+        if (token.isEmpty()) {
+            WooLog.d(WooLog.T.NOTIFICATIONS, "Skipping push registration for $trigger because FCM token is empty")
+            return
+        }
 
         val shouldForce = trigger == Trigger.TOKEN_REFRESH
 
@@ -87,9 +92,14 @@ class RegisterDevice @Inject constructor(
             coroutineScope {
                 sites.map { site ->
                     async {
-                        if (shouldForce ||
+                        val shouldRegisterSite = shouldForce ||
                             pushNotificationRepository.shouldRegisterWooPushForSite(token, site.siteId)
-                        ) {
+
+                        if (shouldRegisterSite) {
+                            WooLog.d(
+                                WooLog.T.NOTIFICATIONS,
+                                "Registering Woo push for site ${site.siteId} for $trigger"
+                            )
                             pushNotificationRepository.registerPushTokenInWooCoreSystem(
                                 token = token,
                                 selectedSite = site,
@@ -105,10 +115,11 @@ class RegisterDevice @Inject constructor(
         val shouldEvaluateWpCom = trigger != Trigger.SITE_SWITCH &&
             (shouldForce || pushNotificationRepository.isWpComPushRegistered())
 
-        if (shouldEvaluateWpCom &&
-            accountStore.hasAccessToken()
-        ) {
+        if (shouldEvaluateWpCom && accountStore.hasAccessToken()) {
+            WooLog.d(WooLog.T.NOTIFICATIONS, "Registering WP.com push for $trigger")
             pushNotificationRepository.registerPushTokenInWpComSystem(token)
+        } else {
+            WooLog.d(WooLog.T.NOTIFICATIONS, "Skipping WP.com push registration for $trigger")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
@@ -84,9 +84,9 @@ class RegisterDevice @Inject constructor(
         if (featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)) {
             val sites = when (trigger) {
                 Trigger.LOGIN_SUCCESS,
-                Trigger.APP_FOREGROUND,
                 Trigger.TOKEN_REFRESH -> getWooVisibleSites()
 
+                Trigger.APP_FOREGROUND,
                 Trigger.SITE_SWITCH -> listOfNotNull(selectedSite.getIfExists())
             }
             supervisorScope {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/RegisterDevice.kt
@@ -113,7 +113,7 @@ class RegisterDevice @Inject constructor(
 
         // For WPCom, site switching doesn't affect registration
         val shouldEvaluateWpCom = trigger != Trigger.SITE_SWITCH &&
-            (shouldForce || pushNotificationRepository.isWpComPushRegistered())
+            (shouldForce || !pushNotificationRepository.isWpComPushRegistered())
 
         if (shouldEvaluateWpCom && accountStore.hasAccessToken()) {
             WooLog.d(WooLog.T.NOTIFICATIONS, "Registering WP.com push for $trigger")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -56,6 +56,7 @@ import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
 import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsFragment
 import com.woocommerce.android.ui.login.sitecredentials.applicationpassword.ApplicationPasswordTutorialFragment
 import com.woocommerce.android.ui.main.MainActivity
+import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.util.ActivityUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.ChromeCustomTabUtils.Height.Partial.ThreeQuarters
@@ -155,6 +156,9 @@ class LoginActivity :
 
     @Inject
     internal lateinit var ageEligibilityChecker: AgeEligibilityChecker
+
+    @Inject
+    internal lateinit var registerDevice: RegisterDevice
 
     private var loginMode: LoginMode? = null
     private lateinit var binding: ActivityLoginBinding
@@ -384,6 +388,7 @@ class LoginActivity :
 
     private fun showMainActivityAndFinish() {
         experimentTracker.log(ExperimentTracker.LOGIN_SUCCESSFUL_EVENT)
+        registerDevice.kickoff(RegisterDevice.Trigger.LOGIN_SUCCESS)
 
         val intent = Intent(this, MainActivity::class.java)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/auto/AutoLoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/auto/AutoLoginActivity.kt
@@ -6,9 +6,11 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
+import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.ui.login.LoginActivity
 import com.woocommerce.android.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.wordpress.android.login.LoginMode
 import javax.inject.Inject
 
@@ -17,6 +19,9 @@ class AutoLoginActivity : AppCompatActivity() {
 
     @Inject
     lateinit var autoLoginHandler: AutoLoginHandler
+
+    @Inject
+    lateinit var registerDevice: RegisterDevice
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -32,6 +37,7 @@ class AutoLoginActivity : AppCompatActivity() {
             uri = uri,
             scope = lifecycleScope,
             onSuccess = {
+                registerDevice.kickoff(RegisterDevice.Trigger.LOGIN_SUCCESS)
                 startActivity(Intent(this, MainActivity::class.java))
                 finish()
             },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -20,7 +20,6 @@ import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.model.UiString.UiStringRes
 import com.woocommerce.android.model.UiString.UiStringText
-import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
@@ -59,8 +58,7 @@ class LoginSiteCredentialsViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val appPrefs: AppPrefsWrapper,
     private val resourceProvider: ResourceProvider,
-    private val applicationPasswordsConfiguration: ApplicationPasswordsConfiguration,
-    private val registerDevice: RegisterDevice
+    private val applicationPasswordsConfiguration: ApplicationPasswordsConfiguration
 ) : ScopedViewModel(savedStateHandle) {
     companion object {
         const val SITE_ADDRESS_KEY = "site-address"
@@ -339,7 +337,6 @@ class LoginSiteCredentialsViewModel @Inject constructor(
                 }
                 appPrefs.removeLoginSiteAddress()
                 selectedSite.set(site)
-                registerDevice(RegisterDevice.Mode.IF_NEEDED)
                 triggerEvent(LoggedIn(selectedSite.getSelectedSiteId()))
             },
             onFailure = { exception ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLogin2FAViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_LOGIN_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPComLoginRepository
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
@@ -34,12 +35,14 @@ class WPComLogin2FAViewModel @Inject constructor(
     jetpackAccountRepository: JetpackActivationRepository,
     private val wpComLoginRepository: WPComLoginRepository,
     private val accountRepository: AccountRepository,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val registerDevice: RegisterDevice
 ) : WPComLoginPostLoginViewModel(
     savedStateHandle,
     selectedSite,
     jetpackAccountRepository,
-    analyticsTrackerWrapper
+    analyticsTrackerWrapper,
+    registerDevice
 ) {
 
     private val navArgs: WPComLogin2FAFragmentArgs by savedStateHandle.navArgs()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginMagicLinkHandlerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.asLiveData
 import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_LOGIN_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
@@ -19,12 +20,14 @@ class WPComLoginMagicLinkHandlerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     selectedSite: SelectedSite,
     jetpackActivationRepository: JetpackActivationRepository,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val registerDevice: RegisterDevice
 ) : WPComLoginPostLoginViewModel(
     savedStateHandle,
     selectedSite,
     jetpackActivationRepository,
-    analyticsTrackerWrapper
+    analyticsTrackerWrapper,
+    registerDevice
 ) {
     private val navArgs: WPComLoginMagicLinkHandlerFragmentArgs by savedStateHandle.navArgs()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_LOGIN_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.JetpackStatus
+import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPComLoginRepository
@@ -41,12 +42,14 @@ class WPComLoginPasswordViewModel @Inject constructor(
     private val wpComLoginRepository: WPComLoginRepository,
     private val accountRepository: AccountRepository,
     private val resourceProvider: ResourceProvider,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val registerDevice: RegisterDevice
 ) : WPComLoginPostLoginViewModel(
     savedStateHandle,
     selectedSite,
     jetpackAccountRepository,
-    analyticsTrackerWrapper
+    analyticsTrackerWrapper,
+    registerDevice
 ) {
     companion object {
         private const val RESET_PASSWORD_URL = "https://wordpress.com/wp-login.php?action=lostpassword"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModel.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.JETPACK_SETUP_LOGIN_COMP
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.JetpackStatus
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.ui.login.jetpack.GoToStore
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -17,7 +18,8 @@ open class WPComLoginPostLoginViewModel(
     savedStateHandle: SavedStateHandle,
     private val selectedSite: SelectedSite,
     private val jetpackActivationRepository: JetpackActivationRepository,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val registerDevice: RegisterDevice
 ) : ScopedViewModel(savedStateHandle) {
     @VisibleForTesting
     internal suspend fun onLoginSuccess(jetpackStatus: JetpackStatus): Result<Unit> {
@@ -36,9 +38,10 @@ open class WPComLoginPostLoginViewModel(
                     .getOrElse {
                         triggerEvent(ShowSnackbar(R.string.error_generic))
                         return Result.failure(it)
-                    }
+            }
 
             jetpackActivationRepository.setSelectedSiteAndCleanOldSites(jetpackSite)
+            registerDevice.kickoff(RegisterDevice.Trigger.LOGIN_SUCCESS)
             if (jetpackStatus.isJetpackInstalled) {
                 triggerEvent(GoToStore)
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModel.kt
@@ -536,7 +536,12 @@ class SitePickerViewModel @Inject constructor(
                             selectedSite.set(siteVerificationModel.siteModel)
                             trackLoginEvent(currentStep = UnifiedLoginTracker.Step.SUCCESS)
                             appPrefsWrapper.removeLoginSiteAddress()
-                            registerDevice(RegisterDevice.Mode.IF_NEEDED)
+                            val registerDeviceTrigger = if (navArgs.openedFromLogin) {
+                                RegisterDevice.Trigger.LOGIN_SUCCESS
+                            } else {
+                                RegisterDevice.Trigger.SITE_SWITCH
+                            }
+                            registerDevice.kickoff(registerDeviceTrigger)
 
                             sitePickerViewState = sitePickerViewState.copy(isProgressDiaLogVisible = false)
                             triggerEvent(SitePickerEvent.NavigateToMainActivityEvent)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/GetWooVisibleSites.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/GetWooVisibleSites.kt
@@ -17,17 +17,18 @@ class GetWooVisibleSites @Inject constructor(
         sitePickerRepository.getSites()
             .filter { it.hasWooCommerce && isSiteVisible(it.siteId) }
             .plusSelectedAppPasswordWooSiteIfMissing()
-            .distinctBy { it.id }
 
     private suspend fun isSiteVisible(siteId: Long): Boolean {
         return visibleSitesDataStore.isSiteVisible(siteId).first()
     }
 
-    private fun List<SiteModel>.plusSelectedAppPasswordWooSiteIfMissing(): List<SiteModel> {
-        val currentSite = selectedSite.getOrNull()
-        if (currentSite != null && currentSite.hasWooCommerce && currentSite.connectionType == ApplicationPasswords) {
-            return this + currentSite
-        }
-        return this
-    }
+    private fun List<SiteModel>.plusSelectedAppPasswordWooSiteIfMissing(): List<SiteModel> =
+        selectedSite.getOrNull()
+            ?.takeIf { selectedSite ->
+                selectedSite.hasWooCommerce &&
+                    selectedSite.connectionType == ApplicationPasswords &&
+                    none { it.id == selectedSite.id }
+            }
+            ?.let { this + it }
+            ?: this
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/GetWooVisibleSites.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/GetWooVisibleSites.kt
@@ -25,9 +25,9 @@ class GetWooVisibleSites @Inject constructor(
 
     private fun List<SiteModel>.plusSelectedAppPasswordWooSiteIfMissing(): List<SiteModel> {
         val currentSite = selectedSite.getOrNull()
-            ?.takeIf { it.hasWooCommerce && it.connectionType == ApplicationPasswords }
-            ?: return this
-
-        return this + currentSite
+        if (currentSite != null && currentSite.hasWooCommerce && currentSite.connectionType == ApplicationPasswords) {
+            return this + currentSite
+        }
+        return this
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/GetWooVisibleSites.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/GetWooVisibleSites.kt
@@ -1,5 +1,8 @@
 package com.woocommerce.android.ui.sitepicker.sitevisibility
 
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType.ApplicationPasswords
+import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import kotlinx.coroutines.flow.first
 import org.wordpress.android.fluxc.model.SiteModel
@@ -7,13 +10,24 @@ import javax.inject.Inject
 
 class GetWooVisibleSites @Inject constructor(
     private val sitePickerRepository: SitePickerRepository,
-    private val visibleSitesDataStore: VisibleWooSitesDataStore
+    private val visibleSitesDataStore: VisibleWooSitesDataStore,
+    private val selectedSite: SelectedSite
 ) {
     suspend operator fun invoke(): List<SiteModel> =
         sitePickerRepository.getSites()
             .filter { it.hasWooCommerce && isSiteVisible(it.siteId) }
+            .plusSelectedAppPasswordWooSiteIfMissing()
+            .distinctBy { it.id }
 
     private suspend fun isSiteVisible(siteId: Long): Boolean {
         return visibleSitesDataStore.isSiteVisible(siteId).first()
+    }
+
+    private fun List<SiteModel>.plusSelectedAppPasswordWooSiteIfMissing(): List<SiteModel> {
+        val currentSite = selectedSite.getOrNull()
+            ?.takeIf { it.hasWooCommerce && it.connectionType == ApplicationPasswords }
+            ?: return this
+
+        return this + currentSite
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/AppInitializerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/AppInitializerTest.kt
@@ -1,26 +1,80 @@
 package com.woocommerce.android
 
+import android.app.Application
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.background.BackgroundUpdatesDisabled
+import com.woocommerce.android.network.ConnectionChangeReceiver
+import com.woocommerce.android.notifications.push.RegisterDevice
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
+import androidx.work.impl.WorkManagerImpl
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.WooCommerceStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AppInitializerTest : BaseUnitTest() {
 
     private val accountStoreMock: AccountStore = mock()
     private val analyticsTrackerMock: AnalyticsTrackerWrapper = mock()
+    private val application: Application = mock()
+    private val networkStatusMock: NetworkStatus = mock()
+    private val registerDeviceMock: RegisterDevice = mock()
+    private val backgroundUpdatesDisabledMock: BackgroundUpdatesDisabled = mock()
+    private val connectionReceiverMock: ConnectionChangeReceiver = mock()
+    private val appWidgetManagerMock: AppWidgetManager = mock()
+    private val workManagerMock: WorkManagerImpl = mock()
+    private val selectedSiteMock: SelectedSite = mock()
+    private val wooCommerceStoreMock: WooCommerceStore = mock()
 
-    private val sut = AppInitializer().apply {
-        this.accountStore = accountStoreMock
-        this.analyticsTracker = analyticsTrackerMock
+    private lateinit var analyticsTrackerStaticMock: MockedStatic<AnalyticsTracker>
+
+    private lateinit var sut: AppInitializer
+
+    @Before
+    fun setup() {
+        analyticsTrackerStaticMock = mockStatic(AnalyticsTracker::class.java)
+
+        sut = AppInitializer().apply {
+            this.accountStore = accountStoreMock
+            this.analyticsTracker = analyticsTrackerMock
+            this.networkStatus = networkStatusMock
+            this.registerDevice = registerDeviceMock
+            this.backgroundUpdatesDisabled = backgroundUpdatesDisabledMock
+            this.connectionReceiver = connectionReceiverMock
+            this.selectedSite = selectedSiteMock
+            this.wooCommerceStore = wooCommerceStoreMock
+            this.appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher)
+            setPrivateApplication(application)
+            setConnectionReceiverRegistered()
+        }
+
+        whenever(selectedSiteMock.getIfExists()).thenReturn(null)
+    }
+
+    @After
+    fun tearDown() {
+        analyticsTrackerStaticMock.close()
     }
 
     @Test
@@ -57,5 +111,57 @@ class AppInitializerTest : BaseUnitTest() {
 
         // then
         verify(analyticsTrackerMock).sendUsageStats = false
+    }
+
+    @Test
+    fun `when app comes from background and network is connected, then app foreground trigger registers device`() = testBlocking {
+        // GIVEN
+        networkStatusMock.stub {
+            on { isConnected() } doReturn true
+        }
+        appWidgetManagerMock.stub {
+            on { installedProviders } doReturn emptyList()
+        }
+
+        // WHEN
+        mockStatic(WorkManagerImpl::class.java).use {
+            whenever(WorkManagerImpl.getInstance(application)).thenReturn(workManagerMock)
+
+            mockStatic(AppWidgetManager::class.java).use {
+                whenever(AppWidgetManager.getInstance(application)).thenReturn(appWidgetManagerMock)
+
+                sut.onAppComesFromBackground()
+                coroutinesTestRule.testDispatcher.scheduler.advanceUntilIdle()
+            }
+        }
+
+        // THEN
+        verify(registerDeviceMock).kickoff(RegisterDevice.Trigger.APP_FOREGROUND)
+    }
+
+    @Test
+    fun `when account fetch completes, then push registration is not triggered directly`() = testBlocking {
+        // WHEN
+        sut.onAccountChanged(
+            AccountStore.OnAccountChanged().apply { causeOfChange = AccountAction.FETCH_ACCOUNT }
+        )
+
+        // THEN
+        verifyBlocking(registerDeviceMock, never()) {
+            invoke(any())
+        }
+    }
+    private fun AppInitializer.setPrivateApplication(application: Application) {
+        AppInitializer::class.java.getDeclaredField("application").apply {
+            isAccessible = true
+            set(this@setPrivateApplication, application)
+        }
+    }
+
+    private fun AppInitializer.setConnectionReceiverRegistered() {
+        AppInitializer::class.java.getDeclaredField("connectionReceiverRegistered").apply {
+            isAccessible = true
+            setBoolean(this@setConnectionReceiverRegistered, true)
+        }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/AppInitializerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/AppInitializerTest.kt
@@ -2,7 +2,7 @@ package com.woocommerce.android
 
 import android.app.Application
 import android.appwidget.AppWidgetManager
-import android.content.Context
+import androidx.work.impl.WorkManagerImpl
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.background.BackgroundUpdatesDisabled
@@ -26,7 +26,6 @@ import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
-import androidx.work.impl.WorkManagerImpl
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
@@ -24,6 +24,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.wheneverBlocking
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -63,6 +64,9 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     fun setUp() {
         whenever(prefsWrapper.getFluxCPreferences()).thenReturn(sharedPreferences)
         whenever(siteModel.siteId).thenReturn(SITE_ID)
+        wheneverBlocking {
+            wpComPushNotificationStore.registerDevice(any(), any())
+        }.doReturn(WpComPushNotificationStore.RegisterDeviceResponsePayload(deviceId = "device-id-123"))
 
         sut = PushNotificationRepository(
             wooPushNotificationsStore,
@@ -114,6 +118,28 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
                 )
             )
             verify(appPrefsWrapper, never()).wooCorePushDeviceUUID = any()
+        }
+
+    @Test
+    fun `given registration succeeds, when registering push token in woo core, then saves token id token and locale`() =
+        testBlocking {
+            whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
+            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any(), any(), any()))
+                .thenReturn(WooResult(RETURNED_TOKEN))
+
+            val mutablePreferences: MutablePreferences = mock()
+            whenever(preferences.toMutablePreferences()).thenReturn(mutablePreferences)
+            whenever(pushNotificationsDataStore.updateData(any())).thenAnswer { invocation ->
+                val transform = invocation.getArgument<suspend (Preferences) -> Preferences>(0)
+                testBlocking { transform(preferences) }
+                preferences
+            }
+
+            sut.registerPushTokenInWooCoreSystem("token", siteModel)
+
+            verify(mutablePreferences)[stringPreferencesKey("push_token_$SITE_ID")] = RETURNED_TOKEN
+            verify(mutablePreferences)[stringPreferencesKey("push_token_value_$SITE_ID")] = "token"
+            verify(mutablePreferences)[stringPreferencesKey("push_locale_$SITE_ID")] = "en_US"
         }
 
     @Test
@@ -213,10 +239,12 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
             val site2 = mock<SiteModel> { on { siteId } doReturn 456L }
             whenever(wooCommerceStore.getWooCommerceSites()).thenReturn(mutableListOf(site1, site2))
 
-            val tokenKey1 = stringPreferencesKey("push_token_123")
-            val tokenKey2 = stringPreferencesKey("push_token_456")
-            whenever(preferences[tokenKey1]).thenReturn("token-id-1")
-            whenever(preferences[tokenKey2]).thenReturn("token-id-2")
+            whenever(preferences[stringPreferencesKey("push_token_123")]).thenReturn("token-id-1")
+            whenever(preferences[stringPreferencesKey("push_token_value_123")]).thenReturn("token-1")
+            whenever(preferences[stringPreferencesKey("push_locale_123")]).thenReturn("en_US")
+            whenever(preferences[stringPreferencesKey("push_token_456")]).thenReturn("token-id-2")
+            whenever(preferences[stringPreferencesKey("push_token_value_456")]).thenReturn("token-2")
+            whenever(preferences[stringPreferencesKey("push_locale_456")]).thenReturn("en_US")
 
             whenever(wooPushNotificationsStore.deletePushToken(any(), any())).thenReturn(WooResult(Unit))
 
@@ -227,16 +255,41 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given site metadata stored, when unregistering woo token succeeds, then removes all site metadata keys`() =
+        testBlocking {
+            val site = mock<SiteModel> { on { siteId } doReturn SITE_ID }
+            whenever(wooCommerceStore.getWooCommerceSites()).thenReturn(mutableListOf(site))
+            whenever(preferences[stringPreferencesKey("push_token_$SITE_ID")]).thenReturn("token-id-1")
+            whenever(preferences[stringPreferencesKey("push_token_value_$SITE_ID")]).thenReturn("token")
+            whenever(preferences[stringPreferencesKey("push_locale_$SITE_ID")]).thenReturn("en_US")
+            whenever(wooPushNotificationsStore.deletePushToken(site, "token-id-1")).thenReturn(WooResult(Unit))
+
+            val mutablePreferences: MutablePreferences = mock()
+            whenever(preferences.toMutablePreferences()).thenReturn(mutablePreferences)
+            whenever(pushNotificationsDataStore.updateData(any())).thenAnswer { invocation ->
+                val transform = invocation.getArgument<suspend (Preferences) -> Preferences>(0)
+                testBlocking { transform(preferences) }
+                preferences
+            }
+
+            sut.unregisterWooCoreTokensFromServer()
+
+            verify(mutablePreferences).remove(stringPreferencesKey("push_token_$SITE_ID"))
+            verify(mutablePreferences).remove(stringPreferencesKey("push_token_value_$SITE_ID"))
+            verify(mutablePreferences).remove(stringPreferencesKey("push_locale_$SITE_ID"))
+        }
+
+    @Test
     fun `given site without stored token, when unregisterDevice called, then does not call delete for that site`() =
         testBlocking {
             val site1 = mock<SiteModel> { on { siteId } doReturn 123L }
             val site2 = mock<SiteModel> { on { siteId } doReturn 456L }
             whenever(wooCommerceStore.getWooCommerceSites()).thenReturn(mutableListOf(site1, site2))
 
-            val tokenKey1 = stringPreferencesKey("push_token_123")
-            val tokenKey2 = stringPreferencesKey("push_token_456")
-            whenever(preferences[tokenKey1]).thenReturn("token-id-1")
-            whenever(preferences[tokenKey2]).thenReturn(null)
+            whenever(preferences[stringPreferencesKey("push_token_123")]).thenReturn("token-id-1")
+            whenever(preferences[stringPreferencesKey("push_token_value_123")]).thenReturn("token-1")
+            whenever(preferences[stringPreferencesKey("push_locale_123")]).thenReturn("en_US")
+            whenever(preferences[stringPreferencesKey("push_token_456")]).thenReturn(null)
 
             whenever(wooPushNotificationsStore.deletePushToken(any(), any())).thenReturn(WooResult(Unit))
 
@@ -262,6 +315,17 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
         testBlocking {
             val tokenKey = stringPreferencesKey("push_token_$SITE_ID")
             whenever(preferences[tokenKey]).thenReturn(null)
+
+            val result = sut.isWooPushTokenRegisteredForSite(SITE_ID)
+
+            assertThat(result).isFalse()
+        }
+
+    @Test
+    fun `given empty token id exists for site, when isWooPushTokenRegisteredForSite called, then returns false`() =
+        testBlocking {
+            val tokenKey = stringPreferencesKey("push_token_$SITE_ID")
+            whenever(preferences[tokenKey]).thenReturn("")
 
             val result = sut.isWooPushTokenRegisteredForSite(SITE_ID)
 
@@ -330,6 +394,30 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given woo locale is missing, when checking whether woo push should register, then returns true`() =
+        testBlocking {
+            whenever(preferences[stringPreferencesKey("push_token_$SITE_ID")]).thenReturn(RETURNED_TOKEN)
+            whenever(preferences[stringPreferencesKey("push_token_value_$SITE_ID")]).thenReturn("token")
+            whenever(preferences[stringPreferencesKey("push_locale_$SITE_ID")]).thenReturn(null)
+
+            val result = sut.shouldRegisterWooPushForSite(currentToken = "token", siteId = SITE_ID)
+
+            assertThat(result).isTrue()
+        }
+
+    @Test
+    fun `given woo token locale and id match, when checking whether woo push should register, then returns false`() =
+        testBlocking {
+            whenever(preferences[stringPreferencesKey("push_token_$SITE_ID")]).thenReturn(RETURNED_TOKEN)
+            whenever(preferences[stringPreferencesKey("push_token_value_$SITE_ID")]).thenReturn("token")
+            whenever(preferences[stringPreferencesKey("push_locale_$SITE_ID")]).thenReturn("en_US")
+
+            val result = sut.shouldRegisterWooPushForSite(currentToken = "token", siteId = SITE_ID)
+
+            assertThat(result).isFalse()
+        }
+
+    @Test
     fun `given registration succeeds, when registering push token, then tracks success event`() =
         testBlocking {
             whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
@@ -370,6 +458,25 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
                 errorType = anyOrNull(),
                 errorCode = anyOrNull()
             )
+        }
+
+    @Test
+    fun `given registration fails and wpcom fallback is disabled, when registering push token, then does not register in wpcom`() =
+        testBlocking {
+            // GIVEN
+            whenever(appPrefsWrapper.wooCorePushDeviceUUID).thenReturn("stored-uuid")
+            whenever(wooPushNotificationsStore.registerPushToken(any(), any(), any(), any(), any()))
+                .thenReturn(PN_REGISTRATION_ERROR)
+
+            // WHEN
+            sut.registerPushTokenInWooCoreSystem(
+                token = "token",
+                selectedSite = siteModel,
+                allowWpComFallback = false
+            )
+
+            // THEN
+            verify(wpComPushNotificationStore, never()).registerDevice(any(), any())
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.notifications.push
 
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.notifications.push.RegisterDevice.Trigger.APP_FOREGROUND
+import com.woocommerce.android.notifications.push.RegisterDevice.Trigger.LOGIN_SUCCESS
 import com.woocommerce.android.notifications.push.RegisterDevice.Trigger.SITE_SWITCH
 import com.woocommerce.android.notifications.push.RegisterDevice.Trigger.TOKEN_REFRESH
 import com.woocommerce.android.tools.SelectedSite
@@ -131,7 +132,7 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
     }
 
     @Test
-    fun `given token refresh trigger, when registration is otherwise unchanged, then forces Woo and WPCom registration`() =
+    fun `given token refresh trigger, then forces Woo and WPCom registration regardless of current state`() =
         testBlocking {
             // WHEN
             sut(TOKEN_REFRESH)
@@ -143,6 +144,30 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
             verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteTwo)
             verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
         }
+
+    @Test
+    fun `given login success trigger, when WPCom is not registered, then registers in WPCom`() = testBlocking {
+        // GIVEN
+        wheneverBlocking { pushNotificationRepository.isWpComPushRegistered() }.thenReturn(false)
+
+        // WHEN
+        sut(LOGIN_SUCCESS)
+
+        // THEN
+        verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
+    }
+
+    @Test
+    fun `given app foreground trigger, when WPCom is already registered, then skips WPCom registration`() = testBlocking {
+        // GIVEN
+        wheneverBlocking { pushNotificationRepository.isWpComPushRegistered() }.thenReturn(true)
+
+        // WHEN
+        sut(APP_FOREGROUND)
+
+        // THEN
+        verify(pushNotificationRepository, never()).registerPushTokenInWpComSystem(TEST_TOKEN)
+    }
 
     @Test
     fun `given no access token, when app foreground trigger runs, then does not register in WPCom`() = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
@@ -1,186 +1,269 @@
 package com.woocommerce.android.notifications.push
 
 import com.woocommerce.android.AppPrefsWrapper
-import com.woocommerce.android.notifications.push.PushNotificationRegistrationStatus.Status
-import com.woocommerce.android.notifications.push.RegisterDevice.Mode.FORCEFULLY
-import com.woocommerce.android.notifications.push.RegisterDevice.Mode.IF_NEEDED
+import com.woocommerce.android.notifications.push.RegisterDevice.Trigger.APP_FOREGROUND
+import com.woocommerce.android.notifications.push.RegisterDevice.Trigger.SITE_SWITCH
+import com.woocommerce.android.notifications.push.RegisterDevice.Trigger.TOKEN_REFRESH
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.sitepicker.sitevisibility.GetWooVisibleSites
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.StandardTestDispatcher
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.atLeast
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.wheneverBlocking
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
+import kotlin.time.Duration.Companion.milliseconds
 
 @ExperimentalCoroutinesApi
-class RegisterDeviceTest : BaseUnitTest() {
+class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
     private lateinit var sut: RegisterDevice
 
-    private val appPrefs: AppPrefsWrapper = mock()
-    private val accountStore: AccountStore = mock()
-    private val pushNotificationRegistrationStatus: PushNotificationRegistrationStatus = mock()
-    private val pushNotificationRepository: PushNotificationRepository = mock()
-    private val selectedSite: SelectedSite = mock()
-    private val featureFlagRepository: FeatureFlagRepository = mock()
-    private val siteModel: SiteModel = mock()
+    private val appPrefs: AppPrefsWrapper = mock {
+        on { getFCMToken() } doReturn TEST_TOKEN
+    }
+    private val accountStore: AccountStore = mock {
+        on { hasAccessToken() } doReturn true
+    }
+    private val pushNotificationRepository: PushNotificationRepository = mock {
+        onBlocking { shouldRegisterWooPushForSite(any(), any()) } doReturn true
+    }
+    private val featureFlagRepository: FeatureFlagRepository = mock {
+        on { isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1) } doReturn true
+    }
+    private val selectedSiteModel: SiteModel = mock {
+        on { siteId } doReturn SELECTED_SITE_ID
+    }
+    private val siteOne: SiteModel = mock {
+        on { siteId } doReturn SITE_ID_ONE
+    }
+    private val siteTwo: SiteModel = mock {
+        on { siteId } doReturn SITE_ID_TWO
+    }
+    private val selectedSite: SelectedSite = mock {
+        on { getIfExists() } doReturn selectedSiteModel
+    }
+    private val getWooVisibleSites: GetWooVisibleSites = mock {
+        onBlocking { invoke() } doReturn listOf(siteOne, siteTwo)
+    }
+    private val appCoroutineScope by lazy { CoroutineScope(coroutinesTestRule.testDispatcher) }
 
     @Before
-    fun setUp() = testBlocking {
-        setupDefaultMocks()
-        createSut()
-    }
-
-    private suspend fun setupDefaultMocks() {
-        whenever(appPrefs.getFCMToken()).thenReturn(TEST_TOKEN)
-        whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(siteModel.siteId).thenReturn(TEST_SITE_ID)
-        whenever(selectedSite.getIfExists()).thenReturn(siteModel)
-        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)).thenReturn(false)
-    }
-
-    private fun createSut() {
+    fun setUp() {
         sut = RegisterDevice(
-            appPrefs,
-            accountStore,
-            pushNotificationRegistrationStatus,
-            pushNotificationRepository,
-            featureFlagRepository,
-            selectedSite
+            appPrefsWrapper = appPrefs,
+            accountStore = accountStore,
+            pushNotificationRepository = pushNotificationRepository,
+            featureFlagRepository = featureFlagRepository,
+            selectedSite = selectedSite,
+            getWooVisibleSites = getWooVisibleSites,
+            appCoroutineScope = appCoroutineScope
         )
     }
 
     @Test
-    fun `given no FCM token, when invoked forcefully, then does not register`() = testBlocking {
+    fun `given no FCM token, when app foreground trigger runs, then does not register`() = testBlocking {
+        // GIVEN
         whenever(appPrefs.getFCMToken()).thenReturn("")
-        setupStatus(Status.UNREGISTERED)
 
-        sut(FORCEFULLY)
+        // WHEN
+        sut(APP_FOREGROUND)
 
+        // THEN
         verify(pushNotificationRepository, never()).registerPushTokenInWpComSystem(TEST_TOKEN)
-        verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(eq(TEST_TOKEN), any())
+        verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(eq(TEST_TOKEN), any(), any())
     }
 
     @Test
-    fun `given no FCM token, when invoked if needed, then does not register`() = testBlocking {
-        whenever(appPrefs.getFCMToken()).thenReturn("")
-        setupStatus(Status.UNREGISTERED)
+    fun `given app foreground trigger, when sites exist, then evaluates all sites`() = testBlocking {
+        // WHEN
+        sut(APP_FOREGROUND)
 
-        sut(IF_NEEDED)
-
-        verify(pushNotificationRepository, never()).registerPushTokenInWpComSystem(TEST_TOKEN)
-        verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(eq(TEST_TOKEN), any())
+        // THEN
+        verify(getWooVisibleSites).invoke()
+        verify(pushNotificationRepository).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_ONE)
+        verify(pushNotificationRepository).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)
+        verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne)
+        verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteTwo)
     }
 
     @Test
-    fun `given user not logged in, when invoked forcefully, then does not register in WPCom`() = testBlocking {
+    fun `given site switch trigger, when selected site exists, then evaluates only selected site and skips wpcom`() = testBlocking {
+        // WHEN
+        sut(SITE_SWITCH)
+
+        // THEN
+        val fallbackCaptor = argumentCaptor<Boolean>()
+        verify(selectedSite).getIfExists()
+        verify(pushNotificationRepository).shouldRegisterWooPushForSite(TEST_TOKEN, SELECTED_SITE_ID)
+        verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(
+            token = eq(TEST_TOKEN),
+            selectedSite = eq(selectedSiteModel),
+            allowWpComFallback = fallbackCaptor.capture()
+        )
+        assertThat(fallbackCaptor.firstValue).isFalse()
+        verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_ONE)
+        verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)
+        verify(pushNotificationRepository, never()).registerPushTokenInWpComSystem(TEST_TOKEN)
+        verify(getWooVisibleSites, never()).invoke()
+    }
+
+    @Test
+    fun `given token refresh trigger, when registration is otherwise unchanged, then forces Woo and WPCom registration`() =
+        testBlocking {
+            // WHEN
+            sut(TOKEN_REFRESH)
+
+            // THEN
+            verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_ONE)
+            verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)
+            verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne)
+            verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteTwo)
+            verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
+        }
+
+    @Test
+    fun `given no access token, when app foreground trigger runs, then does not register in WPCom`() = testBlocking {
+        // GIVEN
         whenever(accountStore.hasAccessToken()).thenReturn(false)
-        setupStatus(Status.UNREGISTERED)
 
-        sut(FORCEFULLY)
+        // WHEN
+        sut(APP_FOREGROUND)
 
+        // THEN
         verify(pushNotificationRepository, never()).registerPushTokenInWpComSystem(TEST_TOKEN)
     }
 
     @Test
-    fun `given user logged in and UNREGISTERED, when invoked forcefully, then registers in WPCom`() = testBlocking {
-        setupStatus(Status.UNREGISTERED)
+    fun `given M1 flag disabled, when app foreground trigger runs, then skips Woo registration`() = testBlocking {
+        // GIVEN
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)).thenReturn(false)
 
-        sut(FORCEFULLY)
+        // WHEN
+        sut(APP_FOREGROUND)
 
-        verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
+        // THEN
+        verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_ONE)
+        verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)
+        verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(eq(TEST_TOKEN), any(), any())
     }
 
     @Test
-    fun `given user logged in and WOO_REGISTERED, when invoked forcefully, then registers in WPCom`() = testBlocking {
-        setupStatus(Status.REGISTERED_WOO_ONLY)
+    fun `given app foreground trigger, when Woo registration is unchanged for one site, then registers only stale sites`() =
+        testBlocking {
+            // GIVEN
+            whenever(pushNotificationRepository.shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)).thenReturn(false)
 
-        sut(FORCEFULLY)
+            // WHEN
+            sut(APP_FOREGROUND)
 
-        verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
-    }
-
-    @Test
-    fun `given user logged in and WPCOM_REGISTERED, when invoked forcefully, then registers in WPCom`() = testBlocking {
-        setupStatus(Status.REGISTERED_WPCOM_ONLY)
-
-        sut(FORCEFULLY)
-
-        verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
-    }
+            // THEN
+            verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne)
+            verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteTwo)
+        }
 
     @Test
-    fun `given REGISTERED_IN_BOTH, when invoked forcefully, then registers in WPCom`() = testBlocking {
-        setupStatus(Status.REGISTERED_BOTH)
-
-        sut(FORCEFULLY)
-
-        verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
-    }
-
-    @Test
-    fun `given UNREGISTERED, when invoked if needed, then registers in WPCom`() = testBlocking {
-        setupStatus(Status.UNREGISTERED)
-
-        sut(IF_NEEDED)
-
-        verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
-    }
-
-    @Test
-    fun `given WPCOM_REGISTERED, when invoked if needed, then does not register`() = testBlocking {
-        setupStatus(Status.REGISTERED_WPCOM_ONLY)
-
-        sut(IF_NEEDED)
-
-        verify(pushNotificationRepository, never()).registerPushTokenInWpComSystem(TEST_TOKEN)
-        verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(eq(TEST_TOKEN), any())
-    }
-
-    @Test
-    fun `given WOO_REGISTERED, when invoked if needed, then does not register`() = testBlocking {
-        setupStatus(Status.REGISTERED_WOO_ONLY)
-
-        sut(IF_NEEDED)
-
-        verify(pushNotificationRepository, never()).registerPushTokenInWpComSystem(TEST_TOKEN)
-        verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(eq(TEST_TOKEN), any())
-    }
-
-    @Test
-    fun `given REGISTERED_IN_BOTH, when invoked if needed, then does not register`() = testBlocking {
-        setupStatus(Status.REGISTERED_BOTH)
-
-        sut(IF_NEEDED)
-
-        verify(pushNotificationRepository, never()).registerPushTokenInWpComSystem(TEST_TOKEN)
-        verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(eq(TEST_TOKEN), any())
-    }
-
-    @Test
-    fun `given no selected site, when invoked forcefully, then registers in WPCom`() = testBlocking {
+    fun `given site switch trigger, when no selected site exists, then does not attempt registration`() = testBlocking {
+        // GIVEN
         whenever(selectedSite.getIfExists()).thenReturn(null)
-        setupStatus(Status.UNREGISTERED)
 
-        sut(FORCEFULLY)
+        // WHEN
+        sut(SITE_SWITCH)
 
-        verify(pushNotificationRepository).registerPushTokenInWpComSystem(TEST_TOKEN)
+        // THEN
+        verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(eq(TEST_TOKEN), any())
+        verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(eq(TEST_TOKEN), any(), any())
+        verify(pushNotificationRepository, never()).registerPushTokenInWpComSystem(TEST_TOKEN)
     }
 
-    private suspend fun setupStatus(status: Status) {
-        whenever(pushNotificationRegistrationStatus.invoke(anyOrNull())).thenReturn(status)
-    }
+    @Test
+    fun `given unforced run in progress, when site switch is kicked off, then it waits for unforced run to finish`() =
+        testBlocking {
+            // GIVEN
+            wheneverBlocking {
+                pushNotificationRepository.registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne, true)
+            }.doSuspendableAnswer {
+                delay(1000.milliseconds)
+                Result.success(Unit)
+            }
+
+            // WHEN
+            sut.kickoff(APP_FOREGROUND)
+            runCurrent()
+
+            val queuedTrigger = launch {
+                sut.kickoff(SITE_SWITCH)
+            }
+            runCurrent()
+
+            // THEN
+            verify(pushNotificationRepository, times(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne, true)
+            verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, false)
+
+            // WHEN
+            advanceTimeBy(1001.milliseconds)
+            queuedTrigger.join()
+            advanceUntilIdle()
+
+            // THEN
+            verify(pushNotificationRepository, times(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, false)
+        }
+
+    @Test
+    fun `given unforced run in progress, when token refresh is kicked off, then it cancels the unforced run and restarts with force`() =
+        testBlocking {
+            // GIVEN
+            var isFirstCall = true
+            wheneverBlocking {
+                pushNotificationRepository.registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne, true)
+            }.doSuspendableAnswer {
+                if (isFirstCall) {
+                    isFirstCall = false
+                    delay(Long.MAX_VALUE.milliseconds) // Suspend indefinitely until cancelled
+                }
+                Result.success(Unit)
+            }
+
+            // WHEN
+            sut.kickoff(APP_FOREGROUND)
+            runCurrent()
+
+            sut.kickoff(TOKEN_REFRESH)
+            advanceUntilIdle()
+
+            // THEN
+            verify(pushNotificationRepository, times(1)).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_ONE)
+            verify(pushNotificationRepository, times(1)).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)
+            verify(pushNotificationRepository, times(2)).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne, true)
+            verify(pushNotificationRepository, atLeast(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteTwo, true)
+            verify(pushNotificationRepository, times(1)).registerPushTokenInWpComSystem(TEST_TOKEN)
+        }
 
     companion object {
         private const val TEST_TOKEN = "test-fcm-token-123"
-        private const val TEST_SITE_ID = 123L
+        private const val SELECTED_SITE_ID = 123L
+        private const val SITE_ID_ONE = 456L
+        private const val SITE_ID_TWO = 789L
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
@@ -96,16 +96,17 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
     }
 
     @Test
-    fun `given app foreground trigger, when sites exist, then evaluates all sites`() = testBlocking {
+    fun `given app foreground trigger, when selected site exists, then evaluates only selected site`() = testBlocking {
         // WHEN
         sut(APP_FOREGROUND)
 
         // THEN
-        verify(getWooVisibleSites).invoke()
-        verify(pushNotificationRepository).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_ONE)
-        verify(pushNotificationRepository).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)
-        verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne)
-        verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteTwo)
+        verify(selectedSite).getIfExists()
+        verify(pushNotificationRepository).shouldRegisterWooPushForSite(TEST_TOKEN, SELECTED_SITE_ID)
+        verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel)
+        verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_ONE)
+        verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)
+        verify(getWooVisibleSites, never()).invoke()
     }
 
     @Test
@@ -176,15 +177,28 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
     fun `given app foreground trigger, when Woo registration is unchanged for one site, then registers only stale sites`() =
         testBlocking {
             // GIVEN
-            whenever(pushNotificationRepository.shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)).thenReturn(false)
+            whenever(pushNotificationRepository.shouldRegisterWooPushForSite(TEST_TOKEN, SELECTED_SITE_ID)).thenReturn(false)
 
             // WHEN
             sut(APP_FOREGROUND)
 
             // THEN
-            verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne)
-            verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteTwo)
+            verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel)
         }
+
+    @Test
+    fun `given app foreground trigger, when no selected site exists, then Woo registration is skipped`() = testBlocking {
+        // GIVEN
+        whenever(selectedSite.getIfExists()).thenReturn(null)
+
+        // WHEN
+        sut(APP_FOREGROUND)
+
+        // THEN
+        verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(eq(TEST_TOKEN), any())
+        verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(eq(TEST_TOKEN), any(), any())
+        verify(getWooVisibleSites, never()).invoke()
+    }
 
     @Test
     fun `given site switch trigger, when no selected site exists, then does not attempt registration`() = testBlocking {
@@ -205,7 +219,7 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
         testBlocking {
             // GIVEN
             wheneverBlocking {
-                pushNotificationRepository.registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne, true)
+                pushNotificationRepository.registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, true)
             }.doSuspendableAnswer {
                 delay(1000.milliseconds)
                 Result.success(Unit)
@@ -221,7 +235,7 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
             runCurrent()
 
             // THEN
-            verify(pushNotificationRepository, times(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne, true)
+            verify(pushNotificationRepository, times(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, true)
             verify(
                 pushNotificationRepository,
                 never()
@@ -245,7 +259,7 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
             // GIVEN
             var isFirstCall = true
             wheneverBlocking {
-                pushNotificationRepository.registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne, true)
+                pushNotificationRepository.registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, true)
             }.doSuspendableAnswer {
                 if (isFirstCall) {
                     isFirstCall = false
@@ -262,9 +276,11 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
             advanceUntilIdle()
 
             // THEN
-            verify(pushNotificationRepository, times(1)).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_ONE)
-            verify(pushNotificationRepository, times(1)).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)
-            verify(pushNotificationRepository, times(2)).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne, true)
+            verify(pushNotificationRepository, times(1)).shouldRegisterWooPushForSite(TEST_TOKEN, SELECTED_SITE_ID)
+            verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_ONE)
+            verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)
+            verify(pushNotificationRepository, times(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, true)
+            verify(pushNotificationRepository, atLeast(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne, true)
             verify(pushNotificationRepository, atLeast(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteTwo, true)
             verify(pushNotificationRepository, times(1)).registerPushTokenInWpComSystem(TEST_TOKEN)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
@@ -132,7 +132,7 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
     }
 
     @Test
-    fun `given token refresh trigger, then forces Woo and WPCom registration regardless of current state`() =
+    fun `given token refresh trigger, when registration runs, then forces Woo and WPCom registration regardless of current state`() =
         testBlocking {
             // WHEN
             sut(TOKEN_REFRESH)
@@ -202,7 +202,9 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
     fun `given app foreground trigger, when Woo registration is unchanged for one site, then registers only stale sites`() =
         testBlocking {
             // GIVEN
-            whenever(pushNotificationRepository.shouldRegisterWooPushForSite(TEST_TOKEN, SELECTED_SITE_ID)).thenReturn(false)
+            whenever(
+                pushNotificationRepository.shouldRegisterWooPushForSite(TEST_TOKEN, SELECTED_SITE_ID)
+            ).thenReturn(false)
 
             // WHEN
             sut(APP_FOREGROUND)
@@ -260,7 +262,10 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
             runCurrent()
 
             // THEN
-            verify(pushNotificationRepository, times(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, true)
+            verify(
+                pushNotificationRepository,
+                times(1)
+            ).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, true)
             verify(
                 pushNotificationRepository,
                 never()
@@ -304,7 +309,10 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
             verify(pushNotificationRepository, times(1)).shouldRegisterWooPushForSite(TEST_TOKEN, SELECTED_SITE_ID)
             verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_ONE)
             verify(pushNotificationRepository, never()).shouldRegisterWooPushForSite(TEST_TOKEN, SITE_ID_TWO)
-            verify(pushNotificationRepository, times(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, true)
+            verify(
+                pushNotificationRepository,
+                times(1)
+            ).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, true)
             verify(pushNotificationRepository, atLeast(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne, true)
             verify(pushNotificationRepository, atLeast(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteTwo, true)
             verify(pushNotificationRepository, times(1)).registerPushTokenInWpComSystem(TEST_TOKEN)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
@@ -13,16 +13,16 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.StandardTestDispatcher
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
@@ -219,7 +219,10 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
 
             // THEN
             verify(pushNotificationRepository, times(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, siteOne, true)
-            verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, false)
+            verify(
+                pushNotificationRepository,
+                never()
+            ).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, false)
 
             // WHEN
             advanceTimeBy(1001.milliseconds)
@@ -227,7 +230,10 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
             advanceUntilIdle()
 
             // THEN
-            verify(pushNotificationRepository, times(1)).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, false)
+            verify(
+                pushNotificationRepository,
+                times(1)
+            ).registerPushTokenInWooCoreSystem(TEST_TOKEN, selectedSiteModel, false)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
@@ -147,6 +147,9 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
     fun `given no access token, when app foreground trigger runs, then does not register in WPCom`() = testBlocking {
         // GIVEN
         whenever(accountStore.hasAccessToken()).thenReturn(false)
+        wheneverBlocking {
+            pushNotificationRepository.isWpComPushRegistered()
+        }.thenReturn(true)
 
         // WHEN
         sut(APP_FOREGROUND)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/RegisterDeviceTest.kt
@@ -175,7 +175,7 @@ class RegisterDeviceTest : BaseUnitTest(StandardTestDispatcher()) {
         whenever(accountStore.hasAccessToken()).thenReturn(false)
         wheneverBlocking {
             pushNotificationRepository.isWpComPushRegistered()
-        }.thenReturn(true)
+        }.thenReturn(false)
 
         // WHEN
         sut(APP_FOREGROUND)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -102,8 +102,7 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
                 override val applicationName: String = clientId
                 override suspend fun isEnabledForJetpackAccess(): Boolean = true
             },
-            resourceProvider = resourceProvider,
-            registerDevice = registerDevice
+            resourceProvider = resourceProvider
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -78,7 +78,6 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }
     }
-    private val registerDevice: RegisterDevice = mock()
 
     private lateinit var viewModel: LoginSiteCredentialsViewModel
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPasswordViewModelTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.JetpackConnectionStatus
 import com.woocommerce.android.model.JetpackSiteRegistrationStatus
 import com.woocommerce.android.model.JetpackStatus
+import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPComLoginRepository
@@ -45,6 +46,7 @@ class WPComLoginPasswordViewModelTest : BaseUnitTest() {
     private val resourceProvider: ResourceProvider = mock()
     private val selectedSite: SelectedSite = mock()
     private val jetpackActivationRepository: JetpackActivationRepository = mock()
+    private val registerDevice: RegisterDevice = mock()
 
     private lateinit var viewModel: WPComLoginPasswordViewModel
 
@@ -57,7 +59,8 @@ class WPComLoginPasswordViewModelTest : BaseUnitTest() {
             wpComLoginRepository = wpComLoginRepository,
             accountRepository = accountRepository,
             resourceProvider = resourceProvider,
-            analyticsTrackerWrapper = analyticsTrackerWrapper
+            analyticsTrackerWrapper = analyticsTrackerWrapper,
+            registerDevice = registerDevice
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/wpcom/WPComLoginPostLoginViewModelTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.model.JetpackConnectionStatus
 import com.woocommerce.android.model.JetpackSiteRegistrationStatus
 import com.woocommerce.android.model.JetpackStatus
+import com.woocommerce.android.notifications.push.RegisterDevice
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.jetpack.GoToStore
 import com.woocommerce.android.ui.login.jetpack.JetpackActivationRepository
@@ -17,6 +18,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 
@@ -32,12 +34,14 @@ class WPComLoginPostLoginViewModelTest : BaseUnitTest() {
     }
     private val jetpackActivationRepository: JetpackActivationRepository = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val registerDevice: RegisterDevice = mock()
 
     private fun createViewModel() = WPComLoginPostLoginViewModel(
         savedStateHandle = SavedStateHandle(),
         selectedSite = selectedSite,
         jetpackActivationRepository = jetpackActivationRepository,
-        analyticsTrackerWrapper = analyticsTrackerWrapper
+        analyticsTrackerWrapper = analyticsTrackerWrapper,
+        registerDevice = registerDevice
     )
 
     @Test
@@ -79,6 +83,7 @@ class WPComLoginPostLoginViewModelTest : BaseUnitTest() {
             val result = viewModel.onLoginSuccess(jetpackStatus)
 
             assertThat(result.isSuccess).isTrue()
+            verify(registerDevice).kickoff(RegisterDevice.Trigger.LOGIN_SUCCESS)
             assertThat(events.last()).isEqualTo(GoToStore)
         }
 
@@ -97,6 +102,7 @@ class WPComLoginPostLoginViewModelTest : BaseUnitTest() {
             val result = viewModel.onLoginSuccess(jetpackStatus)
 
             assertThat(result.isSuccess).isTrue()
+            verify(registerDevice).kickoff(RegisterDevice.Trigger.LOGIN_SUCCESS)
             assertThat(events.last()).isEqualTo(ShowJetpackCPInstallationScreen)
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
@@ -112,7 +112,7 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
     fun `when initialized, then site address is set`() = testBlocking {
         setup {
             whenever(appPrefsWrapper.getFCMToken()).thenReturn("test-token")
-            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any()))
+            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any(), any()))
                 .thenReturn(Result.success(Unit))
         }
 
@@ -149,7 +149,7 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
     fun `when close is clicked, then Exit event is triggered`() = testBlocking {
         setup {
             whenever(appPrefsWrapper.getFCMToken()).thenReturn("test-token")
-            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any()))
+            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any(), any()))
                 .thenReturn(Result.success(Unit))
         }
 
@@ -315,7 +315,7 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
     fun `given push registration fails, when EnablePushNotifications runs, then step is Error`() = testBlocking {
         setup {
             whenever(appPrefsWrapper.getFCMToken()).thenReturn("test-token")
-            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any()))
+            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any(), any()))
                 .thenReturn(Result.failure(Exception("registration failed")))
         }
 
@@ -332,7 +332,7 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
         testBlocking {
             setup {
                 whenever(appPrefsWrapper.getFCMToken()).thenReturn("test-token")
-                whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any()))
+                whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any(), any()))
                     .thenReturn(
                         Result.failure(
                             WooException(
@@ -383,7 +383,7 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
         testBlocking {
             setup {
                 whenever(appPrefsWrapper.getFCMToken()).thenReturn("test-token")
-                whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any()))
+                whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any(), any()))
                     .thenReturn(Result.failure(Exception("registration failed")))
             }
 
@@ -392,7 +392,7 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
             }
             assertThat(errorState.steps[2].state).isInstanceOf(StepState.Error::class.java)
 
-            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any()))
+            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any(), any()))
                 .thenReturn(Result.success(Unit))
             viewModel.onRetryClick()
 
@@ -404,7 +404,7 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
     fun `when all steps succeed, then CheckPluginCompatibility and ConnectStore show as Success`() = testBlocking {
         setup {
             whenever(appPrefsWrapper.getFCMToken()).thenReturn("test-token")
-            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any()))
+            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any(), any()))
                 .thenReturn(Result.success(Unit))
         }
 
@@ -459,7 +459,7 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
             whenever(checkWCPluginSupport(forceRefresh = true))
                 .thenReturn(CheckWooPluginPushNotificationsSupport.Result.Compatible)
             whenever(appPrefsWrapper.getFCMToken()).thenReturn("test-token")
-            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any()))
+            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any(), any()))
                 .thenReturn(Result.success(Unit))
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -53,7 +53,6 @@ import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -53,6 +53,7 @@ import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -543,6 +544,7 @@ class SitePickerViewModelTest : BaseUnitTest() {
         verify(userEligibilityFetcher, times(1)).fetchUserInfo(any())
         verify(selectedSite, times(1)).set(any())
         verify(appPrefsWrapper, times(1)).removeLoginSiteAddress()
+        verify(registerDevice).kickoff(RegisterDevice.Trigger.LOGIN_SUCCESS)
 
         assertThat(view).isEqualTo(NavigateToMainActivityEvent)
         assertThat(isProgressShown).containsExactly(false, true, false)
@@ -574,6 +576,22 @@ class SitePickerViewModelTest : BaseUnitTest() {
             verify(appPrefsWrapper, times(0)).removeLoginSiteAddress()
             assertThat(viewModel.event.value).isEqualTo(ShowSnackbar(R.string.user_role_access_error_fetch_failed))
             assertThat(isProgressShown).containsExactly(false, true, false)
+        }
+
+    @Test
+    fun `given that user is switching stores, when site verification succeeds, then site switch registration is triggered`() =
+        testBlocking {
+            givenTheScreenIsFromLogin(false)
+            givenThatSiteVerificationIsCompleted()
+            whenSitesAreFetched()
+            whenViewModelIsCreated()
+
+            val selectedSiteModel = defaultExpectedSiteList[1]
+
+            viewModel.onSiteSelected(selectedSiteModel)
+            viewModel.onContinueButtonClick()
+
+            verify(registerDevice).kickoff(RegisterDevice.Trigger.SITE_SWITCH)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/GetWooVisibleSitesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/GetWooVisibleSitesTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.sitepicker.sitevisibility
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -11,7 +12,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
-import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GetWooVisibleSitesTest : BaseUnitTest() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/GetWooVisibleSitesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/GetWooVisibleSitesTest.kt
@@ -1,0 +1,95 @@
+package com.woocommerce.android.ui.sitepicker.sitevisibility
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import com.woocommerce.android.ui.sitepicker.SitePickerRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetWooVisibleSitesTest : BaseUnitTest() {
+    private val sitePickerRepository: SitePickerRepository = mock()
+    private val visibleSitesDataStore: VisibleWooSitesDataStore = mock {
+        onBlocking { isSiteVisible(any()) } doReturn flowOf(true)
+    }
+    private val selectedSite: SelectedSite = mock()
+
+    private val wpComVisibleWooSite = SiteModel().apply {
+        id = 1
+        siteId = 101L
+        origin = SiteModel.ORIGIN_WPCOM_REST
+        hasWooCommerce = true
+    }
+    private val appPasswordWooSite = SiteModel().apply {
+        id = 2
+        siteId = 0L
+        origin = SiteModel.ORIGIN_WPAPI
+        hasWooCommerce = true
+    }
+
+    @Test
+    fun `given visible wpcom woo sites, when invoked, then returns visible woo sites`() = testBlocking {
+        // GIVEN
+        val hiddenWooSite = SiteModel().apply {
+            id = 3
+            siteId = 202L
+            origin = SiteModel.ORIGIN_WPCOM_REST
+            hasWooCommerce = true
+        }
+        val nonWooSite = SiteModel().apply {
+            id = 4
+            siteId = 303L
+            origin = SiteModel.ORIGIN_WPCOM_REST
+            hasWooCommerce = false
+        }
+        val visibleSitesDataStore = mock<VisibleWooSitesDataStore> {
+            onBlocking { isSiteVisible(101L) } doReturn flowOf(true)
+            onBlocking { isSiteVisible(202L) } doReturn flowOf(false)
+        }
+        val sut = GetWooVisibleSites(sitePickerRepository, visibleSitesDataStore, selectedSite)
+        doReturn(listOf(wpComVisibleWooSite, hiddenWooSite, nonWooSite)).whenever(sitePickerRepository).getSites()
+        doReturn(null).whenever(selectedSite).getOrNull()
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).containsExactly(wpComVisibleWooSite)
+    }
+
+    @Test
+    fun `given selected app password woo site, when invoked, then includes current selected site`() = testBlocking {
+        // GIVEN
+        val sut = GetWooVisibleSites(sitePickerRepository, visibleSitesDataStore, selectedSite)
+        doReturn(listOf(wpComVisibleWooSite)).whenever(sitePickerRepository).getSites()
+        doReturn(appPasswordWooSite).whenever(selectedSite).getOrNull()
+
+        // WHEN
+        val result = sut()
+
+        // THEN
+        assertThat(result).containsExactly(wpComVisibleWooSite, appPasswordWooSite)
+    }
+
+    @Test
+    fun `given selected app password woo site already present, when invoked, then does not duplicate current site`() =
+        testBlocking {
+            // GIVEN
+            val sut = GetWooVisibleSites(sitePickerRepository, visibleSitesDataStore, selectedSite)
+            doReturn(listOf(wpComVisibleWooSite, appPasswordWooSite)).whenever(sitePickerRepository).getSites()
+            doReturn(appPasswordWooSite).whenever(selectedSite).getOrNull()
+
+            // WHEN
+            val result = sut()
+
+            // THEN
+            assertThat(result).containsExactly(wpComVisibleWooSite, appPasswordWooSite)
+        }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-2696
Fixes WOOMOB-2682

> [!NOTE]
> **Note on diff size**: The PR diff is large, but the majority of the insertions are tests covering new and modified behaviour. Core production changes are concentrated in RegisterDevice.kt, PushNotificationRepository.kt, GetWooVisibleSites.kt, and the updated entry-point callers.
 

#### Problem

Push notification registration had several issues:

- **Scattered login-success triggers**: login-success registration depended on caller-specific side effects instead of shared success callbacks. Some flows triggered it from `LoginSiteCredentialsViewModel` or indirectly via `FETCH_ACCOUNT` in `AppInitializer`, while `LoginActivity`, `AutoLoginActivity`, and Jetpack post-login did not trigger it directly.
- **No staleness check**: `IF_NEEDED` relied on stored registration status for the selected site. Once a site had Woo registration metadata, token or locale drift was not detected during non-forced runs.
- **Spurious registrations**: `AppInitializer` registered on every `FETCH_ACCOUNT` FluxC event, not just on fresh logins.

#### Solution

`RegisterDevice` is refactored into a single-entry-point orchestrator driven by a `Trigger` enum. Each trigger encodes both the **scope** (which sites to register) and the **behaviour** (force vs. staleness-check):

| Trigger | Emitted when | Sites registered | Forces re-registration? |
|---|---|---|---|
| `LOGIN_SUCCESS` | Login completes (all flows) | All visible Woo sites | No — staleness check |
| `APP_FOREGROUND` | App returns to foreground | All visible Woo sites | No — staleness check |
| `SITE_SWITCH` | User changes the active site | Selected site only | No — staleness check, no WP.com registration/fallback |
| `TOKEN_REFRESH` | FCM token is refreshed or retrieved | All visible Woo sites | Yes — also cancels in-progress job |

**Staleness check** — `PushNotificationRepository` now persists per-site registration metadata in DataStore (token value + locale). `shouldRegisterWooPushForSite()` skips re-registration unless the FCM token value or device locale has actually changed since the last registration.

**Concurrency safety** — a `Mutex` serializes concurrent invocations. `TOKEN_REFRESH` cancels any in-progress job before acquiring the lock, ensuring the fresh token is always used.

**`GetWooVisibleSites` extension** — the use case now includes the currently selected Application Passwords site if it is not already in the WP.com site list, so these sites are never missed during a full-sweep registration.

#### Architecture

```mermaid
flowchart TD
    subgraph entryPoints["Entry Points"]
        E1["FCMMessageService / FCMRefreshWorker"]
        E2["LoginActivity / AutoLoginActivity"]
        E3["SitePickerViewModel (from login)"]
        E4["SitePickerViewModel (site changed)"]
        E5["AppInitializer (foreground)"]
        E6["WPComLoginPostLoginViewModel (Jetpack Setup)"]
    end

    E1 -->|TOKEN_REFRESH| RD["RegisterDevice"]
    E2 -->|LOGIN_SUCCESS| RD
    E3 -->|LOGIN_SUCCESS| RD
    E6 -->|LOGIN_SUCCESS| RD
    E4 -->|SITE_SWITCH| RD
    E5 -->|APP_FOREGROUND| RD

    RD --> Scope{"Trigger\nscope"}
    Scope -->|"LOGIN_SUCCESS / APP_FOREGROUND / TOKEN_REFRESH"| AllSites["GetWooVisibleSites()"]
    Scope -->|SITE_SWITCH| SelectedOnly["Selected site only"]

    AllSites --> Sweep["Per-site Woo registration sweep"]
    SelectedOnly --> Sweep

    Sweep --> Force{"TOKEN_REFRESH?"}
    Force -->|Yes| Woo["Register in Woo Core"]
    Force -->|No| Check{"Token or locale\nchanged?"}
    Check -->|Yes| Woo
    Check -->|No| SkipWoo["Skip Woo registration"]

    RD --> WpComCheck{"trigger != SITE_SWITCH\n&& hasAccessToken\n&& (forced || WP.com already registered)"}
    WpComCheck -->|Yes| WpCom["Register in WP.com"]
    WpComCheck -->|No| SkipWpCom["Skip WP.com"]
```

**Staleness check detail:**

```mermaid
flowchart LR
    A["shouldRegisterWooPushForSite(token, siteId)"]
    A --> B{"DataStore record\nexists?"}
    B -->|No| C["Register"]
    B -->|Yes| D{"Token\nchanged?"}
    D -->|Yes| C
    D -->|No| E{"Locale\nchanged?"}
    E -->|Yes| C
    E -->|No| F["Skip"]
```

### Test Steps
**For all tests, make sure PN feature flags are enabled**

#### Correctness tests
1. Make sure at least one of your sites is using the Woo PN test build (from here paaHJt-9VE-p2)
2. Open Logcat filtered to `WooCommerce-NOTIFICATIONS`.
3. Log in via WP.com credentials. Verify logs show:
   - `Starting push registration for LOGIN_SUCCESS`
   - `Registering Woo push for site <siteId> for LOGIN_SUCCESS` for each visible Woo site
   - `Registering WP.com push for LOGIN_SUCCESS`
4. Switch sites in the site picker. Verify logs show:
   - `Starting push registration for SITE_SWITCH`
   - `Registering Woo push for site <selected-site-id> for SITE_SWITCH` (only if the site's registration is stale; absent if up to date)
   - `Skipping WP.com push registration for SITE_SWITCH`
5. Log in via Application Passwords. Verify logs show `Starting push registration for LOGIN_SUCCESS` and `Registering Woo push for site <siteId> for LOGIN_SUCCESS` for the selected site.
6. **Optional:** Log in via Magic Link. Verify the same `LOGIN_SUCCESS` log sequence appears.
8. Background the app and foreground it again. Verify logs show `Starting push registration for APP_FOREGROUND`. `Registering Woo push for site <siteId> for APP_FOREGROUND` appears only for sites with a stale registration; no per-site line appears for up-to-date sites.
10. With a registration already in progress, trigger a token refresh. Verify logs show `Cancelling in-progress push registration before TOKEN_REFRESH` before the `TOKEN_REFRESH` sequence begins.

#### WOOMOB-2696 fix
1. Make sure at least one of your sites is using the Woo PN test build (from here paaHJt-9VE-p2)
2. Sign in (both login options are fine).
3. Change the device language, then background the app and foreground it again, Verify logs show `Starting push registration for APP_FOREGROUND` followed by `Registering Woo push for site <siteId> for APP_FOREGROUND`.

#### WOOMOB-2682 fix
1. Use WordPress.com login, and make sure at least one of your sites is using the Woo PN test build (from here paaHJt-9VE-p2), let's say site A.
2. Start login with a different site.
3. After login, test a PN to site A.
4. Confirm the PN is received.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.