### PR TITLE
[WOOMOB-2726] Treat 404 as success when deleting push tokens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -244,7 +244,8 @@ class PushNotificationRepository @Inject constructor(
         val registration = preferences.getPushRegistration(site.siteId) ?: return Result.success(Unit)
 
         val result = wooPushNotificationsStore.deletePushToken(site, registration.tokenId)
-        if (result.isError) {
+        val isAlreadyDeleted = result.error?.type == WooErrorType.INVALID_ID
+        if (result.isError && !isAlreadyDeleted) {
             WooLog.w(
                 WooLog.T.NOTIFICATIONS,
                 "Failed to delete push token for site ${site.siteId}: ${result.error?.message}"
@@ -255,7 +256,14 @@ class PushNotificationRepository @Inject constructor(
         pushNotificationsDataStore.edit {
             it.clearPushRegistration(site.siteId)
         }
-        WooLog.d(WooLog.T.NOTIFICATIONS, "Woo Core push token deleted for site ${site.siteId}")
+        if (isAlreadyDeleted) {
+            WooLog.d(
+                WooLog.T.NOTIFICATIONS,
+                "Woo Core push token already deleted on server for site ${site.siteId}, clearing local entry"
+            )
+        } else {
+            WooLog.d(WooLog.T.NOTIFICATIONS, "Woo Core push token deleted for site ${site.siteId}")
+        }
         return Result.success(Unit)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
@@ -370,6 +370,46 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given deletePushToken returns INVALID_ID error, when unregisterDevice called, then clears local token`() =
+        testBlocking {
+            val site = mock<SiteModel> { on { siteId } doReturn 123L }
+            whenever(wooCommerceStore.getWooCommerceSites()).thenReturn(mutableListOf(site))
+            val tokenKey = stringPreferencesKey("push_token_123")
+            whenever(preferences[tokenKey]).thenReturn("token-id-1")
+            whenever(wooPushNotificationsStore.deletePushToken(any(), any())).thenReturn(
+                WooResult(WooError(WooErrorType.INVALID_ID, BaseRequest.GenericErrorType.NOT_FOUND, "Not found"))
+            )
+            val mutablePreferences: MutablePreferences = mock()
+            whenever(preferences.toMutablePreferences()).thenReturn(mutablePreferences)
+            whenever(pushNotificationsDataStore.updateData(any())).thenAnswer { invocation ->
+                val transform = invocation.getArgument<suspend (Preferences) -> Preferences>(0)
+                testBlocking { transform(preferences) }
+                preferences
+            }
+
+            sut.unregisterDeviceFromPushNotifications()
+
+            val expectedTokenKey = stringPreferencesKey("push_token_123")
+            verify(mutablePreferences).remove(expectedTokenKey)
+        }
+
+    @Test
+    fun `given deletePushToken returns non-INVALID_ID error, when unregisterDevice called, then keeps local token`() =
+        testBlocking {
+            val site = mock<SiteModel> { on { siteId } doReturn 123L }
+            whenever(wooCommerceStore.getWooCommerceSites()).thenReturn(mutableListOf(site))
+            val tokenKey = stringPreferencesKey("push_token_123")
+            whenever(preferences[tokenKey]).thenReturn("token-id-1")
+            whenever(wooPushNotificationsStore.deletePushToken(any(), any())).thenReturn(
+                WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN, "oops"))
+            )
+
+            sut.unregisterDeviceFromPushNotifications()
+
+            verify(pushNotificationsDataStore, never()).updateData(any())
+        }
+
+    @Test
     fun `given token exists for site and plugin is compatible, when isWooPushTokenRegisteredForSite called, then returns true`() =
         testBlocking {
             val tokenKey = stringPreferencesKey("push_token_$SITE_ID")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
@@ -374,8 +374,9 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
         testBlocking {
             val site = mock<SiteModel> { on { siteId } doReturn 123L }
             whenever(wooCommerceStore.getWooCommerceSites()).thenReturn(mutableListOf(site))
-            val tokenKey = stringPreferencesKey("push_token_123")
-            whenever(preferences[tokenKey]).thenReturn("token-id-1")
+            whenever(preferences[stringPreferencesKey("push_token_123")]).thenReturn("token-id-1")
+            whenever(preferences[stringPreferencesKey("push_token_value_123")]).thenReturn("token-1")
+            whenever(preferences[stringPreferencesKey("push_locale_123")]).thenReturn("en_US")
             whenever(wooPushNotificationsStore.deletePushToken(any(), any())).thenReturn(
                 WooResult(WooError(WooErrorType.INVALID_ID, BaseRequest.GenericErrorType.NOT_FOUND, "Not found"))
             )
@@ -389,8 +390,9 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
 
             sut.unregisterDeviceFromPushNotifications()
 
-            val expectedTokenKey = stringPreferencesKey("push_token_123")
-            verify(mutablePreferences).remove(expectedTokenKey)
+            verify(mutablePreferences).remove(stringPreferencesKey("push_token_123"))
+            verify(mutablePreferences).remove(stringPreferencesKey("push_token_value_123"))
+            verify(mutablePreferences).remove(stringPreferencesKey("push_locale_123"))
         }
 
     @Test
@@ -398,8 +400,9 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
         testBlocking {
             val site = mock<SiteModel> { on { siteId } doReturn 123L }
             whenever(wooCommerceStore.getWooCommerceSites()).thenReturn(mutableListOf(site))
-            val tokenKey = stringPreferencesKey("push_token_123")
-            whenever(preferences[tokenKey]).thenReturn("token-id-1")
+            whenever(preferences[stringPreferencesKey("push_token_123")]).thenReturn("token-id-1")
+            whenever(preferences[stringPreferencesKey("push_token_value_123")]).thenReturn("token-1")
+            whenever(preferences[stringPreferencesKey("push_locale_123")]).thenReturn("en_US")
             whenever(wooPushNotificationsStore.deletePushToken(any(), any())).thenReturn(
                 WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN, "oops"))
             )


### PR DESCRIPTION
Fixes WOOMOB-2726

When unregistering Woo Core push notification tokens during logout or site-switch, the app only cleared the local DataStore entry on a successful server response. If the token was already gone on the server (e.g. server-side cleanup), the API returned a 404 mapped to `WooErrorType.INVALID_ID`, which the app treated as an error — leaving stale tokens that caused repeated failed delete attempts on every subsequent logout.

The fix treats `INVALID_ID` (404) as a successful deletion: the end state is identical (token doesn't exist on the server), so the local DataStore entry should always be cleared. This matches the behaviour of `WpComPushNotificationStore`, which already clears local prefs regardless of server response.

### Test Steps

1. Install a debug build and log in to a Woo store with Woo Core push notifications enabled.

2. Register a fake 404 response for the push-token delete endpoint:
   ```
   adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
     --es api_type "wp-api" \
     --es path "/wc-push-notifications/push-tokens/%" \
     --es http_method "DELETE" \
     --ei response_status_code 404
   ```

3. Enable ApiFaker:
   ```
   adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled true
   ```

4. Log out via **App Settings → ⋮ → Log out**.

5. Check logcat for push token handling:
   ```
   adb logcat -s WooLog -d | grep -i "push token"
   ```
   - **Expected (fixed):** A debug log "Woo Core push token already deleted on server for site …, clearing local entry"
   - **Before fix:** A warning log "Failed to delete push token for site …" and the local entry would be retained.

6. Clean up:
   ```
   adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false
   adb shell am broadcast -p com.woocommerce.android.dev -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS
   ```

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.