### PR TITLE
[WOOMOB-2716] Show notifications settings for all sites when Woo PNs are available

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -29,6 +29,6 @@ interface MainSettingsContract {
         fun showLatestAnnouncementOption(announcement: FeatureAnnouncement)
         fun setEnablePushNotificationsOptionVisible(isVisible: Boolean)
         fun handleJetpackInstallOption(supportsJetpackInstallation: Boolean)
-        fun handleApplicationPasswordsSettings()
+        fun handleApplicationPasswordsSettings(shouldHideNotifications: Boolean)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -13,7 +13,6 @@ interface MainSettingsContract {
         fun setupAnnouncementOption()
         fun setupEnablePushNotificationsOption()
         fun setupJetpackInstallOption()
-        fun setupApplicationPasswordsSettings()
         fun onNotificationsClicked()
 
         val isDomainOptionVisible: Boolean
@@ -29,6 +28,5 @@ interface MainSettingsContract {
         fun showLatestAnnouncementOption(announcement: FeatureAnnouncement)
         fun setEnablePushNotificationsOptionVisible(isVisible: Boolean)
         fun handleJetpackInstallOption(supportsJetpackInstallation: Boolean)
-        fun handleApplicationPasswordsSettings(shouldHideNotifications: Boolean)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -29,7 +29,6 @@ import com.woocommerce.android.analytics.AnalyticsEvent.SETTINGS_PRIVACY_SETTING
 import com.woocommerce.android.analytics.AnalyticsEvent.SETTINGS_WE_ARE_HIRING_BUTTON_TAPPED
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.databinding.FragmentSettingsMainBinding
-import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.extensions.show
 import com.woocommerce.android.model.FeatureAnnouncement
@@ -312,8 +311,8 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         }
     }
 
-    override fun handleApplicationPasswordsSettings() {
-        binding.optionNotifications.hide()
+    override fun handleApplicationPasswordsSettings(shouldHideNotifications: Boolean) {
+        binding.optionNotifications.isVisible = !shouldHideNotifications
     }
 
     private fun showThemeChooser() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -201,7 +201,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         presenter.setupAnnouncementOption()
         presenter.setupEnablePushNotificationsOption()
         presenter.setupJetpackInstallOption()
-        presenter.setupApplicationPasswordsSettings()
 
         binding.optionEnablePushNotifications.setOnClickListener {
             AnalyticsTracker.track(AnalyticsEvent.SETTINGS_PUSH_NOTIFICATIONS_BUTTON_TAP)
@@ -309,10 +308,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
                     )
                 )
         }
-    }
-
-    override fun handleApplicationPasswordsSettings(shouldHideNotifications: Boolean) {
-        binding.optionNotifications.isVisible = !shouldHideNotifications
     }
 
     private fun showThemeChooser() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -13,6 +13,8 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.StringUtils
 import kotlinx.coroutines.CoroutineScope
@@ -36,7 +38,8 @@ class MainSettingsPresenter @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val getWooVersion: GetWooCorePluginCachedVersion,
     private val appPrefs: AppPrefsWrapper,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
+    private val featureFlagRepository: FeatureFlagRepository,
 ) : MainSettingsContract.Presenter {
     override val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var appSettingsFragmentView: MainSettingsContract.View? = null
@@ -85,7 +88,9 @@ class MainSettingsPresenter @Inject constructor(
 
     override fun setupApplicationPasswordsSettings() {
         if (selectedSite.connectionType == SiteConnectionType.ApplicationPasswords) {
-            appSettingsFragmentView?.handleApplicationPasswordsSettings()
+            val shouldHideNotifications = !featureFlagRepository
+                .isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2)
+            appSettingsFragmentView?.handleApplicationPasswordsSettings(shouldHideNotifications)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -13,8 +13,6 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
-import com.woocommerce.android.util.FeatureFlag
-import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.StringUtils
 import kotlinx.coroutines.CoroutineScope
@@ -38,8 +36,7 @@ class MainSettingsPresenter @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val getWooVersion: GetWooCorePluginCachedVersion,
     private val appPrefs: AppPrefsWrapper,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
-    private val featureFlagRepository: FeatureFlagRepository,
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper
 ) : MainSettingsContract.Presenter {
     override val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var appSettingsFragmentView: MainSettingsContract.View? = null
@@ -84,14 +81,6 @@ class MainSettingsPresenter @Inject constructor(
                 (it == SiteConnectionType.ApplicationPasswords && !appPrefs.isSiteWPComSuspended)
         }
         appSettingsFragmentView?.handleJetpackInstallOption(supportsJetpackInstallation = supportsJetpackInstallation)
-    }
-
-    override fun setupApplicationPasswordsSettings() {
-        if (selectedSite.connectionType == SiteConnectionType.ApplicationPasswords) {
-            val shouldHideNotifications = !featureFlagRepository
-                .isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2)
-            appSettingsFragmentView?.handleApplicationPasswordsSettings(shouldHideNotifications)
-        }
     }
 
     override fun onNotificationsClicked() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
@@ -13,8 +13,6 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
-import com.woocommerce.android.util.FeatureFlag
-import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -23,9 +21,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -48,7 +44,6 @@ class MainSettingsPresenterTest : BaseUnitTest() {
     private val getWooVersion: GetWooCorePluginCachedVersion = mock()
     private val appPrefs: AppPrefsWrapper = mock()
     private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock()
-    private val featureFlagRepository: FeatureFlagRepository = mock()
     private val shouldShowEnablePushNotificationsUi: ShouldShowEnablePushNotificationsUi = mock()
 
     private val view: MainSettingsContract.View = mock()
@@ -68,8 +63,7 @@ class MainSettingsPresenterTest : BaseUnitTest() {
             analyticsTracker = analyticsTracker,
             getWooVersion = getWooVersion,
             appPrefs = appPrefs,
-            ciabSiteGateKeeper = ciabSiteGateKeeper,
-            featureFlagRepository = featureFlagRepository,
+            ciabSiteGateKeeper = ciabSiteGateKeeper
         )
         presenter.takeView(view)
     }
@@ -207,44 +201,4 @@ class MainSettingsPresenterTest : BaseUnitTest() {
         advanceUntilIdle()
         assertThat(shouldShowPushNotificationOption.subscriptionCount.value).isEqualTo(0)
     }
-
-    @Test
-    fun `given app passwords and M2 disabled, when setup application password settings, then hide notifications`() =
-        testBlocking {
-            setup {
-                whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
-                whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2))
-                    .thenReturn(false)
-            }
-
-            presenter.setupApplicationPasswordsSettings()
-
-            verify(view).handleApplicationPasswordsSettings(shouldHideNotifications = true)
-        }
-
-    @Test
-    fun `given app passwords and M2 enabled, when setup application password settings, then keep notifications visible`() =
-        testBlocking {
-            setup {
-                whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
-                whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2))
-                    .thenReturn(true)
-            }
-
-            presenter.setupApplicationPasswordsSettings()
-
-            verify(view).handleApplicationPasswordsSettings(shouldHideNotifications = false)
-        }
-
-    @Test
-    fun `given non app passwords site, when setup application password settings, then do not handle notifications visibility`() =
-        testBlocking {
-            setup {
-                whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.Jetpack)
-            }
-
-            presenter.setupApplicationPasswordsSettings()
-
-            verify(view, never()).handleApplicationPasswordsSettings(any())
-        }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
@@ -13,14 +13,19 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -43,6 +48,7 @@ class MainSettingsPresenterTest : BaseUnitTest() {
     private val getWooVersion: GetWooCorePluginCachedVersion = mock()
     private val appPrefs: AppPrefsWrapper = mock()
     private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock()
+    private val featureFlagRepository: FeatureFlagRepository = mock()
     private val shouldShowEnablePushNotificationsUi: ShouldShowEnablePushNotificationsUi = mock()
 
     private val view: MainSettingsContract.View = mock()
@@ -62,7 +68,8 @@ class MainSettingsPresenterTest : BaseUnitTest() {
             analyticsTracker = analyticsTracker,
             getWooVersion = getWooVersion,
             appPrefs = appPrefs,
-            ciabSiteGateKeeper = ciabSiteGateKeeper
+            ciabSiteGateKeeper = ciabSiteGateKeeper,
+            featureFlagRepository = featureFlagRepository,
         )
         presenter.takeView(view)
     }
@@ -198,6 +205,46 @@ class MainSettingsPresenterTest : BaseUnitTest() {
 
         presenter.dropView()
         advanceUntilIdle()
-        assertEquals(0, shouldShowPushNotificationOption.subscriptionCount.value)
+        assertThat(shouldShowPushNotificationOption.subscriptionCount.value).isEqualTo(0)
     }
+
+    @Test
+    fun `given app passwords and M2 disabled, when setup application password settings, then hide notifications`() =
+        testBlocking {
+            setup {
+                whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
+                whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2))
+                    .thenReturn(false)
+            }
+
+            presenter.setupApplicationPasswordsSettings()
+
+            verify(view).handleApplicationPasswordsSettings(shouldHideNotifications = true)
+        }
+
+    @Test
+    fun `given app passwords and M2 enabled, when setup application password settings, then keep notifications visible`() =
+        testBlocking {
+            setup {
+                whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
+                whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2))
+                    .thenReturn(true)
+            }
+
+            presenter.setupApplicationPasswordsSettings()
+
+            verify(view).handleApplicationPasswordsSettings(shouldHideNotifications = false)
+        }
+
+    @Test
+    fun `given non app passwords site, when setup application password settings, then do not handle notifications visibility`() =
+        testBlocking {
+            setup {
+                whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.Jetpack)
+            }
+
+            presenter.setupApplicationPasswordsSettings()
+
+            verify(view, never()).handleApplicationPasswordsSettings(any())
+        }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2716

Keep the Settings notifications row available for application-password sites when `WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2` is enabled. This preserves the existing hide behavior when M2 is off, while restoring a notification management entry point once the self-driven push notifications flow is available.

### Test Steps
1. Enable `WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2` for a site that uses application-password authentication.
2. Open Settings.
3. Verify the `Notifications` row is visible.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.