### PR TITLE
Update outdated GitHub Actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   dangermattic:
     if: ${{ (github.event.pull_request.draft == false) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@1.2.0
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1
     with:
       org-slug: "automattic"
       pipeline-slug: "woocommerce-android"

--- a/.github/workflows/validate-issues.yml
+++ b/.github/workflows/validate-issues.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-labels-on-issues:
-    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@v1.0.0
+    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@v1
     with:
       label-format-list: '[
         "^type: .+",


### PR DESCRIPTION
Fixes AINFRA-2297

## Summary
- Upgrade `actions/setup-java` from v3 to v4
- Upgrade `dependabot/fetch-metadata` from v2 to v3
- Update dangermattic reusable workflows to `@v1`

## Test plan
- [ ] Verify dependency submission workflow runs successfully
- [ ] Verify dependabot auto-merge workflow works on next dependabot PR
- [ ] Verify Danger workflow runs on next PR

🤖 Generated with [Claude Code](https://claude.ai/code)