### PR TITLE
[WOOMOB-2732] Use a single local PN feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/ShouldShowEnablePushNotificationsUi.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/ShouldShowEnablePushNotificationsUi.kt
@@ -25,7 +25,7 @@ class ShouldShowEnablePushNotificationsUi @Inject constructor(
     private val featureFlagRepository: FeatureFlagRepository
 ) {
     operator fun invoke(): Flow<Boolean> {
-        if (!featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2)) return flowOf(false)
+        if (!featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)) return flowOf(false)
         return selectedSite.observe()
             .flatMapLatest { site ->
                 if (site == null || site.connectionType == SiteConnectionType.Jetpack) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModel.kt
@@ -51,7 +51,7 @@ class JetpackBenefitsViewModel @Inject constructor(
             isUsingJetpackCP = selectedSite.connectionType == SiteConnectionType.JetpackConnectionPackage,
             isLoadingDialogShown = false,
             isPushNotificationsBenefitVisible = !featureFlagRepository.isEnabled(
-                FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2
+                FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1
             ),
         )
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -31,6 +31,5 @@ enum class FeatureFlag(
     AGE_ELIGIBILITY_CHECKS("age_eligibility_checks", localValue = PackageUtils.isDebugBuild()),
     BOOKINGS_RESCHEDULE("bookings_reschedule", localValue = PackageUtils.isDebugBuild()),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1("woo_self_driven_push_notifications_m1", localValue = false),
-    WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2("woo_self_driven_push_notifications_m2", localValue = false),
     LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/ShouldShowEnablePushNotificationsUiTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/ShouldShowEnablePushNotificationsUiTest.kt
@@ -1,0 +1,113 @@
+package com.woocommerce.android.notifications.push
+
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+
+@ExperimentalCoroutinesApi
+class ShouldShowEnablePushNotificationsUiTest : BaseUnitTest() {
+    private val selectedSite: SelectedSite = mock()
+    private val pushNotificationRegistrationStatus: PushNotificationRegistrationStatus = mock()
+    private val featureFlagRepository: FeatureFlagRepository = mock()
+
+    private lateinit var sut: ShouldShowEnablePushNotificationsUi
+
+    @Before
+    fun setUp() {
+        sut = ShouldShowEnablePushNotificationsUi(
+            selectedSite = selectedSite,
+            pushNotificationRegistrationStatus = pushNotificationRegistrationStatus,
+            featureFlagRepository = featureFlagRepository
+        )
+    }
+
+    @Test
+    fun `given M1 flag is disabled, when invoked, then returns false without observing site`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1))
+            .thenReturn(false)
+
+        val result = sut().first()
+
+        assertThat(result).isFalse()
+        verify(selectedSite, never()).observe()
+    }
+
+    @Test
+    fun `given M1 flag is enabled and no site selected, when invoked, then returns false`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1))
+            .thenReturn(true)
+        whenever(selectedSite.observe()).thenReturn(flowOf(null))
+
+        val result = sut().first()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given M1 flag is enabled and Jetpack site selected, when invoked, then returns false`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1))
+            .thenReturn(true)
+        val jetpackSite: SiteModel = mock {
+            on { origin } doReturn SiteModel.ORIGIN_WPCOM_REST
+            on { isJetpackConnected } doReturn true
+        }
+        whenever(selectedSite.observe()).thenReturn(flowOf(jetpackSite))
+
+        val result = sut().first()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `given M1 flag is enabled and non-Jetpack site is already Woo-registered, when invoked, then returns false`() =
+        testBlocking {
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1))
+                .thenReturn(true)
+            val appPasswordsSite: SiteModel = mock {
+                on { siteId } doReturn TEST_SITE_ID
+                on { origin } doReturn 0 // != ORIGIN_WPCOM_REST(1) → ApplicationPasswords
+            }
+            whenever(selectedSite.observe()).thenReturn(flowOf(appPasswordsSite))
+            whenever(pushNotificationRegistrationStatus.observe(TEST_SITE_ID))
+                .thenReturn(flowOf(PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY))
+
+            val result = sut().first()
+
+            assertThat(result).isFalse()
+        }
+
+    @Test
+    fun `given M1 flag is enabled and non-Jetpack site is not Woo-registered, when invoked, then returns true`() =
+        testBlocking {
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1))
+                .thenReturn(true)
+            val appPasswordsSite: SiteModel = mock {
+                on { siteId } doReturn TEST_SITE_ID
+                on { origin } doReturn 0 // != ORIGIN_WPCOM_REST(1) → ApplicationPasswords
+            }
+            whenever(selectedSite.observe()).thenReturn(flowOf(appPasswordsSite))
+            whenever(pushNotificationRegistrationStatus.observe(TEST_SITE_ID))
+                .thenReturn(flowOf(PushNotificationRegistrationStatus.Status.UNREGISTERED))
+
+            val result = sut().first()
+
+            assertThat(result).isTrue()
+        }
+
+    companion object {
+        private const val TEST_SITE_ID = 123L
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/jetpack/benefits/JetpackBenefitsViewModelTest.kt
@@ -46,7 +46,7 @@ class JetpackBenefitsViewModelTest : BaseUnitTest() {
 
     @Before
     fun setup() = testBlocking {
-        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2)).thenReturn(false)
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1)).thenReturn(false)
         sut = JetpackBenefitsViewModel(
             savedState,
             selectedSiteMock,


### PR DESCRIPTION
Fixes WOOMOB-2732

### Description
Replaces the two separate local push notification feature flags (`WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1` and `WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2`) with a single flag. All M2 usages in `ShouldShowEnablePushNotificationsUi` and `JetpackBenefitsViewModel` now use M1, which already matches the remote feature flag key. M2 is then deleted.

This keeps the codebase ready for rollout: when the feature is ready, a single PR can enable M1 and set the target Woo Core version.

### Test Steps
I think code review is enough, given we just replaced `WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2` with `WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.