### PR TITLE
[WOOMOB-511] Fix custom amount card styling on tablets

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditFormFragment.kt
@@ -875,7 +875,6 @@ class OrderCreateEditFormFragment :
         customAmountsSection: OrderCreateEditSectionView,
         customAmounts: List<CustomAmountUIModel>?
     ) {
-        customAmountsSection.setContentHorizontalPadding(R.dimen.minor_00)
         if (customAmounts.isNullOrEmpty()) {
             customAmountsSection.hide()
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineFormSection.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/creation/shipping/ShippingLineFormSection.kt
@@ -170,6 +170,7 @@ fun ShippingLineEditCard(
             Icon(
                 imageVector = ImageVector.vectorResource(R.drawable.ic_edit_pencil),
                 contentDescription = null,
+                tint = MaterialTheme.colors.primary,
                 modifier = Modifier
                     .align(Alignment.CenterVertically)
                     .padding(start = 16.dp)

--- a/WooCommerce/src/main/res/drawable/custom_amount_card_border.xml
+++ b/WooCommerce/src/main/res/drawable/custom_amount_card_border.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <stroke android:width="@dimen/minor_10" android:color="@color/woo_gray_5" />
-    <corners android:radius="@dimen/minor_50" />
+    <stroke android:width="@dimen/minor_10" android:color="@color/divider_color" />
+    <corners android:radius="@dimen/corner_radius_large" />
 </shape>

--- a/WooCommerce/src/main/res/layout/custom_amount_item_view.xml
+++ b/WooCommerce/src/main/res/layout/custom_amount_item_view.xml
@@ -41,6 +41,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingStart="@dimen/major_100"
+        android:paddingEnd="0dp"
         android:src="@drawable/ic_edit_pencil"
         app:layout_constraintBottom_toBottomOf="@+id/customAmountAmount"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/custom_amount_item_view.xml
+++ b/WooCommerce/src/main/res/layout/custom_amount_item_view.xml
@@ -5,17 +5,18 @@
     android:id="@+id/linearLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@drawable/custom_amount_card_border">
+    android:background="@drawable/custom_amount_card_border"
+    android:padding="@dimen/major_100">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/customAmountName"
-        style="@style/Woo.ListItem.Title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         android:ellipsize="end"
         android:includeFontPadding="false"
         android:maxLines="1"
+        android:textColor="@color/color_on_surface"
+        android:textSize="18sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/customAmountAmount"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
@@ -25,9 +26,10 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/customAmountAmount"
-        style="@style/Woo.ListItem.Body"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textColor="@color/color_on_surface"
+        android:textSize="18sp"
         app:layout_constraintBottom_toBottomOf="@+id/customAmountName"
         app:layout_constraintEnd_toStartOf="@+id/customAmountEdit"
         app:layout_constraintStart_toEndOf="@+id/customAmountName"
@@ -36,10 +38,9 @@
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/customAmountEdit"
-        android:layout_width="@dimen/major_150"
-        android:layout_height="@dimen/major_150"
-        android:layout_marginEnd="@dimen/minor_100"
-        android:padding="@dimen/minor_25"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/major_100"
         android:src="@drawable/ic_edit_pencil"
         app:layout_constraintBottom_toBottomOf="@+id/customAmountAmount"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WooCommerce/src/main/res/layout/order_creation_custom_amount_item.xml
+++ b/WooCommerce/src/main/res/layout/order_creation_custom_amount_item.xml
@@ -3,9 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?selectableItemBackground"
-    android:layout_marginBottom="@dimen/minor_100"
-    android:layout_marginStart="@dimen/major_75"
-    android:layout_marginEnd="@dimen/major_75">
+    android:layout_marginBottom="@dimen/minor_100">
 
     <include
         android:id="@+id/custom_amount_layout"


### PR DESCRIPTION
### Description

Fixes WOOMOB-511

The custom amount card in order creation had mismatched styling compared to the shipping line card on tablets — wrong border radius, missing internal padding, smaller text sizes, and inconsistent edit icon styling. This aligns the custom amount item card with the shipping line card:

- Border: 4dp → 8dp corner radius, `woo_gray_5` → `divider_color`
- Padding: added 16dp internal padding, restored default section content padding
- Text: both name and amount now use 18sp `color_on_surface` (was 16sp/14sp)
- Icon: both custom amount and shipping edit icons use purple (`color_primary`) with 16dp start spacing

### Test Steps

1. Go to **Orders** → tap **+** to create a new order
2. Tap **Add custom amount**, enter an amount and name, tap **Add Custom Amount**
3. Also add a product (to unlock shipping), then add a shipping line
4. Verify both the Custom Amount and Shipping cards have matching visual styling: same border radius, padding, text size, and purple edit icon with spacing

### Images/gif

| Before | After |
|--------|-------|
| <img width="2076" height="2152" alt="Screenshot_20260416_140322" src="https://github.com/user-attachments/assets/3ad53106-4699-4f52-a36a-36eda6290325" /> | <img width="2076" height="2152" alt="Screenshot_20260416_135749" src="https://github.com/user-attachments/assets/0a79a92e-0b65-4017-ab0d-0a4750bd186a" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.