### PR TITLE
[WOOMOB-2735] Add REMOTE_TAP_TO_PAY feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 24.7
 -----
+- [Internal] Added REMOTE_TAP_TO_PAY feature flag (off in production) for the upcoming Woo POS Remote Tap-to-Pay feature [https://github.com/woocommerce/woocommerce-android/pull/15696]
 - [*] Fixed a crash when loading the product list on stores with very large product descriptions [https://github.com/woocommerce/woocommerce-android/pull/15693]
 - [Internal] Fixed logout push cleanup sequencing and added a logout loading state in App Settings [https://github.com/woocommerce/woocommerce-android/pull/15667]
 - [Internal] Show the notification permission card for all supported stores on Android 13+ [https://github.com/woocommerce/woocommerce-android/pull/15676/]

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -33,4 +33,5 @@ enum class FeatureFlag(
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1("woo_self_driven_push_notifications_m1", localValue = false),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2("woo_self_driven_push_notifications_m2", localValue = false),
     LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
+    REMOTE_TAP_TO_PAY("remote_tap_to_pay", localValue = PackageUtils.isDebugBuild()),
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FeatureFlagRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/FeatureFlagRepositoryTest.kt
@@ -163,6 +163,15 @@ class FeatureFlagRepositoryTest : BaseUnitTest() {
         assertThat(effectiveValue).isTrue()
     }
 
+    @Test
+    fun `given REMOTE_TAP_TO_PAY flag, when remote key read, then matches contract`() {
+        // GIVEN
+        val flag = FeatureFlag.REMOTE_TAP_TO_PAY
+
+        // WHEN // THEN
+        assertThat(flag.remoteFlagKey).isEqualTo("remote_tap_to_pay")
+    }
+
     private fun createRemoteFlag(key: String, value: Boolean) = FeatureFlagConfigDao.FeatureFlag(
         key = key,
         value = value,


### PR DESCRIPTION
### Description

Fixes WOOMOB-2735

Adds a `REMOTE_TAP_TO_PAY` feature flag that will gate the upcoming Woo POS Remote Tap-to-Pay feature on both the phone and tablet surfaces. Default off in production, on in debug builds — same pattern as `WOO_POS_PHONE`. The flag is read independently on each surface so the phone and tablet can be flipped separately for dogfooding.

With the flag off on both surfaces, the app behaves identically to trunk. All follow-up issues in the Remote Tap-to-Pay project reference this flag for gating.

### Test Steps

1. Build a debug APK. Open Settings → Developer Options → Feature Flags and verify `REMOTE_TAP_TO_PAY` appears in the list with an override toggle.
2. Toggle the override off. Verify the repository reports the flag as disabled.
3. Toggle the override back on. Verify the repository reports the flag as enabled.
4. Run unit tests: \`./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "com.woocommerce.android.util.FeatureFlagRepositoryTest"\` — the new \`given REMOTE_TAP_TO_PAY flag, when remote key read, then matches contract\` test passes alongside the existing suite.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.