### PR TITLE
[WOOMOB-2470] Add POS orders list ViewModel and state (1/3)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,6 +43,8 @@
       "mcp__mobile-mcp__mobile_terminate_app",
       "mcp__mobile-mcp__mobile_type_keys",
       "mcp__mobile-mcp__mobile_uninstall_app",
+      "mcp__claude_ai_Linear__get_issue",
+      "mcp__claude_ai_Linear__list_comments",
       "Skill(verify-on-device)",
       "Skill(store-tests)",
       "Skill(store-compose)",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListState.kt
@@ -1,0 +1,49 @@
+package com.woocommerce.android.ui.woopos.orders.list
+
+import androidx.compose.runtime.Immutable
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderItemViewState
+
+@Immutable
+sealed class WooPosOrdersListState {
+    abstract val pullToRefreshState: WooPosPullToRefreshState
+    abstract val searchInputState: WooPosSearchInputState
+
+    @Immutable
+    data class Content(
+        val items: Items,
+        override val pullToRefreshState: WooPosPullToRefreshState,
+        override val searchInputState: WooPosSearchInputState,
+        val paginationState: WooPosPaginationState
+    ) : WooPosOrdersListState() {
+        sealed class Items {
+            data class Loaded(val items: List<OrderItemViewState>) : Items()
+            data object Searching : Items()
+            data class Error(val title: String, val message: String) : Items()
+            data class NothingFound(val title: String, val message: String) : Items()
+        }
+    }
+
+    @Immutable
+    data class Error(
+        val message: String,
+        override val searchInputState: WooPosSearchInputState
+    ) : WooPosOrdersListState() {
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Disabled
+    }
+
+    @Immutable
+    data class Loading(
+        override val searchInputState: WooPosSearchInputState
+    ) : WooPosOrdersListState() {
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Disabled
+    }
+
+    @Immutable
+    data class Empty(
+        override val pullToRefreshState: WooPosPullToRefreshState = WooPosPullToRefreshState.Enabled,
+        override val searchInputState: WooPosSearchInputState
+    ) : WooPosOrdersListState()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListViewModel.kt
@@ -14,7 +14,6 @@ import com.woocommerce.android.ui.woopos.orders.ORDERS_ROUTE_ORDER_ID_KEY
 import com.woocommerce.android.ui.woopos.orders.SearchOrdersResult
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
-import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderItemViewState
 import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderItemMapper
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListViewModel.kt
@@ -1,0 +1,434 @@
+package com.woocommerce.android.ui.woopos.orders.list
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppUrls
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
+import com.woocommerce.android.ui.woopos.orders.LoadOrdersResult
+import com.woocommerce.android.ui.woopos.orders.ORDERS_ROUTE_ORDER_ID_KEY
+import com.woocommerce.android.ui.woopos.orders.SearchOrdersResult
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderItemViewState
+import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderItemMapper
+import com.woocommerce.android.viewmodel.ResourceProvider
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.time.TimeSource.Monotonic
+
+@HiltViewModel
+class WooPosOrdersListViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val ordersDataSource: WooPosOrdersDataSource,
+    private val resourceProvider: ResourceProvider,
+    private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker,
+    private val orderItemMapper: WooPosOrderItemMapper,
+) : ViewModel() {
+
+    private val singleOrderId: Long? = savedStateHandle.get<Long>(ORDERS_ROUTE_ORDER_ID_KEY)
+
+    private val _state = MutableStateFlow<WooPosOrdersListState>(
+        WooPosOrdersListState.Loading(
+            searchInputState = WooPosSearchInputState.Closed
+        )
+    )
+    val state: StateFlow<WooPosOrdersListState> = _state.asStateFlow()
+
+    private val _selectedOrderId = MutableStateFlow<Long?>(null)
+    val selectedOrderId: StateFlow<Long?> = _selectedOrderId.asStateFlow()
+
+    private val _openUrlEvent = MutableSharedFlow<String>()
+    val openUrlEvent: SharedFlow<String> = _openUrlEvent.asSharedFlow()
+
+    private val _scrollToTopEvent = MutableSharedFlow<Unit>()
+    val scrollToTopEvent: SharedFlow<Unit> = _scrollToTopEvent.asSharedFlow()
+
+    private var searchJob: Job? = null
+    private var loadingJob: Job? = null
+    private var loadingMoreOrdersJob: Job? = null
+
+    private val currentSearchQuery: String?
+        get() = (
+            (
+                _state.value.searchInputState as? WooPosSearchInputState.Open
+                )?.input as? WooPosSearchInputState.Open.Input.Query
+            )?.query
+
+    companion object {
+        private const val SEARCH_DEBOUNCE_DELAY_MS = 300L
+    }
+
+    init {
+        if (singleOrderId == null) {
+            loadOrders()
+        }
+    }
+
+    fun onOrderSelected(orderId: Long) {
+        val current = _state.value as? WooPosOrdersListState.Content ?: return
+        val loadedItems = current.items as? WooPosOrdersListState.Content.Items.Loaded ?: return
+
+        if (_selectedOrderId.value == orderId) return
+
+        val position = loadedItems.items.indexOfFirst { it.id == orderId }.coerceAtLeast(0)
+        val selectedItem = loadedItems.items.firstOrNull { it.id == orderId } ?: return
+
+        viewModelScope.launch {
+            ordersAnalyticsTracker.trackOrdersListRowTapped(
+                orderId = selectedItem.id,
+                orderStatus = selectedItem.statusSlug,
+                listPosition = position,
+                createdAtMillis = selectedItem.createdAtMillis
+            )
+        }
+
+        val updatedItems = loadedItems.items.map { it.copy(isSelected = it.id == orderId) }
+        _state.value = current.copy(
+            items = WooPosOrdersListState.Content.Items.Loaded(updatedItems)
+        )
+        _selectedOrderId.value = orderId
+    }
+
+    fun onRefresh() {
+        viewModelScope.launch {
+            ordersAnalyticsTracker.trackOrdersListPullToRefreshTriggered()
+        }
+
+        val currentState = _state.value
+        _state.value = when (currentState) {
+            is WooPosOrdersListState.Content -> currentState.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Refreshing
+            )
+            is WooPosOrdersListState.Empty -> currentState.copy(
+                pullToRefreshState = WooPosPullToRefreshState.Refreshing
+            )
+            is WooPosOrdersListState.Error -> currentState
+            is WooPosOrdersListState.Loading -> currentState
+        }
+
+        ordersDataSource.clearCache()
+
+        val query = currentSearchQuery
+        if (query.isNullOrEmpty()) {
+            loadOrders(isRefreshing = true)
+        } else {
+            performSearch(query, isRefreshing = true)
+        }
+    }
+
+    fun onEndOfOrdersListReached() {
+        val currentState = _state.value
+        if (currentState !is WooPosOrdersListState.Content ||
+            currentState.paginationState != WooPosPaginationState.None ||
+            currentState.pullToRefreshState == WooPosPullToRefreshState.Refreshing
+        ) {
+            return
+        }
+
+        loadMoreIfPossible()
+    }
+
+    fun onPaginationErrorTryAgain() {
+        loadMoreIfPossible()
+    }
+
+    fun onSearchEvent(event: WooPosSearchUIEvent) {
+        when (event) {
+            is WooPosSearchUIEvent.SearchIconClicked -> {
+                viewModelScope.launch {
+                    ordersAnalyticsTracker.trackOrdersListSearchButtonTapped()
+                }
+                updateSearchState(
+                    WooPosSearchInputState.Open(
+                        input = WooPosSearchInputState.Open.Input.Hint(
+                            resourceProvider.getString(R.string.woopos_search_orders)
+                        ),
+                        isLoading = false,
+                        requestFocus = true
+                    )
+                )
+            }
+
+            is WooPosSearchUIEvent.Search -> {
+                updateSearchState(
+                    WooPosSearchInputState.Open(
+                        input = WooPosSearchInputState.Open.Input.Query(
+                            event.query,
+                            event.cursorPosition
+                        ),
+                        isLoading = false,
+                    )
+                )
+                if (event.query.isEmpty()) {
+                    loadOrders()
+                } else {
+                    performSearch(event.query)
+                }
+            }
+
+            is WooPosSearchUIEvent.Clear -> {
+                updateSearchState(
+                    WooPosSearchInputState.Open(
+                        input = WooPosSearchInputState.Open.Input.Hint(
+                            resourceProvider.getString(R.string.woopos_search_orders)
+                        ),
+                        isLoading = false,
+                        requestFocus = true
+                    )
+                )
+                loadOrders()
+            }
+
+            is WooPosSearchUIEvent.Close -> {
+                updateSearchState(WooPosSearchInputState.Closed)
+                loadOrders()
+            }
+        }
+    }
+
+    fun onSearchErrorRetry() {
+        val query = currentSearchQuery
+        if (!query.isNullOrEmpty()) {
+            performSearch(query)
+        }
+    }
+
+    fun onOrdersEmptyActionClicked() {
+        viewModelScope.launch {
+            _openUrlEvent.emit(AppUrls.URL_LEARN_MORE_ORDERS)
+        }
+    }
+
+    fun onOrdersLoadingErrorRetryButtonClicked() {
+        _state.value = WooPosOrdersListState.Loading(
+            searchInputState = WooPosSearchInputState.Closed
+        )
+        loadOrders()
+    }
+
+    fun refreshOrderItem(orderId: Long) {
+        viewModelScope.launch {
+            val order = ordersDataSource.getOrderById(orderId).getOrNull() ?: return@launch
+            val current = _state.value as? WooPosOrdersListState.Content ?: return@launch
+            val loadedItems = current.items as? WooPosOrdersListState.Content.Items.Loaded ?: return@launch
+
+            val updatedItems = loadedItems.items.map { item ->
+                if (item.id == orderId) {
+                    orderItemMapper.mapOrderItem(order, _selectedOrderId.value)
+                } else {
+                    item
+                }
+            }
+            _state.value = current.copy(
+                items = WooPosOrdersListState.Content.Items.Loaded(updatedItems)
+            )
+        }
+    }
+
+    private fun loadOrders(isRefreshing: Boolean = false) {
+        cancelJobs()
+        val mark = Monotonic.markNow()
+        loadingJob = viewModelScope.launch {
+            ordersDataSource.loadOrders(forceRefreshRefunds = isRefreshing).collect { result ->
+                when (result) {
+                    is LoadOrdersResult.Error -> {
+                        val elapsedMs = mark.elapsedNow().inWholeMilliseconds
+                        ordersAnalyticsTracker.trackOrdersListFetched(elapsedMs)
+
+                        _state.value = WooPosOrdersListState.Error(
+                            message = result.message,
+                            searchInputState = WooPosSearchInputState.Closed
+                        )
+                    }
+
+                    is LoadOrdersResult.SuccessCache -> {
+                        if (result.ordersWithRefunds.isEmpty()) {
+                            _state.value = WooPosOrdersListState.Loading(
+                                searchInputState = WooPosSearchInputState.Closed
+                            )
+                        } else {
+                            replaceOrders(result.ordersWithRefunds.keys.toList())
+                        }
+                    }
+
+                    is LoadOrdersResult.SuccessRemote -> {
+                        val elapsedMs = mark.elapsedNow().inWholeMilliseconds
+                        ordersAnalyticsTracker.trackOrdersListFetched(elapsedMs)
+
+                        if (result.ordersWithRefunds.isEmpty()) {
+                            _state.value = WooPosOrdersListState.Empty(
+                                searchInputState = WooPosSearchInputState.Closed
+                            )
+                        } else {
+                            replaceOrders(result.ordersWithRefunds.keys.toList())
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun performSearch(query: String, isRefreshing: Boolean = false) {
+        cancelJobs()
+        searchJob = viewModelScope.launch {
+            delay(SEARCH_DEBOUNCE_DELAY_MS)
+            if (!isRefreshing) {
+                _state.value = WooPosOrdersListState.Content(
+                    items = WooPosOrdersListState.Content.Items.Searching,
+                    pullToRefreshState = WooPosPullToRefreshState.Disabled,
+                    searchInputState = _state.value.searchInputState,
+                    paginationState = WooPosPaginationState.None
+                )
+            }
+
+            val mark = Monotonic.markNow()
+            val result = ordersDataSource.searchOrders(query, forceRefreshRefunds = isRefreshing)
+            val elapsedMs = mark.elapsedNow().inWholeMilliseconds
+            ordersAnalyticsTracker.trackOrdersListSearchResultsFetched(elapsedMs)
+            when (result) {
+                is SearchOrdersResult.Error -> {
+                    _state.value = WooPosOrdersListState.Content(
+                        items = WooPosOrdersListState.Content.Items.Error(
+                            title = resourceProvider.getString(R.string.woopos_search_orders_error_title),
+                            message = resourceProvider.getString(R.string.woopos_search_orders_error_description)
+                        ),
+                        pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                        searchInputState = _state.value.searchInputState,
+                        paginationState = WooPosPaginationState.None
+                    )
+                }
+
+                is SearchOrdersResult.Success -> {
+                    if (result.ordersWithRefunds.isEmpty()) {
+                        _state.value = WooPosOrdersListState.Content(
+                            items = WooPosOrdersListState.Content.Items.NothingFound(
+                                title = resourceProvider.getString(R.string.woopos_search_orders_empty_title),
+                                message = resourceProvider.getString(R.string.woopos_search_orders_empty_description)
+                            ),
+                            pullToRefreshState = WooPosPullToRefreshState.Enabled,
+                            searchInputState = _state.value.searchInputState,
+                            paginationState = WooPosPaginationState.None
+                        )
+                    } else {
+                        replaceOrders(result.ordersWithRefunds.keys.toList())
+                    }
+                }
+            }
+        }
+    }
+
+    private fun loadMoreIfPossible() {
+        if (loadingJob?.isActive == true || loadingMoreOrdersJob?.isActive == true) return
+        if (!ordersDataSource.hasMorePages) return
+
+        val currentState = _state.value
+        val newState = when (currentState) {
+            is WooPosOrdersListState.Content -> currentState.copy(
+                paginationState = WooPosPaginationState.Loading
+            )
+            else -> return
+        }
+        _state.value = newState
+
+        loadingMoreOrdersJob?.cancel()
+        loadingMoreOrdersJob = viewModelScope.launch {
+            val normalizedQuery = currentSearchQuery.takeUnless { it.isNullOrEmpty() }
+            val result = ordersDataSource.loadMore(normalizedQuery)
+
+            if (result.isSuccess) {
+                ordersAnalyticsTracker.trackOrdersListNextPageLoaded()
+                appendOrders(result.getOrThrow().keys.toList())
+            } else {
+                _state.value = newState.copy(paginationState = WooPosPaginationState.Error)
+            }
+        }
+    }
+
+    private fun replaceOrders(
+        orders: List<com.woocommerce.android.model.Order>,
+        paginationState: WooPosPaginationState = WooPosPaginationState.None
+    ) {
+        val currentState = _state.value
+        val currentFirstOrderId = (currentState as? WooPosOrdersListState.Content)
+            ?.let { it.items as? WooPosOrdersListState.Content.Items.Loaded }
+            ?.items?.firstOrNull()?.id
+
+        val newFirstOrderId = orders.firstOrNull()?.id
+
+        val currentSelectedId = _selectedOrderId.value
+        val isSelectedOrderStillInList = currentSelectedId != null && orders.any { it.id == currentSelectedId }
+        val newSelectedId = if (isSelectedOrderStillInList) {
+            currentSelectedId
+        } else {
+            requireNotNull(newFirstOrderId) { "Content requires at least one order" }
+        }
+
+        val items = orders.map { order ->
+            orderItemMapper.mapOrderItem(order, newSelectedId)
+        }
+
+        _state.value = WooPosOrdersListState.Content(
+            items = WooPosOrdersListState.Content.Items.Loaded(items),
+            pullToRefreshState = WooPosPullToRefreshState.Enabled,
+            paginationState = paginationState,
+            searchInputState = _state.value.searchInputState
+        )
+
+        _selectedOrderId.value = newSelectedId
+
+        viewModelScope.launch {
+            if (currentFirstOrderId != null && currentFirstOrderId != newFirstOrderId) {
+                _scrollToTopEvent.emit(Unit)
+            }
+        }
+    }
+
+    private fun appendOrders(
+        orders: List<com.woocommerce.android.model.Order>,
+        paginationState: WooPosPaginationState = WooPosPaginationState.None
+    ) {
+        val current = _state.value as? WooPosOrdersListState.Content ?: return
+        val loadedItems = current.items as? WooPosOrdersListState.Content.Items.Loaded ?: return
+
+        val newItems = orders.map { order ->
+            orderItemMapper.mapOrderItem(order, _selectedOrderId.value)
+        }
+        val allItems = loadedItems.items + newItems
+
+        _state.value = WooPosOrdersListState.Content(
+            items = WooPosOrdersListState.Content.Items.Loaded(allItems),
+            pullToRefreshState = WooPosPullToRefreshState.Enabled,
+            paginationState = paginationState,
+            searchInputState = _state.value.searchInputState
+        )
+    }
+
+    private fun updateSearchState(searchState: WooPosSearchInputState) {
+        _state.value = when (val currentState = _state.value) {
+            is WooPosOrdersListState.Content -> currentState.copy(searchInputState = searchState)
+            is WooPosOrdersListState.Empty -> currentState.copy(searchInputState = searchState)
+            is WooPosOrdersListState.Error -> currentState.copy(searchInputState = searchState)
+            is WooPosOrdersListState.Loading -> currentState.copy(searchInputState = searchState)
+        }
+    }
+
+    private fun cancelJobs() {
+        searchJob?.cancel()
+        loadingJob?.cancel()
+        loadingMoreOrdersJob?.cancel()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListViewModelTest.kt
@@ -1,0 +1,582 @@
+package com.woocommerce.android.ui.woopos.orders.list
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchUIEvent
+import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
+import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
+import com.woocommerce.android.ui.woopos.orders.LoadOrdersResult
+import com.woocommerce.android.ui.woopos.orders.ORDERS_ROUTE_ORDER_ID_KEY
+import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
+import com.woocommerce.android.ui.woopos.orders.SearchOrdersResult
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
+import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderItemMapper
+import com.woocommerce.android.ui.woopos.orders.details.WooPosOrderStatusMapper
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.util.DateTimeUtils
+import java.math.BigDecimal
+import java.util.Locale
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosOrdersListViewModelTest {
+
+    @Rule @JvmField
+    val coroutineTestRule = WooPosCoroutineTestRule()
+
+    private val dataSource: WooPosOrdersDataSource = mock()
+    private val resourceProvider: ResourceProvider = mock()
+    private val formatPrice: WooPosFormatPrice = mock()
+    private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker = mock()
+    private lateinit var orderItemMapper: WooPosOrderItemMapper
+    private lateinit var orderStatusMapper: WooPosOrderStatusMapper
+    private lateinit var viewModel: WooPosOrdersListViewModel
+    private val providedLocale: Locale = Locale.US
+
+    private fun order(id: Long = 1L): Order = OrderTestUtils.generateTestOrder(orderId = id).copy(
+        datePaid = DateTimeUtils.dateUTCFromIso8601("2018-02-02T16:11:13Z")
+    )
+
+    private fun ordersMap(vararg orders: Order): Map<Order, RefundsFetchResult> =
+        orders.associateWith { RefundsFetchResult.Success(emptyList()) }
+
+    private fun createViewModel(
+        savedStateHandle: SavedStateHandle = SavedStateHandle()
+    ): WooPosOrdersListViewModel {
+        return WooPosOrdersListViewModel(
+            savedStateHandle = savedStateHandle,
+            ordersDataSource = dataSource,
+            resourceProvider = resourceProvider,
+            ordersAnalyticsTracker = ordersAnalyticsTracker,
+            orderItemMapper = orderItemMapper,
+        )
+    }
+
+    @Before
+    fun setUp() = runTest {
+        setupResourceProviderMocks()
+        setupMockBehaviors()
+        setupMappers()
+        setupDataSourceMocks()
+    }
+
+    private fun setupResourceProviderMocks() {
+        whenever(resourceProvider.getString(R.string.date_time_connector)).thenReturn("at")
+        whenever(resourceProvider.getString(R.string.woopos_search_orders)).thenReturn("Search orders")
+        whenever(resourceProvider.getString(R.string.woopos_search_orders_error_title)).thenReturn("Search error")
+        whenever(resourceProvider.getString(R.string.woopos_search_orders_error_description))
+            .thenReturn("Search error description")
+        whenever(resourceProvider.getString(R.string.woopos_search_orders_empty_title)).thenReturn("No results")
+        whenever(resourceProvider.getString(R.string.woopos_search_orders_empty_description))
+            .thenReturn("No results description")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_auto_draft)).thenReturn("Draft")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_pending)).thenReturn("Pending")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_processing)).thenReturn("Processing")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_on_hold)).thenReturn("On hold")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_failed)).thenReturn("Failed")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_cancelled)).thenReturn("Canceled")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_completed)).thenReturn("Completed")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_refunded)).thenReturn("Refunded")
+        whenever(resourceProvider.getString(R.string.woopos_orders_loading_error_message))
+            .thenReturn("Please check your connection try again.")
+    }
+
+    private suspend fun setupMockBehaviors() {
+        whenever(formatPrice(any<BigDecimal>(), any())).thenAnswer { invocation ->
+            val amount = invocation.arguments[0] as? BigDecimal
+            amount?.let { "$${it.abs()}" } ?: "$0.00"
+        }
+        whenever(formatPrice(any<BigDecimal>())).thenAnswer { invocation ->
+            val amount = invocation.arguments[0] as? BigDecimal
+            amount?.let { "$${it.abs()}" } ?: "$0.00"
+        }
+    }
+
+    private fun setupMappers() {
+        orderStatusMapper = WooPosOrderStatusMapper(resourceProvider, providedLocale)
+        orderItemMapper = WooPosOrderItemMapper(resourceProvider, formatPrice, orderStatusMapper)
+    }
+
+    private suspend fun setupDataSourceMocks() {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessCache(ordersMap(order(1), order(2)))) }
+        )
+        whenever(dataSource.getOrderById(any())).thenAnswer { invocation ->
+            val orderId = invocation.arguments[0] as Long
+            Result.success(order(orderId))
+        }
+    }
+
+    // region Init / Loading
+
+    @Test
+    fun `given cache and network data, when init, then final state shows network content`() = runTest {
+        val cached = listOf(order(1))
+        val network = listOf(order(2), order(3))
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow {
+                emit(LoadOrdersResult.SuccessCache(ordersMap(*cached.toTypedArray())))
+                emit(LoadOrdersResult.SuccessRemote(ordersMap(*network.toTypedArray())))
+            }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertThat(state).isInstanceOf(WooPosOrdersListState.Content::class.java)
+        val content = state as WooPosOrdersListState.Content
+        val loadedItems = content.items as WooPosOrdersListState.Content.Items.Loaded
+        assertThat(loadedItems.items.map { it.id }).containsExactly(2L, 3L)
+        assertThat(content.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
+        assertThat(content.paginationState).isEqualTo(WooPosPaginationState.None)
+        assertThat(viewModel.selectedOrderId.value).isEqualTo(2L)
+    }
+
+    @Test
+    fun `given empty cache and non-empty network, when init, then final state shows network content`() = runTest {
+        val network = listOf(order(10))
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow {
+                emit(LoadOrdersResult.SuccessCache(emptyMap()))
+                emit(LoadOrdersResult.SuccessRemote(ordersMap(*network.toTypedArray())))
+            }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        val content = state as WooPosOrdersListState.Content
+        val loadedItems = content.items as WooPosOrdersListState.Content.Items.Loaded
+        assertThat(loadedItems.items.map { it.id }).containsExactly(10L)
+        assertThat(viewModel.selectedOrderId.value).isEqualTo(10L)
+    }
+
+    @Test
+    fun `given empty cache and empty network, when init, then final state is Empty`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow {
+                emit(LoadOrdersResult.SuccessCache(emptyMap()))
+                emit(LoadOrdersResult.SuccessRemote(emptyMap()))
+            }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value).isInstanceOf(WooPosOrdersListState.Empty::class.java)
+    }
+
+    @Test
+    fun `given data source error, when init, then state is Error`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.Error("boom")) }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertThat(state).isInstanceOf(WooPosOrdersListState.Error::class.java)
+        assertThat((state as WooPosOrdersListState.Error).message).isEqualTo("boom")
+    }
+
+    @Test
+    fun `given single order mode, when init, then loadOrders is not called`() = runTest {
+        val savedStateHandle = SavedStateHandle(mapOf(ORDERS_ROUTE_ORDER_ID_KEY to 42L))
+
+        viewModel = createViewModel(savedStateHandle)
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value).isInstanceOf(WooPosOrdersListState.Loading::class.java)
+        verify(dataSource, times(0)).loadOrders(any())
+    }
+
+    // endregion
+
+    // region Refresh
+
+    @Test
+    fun `given initial content, when refresh, then clear cache and update with network result`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1)))) }
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow {
+                emit(LoadOrdersResult.SuccessCache(emptyMap()))
+                emit(LoadOrdersResult.SuccessRemote(ordersMap(order(5), order(6))))
+            }
+        )
+
+        viewModel.onRefresh()
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersListState.Content
+        val loadedItems = content.items as WooPosOrdersListState.Content.Items.Loaded
+        assertThat(loadedItems.items.map { it.id }).containsExactly(5L, 6L)
+        assertThat(content.pullToRefreshState).isEqualTo(WooPosPullToRefreshState.Enabled)
+        verify(dataSource).clearCache()
+    }
+
+    @Test
+    fun `given selection removed after reload, when refreshing, then first item is auto selected`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(100), order(200)))) }
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onOrderSelected(200L)
+        advanceUntilIdle()
+
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow {
+                emit(LoadOrdersResult.SuccessCache(emptyMap()))
+                emit(LoadOrdersResult.SuccessRemote(ordersMap(order(300), order(400))))
+            }
+        )
+
+        viewModel.onRefresh()
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersListState.Content
+        val loadedItems = content.items as WooPosOrdersListState.Content.Items.Loaded
+        assertThat(loadedItems.items.map { it.id }).containsExactly(300L, 400L)
+        assertThat(viewModel.selectedOrderId.value).isEqualTo(300L)
+    }
+
+    // endregion
+
+    // region Selection
+
+    @Test
+    fun `given orders loaded, when selecting an order, then isSelected flags update`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1), order(2), order(3)))) }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onOrderSelected(3L)
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersListState.Content
+        val loadedItems = content.items as WooPosOrdersListState.Content.Items.Loaded
+        val selectedFlags = loadedItems.items.associate { it.id to it.isSelected }
+        assertThat(selectedFlags[1L]).isFalse()
+        assertThat(selectedFlags[2L]).isFalse()
+        assertThat(selectedFlags[3L]).isTrue()
+        assertThat(viewModel.selectedOrderId.value).isEqualTo(3L)
+    }
+
+    @Test
+    fun `given order already selected, when selecting same order, then no state change`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1), order(2)))) }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val stateBefore = viewModel.state.value
+        viewModel.onOrderSelected(1L)
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value).isSameAs(stateBefore)
+    }
+
+    // endregion
+
+    // region Search
+
+    @Test
+    fun `given ViewModel initialized, when search icon clicked, then search input state opens`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersListState.Content
+        assertThat(content.searchInputState).isInstanceOf(WooPosSearchInputState.Open::class.java)
+        val openState = content.searchInputState as WooPosSearchInputState.Open
+        val hint = openState.input as WooPosSearchInputState.Open.Input.Hint
+        assertThat(hint.hint).isEqualTo("Search orders")
+        assertThat(openState.requestFocus).isTrue()
+        verify(ordersAnalyticsTracker).trackOrdersListSearchButtonTapped()
+    }
+
+    @Test
+    fun `given search data available, when search with query, then results shown`() = runTest {
+        val query = "test query"
+        val searchResult = listOf(order(10), order(20))
+        whenever(dataSource.searchOrders(eq(query), any())).thenReturn(
+            SearchOrdersResult.Success(ordersMap(*searchResult.toTypedArray()))
+        )
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1)))) }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onSearchEvent(WooPosSearchUIEvent.Search(query, query.length))
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersListState.Content
+        val loadedItems = content.items as WooPosOrdersListState.Content.Items.Loaded
+        assertThat(loadedItems.items.map { it.id }).containsExactly(10L, 20L)
+        assertThat(content.searchInputState).isInstanceOf(WooPosSearchInputState.Open::class.java)
+        verify(dataSource).searchOrders(query)
+    }
+
+    @Test
+    fun `given search with empty query, when search event, then loadOrders is called`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onSearchEvent(WooPosSearchUIEvent.Search("", 0))
+        advanceUntilIdle()
+
+        verify(dataSource, times(2)).loadOrders()
+    }
+
+    @Test
+    fun `given search will fail, when search is performed, then Error items shown`() = runTest {
+        val query = "test query"
+        whenever(dataSource.searchOrders(eq(query), any())).thenReturn(SearchOrdersResult.Error("search failed"))
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1)))) }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
+        advanceUntilIdle()
+
+        viewModel.onSearchEvent(WooPosSearchUIEvent.Search(query, query.length))
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersListState.Content
+        assertThat(content.items).isInstanceOf(WooPosOrdersListState.Content.Items.Error::class.java)
+        val error = content.items as WooPosOrdersListState.Content.Items.Error
+        assertThat(error.title).isEqualTo("Search error")
+        assertThat(error.message).isEqualTo("Search error description")
+    }
+
+    @Test
+    fun `given search returns empty, when search performed, then NothingFound shown`() = runTest {
+        val query = "no results"
+        whenever(dataSource.searchOrders(eq(query), any())).thenReturn(
+            SearchOrdersResult.Success(emptyMap())
+        )
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1)))) }
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onSearchEvent(WooPosSearchUIEvent.Search(query, query.length))
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersListState.Content
+        assertThat(content.items).isInstanceOf(WooPosOrdersListState.Content.Items.NothingFound::class.java)
+    }
+
+    @Test
+    fun `given search open, when close event, then search state closed and orders reloaded`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
+        advanceUntilIdle()
+
+        viewModel.onSearchEvent(WooPosSearchUIEvent.Close)
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value.searchInputState).isEqualTo(WooPosSearchInputState.Closed)
+    }
+
+    @Test
+    fun `given search open, when clear event, then search hint restored and orders reloaded`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onSearchEvent(WooPosSearchUIEvent.SearchIconClicked)
+        advanceUntilIdle()
+
+        viewModel.onSearchEvent(WooPosSearchUIEvent.Clear)
+        advanceUntilIdle()
+
+        val searchState = viewModel.state.value.searchInputState as WooPosSearchInputState.Open
+        assertThat(searchState.input).isInstanceOf(WooPosSearchInputState.Open.Input.Hint::class.java)
+        assertThat(searchState.requestFocus).isTrue()
+    }
+
+    // endregion
+
+    // region Pagination
+
+    @Test
+    fun `given more pages, when end reached and loadMore succeeds, then items append`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1), order(2)))) }
+        )
+        whenever(dataSource.hasMorePages).thenReturn(true)
+        whenever(dataSource.loadMore()).thenReturn(
+            Result.success(ordersMap(order(3), order(4)))
+        )
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onEndOfOrdersListReached()
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersListState.Content
+        val loadedItems = content.items as WooPosOrdersListState.Content.Items.Loaded
+        assertThat(loadedItems.items.map { it.id }).containsExactly(1L, 2L, 3L, 4L)
+        assertThat(content.paginationState).isEqualTo(WooPosPaginationState.None)
+        verify(ordersAnalyticsTracker).trackOrdersListNextPageLoaded()
+    }
+
+    @Test
+    fun `given more pages, when end reached and loadMore fails, then show pagination error`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1), order(2)))) }
+        )
+        whenever(dataSource.hasMorePages).thenReturn(true)
+        whenever(dataSource.loadMore()).thenReturn(Result.failure(RuntimeException("boom")))
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onEndOfOrdersListReached()
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersListState.Content
+        val loadedItems = content.items as WooPosOrdersListState.Content.Items.Loaded
+        assertThat(loadedItems.items.map { it.id }).containsExactly(1L, 2L)
+        assertThat(content.paginationState).isEqualTo(WooPosPaginationState.Error)
+    }
+
+    @Test
+    fun `given no more pages, when end reached, then no loadMore call`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1)))) }
+        )
+        whenever(dataSource.hasMorePages).thenReturn(false)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onEndOfOrdersListReached()
+        advanceUntilIdle()
+
+        verify(dataSource, times(0)).loadMore(any())
+    }
+
+    // endregion
+
+    // region Error retry
+
+    @Test
+    fun `given error state, when retry clicked, then reload orders`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.Error("boom")) }
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1)))) }
+        )
+
+        viewModel.onOrdersLoadingErrorRetryButtonClicked()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertThat(state).isInstanceOf(WooPosOrdersListState.Content::class.java)
+    }
+
+    // endregion
+
+    // region refreshOrderItem
+
+    @Test
+    fun `given orders loaded, when refreshOrderItem, then specific item updated`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1), order(2)))) }
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val updatedOrder = order(1).copy(total = BigDecimal("999.00"))
+        whenever(dataSource.getOrderById(1L)).thenReturn(Result.success(updatedOrder))
+
+        viewModel.refreshOrderItem(1L)
+        advanceUntilIdle()
+
+        val content = viewModel.state.value as WooPosOrdersListState.Content
+        val loadedItems = content.items as WooPosOrdersListState.Content.Items.Loaded
+        val item = loadedItems.items.first { it.id == 1L }
+        assertThat(item.total).isEqualTo("$999.00")
+    }
+
+    // endregion
+
+    // region Analytics
+
+    @Test
+    fun `when refresh called, then pull-to-refresh analytics tracked`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1)))) }
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onRefresh()
+        advanceUntilIdle()
+
+        verify(ordersAnalyticsTracker).trackOrdersListPullToRefreshTriggered()
+    }
+
+    @Test
+    fun `when order selected, then row tapped analytics tracked`() = runTest {
+        whenever(dataSource.loadOrders(any())).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersMap(order(1), order(2)))) }
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onOrderSelected(2L)
+        advanceUntilIdle()
+
+        verify(ordersAnalyticsTracker).trackOrdersListRowTapped(
+            orderId = eq(2L),
+            orderStatus = any(),
+            listPosition = eq(1),
+            createdAtMillis = any()
+        )
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### Description

Fixes WOOMOB-2470

Do not merge label - all three PRs in the series should be merged one after another.

First PR in a 3-part series to split the monolithic `WooPosOrdersViewModel` (924 lines) into two focused ViewModels — one for the orders list and one for order details.

This PR adds the new list ViewModel and its state class as **additive code only** — no existing files are modified (except project settings), so it compiles alongside the old VM with zero risk.

**New files:**
- `WooPosOrdersListState.kt` — list-specific state hierarchy. Key change: `Items.Loaded` holds `List<OrderItemViewState>` instead of the old `Map<OrderItemViewState, OrderDetailsViewState>`, removing the coupling between list items and their detail state.
- `WooPosOrdersListViewModel.kt` — all list concerns extracted: load/refresh/paginate orders, search, selection tracking. Exposes `selectedOrderId: StateFlow<Long?>` for the composable bridge pattern.
- `WooPosOrdersListViewModelTest.kt` — 22 unit tests covering init, refresh, selection, search, pagination, error retry, and analytics.

### Test Steps

CI

### Images/gif

N/A — additive code only, no UI changes.

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.