### PR TITLE
[WOOMOB-2724] Replace POS Orders empty-state Learn more with Refresh

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [Internal] Fixed logout push cleanup sequencing and added a logout loading state in App Settings [https://github.com/woocommerce/woocommerce-android/pull/15667]
 - [Internal] Show the notification permission card for all supported stores on Android 13+ [https://github.com/woocommerce/woocommerce-android/pull/15676/]
 - [*] Stop POS background catalog sync once the initial sync completes for users who never open POS [https://github.com/woocommerce/woocommerce-android/pull/15651]
+- [*] Replaced the POS Orders "Learn more" empty-state button with a "Refresh" action and updated the empty-state copy [https://github.com/woocommerce/woocommerce-android/pull/15694]
 
 24.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -74,11 +73,9 @@ import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundDetai
 import com.woocommerce.android.ui.woopos.orders.list.WooPosOrdersListState
 import com.woocommerce.android.ui.woopos.orders.list.WooPosOrdersListViewModel
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
-import com.woocommerce.android.util.ChromeCustomTabUtils
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 
@@ -99,13 +96,6 @@ fun WooPosOrdersScreen(
     LaunchedEffect(navigatedFromEmailReceiptSent) {
         if (navigatedFromEmailReceiptSent) {
             detailViewModel.onBackFromSuccessfullySendingEmailReceipt()
-        }
-    }
-
-    val context = LocalContext.current
-    LaunchedEffect(Unit) {
-        listViewModel.openUrlEvent.collectLatest { url ->
-            ChromeCustomTabUtils.launchUrl(context, url, enableSlideAnimation = true)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListViewModel.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.woopos.orders.list
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.woocommerce.android.AppUrls
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
@@ -49,9 +48,6 @@ class WooPosOrdersListViewModel @Inject constructor(
         )
     )
     val state: StateFlow<WooPosOrdersListState> = _state.asStateFlow()
-
-    private val _openUrlEvent = MutableSharedFlow<String>()
-    val openUrlEvent: SharedFlow<String> = _openUrlEvent.asSharedFlow()
 
     private val _scrollToTopEvent = MutableSharedFlow<Unit>()
     val scrollToTopEvent: SharedFlow<Unit> = _scrollToTopEvent.asSharedFlow()
@@ -216,9 +212,7 @@ class WooPosOrdersListViewModel @Inject constructor(
     }
 
     fun onOrdersEmptyActionClicked() {
-        viewModelScope.launch {
-            _openUrlEvent.emit(AppUrls.URL_LEARN_MORE_ORDERS)
-        }
+        onRefresh()
     }
 
     fun onOrdersLoadingErrorRetryButtonClicked() {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3812,8 +3812,8 @@
     <string name="woopos_coupons_pagination_error_description">Please check your internet connection and try again.</string>
 
     <string name="woopos_orders_empty_list_title">No orders found</string>
-    <string name="woopos_orders_empty_list_message">Explore how you can increase your store sales.</string>
-    <string name="woopos_orders_empty_action_label">Learn more</string>
+    <string name="woopos_orders_empty_list_message">Orders will appear here once you start processing sales on the POS.</string>
+    <string name="woopos_orders_empty_action_label">Refresh</string>
     <string name="woopos_orders_empty_list_image_description">No orders</string>
     <string name="woopos_orders_no_order_selected">No order selected.</string>
     <string name="woopos_orders_loading_error_title">Unable to load orders</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/list/WooPosOrdersListViewModelTest.kt
@@ -218,6 +218,31 @@ class WooPosOrdersListViewModelTest {
     // region Refresh
 
     @Test
+    fun `given empty state, when empty action clicked, then refresh orders`() = runTest {
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow {
+                emit(LoadOrdersResult.SuccessCache(emptyList()))
+                emit(LoadOrdersResult.SuccessRemote(emptyList()))
+            }
+        )
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        assertThat(viewModel.state.value).isInstanceOf(WooPosOrdersListState.Empty::class.java)
+
+        whenever(dataSource.loadOrders()).thenReturn(
+            flow { emit(LoadOrdersResult.SuccessRemote(ordersList(order(1)))) }
+        )
+
+        viewModel.onOrdersEmptyActionClicked()
+        advanceUntilIdle()
+
+        verify(dataSource).clearCache()
+        val content = viewModel.state.value as WooPosOrdersListState.Content
+        val loadedItems = content.items as WooPosOrdersListState.Content.Items.Loaded
+        assertThat(loadedItems.items.map { it.id }).containsExactly(1L)
+    }
+
+    @Test
     fun `given initial content, when refresh, then clear cache and update with network result`() = runTest {
         whenever(dataSource.loadOrders()).thenReturn(
             flow { emit(LoadOrdersResult.SuccessRemote(ordersList(order(1)))) }


### PR DESCRIPTION
Fixes #WOOMOB-2724

### Description

The "No orders found" empty state in POS Orders had a "Learn more" CTA that linked to the generic WooCommerce blog (`https://woocommerce.com/blog/`) — not actionable or relevant. Per the decision captured on the [Linear issue](https://linear.app/a8c/issue/WOOMOB-2724/pos-orders-no-orders-found-learn-more-button-links-to-wrong-url), the behavior is now:

- **CTA**: `Refresh` (triggers the same refresh path as pull-to-refresh)
- **Message**: `Orders will appear here once you start processing sales on the POS.`

Also removed the now-unused `openUrlEvent` SharedFlow and its Chrome Custom Tab launcher, and added a unit test for the Empty → refresh flow.

> [!WARNING]
> **Do not merge — depends on parent PR.** This branch is based on `issue/WOOMOB-2470-pos-orders-split-wire-screen`. That parent PR must be merged into `trunk` first, then this PR can be retargeted to `trunk` and merged.

### Test Steps

1. Build and run on a tablet (POS is tablet-only).
2. Navigate to POS → Orders on a store with no POS orders (or force an empty result).
3. Verify the empty state shows:
   - Title: **No orders found**
   - Message: **Orders will appear here once you start processing sales on the POS.**
   - CTA button: **Refresh**
4. Tap **Refresh** — it should trigger a fresh orders fetch (no browser/custom tab should open) and remain on the empty state if there are still no orders.

### Images/gif

| Before | After |
| --- | --- |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/cf77170d-8be7-4418-ab72-35e63b0357d9" /> | <img width="400" alt="woomob-2724-empty-state-v2" src="https://github.com/user-attachments/assets/96889932-3fc1-43ba-b12e-6ea0654e6b02" /> |

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.