### PR TITLE
[WOOMOB-2723] Unregister/register Woo push tokens when hiding/unhiding sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -239,29 +239,32 @@ class PushNotificationRepository @Inject constructor(
         }
     }
 
-    private suspend fun unregisterWooCoreTokensFromServer() = coroutineScope {
+    suspend fun unregisterWooPushTokenForSite(site: SiteModel): Result<Unit> {
         val preferences = pushNotificationsDataStore.data.first()
+        val registration = preferences.getPushRegistration(site.siteId) ?: return Result.success(Unit)
+
+        val result = wooPushNotificationsStore.deletePushToken(site, registration.tokenId)
+        if (result.isError) {
+            WooLog.w(
+                WooLog.T.NOTIFICATIONS,
+                "Failed to delete push token for site ${site.siteId}: ${result.error?.message}"
+            )
+            return Result.failure(WooException(result.error))
+        }
+
+        pushNotificationsDataStore.edit {
+            it.clearPushRegistration(site.siteId)
+        }
+        WooLog.d(WooLog.T.NOTIFICATIONS, "Woo Core push token deleted for site ${site.siteId}")
+        return Result.success(Unit)
+    }
+
+    private suspend fun unregisterWooCoreTokensFromServer() = coroutineScope {
         val sites = withContext(coroutineDispatchers.io) {
             wooCommerceStore.getWooCommerceSites()
         }
 
-        val deleteJobs = sites.mapNotNull { site ->
-            val registration = preferences.getPushRegistration(site.siteId) ?: return@mapNotNull null
-            async {
-                val result = wooPushNotificationsStore.deletePushToken(site, registration.tokenId)
-                if (result.isError) {
-                    WooLog.w(
-                        WooLog.T.NOTIFICATIONS,
-                        "Failed to delete push token for site ${site.siteId}: ${result.error?.message}"
-                    )
-                } else {
-                    pushNotificationsDataStore.edit {
-                        it.clearPushRegistration(site.siteId)
-                    }
-                    WooLog.d(WooLog.T.NOTIFICATIONS, "Woo Core push token deleted for site ${site.siteId}")
-                }
-            }
-        }
+        val deleteJobs = sites.map { async { unregisterWooPushTokenForSite(it) } }
 
         deleteJobs.awaitAll()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.sitepicker.sitevisibility
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR
@@ -9,6 +10,8 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.push.PushNotificationRepository
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.sitepicker.SitePickerRepository
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
@@ -30,9 +33,12 @@ class WooSitesVisibilityViewModel @Inject constructor(
     private val visibleSitesDataStore: VisibleWooSitesDataStore,
     private val notificationsStore: WpComPushNotificationStore,
     private val pushNotificationRepository: PushNotificationRepository,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val featureFlagRepository: FeatureFlagRepository,
     private val trackerWrapper: AnalyticsTrackerWrapper,
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
+    private var availableWooSites: List<SiteModel> = emptyList()
     private var initiallySelectedSiteIds: List<Long> = emptyList()
     private val _wooStoresState = MutableStateFlow(
         WooStoresUiState(
@@ -46,10 +52,11 @@ class WooSitesVisibilityViewModel @Inject constructor(
 
     init {
         launch {
+            availableWooSites = sitePickerRepository.getSites()
+                .filter { it.hasWooCommerce && it.siteId != selectedSite.get().siteId }
+
             _wooStoresState.value = _wooStoresState.value.copy(
-                wooStores = sitePickerRepository.getSites()
-                    .filter { it.hasWooCommerce && it.siteId != selectedSite.get().siteId }
-                    .map { it.toWooStoreUi(isSiteVisible(it.siteId)) }
+                wooStores = availableWooSites.map { it.toWooStoreUi(isSiteVisible(it.siteId)) }
             )
             initiallySelectedSiteIds = _wooStoresState.value.wooStores
                 .filter { it.isSelected }
@@ -70,49 +77,30 @@ class WooSitesVisibilityViewModel @Inject constructor(
         )
         _wooStoresState.value = _wooStoresState.value.copy(isLoading = true)
         launch {
-            val wooPushRegisteredSiteIds = pushNotificationRepository.getWooPushRegisteredSiteIds()
-            val sitesToUpdate = _wooStoresState.value.wooStores
-                // Exclude sites using Woo Push Notifications System
-                .filterNot { it.siteId in wooPushRegisteredSiteIds }
-                .map {
-                    SiteNotificationSetting(
-                        siteId = it.siteId,
-                        newCommentEnabled = it.isSelected,
-                        storeOrderEnabled = it.isSelected
-                    )
-                }
+            try {
+                runCatching {
+                    val currentSelectedSiteIds = _wooStoresState.value.wooStores
+                        .filter { it.isSelected }
+                        .map { it.siteId }
+                        .toSet()
+                    val initialSelectedSiteIds = initiallySelectedSiteIds.toSet()
+                    val hiddenSiteIds = initialSelectedSiteIds - currentSelectedSiteIds
+                    val unhiddenSiteIds = currentSelectedSiteIds - initialSelectedSiteIds
+                    val sitesById = availableWooSites.associateBy { it.siteId }
+                    val wooPushRegisteredSiteIds = pushNotificationRepository.getWooPushRegisteredSiteIds()
 
-            if (sitesToUpdate.isEmpty()) {
-                onSaveSuccess()
-            } else {
-                notificationsStore.updateNotificationSettingsFor(sitesToUpdate).fold(
-                    onSuccess = { onSaveSuccess() },
-                    onFailure = {
-                        if (it is NotificationSettingsUpdateError) {
-                            trackerWrapper.track(
-                                stat = AnalyticsEvent.SITE_PICKER_LIST_SAVING_FAILURE,
-                                properties = mapOf(KEY_ERROR to it.type.toString())
-                            )
-                        }
-                        triggerEvent(
-                            Event.ShowDialog(
-                                titleId = R.string.site_picker_edit_store_list_error_title,
-                                positiveButtonId = R.string.retry,
-                                positiveBtnAction = { dialog, _ ->
-                                    dialog.dismiss()
-                                    onSaveTapped()
-                                },
-                                negativeButtonId = R.string.cancel,
-                                negativeBtnAction = { dialog, _ ->
-                                    dialog.dismiss()
-                                    triggerEvent(Exit)
-                                }
-                            )
-                        )
-                    }
-                )
+                    updateWpComNotificationSettings(wooPushRegisteredSiteIds)
+                    syncWooPushVisibilityChanges(
+                        hiddenSiteIds = hiddenSiteIds,
+                        unhiddenSiteIds = unhiddenSiteIds,
+                        wooPushRegisteredSiteIds = wooPushRegisteredSiteIds,
+                        sitesById = sitesById
+                    )
+                    onSaveSuccess()
+                }.onFailure(::showSaveFailureDialog)
+            } finally {
+                _wooStoresState.value = _wooStoresState.value.copy(isLoading = false)
             }
-            _wooStoresState.value = _wooStoresState.value.copy(isLoading = false)
         }
     }
 
@@ -122,6 +110,76 @@ class WooSitesVisibilityViewModel @Inject constructor(
             _wooStoresState.value.wooStores.associate { it.siteId to it.isSelected }
         )
         triggerEvent(ExitWithResult(data = true))
+    }
+
+    private suspend fun updateWpComNotificationSettings(wooPushRegisteredSiteIds: Set<Long>) {
+        val sitesToUpdate = _wooStoresState.value.wooStores
+            .filterNot { it.siteId in wooPushRegisteredSiteIds }
+            .map {
+                SiteNotificationSetting(
+                    siteId = it.siteId,
+                    newCommentEnabled = it.isSelected,
+                    storeOrderEnabled = it.isSelected
+                )
+            }
+
+        if (sitesToUpdate.isNotEmpty()) {
+            notificationsStore.updateNotificationSettingsFor(sitesToUpdate).getOrThrow()
+        }
+    }
+
+    private suspend fun syncWooPushVisibilityChanges(
+        hiddenSiteIds: Set<Long>,
+        unhiddenSiteIds: Set<Long>,
+        wooPushRegisteredSiteIds: Set<Long>,
+        sitesById: Map<Long, SiteModel>
+    ) {
+        hiddenSiteIds
+            .filter { it in wooPushRegisteredSiteIds }
+            .mapNotNull(sitesById::get)
+            .forEach { pushNotificationRepository.unregisterWooPushTokenForSite(it) }
+
+        if (!featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)) {
+            return
+        }
+
+        val token = appPrefsWrapper.getFCMToken().takeIf { it.isNotEmpty() } ?: return
+
+        unhiddenSiteIds
+            .filterNot { it in wooPushRegisteredSiteIds }
+            .mapNotNull(sitesById::get)
+            .filter { pushNotificationRepository.shouldRegisterWooPushForSite(token, it.siteId) }
+            .forEach {
+                pushNotificationRepository.registerPushTokenInWooCoreSystem(
+                    token = token,
+                    selectedSite = it,
+                    allowWpComFallback = false
+                )
+            }
+    }
+
+    private fun showSaveFailureDialog(error: Throwable) {
+        if (error is NotificationSettingsUpdateError) {
+            trackerWrapper.track(
+                stat = AnalyticsEvent.SITE_PICKER_LIST_SAVING_FAILURE,
+                properties = mapOf(KEY_ERROR to error.type.toString())
+            )
+        }
+        triggerEvent(
+            Event.ShowDialog(
+                titleId = R.string.site_picker_edit_store_list_error_title,
+                positiveButtonId = R.string.retry,
+                positiveBtnAction = { dialog, _ ->
+                    dialog.dismiss()
+                    onSaveTapped()
+                },
+                negativeButtonId = R.string.cancel,
+                negativeBtnAction = { dialog, _ ->
+                    dialog.dismiss()
+                    triggerEvent(Exit)
+                }
+            )
+        )
     }
 
     fun onSiteTapped(wooStoreUi: WooStoreUi) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
@@ -99,33 +99,25 @@ class WooSitesVisibilityViewModel @Inject constructor(
         _wooStoresState.value = _wooStoresState.value.copy(isLoading = isLoading)
     }
 
-    private suspend fun performSave(): Result<Unit> = coroutineScope {
+    private suspend fun performSave(): Result<Unit> {
         val currentSelectedSiteIds = _wooStoresState.value.wooStores
             .filter { it.isSelected }
             .map { it.siteId }
             .toSet()
+        val newlyVisibleSiteIds = currentSelectedSiteIds - initiallySelectedSiteIds
+        val newlyHiddenSiteIds = initiallySelectedSiteIds - currentSelectedSiteIds
         val wooPushRegisteredSiteIds = pushNotificationRepository.getWooPushRegisteredSiteIds()
 
-        launch {
-            unregisterNewlyHiddenWooPushSites(
-                newlyHiddenSiteIds = initiallySelectedSiteIds - currentSelectedSiteIds,
-                wooPushRegisteredSiteIds = wooPushRegisteredSiteIds
-            )
-        }
-        val wpComDeferred = async {
-            updateWpComNotificationSettings(wooPushRegisteredSiteIds)
-        }
-        val registerDeferred = async {
-            registerNewlyVisibleWooPushSites(
-                newlyVisibleSiteIds = currentSelectedSiteIds - initiallySelectedSiteIds,
-                wooPushRegisteredSiteIds = wooPushRegisteredSiteIds
-            )
-        }
+        unregisterNewlyHiddenWooPushSites(newlyHiddenSiteIds, wooPushRegisteredSiteIds)
 
-        val wpComResult = wpComDeferred.await()
-        val registerResult = registerDeferred.await()
+        val registerResult = registerNewlyVisibleWooPushSites(newlyVisibleSiteIds, wooPushRegisteredSiteIds)
+        if (registerResult.isFailure) return registerResult
 
-        if (wpComResult.isFailure) wpComResult else registerResult
+        // Re-read to exclude sites just registered — WPCom notifications disabling was already handled for them
+        // when registering them with Woo.
+        return updateWpComNotificationSettings(
+            excludedSiteIds = pushNotificationRepository.getWooPushRegisteredSiteIds()
+        )
     }
 
     private suspend fun onSaveSuccess() {
@@ -136,9 +128,9 @@ class WooSitesVisibilityViewModel @Inject constructor(
         triggerEvent(ExitWithResult(data = true))
     }
 
-    private suspend fun updateWpComNotificationSettings(wooPushRegisteredSiteIds: Set<Long>): Result<Unit> {
+    private suspend fun updateWpComNotificationSettings(excludedSiteIds: Set<Long>): Result<Unit> {
         val sitesToUpdate = _wooStoresState.value.wooStores
-            .filterNot { it.siteId in wooPushRegisteredSiteIds }
+            .filterNot { it.siteId in excludedSiteIds }
             .map { it.toNotificationSetting() }
 
         return if (sitesToUpdate.isNotEmpty()) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
+import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_ERROR
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -24,6 +25,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore.NotificationSettingsUpdateError
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore.SiteNotificationSetting
@@ -169,7 +171,15 @@ class WooSitesVisibilityViewModel @Inject constructor(
                             token = token,
                             selectedSite = site,
                             allowWpComFallback = false
-                        )
+                        ).recoverCatching { error ->
+                            // `rest_no_route` means the site doesn't have the wc-push-notifications
+                            // endpoint — it will continue to use WPCom notifications instead.
+                            if ((error as? WooException)?.error?.type == WooErrorType.API_NOT_FOUND) {
+                                Unit
+                            } else {
+                                throw error
+                            }
+                        }
                     } else {
                         Result.success(Unit)
                     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModel.kt
@@ -17,6 +17,9 @@ import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ExitWithResult
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -39,7 +42,7 @@ class WooSitesVisibilityViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ScopedViewModel(savedStateHandle) {
     private var availableWooSites: List<SiteModel> = emptyList()
-    private var initiallySelectedSiteIds: List<Long> = emptyList()
+    private var initiallySelectedSiteIds: Set<Long> = emptySet()
     private val _wooStoresState = MutableStateFlow(
         WooStoresUiState(
             wooStores = emptyList(),
@@ -61,6 +64,7 @@ class WooSitesVisibilityViewModel @Inject constructor(
             initiallySelectedSiteIds = _wooStoresState.value.wooStores
                 .filter { it.isSelected }
                 .map { it.siteId }
+                .toSet()
         }
     }
 
@@ -69,39 +73,59 @@ class WooSitesVisibilityViewModel @Inject constructor(
     }
 
     fun onSaveTapped() {
+        trackSaveTapped()
+        setLoading(isLoading = true)
+        launch {
+            try {
+                performSave()
+                    .onSuccess { onSaveSuccess() }
+                    .onFailure(::showSaveFailureDialog)
+            } finally {
+                setLoading(isLoading = false)
+            }
+        }
+    }
+
+    private fun trackSaveTapped() {
         trackerWrapper.track(
             stat = AnalyticsEvent.SITE_PICKER_LIST_SAVE_BUTTON_TAPPED,
             properties = mapOf(
                 "hidden_site_count" to _wooStoresState.value.wooStores.count { !it.isSelected }
             )
         )
-        _wooStoresState.value = _wooStoresState.value.copy(isLoading = true)
-        launch {
-            try {
-                runCatching {
-                    val currentSelectedSiteIds = _wooStoresState.value.wooStores
-                        .filter { it.isSelected }
-                        .map { it.siteId }
-                        .toSet()
-                    val initialSelectedSiteIds = initiallySelectedSiteIds.toSet()
-                    val hiddenSiteIds = initialSelectedSiteIds - currentSelectedSiteIds
-                    val unhiddenSiteIds = currentSelectedSiteIds - initialSelectedSiteIds
-                    val sitesById = availableWooSites.associateBy { it.siteId }
-                    val wooPushRegisteredSiteIds = pushNotificationRepository.getWooPushRegisteredSiteIds()
+    }
 
-                    updateWpComNotificationSettings(wooPushRegisteredSiteIds)
-                    syncWooPushVisibilityChanges(
-                        hiddenSiteIds = hiddenSiteIds,
-                        unhiddenSiteIds = unhiddenSiteIds,
-                        wooPushRegisteredSiteIds = wooPushRegisteredSiteIds,
-                        sitesById = sitesById
-                    )
-                    onSaveSuccess()
-                }.onFailure(::showSaveFailureDialog)
-            } finally {
-                _wooStoresState.value = _wooStoresState.value.copy(isLoading = false)
-            }
+    private fun setLoading(isLoading: Boolean) {
+        _wooStoresState.value = _wooStoresState.value.copy(isLoading = isLoading)
+    }
+
+    private suspend fun performSave(): Result<Unit> = coroutineScope {
+        val currentSelectedSiteIds = _wooStoresState.value.wooStores
+            .filter { it.isSelected }
+            .map { it.siteId }
+            .toSet()
+        val wooPushRegisteredSiteIds = pushNotificationRepository.getWooPushRegisteredSiteIds()
+
+        launch {
+            unregisterNewlyHiddenWooPushSites(
+                newlyHiddenSiteIds = initiallySelectedSiteIds - currentSelectedSiteIds,
+                wooPushRegisteredSiteIds = wooPushRegisteredSiteIds
+            )
         }
+        val wpComDeferred = async {
+            updateWpComNotificationSettings(wooPushRegisteredSiteIds)
+        }
+        val registerDeferred = async {
+            registerNewlyVisibleWooPushSites(
+                newlyVisibleSiteIds = currentSelectedSiteIds - initiallySelectedSiteIds,
+                wooPushRegisteredSiteIds = wooPushRegisteredSiteIds
+            )
+        }
+
+        val wpComResult = wpComDeferred.await()
+        val registerResult = registerDeferred.await()
+
+        if (wpComResult.isFailure) wpComResult else registerResult
     }
 
     private suspend fun onSaveSuccess() {
@@ -112,50 +136,56 @@ class WooSitesVisibilityViewModel @Inject constructor(
         triggerEvent(ExitWithResult(data = true))
     }
 
-    private suspend fun updateWpComNotificationSettings(wooPushRegisteredSiteIds: Set<Long>) {
+    private suspend fun updateWpComNotificationSettings(wooPushRegisteredSiteIds: Set<Long>): Result<Unit> {
         val sitesToUpdate = _wooStoresState.value.wooStores
             .filterNot { it.siteId in wooPushRegisteredSiteIds }
-            .map {
-                SiteNotificationSetting(
-                    siteId = it.siteId,
-                    newCommentEnabled = it.isSelected,
-                    storeOrderEnabled = it.isSelected
-                )
-            }
+            .map { it.toNotificationSetting() }
 
-        if (sitesToUpdate.isNotEmpty()) {
-            notificationsStore.updateNotificationSettingsFor(sitesToUpdate).getOrThrow()
+        return if (sitesToUpdate.isNotEmpty()) {
+            notificationsStore.updateNotificationSettingsFor(sitesToUpdate)
+        } else {
+            Result.success(Unit)
         }
     }
 
-    private suspend fun syncWooPushVisibilityChanges(
-        hiddenSiteIds: Set<Long>,
-        unhiddenSiteIds: Set<Long>,
-        wooPushRegisteredSiteIds: Set<Long>,
-        sitesById: Map<Long, SiteModel>
-    ) {
-        hiddenSiteIds
-            .filter { it in wooPushRegisteredSiteIds }
-            .mapNotNull(sitesById::get)
-            .forEach { pushNotificationRepository.unregisterWooPushTokenForSite(it) }
+    private suspend fun unregisterNewlyHiddenWooPushSites(
+        newlyHiddenSiteIds: Set<Long>,
+        wooPushRegisteredSiteIds: Set<Long>
+    ) = coroutineScope {
+        availableWooSites
+            .filter { it.siteId in newlyHiddenSiteIds && it.siteId in wooPushRegisteredSiteIds }
+            .map { async { pushNotificationRepository.unregisterWooPushTokenForSite(it) } }
+            .awaitAll()
+    }
 
+    private suspend fun registerNewlyVisibleWooPushSites(
+        newlyVisibleSiteIds: Set<Long>,
+        wooPushRegisteredSiteIds: Set<Long>
+    ): Result<Unit> = coroutineScope {
         if (!featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)) {
-            return
+            return@coroutineScope Result.success(Unit)
         }
+        val token = appPrefsWrapper.getFCMToken().takeIf { it.isNotEmpty() }
+            ?: return@coroutineScope Result.success(Unit)
 
-        val token = appPrefsWrapper.getFCMToken().takeIf { it.isNotEmpty() } ?: return
-
-        unhiddenSiteIds
-            .filterNot { it in wooPushRegisteredSiteIds }
-            .mapNotNull(sitesById::get)
-            .filter { pushNotificationRepository.shouldRegisterWooPushForSite(token, it.siteId) }
-            .forEach {
-                pushNotificationRepository.registerPushTokenInWooCoreSystem(
-                    token = token,
-                    selectedSite = it,
-                    allowWpComFallback = false
-                )
+        val results = availableWooSites
+            .filter { it.siteId in newlyVisibleSiteIds && it.siteId !in wooPushRegisteredSiteIds }
+            .map { site ->
+                async {
+                    if (pushNotificationRepository.shouldRegisterWooPushForSite(token, site.siteId)) {
+                        pushNotificationRepository.registerPushTokenInWooCoreSystem(
+                            token = token,
+                            selectedSite = site,
+                            allowWpComFallback = false
+                        )
+                    } else {
+                        Result.success(Unit)
+                    }
+                }
             }
+            .awaitAll()
+
+        results.firstOrNull { it.isFailure } ?: Result.success(Unit)
     }
 
     private fun showSaveFailureDialog(error: Throwable) {
@@ -194,12 +224,19 @@ class WooSitesVisibilityViewModel @Inject constructor(
         _wooStoresState.value = _wooStoresState.value.copy(
             isSaveButtonEnabled = _wooStoresState.value.wooStores
                 .filter { it.isSelected }
-                .map { it.siteId } != initiallySelectedSiteIds
+                .map { it.siteId }
+                .toSet() != initiallySelectedSiteIds
         )
     }
 
     private suspend fun isSiteVisible(siteId: Long): Boolean =
         visibleSitesDataStore.isSiteVisible(siteId).first()
+
+    private fun WooStoreUi.toNotificationSetting() = SiteNotificationSetting(
+        siteId = siteId,
+        newCommentEnabled = isSelected,
+        storeOrderEnabled = isSelected
+    )
 
     private fun SiteModel.toWooStoreUi(isSiteVisible: Boolean) = WooStoreUi(
         siteName = name,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
@@ -302,7 +302,6 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     fun `given site metadata stored, when unregistering woo token succeeds, then removes all site metadata keys`() =
         testBlocking {
             val site = mock<SiteModel> { on { siteId } doReturn SITE_ID }
-            whenever(wooCommerceStore.getWooCommerceSites()).thenReturn(mutableListOf(site))
             whenever(preferences[stringPreferencesKey("push_token_$SITE_ID")]).thenReturn("token-id-1")
             whenever(preferences[stringPreferencesKey("push_token_value_$SITE_ID")]).thenReturn("token")
             whenever(preferences[stringPreferencesKey("push_locale_$SITE_ID")]).thenReturn("en_US")
@@ -316,11 +315,38 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
                 preferences
             }
 
-            sut.unregisterDeviceFromPushNotifications()
+            val result = sut.unregisterWooPushTokenForSite(site)
 
+            assertThat(result.isSuccess).isTrue()
             verify(mutablePreferences).remove(stringPreferencesKey("push_token_$SITE_ID"))
             verify(mutablePreferences).remove(stringPreferencesKey("push_token_value_$SITE_ID"))
             verify(mutablePreferences).remove(stringPreferencesKey("push_locale_$SITE_ID"))
+        }
+
+    @Test
+    fun `given site without stored metadata, when unregistering single woo site, then succeeds without deleting token`() =
+        testBlocking {
+            whenever(preferences[stringPreferencesKey("push_token_$SITE_ID")]).thenReturn(null)
+
+            val result = sut.unregisterWooPushTokenForSite(siteModel)
+
+            assertThat(result.isSuccess).isTrue()
+            verify(wooPushNotificationsStore, never()).deletePushToken(eq(siteModel), any())
+        }
+
+    @Test
+    fun `given site metadata stored, when unregistering single woo site fails, then returns failure and keeps metadata`() =
+        testBlocking {
+            whenever(preferences[stringPreferencesKey("push_token_$SITE_ID")]).thenReturn("token-id-1")
+            whenever(preferences[stringPreferencesKey("push_token_value_$SITE_ID")]).thenReturn("token")
+            whenever(preferences[stringPreferencesKey("push_locale_$SITE_ID")]).thenReturn("en_US")
+            whenever(wooPushNotificationsStore.deletePushToken(siteModel, "token-id-1"))
+                .thenReturn(PN_UNREGISTER_ERROR)
+
+            val result = sut.unregisterWooPushTokenForSite(siteModel)
+
+            assertThat(result.isFailure).isTrue()
+            verify(pushNotificationsDataStore, never()).updateData(any())
         }
 
     @Test
@@ -603,6 +629,14 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
         const val SITE_ID = 123L
 
         val PN_REGISTRATION_ERROR = WooResult<String>(
+            WooError(
+                WooErrorType.GENERIC_ERROR,
+                BaseRequest.GenericErrorType.UNKNOWN,
+                "oops"
+            )
+        )
+
+        val PN_UNREGISTER_ERROR = WooResult<Unit>(
             WooError(
                 WooErrorType.GENERIC_ERROR,
                 BaseRequest.GenericErrorType.UNKNOWN,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
@@ -234,7 +234,8 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
     fun `given hidden woo push site, when tapping save, then unregister woo push for that site`() =
         testBlocking {
             whenever(visibleWooSitesDataStore.isSiteVisible(HIDDEN_WOO_SITE.siteId)).thenReturn(flowOf(false))
-            whenever(pushNotificationRepository.getWooPushRegisteredSiteIds()).thenReturn(setOf(A_WOO_SITE_UI_MODEL.siteId))
+            whenever(pushNotificationRepository.getWooPushRegisteredSiteIds())
+                .thenReturn(setOf(A_WOO_SITE_UI_MODEL.siteId))
             whenever(wpComPushNotificationStore.updateNotificationSettingsFor(any())).thenReturn(Result.success(Unit))
             val viewModel = createViewModel()
 
@@ -282,9 +283,30 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given woo register fails for unhidden site, when tapping save, then show error dialog and do not persist visibility`() =
+        testBlocking {
+            whenever(visibleWooSitesDataStore.isSiteVisible(HIDDEN_WOO_SITE.siteId)).thenReturn(flowOf(false))
+            whenever(wpComPushNotificationStore.updateNotificationSettingsFor(any())).thenReturn(Result.success(Unit))
+            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any(), any()))
+                .thenReturn(Result.failure(IllegalStateException("registration failed")))
+            val viewModel = createViewModel()
+
+            viewModel.onSiteTapped(HIDDEN_WOO_SITE_UI_MODEL)
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onSaveTapped()
+            }.last()
+
+            verify(visibleWooSitesDataStore, never()).updateSiteVisibilityStatus(any())
+            assertThat(event).isInstanceOf(ShowDialog::class.java)
+            assertFalse(viewModel.viewState.getOrAwaitValue().isLoading)
+        }
+
+    @Test
     fun `given woo unregister fails, when tapping save, then persist visibility and still exit with success`() =
         testBlocking {
-            whenever(pushNotificationRepository.getWooPushRegisteredSiteIds()).thenReturn(setOf(A_WOO_SITE_UI_MODEL.siteId))
+            whenever(pushNotificationRepository.getWooPushRegisteredSiteIds())
+                .thenReturn(setOf(A_WOO_SITE_UI_MODEL.siteId))
             whenever(pushNotificationRepository.unregisterWooPushTokenForSite(any()))
                 .thenReturn(Result.failure(IllegalStateException("delete failed")))
             whenever(wpComPushNotificationStore.updateNotificationSettingsFor(any())).thenReturn(Result.success(Unit))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.sitepicker.sitevisibility
 
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.WooException
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.push.PushNotificationRepository
 import com.woocommerce.android.tools.SelectedSite
@@ -26,6 +27,9 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore.NotificationSettingErrorType
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore.NotificationSettingsUpdateError
@@ -337,6 +341,38 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
             verify(visibleWooSitesDataStore, never()).updateSiteVisibilityStatus(any())
             assertThat(event).isInstanceOf(ShowDialog::class.java)
             assertFalse(viewModel.viewState.getOrAwaitValue().isLoading)
+        }
+
+    @Test
+    fun `given site lacks woo push endpoint, when tapping save, then skip registration and persist visibility`() =
+        testBlocking {
+            whenever(visibleWooSitesDataStore.isSiteVisible(HIDDEN_WOO_SITE.siteId)).thenReturn(flowOf(false))
+            whenever(wpComPushNotificationStore.updateNotificationSettingsFor(any())).thenReturn(Result.success(Unit))
+            whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any(), any()))
+                .thenReturn(
+                    Result.failure(
+                        WooException(
+                            WooError(
+                                type = WooErrorType.API_NOT_FOUND,
+                                original = GenericErrorType.NOT_FOUND,
+                                apiErrorCode = "rest_no_route"
+                            )
+                        )
+                    )
+                )
+            val viewModel = createViewModel()
+
+            viewModel.onSiteTapped(HIDDEN_WOO_SITE_UI_MODEL)
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onSaveTapped()
+            }.last()
+
+            verify(visibleWooSitesDataStore).updateSiteVisibilityStatus(any())
+            verify(wpComPushNotificationStore).updateNotificationSettingsFor(
+                argThat { any { it.siteId == HIDDEN_WOO_SITE.siteId } }
+            )
+            assertThat(event).isEqualTo(ExitWithResult(data = true))
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
@@ -91,6 +91,8 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
     private val pushNotificationRepository: PushNotificationRepository = mock {
         on { getWooPushRegisteredSiteIds() } doReturn emptySet()
         on { shouldRegisterWooPushForSite(any(), any()) } doReturn true
+        on { registerPushTokenInWooCoreSystem(any(), any(), any()) } doReturn Result.success(Unit)
+        on { unregisterWooPushTokenForSite(any()) } doReturn Result.success(Unit)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
@@ -250,6 +250,42 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given newly visible site will be woo registered, when tapping save, then exclude it from wpcom update`() =
+        testBlocking {
+            whenever(visibleWooSitesDataStore.isSiteVisible(HIDDEN_WOO_SITE.siteId)).thenReturn(flowOf(false))
+            whenever(wpComPushNotificationStore.updateNotificationSettingsFor(any())).thenReturn(Result.success(Unit))
+            // Simulate registration side effect: the site becomes woo-registered after registerPushTokenInWooCoreSystem.
+            whenever(pushNotificationRepository.getWooPushRegisteredSiteIds())
+                .thenReturn(emptySet())
+                .thenReturn(setOf(HIDDEN_WOO_SITE.siteId))
+            val viewModel = createViewModel()
+
+            viewModel.onSiteTapped(HIDDEN_WOO_SITE_UI_MODEL)
+            viewModel.onSaveTapped()
+
+            verify(wpComPushNotificationStore).updateNotificationSettingsFor(
+                argThat { none { it.siteId == HIDDEN_WOO_SITE.siteId } }
+            )
+        }
+
+    @Test
+    fun `given feature flag disabled, when tapping save, then newly visible site is included in wpcom update`() =
+        testBlocking {
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1))
+                .thenReturn(false)
+            whenever(visibleWooSitesDataStore.isSiteVisible(HIDDEN_WOO_SITE.siteId)).thenReturn(flowOf(false))
+            whenever(wpComPushNotificationStore.updateNotificationSettingsFor(any())).thenReturn(Result.success(Unit))
+            val viewModel = createViewModel()
+
+            viewModel.onSiteTapped(HIDDEN_WOO_SITE_UI_MODEL)
+            viewModel.onSaveTapped()
+
+            verify(wpComPushNotificationStore).updateNotificationSettingsFor(
+                argThat { any { it.siteId == HIDDEN_WOO_SITE.siteId } }
+            )
+        }
+
+    @Test
     fun `given previously hidden site, when tapping save, then register woo push immediately without wpcom fallback`() =
         testBlocking {
             whenever(visibleWooSitesDataStore.isSiteVisible(HIDDEN_WOO_SITE.siteId)).thenReturn(flowOf(false))
@@ -288,7 +324,6 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
     fun `given woo register fails for unhidden site, when tapping save, then show error dialog and do not persist visibility`() =
         testBlocking {
             whenever(visibleWooSitesDataStore.isSiteVisible(HIDDEN_WOO_SITE.siteId)).thenReturn(flowOf(false))
-            whenever(wpComPushNotificationStore.updateNotificationSettingsFor(any())).thenReturn(Result.success(Unit))
             whenever(pushNotificationRepository.registerPushTokenInWooCoreSystem(any(), any(), any()))
                 .thenReturn(Result.failure(IllegalStateException("registration failed")))
             val viewModel = createViewModel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/sitepicker/sitevisibility/WooSitesVisibilityViewModelTest.kt
@@ -1,11 +1,14 @@
 package com.woocommerce.android.ui.sitepicker.sitevisibility
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.push.PushNotificationRepository
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.sitepicker.SitePickerRepository
 import com.woocommerce.android.ui.sitepicker.SitePickerTestUtils
 import com.woocommerce.android.ui.sitepicker.sitevisibility.WooSitesVisibilityViewModel.WooStoreUi
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -16,7 +19,9 @@ import kotlinx.coroutines.flow.flowOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -49,6 +54,13 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
                     isSelected = true
                 )
             }
+        private val HIDDEN_WOO_SITE = ALL_WOO_SITES[1]
+        private val HIDDEN_WOO_SITE_UI_MODEL = WooStoreUi(
+            siteName = HIDDEN_WOO_SITE.name,
+            siteUrl = HIDDEN_WOO_SITE.url,
+            siteId = HIDDEN_WOO_SITE.siteId,
+            isSelected = false
+        )
         private val A_WOO_SITE_UI_MODEL = ALL_WOO_SITES.last().let {
             WooStoreUi(
                 siteName = it.name,
@@ -70,8 +82,15 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
     }
     private val trackerWrapper: AnalyticsTrackerWrapper = mock()
     private val wpComPushNotificationStore: WpComPushNotificationStore = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock {
+        on { getFCMToken() }.thenReturn("token")
+    }
+    private val featureFlagRepository: FeatureFlagRepository = mock {
+        on { isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1) }.thenReturn(true)
+    }
     private val pushNotificationRepository: PushNotificationRepository = mock {
         on { getWooPushRegisteredSiteIds() } doReturn emptySet()
+        on { shouldRegisterWooPushForSite(any(), any()) } doReturn true
     }
 
     @Test
@@ -211,12 +230,84 @@ class WooSitesVisibilityViewModelTest : BaseUnitTest() {
             verify(wpComPushNotificationStore, never()).updateNotificationSettingsFor(any())
         }
 
+    @Test
+    fun `given hidden woo push site, when tapping save, then unregister woo push for that site`() =
+        testBlocking {
+            whenever(visibleWooSitesDataStore.isSiteVisible(HIDDEN_WOO_SITE.siteId)).thenReturn(flowOf(false))
+            whenever(pushNotificationRepository.getWooPushRegisteredSiteIds()).thenReturn(setOf(A_WOO_SITE_UI_MODEL.siteId))
+            whenever(wpComPushNotificationStore.updateNotificationSettingsFor(any())).thenReturn(Result.success(Unit))
+            val viewModel = createViewModel()
+
+            viewModel.onSiteTapped(A_WOO_SITE_UI_MODEL)
+            viewModel.onSaveTapped()
+
+            verify(pushNotificationRepository).unregisterWooPushTokenForSite(
+                argThat { siteId == A_WOO_SITE_UI_MODEL.siteId }
+            )
+        }
+
+    @Test
+    fun `given previously hidden site, when tapping save, then register woo push immediately without wpcom fallback`() =
+        testBlocking {
+            whenever(visibleWooSitesDataStore.isSiteVisible(HIDDEN_WOO_SITE.siteId)).thenReturn(flowOf(false))
+            whenever(wpComPushNotificationStore.updateNotificationSettingsFor(any())).thenReturn(Result.success(Unit))
+            val viewModel = createViewModel()
+
+            viewModel.onSiteTapped(HIDDEN_WOO_SITE_UI_MODEL)
+            viewModel.onSaveTapped()
+
+            verify(pushNotificationRepository).registerPushTokenInWooCoreSystem(
+                token = eq("token"),
+                selectedSite = argThat { siteId == HIDDEN_WOO_SITE.siteId },
+                allowWpComFallback = eq(false)
+            )
+        }
+
+    @Test
+    fun `given previously hidden site still marked as woo registered, when tapping save, then do not register again`() =
+        testBlocking {
+            whenever(visibleWooSitesDataStore.isSiteVisible(HIDDEN_WOO_SITE.siteId)).thenReturn(flowOf(false))
+            whenever(pushNotificationRepository.getWooPushRegisteredSiteIds()).thenReturn(setOf(HIDDEN_WOO_SITE.siteId))
+            whenever(wpComPushNotificationStore.updateNotificationSettingsFor(any())).thenReturn(Result.success(Unit))
+            val viewModel = createViewModel()
+
+            viewModel.onSiteTapped(HIDDEN_WOO_SITE_UI_MODEL)
+            viewModel.onSaveTapped()
+
+            verify(pushNotificationRepository, never()).registerPushTokenInWooCoreSystem(
+                token = eq("token"),
+                selectedSite = argThat { siteId == HIDDEN_WOO_SITE.siteId },
+                allowWpComFallback = eq(false)
+            )
+        }
+
+    @Test
+    fun `given woo unregister fails, when tapping save, then persist visibility and still exit with success`() =
+        testBlocking {
+            whenever(pushNotificationRepository.getWooPushRegisteredSiteIds()).thenReturn(setOf(A_WOO_SITE_UI_MODEL.siteId))
+            whenever(pushNotificationRepository.unregisterWooPushTokenForSite(any()))
+                .thenReturn(Result.failure(IllegalStateException("delete failed")))
+            whenever(wpComPushNotificationStore.updateNotificationSettingsFor(any())).thenReturn(Result.success(Unit))
+            val viewModel = createViewModel()
+
+            viewModel.onSiteTapped(A_WOO_SITE_UI_MODEL)
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onSaveTapped()
+            }.last()
+
+            verify(visibleWooSitesDataStore).updateSiteVisibilityStatus(any())
+            assertThat(event).isEqualTo(ExitWithResult(data = true))
+        }
+
     private fun createViewModel() = WooSitesVisibilityViewModel(
         sitePickerRepository = sitePickerRepository,
         selectedSite = selectedSite,
         visibleSitesDataStore = visibleWooSitesDataStore,
         notificationsStore = wpComPushNotificationStore,
         pushNotificationRepository = pushNotificationRepository,
+        appPrefsWrapper = appPrefsWrapper,
+        featureFlagRepository = featureFlagRepository,
         trackerWrapper = trackerWrapper,
         savedStateHandle = mock()
     )


### PR DESCRIPTION
### Description
Fixes WOOMOB-2723

When a merchant hides a Woo store from the **Edit Stores** screen, this PR unregisters its Woo push token so the device stops receiving notifications for that store. When a previously hidden store is made visible again, its Woo push token is re-registered (gated by `WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1`).

### How it works

The save flow in `WooSitesVisibilityViewModel.performSave` runs sequentially:

1. Unregister Woo push for newly hidden sites (best-effort).
2. Register Woo push for newly visible sites (without WPCom fallback). This internally disables WPCom notifications for those sites. Step 2 tolerates 404 `rest_no_route`, treating sites without the `wc-push-notifications` endpoint as WPCom-only.
3. Update WPCom notification settings, excluding sites currently on Woo push (re-read after step 2 to include sites just registered).

Running register before the WPCom update avoids a race where the WPCom update could re-enable notifications on a site that step 2 just disabled them for.

### Error semantics

| Operation | On failure |
|---|---|
| Unregister Woo push | Best-effort: logged, save continues |
| Register Woo push — site lacks `wc-push-notifications` (404 `rest_no_route`) | Silently skipped, site stays on WPCom, save continues |
| Register Woo push — other errors | Error dialog, save returns early, visibility **not** persisted |
| WPCom settings update | Error dialog, visibility **not** persisted |

### Test Steps

Setup:
- Enable `WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1`.
- Log into an account with 2+ Woo stores; let push registration run.
- Open Logcat with the `NOTIFICATIONS` tag and/or attach a proxy (Proxyman/Charles) to inspect network traffic.

Relevant endpoints:
- Register: `POST /wc-push-notifications/push-tokens`
- Unregister: `DELETE /wc-push-notifications/push-tokens/<tokenId>`
- WPCom settings: `POST /rest/v1.1/me/notifications/settings/`

1. **Hide a Woo-push-registered store.** **Edit Stores** → hide the store → **Save**.
    - Logcat: `Woo Core push token deleted for site <siteId>`.
    - Network: `DELETE /wc-push-notifications/push-tokens/<tokenId>` for that site.
    - No `POST /rest/v1.1/me/notifications/settings/` call is made for that site (it's excluded).
2. **Unhide the same store.** **Edit Stores** → unhide → **Save**.
    - Network: `POST /wc-push-notifications/push-tokens` for that site.
    - Logcat: `WPCom notifications disabled for site <siteId>` (side effect of register).
    - The site is not included in the subsequent `/rest/v1.1/me/notifications/settings/` payload.
3. **Toggle visibility on a store *without* Woo push.** Hide/unhide → **Save**.
    - Network: `POST /rest/v1.1/me/notifications/settings/` with that `blog_id` and the expected `new_comment`/`store_order` flags.
    - On unhide, a `POST /wc-push-notifications/push-tokens` may be attempted and return 404 `rest_no_route` — this is tolerated; the save still succeeds and the site is included in the WPCom settings payload.
4. **Register failure.** Simulate a non-404 failure on `POST /wc-push-notifications/push-tokens` (proxy rewrite or toggle airplane mode after unhide + save).
    - Error dialog shown.
    - No `/rest/v1.1/me/notifications/settings/` call is made after the failure.
    - Visibility is not persisted (reopen the screen; the hidden store is still hidden).
5. **Unregister failure.** Simulate a failure on `DELETE /wc-push-notifications/push-tokens/<tokenId>`.
    - Logcat: `Failed to delete push token for site <siteId>: ...`
    - Save still succeeds and visibility is persisted.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.