### PR TITLE
[WOOMOB-2470] Add POS order details ViewModel and state (2/3)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsState.kt
@@ -1,0 +1,42 @@
+package com.woocommerce.android.ui.woopos.orders.details
+
+import androidx.compose.runtime.Immutable
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow
+
+@Immutable
+sealed class WooPosOrderDetailsState {
+    @Immutable
+    data object Idle : WooPosOrderDetailsState()
+
+    @Immutable
+    data object Loading : WooPosOrderDetailsState()
+
+    @Immutable
+    data class Loaded(
+        val details: Details,
+        val dialogState: DialogState
+    ) : WooPosOrderDetailsState()
+
+    @Immutable
+    data class Error(val message: String) : WooPosOrderDetailsState()
+
+    @Immutable
+    sealed class DialogState {
+        data object Hidden : DialogState()
+
+        data class IssueRefund(
+            val orderId: Long
+        ) : DialogState()
+
+        data class RefundDetails(
+            val label: String,
+            val items: List<LineItemRow>,
+            val itemsSubtotalLabel: String,
+            val itemsSubtotalAmount: String,
+            val tax: String,
+            val refundTotal: String,
+            val paymentMethodTitle: String?,
+        ) : DialogState()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
@@ -10,13 +10,13 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.orders.ORDERS_ROUTE_ORDER_ID_KEY
 import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
+import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderActionsState
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.BookingInfo
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState
-import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersUIEvent
 import com.woocommerce.android.ui.woopos.orders.details.refund.RefundRowData
 import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
@@ -1,0 +1,308 @@
+package com.woocommerce.android.ui.woopos.orders.details
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToEmailReceipt
+import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
+import com.woocommerce.android.ui.woopos.orders.ORDERS_ROUTE_ORDER_ID_KEY
+import com.woocommerce.android.ui.woopos.orders.RefundsFetchResult
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderActionsState
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.BookingInfo
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemsState
+import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersUIEvent
+import com.woocommerce.android.ui.woopos.orders.details.refund.RefundRowData
+import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.viewmodel.ResourceProvider
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.math.BigDecimal
+import javax.inject.Inject
+
+@HiltViewModel
+class WooPosOrderDetailsViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val ordersDataSource: WooPosOrdersDataSource,
+    private val resourceProvider: ResourceProvider,
+    private val childrenToParentEventSender: WooPosChildrenToParentEventSender,
+    private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds,
+    private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker,
+    private val orderDetailsMapper: WooPosOrderDetailsMapper,
+    private val refundInfoBuilder: WooPosRefundInfoBuilder,
+    private val orderActionsProvider: WooPosOrderActionsProvider,
+    private val bookingInfoMapper: WooPosBookingInfoMapper,
+    private val formatPrice: WooPosFormatPrice,
+) : ViewModel() {
+
+    private val singleOrderId: Long? = savedStateHandle.get<Long>(ORDERS_ROUTE_ORDER_ID_KEY)
+
+    val isSingleOrderMode: Boolean = singleOrderId != null
+
+    private val _state = MutableStateFlow<WooPosOrderDetailsState>(
+        if (singleOrderId != null) WooPosOrderDetailsState.Loading else WooPosOrderDetailsState.Idle
+    )
+    val state: StateFlow<WooPosOrderDetailsState> = _state.asStateFlow()
+
+    private val _orderRefreshed = MutableSharedFlow<Long>()
+    val orderRefreshed: SharedFlow<Long> = _orderRefreshed.asSharedFlow()
+
+    private var sideLoadJob: Job? = null
+    private var refreshOrderJob: Job? = null
+    private var cachedRefundData: CachedRefundData? = null
+
+    init {
+        if (singleOrderId != null) {
+            viewModelScope.launch { loadOrder(singleOrderId) }
+        }
+    }
+
+    fun loadOrder(orderId: Long) {
+        sideLoadJob?.cancel()
+        refreshOrderJob?.cancel()
+
+        viewModelScope.launch {
+            _state.value = WooPosOrderDetailsState.Loading
+
+            val order = ordersDataSource.getOrderById(orderId).getOrElse {
+                _state.value = WooPosOrderDetailsState.Error(
+                    message = resourceProvider.getString(R.string.woopos_orders_loading_error_message)
+                )
+                return@launch
+            }
+
+            val details = orderDetailsMapper.mapOrderDetailsWithoutActions(order)
+            _state.value = WooPosOrderDetailsState.Loaded(
+                details = details,
+                dialogState = WooPosOrderDetailsState.DialogState.Hidden
+            )
+
+            ordersAnalyticsTracker.trackOrderDetailsLoaded(
+                orderId = orderId,
+                orderStatus = order.status.value,
+                createdAtMillis = order.dateCreated.time
+            )
+
+            sideLoadActionsAndRefundData(orderId, order)
+        }
+    }
+
+    fun onUIEvent(event: WooPosOrdersUIEvent) {
+        when (event) {
+            is WooPosOrdersUIEvent.OrderActionClicked -> handleActionClicked(event.action)
+            is WooPosOrdersUIEvent.ViewRefundDetailsClicked -> onViewRefundDetailsClicked(event.refundIndex)
+        }
+    }
+
+    private fun handleActionClicked(action: com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderAction) {
+        when (action) {
+            is com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderAction.EmailReceipt ->
+                onEmailReceiptButtonClicked(action.orderId)
+            is com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderAction.IssueRefund ->
+                onIssueRefundButtonClicked(action.orderId)
+        }
+    }
+
+    fun onEmailReceiptButtonClicked(orderId: Long) {
+        viewModelScope.launch {
+            ordersAnalyticsTracker.trackOrderDetailsEmailReceiptTapped()
+            childrenToParentEventSender.sendToParent(ToEmailReceipt(orderId))
+        }
+    }
+
+    fun onIssueRefundButtonClicked(orderId: Long) {
+        val current = _state.value as? WooPosOrderDetailsState.Loaded ?: return
+        _state.value = current.copy(
+            dialogState = WooPosOrderDetailsState.DialogState.IssueRefund(orderId = orderId)
+        )
+    }
+
+    fun onIssueRefundDialogDismissed() {
+        val current = _state.value as? WooPosOrderDetailsState.Loaded ?: return
+        _state.value = current.copy(
+            dialogState = WooPosOrderDetailsState.DialogState.Hidden
+        )
+        refreshSelectedOrder()
+    }
+
+    fun onRefundDetailsDialogDismissed() {
+        val current = _state.value as? WooPosOrderDetailsState.Loaded ?: return
+        _state.value = current.copy(
+            dialogState = WooPosOrderDetailsState.DialogState.Hidden
+        )
+    }
+
+    fun onBackFromSuccessfullySendingEmailReceipt() {
+        refreshSelectedOrder()
+    }
+
+    private fun onViewRefundDetailsClicked(refundIndex: Int) {
+        val cached = cachedRefundData ?: return
+        val rowData = cached.rows.getOrNull(refundIndex) ?: return
+        val order = cached.order
+        if (_state.value !is WooPosOrderDetailsState.Loaded) return
+
+        viewModelScope.launch {
+            val items = orderDetailsMapper.buildLineItemsForSingleRefund(order, rowData.refund)
+            val itemsSubtotal = formatPrice(
+                rowData.refund.items.fold(BigDecimal.ZERO) { acc, item -> acc + item.total },
+                order.currency
+            )
+            val tax = formatPrice(
+                rowData.refund.items.fold(BigDecimal.ZERO) { acc, item -> acc + item.totalTax },
+                order.currency
+            )
+            val refundTotal = formatPrice(rowData.refund.amount, order.currency)
+
+            val updatedState = _state.value as? WooPosOrderDetailsState.Loaded ?: return@launch
+            if (updatedState.details.id != cached.orderId) return@launch
+            _state.value = updatedState.copy(
+                dialogState = WooPosOrderDetailsState.DialogState.RefundDetails(
+                    label = rowData.label,
+                    items = items,
+                    itemsSubtotalLabel = resourceProvider.getQuantityString(
+                        quantity = items.size,
+                        default = R.string.woopos_orders_details_refund_items_subtotal_other,
+                        one = R.string.woopos_orders_details_refund_items_subtotal_one,
+                    ),
+                    itemsSubtotalAmount = itemsSubtotal,
+                    tax = tax,
+                    refundTotal = refundTotal,
+                    paymentMethodTitle = order.paymentMethodTitle.takeIf { it.isNotBlank() },
+                )
+            )
+        }
+    }
+
+    private fun sideLoadActionsAndRefundData(orderId: Long, order: Order) {
+        sideLoadJob?.cancel()
+        sideLoadJob = viewModelScope.launch {
+            val refundsResult = retrieveOrderRefunds(order = order, forceRefresh = true).fold(
+                onSuccess = { refunds -> RefundsFetchResult.Success(refunds) },
+                onFailure = { RefundsFetchResult.Error }
+            )
+
+            val currentLoaded = _state.value as? WooPosOrderDetailsState.Loaded
+            if (currentLoaded?.details?.id != orderId) return@launch
+
+            val actions = orderActionsProvider.getAvailableActions(order)
+            val refundInfo = refundInfoBuilder.buildRefundInfo(order, refundsResult)
+            val updatedBreakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
+            val refundedLineItems = orderDetailsMapper.buildRefundedLineItems(order, refundsResult)
+            val nonRefundedLineItems = orderDetailsMapper.buildNonRefundedLineItems(order, refundsResult)
+
+            cacheRefundData(orderId, refundInfo.refundRows, order)
+
+            val stateNow = _state.value as? WooPosOrderDetailsState.Loaded ?: return@launch
+            if (stateNow.details.id == orderId &&
+                stateNow.details.actionsState is OrderActionsState.Loading
+            ) {
+                _state.value = stateNow.copy(
+                    details = stateNow.details.copy(
+                        actionsState = OrderActionsState.Loaded(actions),
+                        breakdown = updatedBreakdown,
+                        lineItems = LineItemsState.Loaded(nonRefundedLineItems),
+                        refundedLineItems = LineItemsState.Loaded(refundedLineItems)
+                    )
+                )
+
+                val updatedLoaded = _state.value as? WooPosOrderDetailsState.Loaded
+                if (updatedLoaded != null) {
+                    sideLoadBookings(orderId, updatedLoaded.details)
+                }
+            }
+        }
+    }
+
+    private fun sideLoadBookings(
+        orderId: Long,
+        details: Details
+    ) {
+        val loadedItems = (details.lineItems as? LineItemsState.Loaded)?.items ?: return
+        val loadingItems = loadedItems.filter { it.bookingInfo is BookingInfo.Loading }
+        if (loadingItems.isEmpty()) return
+
+        viewModelScope.launch {
+            val results = coroutineScope {
+                loadingItems.map { item ->
+                    async {
+                        val bookingId = (item.bookingInfo as BookingInfo.Loading).bookingId
+                        item.id to bookingInfoMapper.fetchBookingInfo(bookingId)
+                    }
+                }.awaitAll()
+            }.toMap()
+
+            val currentLoaded = _state.value as? WooPosOrderDetailsState.Loaded ?: return@launch
+            if (currentLoaded.details.id != orderId) return@launch
+
+            val currentItems = (currentLoaded.details.lineItems as? LineItemsState.Loaded)?.items
+                ?: return@launch
+            _state.value = currentLoaded.copy(
+                details = currentLoaded.details.copy(
+                    lineItems = LineItemsState.Loaded(
+                        currentItems.map { lineItem ->
+                            results[lineItem.id]?.let { lineItem.copy(bookingInfo = it) } ?: lineItem
+                        }
+                    )
+                )
+            )
+        }
+    }
+
+    private fun refreshSelectedOrder() {
+        val current = _state.value as? WooPosOrderDetailsState.Loaded ?: return
+        val selectedOrderId = current.details.id
+
+        sideLoadJob?.cancel()
+        refreshOrderJob?.cancel()
+        refreshOrderJob = viewModelScope.launch {
+            ordersDataSource.refreshOrderById(selectedOrderId)
+                .onSuccess { applyOrderUpdate(it) }
+        }
+    }
+
+    private suspend fun applyOrderUpdate(updated: Order) {
+        val historicalRefundsResult = retrieveOrderRefunds(updated, forceRefresh = true).fold(
+            onSuccess = { refunds -> RefundsFetchResult.Success(refunds) },
+            onFailure = { RefundsFetchResult.Error }
+        )
+
+        val refundInfo = refundInfoBuilder.buildRefundInfo(updated, historicalRefundsResult)
+        cacheRefundData(updated.id, refundInfo.refundRows, updated)
+
+        val newDetailsViewState = orderDetailsMapper.mapOrderDetails(updated, historicalRefundsResult)
+
+        val current = _state.value as? WooPosOrderDetailsState.Loaded ?: return
+        if (current.details.id == updated.id) {
+            _state.value = current.copy(details = newDetailsViewState)
+            _orderRefreshed.emit(updated.id)
+        }
+    }
+
+    private fun cacheRefundData(orderId: Long, refundRows: List<RefundRowData>, order: Order) {
+        cachedRefundData = CachedRefundData(orderId = orderId, rows = refundRows, order = order)
+    }
+
+    private data class CachedRefundData(
+        val orderId: Long,
+        val rows: List<RefundRowData>,
+        val order: Order,
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModelTest.kt
@@ -1,0 +1,376 @@
+package com.woocommerce.android.ui.woopos.orders.details
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.woopos.common.data.WooPosGetProductById
+import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToEmailReceipt
+import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
+import com.woocommerce.android.ui.woopos.orders.ORDERS_ROUTE_ORDER_ID_KEY
+import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderActionsState
+import com.woocommerce.android.ui.woopos.orders.WooPosOrdersUIEvent
+import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.util.DateTimeUtils
+import java.math.BigDecimal
+import java.util.Locale
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosOrderDetailsViewModelTest {
+
+    @Rule @JvmField
+    val coroutineTestRule = WooPosCoroutineTestRule()
+
+    private val dataSource: WooPosOrdersDataSource = mock()
+    private val resourceProvider: ResourceProvider = mock()
+    private val formatPrice: WooPosFormatPrice = mock()
+    private val retrieveOrderRefunds: WooPosRetrieveOrderRefunds = mock()
+    private val childrenToParentEventSender: WooPosChildrenToParentEventSender = mock()
+    private val ordersAnalyticsTracker: WooPosOrdersAnalyticsTracker = mock()
+    private val bookingInfoMapper: WooPosBookingInfoMapper = mock()
+    private val getProductById: WooPosGetProductById = mock()
+    private lateinit var orderDetailsMapper: WooPosOrderDetailsMapper
+    private lateinit var refundInfoBuilder: WooPosRefundInfoBuilder
+    private lateinit var orderActionsProvider: WooPosOrderActionsProvider
+    private lateinit var orderStatusMapper: WooPosOrderStatusMapper
+    private lateinit var viewModel: WooPosOrderDetailsViewModel
+    private val providedLocale: Locale = Locale.US
+
+    private fun order(id: Long = 1L): Order = OrderTestUtils.generateTestOrder(orderId = id).copy(
+        datePaid = DateTimeUtils.dateUTCFromIso8601("2018-02-02T16:11:13Z")
+    )
+
+    private fun createViewModel(
+        savedStateHandle: SavedStateHandle = SavedStateHandle()
+    ): WooPosOrderDetailsViewModel {
+        return WooPosOrderDetailsViewModel(
+            savedStateHandle = savedStateHandle,
+            ordersDataSource = dataSource,
+            resourceProvider = resourceProvider,
+            childrenToParentEventSender = childrenToParentEventSender,
+            retrieveOrderRefunds = retrieveOrderRefunds,
+            ordersAnalyticsTracker = ordersAnalyticsTracker,
+            orderDetailsMapper = orderDetailsMapper,
+            refundInfoBuilder = refundInfoBuilder,
+            orderActionsProvider = orderActionsProvider,
+            bookingInfoMapper = bookingInfoMapper,
+            formatPrice = formatPrice,
+        )
+    }
+
+    @Before
+    fun setUp() = runTest {
+        setupResourceProviderMocks()
+        setupMockBehaviors()
+        setupMappers()
+        setupDataSourceMocks()
+    }
+
+    private fun setupResourceProviderMocks() {
+        whenever(resourceProvider.getString(R.string.date_time_connector)).thenReturn("at")
+        whenever(resourceProvider.getString(R.string.woopos_orders_details_refund_error))
+            .thenReturn("Refund error")
+        whenever(resourceProvider.getString(R.string.woopos_orders_loading_error_message))
+            .thenReturn("Please check your connection try again.")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_auto_draft)).thenReturn("Draft")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_pending)).thenReturn("Pending")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_processing)).thenReturn("Processing")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_on_hold)).thenReturn("On hold")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_failed)).thenReturn("Failed")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_cancelled)).thenReturn("Canceled")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_completed)).thenReturn("Completed")
+        whenever(resourceProvider.getString(R.string.woopos_orders_status_refunded)).thenReturn("Refunded")
+        whenever(resourceProvider.getString(eq(R.string.woopos_orders_details_refund_label_numbered), any()))
+            .thenAnswer { invocation ->
+                val index = invocation.arguments[1] as Int
+                "Refund #$index"
+            }
+        whenever(resourceProvider.getQuantityString(any(), any(), anyOrNull(), anyOrNull()))
+            .thenAnswer { invocation ->
+                val count = invocation.arguments[0] as Int
+                if (count == 1) "Items subtotal ($count item)" else "Items subtotal ($count items)"
+            }
+    }
+
+    private suspend fun setupMockBehaviors() {
+        whenever(formatPrice(any<BigDecimal>(), any())).thenAnswer { invocation ->
+            val amount = invocation.arguments[0] as? BigDecimal
+            amount?.let { "$${it.abs()}" } ?: "$0.00"
+        }
+        whenever(formatPrice(any<BigDecimal>())).thenAnswer { invocation ->
+            val amount = invocation.arguments[0] as? BigDecimal
+            amount?.let { "$${it.abs()}" } ?: "$0.00"
+        }
+        whenever(getProductById.invoke(any())).thenReturn(null)
+        whenever(retrieveOrderRefunds.invoke(any(), any())).thenReturn(Result.success(emptyList()))
+    }
+
+    private fun setupMappers() {
+        orderStatusMapper = WooPosOrderStatusMapper(resourceProvider, providedLocale)
+        refundInfoBuilder = WooPosRefundInfoBuilder(resourceProvider, formatPrice)
+        orderActionsProvider = WooPosOrderActionsProvider()
+        orderDetailsMapper = WooPosOrderDetailsMapper(
+            resourceProvider,
+            getProductById,
+            formatPrice,
+            orderStatusMapper,
+            refundInfoBuilder,
+            orderActionsProvider,
+            bookingInfoMapper,
+            WooPosGetNonRefundedItems(),
+            WooPosGroupRefundedItems(),
+        )
+    }
+
+    private suspend fun setupDataSourceMocks() {
+        // Use doReturn().whenever() pattern for suspend functions returning Result<T> (inline class)
+        doReturn(Result.success(order(1L))).whenever(dataSource).getOrderById(any())
+        doReturn(Result.success(order(1L))).whenever(dataSource).refreshOrderById(any())
+    }
+
+    // region loadOrder
+
+    @Test
+    fun `when loadOrder called, then state transitions to Loaded with details`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.loadOrder(1L)
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertThat(state).isInstanceOf(WooPosOrderDetailsState.Loaded::class.java)
+        val loaded = state as WooPosOrderDetailsState.Loaded
+        assertThat(loaded.details.id).isEqualTo(1L)
+        assertThat(loaded.dialogState).isEqualTo(WooPosOrderDetailsState.DialogState.Hidden)
+    }
+
+    @Test
+    fun `when loadOrder called, then analytics tracked`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.loadOrder(1L)
+        advanceUntilIdle()
+
+        verify(ordersAnalyticsTracker).trackOrderDetailsLoaded(
+            orderId = eq(1L),
+            orderStatus = any(),
+            createdAtMillis = any()
+        )
+    }
+
+    @Test
+    fun `given order not found, when loadOrder called, then state is Error`() = runTest {
+        doReturn(Result.failure<Order>(RuntimeException("not found"))).whenever(dataSource).getOrderById(99L)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.loadOrder(99L)
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertThat(state).isInstanceOf(WooPosOrderDetailsState.Error::class.java)
+    }
+
+    @Test
+    fun `when loadOrder completes, then actions are side-loaded`() = runTest {
+        val completedOrder = order(1).copy(status = Order.Status.Completed)
+        doReturn(Result.success(completedOrder)).whenever(dataSource).getOrderById(1L)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.loadOrder(1L)
+        advanceUntilIdle()
+
+        val loaded = viewModel.state.value as WooPosOrderDetailsState.Loaded
+        assertThat(loaded.details.actionsState).isInstanceOf(OrderActionsState.Loaded::class.java)
+    }
+
+    // endregion
+
+    // region Single order mode
+
+    @Test
+    fun `given single order mode, when init, then order is loaded automatically`() = runTest {
+        doReturn(Result.success(order(42L))).whenever(dataSource).getOrderById(42L)
+        val savedStateHandle = SavedStateHandle(mapOf(ORDERS_ROUTE_ORDER_ID_KEY to 42L))
+
+        viewModel = createViewModel(savedStateHandle)
+        advanceUntilIdle()
+
+        assertThat(viewModel.isSingleOrderMode).isTrue()
+        val state = viewModel.state.value
+        assertThat(state).isInstanceOf(WooPosOrderDetailsState.Loaded::class.java)
+        assertThat((state as WooPosOrderDetailsState.Loaded).details.id).isEqualTo(42L)
+    }
+
+    @Test
+    fun `given single order mode with fetch failure, when init, then state is Error`() = runTest {
+        doReturn(Result.failure<Order>(RuntimeException("not found"))).whenever(dataSource).getOrderById(42L)
+
+        val savedStateHandle = SavedStateHandle(mapOf(ORDERS_ROUTE_ORDER_ID_KEY to 42L))
+        viewModel = createViewModel(savedStateHandle)
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value).isInstanceOf(WooPosOrderDetailsState.Error::class.java)
+    }
+
+    // endregion
+
+    // region Email receipt
+
+    @Test
+    fun `when email receipt button clicked, then ToEmailReceipt event sent`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onEmailReceiptButtonClicked(123L)
+        advanceUntilIdle()
+
+        verify(childrenToParentEventSender).sendToParent(ToEmailReceipt(123L))
+        verify(ordersAnalyticsTracker).trackOrderDetailsEmailReceiptTapped()
+    }
+
+    // endregion
+
+    // region Issue refund dialog
+
+    @Test
+    fun `given loaded state, when issue refund clicked, then dialog state is IssueRefund`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.loadOrder(1L)
+        advanceUntilIdle()
+
+        viewModel.onIssueRefundButtonClicked(1L)
+
+        val loaded = viewModel.state.value as WooPosOrderDetailsState.Loaded
+        assertThat(loaded.dialogState).isInstanceOf(WooPosOrderDetailsState.DialogState.IssueRefund::class.java)
+        assertThat((loaded.dialogState as WooPosOrderDetailsState.DialogState.IssueRefund).orderId).isEqualTo(1L)
+    }
+
+    @Test
+    fun `given issue refund dialog open, when dismissed, then dialog hidden`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.loadOrder(1L)
+        advanceUntilIdle()
+        viewModel.onIssueRefundButtonClicked(1L)
+
+        viewModel.onIssueRefundDialogDismissed()
+        advanceUntilIdle()
+
+        val loaded = viewModel.state.value as WooPosOrderDetailsState.Loaded
+        assertThat(loaded.dialogState).isEqualTo(WooPosOrderDetailsState.DialogState.Hidden)
+    }
+
+    // endregion
+
+    // region Refund details dialog
+
+    @Test
+    fun `given refund details dialog open, when dismissed, then dialog hidden`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.loadOrder(1L)
+        advanceUntilIdle()
+
+        viewModel.onRefundDetailsDialogDismissed()
+        advanceUntilIdle()
+
+        val loaded = viewModel.state.value as WooPosOrderDetailsState.Loaded
+        assertThat(loaded.dialogState).isEqualTo(WooPosOrderDetailsState.DialogState.Hidden)
+    }
+
+    // endregion
+
+    // region Order actions by status
+
+    @Test
+    fun `given completed order, when loaded, then IssueRefund action available`() = runTest {
+        val completedOrder = order(1).copy(status = Order.Status.Completed)
+        doReturn(Result.success(completedOrder)).whenever(dataSource).getOrderById(1L)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.loadOrder(1L)
+        advanceUntilIdle()
+
+        val loaded = viewModel.state.value as WooPosOrderDetailsState.Loaded
+        val actions = loaded.details.actionsState as OrderActionsState.Loaded
+        assertThat(actions.actions).anyMatch {
+            it is com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderAction.IssueRefund
+        }
+    }
+
+    @Test
+    fun `given pending order, when loaded, then no actions available`() = runTest {
+        val pendingOrder = order(1).copy(status = Order.Status.Pending)
+        doReturn(Result.success(pendingOrder)).whenever(dataSource).getOrderById(1L)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.loadOrder(1L)
+        advanceUntilIdle()
+
+        val loaded = viewModel.state.value as WooPosOrderDetailsState.Loaded
+        val actions = loaded.details.actionsState as OrderActionsState.Loaded
+        assertThat(actions.actions).isEmpty()
+    }
+
+    @Test
+    fun `given processing order, when loaded, then EmailReceipt action available`() = runTest {
+        val processingOrder = order(1).copy(status = Order.Status.Processing)
+        doReturn(Result.success(processingOrder)).whenever(dataSource).getOrderById(1L)
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.loadOrder(1L)
+        advanceUntilIdle()
+
+        val loaded = viewModel.state.value as WooPosOrderDetailsState.Loaded
+        val actions = loaded.details.actionsState as OrderActionsState.Loaded
+        assertThat(actions.actions).anyMatch {
+            it is com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderAction.EmailReceipt
+        }
+    }
+
+    // endregion
+
+    // region Idle state
+
+    @Test
+    fun `given no single order mode, when init, then state is Idle`() = runTest {
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertThat(viewModel.state.value).isEqualTo(WooPosOrderDetailsState.Idle)
+        assertThat(viewModel.isSingleOrderMode).isFalse()
+    }
+
+    // endregion
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModelTest.kt
@@ -13,7 +13,6 @@ import com.woocommerce.android.ui.woopos.orders.WooPosOrderActionsProvider
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersAnalyticsTracker
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderActionsState
-import com.woocommerce.android.ui.woopos.orders.WooPosOrdersUIEvent
 import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice


### PR DESCRIPTION
### Description

Fixes WOOMOB-2470

Second PR in a 3-part series to split `WooPosOrdersViewModel` into two focused ViewModels.

This PR adds the detail ViewModel and its state class as **additive code only** — no existing files are modified, so it compiles alongside the old VM with zero risk.

**New files:**
- `WooPosOrderDetailsState.kt` — detail-specific state hierarchy: `Idle`, `Loading`, `Loaded(details, dialogState)`, `Error`. `DialogState` (Issue Refund, Refund Details) is moved here from the old monolithic state.
- `WooPosOrderDetailsViewModel.kt` — all detail concerns extracted: load order from cache, side-load actions/refunds/bookings, refund dialogs, email receipt, refresh after mutations. Exposes `orderRefreshed: SharedFlow<Long>` for the composable bridge pattern. Supports single-order mode via `SavedStateHandle`.
- `WooPosOrderDetailsViewModelTest.kt` — 14 unit tests covering load order, single-order mode, email receipt, issue refund dialog, refund details dialog, order actions by status, and idle state.

**Depends on:** #15671

### Test Steps

1. Verify the project compiles: `./gradlew :WooCommerce:assembleWasabiDebug`
2. Run the new tests: `./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "*.WooPosOrderDetailsViewModelTest"`
3. Verify all POS orders tests still pass: `./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "*.WooPosOrders*"`

### Images/gif

N/A — additive code only, no UI changes.

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.