### PR TITLE
Migrate deprecated mockito-kotlin APIs for 6.2.3

### DIFF
--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/SiteObserverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/SiteObserverTest.kt
@@ -26,7 +26,7 @@ class SiteObserverTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
     private val wooCommerceStore: WooCommerceStore = mock()
     private val environmentRepository: EnvironmentRepository = mock {
-        onBlocking { fetchOrGetStoreID(any()) } doReturn Result.success("storeID")
+        on { fetchOrGetStoreID(any()) } doReturn Result.success("storeID")
     }
     private val wearableConnectionRepository: WearableConnectionRepository = mock()
     private val featureFlagRepository: WPComRemoteFeatureFlagRepository = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/media/ProductImagesUploadWorkerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/media/ProductImagesUploadWorkerTest.kt
@@ -57,8 +57,8 @@ class ProductImagesUploadWorkerTest : BaseUnitTest() {
     private val productImagesServiceWrapper: ProductImagesServiceWrapper = mock()
     private lateinit var worker: ProductImagesUploadWorker
     private val mediaFilesRepository: MediaFilesRepository = mock {
-        onBlocking { getLocalMedia(TEST_URI) } doReturn FETCHED_MEDIA
-        onBlocking { uploadMedia(any(), any()) } doReturn flowOf(UploadResult.UploadSuccess(UPLOADED_MEDIA))
+        on { getLocalMedia(TEST_URI) } doReturn FETCHED_MEDIA
+        on { uploadMedia(any(), any()) } doReturn flowOf(UploadResult.UploadSuccess(UPLOADED_MEDIA))
     }
     private val productDetailRepository: ProductDetailRepository = mock()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -58,7 +58,7 @@ class NotificationMessageHandlerTest {
         on { account } doReturn accountModel
     }
     private val registrationStatus: PushNotificationRegistrationStatus = mock {
-        onBlocking { invoke(any()) } doReturn UNREGISTERED
+        on { invoke(any()) } doReturn UNREGISTERED
     }
     private val dispatcher: Dispatcher = mock()
     private val actionCaptor: KArgumentCaptor<Action<*>> = argumentCaptor()
@@ -154,7 +154,7 @@ class NotificationMessageHandlerTest {
             }
         }
         getWooVisibleSites = mock {
-            onBlocking { invoke() } doReturn visibleSites
+            on { invoke() } doReturn visibleSites
         }
         createNotificationMessageHandler()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
@@ -54,7 +54,7 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
         on { data } doReturn flowOf(preferences)
     }
     private val checkWooPluginPushNotificationsSupport: CheckWooPluginPushNotificationsSupport = mock {
-        onBlocking { invoke(forceRefresh = false) } doReturn CheckWooPluginPushNotificationsSupport.Result.Compatible
+        on { invoke(forceRefresh = false) } doReturn CheckWooPluginPushNotificationsSupport.Result.Compatible
     }
 
     private lateinit var sut: PushNotificationRepository

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/ZendeskTicketRepositoryTest.kt
@@ -49,7 +49,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
     private lateinit var envDataSource: ZendeskEnvironmentDataSource
     private lateinit var siteStore: SiteStore
     private val ssrFetcher: WCSSRModelCachingFetcher = mock {
-        onBlocking { load(any(), any()) } doReturn WooResult(model = null)
+        on { load(any(), any()) } doReturn WooResult(model = null)
     }
     private val isAppPasswordsSupportedForJetpackSite: IsAppPasswordsSupportedForJetpackSite = mock()
 
@@ -409,7 +409,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
             val captor = argumentCaptor<CreateRequest>()
 
             ssrFetcher.stub {
-                onBlocking { load(selectedSite, false) } doReturn WooResult(model = WCSSRModel(123))
+                on { load(selectedSite, false) } doReturn WooResult(model = WCSSRModel(123))
             }
 
             // When
@@ -573,7 +573,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
         testBlocking {
             // given
             ssrFetcher.stub {
-                onBlocking { load(any(), any()) } doReturn WooResult(model = WCSSRModel(123))
+                on { load(any(), any()) } doReturn WooResult(model = WCSSRModel(123))
             }
 
             val siteAddress = "www.test.com"
@@ -607,7 +607,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
         testBlocking {
             // given
             ssrFetcher.stub {
-                onBlocking { load(any(), any()) } doReturn WooResult(model = WCSSRModel(123))
+                on { load(any(), any()) } doReturn WooResult(model = WCSSRModel(123))
             }
             val captor = argumentCaptor<CreateRequest>()
             createSUT()
@@ -666,7 +666,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
         testBlocking {
             // given
             ssrFetcher.stub {
-                onBlocking { load(any(), any()) } doReturn WooResult(
+                on { load(any(), any()) } doReturn WooResult(
                     WooError(
                         WooErrorType.GENERIC_ERROR,
                         BaseRequest.GenericErrorType.NETWORK_ERROR
@@ -739,7 +739,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
             val captor = argumentCaptor<CreateRequest>()
 
             ssrFetcher.stub {
-                onBlocking { load(selectedSite) } doReturn WooResult(model = null)
+                on { load(selectedSite) } doReturn WooResult(model = null)
             }
 
             // When
@@ -775,7 +775,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
             val captor = argumentCaptor<CreateRequest>()
 
             ssrFetcher.stub {
-                onBlocking { load(selectedSite) } doReturn WooResult(model = null)
+                on { load(selectedSite) } doReturn WooResult(model = null)
             }
 
             // When
@@ -812,7 +812,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
             val captor = argumentCaptor<CreateRequest>()
 
             ssrFetcher.stub {
-                onBlocking { load(selectedSite) } doReturn WooResult(model = null)
+                on { load(selectedSite) } doReturn WooResult(model = null)
             }
 
             // When
@@ -853,7 +853,7 @@ internal class ZendeskTicketRepositoryTest : BaseUnitTest() {
     private fun mockEnvDataSource() = mock<ZendeskEnvironmentDataSource> {
         on { totalAvailableMemorySize } doReturn "100"
         on { deviceLanguage } doReturn "testLanguage"
-        onBlocking { getDeviceLogs() } doReturn "logs"
+        on { getDeviceLogs() } doReturn "logs"
         on { generateVersionName(any()) } doReturn "version"
         on { generateNetworkInformation(any()) } doReturn "networkInfo"
         on { generateCombinedLogInformationOfSites(any()) } doReturn "sitesInfo"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/requests/SupportRequestFormViewModelTest.kt
@@ -242,7 +242,7 @@ internal class SupportRequestFormViewModelTest : BaseUnitTest() {
             on { getIfExists() }.then { testSite }
         }
         zendeskTicketRepository = mock {
-            onBlocking {
+            on {
                 createRequest(
                     any(),
                     any(),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsHubViewModelTest.kt
@@ -253,7 +253,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         testBlocking {
             configureVisibleCards()
             updateStats.stub {
-                onBlocking { revenueState } doReturn flow {
+                on { revenueState } doReturn flow {
                     emit(RevenueState.Available(getRevenueStats(netDelta = NotExist, totalDelta = NotExist)))
                 }
             }
@@ -297,7 +297,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         )
 
         updateStats.stub {
-            onBlocking { revenueState } doReturn flow { emit(RevenueState.Available(weekRevenueStats)) }
+            on { revenueState } doReturn flow { emit(RevenueState.Available(weekRevenueStats)) }
         }
 
         configureVisibleCards()
@@ -390,7 +390,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         )
 
         updateStats.stub {
-            onBlocking { ordersState } doReturn flow { emit(OrdersState.Available(weekOrdersData)) }
+            on { ordersState } doReturn flow { emit(OrdersState.Available(weekOrdersData)) }
         }
 
         sut = givenAViewModel()
@@ -427,7 +427,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         )
 
         updateStats.stub {
-            onBlocking { revenueState } doReturn flow { emit(RevenueState.Available(weekRevenueStats)) }
+            on { revenueState } doReturn flow { emit(RevenueState.Available(weekRevenueStats)) }
         }
 
         sut = givenAViewModel()
@@ -457,7 +457,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         )
 
         updateStats.stub {
-            onBlocking { productsState } doReturn flow { emit(ProductsState.Available(weekOrdersData)) }
+            on { productsState } doReturn flow { emit(ProductsState.Available(weekOrdersData)) }
         }
 
         sut = givenAViewModel()
@@ -489,7 +489,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
     fun `given a view, when refresh is requested, then show indicator is the expected`() = testBlocking {
         configureSuccessfulStatsResponse()
         updateStats.stub {
-            onBlocking { invoke(any(), any(), any(), any()) } doReturn flow {
+            on { invoke(any(), any(), any(), any()) } doReturn flow {
                 emit(AnalyticsHubUpdateState.Finished)
                 emit(AnalyticsHubUpdateState.Loading)
             }
@@ -534,7 +534,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         configureVisibleCards()
         configureSuccessfulStatsResponse()
         updateStats.stub {
-            onBlocking { revenueState } doReturn flow { RevenueState.Error }
+            on { revenueState } doReturn flow { RevenueState.Error }
         }
 
         sut = givenAViewModel()
@@ -550,7 +550,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         configureVisibleCards()
         configureSuccessfulStatsResponse()
         updateStats.stub {
-            onBlocking { ordersState } doReturn flow { OrdersState.Error }
+            on { ordersState } doReturn flow { OrdersState.Error }
         }
 
         sut = givenAViewModel()
@@ -566,7 +566,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         configureVisibleCards()
         configureSuccessfulStatsResponse()
         updateStats.stub {
-            onBlocking { productsState } doReturn flow { ProductsState.Error }
+            on { productsState } doReturn flow { ProductsState.Error }
         }
 
         sut = givenAViewModel()
@@ -582,7 +582,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         configureVisibleCards()
         configureSuccessfulStatsResponse()
         updateStats.stub {
-            onBlocking { sessionState } doReturn flow { SessionState.Error }
+            on { sessionState } doReturn flow { SessionState.Error }
         }
 
         sut = givenAViewModel()
@@ -598,7 +598,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
         configureVisibleCards()
         configureSuccessfulStatsResponse()
         updateStats.stub {
-            onBlocking { sessionState } doReturn flow { emit(SessionState.Available(defaultSessionStat)) }
+            on { sessionState } doReturn flow { emit(SessionState.Available(defaultSessionStat)) }
         }
 
         sut = givenAViewModel()
@@ -1088,27 +1088,27 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
 
     private fun configureSuccessfulStatsResponse() {
         updateStats.stub {
-            onBlocking { revenueState } doReturn flow {
+            on { revenueState } doReturn flow {
                 emit(RevenueState.Available(RevenueStat.EMPTY))
                 emit(RevenueState.Loading)
                 emit(RevenueState.Available(getRevenueStats()))
             }
-            onBlocking { ordersState } doReturn flow {
+            on { ordersState } doReturn flow {
                 emit(OrdersState.Available(OrdersStat.EMPTY))
                 emit(OrdersState.Loading)
                 emit(OrdersState.Available(getOrdersStats()))
             }
-            onBlocking { productsState } doReturn flow {
+            on { productsState } doReturn flow {
                 emit(ProductsState.Available(ProductsStat.EMPTY))
                 emit(ProductsState.Loading)
                 emit(ProductsState.Available(getProductsStats()))
             }
-            onBlocking { sessionState } doReturn flow {
+            on { sessionState } doReturn flow {
                 emit(SessionState.Available(SessionStat.EMPTY))
                 emit(SessionState.Loading)
                 emit(SessionState.Available(testSessionStat))
             }
-            onBlocking { invoke(any(), any(), any(), any()) } doReturn flow {
+            on { invoke(any(), any(), any(), any()) } doReturn flow {
                 emit(AnalyticsHubUpdateState.Finished)
             }
         }
@@ -1116,7 +1116,7 @@ class AnalyticsHubViewModelTest : BaseUnitTest() {
 
     private fun configureVisibleCards(configuration: List<AnalyticCardConfiguration> = defaultCardsConfiguration) {
         observeAnalyticsCardsConfiguration.stub {
-            onBlocking { observeAnalyticsCardsConfiguration.invoke() } doReturn flowOf(configuration)
+            on { observeAnalyticsCardsConfiguration.invoke() } doReturn flowOf(configuration)
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/UpdateAnalyticsHubStatsTest.kt
@@ -53,7 +53,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     @Before
     fun setUp() {
         analyticsDataStore = mock {
-            onBlocking {
+            on {
                 shouldUpdateAnalytics(
                     rangeSelection = eq(testRangeSelection),
                     analyticDataList = any(),
@@ -401,7 +401,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     fun `when data store does NOT allows net stats fetch, then request data with Saved strategy`() = testBlocking {
         // Given
         analyticsDataStore = mock {
-            onBlocking {
+            on {
                 shouldUpdateAnalytics(
                     rangeSelection = eq(testRangeSelection),
                     analyticDataList = any(),
@@ -431,7 +431,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         testBlocking {
             // Given
             analyticsDataStore = mock {
-                onBlocking {
+                on {
                     shouldUpdateAnalytics(
                         rangeSelection = eq(testCustomRangeSelection),
                         analyticDataList = any(),
@@ -488,7 +488,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
     fun `when syncing stats data starts with forceUpdate false, then follow data store response`() = testBlocking {
         // Given
         analyticsDataStore = mock {
-            onBlocking {
+            on {
                 shouldUpdateAnalytics(
                     rangeSelection = eq(testRangeSelection),
                     analyticDataList = any(),
@@ -539,7 +539,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         // Given
         configureSuccessResponseStub()
         analyticsDataStore = mock {
-            onBlocking {
+            on {
                 shouldUpdateAnalytics(
                     rangeSelection = eq(testRangeSelection),
                     analyticDataList = any(),
@@ -569,7 +569,7 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
         // Given
         configureSuccessResponseStub()
         analyticsDataStore = mock {
-            onBlocking {
+            on {
                 shouldUpdateAnalytics(
                     rangeSelection = eq(testRangeSelection),
                     analyticDataList = any(),
@@ -594,25 +594,25 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
 
     private fun configureSuccessResponseStub() {
         repository.stub {
-            onBlocking {
+            on {
                 repository.fetchRevenueData(testRangeSelection, ForceNew)
             } doReturn testRevenueResult
 
-            onBlocking {
+            on {
                 repository.fetchOrdersData(testRangeSelection, ForceNew)
             } doReturn testOrdersResult
 
-            onBlocking {
+            on {
                 repository.fetchProductsData(testRangeSelection, ForceNew)
             } doReturn testProductsResult
 
-            onBlocking {
+            on {
                 repository.fetchVisitorsData(testRangeSelection, ForceNew)
             } doReturn testVisitorsResult
-            onBlocking {
+            on {
                 repository.fetchProductBundlesStats(testRangeSelection)
             } doReturn testBundlesResult
-            onBlocking {
+            on {
                 repository.fetchGiftCardsStats(testRangeSelection)
             } doReturn testGiftCardResult
         }
@@ -620,25 +620,25 @@ internal class UpdateAnalyticsHubStatsTest : BaseUnitTest() {
 
     private fun configureErrorResponseStub() {
         repository.stub {
-            onBlocking {
+            on {
                 repository.fetchRevenueData(testRangeSelection, ForceNew)
             } doReturn RevenueResult.RevenueError
 
-            onBlocking {
+            on {
                 repository.fetchOrdersData(testRangeSelection, ForceNew)
             } doReturn OrdersResult.OrdersError
 
-            onBlocking {
+            on {
                 repository.fetchProductsData(testRangeSelection, ForceNew)
             } doReturn ProductsResult.ProductsError
 
-            onBlocking {
+            on {
                 repository.fetchVisitorsData(testRangeSelection, ForceNew)
             } doReturn VisitorsResult.VisitorsError
-            onBlocking {
+            on {
                 repository.fetchProductBundlesStats(testRangeSelection)
             } doReturn BundlesResult.BundlesError
-            onBlocking {
+            on {
                 repository.fetchGiftCardsStats(testRangeSelection)
             } doReturn GiftCardResult.GiftCardError
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/BlazeRepositoryTest.kt
@@ -56,7 +56,7 @@ class BlazeRepositoryTest : BaseUnitTest() {
         isEndlessCampaign = false
     )
     private val blazeCampaignsStore: BlazeCampaignsStore = mock {
-        onBlocking { createCampaign(any(), any()) } doReturn
+        on { createCampaign(any(), any()) } doReturn
             BlazeResult(blazeModel)
     }
     private val productDetailRepository: ProductDetailRepository = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/payment/BlazeCampaignPaymentSummaryViewModelTests.kt
@@ -49,7 +49,7 @@ class BlazeCampaignPaymentSummaryViewModelTests : BaseUnitTest() {
     }
 
     private val blazeRepository: BlazeRepository = mock {
-        onBlocking { fetchPaymentMethods() } doReturn Result.success(BlazePaymentSampleData.paymentMethodsData)
+        on { fetchPaymentMethods() } doReturn Result.success(BlazePaymentSampleData.paymentMethodsData)
     }
     private val currencyFormatter: CurrencyFormatter = mock {
         on { formatCurrency(amount = any(), any(), any()) }.doAnswer { it.getArgument<BigDecimal>(0).toString() }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/preview/BlazeCampaignCreationPreviewViewModelTests.kt
@@ -79,12 +79,12 @@ class BlazeCampaignCreationPreviewViewModelTests : BaseUnitTest() {
         on { getString(any(), anyVararg()) } doAnswer { it.arguments.joinToString { it.toString() } }
     }
     private val blazeRepository: BlazeRepository = mock {
-        onBlocking { generateDefaultCampaignDetails(PRODUCT_ID) } doReturn defaultCampaignDetails
+        on { generateDefaultCampaignDetails(PRODUCT_ID) } doReturn defaultCampaignDetails
         on { observeDevices() } doReturn flowOf(devices)
         on { observeInterests() } doReturn flowOf(interests)
         on { observeLanguages() } doReturn flowOf(languages)
         on { observeObjectives() } doReturn flowOf(objectives)
-        onBlocking { fetchAdSuggestions(any()) } doReturn Result.success(emptyList())
+        on { fetchAdSuggestions(any()) } doReturn Result.success(emptyList())
     }
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private lateinit var viewModel: BlazeCampaignCreationPreviewViewModel

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetLocationSelectionViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/blaze/creation/targets/BlazeCampaignTargetLocationSelectionViewModelTests.kt
@@ -30,7 +30,7 @@ class BlazeCampaignTargetLocationSelectionViewModelTests : BaseUnitTest() {
 
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private val blazeRepository: BlazeRepository = mock {
-        onBlocking { fetchLocations(any()) } doReturn Result.success(sampleLocations)
+        on { fetchLocations(any()) } doReturn Result.success(sampleLocations)
     }
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.getArgument<Any>(0).toString() }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/details/BookingDetailsViewModelTest.kt
@@ -72,14 +72,14 @@ class BookingDetailsViewModelTest : BaseUnitTest() {
     private val bookingMapper = BookingMapper(dateFormatter, currencyFormatter, getLocations, resourceProvider)
     private val bookingsRepository = mock<BookingsRepository> {
         on { observeBooking(any()) } doReturn bookingFlow
-        onBlocking { fetchBooking(any()) } doReturn Result.success(bookingFlow.value)
-        onBlocking { fetchProductBookingLocation(any(), anyOrNull()) } doReturn Result.success(null)
+        on { fetchBooking(any()) } doReturn Result.success(bookingFlow.value)
+        on { fetchProductBookingLocation(any(), anyOrNull()) } doReturn Result.success(null)
     }
     private val networkStatus = mock<NetworkStatus> {
         on { isConnected() } doReturn true
     }
     private val paymentStatusResolver = mock<PaymentStatusResolver> {
-        onBlocking { resolve(any()) } doReturn PaymentStatus.UNPAID
+        on { resolve(any()) } doReturn PaymentStatus.UNPAID
     }
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val orderDetailRepository = mock<OrderDetailRepository>()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/teammember/BookingTeamMemberFilterViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/filter/teammember/BookingTeamMemberFilterViewModelTest.kt
@@ -4,12 +4,13 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.ui.bookings.BookingsRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
 import org.wordpress.android.fluxc.model.LocalOrRemoteId
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.bookings.BookingsFilterOption
@@ -24,7 +25,7 @@ class BookingTeamMemberFilterViewModelTest : BaseUnitTest() {
     ): BookingTeamMemberFilterViewModel {
         val repository = bookingsRepository ?: mock<BookingsRepository> {
             on { observeResources() } doReturn flowOf(emptyList())
-            onBlocking { fetchResources() } doReturn Result.success(Unit)
+            on { fetchResources() } doReturn Result.success(Unit)
         }
 
         return BookingTeamMemberFilterViewModel(
@@ -101,8 +102,8 @@ class BookingTeamMemberFilterViewModelTest : BaseUnitTest() {
             val resourcesFlow = MutableStateFlow<List<BookingResourceEntity>>(emptyList())
             val bookingsRepository = mock<BookingsRepository> {
                 on { observeResources() } doReturn resourcesFlow
-                onBlocking { fetchResources() } doAnswer {
-                    Thread.sleep(50)
+                on { fetchResources() } doSuspendableAnswer {
+                    delay(Long.MAX_VALUE / 2)
                     Result.success(Unit)
                 }
             }
@@ -122,7 +123,7 @@ class BookingTeamMemberFilterViewModelTest : BaseUnitTest() {
         val resourcesFlow = MutableStateFlow<List<BookingResourceEntity>>(emptyList())
         val bookingsRepository = mock<BookingsRepository> {
             on { observeResources() } doReturn resourcesFlow
-            onBlocking { fetchResources() } doReturn Result.failure(Exception("boom"))
+            on { fetchResources() } doReturn Result.failure(Exception("boom"))
         }
 
         val vm = createViewModel(BookingsFilterOption.TeamMembers.DEFAULT, bookingsRepository)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListHandlerTest.kt
@@ -40,11 +40,11 @@ class BookingListHandlerTest : BaseUnitTest() {
             val limit = invocation.getArgument<Int>(0)
             results.map { it.take(limit) }
         }
-        onBlocking { getBookingsList(any(), anyOrNull(), any()) } doAnswer { invocation ->
+        on { getBookingsList(any(), anyOrNull(), any()) } doAnswer { invocation ->
             val limit = invocation.getArgument<Int>(0)
             results.value.take(limit)
         }
-        onBlocking {
+        on {
             fetchBookings(
                 any(),
                 any(),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/list/BookingListViewModelTest.kt
@@ -62,14 +62,14 @@ import kotlin.test.Test
 class BookingListViewModelTest : BaseUnitTest() {
     private val bookingListHandler: BookingListHandler = mock {
         on { bookingsFlow } doReturn flowOf(emptyList())
-        onBlocking {
+        on {
             loadBookings(
                 searchQuery = anyOrNull(),
                 filters = any(),
                 sortBy = any()
             )
         } doReturn Result.success(0)
-        onBlocking { loadMore() } doReturn Result.success(0)
+        on { loadMore() } doReturn Result.success(0)
     }
     private val mockedNow = Instant.parse("2025-01-01T12:00:00Z")
     private val filtersBuilder = BookingListDateFilterBuilder(Clock.fixed(mockedNow, ZoneId.of("UTC")))
@@ -85,7 +85,7 @@ class BookingListViewModelTest : BaseUnitTest() {
     }
     private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact = mock()
     private val paymentStatusResolver: PaymentStatusResolver = mock {
-        onBlocking { resolveAll(any()) } doReturn mapOf(1L to PaymentStatus.UNPAID)
+        on { resolveAll(any()) } doReturn mapOf(1L to PaymentStatus.UNPAID)
     }
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/bookings/note/BookingNoteViewModelTest.kt
@@ -60,8 +60,8 @@ class BookingNoteViewModelTest : BaseUnitTest() {
     private val savedStateHandle: SavedStateHandle = BookingNoteFragmentArgs(bookingId).toSavedStateHandle()
 
     private val bookingsRepository = mock<BookingsRepository> {
-        onBlocking { getBooking(any()) } doReturn booking
-        onBlocking { updateNote(any(), any()) } doReturn Result.success(Unit)
+        on { getBooking(any()) } doReturn booking
+        on { updateNote(any(), any()) } doReturn Result.success(Unit)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/coupons/details/CouponDetailsViewModelTest.kt
@@ -50,9 +50,9 @@ class CouponDetailsViewModelTest : BaseUnitTest() {
     private val couponFlow = MutableSharedFlow<Coupon>(extraBufferCapacity = 1)
     private val couponRepository: CouponRepository = mock {
         on { observeCoupon(any()) } doReturn couponFlow
-        onBlocking { fetchCouponPerformance(any()) } doReturn
+        on { fetchCouponPerformance(any()) } doReturn
             Result.success(CouponTestUtils.generateTestCouponPerformance(COUPON_ID))
-        onBlocking { fetchCoupon(any()) } doReturn
+        on { fetchCoupon(any()) } doReturn
             Result.success(Unit)
     }
     private val wooCommerceStore: WooCommerceStore = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/customfields/list/CustomFieldsViewModelTest.kt
@@ -60,7 +60,7 @@ class CustomFieldsViewModelTest : BaseUnitTest() {
     }
 
     private val repository: CustomFieldsRepository = mock {
-        onBlocking { observeDisplayableCustomFields(PARENT_ITEM_ID) }.thenReturn(flowOf(CUSTOM_FIELDS))
+        on { observeDisplayableCustomFields(PARENT_ITEM_ID) }.thenReturn(flowOf(CUSTOM_FIELDS))
     }
     private val appPrefs: AppPrefsWrapper = mock {
         val bannerDismissed = MutableStateFlow(false)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -46,7 +46,7 @@ class DashboardViewModelTest : BaseUnitTest() {
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val myStoreTransactionLauncher: DashboardTransactionLauncher = mock()
     private val shouldShowPrivacyBanner: ShouldShowPrivacyBanner = mock {
-        onBlocking { invoke() } doReturn true
+        on { invoke() } doReturn true
     }
     private val dashboardRepository: DashboardRepository = mock {
         on { widgets } doReturn flowOf(
@@ -65,7 +65,7 @@ class DashboardViewModelTest : BaseUnitTest() {
         on { observe(any()) } doReturn flowOf(Status.REGISTERED_WPCOM_ONLY)
     }
     private val feedbackPrefs: FeedbackPrefs = mock {
-        onBlocking { userFeedbackIsDueObservable } doReturn flowOf(false)
+        on { userFeedbackIsDueObservable } doReturn flowOf(false)
     }
     private val shouldShowEnablePushNotificationsUi: ShouldShowEnablePushNotificationsUi = mock {
         on { invoke() } doReturn flowOf(false)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/coupons/DashboardCouponsViewModelTest.kt
@@ -62,9 +62,9 @@ class DashboardCouponsViewModelTest : BaseUnitTest() {
         on { refreshTrigger } doReturn emptyFlow()
     }
     private val couponRepository: CouponRepository = mock {
-        onBlocking { fetchMostActiveCoupons(any(), any()) } doReturn Result.success(sampleCouponReports)
-        onBlocking { getCoupons(any()) } doReturn sampleCoupons
-        onBlocking { fetchCoupons(any(), any(), any(), anyBoolean()) } doReturn Result.success(false)
+        on { fetchMostActiveCoupons(any(), any()) } doReturn Result.success(sampleCouponReports)
+        on { getCoupons(any()) } doReturn sampleCoupons
+        on { fetchCoupons(any(), any(), any(), anyBoolean()) } doReturn Result.success(false)
         on { observeCoupons(any()) } doReturn flowOf(sampleCoupons)
     }
     private val couponUtils: CouponUtils = mock {
@@ -79,7 +79,7 @@ class DashboardCouponsViewModelTest : BaseUnitTest() {
     }
     private val dateUtils: DateUtils = mock()
     private val parameterRepository: ParameterRepository = mock {
-        onBlocking { getParameters() } doReturn SiteParameters(
+        on { getParameters() } doReturn SiteParameters(
             currencyCode = "USD",
             currencySymbol = "$",
             currencyFormattingParameters = null,
@@ -92,7 +92,7 @@ class DashboardCouponsViewModelTest : BaseUnitTest() {
     private val customDateRangeDataStore: CouponsCustomDateRangeDataStore = mock {
         val rangeFlow = MutableStateFlow<StatsTimeRange?>(null)
         on { dateRange } doReturn rangeFlow
-        onBlocking { updateDateRange(any()) } doAnswer { rangeFlow.value = it.arguments[0] as StatsTimeRange }
+        on { updateDateRange(any()) } doAnswer { rangeFlow.value = it.arguments[0] as StatsTimeRange }
     }
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersViewModelTest.kt
@@ -39,11 +39,11 @@ class DashboardOrdersViewModelTest : BaseUnitTest() {
         on { refreshTrigger } doReturn emptyFlow()
     }
     private val orderListRepository: OrderListRepository = mock {
-        onBlocking { hasOrdersLocally(any()) } doReturn false
+        on { hasOrdersLocally(any()) } doReturn false
         on { observeTopOrders(any(), any(), any()) } doReturn flowOf(Result.success(sampleOrders))
     }
     private val getOrderStatusFilterOptions: GetOrderStatusFilterOptions = mock {
-        onBlocking { invoke() } doReturn emptyList()
+        on { invoke() } doReturn emptyList()
     }
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/reviews/DashboardReviewsViewModelTest.kt
@@ -42,8 +42,8 @@ class DashboardReviewsViewModelTest : BaseUnitTest() {
     }
 
     private val reviewListRepository: ReviewListRepository = mock {
-        onBlocking { getCachedProductReviews(anyOrNull()) } doReturn sampleReviews
-        onBlocking { fetchMostRecentReviews(any()) } doReturn Result.success(Unit)
+        on { getCachedProductReviews(anyOrNull()) } doReturn sampleReviews
+        on { fetchMostRecentReviews(any()) } doReturn Result.success(Unit)
     }
     private val reviewModerationHandler: ReviewModerationHandler = mock {
         on { pendingModerationStatus } doReturn flowOf(emptyList())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
@@ -53,7 +53,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     }
 
     private val getStats: GetStats = mock {
-        onBlocking { invoke(any(), any()) } doReturn flowOf(GetStats.LoadStatsResult.RevenueStatsSuccess(null))
+        on { invoke(any(), any()) } doReturn flowOf(GetStats.LoadStatsResult.RevenueStatsSuccess(null))
     }
     private val networkStatus: NetworkStatus = mock {
         on { isConnected() } doReturn true
@@ -74,7 +74,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     }
     private val timezoneProvider: TimezoneProvider = mock()
     private val observeLastUpdate: ObserveLastUpdate = mock {
-        onBlocking { invoke(any(), ArgumentMatchers.anyList(), eq(false)) } doReturn flowOf(DEFAULT_LAST_UPDATE)
+        on { invoke(any(), ArgumentMatchers.anyList(), eq(false)) } doReturn flowOf(DEFAULT_LAST_UPDATE)
     }
     private val dateUtils: DateUtils = mock()
     private val parentViewModel: DashboardViewModel = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/JetpackActivationRepositoryTest.kt
@@ -23,8 +23,8 @@ class JetpackActivationRepositoryTest : BaseUnitTest() {
     private val dispatcher: Dispatcher = mock()
     private val siteStore: SiteStore = mock()
     private val jetpackStore: JetpackStore = mock {
-        onBlocking { registerSite(any(), any()) }.thenReturn(JetpackStore.JetpackResult(123L))
-        onBlocking { connectJetpackAccount(any(), any(), any()) }.thenReturn(JetpackStore.JetpackResult(Unit))
+        on { registerSite(any(), any()) }.thenReturn(JetpackStore.JetpackResult(123L))
+        on { connectJetpackAccount(any(), any(), any()) }.thenReturn(JetpackStore.JetpackResult(Unit))
     }
     private val wooCommerceStore: WooCommerceStore = mock()
     private val selectedSite: SelectedSite = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/jetpack/main/JetpackActivationMainViewModelTest.kt
@@ -52,8 +52,8 @@ class JetpackActivationMainViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: JetpackActivationMainViewModel
 
     private val jetpackActivationRepository: JetpackActivationRepository = mock {
-        onBlocking { fetchJetpackSite(siteUrl) } doReturn Result.success(site)
-        onBlocking { getSiteByUrl(siteUrl) } doReturn site
+        on { fetchJetpackSite(siteUrl) } doReturn Result.success(site)
+        on { getSiteByUrl(siteUrl) } doReturn site
     }
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val pluginRepository: PluginRepository = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -63,9 +63,9 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
     private val applicationPasswordsUnavailableEvents = MutableSharedFlow<WPAPINetworkError>(extraBufferCapacity = 1)
 
     private val wpApiSiteRepository: WPApiSiteRepository = mock {
-        onBlocking { fetchSite(eq(siteAddress), any(), any()) } doReturn Result.success(testSite)
-        onBlocking { checkIfUserIsEligible(testSite) } doReturn Result.success(true)
-        onBlocking { getSiteByLocalId(testSite.id) } doReturn testSite
+        on { fetchSite(eq(siteAddress), any(), any()) } doReturn Result.success(testSite)
+        on { checkIfUserIsEligible(testSite) } doReturn Result.success(true)
+        on { getSiteByLocalId(testSite.id) } doReturn testSite
     }
     private var isJetpackConnected: Boolean = false
     private val selectedSite: SelectedSite = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -640,7 +640,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
                 moreMenuNewFeatureHandler = moreMenuNewFeatureHandler,
                 unseenReviewsCountHandler = unseenReviewsCountHandler,
                 determineTrialStatusBarState = mock {
-                    onBlocking { invoke(any()) } doReturn emptyFlow()
+                    on { invoke(any()) } doReturn emptyFlow()
                 },
                 ageEligibilityChecker = ageEligibilityChecker,
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -55,7 +55,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         on { get() } doReturn selectedSiteFlow.value
     }
     private val moreMenuRepository: MoreMenuRepository = mock {
-        onBlocking { isInboxEnabled() } doReturn true
+        on { isInboxEnabled() } doReturn true
     }
     private val accountStore: AccountStore = mock {
         on { account } doReturn AccountModel().apply {
@@ -63,7 +63,7 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         }
     }
     private val planRepository: SitePlanRepository = mock {
-        onBlocking { fetchCurrentPlanDetails(any()) } doReturn SitePlan(
+        on { fetchCurrentPlanDetails(any()) } doReturn SitePlan(
             name = "",
             expirationDate = ZonedDateTime.now(),
             type = SitePlan.Type.FREE_TRIAL
@@ -78,11 +78,11 @@ class MoreMenuViewModelTests : BaseUnitTest() {
     }
 
     private val isBlazeEnabled: IsBlazeEnabled = mock {
-        onBlocking { invoke() } doReturn true
+        on { invoke() } doReturn true
     }
 
     private val isGoogleForWooEnabled: IsGoogleForWooEnabled = mock {
-        onBlocking { invoke() } doReturn true
+        on { invoke() } doReturn true
     }
 
     private val hasGoogleAdsCampaigns: HasGoogleAdsCampaigns = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderDetailViewModelTest.kt
@@ -120,10 +120,10 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
     private val pluginsInfo = HashMap<String, WooPlugin>()
     private val orderDetailRepository: OrderDetailRepository = mock {
-        onBlocking { getOrderDetailsPluginsInfo() } doReturn pluginsInfo
+        on { getOrderDetailsPluginsInfo() } doReturn pluginsInfo
     }
     private val addonsRepository: AddonRepository = mock {
-        onBlocking { containsAddonsFrom(any()) } doReturn false
+        on { containsAddonsFrom(any()) } doReturn false
     }
     private val paymentsFlowTracker: PaymentsFlowTracker = mock()
     private val orderDetailTracker: OrderDetailTracker = mock()
@@ -150,8 +150,8 @@ class OrderDetailViewModelTest : BaseUnitTest() {
     private val productDetailRepository: ProductDetailRepository = mock()
     private val featureFlagRepository: FeatureFlagRepository = mock()
     private val paymentReceiptHelper: PaymentReceiptHelper = mock {
-        onBlocking { isReceiptAvailable(any()) }.thenReturn(false)
-        onBlocking { getReceiptUrl(any()) }.thenReturn(Result.success("https://www.testname.com"))
+        on { isReceiptAvailable(any()) }.thenReturn(false)
+        on { getReceiptUrl(any()) }.thenReturn(Result.success("https://www.testname.com"))
     }
 
     private val order = OrderTestUtils.generateTestOrder(ORDER_ID)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/OrderListViewModelTest.kt
@@ -96,8 +96,8 @@ class OrderListViewModelTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
     private val networkStatus: NetworkStatus = mock()
     private val orderListRepository: OrderListRepository = mock {
-        onBlocking { fetchPaymentGateways() } doReturn RequestResult.SUCCESS
-        onBlocking { fetchOrderStatusOptionsFromApi() } doReturn RequestResult.SUCCESS
+        on { fetchPaymentGateways() } doReturn RequestResult.SUCCESS
+        on { fetchOrderStatusOptionsFromApi() } doReturn RequestResult.SUCCESS
     }
     private val orderDetailRepository: OrderDetailRepository = mock()
     private val dispatcher: Dispatcher = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreateUpdateOrderTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreateUpdateOrderTests.kt
@@ -29,7 +29,7 @@ import java.util.Date
 @ExperimentalCoroutinesApi
 class CreateUpdateOrderTests : BaseUnitTest() {
     private val orderCreateEditRepository = mock<OrderCreateEditRepository> {
-        onBlocking { createOrUpdateOrder(any(), any(), any()) } doAnswer InlineClassesAnswer {
+        on { createOrUpdateOrder(any(), any(), any()) } doAnswer InlineClassesAnswer {
             val order = it.arguments.first() as Order
             Result.success(order.copy(total = order.total + BigDecimal.TEN))
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/CreationFocusedOrderCreateEditViewModelTest.kt
@@ -104,7 +104,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
 
     override fun initMocksForAnalyticsWithOrder(order: Order) {
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
     }
 
@@ -354,7 +354,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         var orderDraft: Order? = null
         val variationOrderItem = createOrderItem().copy(productId = 0, variationId = 123)
         createOrderItemUseCase = mock {
-            onBlocking { invoke(123, null) } doReturn variationOrderItem
+            on { invoke(123, null) } doReturn variationOrderItem
         }
 
         createSut()
@@ -715,7 +715,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     @Test
     fun `when creating the order fails, then trigger Snackbar with fail message`() {
         orderCreateEditRepository = mock {
-            onBlocking {
+            on {
                 createOrUpdateOrder(defaultOrderValue, source = OrderCreationSource.STORE_MANAGEMENT)
             } doReturn Result.failure(Throwable())
         }
@@ -827,7 +827,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `when editing a fee, then reuse the existent one with different value`() {
         // given
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(
+            on { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
                     Order.getEmptyOrder(Date(), Date()).copy(
                         feesLines = listOf(
@@ -862,7 +862,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `when removing a fee, do not remove the rest of fees`() {
         // given
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(
+            on { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
                     Order.getEmptyOrder(Date(), Date()).copy(
                         feesLines = listOf(
@@ -913,7 +913,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `when editing a shipping fee, then reuse the existent one with different value`() {
         val itemId = 2L
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(
+            on { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
                     Order.getEmptyOrder(Date(), Date()).copy(
                         shippingLines = listOf(
@@ -953,7 +953,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         // given
         val itemId = 2L
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(
+            on { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
                     Order.getEmptyOrder(Date(), Date()).copy(
                         shippingLines = listOf(
@@ -1015,7 +1015,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         // given
         val itemId = 1L
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(
+            on { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
                     Order.getEmptyOrder(Date(), Date()).copy(
                         shippingLines = listOf(
@@ -1046,7 +1046,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     @Test
     fun `when OrderDraftUpdateStatus is WillStart, then adjust view state to reflect the loading preparation`() {
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(PendingDebounce)
+            on { invoke(any(), any()) } doReturn flowOf(PendingDebounce)
         }
         createSut()
 
@@ -1065,7 +1065,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     @Test
     fun `when OrderDraftUpdateStatus is Ongoing, then adjust view state to reflect the loading`() {
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Ongoing)
+            on { invoke(any(), any()) } doReturn flowOf(Ongoing)
         }
         createSut()
 
@@ -1085,7 +1085,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `when OrderDraftUpdateStatus is Succeeded, then adjust view state to reflect the loading end`() {
         val modifiedOrderValue = defaultOrderValue.copy(id = 999)
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(modifiedOrderValue))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(modifiedOrderValue))
         }
         createSut()
 
@@ -1112,7 +1112,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     @Test
     fun `when OrderDraftUpdateStatus is Failed, then adjust view state to reflect the failure`() {
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Failed(throwable = Throwable(message = "fail")))
+            on { invoke(any(), any()) } doReturn flowOf(Failed(throwable = Throwable(message = "fail")))
         }
         createSut()
 
@@ -1133,7 +1133,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
         val myFlow: MutableStateFlow<OrderUpdateStatus> =
             MutableStateFlow(Failed(throwable = Throwable(message = "fail")))
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn myFlow
+            on { invoke(any(), any()) } doReturn myFlow
         }
 
         createSut()
@@ -1206,7 +1206,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `when isEditable is true on the create flow the order is editable`() {
         // When the order is on Creation mode is always editable
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(defaultOrderValue.copy(isEditable = true)))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(defaultOrderValue.copy(isEditable = true)))
         }
         createSut()
         var lastReceivedState: ViewState? = null
@@ -1220,7 +1220,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     fun `when isEditable is false on the edit flow the order is editable`() {
         // When the order is on Creation mode is always editable
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(defaultOrderValue.copy(isEditable = false)))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(defaultOrderValue.copy(isEditable = false)))
         }
         createSut()
         var lastReceivedState: ViewState? = null
@@ -1282,7 +1282,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     @Test
     fun `given coupon code rejected by backend, then should display message`() {
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn
+            on { invoke(any(), any()) } doReturn
                 flowOf(
                     Failed(
                         WooException(
@@ -2175,7 +2175,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     @Test
     fun `when custom amount is updated, then ADD_CUSTOM_AMOUNT_DONE_TAPPED event is tracked`() {
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(
+            on { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
                     Order.getEmptyOrder(Date(), Date()).copy(
                         feesLines = listOf(
@@ -2205,7 +2205,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     @Test
     fun `when custom amount is updated, then do not track order_fee_add event`() {
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(
+            on { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
                     Order.getEmptyOrder(Date(), Date()).copy(
                         feesLines = listOf(
@@ -2241,7 +2241,7 @@ class CreationFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTes
     @Test
     fun `when custom amount is updated, then track order_fee_update event`() {
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(
+            on { invoke(any(), any()) } doReturn flowOf(
                 Succeeded(
                     Order.getEmptyOrder(Date(), Date()).copy(
                         feesLines = listOf(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/EditFocusedOrderCreateEditViewModelTest.kt
@@ -47,20 +47,20 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
 
     override fun initMocksForAnalyticsWithOrder(order: Order) {
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         orderDetailRepository = mock {
-            onBlocking { getOrderById(order.id) }.doReturn(order)
+            on { getOrderById(order.id) }.doReturn(order)
         }
     }
 
     @Test
     fun `should load order from repository`() = testBlocking {
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(defaultOrderValue)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(defaultOrderValue)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(defaultOrderValue))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(defaultOrderValue))
         }
 
         createSut()
@@ -77,7 +77,7 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
     @Test
     fun `when hitting the back button, then close the screen`() {
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(defaultOrderValue)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(defaultOrderValue)
         }
         createSut()
         var lastReceivedEvent: Event? = null
@@ -106,10 +106,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
     fun `when isEditable is true on the edit flow the order is editable`() {
         val order = defaultOrderValue.copy(isEditable = true)
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
         var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
@@ -123,10 +123,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
     fun `when isEditable is false on the edit flow the order is NOT editable`() {
         val order = defaultOrderValue.copy(isEditable = false)
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
         var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
@@ -323,10 +323,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             )
         )
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
         var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
@@ -362,10 +362,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             couponLines = listOf(Order.CouponLine("code", 1L, ""))
         )
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
         var orderDraft: Order? = null
@@ -406,10 +406,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             couponLines = listOf(Order.CouponLine("code", 1L, ""))
         )
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
         var orderDraft: Order? = null
@@ -449,10 +449,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             ),
         )
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
         var orderDraft: Order? = null
@@ -491,10 +491,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             items = listOf(item),
         )
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
         var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
@@ -529,10 +529,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             items = listOf(item),
         )
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
         var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
@@ -552,10 +552,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             couponLines = listOf(Order.CouponLine("Dummy coupon 1"))
         )
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
 
         createSut()
@@ -572,10 +572,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             couponLines = listOf(Order.CouponLine("Dummy coupon 1"))
         )
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
 
         createSut()
@@ -595,10 +595,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             whenever(orderCreateEditRepository.fetchTaxBasedOnSetting()).thenReturn(TaxBasedOnSetting.BillingAddress)
 
             orderDetailRepository.stub {
-                onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+                on { getOrderById(defaultOrderValue.id) }.doReturn(order)
             }
             createUpdateOrderUseCase = mock {
-                onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+                on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
             }
 
             createSut()
@@ -619,10 +619,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             whenever(resourceProvider.getString(any())).thenReturn("label")
 
             orderDetailRepository.stub {
-                onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+                on { getOrderById(defaultOrderValue.id) }.doReturn(order)
             }
             createUpdateOrderUseCase = mock {
-                onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+                on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
             }
 
             createSut()
@@ -654,10 +654,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             )
         )
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
         var lastReceivedState: OrderCreateEditViewModel.ViewState? = null
@@ -716,10 +716,10 @@ class EditFocusedOrderCreateEditViewModelTest : UnifiedOrderEditViewModelTest() 
             items = listOf(item)
         )
         orderDetailRepository.stub {
-            onBlocking { getOrderById(defaultOrderValue.id) }.doReturn(order)
+            on { getOrderById(defaultOrderValue.id) }.doReturn(order)
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(order))
         }
         createSut()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/OrderCreateEditRepositoryTest.kt
@@ -62,7 +62,7 @@ class OrderCreateEditRepositoryTest : BaseUnitTest() {
         }
 
         orderUpdateStore = mock {
-            onBlocking {
+            on {
                 createSimplePayment(eq(defaultSiteModel), eq("1"), eq(true), eq(null), eq(null))
             } doReturn WooResult(
                 WooError(WooErrorType.API_ERROR, BaseRequest.GenericErrorType.NETWORK_ERROR, DEFAULT_ERROR_MESSAGE)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/SyncStrategyTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/SyncStrategyTest.kt
@@ -16,7 +16,7 @@ import java.util.Date
 @ExperimentalCoroutinesApi
 abstract class SyncStrategyTest : BaseUnitTest() {
     protected val orderCreateEditRepository = mock<OrderCreateEditRepository> {
-        onBlocking { createOrUpdateOrder(any(), any(), any()) } doAnswer InlineClassesAnswer {
+        on { createOrUpdateOrder(any(), any(), any()) } doAnswer InlineClassesAnswer {
             val order = it.arguments.first() as Order
             Result.success(order.copy(total = order.total + BigDecimal.TEN))
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/UnifiedOrderEditViewModelTest.kt
@@ -144,13 +144,13 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             } doReturn MutableLiveData(HashMap())
         }
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Succeeded(Order.getEmptyOrder(Date(), Date())))
+            on { invoke(any(), any()) } doReturn flowOf(Succeeded(Order.getEmptyOrder(Date(), Date())))
         }
         createOrderItemUseCase = mock {
-            onBlocking { invoke(123, null) } doReturn defaultOrderItem
-            onBlocking { invoke(456, null) } doReturn createOrderItem(456)
-            onBlocking { invoke(789, null) } doReturn createOrderItem(789)
-            onBlocking { invoke(1, 2) } doReturn createOrderItem(1, 2)
+            on { invoke(123, null) } doReturn defaultOrderItem
+            on { invoke(456, null) } doReturn createOrderItem(456)
+            on { invoke(789, null) } doReturn createOrderItem(789)
+            on { invoke(1, 2) } doReturn createOrderItem(1, 2)
             ProductSelectorViewModel.SelectedItem.ProductVariation(1, 2)
         }
         parameterRepository = mock {
@@ -165,7 +165,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
                 )
         }
         orderCreateEditRepository = mock {
-            onBlocking {
+            on {
                 createOrUpdateOrder(defaultOrderValue, source = OrderCreationSource.STORE_MANAGEMENT)
             } doReturn Result.success(defaultOrderValue)
         }
@@ -174,7 +174,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         }
         @Suppress("UNCHECKED_CAST")
         orderCreationProductMapper = mock {
-            onBlocking { toOrderProducts(any(), any()) } doAnswer { invocationOnMock ->
+            on { toOrderProducts(any(), any()) } doAnswer { invocationOnMock ->
                 val args = invocationOnMock.arguments
                 (args.first() as? List<Order.Item>)?.let { list ->
                     if (list.isEmpty()) {
@@ -197,7 +197,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         selectedSite = mock()
         taxRateToAddress = mock()
         getAutoTaxRateSetting = mock {
-            onBlocking { invoke() } doReturn null
+            on { invoke() } doReturn null
         }
         getTaxRatePercentageValueText = mock()
         getTaxRateLabel = mock()
@@ -205,7 +205,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         mapFeeLineToCustomAmountUiModel = mock()
         totalsHelper = mock()
         getShippingMethodsWithOtherValue = mock {
-            onBlocking { invoke() } doReturn flowOf(
+            on { invoke() } doReturn flowOf(
                 listOf(
                     ShippingMethod(
                         id = "other",
@@ -215,7 +215,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
             )
         }
         feedbackRepository = mock {
-            onBlocking {
+            on {
                 getFeatureFeedbackSetting(eq(FeatureFeedbackSettings.Feature.ORDER_SHIPPING_LINES))
             } doReturn FeatureFeedbackSettings(
                 feature = FeatureFeedbackSettings.Feature.ORDER_SHIPPING_LINES,
@@ -517,7 +517,7 @@ abstract class UnifiedOrderEditViewModelTest : BaseUnitTest() {
         val throwable = WooException(error = wooError)
         initMocksForAnalyticsWithOrder(defaultOrderValue)
         createUpdateOrderUseCase = mock {
-            onBlocking { invoke(any(), any()) } doReturn flowOf(Failed(throwable))
+            on { invoke(any(), any()) } doReturn flowOf(Failed(throwable))
         }
 
         createSut()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/configuration/ProductConfigurationViewModelTest.kt
@@ -23,11 +23,11 @@ class ProductConfigurationViewModelTest : BaseUnitTest() {
 
     private val tracker: AnalyticsTrackerWrapper = mock()
     private val getProductRules: GetProductRules = mock {
-        onBlocking { getRules(defaultProductId) } doReturn defaultProductRules
+        on { getRules(defaultProductId) } doReturn defaultProductRules
     }
     private val getProductConfiguration: GetProductConfiguration = GetProductConfiguration(mock(), Gson())
     private val getChildrenProductInfo: GetChildrenProductInfo = mock {
-        onBlocking { invoke(defaultProductId) } doReturn mock()
+        on { invoke(defaultProductId) } doReturn mock()
     }
     private val navArgs = ProductConfigurationFragmentArgs(flow = Flow.Selection(defaultProductId))
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/creation/customerlist/CustomerListSelectionViewModelTest.kt
@@ -32,7 +32,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 @ExperimentalCoroutinesApi
 class CustomerListSelectionViewModelTest : BaseUnitTest() {
     private val customerListRepository: CustomerListRepository = mock {
-        onBlocking {
+        on {
             searchCustomerListWithEmail(
                 any(),
                 any(),
@@ -41,14 +41,14 @@ class CustomerListSelectionViewModelTest : BaseUnitTest() {
             )
         }.thenReturn(Result.success(listOf(mock())))
 
-        onBlocking { getCustomerList(any()) }.thenReturn(emptyList())
+        on { getCustomerList(any()) }.thenReturn(emptyList())
     }
     private val mockCustomer: CustomerListViewState.CustomerList.Item.Customer = mock()
     private val customerListViewModelMapper: CustomerListViewModelMapper = mock {
         on { mapFromWCCustomerToItem(any(), any(), any()) }.thenReturn(mockCustomer)
     }
     private val getSupportedSearchModes: CustomerListGetSupportedSearchModes = mock {
-        onBlocking { invoke(true) }.thenReturn(
+        on { invoke(true) }.thenReturn(
             listOf(
                 SearchMode(
                     labelResId = R.string.order_creation_customer_search_name,
@@ -64,7 +64,7 @@ class CustomerListSelectionViewModelTest : BaseUnitTest() {
         )
     }
     private val isAdvancedSearchSupported: CustomerListIsAdvancedSearchSupported = mock {
-        onBlocking { invoke() }.thenReturn(true)
+        on { invoke() }.thenReturn(true)
     }
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val stringUtils: StringUtils = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepositoryTest.kt
@@ -16,7 +16,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.mockito.kotlin.wheneverBlocking
+import kotlinx.coroutines.runBlocking
 import java.util.Date
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -201,9 +201,9 @@ class ShippingLabelOnboardingRepositoryTest : BaseUnitTest() {
     }
 
     private fun givenOrderHasVirtualProductsOnly() {
-        wheneverBlocking {
-            orderDetailRepository.hasVirtualProductsOnly(any())
-        }.thenReturn(true)
+        runBlocking {
+            whenever(orderDetailRepository.hasVirtualProductsOnly(any())).thenReturn(true)
+        }
     }
 
     private fun givenWcShippingBannerIsDismissed(dismissed: Boolean) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/ShippingLabelOnboardingRepositoryTest.kt
@@ -10,13 +10,13 @@ import com.woocommerce.android.ui.orders.details.ShippingLabelOnboardingReposito
 import com.woocommerce.android.ui.orders.details.ShippingLabelOnboardingRepository.ShippingLabelSupport
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import kotlinx.coroutines.runBlocking
 import java.util.Date
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/details/editing/OrderEditingViewModelTest.kt
@@ -28,7 +28,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
 
     private val orderEditingRepository: OrderEditingRepository = mock()
     private val orderDetailRepository: OrderDetailRepository = mock {
-        onBlocking { getOrderById(any()) } doReturn testOrder
+        on { getOrderById(any()) } doReturn testOrder
     }
     private val networkStatus: NetworkStatus = mock {
         on { isConnected() } doReturn true
@@ -49,7 +49,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
     fun `should replicate billing to shipping when toggle is activated`() =
         testBlocking {
             orderEditingRepository.stub {
-                onBlocking {
+                on {
                     updateBothOrderAddresses(any(), any(), any())
                 } doReturn flowOf()
             }
@@ -72,7 +72,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
     fun `should replicate shipping to billing when toggle is activated`() =
         testBlocking {
             orderEditingRepository.stub {
-                onBlocking {
+                on {
                     updateBothOrderAddresses(any(), any(), any())
                 } doReturn flowOf()
             }
@@ -141,11 +141,11 @@ class OrderEditingViewModelTest : BaseUnitTest() {
             )
 
             orderDetailRepository.stub {
-                onBlocking { getOrderById(any()) } doReturn originalOrder
+                on { getOrderById(any()) } doReturn originalOrder
             }
 
             orderEditingRepository.stub {
-                onBlocking {
+                on {
                     updateBothOrderAddresses(any(), any(), any())
                 } doReturn flowOf()
             }
@@ -234,7 +234,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
     fun `should emit success event if update was successful`() {
         var eventWasCalled = false
         orderEditingRepository.stub {
-            onBlocking {
+            on {
                 updateOrderAddress(testOrder.id, addressToUpdate.toBillingAddressModel())
             } doReturn flowOf(
                 WCOrderStore.UpdateOrderResult.OptimisticUpdateResult(
@@ -259,7 +259,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
     @Test
     fun `should emit generic error event for errors other than empty billing mail error`() {
         orderEditingRepository.stub {
-            onBlocking {
+            on {
                 updateOrderAddress(testOrder.id, addressToUpdate.toBillingAddressModel())
             } doReturn flowOf(
                 WCOrderStore.UpdateOrderResult.RemoteUpdateResult(
@@ -283,7 +283,7 @@ class OrderEditingViewModelTest : BaseUnitTest() {
     @Test
     fun `should emit empty mail failure if store returns empty billing mail error`() {
         orderEditingRepository.stub {
-            onBlocking {
+            on {
                 updateOrderAddress(testOrder.id, addressToUpdate.toBillingAddressModel())
             } doReturn flowOf(
                 WCOrderStore.UpdateOrderResult.RemoteUpdateResult(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/GetShipmentsTests.kt
@@ -30,8 +30,8 @@ import kotlin.test.assertNotNull
 @OptIn(ExperimentalCoroutinesApi::class)
 class GetShipmentsTests : BaseUnitTest() {
     private val wooShippingLabelRepository: WooShippingLabelRepository = mock {
-        onBlocking { getLabels(any()) } doReturn emptyList()
-        onBlocking { getShipments(any()) } doReturn emptyMap()
+        on { getLabels(any()) } doReturn emptyList()
+        on { getShipments(any()) } doReturn emptyMap()
     }
     private val orderDetailRepository: OrderDetailRepository = mock()
     private val productDetailRepository: ProductDetailRepository = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/WooShippingLabelCreationViewModelTest.kt
@@ -262,7 +262,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
     )
 
     private val orderDetailRepository: OrderDetailRepository = mock {
-        onBlocking { getOrderById(any()) } doReturn OrderTestUtils.generateTestOrder(orderId = orderId).copy(
+        on { getOrderById(any()) } doReturn OrderTestUtils.generateTestOrder(orderId = orderId).copy(
             shippingLines = defaultShippingLines,
             customer = Order.Customer(
                 billingAddress = defaultShipToAddress,
@@ -271,7 +271,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         )
     }
     private val getShipments: GetShipments = mock {
-        onBlocking { invoke(any()) } doReturn defaultShipments
+        on { invoke(any()) } doReturn defaultShipments
     }
     private val currencyFormatter: CurrencyFormatter = mock {
         on { formatCurrency(any<BigDecimal>(), any(), any()) } doAnswer {
@@ -296,7 +296,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         on { invoke() } doReturn flowOf(defaultOriginAddresses)
     }
     private val getShippingRates: GetShippingRates = mock {
-        onBlocking {
+        on {
             invoke(
                 any(),
                 any(),
@@ -310,7 +310,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         } doReturn Result.success(defaultShippingRates)
     }
     private val purchaseShippingLabel: PurchaseShippingLabel = mock {
-        onBlocking {
+        on {
             invoke(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(), isNull())
         } doReturn Result.success(
             PurchasedLabelData(
@@ -326,7 +326,7 @@ class WooShippingLabelCreationViewModelTest : BaseUnitTest() {
         on { invoke() } doReturn flowOf(defaultAccountSettings)
     }
     private val verifyDestinationAddress: VerifyDestinationAddress = mock {
-        onBlocking { invoke(orderId) } doReturn Result.success(DestinationShippingAddress(defaultShipToAddress, true))
+        on { invoke(orderId) } doReturn Result.success(DestinationShippingAddress(defaultShipToAddress, true))
     }
     private val observeShippingLabelNotice: ObserveShippingLabelNotice = mock {
         on { invoke(any(), any(), any(), any()) } doReturn flowOf(null)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/customs/WooShippingCustomsFormViewModelTest.kt
@@ -34,7 +34,7 @@ class WooShippingCustomsFormViewModelTest : BaseUnitTest() {
         Location(code = "CA", name = "Canada")
     )
     private val getAllCountries: GetAllCountries = mock {
-        onBlocking { invoke() } doReturn Result.success(locations)
+        on { invoke() } doReturn Result.success(locations)
     }
 
     private val customsValidator: WooShippingCustomsValidator = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/orders/wooshippinglabels/payment/WooShippingEditPaymentViewModelTest.kt
@@ -75,7 +75,7 @@ class WooShippingEditPaymentViewModelTest : BaseUnitTest() {
         on { invoke() } doReturn flowOf(defaultAccountSettings)
     }
     private val fetchAccountSettings: FetchAccountSettings = mock {
-        onBlocking { invoke() } doReturn Result.success(defaultAccountSettings)
+        on { invoke() } doReturn Result.success(defaultAccountSettings)
     }
     private val updatePaymentOptions: UpdatePaymentOptions = mock()
     private val webViewAuthenticator: WebViewAuthenticator = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/SelectPaymentMethodViewModelTest.kt
@@ -87,9 +87,9 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         on { get() }.thenReturn(site)
     }
     private val orderStore: WCOrderStore = mock {
-        onBlocking { getOrderByIdAndSite(any(), any()) }.thenReturn(orderEntity)
-        onBlocking { getOrderStatusForSiteAndKey(any(), any()) }.thenReturn(mock())
-        onBlocking { updateOrderStatus(any(), any(), any()) }.thenReturn(
+        on { getOrderByIdAndSite(any(), any()) }.thenReturn(orderEntity)
+        on { getOrderStatusForSiteAndKey(any(), any()) }.thenReturn(mock())
+        on { updateOrderStatus(any(), any(), any()) }.thenReturn(
             flowOf(WCOrderStore.UpdateOrderResult.RemoteUpdateResult(OnOrderChanged()))
         )
     }
@@ -105,10 +105,10 @@ class SelectPaymentMethodViewModelTest : BaseUnitTest() {
         on { getSiteSettings(site) }.thenReturn(mock())
     }
     private val orderMapper: OrderMapper = mock {
-        onBlocking { toAppModel(orderEntity) }.thenReturn(order)
+        on { toAppModel(orderEntity) }.thenReturn(order)
     }
     private val cardPaymentCollectibilityChecker: CardReaderPaymentCollectibilityChecker = mock {
-        onBlocking { isCollectable(order) }.thenReturn(false)
+        on { isCollectable(order) }.thenReturn(false)
     }
     private val learnMoreUrlProvider: LearnMoreUrlProvider = mock()
     private val paymentsFlowTracker: PaymentsFlowTracker = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentC
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCurrencySupportedChecker
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -16,7 +17,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import kotlinx.coroutines.runBlocking
 import java.math.BigDecimal
 import java.util.Date
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderPaymentCollectibilityCheckerTest.kt
@@ -16,7 +16,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.mockito.kotlin.wheneverBlocking
+import kotlinx.coroutines.runBlocking
 import java.math.BigDecimal
 import java.util.Date
 
@@ -37,9 +37,9 @@ class CardReaderPaymentCollectibilityCheckerTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        wheneverBlocking {
-            repository.hasSubscriptionProducts(any())
-        }.doReturn(false)
+        runBlocking {
+            whenever(repository.hasSubscriptionProducts(any())).doReturn(false)
+        }
         testBlocking {
             whenever(cardReaderPaymentCurrencySupportedChecker.isCurrencySupported(any())).thenReturn(true)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/detail/CardReaderDetailViewModelTest.kt
@@ -45,7 +45,7 @@ private const val DUMMY_FIRMWARE_VERSION = "1.0.0.123-abcd-test-3000"
 @ExperimentalCoroutinesApi
 class CardReaderDetailViewModelTest : BaseUnitTest() {
     private val cardReaderManager: CardReaderManager = mock {
-        onBlocking { readerStatus }.thenReturn(MutableStateFlow(CardReaderStatus.Connecting))
+        on { readerStatus }.thenReturn(MutableStateFlow(CardReaderStatus.Connecting))
     }
 
     private val tracker: PaymentsFlowTracker = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/hub/PaymentsHubViewModelTest.kt
@@ -77,10 +77,10 @@ class PaymentsHubViewModelTest : BaseUnitTest() {
     private val wooStore: WooCommerceStore = mock()
     private val cardReaderCountryConfigProvider: CardReaderCountryConfigProvider = mock()
     private val cardReaderChecker: CardReaderOnboardingChecker = mock {
-        onBlocking { getOnboardingState() } doReturn mock<CardReaderOnboardingState.OnboardingCompleted>()
+        on { getOnboardingState() } doReturn mock<CardReaderOnboardingState.OnboardingCompleted>()
     }
     private val cashOnDeliverySettingsRepository: CashOnDeliverySettingsRepository = mock {
-        onBlocking { isCashOnDeliveryEnabled() } doReturn false
+        on { isCashOnDeliveryEnabled() } doReturn false
     }
     private val learnMoreUrlProvider: LearnMoreUrlProvider = mock()
     private val paymentsFlowTracker: PaymentsFlowTracker = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/IssueRefundViewModelTest.kt
@@ -45,7 +45,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
     private val orderStore: WCOrderStore = mock()
     private val selectedSite: SelectedSite = mock()
     private val refundStore: WCRefundStore = mock {
-        onBlocking { getAllRefunds(any(), any()) } doReturn emptyList()
+        on { getAllRefunds(any(), any()) } doReturn emptyList()
     }
     private val currencyFormatter: CurrencyFormatter = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
@@ -227,7 +227,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
         }
         val orderEntity = mock<OrderEntity>()
         val orderMapper = mock<OrderMapper> {
-            onBlocking { toAppModel(orderEntity) }.thenReturn(order)
+            on { toAppModel(orderEntity) }.thenReturn(order)
         }
         whenever(orderStore.getOrderByIdAndSite(any(), any())).thenReturn(orderEntity)
         whenever(refundStore.getAllRefunds(any(), any())).thenReturn(emptyList())
@@ -267,7 +267,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
         }
         val orderEntity = mock<OrderEntity>()
         val orderMapper = mock<OrderMapper> {
-            onBlocking { toAppModel(orderEntity) }.thenReturn(order)
+            on { toAppModel(orderEntity) }.thenReturn(order)
         }
         val refundedItems = listOf(
             mock<WCRefundItem> {
@@ -331,7 +331,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
             }
             val orderEntity = mock<OrderEntity>()
             val orderMapper = mock<OrderMapper> {
-                onBlocking { toAppModel(orderEntity) }.thenReturn(order)
+                on { toAppModel(orderEntity) }.thenReturn(order)
             }
             val refundedItems = listOf(
                 mock<WCRefundItem> {
@@ -416,7 +416,7 @@ class IssueRefundViewModelTest : BaseUnitTest() {
             }
             val orderEntity = mock<OrderEntity>()
             val orderMapper = mock<OrderMapper> {
-                onBlocking { toAppModel(orderEntity) }.thenReturn(order)
+                on { toAppModel(orderEntity) }.thenReturn(order)
             }
             val refundedItems = listOf(
                 mock<WCRefundItem> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/plans/trial/DetermineTrialStatusBarStateTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/plans/trial/DetermineTrialStatusBarStateTest.kt
@@ -111,7 +111,7 @@ class DetermineTrialStatusBarStateTest : BaseUnitTest() {
                 on { observe() } doReturn flowOf(site)
             }
             sitePlanRepository.stub {
-                onBlocking { fetchFreeTrialExpiryDate(any()) } doReturn FreeTrialExpiryDateResult.ExpiryAt(
+                on { fetchFreeTrialExpiryDate(any()) } doReturn FreeTrialExpiryDateResult.ExpiryAt(
                     ANY_DATE
                 )
             }
@@ -141,7 +141,7 @@ class DetermineTrialStatusBarStateTest : BaseUnitTest() {
             }
             val errorMessage = ""
             sitePlanRepository.stub {
-                onBlocking { fetchFreeTrialExpiryDate(any()) } doReturn FreeTrialExpiryDateResult.Error(
+                on { fetchFreeTrialExpiryDate(any()) } doReturn FreeTrialExpiryDateResult.Error(
                     errorMessage
                 )
             }
@@ -166,7 +166,7 @@ class DetermineTrialStatusBarStateTest : BaseUnitTest() {
                 on { observe() } doReturn flowOf(site)
             }
             sitePlanRepository.stub {
-                onBlocking { fetchFreeTrialExpiryDate(any()) } doReturn FreeTrialExpiryDateResult.NotTrial
+                on { fetchFreeTrialExpiryDate(any()) } doReturn FreeTrialExpiryDateResult.NotTrial
             }
 
             // when

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/plansubscriptions/PlanSubscriptionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/plansubscriptions/PlanSubscriptionViewModelTest.kt
@@ -273,11 +273,11 @@ class PlanSubscriptionViewModelTest : BaseUnitTest() {
         }
 
         planRepository = mock {
-            onBlocking { fetchCurrentPlanDetails(siteModel) } doReturn sitePlan
+            on { fetchCurrentPlanDetails(siteModel) } doReturn sitePlan
         }
 
         remainingTrialPeriodUseCase = mock {
-            onBlocking { invoke(sitePlan.expirationDate) } doReturn remainingTrialPeriod
+            on { invoke(sitePlan.expirationDate) } doReturn remainingTrialPeriod
         }
 
         sut = PlanSubscriptionViewModel(
@@ -298,7 +298,7 @@ class PlanSubscriptionViewModelTest : BaseUnitTest() {
         }
 
         planRepository = mock {
-            onBlocking { fetchCurrentPlanDetails(siteModel) } doReturn null
+            on { fetchCurrentPlanDetails(siteModel) } doReturn null
         }
 
         sut = PlanSubscriptionViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/PrivacySettingsViewModelTest.kt
@@ -66,7 +66,7 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
             // given
             analyticsTrackerWrapper.sendUsageStats = false
             repository.stub {
-                onBlocking { updateTracksSetting(true) } doReturn Result.success(Unit)
+                on { updateTracksSetting(true) } doReturn Result.success(Unit)
             }
             init()
 
@@ -85,7 +85,7 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
             // given
             analyticsTrackerWrapper.sendUsageStats = false
             repository.stub {
-                onBlocking { updateTracksSetting(true) } doReturn Result.failure(Exception())
+                on { updateTracksSetting(true) } doReturn Result.failure(Exception())
             }
             init()
 
@@ -104,7 +104,7 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
             // given
             analyticsTrackerWrapper.sendUsageStats = false
             repository.stub {
-                onBlocking { updateAccountSettings() } doReturn Result.failure(Exception())
+                on { updateAccountSettings() } doReturn Result.failure(Exception())
             }
 
             // when
@@ -141,7 +141,7 @@ class PrivacySettingsViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
             // given
             analyticsTrackerWrapper.sendUsageStats = false
             repository.stub {
-                onBlocking { updateTracksSetting(true) } doReturn Result.failure(Exception())
+                on { updateTracksSetting(true) } doReturn Result.failure(Exception())
             }
             init()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/PrivacyBannerViewModelTest.kt
@@ -92,7 +92,7 @@ class PrivacyBannerViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
             // given
             repository.stub {
                 on { isUserWPCOM() } doReturn true
-                onBlocking { updateTracksSetting(true) } doReturn Result.failure(Exception())
+                on { updateTracksSetting(true) } doReturn Result.failure(Exception())
             }
             sut.analyticsState.observeForever { }
 
@@ -113,10 +113,10 @@ class PrivacyBannerViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         testBlocking {
             // given
             repository.stub {
-                onBlocking { isUserWPCOM() } doReturn false
+                on { isUserWPCOM() } doReturn false
             }
             analyticsTracker.stub {
-                onBlocking { sendUsageStats } doReturn true
+                on { sendUsageStats } doReturn true
             }
             sut.analyticsState.observeForever { }
 
@@ -159,7 +159,7 @@ class PrivacyBannerViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
             // given
             repository.stub {
                 on { isUserWPCOM() } doReturn true
-                onBlocking { updateTracksSetting(true) } doReturn Result.failure(Exception())
+                on { updateTracksSetting(true) } doReturn Result.failure(Exception())
             }
             sut.analyticsState.observeForever { }
 
@@ -184,10 +184,10 @@ class PrivacyBannerViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         testBlocking {
             // given
             repository.stub {
-                onBlocking { isUserWPCOM() } doReturn false
+                on { isUserWPCOM() } doReturn false
             }
             analyticsTracker.stub {
-                onBlocking { sendUsageStats } doReturn true
+                on { sendUsageStats } doReturn true
             }
             sut.analyticsState.observeForever { }
 
@@ -208,7 +208,7 @@ class PrivacyBannerViewModelTest : BaseUnitTest(StandardTestDispatcher()) {
         testBlocking {
             // given
             analyticsTracker.stub {
-                onBlocking { sendUsageStats } doReturn true
+                on { sendUsageStats } doReturn true
             }
             sut.analyticsState.observeForever { }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/domain/IsUsersCountryGdprCompliantTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/privacy/banner/domain/IsUsersCountryGdprCompliantTest.kt
@@ -23,7 +23,7 @@ class IsUsersCountryGdprCompliantTest : BaseUnitTest() {
         runBlocking {
             // given
             geoRepository.stub {
-                onBlocking { fetchCountryCode() }.thenReturn(Result.success("DE"))
+                on { fetchCountryCode() }.thenReturn(Result.success("DE"))
             }
 
             // then
@@ -35,7 +35,7 @@ class IsUsersCountryGdprCompliantTest : BaseUnitTest() {
         runBlocking {
             // given
             geoRepository.stub {
-                onBlocking { fetchCountryCode() }.thenReturn(Result.success("US"))
+                on { fetchCountryCode() }.thenReturn(Result.success("US"))
             }
 
             // then
@@ -47,7 +47,7 @@ class IsUsersCountryGdprCompliantTest : BaseUnitTest() {
         runBlocking {
             // given
             geoRepository.stub {
-                onBlocking { fetchCountryCode() }.thenReturn(Result.failure(Exception()))
+                on { fetchCountryCode() }.thenReturn(Result.failure(Exception()))
             }
 
             // then
@@ -59,7 +59,7 @@ class IsUsersCountryGdprCompliantTest : BaseUnitTest() {
         runBlocking {
             // given
             geoRepository.stub {
-                onBlocking { fetchCountryCode() }.thenReturn(Result.success(""))
+                on { fetchCountryCode() }.thenReturn(Result.success(""))
             }
 
             // then

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/DuplicateProductTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/DuplicateProductTest.kt
@@ -43,7 +43,7 @@ class DuplicateProductTest : BaseUnitTest() {
         // given
         val productToDuplicate = ProductAggregate(ProductTestUtils.generateProduct().copy(sku = "not an empty value"))
         productDetailRepository.stub {
-            onBlocking { addProduct(any<ProductAggregate>()) } doReturn Pair(true, 123)
+            on { addProduct(any<ProductAggregate>()) } doReturn Pair(true, 123)
         }
 
         // when
@@ -70,17 +70,17 @@ class DuplicateProductTest : BaseUnitTest() {
             val productToDuplicate = ProductAggregate(ProductTestUtils.generateProduct().copy(numVariations = 15))
             val duplicatedProductId = 456L
             productDetailRepository.stub {
-                onBlocking { addProduct(any<ProductAggregate>()) } doReturn Pair(true, duplicatedProductId)
+                on { addProduct(any<ProductAggregate>()) } doReturn Pair(true, duplicatedProductId)
             }
 
             val variationsOfProductToDuplicate =
                 ProductTestUtils.generateProductVariationList(productToDuplicate.remoteId)
                     .map { it.copy(sku = "not an empty value") }
             variationRepository.stub {
-                onBlocking {
+                on {
                     fetchProductVariations(eq(productToDuplicate.remoteId), any())
                 } doReturn variationsOfProductToDuplicate
-                onBlocking { createVariations(any(), any()) } doReturn Result.success(Unit)
+                on { createVariations(any(), any()) } doReturn Result.success(Unit)
             }
 
             // when

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/VariationListViewModelTest.kt
@@ -61,8 +61,8 @@ class VariationListViewModelTest : BaseUnitTest() {
         whenever(productRepository.getProduct(productRemoteId)).thenReturn(product)
 
         variationRepository = mock {
-            onBlocking { fetchProductVariations(any(), any()) } doReturn emptyList()
-            onBlocking { bulkCreateVariations(any(), any()) } doReturn RequestResult.SUCCESS
+            on { fetchProductVariations(any(), any()) } doReturn emptyList()
+            on { bulkCreateVariations(any(), any()) } doReturn RequestResult.SUCCESS
         }
     }
 
@@ -251,8 +251,8 @@ class VariationListViewModelTest : BaseUnitTest() {
     fun `Show error and hide progress bar if variation generation failed`() = testBlocking {
         // given
         variationRepository.stub {
-            onBlocking { bulkCreateVariations(any(), any()) } doReturn RequestResult.ERROR
-            onBlocking { getProductVariationList(productRemoteId) } doReturn emptyList()
+            on { bulkCreateVariations(any(), any()) } doReturn RequestResult.ERROR
+            on { getProductVariationList(productRemoteId) } doReturn emptyList()
         }
         val variationCandidates = List(5) { id ->
             listOf(VariantOption(id.toLong(), "Number", id.toString()))
@@ -369,7 +369,7 @@ class VariationListViewModelTest : BaseUnitTest() {
 
         // When AddAllVariations fails
         variationRepository.stub {
-            onBlocking { bulkCreateVariations(any(), any()) } doReturn RequestResult.ERROR
+            on { bulkCreateVariations(any(), any()) } doReturn RequestResult.ERROR
         }
         viewModel.onGenerateVariationsConfirmed(variationCandidates)
 
@@ -391,7 +391,7 @@ class VariationListViewModelTest : BaseUnitTest() {
         val expectedUpdatedProduct = product.copy(name = "Updated Product")
 
         productRepository.stub {
-            onBlocking { fetchAndGetProduct(productRemoteId) } doReturn expectedUpdatedProduct
+            on { fetchAndGetProduct(productRemoteId) } doReturn expectedUpdatedProduct
         }
         createViewModel()
         viewModel.start()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ai/preview/AiProductPreviewViewModelTest.kt
@@ -40,13 +40,13 @@ class AiProductPreviewViewModelTest : BaseUnitTest() {
 
     private val buildProductPreviewProperties: BuildProductPreviewProperties = mock()
     private val generateProductWithAI: GenerateProductWithAI = mock {
-        onBlocking { invoke(any()) } doSuspendableAnswer {
+        on { invoke(any()) } doSuspendableAnswer {
             delay(100)
             Result.success(SAMPLE_PRODUCT)
         }
     }
     private val saveAiGeneratedProduct: SaveAiGeneratedProduct = mock {
-        onBlocking { invoke(any(), anyOrNull()) } doSuspendableAnswer {
+        on { invoke(any(), anyOrNull()) } doSuspendableAnswer {
             delay(100)
             AiProductSaveResult.Success(1L)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ai/preview/GenerateProductWithAITest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/ai/preview/GenerateProductWithAITest.kt
@@ -54,16 +54,16 @@ class GenerateProductWithAITest : BaseUnitTest() {
     }
 
     private val aiRepository: AIRepository = mock {
-        onBlocking { identifyISOLanguageCode(any(), any()) } doReturn Result.success("en")
-        onBlocking { generateProduct(any(), any(), any(), any(), any(), any(), any(), any()) } doReturn
+        on { identifyISOLanguageCode(any(), any()) } doReturn Result.success("en")
+        on { generateProduct(any(), any(), any(), any(), any(), any(), any(), any()) } doReturn
             Result.success(TEST_PRODUCT_JSON)
     }
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private val categoriesRepository: ProductCategoriesRepository = mock {
-        onBlocking { fetchProductCategories() }.thenReturn(Result.success(emptyList()))
+        on { fetchProductCategories() }.thenReturn(Result.success(emptyList()))
     }
     private val tagsRepository: ProductTagsRepository = mock {
-        onBlocking { fetchProductTags() }.thenReturn(Result.success(emptyList()))
+        on { fetchProductTags() }.thenReturn(Result.success(emptyList()))
     }
     private val parametersRepository: ParameterRepository = mock {
         on { getParameters() }.thenReturn(TEST_SITE_PARAMETERS)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandlerTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/categories/selector/ProductCategoryListHandlerTests.kt
@@ -21,7 +21,7 @@ class ProductCategoryListHandlerTests : BaseUnitTest() {
 
     private val repository: ProductCategorySelectorRepository = mock {
         on { observeCategories() } doReturn flowOf(emptyList())
-        onBlocking { fetchCategories(any(), any()) } doReturn Result.success(false)
+        on { fetchCategories(any(), any()) } doReturn Result.success(false)
     }
 
     suspend fun setup(prepareMocks: suspend () -> Unit = {}) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailBottomSheetBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailBottomSheetBuilderTest.kt
@@ -23,7 +23,7 @@ class ProductDetailBottomSheetBuilderTest : BaseUnitTest() {
     private val resourceProvider: ResourceProvider = mock()
     private val variationRepository: VariationRepository = mock()
     private val customFieldsRepository: CustomFieldsRepository = mock {
-        onBlocking { hasDisplayableCustomFields(any()) } doReturn false
+        on { hasDisplayableCustomFields(any()) } doReturn false
     }
 
     @Before

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailCardBuilderTest.kt
@@ -33,10 +33,10 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
     private lateinit var sut: ProductDetailCardBuilder
     private lateinit var productStub: Product
     private val isBlazeEnabled: IsBlazeEnabled = mock {
-        onBlocking { invoke() } doReturn false
+        on { invoke() } doReturn false
     }
     private val customFieldsRepository: CustomFieldsRepository = mock {
-        onBlocking { hasDisplayableCustomFields(any()) } doReturn false
+        on { hasDisplayableCustomFields(any()) } doReturn false
     }
 
     private val resourceProvider: ResourceProvider = mock {
@@ -46,7 +46,7 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
     @Before
     fun setUp() {
         val viewModel: ProductDetailViewModel = mock {
-            onBlocking { getShippingClassByRemoteShippingClassId(any()) } doReturn ""
+            on { getShippingClassByRemoteShippingClassId(any()) } doReturn ""
         }
 
         val resources: ResourceProvider = mock {
@@ -55,7 +55,7 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
         }
 
         val addonRepo: AddonRepository = mock {
-            onBlocking { hasAnyProductSpecificAddons(any()) } doReturn false
+            on { hasAnyProductSpecificAddons(any()) } doReturn false
         }
 
         val selectedSite: SelectedSite = mock {
@@ -63,7 +63,7 @@ class ProductDetailCardBuilderTest : BaseUnitTest() {
         }
 
         val variationRepository: VariationRepository = mock {
-            onBlocking { getProductVariationList(any()) } doReturn emptyList()
+            on { getProductVariationList(any()) } doReturn emptyList()
         }
 
         sut = ProductDetailCardBuilder(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelGenerateVariationFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelGenerateVariationFlowTest.kt
@@ -93,11 +93,11 @@ class ProductDetailViewModelGenerateVariationFlowTest : BaseUnitTest() {
         doReturn(true).whenever(networkStatus).isConnected()
 
         productRepository = mock {
-            onBlocking { fetchAndGetProductAggregate(PRODUCT_REMOTE_ID) } doReturn ProductAggregate(product)
+            on { fetchAndGetProductAggregate(PRODUCT_REMOTE_ID) } doReturn ProductAggregate(product)
         }
 
         variationRepository = mock {
-            onBlocking { bulkCreateVariations(any(), any()) } doReturn RequestResult.SUCCESS
+            on { bulkCreateVariations(any(), any()) } doReturn RequestResult.SUCCESS
         }
 
         viewModel = spy(
@@ -243,7 +243,7 @@ class ProductDetailViewModelGenerateVariationFlowTest : BaseUnitTest() {
     fun `Show error and hide progress bar if variation generation failed`() = testBlocking {
         // given
         variationRepository.stub {
-            onBlocking { bulkCreateVariations(any(), any()) } doReturn RequestResult.ERROR
+            on { bulkCreateVariations(any(), any()) } doReturn RequestResult.ERROR
         }
         val variationCandidates = List(5) { id ->
             listOf(VariantOption(id.toLong(), "Number", id.toString()))
@@ -347,7 +347,7 @@ class ProductDetailViewModelGenerateVariationFlowTest : BaseUnitTest() {
 
         // When AddAllVariations fails
         variationRepository.stub {
-            onBlocking { bulkCreateVariations(any(), any()) } doReturn RequestResult.ERROR
+            on { bulkCreateVariations(any(), any()) } doReturn RequestResult.ERROR
         }
         viewModel.onGenerateVariationsConfirmed(variationCandidates)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModelTest.kt
@@ -86,7 +86,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     private val wooCommerceStore: WooCommerceStore = mock()
     private val networkStatus: NetworkStatus = mock()
     private val productRepository: ProductDetailRepository = mock {
-        onBlocking { getCachedVariationCount(any()) } doReturn 0
+        on { getCachedVariationCount(any()) } doReturn 0
     }
     private val productCategoriesRepository: ProductCategoriesRepository = mock()
     private val productTagsRepository: ProductTagsRepository = mock()
@@ -107,11 +107,11 @@ class ProductDetailViewModelTest : BaseUnitTest() {
         on { it.observeSuccessfulUploads(any()) } doReturn emptyFlow()
     }
     private val addonRepository: AddonRepository = mock {
-        onBlocking { hasAnyProductSpecificAddons(any()) } doReturn false
+        on { hasAnyProductSpecificAddons(any()) } doReturn false
     }
 
     private val isBlazeEnabled: IsBlazeEnabled = mock {
-        onBlocking { invoke() } doReturn false
+        on { invoke() } doReturn false
     }
 
     private var savedState: SavedStateHandle =
@@ -141,7 +141,7 @@ class ProductDetailViewModelTest : BaseUnitTest() {
     private val isWindowClassLargeThanCompact: IsWindowClassLargeThanCompact = mock()
     private val determineProductPasswordApi: DetermineProductPasswordApi = mock()
     private val customFieldsRepository: CustomFieldsRepository = mock {
-        onBlocking { hasDisplayableCustomFields(any()) } doReturn false
+        on { hasDisplayableCustomFields(any()) } doReturn false
     }
     private val canAutoAuthenticateInWebView: CanAutoAuthenticateInWebView = mock()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/details/ProductDetailViewModel_AddFlowTest.kt
@@ -82,7 +82,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         on { it.observeSuccessfulUploads(any()) } doReturn emptyFlow()
     }
     private val isBlazeEnabled: IsBlazeEnabled = mock {
-        onBlocking { invoke() } doReturn false
+        on { invoke() } doReturn false
     }
     private var savedState: SavedStateHandle =
         ProductDetailFragmentArgs(
@@ -107,7 +107,7 @@ class ProductDetailViewModel_AddFlowTest : BaseUnitTest() {
         on(it.getSelectedProductType()).then { "simple" }
     }
     private val addonRepository: AddonRepository = mock {
-        onBlocking { hasAnyProductSpecificAddons(any()) } doReturn false
+        on { hasAnyProductSpecificAddons(any()) } doReturn false
     }
 
     private val productUtils = ProductUtils()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/list/ProductListViewModelTest.kt
@@ -481,7 +481,7 @@ class ProductListViewModelTest : BaseUnitTest() {
         createViewModel()
         val selectedProducts = listOf(1L, 2L)
         productRepository.stub {
-            onBlocking { bulkUpdateProductsPrice(any(), any()) } doReturn RequestResult.SUCCESS
+            on { bulkUpdateProductsPrice(any(), any()) } doReturn RequestResult.SUCCESS
         }
 
         // when
@@ -500,7 +500,7 @@ class ProductListViewModelTest : BaseUnitTest() {
         createViewModel()
         val selectedProducts = listOf(1L, 2L)
         productRepository.stub {
-            onBlocking { bulkUpdateProductsPrice(any(), any()) } doReturn RequestResult.ERROR
+            on { bulkUpdateProductsPrice(any(), any()) } doReturn RequestResult.ERROR
         }
 
         // when
@@ -519,7 +519,7 @@ class ProductListViewModelTest : BaseUnitTest() {
         createViewModel()
         val selectedProducts = listOf(1L, 2L)
         productRepository.stub {
-            onBlocking { bulkUpdateProductsStatus(any(), any()) } doReturn RequestResult.SUCCESS
+            on { bulkUpdateProductsStatus(any(), any()) } doReturn RequestResult.SUCCESS
         }
 
         // when
@@ -538,7 +538,7 @@ class ProductListViewModelTest : BaseUnitTest() {
         createViewModel()
         val selectedProducts = listOf(1L, 2L)
         productRepository.stub {
-            onBlocking { bulkUpdateProductsStatus(any(), any()) } doReturn RequestResult.ERROR
+            on { bulkUpdateProductsStatus(any(), any()) } doReturn RequestResult.ERROR
         }
 
         // when

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/selector/ProductListHandlerTest.kt
@@ -21,7 +21,7 @@ internal class ProductListHandlerTest : BaseUnitTest() {
     private val repo: ProductSelectorRepository = mock {
         on(it.observeProducts(any())) doReturn flow { emit(generateSampleProducts()) }
 
-        onBlocking {
+        on {
             (it.fetchProducts(any(), any(), any(), any(), any(), any()))
         } doReturn Result.success(true)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/typesbottomsheet/ProductTypeBottomSheetBuilderTest.kt
@@ -16,7 +16,7 @@ import org.mockito.kotlin.mock
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProductTypeBottomSheetBuilderTest : BaseUnitTest() {
     private val isEligibleForSubscriptions: IsEligibleForSubscriptions = mock {
-        onBlocking { invoke() } doReturn true
+        on { invoke() } doReturn true
     }
     private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
         on { isFeatureSupported(any()) } doReturn true

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/VariationDetailViewModelTest.kt
@@ -68,8 +68,8 @@ class VariationDetailViewModelTest : BaseUnitTest() {
         on { getParameters(any(), any<SavedStateHandle>()) } doReturn (siteParams)
     }
     private val variationRepository: VariationDetailRepository = mock {
-        onBlocking { getVariation(any(), any()) } doReturn TEST_VARIATION
-        onBlocking { fetchVariation(any(), any()) } doAnswer {
+        on { getVariation(any(), any()) } doReturn TEST_VARIATION
+        on { fetchVariation(any(), any()) } doAnswer {
             OnVariationChanged(it.arguments[0] as Long, it.arguments[1] as Long)
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/attributes/AddAttributeTermsViewModelTest.kt
@@ -106,8 +106,8 @@ class AddAttributeTermsViewModelTest : BaseUnitTest() {
         attributeId: Long = defaultAttributeId
     ) {
         termsListHandler = mock {
-            onBlocking { fetchAttributeTerms(attributeId) } doReturn attributesFirstPage
-            onBlocking { loadMore(attributeId) } doReturn attributesSecondPage
+            on { fetchAttributeTerms(attributeId) } doReturn attributesFirstPage
+            on { loadMore(attributeId) } doReturn attributesSecondPage
         }
 
         sut = AddAttributeTermsViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/attributes/AttributeTermsListHandlerTest.kt
@@ -84,11 +84,11 @@ class AttributeTermsListHandlerTest : BaseUnitTest() {
         attributesSecondPage: List<ProductAttributeTerm>
     ) {
         repository = mock {
-            onBlocking {
+            on {
                 fetchGlobalAttributeTerms(defaultAttributeId, 1, defaultPageSize)
             } doReturn attributesFirstPage
 
-            onBlocking {
+            on {
                 fetchGlobalAttributeTerms(defaultAttributeId, 2, defaultPageSize)
             } doReturn attributesSecondPage
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidatesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/domain/GenerateVariationCandidatesTest.kt
@@ -21,7 +21,7 @@ import org.mockito.kotlin.mock
 class GenerateVariationCandidatesTest : BaseUnitTest() {
 
     private var mockedVariationRepository: VariationRepository = mock {
-        onBlocking { getAllVariations(any()) } doReturn emptyList()
+        on { getAllVariations(any()) } doReturn emptyList()
     }
 
     private lateinit var sut: GenerateVariationCandidates
@@ -153,7 +153,7 @@ class GenerateVariationCandidatesTest : BaseUnitTest() {
         }
 
         mockedVariationRepository = mock {
-            onBlocking { getAllVariations(product.remoteId) } doReturn existingVariations
+            on { getAllVariations(product.remoteId) } doReturn existingVariations
         }
         initializeSut()
 
@@ -190,7 +190,7 @@ class GenerateVariationCandidatesTest : BaseUnitTest() {
         }
 
         mockedVariationRepository = mock {
-            onBlocking { getAllVariations(product.remoteId) } doReturn existingVariations
+            on { getAllVariations(product.remoteId) } doReturn existingVariations
         }
         initializeSut()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/picker/VariationPickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/variations/picker/VariationPickerViewModelTest.kt
@@ -39,12 +39,12 @@ class VariationPickerViewModelTest : BaseUnitTest() {
     fun setup() {
         // Initialize mocks
         variationListHandler = mock {
-            onBlocking { getVariationsFlow(any()) } doReturn flowOf(emptyList())
+            on { getVariationsFlow(any()) } doReturn flowOf(emptyList())
         }
 
         val productMock = mock<Product>()
         variationRepository = mock {
-            onBlocking { getProduct(any()) } doReturn productMock
+            on { getProduct(any()) } doReturn productMock
         }
 
         val savedState = navArgs.toSavedStateHandle()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/connection/WooPushNotificationsConnectionStepsViewModelTest.kt
@@ -53,7 +53,7 @@ class WooPushNotificationsConnectionStepsViewModelTest : BaseUnitTest() {
     private val pushNotificationRepository: PushNotificationRepository = mock()
     private val jetpackActivationRepository: JetpackActivationRepository = mock()
     private val checkWCPluginSupport: CheckWooPluginPushNotificationsSupport = mock {
-        onBlocking { invoke(forceRefresh = true) } doReturn CheckWooPluginPushNotificationsSupport.Result.Compatible
+        on { invoke(forceRefresh = true) } doReturn CheckWooPluginPushNotificationsSupport.Result.Compatible
     }
     private val stringUtils: StringUtils = mock()
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/pushnotifications/introduction/WooPushNotificationsIntroductionViewModelTest.kt
@@ -36,7 +36,7 @@ class WooPushNotificationsIntroductionViewModelTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock()
 
     private val fetchJetpackStatus: FetchJetpackStatus = mock {
-        onBlocking { invoke(any(), any(), anyOrNull()) } doReturn Result.success(
+        on { invoke(any(), any(), anyOrNull()) } doReturn Result.success(
             JetpackStatusFetchResponse.Success(
                 JetpackStatus(
                     isJetpackInstalled = false,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewDetailViewModelTest.kt
@@ -212,8 +212,8 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
         val events = mutableListOf<MultiLiveEvent.Event>()
         viewModel.event.observeForever(events::add)
         repository.stub {
-            onBlocking { reply(any(), any(), any()) } doReturn WooResult()
-            onBlocking { getCachedProductReview(review.remoteId) } doReturn review
+            on { reply(any(), any(), any()) } doReturn WooResult()
+            on { getCachedProductReview(review.remoteId) } doReturn review
         }
 
         // when
@@ -232,8 +232,8 @@ class ReviewDetailViewModelTest : BaseUnitTest() {
         val events = mutableListOf<MultiLiveEvent.Event>()
         viewModel.event.observeForever(events::add)
         repository.stub {
-            onBlocking { reply(any(), any(), any()) } doReturn WooResult(WooError(GENERIC_ERROR, UNKNOWN))
-            onBlocking { getCachedProductReview(review.remoteId) } doReturn review
+            on { reply(any(), any(), any()) } doReturn WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+            on { getCachedProductReview(review.remoteId) } doReturn review
         }
 
         // when

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/SitePickerViewModelTest.kt
@@ -78,13 +78,13 @@ class SitePickerViewModelTest : BaseUnitTest() {
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
     private val userEligibilityFetcher: UserEligibilityFetcher = mock()
     private val repository: SitePickerRepository = mock {
-        onBlocking { getSites() } doReturn defaultExpectedSiteList.toMutableList()
+        on { getSites() } doReturn defaultExpectedSiteList.toMutableList()
     }
     private val accountRepository: AccountRepository = mock()
     private val unifiedLoginTracker: UnifiedLoginTracker = mock()
     private val experimentTracker: ExperimentTracker = mock()
     private val getWooVisibleSites: GetWooVisibleSites = mock {
-        onBlocking { invoke() } doReturn defaultExpectedSiteList
+        on { invoke() } doReturn defaultExpectedSiteList
     }
     private val visibleWooSitesDataStore: VisibleWooSitesDataStore = mock()
     private val registerDevice: RegisterDevice = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
@@ -60,18 +60,18 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
     }
 
     private val sitePickerRepository: SitePickerRepository = mock {
-        onBlocking { getSites() } doReturn ALL_WOO_SITES
+        on { getSites() } doReturn ALL_WOO_SITES
     }
     private val selectedSite: SelectedSite = mock {
         on { get() }.thenReturn(CURRENT_SELECTED_SITE)
     }
     private val visibleWooSitesDataStore: VisibleWooSitesDataStore = mock {
-        onBlocking { isSiteVisible(any()) } doReturn flowOf(true)
+        on { isSiteVisible(any()) } doReturn flowOf(true)
     }
     private val trackerWrapper: AnalyticsTrackerWrapper = mock()
     private val wpComPushNotificationStore: WpComPushNotificationStore = mock()
     private val pushNotificationRepository: PushNotificationRepository = mock {
-        onBlocking { getWooPushRegisteredSiteIds() } doReturn emptySet()
+        on { getWooPushRegisteredSiteIds() } doReturn emptySet()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosBookingsViewModelTest.kt
@@ -60,7 +60,7 @@ class WooPosBookingsViewModelTest {
     private val bookingListHandler: BookingListHandler = mock()
     private val bookingsRepository: BookingsRepository = mock {
         on { observeResources() } doAnswer { flowOf(emptyList()) }
-        onBlocking { fetchResources() } doAnswer { Result.success(Unit) }
+        on { fetchResources() } doAnswer { Result.success(Unit) }
     }
     private val dateTimeProvider: DateTimeProvider = mock()
     private val formatPrice: WooPosFormatPrice = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosPaymentStatusResolverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/WooPosPaymentStatusResolverTest.kt
@@ -12,7 +12,7 @@ import org.mockito.kotlin.mock
 class WooPosPaymentStatusResolverTest {
 
     private val paymentStatusResolver: PaymentStatusResolver = mock {
-        onBlocking { resolve(any()) } doReturn PaymentStatus.PAID
+        on { resolve(any()) } doReturn PaymentStatus.PAID
     }
     private val sut = WooPosPaymentStatusResolver(paymentStatusResolver)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/bookings/note/WooPosBookingNoteViewModelTest.kt
@@ -65,8 +65,8 @@ class WooPosBookingNoteViewModelTest {
 
     private val analyticsTracker: WooPosBookingsAnalyticsTracker = mock()
     private val bookingsRepository = mock<BookingsRepository> {
-        onBlocking { getBooking(any()) } doReturn booking
-        onBlocking { updateNote(any(), any()) } doReturn Result.success(Unit)
+        on { getBooking(any()) } doReturn booking
+        on { updateNote(any(), any()) } doReturn Result.success(Unit)
     }
 
     private fun createSavedStateHandle() = SavedStateHandle(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -72,7 +72,7 @@ class WooPosCardPaymentViewModelTest {
     private val analyticsTracker: WooPosCardPaymentAnalyticsTracker = mock()
     private val cardPaymentRepository: WooPosCardPaymentRepository = mock()
     private val priceFormat: WooPosFormatPrice = mock {
-        onBlocking { invoke(any<BigDecimal>()) } doReturn "$0.00"
+        on { invoke(any<BigDecimal>()) } doReturn "$0.00"
     }
 
     private val testOrder: Order = Order.getEmptyOrder(Date(), Date()).copy(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdaterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartItemsUpdaterTest.kt
@@ -38,16 +38,16 @@ class WooPosCartItemsUpdaterTest {
     val coroutinesTestRule = WooPosCoroutineTestRule()
 
     private val formatPrice: WooPosFormatPrice = mock {
-        onBlocking { invoke(argThat { this == BigDecimal("10.0") }) }.thenReturn("10.0$")
-        onBlocking { invoke(argThat { this == BigDecimal("5.0") }) }.thenReturn("5.0$")
+        on { invoke(argThat { this == BigDecimal("10.0") }) }.thenReturn("10.0$")
+        on { invoke(argThat { this == BigDecimal("5.0") }) }.thenReturn("5.0$")
     }
     private val productsCache: WooPosProductsCache = mock()
     private val localCatalogStore: WooPosLocalCatalogStore = mock {
-        onBlocking { deleteProducts(any(), any()) }.thenReturn(Result.success(Unit))
-        onBlocking { deleteVariations(any(), any()) }.thenReturn(Result.success(Unit))
+        on { deleteProducts(any(), any()) }.thenReturn(Result.success(Unit))
+        on { deleteVariations(any(), any()) }.thenReturn(Result.success(Unit))
     }
     private val selectedSite: SelectedSite = mock {
-        onBlocking { getOrNull() }.thenReturn(SiteModel().apply { id = 1 })
+        on { getOrNull() }.thenReturn(SiteModel().apply { id = 1 })
     }
     private val crashLogger: CrashLogging = mock()
     private val logger: WooPosLogWrapper = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModelTest.kt
@@ -83,7 +83,7 @@ class WooPosCartViewModelTest {
         )
     private val getProductById: WooPosGetProductById = mock()
     private val getCouponById: WooPosGetCouponById = mock {
-        onBlocking { invoke(any()) }.thenReturn(
+        on { invoke(any()) }.thenReturn(
             Coupon(
                 1L,
                 "coupon_code",
@@ -103,7 +103,7 @@ class WooPosCartViewModelTest {
     }
 
     private val getCachedStoreCurrency: WooPosGetCachedStoreCurrency = mock {
-        onBlocking { invoke() }.thenReturn("USD")
+        on { invoke() }.thenReturn("USD")
     }
 
     private val getVariationsById: WooPosGetVariationById = mock()
@@ -118,7 +118,7 @@ class WooPosCartViewModelTest {
         }.thenReturn("Item in cart: 1")
     }
     private val formatPrice: WooPosFormatPrice = mock {
-        onBlocking { invoke(eq(BigDecimal("10.0"))) }.thenReturn("10.0$")
+        on { invoke(eq(BigDecimal("10.0"))) }.thenReturn("10.0$")
     }
 
     private val analyticsTracker: WooPosAnalyticsTracker = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsRemoteDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosProductsRemoteDataSourceTest.kt
@@ -112,7 +112,7 @@ class WooPosProductsRemoteDataSourceTest {
         on { get() }.thenReturn(siteModel)
     }
     private val productsCache: WooPosProductsCache = mock {
-        onBlocking { getAll() }.thenReturn(sampleProducts)
+        on { getAll() }.thenReturn(sampleProducts)
     }
     private val productsIndex: WooPosProductsIndex = mock()
     private val productsTypesFilterConfig = WooPosProductsTypesFilterConfig()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
@@ -31,7 +31,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.mockito.kotlin.wheneverBlocking
+import kotlinx.coroutines.runBlocking
 import java.util.Date
 import com.woocommerce.android.model.Coupon as CouponDBModel
 
@@ -52,7 +52,7 @@ class WooPosCouponsListViewStateManagerTest {
     private val couponsDataFlow = MutableStateFlow<List<CouponDBModel>>(emptyList())
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val cachedCouponEnabledChecker: CachedCouponEnabledChecker = mock {
-        onBlocking { isEnabled() } doReturn true
+        on { isEnabled() } doReturn true
     }
 
     private val couponsDataSource: WooPosCouponsDataSource = mock {
@@ -69,7 +69,7 @@ class WooPosCouponsListViewStateManagerTest {
 
     @Before
     fun setup() {
-        wheneverBlocking { getCachedStoreCurrency() }.thenReturn("USD")
+        runBlocking { whenever(getCachedStoreCurrency()).thenReturn("USD") }
         whenever(couponFormatter.formatSummary(anyOrNull(), anyOrNull())).thenAnswer { "" }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/coupons/WooPosCouponsListViewStateManagerTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -31,7 +32,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import kotlinx.coroutines.runBlocking
 import java.util.Date
 import com.woocommerce.android.model.Coupon as CouponDBModel
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -55,8 +55,8 @@ class WooPosProductsViewModelTest {
     val coroutinesTestRule = WooPosCoroutineTestRule()
 
     private val priceFormat: WooPosFormatPrice = mock {
-        onBlocking { invoke(BigDecimal("10.0")) }.thenReturn("$10.0")
-        onBlocking { invoke(BigDecimal("20.0")) }.thenReturn("$20.0")
+        on { invoke(BigDecimal("10.0")) }.thenReturn("$10.0")
+        on { invoke(BigDecimal("20.0")) }.thenReturn("$20.0")
     }
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -29,7 +29,7 @@ class WooPosHomeFloatingToolbarViewModelTest {
     val coroutinesTestRule = WooPosCoroutineTestRule()
 
     private val cardReaderFacade: WooPosCardReaderFacade = mock {
-        onBlocking { readerStatus }.thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+        on { readerStatus }.thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
     }
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val networkStatus: WooPosNetworkStatus = mock()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -242,14 +242,14 @@ class WooPosTotalsViewModelTest {
         )
 
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(Result.success(order))
+            on { createOrderFromCartItems(itemClickedData) }.thenReturn(Result.success(order))
         }
 
         val priceFormat: WooPosFormatPrice = mock {
-            onBlocking { invoke(BigDecimal("1.00")) }.thenReturn("$1.00")
-            onBlocking { invoke(BigDecimal("2.00")) }.thenReturn("$2.00")
-            onBlocking { invoke(BigDecimal("3.00")) }.thenReturn("$3.00")
-            onBlocking { invoke(BigDecimal("5.00")) }.thenReturn("$5.00")
+            on { invoke(BigDecimal("1.00")) }.thenReturn("$1.00")
+            on { invoke(BigDecimal("2.00")) }.thenReturn("$2.00")
+            on { invoke(BigDecimal("3.00")) }.thenReturn("$3.00")
+            on { invoke(BigDecimal("5.00")) }.thenReturn("$5.00")
         }
 
         // WHEN
@@ -307,14 +307,14 @@ class WooPosTotalsViewModelTest {
                 productsTotal = BigDecimal("3.00"),
             )
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
+                on { createOrderFromCartItems(itemClickedData) }.thenReturn(
                     Result.success(order)
                 )
             }
             val priceFormat: WooPosFormatPrice = mock {
-                onBlocking { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
-                onBlocking { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
-                onBlocking { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
+                on { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
+                on { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
+                on { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
             }
 
             // WHEN
@@ -393,7 +393,7 @@ class WooPosTotalsViewModelTest {
         }
         val errorMessage = "Order creation failed"
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
+            on { createOrderFromCartItems(itemClickedData) }.thenReturn(
                 Result.failure(Exception(errorMessage))
             )
         }
@@ -431,7 +431,7 @@ class WooPosTotalsViewModelTest {
         }
         val errorMessage = "Order creation failed"
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
+            on { createOrderFromCartItems(itemClickedData) }.thenReturn(
                 Result.failure(Exception(errorMessage))
             )
         }
@@ -442,10 +442,10 @@ class WooPosTotalsViewModelTest {
 
         val savedState = createMockSavedStateHandle()
         val priceFormat: WooPosFormatPrice = mock {
-            onBlocking { invoke(BigDecimal("1.00")) }.thenReturn("$1.00")
-            onBlocking { invoke(BigDecimal("2.00")) }.thenReturn("$2.00")
-            onBlocking { invoke(BigDecimal("3.00")) }.thenReturn("$3.00")
-            onBlocking { invoke(BigDecimal("5.00")) }.thenReturn("$5.00")
+            on { invoke(BigDecimal("1.00")) }.thenReturn("$1.00")
+            on { invoke(BigDecimal("2.00")) }.thenReturn("$2.00")
+            on { invoke(BigDecimal("3.00")) }.thenReturn("$3.00")
+            on { invoke(BigDecimal("5.00")) }.thenReturn("$5.00")
         }
 
         val viewModel = createViewModel(
@@ -507,13 +507,13 @@ class WooPosTotalsViewModelTest {
         )
 
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(Result.success(order))
+            on { createOrderFromCartItems(itemClickedData) }.thenReturn(Result.success(order))
         }
 
         val priceFormat: WooPosFormatPrice = mock {
-            onBlocking { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
-            onBlocking { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
-            onBlocking { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
+            on { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
+            on { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
+            on { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
         }
 
         // WHEN
@@ -543,7 +543,7 @@ class WooPosTotalsViewModelTest {
         }
         val errorMessage = "Order creation failed"
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
+            on { createOrderFromCartItems(itemClickedData) }.thenReturn(
                 Result.failure(
                     WooException(
                         WooError(
@@ -631,14 +631,14 @@ class WooPosTotalsViewModelTest {
         }
         val order = createNonEmptyOrder(listOf(1L))
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
+            on { createOrderFromCartItems(itemClickedData) }.thenReturn(
                 Result.success(order)
             )
         }
         val priceFormat: WooPosFormatPrice = mock {
-            onBlocking { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
-            onBlocking { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
-            onBlocking { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
+            on { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
+            on { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
+            on { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
         }
 
         // WHEN
@@ -1181,12 +1181,12 @@ class WooPosTotalsViewModelTest {
                 productsTotal = BigDecimal("0.00"),
             )
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
+                on { createOrderFromCartItems(itemClickedData) }.thenReturn(
                     Result.success(order)
                 )
             }
             val priceFormat: WooPosFormatPrice = mock {
-                onBlocking { invoke(BigDecimal("0.00")) }.thenReturn("0.00$")
+                on { invoke(BigDecimal("0.00")) }.thenReturn("0.00$")
             }
 
             // WHEN
@@ -1240,14 +1240,14 @@ class WooPosTotalsViewModelTest {
                 productsTotal = BigDecimal("3.00"),
             )
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(
+                on { createOrderFromCartItems(itemClickedData) }.thenReturn(
                     Result.success(order)
                 )
             }
             val priceFormat: WooPosFormatPrice = mock {
-                onBlocking { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
-                onBlocking { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
-                onBlocking { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
+                on { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
+                on { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
+                on { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
             }
 
             // WHEN
@@ -1457,7 +1457,7 @@ class WooPosTotalsViewModelTest {
         }
         val wooError = WooErrorTestUtils.createInvalidCouponError()
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderFromCartItems(any()) }.thenReturn(
+            on { createOrderFromCartItems(any()) }.thenReturn(
                 Result.failure(WooException(wooError))
             )
         }
@@ -1481,7 +1481,7 @@ class WooPosTotalsViewModelTest {
         }
         val wooError = WooErrorTestUtils.createInvalidCouponError()
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderFromCartItems(any()) }.thenReturn(
+            on { createOrderFromCartItems(any()) }.thenReturn(
                 Result.failure(WooException(wooError))
             )
         }
@@ -1508,7 +1508,7 @@ class WooPosTotalsViewModelTest {
                 variationId = 101L
             )
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(any()) }.thenReturn(
+                on { createOrderFromCartItems(any()) }.thenReturn(
                     Result.failure(WooException(wooError))
                 )
             }
@@ -1541,7 +1541,7 @@ class WooPosTotalsViewModelTest {
             }
             val wooError = WooErrorTestUtils.createInvalidVariationIdError(variationId = 101L)
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(any()) }.thenReturn(
+                on { createOrderFromCartItems(any()) }.thenReturn(
                     Result.failure(WooException(wooError))
                 )
             }
@@ -1572,7 +1572,7 @@ class WooPosTotalsViewModelTest {
             }
             val wooError = WooErrorTestUtils.createInvalidVariationIdError()
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(any()) }.thenReturn(
+                on { createOrderFromCartItems(any()) }.thenReturn(
                     Result.failure(WooException(wooError))
                 )
             }
@@ -1605,7 +1605,7 @@ class WooPosTotalsViewModelTest {
             }
             val wooError = WooErrorTestUtils.createInvalidVariationIdError()
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(any()) }.thenReturn(
+                on { createOrderFromCartItems(any()) }.thenReturn(
                     Result.failure(WooException(wooError))
                 )
             }
@@ -1664,11 +1664,11 @@ class WooPosTotalsViewModelTest {
         )
 
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderFromCartItems(itemClickedData) }.thenReturn(Result.success(order))
+            on { createOrderFromCartItems(itemClickedData) }.thenReturn(Result.success(order))
         }
 
         val priceFormat: WooPosFormatPrice = mock {
-            onBlocking { invoke(any()) }.thenReturn("$10.00")
+            on { invoke(any()) }.thenReturn("$10.00")
         }
 
         // WHEN
@@ -1696,7 +1696,7 @@ class WooPosTotalsViewModelTest {
             }
 
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(itemClickedData) }.doSuspendableAnswer {
+                on { createOrderFromCartItems(itemClickedData) }.doSuspendableAnswer {
                     delay(2000)
                     Result.success(createNonEmptyOrder())
                 }
@@ -1731,7 +1731,7 @@ class WooPosTotalsViewModelTest {
 
             val order = Order.getEmptyOrder(Date(), Date()).copy(id = 123L)
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(any()) }.thenReturn(Result.success(order))
+                on { createOrderFromCartItems(any()) }.thenReturn(Result.success(order))
             }
 
             // WHEN
@@ -1764,7 +1764,7 @@ class WooPosTotalsViewModelTest {
 
         val order = Order.getEmptyOrder(Date(), Date()).copy(id = 123L)
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderFromCartItems(any()) }.thenReturn(Result.success(order))
+            on { createOrderFromCartItems(any()) }.thenReturn(Result.success(order))
         }
         val viewModel = createViewModel(
             parentToChildrenEventReceiver = parentToChildrenEventReceiver,
@@ -1796,7 +1796,7 @@ class WooPosTotalsViewModelTest {
         }
         val order = Order.getEmptyOrder(Date(), Date()).copy(id = 123L)
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking { createOrderFromCartItems(any()) }.thenReturn(Result.success(order))
+            on { createOrderFromCartItems(any()) }.thenReturn(Result.success(order))
         }
 
         val viewModel = createViewModel(
@@ -1830,7 +1830,7 @@ class WooPosTotalsViewModelTest {
                 variationId = variationId
             )
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(any()) }.thenReturn(
+                on { createOrderFromCartItems(any()) }.thenReturn(
                     Result.failure(WooException(wooError))
                 )
             }
@@ -1871,8 +1871,8 @@ class WooPosTotalsViewModelTest {
 
             val order = createNonEmptyOrder(productIds = listOf(1L)) // Missing product 999L
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(any()) }.thenReturn(Result.success(order))
-                onBlocking { getOrderById(any()) }.thenReturn(order)
+                on { createOrderFromCartItems(any()) }.thenReturn(Result.success(order))
+                on { getOrderById(any()) }.thenReturn(order)
             }
 
             val viewModel = createViewModel(
@@ -1923,8 +1923,8 @@ class WooPosTotalsViewModelTest {
             )
 
             val totalsRepository: WooPosTotalsRepository = mock {
-                onBlocking { createOrderFromCartItems(any()) }.thenReturn(Result.success(order))
-                onBlocking { getOrderById(any()) }.thenReturn(order)
+                on { createOrderFromCartItems(any()) }.thenReturn(Result.success(order))
+                on { getOrderById(any()) }.thenReturn(order)
             }
 
             val viewModel = createViewModel(
@@ -2049,15 +2049,15 @@ class WooPosTotalsViewModelTest {
             couponLines = couponLines,
         )
         val totalsRepository: WooPosTotalsRepository = mock {
-            onBlocking {
+            on {
                 createOrderFromCartItems(itemClickedData)
             }.thenReturn(Result.success(order))
         }
         val priceFormat: WooPosFormatPrice = mock {
-            onBlocking { invoke(BigDecimal("1.00")) }.thenReturn("1.00$")
-            onBlocking { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
-            onBlocking { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
-            onBlocking { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
+            on { invoke(BigDecimal("1.00")) }.thenReturn("1.00$")
+            on { invoke(BigDecimal("2.00")) }.thenReturn("2.00$")
+            on { invoke(BigDecimal("3.00")) }.thenReturn("3.00$")
+            on { invoke(BigDecimal("5.00")) }.thenReturn("5.00$")
         }
         val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
             on { events }.thenReturn(parentToChildrenEventFlow)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/variations/WooPosVariationsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/variations/WooPosVariationsViewModelTest.kt
@@ -55,10 +55,10 @@ class WooPosVariationsViewModelTest {
     private val fromChildToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val resourceProvider: ResourceProvider = mock()
     private val priceFormat: WooPosFormatPrice = mock {
-        onBlocking { invoke(BigDecimal("10.0")) }.thenReturn("$10.0")
-        onBlocking { invoke(BigDecimal("20.0")) }.thenReturn("$20.0")
-        onBlocking { invoke(BigDecimal("0.00")) }.thenReturn("$0.00")
-        onBlocking { invoke(null) }.thenReturn("$0.00")
+        on { invoke(BigDecimal("10.0")) }.thenReturn("$10.0")
+        on { invoke(BigDecimal("20.0")) }.thenReturn("$20.0")
+        on { invoke(BigDecimal("0.00")) }.thenReturn("$0.00")
+        on { invoke(null) }.thenReturn("$0.00")
     }
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val mapper: WooPosVariationMapper = mock {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/EnqueueSendingEncryptedLogsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/crashlogging/EnqueueSendingEncryptedLogsTest.kt
@@ -27,7 +27,7 @@ class EnqueueSendingEncryptedLogsTest : BaseUnitTest() {
     private val tempFile = File("temp")
 
     private val encryptedLogsFileProvider: EncryptedLogsFileProvider = mock {
-        onBlocking { provide() } doReturn tempFile
+        on { provide() } doReturn tempFile
     }
 
     @Before

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapperTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/order/OrderDtoMapperTest.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 
 internal class OrderDtoMapperTest {
     private val stripOrder: StripOrder = mock {
-        onBlocking { invoke(any()) }.then(AdditionalAnswers.returnsFirstArg<OrderEntity>())
+        on { invoke(any()) }.then(AdditionalAnswers.returnsFirstArg<OrderEntity>())
     }
     private val stripOrderMetaData: StripOrderMetaData = mock()
 

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/product/ProductRestClientTest.kt
@@ -30,7 +30,7 @@ class ProductRestClientTest {
     private val productId = 5L
     private val site = SiteModel()
     private val wooNetwork: WooNetwork = mock {
-        onBlocking {
+        on {
             executePostGsonRequest(
                 any(), any(), eq(BatchProductApiResponse::class.java), any()
             )

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/OrderUpdateStoreTest.kt
@@ -50,7 +50,7 @@ class OrderUpdateStoreTest {
     }
     private val orderSummaryDao: OrderSummaryDao = mock()
     private val ordersDaoDecorator: OrdersDaoDecorator = mock {
-        onBlocking { getOrder(TEST_REMOTE_ORDER_ID, TEST_LOCAL_SITE_ID) } doReturn initialOrder
+        on { getOrder(TEST_REMOTE_ORDER_ID, TEST_LOCAL_SITE_ID) } doReturn initialOrder
     }
     private val metaDataDao: MetaDataDao = mock()
 
@@ -80,7 +80,7 @@ class OrderUpdateStoreTest {
 
         setUp {
             orderRestClient = mock {
-                onBlocking { updateCustomerOrderNote(initialOrder, site, UPDATED_CUSTOMER_NOTE) }.doReturn(
+                on { updateCustomerOrderNote(initialOrder, site, UPDATED_CUSTOMER_NOTE) }.doReturn(
                         RemoteOrderPayload.Updating(
                                 updatedOrder,
                                 site
@@ -115,7 +115,7 @@ class OrderUpdateStoreTest {
         val specificOrderError = "order error"
         setUp {
             orderRestClient = mock {
-                onBlocking { updateCustomerOrderNote(initialOrder, site, UPDATED_CUSTOMER_NOTE) }.doReturn(
+                on { updateCustomerOrderNote(initialOrder, site, UPDATED_CUSTOMER_NOTE) }.doReturn(
                         RemoteOrderPayload.Updating(
                                 error = OrderError(message = specificOrderError),
                                 initialOrder,
@@ -190,7 +190,7 @@ class OrderUpdateStoreTest {
 
         setUp {
             orderRestClient = mock {
-                onBlocking {
+                on {
                     updateBothOrderAddresses(
                             initialOrder,
                             site,
@@ -229,7 +229,7 @@ class OrderUpdateStoreTest {
 
         setUp {
             orderRestClient = mock {
-                onBlocking {
+                on {
                     updateShippingAddress(
                             initialOrder,
                             site,
@@ -261,7 +261,7 @@ class OrderUpdateStoreTest {
         // given
         setUp {
             orderRestClient = mock {
-                onBlocking {
+                on {
                     updateShippingAddress(
                             initialOrder, site, emptyShippingDto.copy(first_name = UPDATED_SHIPPING_FIRST_NAME)
                     )
@@ -359,7 +359,7 @@ class OrderUpdateStoreTest {
         // given
         setUp {
             orderRestClient = mock {
-                onBlocking {
+                on {
                     updateBillingAddress(
                             initialOrder, site, emptyBillingDto
                     )
@@ -389,7 +389,7 @@ class OrderUpdateStoreTest {
         // given
         setUp {
             orderRestClient = mock {
-                onBlocking {
+                on {
                     updateBillingAddress(
                             initialOrder, site, emptyBillingDto.copy(email = "custom@mail.com")
                     )
@@ -431,7 +431,7 @@ class OrderUpdateStoreTest {
 
         setUp {
             orderRestClient = mock {
-                onBlocking {
+                on {
                     createOrder(any(), any(), anyOrNull())
                 }.doReturn(
                     WooPayload(newOrder)
@@ -473,7 +473,7 @@ class OrderUpdateStoreTest {
 
         setUp {
             orderRestClient = mock {
-                onBlocking {
+                on {
                     updateOrder(any(), any(), any())
                 }.doReturn(
                     WooPayload(updatedOrder)
@@ -511,7 +511,7 @@ class OrderUpdateStoreTest {
     fun `should delete local copy of order when delete request succeeds`(): Unit = runBlocking {
         setUp {
             orderRestClient = mock {
-                onBlocking {
+                on {
                     deleteOrder(any(), any(), any())
                 }.doReturn(
                     WooPayload(Unit)

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/CouponStoreTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/CouponStoreTest.kt
@@ -38,7 +38,7 @@ class CouponStoreTest {
 
     private val transactionExecutor: TransactionExecutor = mock {
         val blockArg1 = argumentCaptor<suspend () -> Unit>()
-        onBlocking { executeInTransaction(blockArg1.capture()) }.then {
+        on { executeInTransaction(blockArg1.capture()) }.then {
             runBlocking {
                 blockArg1.lastValue.invoke()
             }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/CouponStoreTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/store/CouponStoreTest.kt
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -36,12 +36,11 @@ class CouponStoreTest {
     @Mock private lateinit var restClient: CouponRestClient
     @Mock private lateinit var couponsDao: CouponsDao
 
+    @Suppress("UNCHECKED_CAST")
     private val transactionExecutor: TransactionExecutor = mock {
-        val blockArg1 = argumentCaptor<suspend () -> Unit>()
-        on { executeInTransaction(blockArg1.capture()) }.then {
-            runBlocking {
-                blockArg1.lastValue.invoke()
-            }
+        on { executeInTransaction<Unit>(any()) } doAnswer { invocation ->
+            val block = invocation.arguments[0] as suspend () -> Unit
+            runBlocking { block() }
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace `onBlocking` with `on` across 95 test files (~390 occurrences) — deprecated in mockito-kotlin 6.2.3
- Replace `wheneverBlocking` with `runBlocking { whenever(...) }` in 3 test files
- Fix `BookingTeamMemberFilterViewModelTest` to use `doSuspendableAnswer` with `delay()` instead of `doAnswer` with `Thread.sleep()`, which no longer works with `on`-based suspend function stubbing

## Test plan
- [x] `./gradlew testWasabiDebugUnitTest` passes (6571 tests, 0 failures)
- [x] `./gradlew :WooCommerce:compileWasabiDebugUnitTestKotlin` compiles with zero warnings under `-Werror`