### PR TITLE
[WOOMOB-2585] Increase Room CursorWindow size to avoid SQLiteBlobTooBigException

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 24.7
 -----
+- [*] Fixed a crash when loading the product list on stores with very large product descriptions [https://github.com/woocommerce/woocommerce-android/pull/15693]
 - [Internal] Fixed logout push cleanup sequencing and added a logout loading state in App Settings [https://github.com/woocommerce/woocommerce-android/pull/15667]
 
 24.6

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/LargeCursorWindowOpenHelperFactory.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/LargeCursorWindowOpenHelperFactory.kt
@@ -49,7 +49,7 @@ internal class LargeCursorWindowOpenHelperFactory(
 
         private fun Cursor.withLargerWindow(): Cursor = apply {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && this is SQLiteCursor) {
-                setWindow(CursorWindow(null, windowSizeBytes))
+                window = CursorWindow(null, windowSizeBytes)
             }
         }
     }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/LargeCursorWindowOpenHelperFactory.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/LargeCursorWindowOpenHelperFactory.kt
@@ -1,0 +1,56 @@
+package org.wordpress.android.fluxc.persistence
+
+import android.database.Cursor
+import android.database.CursorWindow
+import android.database.sqlite.SQLiteCursor
+import android.os.Build
+import android.os.CancellationSignal
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.SupportSQLiteQuery
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+
+// Mirrors `WooWellSqlConfig.getCursorWindowSize`; only active on API 28+.
+internal class LargeCursorWindowOpenHelperFactory(
+    private val windowSizeBytes: Long,
+    private val delegate: SupportSQLiteOpenHelper.Factory = FrameworkSQLiteOpenHelperFactory()
+) : SupportSQLiteOpenHelper.Factory {
+
+    override fun create(
+        configuration: SupportSQLiteOpenHelper.Configuration
+    ): SupportSQLiteOpenHelper = OpenHelperWrapper(delegate.create(configuration), windowSizeBytes)
+
+    private class OpenHelperWrapper(
+        private val delegate: SupportSQLiteOpenHelper,
+        private val windowSizeBytes: Long
+    ) : SupportSQLiteOpenHelper by delegate {
+        override val writableDatabase: SupportSQLiteDatabase
+            get() = DatabaseWrapper(delegate.writableDatabase, windowSizeBytes)
+
+        override val readableDatabase: SupportSQLiteDatabase
+            get() = DatabaseWrapper(delegate.readableDatabase, windowSizeBytes)
+    }
+
+    private class DatabaseWrapper(
+        private val delegate: SupportSQLiteDatabase,
+        private val windowSizeBytes: Long
+    ) : SupportSQLiteDatabase by delegate {
+        override fun query(query: String): Cursor =
+            delegate.query(query).withLargerWindow()
+
+        override fun query(query: String, bindArgs: Array<out Any?>): Cursor =
+            delegate.query(query, bindArgs).withLargerWindow()
+
+        override fun query(query: SupportSQLiteQuery): Cursor =
+            delegate.query(query).withLargerWindow()
+
+        override fun query(query: SupportSQLiteQuery, cancellationSignal: CancellationSignal?): Cursor =
+            delegate.query(query, cancellationSignal).withLargerWindow()
+
+        private fun Cursor.withLargerWindow(): Cursor = apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && this is SQLiteCursor) {
+                setWindow(CursorWindow(null, windowSizeBytes))
+            }
+        }
+    }
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/persistence/WCAndroidDatabase.kt
@@ -141,6 +141,10 @@ import org.wordpress.android.fluxc.persistence.migrations.MIGRATION_9_10
 
 const val WC_DATABASE_VERSION = 82
 
+// Matches the CursorWindow size used by WooWellSqlConfig; raises SQLite's ~2 MB default on API 28+.
+@Suppress("MagicNumber")
+private val CURSOR_WINDOW_SIZE_BYTES = 1024L * 1024L * 10L
+
 @Database(
     version = WC_DATABASE_VERSION,
     entities = [
@@ -323,7 +327,8 @@ abstract class WCAndroidDatabase : RoomDatabase(), TransactionExecutor {
             applicationContext,
             WCAndroidDatabase::class.java,
             "wc-android-database"
-        ).allowMainThreadQueries()
+        ).openHelperFactory(LargeCursorWindowOpenHelperFactory(CURSOR_WINDOW_SIZE_BYTES))
+            .allowMainThreadQueries()
             .addTypeConverter(currencyPositionConverter)
             .addTypeConverter(statsGranularityConverter)
             .fallbackToDestructiveMigrationOnDowngrade()

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/LargeCursorWindowRoomIntegrationTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/LargeCursorWindowRoomIntegrationTest.kt
@@ -15,6 +15,7 @@ import org.robolectric.annotation.Config
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.persistence.dao.ProductsDao
 import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
 
 @RunWith(RobolectricTestRunner::class)
@@ -54,7 +55,7 @@ internal class LargeCursorWindowRoomIntegrationTest {
         description = "x".repeat(HUGE_DESCRIPTION_LENGTH)
     )
 
-    private suspend fun org.wordpress.android.fluxc.persistence.dao.ProductsDao.fetchAllProducts() = getProducts(
+    private suspend fun ProductsDao.fetchAllProducts() = getProducts(
         localSiteId = SITE_ID,
         status = null,
         stockStatus = null,

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/LargeCursorWindowRoomIntegrationTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/persistence/LargeCursorWindowRoomIntegrationTest.kt
@@ -1,0 +1,74 @@
+package org.wordpress.android.fluxc.persistence
+
+import android.app.Application
+import android.database.sqlite.SQLiteBlobTooBigException
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.store.WCProductStore.ProductSorting
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+internal class LargeCursorWindowRoomIntegrationTest {
+    private val appContext = ApplicationProvider.getApplicationContext<Application>()
+
+    @get:Rule
+    val defaultDb = DatabaseTestRule(appContext)
+
+    @get:Rule
+    val enlargedDb = DatabaseTestRule(appContext, LargeCursorWindowOpenHelperFactory(TEN_MEGABYTES))
+
+    @Test
+    fun `given default open helper factory, when product row exceeds default window, then query throws`() {
+        runBlocking { defaultDb.db.productsDao.upsertProduct(hugeProduct()) }
+
+        assertThatThrownBy {
+            runBlocking { defaultDb.db.productsDao.fetchAllProducts() }
+        }.isInstanceOf(SQLiteBlobTooBigException::class.java)
+    }
+
+    @Test
+    fun `given enlarged cursor window factory, when product row exceeds default window, then query succeeds`() {
+        runBlocking { enlargedDb.db.productsDao.upsertProduct(hugeProduct()) }
+
+        val products = runBlocking { enlargedDb.db.productsDao.fetchAllProducts() }
+
+        assertThat(products).hasSize(1)
+        assertThat(products.first().description.length).isEqualTo(HUGE_DESCRIPTION_LENGTH)
+    }
+
+    private fun hugeProduct() = WCProductModel(
+        localSiteId = LocalId(SITE_ID),
+        remoteId = RemoteId(1L),
+        name = "huge",
+        description = "x".repeat(HUGE_DESCRIPTION_LENGTH)
+    )
+
+    private suspend fun org.wordpress.android.fluxc.persistence.dao.ProductsDao.fetchAllProducts() = getProducts(
+        localSiteId = SITE_ID,
+        status = null,
+        stockStatus = null,
+        type = null,
+        category = null,
+        excludeSampleProducts = false,
+        limit = null,
+        excludedProductIds = emptyList(),
+        sortType = ProductSorting.DATE_ASC
+    )
+
+    companion object {
+        private const val SITE_ID = 1
+        private const val HUGE_DESCRIPTION_LENGTH = 3 * 1024 * 1024 // 3 MB — over the default ~2 MB window
+        private const val TEN_MEGABYTES = 10L * 1024L * 1024L
+    }
+}

--- a/libs/fluxc-plugin/src/testFixtures/kotlin/org/wordpress/android/fluxc/persistence/DatabaseTestRule.kt
+++ b/libs/fluxc-plugin/src/testFixtures/kotlin/org/wordpress/android/fluxc/persistence/DatabaseTestRule.kt
@@ -2,22 +2,27 @@ package org.wordpress.android.fluxc.persistence
 
 import android.content.Context
 import androidx.room.Room
+import androidx.sqlite.db.SupportSQLiteOpenHelper
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 import org.mockito.Mockito
 import org.wordpress.android.fluxc.persistence.converters.CurrencyPositionConverter
 import org.wordpress.android.fluxc.persistence.converters.StatsGranularityConverter
 
-class DatabaseTestRule(private val appContext: Context) : TestWatcher() {
+class DatabaseTestRule(
+    private val appContext: Context,
+    private val openHelperFactory: SupportSQLiteOpenHelper.Factory? = null
+) : TestWatcher() {
 
     lateinit var db: WCAndroidDatabase
 
     override fun starting(description: Description?) {
-        db = Room.inMemoryDatabaseBuilder(appContext, WCAndroidDatabase::class.java)
+        val builder = Room.inMemoryDatabaseBuilder(appContext, WCAndroidDatabase::class.java)
             .addTypeConverter(CurrencyPositionConverter(Mockito.mock()))
             .addTypeConverter(StatsGranularityConverter(Mockito.mock()))
             .allowMainThreadQueries()
-            .build()
+        openHelperFactory?.let { builder.openHelperFactory(it) }
+        db = builder.build()
     }
 
     override fun finished(description: Description?) {


### PR DESCRIPTION
### Description

Fixes WOOMOB-2585

Applies the same mitigation as the WellSql side to Room-backed queries: wrap `SupportSQLiteOpenHelper.Factory` so every `query(...)` call installs a 10 MB `CursorWindow` on API 28+, avoiding `SQLiteBlobTooBigException` when a product row's combined columns exceed SQLite's default ~2 MB window.

Precedent:
- #11400 — bumped WellSql cursor window to 10 MB
- #2627 — original 5 MB bump on API 28+
- wordpress-mobile/WordPress-FluxC-Android#1586 — added `getCursorWindowSize()` to fluxc's `WellSqlConfig`

Not a structural fix — a single row over 10 MB would still crash, and the long-term answer is pagination or narrower projections on `ProductsDao.getProducts`. But product row sizes vary widely per site and matching the WellSql precedent gives immediate relief with minimal risk.

### Test Steps

Automated coverage:
- Unit tests verify the factory invokes `setWindow(...)` on all four `query(...)` overloads on API 28+ and skips it below.
- Robolectric integration test inserts a 3 MB product row into an in-memory `WCAndroidDatabase`: reproduces the crash with the default factory and confirms the row round-trips cleanly with the new factory.

Non regression tests on device (API 28+):
1. Open the Products tab and scroll — no crash in Logcat/Sentry.
2. Pull-to-refresh — still no crash.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.