### PR TITLE
[WOOMOB-2574] Remove FedEx feature flag gate

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/ObserveShippingPackages.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/ObserveShippingPackages.kt
@@ -6,8 +6,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.StoreOptionsForPackages
-import com.woocommerce.android.util.FeatureFlag
-import com.woocommerce.android.util.FeatureFlagRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.transformLatest
@@ -20,8 +18,7 @@ import javax.inject.Inject
 class ObserveShippingPackages @Inject constructor(
     private val selectedSite: SelectedSite,
     private val packageRepository: WooShippingLabelPackageRepository,
-    private val fetchShippingPackages: FetchShippingPackages,
-    private val featureFlagRepository: FeatureFlagRepository
+    private val fetchShippingPackages: FetchShippingPackages
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
     operator fun invoke(): Flow<PackagesState> = packageRepository.observeShippingPackages(selectedSite.get())
@@ -59,11 +56,9 @@ class ObserveShippingPackages @Inject constructor(
                 .takeIf { it.isNotEmpty() }
                 ?.let { packageGroups -> put(Carrier.USPS, packageGroups) }
 
-            if (featureFlagRepository.isEnabled(FeatureFlag.WOO_SHIPPING_FEDEX)) {
-                carrierPackageGroups.parseCarrierData(WooShippingPackagesEntity.CarrierType.FEDEX)
-                    .takeIf { it.isNotEmpty() }
-                    ?.let { packageGroups -> put(Carrier.FEDEX, packageGroups) }
-            }
+            carrierPackageGroups.parseCarrierData(WooShippingPackagesEntity.CarrierType.FEDEX)
+                .takeIf { it.isNotEmpty() }
+                ?.let { packageGroups -> put(Carrier.FEDEX, packageGroups) }
 
             carrierPackageGroups.parseCarrierData(WooShippingPackagesEntity.CarrierType.DHL)
                 .takeIf { it.isNotEmpty() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapper.kt
@@ -11,23 +11,19 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.CarrierUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateOptionUI
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.ui.ShippingRateUI
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
-import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.ResourceProvider
 import java.math.BigDecimal
 import javax.inject.Inject
 
 class WooShippingRatesDomainMapper @Inject constructor(
     private val resourceProvider: ResourceProvider,
-    private val currencyFormatter: CurrencyFormatter,
-    private val featureFlagRepository: FeatureFlagRepository
+    private val currencyFormatter: CurrencyFormatter
 ) {
     operator fun invoke(
         rates: List<WooShippingRateOptionsModel>,
         currencyCode: String?
     ): Map<CarrierUI, List<ShippingRateUI>> {
         return rates.groupBy { it.defaultRate.carrier }
-            .filterKeys(::isCarrierEnabled)
             .map { (carrier, models) ->
                 getCarrier(carrier) to models
                     .map { getShippingRate(it, resourceProvider, currencyCode) }
@@ -51,13 +47,6 @@ class WooShippingRatesDomainMapper @Inject constructor(
                 selectedRate.options.getValue(it).rate
             }
         )
-    }
-
-    private fun isCarrierEnabled(carrier: WooShippingCarrier): Boolean {
-        return when (carrier) {
-            WooShippingCarrier.FEDEX -> featureFlagRepository.isEnabled(FeatureFlag.WOO_SHIPPING_FEDEX)
-            else -> true
-        }
     }
 
     private fun getCarrier(carrier: WooShippingCarrier): CarrierUI {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -32,6 +32,5 @@ enum class FeatureFlag(
     BOOKINGS_RESCHEDULE("bookings_reschedule", localValue = PackageUtils.isDebugBuild()),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1("woo_self_driven_push_notifications_m1", localValue = false),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2("woo_self_driven_push_notifications_m2", localValue = false),
-    WOO_SHIPPING_FEDEX("woo_shipping_fedex", localValue = false),
     LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/ObserveShippingPackagesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/packages/datasource/ObserveShippingPackagesTest.kt
@@ -5,8 +5,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.packages.WooShippingL
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.Carrier
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.CarrierPackageGroup
 import com.woocommerce.android.ui.orders.wooshippinglabels.packages.ui.PackageData
-import com.woocommerce.android.util.FeatureFlag
-import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -15,7 +13,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
@@ -28,14 +25,10 @@ class ObserveShippingPackagesTest : BaseUnitTest() {
     private val packageRepository: WooShippingLabelPackageRepository = mock()
     private val fetchShippingPackages: FetchShippingPackages = mock()
     private val selectedSite: SelectedSite = mock()
-    private val featureFlagRepository: FeatureFlagRepository = mock {
-        on { isEnabled(FeatureFlag.WOO_SHIPPING_FEDEX) } doReturn true
-    }
     private val observeShippingPackages = ObserveShippingPackages(
         selectedSite,
         packageRepository,
-        fetchShippingPackages,
-        featureFlagRepository
+        fetchShippingPackages
     )
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/rates/domain/WooShippingRatesDomainMapperTest.kt
@@ -4,8 +4,6 @@ import com.woocommerce.android.ui.orders.wooshippinglabels.models.WooShippingCar
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateModel
 import com.woocommerce.android.ui.orders.wooshippinglabels.rates.datasource.WooShippingRateOptionsModel
 import com.woocommerce.android.util.CurrencyFormatter
-import com.woocommerce.android.util.FeatureFlag
-import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import junit.framework.TestCase.assertEquals
@@ -14,7 +12,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.math.BigDecimal
 
@@ -30,13 +27,9 @@ class WooShippingRatesDomainMapperTest : BaseUnitTest() {
         on(it.getQuantityString(any(), anyOrNull(), anyOrNull(), anyOrNull()))
             .thenAnswer { i -> "formatted ${i.arguments[0]}" }
     }
-    private val featureFlagRepository: FeatureFlagRepository = mock {
-        on { isEnabled(FeatureFlag.WOO_SHIPPING_FEDEX) } doReturn true
-    }
     private val sut = WooShippingRatesDomainMapper(
         resourceProvider = resourceProvider,
-        currencyFormatter = currencyFormatter,
-        featureFlagRepository = featureFlagRepository
+        currencyFormatter = currencyFormatter
     )
 
     @Test


### PR DESCRIPTION
### Description
Fixes WOOMOB-2574

Removes the `WOO_SHIPPING_FEDEX` gate from the Android shipping labels flow now that FedEx availability is controlled by the `features_supported_by_client` network parameter.

### Test Steps
1. Log in to a site that can purchase shipping labels and is connected to the staging connect-server with FedEx enabled.
2. Open an order with shippable products.
3. Start the Create Shipping Label flow.
4. Verify the FedEx package section is shown on the package selection step.
5. Continue to the rates step.
6. Verify FedEx rates are shown.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.