### PR TITLE
[WOOMOB-2712] Fix push notification tracking for Woo-driven notifications

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/notifications/NotificationsScreen.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/e2e/screens/notifications/NotificationsScreen.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.e2e.helpers.util.Screen
 import com.woocommerce.android.e2e.screens.TabNavComponent
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.notifications.NotificationChannelType
+import com.woocommerce.android.notifications.NotificationSource
 import com.woocommerce.android.notifications.WooNotificationBuilder
 import com.woocommerce.android.notifications.WooNotificationType.NewOrder
 
@@ -34,6 +35,8 @@ class NotificationsScreen(private val wooNotificationBuilder: WooNotificationBui
                 noteType = NewOrder,
                 channelType = NotificationChannelType.NEW_ORDER
             ),
+            source = NotificationSource.WOO_DRIVEN,
+            analyticsId = null,
             isGroupNotification = false
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationSource.kt
@@ -4,25 +4,3 @@ enum class NotificationSource(val trackingValue: String) {
     WPCOM("wpcom"),
     WOO_DRIVEN("woo_driven")
 }
-
-/**
- * Builds the stable `<site-or-store>:<type>:<entity-id>` analytics id for a Woo-driven
- * notification, or `null` when the type has no segment (Blaze, local reminder), the entity id
- * is zero, or no site/store fallback is available.
- */
-fun buildWooDrivenAnalyticsId(
-    remoteSiteId: Long,
-    uniqueId: Long,
-    wooTypeSegment: String?,
-    storeIdFallback: String?
-): String? {
-    val siteSegment = when {
-        remoteSiteId != 0L -> remoteSiteId.toString()
-        !storeIdFallback.isNullOrEmpty() -> storeIdFallback
-        else -> null
-    }
-    return when {
-        wooTypeSegment == null || siteSegment == null || uniqueId == 0L -> null
-        else -> "$siteSegment:$wooTypeSegment:$uniqueId"
-    }
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationSource.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.notifications
+
+enum class NotificationSource(val trackingValue: String) {
+    WPCOM("wpcom"),
+    WOO_DRIVEN("woo_driven")
+}
+
+/**
+ * Builds the stable `<site-or-store>:<type>:<entity-id>` analytics id for a Woo-driven
+ * notification, or `null` when the type has no segment (Blaze, local reminder), the entity id
+ * is zero, or no site/store fallback is available.
+ */
+fun buildWooDrivenAnalyticsId(
+    remoteSiteId: Long,
+    uniqueId: Long,
+    wooTypeSegment: String?,
+    storeIdFallback: String?
+): String? {
+    val siteSegment = when {
+        remoteSiteId != 0L -> remoteSiteId.toString()
+        !storeIdFallback.isNullOrEmpty() -> storeIdFallback
+        else -> null
+    }
+    return when {
+        wooTypeSegment == null || siteSegment == null || uniqueId == 0L -> null
+        else -> "$siteSegment:$wooTypeSegment:$uniqueId"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
@@ -51,6 +51,10 @@ class WooNotificationBuilder @Inject constructor(
                 channelType = sbn.notification.extras.getString(EXTRA_CHANNEL_TYPE),
                 noteMessage = sbn.notification.extras.getString(EXTRA_NOTE_MESSAGE),
                 noteTypeTrackingValue = sbn.notification.extras.getString(EXTRA_NOTE_TYPE),
+                source = sbn.notification.extras.getString(EXTRA_SOURCE)
+                    ?.let { runCatching { NotificationSource.valueOf(it) }.getOrNull() }
+                    ?: NotificationSource.WPCOM,
+                analyticsId = sbn.notification.extras.getString(EXTRA_ANALYTICS_ID),
                 isGroupSummary = (sbn.notification.flags and FLAG_GROUP_SUMMARY) != 0
             )
         }
@@ -130,6 +134,8 @@ class WooNotificationBuilder @Inject constructor(
     fun buildAndDisplayWooNotification(
         pushId: Int,
         notification: Notification,
+        source: NotificationSource,
+        analyticsId: String?,
         isGroupNotification: Boolean
     ) {
         val channelType = notification.channelType
@@ -137,7 +143,7 @@ class WooNotificationBuilder @Inject constructor(
             setLargeIcon(getLargeIconBitmap(context, notification.icon, channelType.shouldCircularizeNoteIcon()))
             setDefaults(NotificationCompat.DEFAULT_ALL)
         }.apply {
-            showNotification(pushId, notification, this)
+            showNotification(pushId, notification, source, analyticsId, this)
 
             // Also add a group summary notification, which is required for non-wearable devices
             // Do not need to play the sound again. We've already played it in the individual builder.
@@ -147,7 +153,7 @@ class WooNotificationBuilder @Inject constructor(
                 setDefaults(0)
                 setSound(null)
                 setVibrate(null)
-                showNotification(notification.getGroupPushId(), notification, this)
+                showNotification(notification.getGroupPushId(), notification, source, analyticsId, this)
             }
         }
     }
@@ -155,7 +161,9 @@ class WooNotificationBuilder @Inject constructor(
     fun buildAndDisplayWooGroupNotification(
         inboxMessage: String,
         subject: String,
-        notification: Notification
+        notification: Notification,
+        source: NotificationSource,
+        analyticsId: String?
     ) {
         val inboxStyle = NotificationCompat.InboxStyle().addLine(inboxMessage)
         val channelId = with(notificationChannelsHandler) { notification.channelType.getChannelId() }
@@ -176,6 +184,8 @@ class WooNotificationBuilder @Inject constructor(
                 showNotification(
                     notification.getGroupPushId(),
                     notification,
+                    source,
+                    analyticsId,
                     this
                 )
             }
@@ -184,6 +194,8 @@ class WooNotificationBuilder @Inject constructor(
     private fun showNotification(
         pushId: Int,
         notification: Notification,
+        source: NotificationSource,
+        analyticsId: String?,
         builder: NotificationCompat.Builder
     ) {
         try {
@@ -194,6 +206,8 @@ class WooNotificationBuilder @Inject constructor(
                     putString(EXTRA_CHANNEL_TYPE, notification.channelType.name)
                     putString(EXTRA_NOTE_MESSAGE, notification.noteMessage)
                     putString(EXTRA_NOTE_TYPE, notification.noteType.trackingValue)
+                    putString(EXTRA_SOURCE, source.name)
+                    putString(EXTRA_ANALYTICS_ID, analyticsId)
                 }
             )
 
@@ -275,6 +289,8 @@ class WooNotificationBuilder @Inject constructor(
         private const val EXTRA_CHANNEL_TYPE = "channel_type"
         private const val EXTRA_NOTE_MESSAGE = "note_message"
         private const val EXTRA_NOTE_TYPE = "note_type"
+        private const val EXTRA_SOURCE = "source"
+        private const val EXTRA_ANALYTICS_ID = "analytics_id"
     }
 }
 
@@ -285,5 +301,7 @@ data class ActiveNotificationData(
     val channelType: String?,
     val noteMessage: String?,
     val noteTypeTrackingValue: String?,
+    val source: NotificationSource,
+    val analyticsId: String?,
     val isGroupSummary: Boolean = false
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationBuilder.kt
@@ -52,8 +52,7 @@ class WooNotificationBuilder @Inject constructor(
                 noteMessage = sbn.notification.extras.getString(EXTRA_NOTE_MESSAGE),
                 noteTypeTrackingValue = sbn.notification.extras.getString(EXTRA_NOTE_TYPE),
                 source = sbn.notification.extras.getString(EXTRA_SOURCE)
-                    ?.let { runCatching { NotificationSource.valueOf(it) }.getOrNull() }
-                    ?: NotificationSource.WPCOM,
+                    ?.let { runCatching { NotificationSource.valueOf(it) }.getOrNull() },
                 analyticsId = sbn.notification.extras.getString(EXTRA_ANALYTICS_ID),
                 isGroupSummary = (sbn.notification.flags and FLAG_GROUP_SUMMARY) != 0
             )
@@ -301,7 +300,7 @@ data class ActiveNotificationData(
     val channelType: String?,
     val noteMessage: String?,
     val noteTypeTrackingValue: String?,
-    val source: NotificationSource,
+    val source: NotificationSource?,
     val analyticsId: String?,
     val isGroupSummary: Boolean = false
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.utils.extensions.putIfNotNull
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -31,18 +32,18 @@ class NotificationAnalyticsTracker @Inject constructor(
         siteId: Long,
         notificationId: String?,
         noteTypeTrackingValue: String,
-        source: NotificationSource
+        source: NotificationSource?
     ) {
         val site = resolveNotificationSite(siteId) ?: return
         val properties = mutableMapOf<String, Any>(
             "notification_type" to noteTypeTrackingValue,
             "push_notification_token" to appPrefsWrapper.getFCMToken(),
-            "push_notification_source" to source.trackingValue,
             "is_from_selected_site" to site.isSelectedSite()
         ).addCommonSiteProperties(site)
-        if (notificationId != null) {
-            properties["notification_note_id"] = notificationId
-        }
+        properties.putIfNotNull(
+            "push_notification_source" to source?.trackingValue,
+            "notification_note_id" to notificationId
+        )
         analyticsTrackerWrapper.track(stat, properties)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.notifications.NotificationSource
 import com.woocommerce.android.tools.SelectedSite
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
@@ -26,18 +27,20 @@ class NotificationAnalyticsTracker @Inject constructor(
     fun trackNotificationAnalytics(
         stat: AnalyticsEvent,
         siteId: Long,
-        remoteNoteId: Long,
-        noteTypeTrackingValue: String
+        notificationId: String?,
+        noteTypeTrackingValue: String,
+        source: NotificationSource
     ) {
         val site = siteStore.getSiteBySiteId(siteId) ?: return
         val isFromSelectedSite = selectedSite.getIfExists()?.siteId == siteId
         val properties = mutableMapOf<String, Any>(
             "notification_type" to noteTypeTrackingValue,
             "push_notification_token" to appPrefsWrapper.getFCMToken(),
+            "push_notification_source" to source.trackingValue,
             "is_from_selected_site" to isFromSelectedSite
         ).addCommonSiteProperties(site)
-        if (remoteNoteId != 0L) {
-            properties["notification_note_id"] = remoteNoteId
+        if (notificationId != null) {
+            properties["notification_note_id"] = notificationId
         }
         analyticsTrackerWrapper.track(stat, properties)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -32,11 +32,13 @@ class NotificationAnalyticsTracker @Inject constructor(
         val site = siteStore.getSiteBySiteId(siteId) ?: return
         val isFromSelectedSite = selectedSite.getIfExists()?.siteId == siteId
         val properties = mutableMapOf<String, Any>(
-            "notification_note_id" to remoteNoteId,
             "notification_type" to noteTypeTrackingValue,
             "push_notification_token" to appPrefsWrapper.getFCMToken(),
             "is_from_selected_site" to isFromSelectedSite
         ).addCommonSiteProperties(site)
+        if (remoteNoteId != 0L) {
+            properties["notification_note_id"] = remoteNoteId
+        }
         analyticsTrackerWrapper.track(stat, properties)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -72,11 +72,14 @@ class NotificationAnalyticsTracker @Inject constructor(
         }
     }
 
-    private fun SiteModel.isSelectedSite() = if (connectionType == SiteConnectionType.ApplicationPasswords) {
-        true
-    } else {
-        siteId == selectedSite.getOrNull()?.siteId
-    }
+    // App-password sites don't have a reliable wpcom siteId to compare against, but multi-site
+    // is unsupported there so any app-password notification targets the one selected site.
+    private fun SiteModel.isSelectedSite() =
+        if (connectionType == SiteConnectionType.ApplicationPasswords) {
+            true
+        } else {
+            siteId == selectedSite.getOrNull()?.siteId
+        }
 
     private fun MutableMap<String, Any>.addCommonSiteProperties(site: SiteModel) = apply {
         this[AnalyticsTracker.IS_JETPACK_INSTALLED] = site.isJetpackInstalled

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTracker.kt
@@ -6,6 +6,8 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.NotificationSource
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.tools.connectionType
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
@@ -19,7 +21,7 @@ class NotificationAnalyticsTracker @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
     fun track(stat: AnalyticsEvent, siteId: Long) {
-        val site = siteStore.getSiteBySiteId(siteId) ?: return
+        val site = resolveNotificationSite(siteId) ?: return
         val properties = mutableMapOf<String, Any>().addCommonSiteProperties(site)
         analyticsTrackerWrapper.track(stat, properties)
     }
@@ -31,13 +33,12 @@ class NotificationAnalyticsTracker @Inject constructor(
         noteTypeTrackingValue: String,
         source: NotificationSource
     ) {
-        val site = siteStore.getSiteBySiteId(siteId) ?: return
-        val isFromSelectedSite = selectedSite.getIfExists()?.siteId == siteId
+        val site = resolveNotificationSite(siteId) ?: return
         val properties = mutableMapOf<String, Any>(
             "notification_type" to noteTypeTrackingValue,
             "push_notification_token" to appPrefsWrapper.getFCMToken(),
             "push_notification_source" to source.trackingValue,
-            "is_from_selected_site" to isFromSelectedSite
+            "is_from_selected_site" to site.isSelectedSite()
         ).addCommonSiteProperties(site)
         if (notificationId != null) {
             properties["notification_note_id"] = notificationId
@@ -52,13 +53,29 @@ class NotificationAnalyticsTracker @Inject constructor(
         errorType: String?,
         errorCode: String? = null
     ) {
-        val site = siteStore.getSiteBySiteId(siteId) ?: return
+        val site = resolveNotificationSite(siteId) ?: return
         val properties = mutableMapOf<String, Any>().apply {
             errorDescription?.let { this[AnalyticsTracker.KEY_ERROR_DESC] = it }
             errorType?.let { this[AnalyticsTracker.KEY_ERROR_TYPE] = it }
             errorCode?.let { this[AnalyticsTracker.KEY_ERROR_CODE] = it }
         }.addCommonSiteProperties(site)
         analyticsTrackerWrapper.track(stat, properties)
+    }
+
+    // Application-password sites have no wpcom site id, so the payload siteId is unreliable;
+    // fall back to the selected site we don't support multi-sites with app passwords.
+    private fun resolveNotificationSite(siteId: Long): SiteModel? {
+        return if (selectedSite.connectionType == SiteConnectionType.ApplicationPasswords) {
+            selectedSite.getOrNull()
+        } else {
+            siteStore.getSiteBySiteId(siteId)
+        }
+    }
+
+    private fun SiteModel.isSelectedSite() = if (connectionType == SiteConnectionType.ApplicationPasswords) {
+        true
+    } else {
+        siteId == selectedSite.getOrNull()?.siteId
     }
 
     private fun MutableMap<String, Any>.addCommonSiteProperties(site: SiteModel) = apply {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -314,8 +314,8 @@ class NotificationMessageHandler @Inject constructor(
      */
     private fun Notification.buildWooDrivenAnalyticsId(): String? {
         val wooTypeSegment = when (noteType) {
-            is WooNotificationType.NewOrder -> "order"
-            is WooNotificationType.ProductReview -> "review"
+            is WooNotificationType.NewOrder -> NotificationModel.Kind.STORE_ORDER.name
+            is WooNotificationType.ProductReview -> NotificationModel.Kind.COMMENT.name
             else -> null
         }
         return when {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -17,7 +17,6 @@ import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.NotificationSource
 import com.woocommerce.android.notifications.WooNotificationBuilder
 import com.woocommerce.android.notifications.WooNotificationType
-import com.woocommerce.android.notifications.buildWooDrivenAnalyticsId
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.sitepicker.sitevisibility.GetWooVisibleSites
 import com.woocommerce.android.util.NotificationsParser
@@ -308,24 +307,29 @@ class NotificationMessageHandler @Inject constructor(
 
     private fun Notification.buildAnalyticsId(source: NotificationSource): String? = when (source) {
         NotificationSource.WPCOM -> remoteNoteId.takeIf { it != 0L }?.toString()
-        NotificationSource.WOO_DRIVEN -> buildWooDrivenAnalyticsId(
-            remoteSiteId = remoteSiteId,
-            uniqueId = uniqueId,
-            wooTypeSegment = noteType.wooAnalyticsSegment(),
-            storeIdFallback = storeIdFallbackFor(remoteSiteId)
-        )
+        NotificationSource.WOO_DRIVEN -> buildWooDrivenAnalyticsId()
     }
 
-    private fun storeIdFallbackFor(remoteSiteId: Long): String? =
-        if (remoteSiteId != 0L) {
-            null
-        } else {
-            selectedSite.getIfExists()?.let { appPrefsWrapper.getWCStoreID(it.siteId) }
+    /**
+     * Builds the stable `<siteId-or-storeId>:<type>:<entity-id>` analytics id for a Woo-driven
+     * notification, or `null` when the type has no segment (Blaze, local reminder), the entity id
+     * is zero, or no site/store fallback is available.
+     */
+    fun Notification.buildWooDrivenAnalyticsId(): String? {
+        fun WooNotificationType.wooAnalyticsSegment(): String? = when (this) {
+            is WooNotificationType.NewOrder -> "order"
+            is WooNotificationType.ProductReview -> "review"
+            else -> null
         }
-}
 
-private fun WooNotificationType.wooAnalyticsSegment(): String? = when (this) {
-    is WooNotificationType.NewOrder -> "order"
-    is WooNotificationType.ProductReview -> "review"
-    else -> null
+        val siteSegment = when {
+            remoteSiteId != 0L -> remoteSiteId.toString()
+            else -> selectedSite.getIfExists()?.let { appPrefsWrapper.getWCStoreID(it.siteId) }
+        }
+        val wooTypeSegment = noteType.wooAnalyticsSegment()
+        return when {
+            wooTypeSegment == null || siteSegment == null || uniqueId == 0L -> null
+            else -> "$siteSegment:$wooTypeSegment:$uniqueId"
+        }
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -216,10 +216,10 @@ class NotificationMessageHandler @Inject constructor(
     /**
      * Find the matching notification and send a track event for [PUSH_NOTIFICATION_TAPPED].
      */
-    fun markNotificationTapped(remoteNoteId: Long) {
+    fun markNotificationTapped(localPushId: Int) {
         with(notificationBuilder) {
             getActiveNotifications()
-                .firstOrNull { it.remoteNoteId == remoteNoteId }
+                .firstOrNull { it.id == localPushId }
                 ?.let {
                     analyticsTracker.trackNotificationAnalytics(
                         stat = PUSH_NOTIFICATION_TAPPED,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.notifications.push
 
 import androidx.annotation.VisibleForTesting
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.LOCAL_NOTIFICATION_DISMISSED
 import com.woocommerce.android.analytics.AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED
@@ -45,8 +44,7 @@ class NotificationMessageHandler @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val getWooVisibleSites: GetWooVisibleSites,
     private val selectedSite: SelectedSite,
-    private val workManagerScheduler: WorkManagerScheduler,
-    private val appPrefsWrapper: AppPrefsWrapper
+    private val workManagerScheduler: WorkManagerScheduler
 ) {
     companion object {
         private const val PUSH_NOTIFICATION_ID = 10000
@@ -311,25 +309,18 @@ class NotificationMessageHandler @Inject constructor(
     }
 
     /**
-     * Builds the stable `<siteId-or-storeId>:<type>:<entity-id>` analytics id for a Woo-driven
-     * notification, or `null` when the type has no segment (Blaze, local reminder), the entity id
-     * is zero, or no site/store fallback is available.
+     * Builds the stable `<siteId>:<type>:<entity-id>` analytics id for a Woo-driven notification,
+     * or `null` when the type has no segment (Blaze, local reminder) or the entity id is zero.
      */
     private fun Notification.buildWooDrivenAnalyticsId(): String? {
-        fun WooNotificationType.wooAnalyticsSegment(): String? = when (this) {
+        val wooTypeSegment = when (noteType) {
             is WooNotificationType.NewOrder -> "order"
             is WooNotificationType.ProductReview -> "review"
             else -> null
         }
-
-        val siteSegment = when {
-            remoteSiteId != 0L -> remoteSiteId.toString()
-            else -> selectedSite.getIfExists()?.let { appPrefsWrapper.getWCStoreID(it.siteId) }
-        }
-        val wooTypeSegment = noteType.wooAnalyticsSegment()
         return when {
-            wooTypeSegment == null || siteSegment == null || uniqueId == 0L -> null
-            else -> "$siteSegment:$wooTypeSegment:$uniqueId"
+            wooTypeSegment == null || uniqueId == 0L -> null
+            else -> "$remoteSiteId:$wooTypeSegment:$uniqueId"
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.notifications.push
 
 import androidx.annotation.VisibleForTesting
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent.LOCAL_NOTIFICATION_DISMISSED
 import com.woocommerce.android.analytics.AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED
@@ -11,9 +12,12 @@ import com.woocommerce.android.extensions.NotificationReceivedEvent
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.model.isOrderNotification
 import com.woocommerce.android.model.toAppModel
+import com.woocommerce.android.notifications.ActiveNotificationData
 import com.woocommerce.android.notifications.NotificationChannelType
+import com.woocommerce.android.notifications.NotificationSource
 import com.woocommerce.android.notifications.WooNotificationBuilder
 import com.woocommerce.android.notifications.WooNotificationType
+import com.woocommerce.android.notifications.buildWooDrivenAnalyticsId
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.sitepicker.sitevisibility.GetWooVisibleSites
 import com.woocommerce.android.util.NotificationsParser
@@ -42,7 +46,8 @@ class NotificationMessageHandler @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val getWooVisibleSites: GetWooVisibleSites,
     private val selectedSite: SelectedSite,
-    private val workManagerScheduler: WorkManagerScheduler
+    private val workManagerScheduler: WorkManagerScheduler,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     companion object {
         private const val PUSH_NOTIFICATION_ID = 10000
@@ -120,7 +125,7 @@ class NotificationMessageHandler @Inject constructor(
         }
 
         dispatchBackgroundEvents(notificationModel)
-        handleWooNotification(notification)
+        handleWooNotification(notification, notificationSource)
     }
 
     private fun isWooSiteVisible(siteId: Long): Boolean = runBlocking {
@@ -149,15 +154,17 @@ class NotificationMessageHandler @Inject constructor(
         }
     }
 
-    private fun handleWooNotification(notification: Notification) {
+    private fun handleWooNotification(notification: Notification, source: NotificationSource) {
         val localPushId = getLocalPushIdForNoteId(notification.remoteNoteId)
+        val analyticsId = notification.buildAnalyticsId(source)
         with(notificationBuilder) {
             if (isNotificationsEnabled()) {
                 analyticsTracker.trackNotificationAnalytics(
                     stat = PUSH_NOTIFICATION_RECEIVED,
                     siteId = notification.remoteSiteId,
-                    remoteNoteId = notification.remoteNoteId,
-                    noteTypeTrackingValue = notification.noteType.trackingValue
+                    notificationId = analyticsId,
+                    noteTypeTrackingValue = notification.noteType.trackingValue,
+                    source = source
                 )
                 analyticsTracker.flush()
             }
@@ -168,6 +175,8 @@ class NotificationMessageHandler @Inject constructor(
             buildAndDisplayWooNotification(
                 pushId = localPushId,
                 notification = notification,
+                source = source,
+                analyticsId = analyticsId,
                 isGroupNotification = isGroupNotification
             )
 
@@ -182,7 +191,9 @@ class NotificationMessageHandler @Inject constructor(
                 buildAndDisplayWooGroupNotification(
                     inboxMessage = message,
                     subject = subject,
-                    notification = notification
+                    notification = notification,
+                    source = source,
+                    analyticsId = analyticsId
                 )
             }
         }
@@ -220,15 +231,7 @@ class NotificationMessageHandler @Inject constructor(
         with(notificationBuilder) {
             getActiveNotifications()
                 .firstOrNull { it.id == localPushId }
-                ?.let {
-                    analyticsTracker.trackNotificationAnalytics(
-                        stat = PUSH_NOTIFICATION_TAPPED,
-                        siteId = it.remoteSiteId,
-                        remoteNoteId = it.remoteNoteId,
-                        noteTypeTrackingValue = it.noteTypeTrackingValue.orEmpty()
-                    )
-                    analyticsTracker.flush()
-                }
+                ?.let { it.trackTapped() }
         }
     }
 
@@ -238,15 +241,7 @@ class NotificationMessageHandler @Inject constructor(
     fun markNotificationsOfTypeTapped(type: NotificationChannelType) {
         notificationBuilder.getActiveNotifications()
             .filter { it.channelType == type.name && !it.isGroupSummary }
-            .forEach {
-                analyticsTracker.trackNotificationAnalytics(
-                    stat = PUSH_NOTIFICATION_TAPPED,
-                    siteId = it.remoteSiteId,
-                    remoteNoteId = it.remoteNoteId,
-                    noteTypeTrackingValue = it.noteTypeTrackingValue.orEmpty()
-                )
-                analyticsTracker.flush()
-            }
+            .forEach { it.trackTapped() }
     }
 
     fun removeAllNotificationsFromSystemsBar() {
@@ -297,11 +292,40 @@ class NotificationMessageHandler @Inject constructor(
     private fun Map<String, String>.detectNotificationSource(remoteNoteId: Long): NotificationSource =
         when {
             this[PUSH_ARG_USER] != null || remoteNoteId != 0L -> NotificationSource.WPCOM
-            else -> NotificationSource.WOO
+            else -> NotificationSource.WOO_DRIVEN
         }
 
-    private enum class NotificationSource {
-        WOO,
-        WPCOM
+    private fun ActiveNotificationData.trackTapped() {
+        analyticsTracker.trackNotificationAnalytics(
+            stat = PUSH_NOTIFICATION_TAPPED,
+            siteId = remoteSiteId,
+            notificationId = analyticsId,
+            noteTypeTrackingValue = noteTypeTrackingValue.orEmpty(),
+            source = source
+        )
+        analyticsTracker.flush()
     }
+
+    private fun Notification.buildAnalyticsId(source: NotificationSource): String? = when (source) {
+        NotificationSource.WPCOM -> remoteNoteId.takeIf { it != 0L }?.toString()
+        NotificationSource.WOO_DRIVEN -> buildWooDrivenAnalyticsId(
+            remoteSiteId = remoteSiteId,
+            uniqueId = uniqueId,
+            wooTypeSegment = noteType.wooAnalyticsSegment(),
+            storeIdFallback = storeIdFallbackFor(remoteSiteId)
+        )
+    }
+
+    private fun storeIdFallbackFor(remoteSiteId: Long): String? =
+        if (remoteSiteId != 0L) {
+            null
+        } else {
+            selectedSite.getIfExists()?.let { appPrefsWrapper.getWCStoreID(it.siteId) }
+        }
+}
+
+private fun WooNotificationType.wooAnalyticsSegment(): String? = when (this) {
+    is WooNotificationType.NewOrder -> "order"
+    is WooNotificationType.ProductReview -> "review"
+    else -> null
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -315,7 +315,7 @@ class NotificationMessageHandler @Inject constructor(
      * notification, or `null` when the type has no segment (Blaze, local reminder), the entity id
      * is zero, or no site/store fallback is available.
      */
-    fun Notification.buildWooDrivenAnalyticsId(): String? {
+    private fun Notification.buildWooDrivenAnalyticsId(): String? {
         fun WooNotificationType.wooAnalyticsSegment(): String? = when (this) {
             is WooNotificationType.NewOrder -> "order"
             is WooNotificationType.ProductReview -> "review"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -195,7 +195,7 @@ class MainActivityViewModel @Inject constructor(
     }
 
     private fun onSinglePushNotificationOpened(localPushId: Int, notification: Notification) {
-        notificationHandler.markNotificationTapped(notification.remoteNoteId)
+        notificationHandler.markNotificationTapped(localPushId)
         notificationHandler.removeTappedNotificationAndSummaryIfNeeded(localPushId, notification)
         when (notification.noteType) {
             is WooNotificationType.NewOrder -> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTrackerTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.notifications.push
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.notifications.NotificationSource
 import com.woocommerce.android.tools.SelectedSite
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -36,32 +37,52 @@ class NotificationAnalyticsTrackerTest {
     )
 
     @Test
-    fun `given remote note id is non zero, when tracking notification, then include note id property`() {
+    fun `given wpcom notification id, when tracking, then include it verbatim`() {
         tracker.trackNotificationAnalytics(
             stat = AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED,
             siteId = siteId,
-            remoteNoteId = 987L,
-            noteTypeTrackingValue = "store_order"
+            notificationId = "987",
+            noteTypeTrackingValue = "store_order",
+            source = NotificationSource.WPCOM
         )
 
         val captor = argumentCaptor<Map<String, Any>>()
         verify(analyticsTrackerWrapper).track(eq(AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED), captor.capture())
-        assertThat(captor.firstValue).containsEntry("notification_note_id", 987L)
+        assertThat(captor.firstValue).containsEntry("notification_note_id", "987")
+        assertThat(captor.firstValue).containsEntry("push_notification_source", "wpcom")
     }
 
     @Test
-    fun `given remote note id is zero, when tracking notification, then omit note id property`() {
+    fun `given woo-driven composite notification id, when tracking, then include composite string`() {
         tracker.trackNotificationAnalytics(
             stat = AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED,
             siteId = siteId,
-            remoteNoteId = 0L,
-            noteTypeTrackingValue = "store_order"
+            notificationId = "12345:order:4321",
+            noteTypeTrackingValue = "new_order",
+            source = NotificationSource.WOO_DRIVEN
+        )
+
+        val captor = argumentCaptor<Map<String, Any>>()
+        verify(analyticsTrackerWrapper).track(eq(AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED), captor.capture())
+        assertThat(captor.firstValue).containsEntry("notification_note_id", "12345:order:4321")
+        assertThat(captor.firstValue).containsEntry("push_notification_source", "woo_driven")
+    }
+
+    @Test
+    fun `given notification id is null, when tracking, then omit note id property`() {
+        tracker.trackNotificationAnalytics(
+            stat = AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED,
+            siteId = siteId,
+            notificationId = null,
+            noteTypeTrackingValue = "new_order",
+            source = NotificationSource.WOO_DRIVEN
         )
 
         val captor = argumentCaptor<Map<String, Any>>()
         verify(analyticsTrackerWrapper).track(eq(AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED), captor.capture())
         assertThat(captor.firstValue).doesNotContainKey("notification_note_id")
-        assertThat(captor.firstValue).containsEntry("notification_type", "store_order")
+        assertThat(captor.firstValue).containsEntry("notification_type", "new_order")
+        assertThat(captor.firstValue).containsEntry("push_notification_source", "woo_driven")
     }
 
     @Test
@@ -69,8 +90,9 @@ class NotificationAnalyticsTrackerTest {
         tracker.trackNotificationAnalytics(
             stat = AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED,
             siteId = 99999L,
-            remoteNoteId = 987L,
-            noteTypeTrackingValue = "store_order"
+            notificationId = "987",
+            noteTypeTrackingValue = "store_order",
+            source = NotificationSource.WPCOM
         )
 
         verify(analyticsTrackerWrapper, never()).track(any(), any<Map<String, Any>>())

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTrackerTest.kt
@@ -1,0 +1,78 @@
+package com.woocommerce.android.notifications.push
+
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.tools.SelectedSite
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+
+class NotificationAnalyticsTrackerTest {
+    private val siteId = 12345L
+    private val site: SiteModel = mock()
+    private val siteStore: SiteStore = mock {
+        on { getSiteBySiteId(siteId) } doReturn site
+    }
+    private val selectedSite: SelectedSite = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock {
+        on { getFCMToken() } doReturn "fcm-token"
+    }
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+
+    private val tracker = NotificationAnalyticsTracker(
+        siteStore = siteStore,
+        selectedSite = selectedSite,
+        appPrefsWrapper = appPrefsWrapper,
+        analyticsTrackerWrapper = analyticsTrackerWrapper
+    )
+
+    @Test
+    fun `given remote note id is non zero, when tracking notification, then include note id property`() {
+        tracker.trackNotificationAnalytics(
+            stat = AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED,
+            siteId = siteId,
+            remoteNoteId = 987L,
+            noteTypeTrackingValue = "store_order"
+        )
+
+        val captor = argumentCaptor<Map<String, Any>>()
+        verify(analyticsTrackerWrapper).track(eq(AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED), captor.capture())
+        assertThat(captor.firstValue).containsEntry("notification_note_id", 987L)
+    }
+
+    @Test
+    fun `given remote note id is zero, when tracking notification, then omit note id property`() {
+        tracker.trackNotificationAnalytics(
+            stat = AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED,
+            siteId = siteId,
+            remoteNoteId = 0L,
+            noteTypeTrackingValue = "store_order"
+        )
+
+        val captor = argumentCaptor<Map<String, Any>>()
+        verify(analyticsTrackerWrapper).track(eq(AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED), captor.capture())
+        assertThat(captor.firstValue).doesNotContainKey("notification_note_id")
+        assertThat(captor.firstValue).containsEntry("notification_type", "store_order")
+    }
+
+    @Test
+    fun `given site does not exist, when tracking notification, then do not track`() {
+        tracker.trackNotificationAnalytics(
+            stat = AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED,
+            siteId = 99999L,
+            remoteNoteId = 987L,
+            noteTypeTrackingValue = "store_order"
+        )
+
+        verify(analyticsTrackerWrapper, never()).track(any(), any<Map<String, Any>>())
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTrackerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationAnalyticsTrackerTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.NotificationSource
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -14,6 +15,8 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 
@@ -96,5 +99,28 @@ class NotificationAnalyticsTrackerTest {
         )
 
         verify(analyticsTrackerWrapper, never()).track(any(), any<Map<String, Any>>())
+    }
+
+    @Test
+    fun `given app-password site, when tracking, then resolve via selected site and flag as selected`() {
+        val appPasswordSite: SiteModel = mock()
+        whenever(selectedSite.connectionType).thenReturn(SiteConnectionType.ApplicationPasswords)
+        whenever(selectedSite.getOrNull()).thenReturn(appPasswordSite)
+
+        // App-password notifications carry a non-zero payload siteId that doesn't match any
+        // wpcom site in the store — resolution must fall back to the selected site.
+        tracker.trackNotificationAnalytics(
+            stat = AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED,
+            siteId = 7777L,
+            notificationId = "7777:order:42",
+            noteTypeTrackingValue = "new_order",
+            source = NotificationSource.WOO_DRIVEN
+        )
+
+        verifyNoInteractions(siteStore)
+        val captor = argumentCaptor<Map<String, Any>>()
+        verify(analyticsTrackerWrapper).track(eq(AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED), captor.capture())
+        assertThat(captor.firstValue).containsEntry("is_from_selected_site", true)
+        assertThat(captor.firstValue).containsEntry("notification_note_id", "7777:order:42")
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -1,12 +1,15 @@
 package com.woocommerce.android.notifications.push
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.background.WorkManagerScheduler
 import com.woocommerce.android.model.Notification
 import com.woocommerce.android.model.toAppModel
 import com.woocommerce.android.notifications.ActiveNotificationData
+import com.woocommerce.android.notifications.NotificationSource
 import com.woocommerce.android.notifications.WooNotificationBuilder
+import com.woocommerce.android.notifications.WooNotificationType
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_ORDER_NOTE_FULL_DATA_2
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_ORDER_NOTE_FULL_DATA_SITE_2
 import com.woocommerce.android.notifications.push.NotificationTestUtils.TEST_REVIEW_NOTE_FULL_DATA_2
@@ -48,6 +51,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WpComPushNotificationStore.FetchNotificationPayload
+import org.wordpress.android.fluxc.tools.FormattableMeta
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NotificationMessageHandlerTest {
@@ -108,6 +112,7 @@ class NotificationMessageHandlerTest {
         .buildNotificationModelFromPayloadMap(reviewNotificationSite2Payload)!!.toAppModel(resourceProvider)
 
     private val workManagerScheduler: WorkManagerScheduler = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val wooNotificationPayload = mapOf("type" to "new_order")
     private val wooNotificationModel
         get() = NotificationModel(
@@ -131,6 +136,7 @@ class NotificationMessageHandlerTest {
             getWooVisibleSites = getWooVisibleSites,
             selectedSite = selectedSite,
             workManagerScheduler = workManagerScheduler,
+            appPrefsWrapper = appPrefsWrapper,
         )
     }
 
@@ -224,11 +230,30 @@ class NotificationMessageHandlerTest {
     fun `given payload has no wpcom user and parsed note id is zero, when notification received, then treat it as Woo`() =
         runTest {
             val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload().minus("user")
-            createWooNotificationMessageHandler()
+            val wooDrivenOrderId = 4321L
+            val wooDrivenModel = NotificationModel(
+                remoteNoteId = 0L,
+                remoteSiteId = orderNotification.remoteSiteId,
+                type = NotificationModel.Kind.STORE_ORDER,
+                meta = FormattableMeta(
+                    ids = FormattableMeta.Ids(site = orderNotification.remoteSiteId, order = wooDrivenOrderId)
+                )
+            )
+            val mockParser: NotificationsParser = mock {
+                on { buildNotificationModelFromPayloadMap(any()) } doReturn wooDrivenModel
+            }
+            createNotificationMessageHandler(mockParser)
 
             notificationMessageHandler.onNewMessageReceived(payload)
 
             verify(dispatcher, atLeastOnce()).dispatch(any())
+            verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
+                stat = eq(AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED),
+                siteId = eq(orderNotification.remoteSiteId),
+                notificationId = eq("${orderNotification.remoteSiteId}:order:$wooDrivenOrderId"),
+                noteTypeTrackingValue = eq(WooNotificationType.NewOrder.trackingValue),
+                source = eq(NotificationSource.WOO_DRIVEN)
+            )
         }
 
     @Test
@@ -414,10 +439,12 @@ class NotificationMessageHandlerTest {
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
             notification = eq(orderNotification),
+            source = any(),
+            analyticsId = any(),
             isGroupNotification = eq(false)
         )
 
-        verify(notificationBuilder, never()).buildAndDisplayWooGroupNotification(any(), any(), any())
+        verify(notificationBuilder, never()).buildAndDisplayWooGroupNotification(any(), any(), any(), any(), any())
 
         // Second notification - simulate first notification being active
         val firstNotificationData = orderNotification.toActiveNotificationData(10000)
@@ -429,6 +456,8 @@ class NotificationMessageHandlerTest {
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
             notification = eq(reviewNotification),
+            source = any(),
+            analyticsId = any(),
             isGroupNotification = eq(true)
         )
 
@@ -437,7 +466,9 @@ class NotificationMessageHandlerTest {
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
             inboxMessage = eq("${reviewNotification.noteMessage!!}\n${orderNotification.noteMessage!!}"),
             subject = eq(subject),
-            notification = eq(reviewNotification)
+            notification = eq(reviewNotification),
+            source = any(),
+            analyticsId = any()
         )
     }
 
@@ -453,12 +484,15 @@ class NotificationMessageHandlerTest {
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
             notification = eq(firstNotification),
+            source = any(),
+            analyticsId = any(),
             isGroupNotification = eq(false)
         )
 
         // Simulate first notification being active before second arrives
-        val firstNotificationData = firstNotification.toActiveNotificationData(10000)
+        val firstNotificationData = firstNotification
             .copy(remoteNoteId = simulatedRemoteNoteId)
+            .toActiveNotificationData(10000)
         doReturn(listOf(firstNotificationData)).whenever(notificationBuilder).getActiveNotifications()
 
         // Second notification
@@ -468,6 +502,8 @@ class NotificationMessageHandlerTest {
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
             notification = any(),
+            source = any(),
+            analyticsId = any(),
             isGroupNotification = eq(true)
         )
 
@@ -475,7 +511,9 @@ class NotificationMessageHandlerTest {
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
             inboxMessage = any(),
             subject = any(),
-            notification = any()
+            notification = any(),
+            source = any(),
+            analyticsId = any()
         )
     }
 
@@ -539,15 +577,12 @@ class NotificationMessageHandlerTest {
     fun `when more than 5 notifications are received for same store, then display correctly`() {
         // Simulate 5 existing notifications
         val existingNotifications = (0 until 5).map { index ->
-            ActiveNotificationData(
-                id = 10000 + index,
-                remoteNoteId = (100000 + index).toLong(),
-                remoteSiteId = orderNotification.remoteSiteId,
-                channelType = orderNotification.channelType.name,
-                noteMessage = "Message $index",
-                noteTypeTrackingValue = orderNotification.noteType.trackingValue,
-                isGroupSummary = false
-            )
+            orderNotification
+                .copy(
+                    remoteNoteId = (100000 + index).toLong(),
+                    noteMessage = "Message $index"
+                )
+                .toActiveNotificationData(id = 10000 + index)
         }
         doReturn(existingNotifications).whenever(notificationBuilder).getActiveNotifications()
 
@@ -558,6 +593,8 @@ class NotificationMessageHandlerTest {
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
             pushId = any(),
             notification = any(),
+            source = any(),
+            analyticsId = any(),
             isGroupNotification = eq(true)
         )
 
@@ -566,7 +603,9 @@ class NotificationMessageHandlerTest {
         verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooGroupNotification(
             inboxMessage = any(),
             subject = eq(subject),
-            notification = any()
+            notification = any(),
+            source = any(),
+            analyticsId = any()
         )
     }
 
@@ -580,8 +619,9 @@ class NotificationMessageHandlerTest {
         verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
             stat = eq(AnalyticsEvent.PUSH_NOTIFICATION_TAPPED),
             siteId = eq(orderNotification.remoteSiteId),
-            remoteNoteId = eq(orderNotification.remoteNoteId),
-            noteTypeTrackingValue = eq(orderNotification.noteType.trackingValue)
+            notificationId = eq(orderNotification.remoteNoteId.toString()),
+            noteTypeTrackingValue = eq(orderNotification.noteType.trackingValue),
+            source = eq(NotificationSource.WPCOM)
         )
     }
 
@@ -595,8 +635,9 @@ class NotificationMessageHandlerTest {
         verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
             stat = eq(AnalyticsEvent.PUSH_NOTIFICATION_TAPPED),
             siteId = eq(orderNotification.remoteSiteId),
-            remoteNoteId = eq(orderNotification.remoteNoteId),
-            noteTypeTrackingValue = eq(orderNotification.noteType.trackingValue)
+            notificationId = eq(orderNotification.remoteNoteId.toString()),
+            noteTypeTrackingValue = eq(orderNotification.noteType.trackingValue),
+            source = eq(NotificationSource.WPCOM)
         )
     }
 
@@ -695,6 +736,8 @@ class NotificationMessageHandlerTest {
         channelType = channelType.name,
         noteMessage = noteMessage,
         noteTypeTrackingValue = noteType.trackingValue,
+        source = NotificationSource.WPCOM,
+        analyticsId = remoteNoteId.takeIf { it != 0L }?.toString(),
         isGroupSummary = isGroupSummary
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -575,7 +575,7 @@ class NotificationMessageHandlerTest {
         val mockNotificationData = orderNotification.toActiveNotificationData(10000)
         doReturn(listOf(mockNotificationData)).whenever(notificationBuilder).getActiveNotifications()
 
-        notificationMessageHandler.markNotificationTapped(orderNotification.remoteNoteId)
+        notificationMessageHandler.markNotificationTapped(mockNotificationData.id)
 
         verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
             stat = eq(AnalyticsEvent.PUSH_NOTIFICATION_TAPPED),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.notifications.push
 
-import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.background.WorkManagerScheduler
@@ -112,7 +111,6 @@ class NotificationMessageHandlerTest {
         .buildNotificationModelFromPayloadMap(reviewNotificationSite2Payload)!!.toAppModel(resourceProvider)
 
     private val workManagerScheduler: WorkManagerScheduler = mock()
-    private val appPrefsWrapper: AppPrefsWrapper = mock()
     private val wooNotificationPayload = mapOf("type" to "new_order")
     private val wooNotificationModel
         get() = NotificationModel(
@@ -136,7 +134,6 @@ class NotificationMessageHandlerTest {
             getWooVisibleSites = getWooVisibleSites,
             selectedSite = selectedSite,
             workManagerScheduler = workManagerScheduler,
-            appPrefsWrapper = appPrefsWrapper,
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -247,7 +247,9 @@ class NotificationMessageHandlerTest {
             verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
                 stat = eq(AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED),
                 siteId = eq(orderNotification.remoteSiteId),
-                notificationId = eq("${orderNotification.remoteSiteId}:order:$wooDrivenOrderId"),
+                notificationId = eq(
+                    "${orderNotification.remoteSiteId}:${NotificationModel.Kind.STORE_ORDER.name}:$wooDrivenOrderId"
+                ),
                 noteTypeTrackingValue = eq(WooNotificationType.NewOrder.trackingValue),
                 source = eq(NotificationSource.WOO_DRIVEN)
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -197,7 +197,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
 
         viewModel.onPushNotificationTapped(localPushId, testOrderNotification)
 
-        verify(notificationMessageHandler, atLeastOnce()).markNotificationTapped(eq(testOrderNotification.remoteNoteId))
+        verify(notificationMessageHandler, atLeastOnce()).markNotificationTapped(eq(localPushId))
         verify(notificationMessageHandler, atLeastOnce())
             .removeTappedNotificationAndSummaryIfNeeded(eq(localPushId), eq(testOrderNotification))
         assertThat(event).isEqualTo(ViewOrderDetail(testOrderNotification.uniqueId))
@@ -214,7 +214,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         viewModel.onPushNotificationTapped(localPushId, testReviewNotification)
 
         verify(notificationMessageHandler, atLeastOnce())
-            .markNotificationTapped(eq(testReviewNotification.remoteNoteId))
+            .markNotificationTapped(eq(localPushId))
         verify(notificationMessageHandler, atLeastOnce())
             .removeTappedNotificationAndSummaryIfNeeded(eq(localPushId), eq(testReviewNotification))
         assertThat(event).isEqualTo(ViewReviewDetail(testReviewNotification.uniqueId))
@@ -555,7 +555,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         viewModel.onPushNotificationTapped(localPushId, testBlazeNotification)
 
         verify(notificationMessageHandler, atLeastOnce())
-            .markNotificationTapped(eq(testBlazeNotification.remoteNoteId))
+            .markNotificationTapped(eq(localPushId))
         verify(notificationMessageHandler, atLeastOnce())
             .removeTappedNotificationAndSummaryIfNeeded(eq(localPushId), eq(testBlazeNotification))
         assertThat(event).isEqualTo(


### PR DESCRIPTION
### Description

Part of WOOMOB-2712

Push notification analytics depended on the wp.com `note_id`, which Woo-driven notifications don't carry (they arrive with `remoteNoteId == 0L`). That caused two issues in the original code:

- `notification_note_id: 0` was emitted on every Woo-driven `PUSH_NOTIFICATION_RECEIVED` / `PUSH_NOTIFICATION_TAPPED` event — analytics noise that also broke received-vs-tapped correlation.
- `markNotificationTapped(remoteNoteId)` matched the first active notification with id 0, so taps could be attributed to the wrong notification when several Woo-driven notifications coexisted.

This PR:

- **Fixes the wrong-tap correlation bug** — matches active notifications by their local push id instead of `remoteNoteId`, so each tap is attributed to the right notification even when several Woo-driven notifications coexist in the tray.
- **Adds `push_notification_source` + stable `notification_note_id`** — new analytics property with values `wpcom` / `woo_driven`, emitted on both received and tapped events so funnels can distinguish the two delivery paths. `notification_note_id` is now computed for every push: WPCOM uses the numeric wp.com note id as before; Woo-driven uses a stable composite string `<siteId>:<type>:<entity-id>` (e.g. `98765:store_order:4321`). The property is only omitted when no meaningful id can be built (e.g. Blaze notifications).
- **Resolves the tracking site for app-password notifications** — `siteStore.getSiteBySiteId(payloadSiteId)` returns `null` for app-password sites, which previously caused all `PUSH_NOTIFICATION_RECEIVED/TAPPED` events for those sites to be silently dropped. Tracking now falls back to the selected site (safe because multi-site is unsupported under app-password auth).

### Test Steps

Non-user-facing change — validation is in Tracks. For each scenario below, receive and then tap the notification and confirm the Tracks event shape.

- [ ] `./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "*NotificationAnalyticsTrackerTest" --tests "*NotificationMessageHandlerTest"` — green.
- [ ] **WPCOM (Jetpack-connected site)** — `push_notification_source = wpcom`; `notification_note_id` is the numeric wp.com note id (unchanged behavior).
- [ ] **Woo-driven** — `push_notification_source = woo_driven`; `notification_note_id` is the composite `<siteId>:order:<orderId>`; the received and tapped events carry the **same** id.
- [ ] **App-password site** — `PUSH_NOTIFICATION_RECEIVED/TAPPED` events are emitted (previously dropped).

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
