### PR TITLE
[WOOMOB-2748] Fix notification navigation for App Passwords sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -1034,7 +1034,6 @@ class MainActivity :
         intent.data = null
         showOrderDetail(
             orderId = event.uniqueId,
-            remoteNoteId = event.remoteNoteId,
             launchedFromNotification = true
         )
     }
@@ -1248,7 +1247,6 @@ class MainActivity :
     override fun showOrderDetail(
         orderId: Long,
         navHostFragment: NavHostFragment?,
-        remoteNoteId: Long,
         launchedFromNotification: Boolean,
         startPaymentsFlow: Boolean,
     ) {
@@ -1260,15 +1258,13 @@ class MainActivity :
 
         val action = OrderListFragmentDirections.actionOrderListFragmentToOrderDetailFragment(
             orderId,
-            arrayOf(orderId).toLongArray(),
-            remoteNoteId
+            longArrayOf(orderId)
         )
         navHostFragment?.navController?.let { navController ->
             val bundle = OrderDetailFragmentArgs(
-                orderId,
-                longArrayOf(orderId),
-                remoteNoteId,
-                startPaymentsFlow
+                orderId = orderId,
+                allOrderIds = longArrayOf(orderId),
+                startPaymentFlow = startPaymentsFlow
             ).toBundle()
             navController.navigate(
                 R.id.orderDetailFragment,
@@ -1284,7 +1280,6 @@ class MainActivity :
     override fun showOrderDetailWithSharedTransition(
         orderId: Long,
         allOrderIds: List<Long>,
-        remoteNoteId: Long,
         sharedView: View
     ) {
         val orderCardDetailTransitionName = getString(R.string.order_card_detail_transition_name)
@@ -1292,8 +1287,7 @@ class MainActivity :
 
         val action = OrderListFragmentDirections.actionOrderListFragmentToOrderDetailFragment(
             orderId,
-            allOrderIds.toLongArray(),
-            remoteNoteId
+            allOrderIds.toLongArray()
         )
         crashLogging.recordEvent("Opening order $orderId")
         navController.navigateSafely(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -140,7 +140,7 @@ class MainActivityViewModel @Inject constructor(
             }
 
             is ResolveAppLink.Action.ViewOrderDetail -> {
-                triggerEvent(ViewOrderDetail(uniqueId = event.orderId, remoteNoteId = 0L))
+                triggerEvent(ViewOrderDetail(event.orderId))
             }
 
             ResolveAppLink.Action.ViewStats -> {
@@ -199,7 +199,7 @@ class MainActivityViewModel @Inject constructor(
         notificationHandler.removeTappedNotificationAndSummaryIfNeeded(localPushId, notification)
         when (notification.noteType) {
             is WooNotificationType.NewOrder -> {
-                triggerEvent(ViewOrderDetail(notification.uniqueId, notification.remoteNoteId))
+                triggerEvent(ViewOrderDetail(notification.uniqueId))
             }
 
             is WooNotificationType.ProductReview -> {
@@ -372,7 +372,7 @@ class MainActivityViewModel @Inject constructor(
 
     data class ShowFeatureAnnouncement(val announcement: FeatureAnnouncement) : Event()
     data class ViewReviewDetail(val uniqueId: Long) : Event()
-    data class ViewOrderDetail(val uniqueId: Long, val remoteNoteId: Long) : Event()
+    data class ViewOrderDetail(val uniqueId: Long) : Event()
     data class ViewBlazeCampaignDetail(val campaignId: String) : Event()
     object ViewBlazeCampaignList : Event()
     data class ShowPrivacyPreferenceUpdatedFailed(val analyticsEnabled: Boolean) : Event()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -21,6 +21,8 @@ import com.woocommerce.android.notifications.local.LocalNotificationType.WOO_POS
 import com.woocommerce.android.notifications.local.LocalNotificationType.WOO_POS_SURVEY_POTENTIAL_USER_REMINDER
 import com.woocommerce.android.notifications.push.NotificationMessageHandler
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.tools.SiteConnectionType
+import com.woocommerce.android.tools.connectionType
 import com.woocommerce.android.ui.ageeligibility.AgeEligibilityChecker
 import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.MainActivityViewModel.MoreMenuBadgeState.Hidden
@@ -116,7 +118,8 @@ class MainActivityViewModel @Inject constructor(
         notification?.let {
             // update current selectSite based on the current notification
             val currentSite = selectedSite.get()
-            val isSiteSpecificNotification = it.remoteSiteId != 0L
+            val isSiteSpecificNotification = it.remoteSiteId != 0L &&
+                currentSite.connectionType != SiteConnectionType.ApplicationPasswords
             if (isSiteSpecificNotification && it.remoteSiteId != currentSite.siteId) {
                 changeSiteAndRestart(it.remoteSiteId, RestartActivityForPushNotification(localPushId, notification))
             } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -199,16 +199,7 @@ class MainActivityViewModel @Inject constructor(
         notificationHandler.removeTappedNotificationAndSummaryIfNeeded(localPushId, notification)
         when (notification.noteType) {
             is WooNotificationType.NewOrder -> {
-                when {
-                    siteStore.getSiteBySiteId(notification.remoteSiteId) != null -> triggerEvent(
-                        ViewOrderDetail(
-                            notification.uniqueId,
-                            notification.remoteNoteId
-                        )
-                    )
-
-                    else -> triggerEvent(ViewOrderList)
-                }
+                triggerEvent(ViewOrderDetail(notification.uniqueId, notification.remoteNoteId))
             }
 
             is WooNotificationType.ProductReview -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainNavigationRouter.kt
@@ -18,7 +18,6 @@ interface MainNavigationRouter {
     fun showOrderDetail(
         orderId: Long,
         navHostFragment: NavHostFragment? = null,
-        remoteNoteId: Long = 0,
         launchedFromNotification: Boolean = false,
         startPaymentsFlow: Boolean = false,
     )
@@ -26,7 +25,6 @@ interface MainNavigationRouter {
     fun showOrderDetailWithSharedTransition(
         orderId: Long,
         allOrderIds: List<Long>,
-        remoteNoteId: Long = 0,
         sharedView: View
     )
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -108,10 +108,6 @@
             <argument
                 android:name="allOrderIds"
                 app:argType="long[]" />
-            <argument
-                android:name="remoteNoteId"
-                android:defaultValue="0L"
-                app:argType="long" />
         </action>
         <action
             android:id="@+id/action_orderListFragment_to_orderFilterListFragment"

--- a/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_orders.xml
@@ -174,10 +174,6 @@
             app:argType="long[]"
             app:nullable="true" />
         <argument
-            android:name="remoteNoteId"
-            android:defaultValue="0L"
-            app:argType="long" />
-        <argument
             android:name="startPaymentFlow"
             android:defaultValue="false"
             app:argType="boolean" />
@@ -197,10 +193,6 @@
             <argument
                 android:name="allOrderIds"
                 app:argType="long[]" />
-            <argument
-                android:name="remoteNoteId"
-                android:defaultValue="0L"
-                app:argType="long" />
         </action>
         <action
             android:id="@+id/action_orderDetailFragment_to_addOrderNoteFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -200,12 +200,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
         verify(notificationMessageHandler, atLeastOnce()).markNotificationTapped(eq(testOrderNotification.remoteNoteId))
         verify(notificationMessageHandler, atLeastOnce())
             .removeTappedNotificationAndSummaryIfNeeded(eq(localPushId), eq(testOrderNotification))
-        assertThat(event).isEqualTo(
-            ViewOrderDetail(
-                testOrderNotification.uniqueId,
-                testOrderNotification.remoteNoteId
-            )
-        )
+        assertThat(event).isEqualTo(ViewOrderDetail(testOrderNotification.uniqueId))
     }
 
     @Test
@@ -602,9 +597,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
 
         // THEN
         verify(selectedSite, never()).set(any())
-        assertThat(viewModel.event.value).isEqualTo(
-            ViewOrderDetail(orderNotification.uniqueId, orderNotification.remoteNoteId)
-        )
+        assertThat(viewModel.event.value).isEqualTo(ViewOrderDetail(orderNotification.uniqueId))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -83,6 +83,8 @@ class MainActivityViewModelTest : BaseUnitTest() {
     private val siteModel: SiteModel = SiteModel().apply {
         id = 1
         siteId = TEST_REMOTE_SITE_ID_1
+        origin = SiteModel.ORIGIN_WPCOM_REST
+        setIsJetpackConnected(true)
     }
 
     private val notificationMessageHandler: NotificationMessageHandler = mock()
@@ -604,6 +606,21 @@ class MainActivityViewModelTest : BaseUnitTest() {
                 eq(testBlazeNotification.remoteSiteId)
             )
         assertThat(event).isEqualTo(ViewBlazeCampaignList)
+    }
+
+    @Test
+    fun `given an App Passwords site, when notification for a different remote site is tapped, then do not switch sites`() {
+        // GIVEN
+        val appPasswordsSite = applicationPasswordsSite()
+        lenient().doReturn(appPasswordsSite).whenever(selectedSite).get()
+        val orderNotification = testOrderNotification.copy(remoteSiteId = TEST_REMOTE_SITE_ID_2)
+
+        // WHEN
+        viewModel.onPushNotificationTapped(1000, orderNotification)
+
+        // THEN
+        verify(selectedSite, never()).set(any())
+        assertThat(viewModel.event.value).isNotInstanceOf(RestartActivityForPushNotification::class.java)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -209,24 +209,6 @@ class MainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when a new order notification for non existent site is clicked, then the my store tab is opened`() {
-        doReturn(null).whenever(siteStore).getSiteBySiteId(any())
-
-        val localPushId = 1000
-        var event: ViewOrderList? = null
-        viewModel.event.observeForever {
-            if (it is ViewOrderList) event = it
-        }
-
-        viewModel.onPushNotificationTapped(localPushId, testOrderNotification)
-
-        verify(notificationMessageHandler, atLeastOnce()).markNotificationTapped(eq(testOrderNotification.remoteNoteId))
-        verify(notificationMessageHandler, atLeastOnce())
-            .removeTappedNotificationAndSummaryIfNeeded(eq(localPushId), eq(testOrderNotification))
-        assertThat(event).isEqualTo(ViewOrderList)
-    }
-
-    @Test
     fun `when a new review notification is clicked, then the review detail screen for that review is opened`() {
         val localPushId = 1001
         var event: ViewReviewDetail? = null
@@ -609,7 +591,7 @@ class MainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given an App Passwords site, when notification for a different remote site is tapped, then do not switch sites`() {
+    fun `given an App Passwords site, when order notification for a different remote site is tapped, then open order detail without switching sites`() {
         // GIVEN
         val appPasswordsSite = applicationPasswordsSite()
         lenient().doReturn(appPasswordsSite).whenever(selectedSite).get()
@@ -620,7 +602,9 @@ class MainActivityViewModelTest : BaseUnitTest() {
 
         // THEN
         verify(selectedSite, never()).set(any())
-        assertThat(viewModel.event.value).isNotInstanceOf(RestartActivityForPushNotification::class.java)
+        assertThat(viewModel.event.value).isEqualTo(
+            ViewOrderDetail(orderNotification.uniqueId, orderNotification.remoteNoteId)
+        )
     }
 
     @Test


### PR DESCRIPTION
Fixes WOOMOB-2748

Both issues fixed by this PR only affect users signed in with site credentials (Application Passwords). In that flow the local site is stored with its self-hosted `siteId` rather than the WP.com one, so push notifications — which always carry the WP.com `remoteSiteId` — never match the locally stored site. This surfaced in two places:

1. The site-switch check in `onPushNotificationTapped` compared the notification's `remoteSiteId` to the selected site's `siteId` and always triggered a site switch that could never resolve.
2. The `NewOrder` branch in `onSinglePushNotificationOpened` looked up the site via `SiteStore.getSiteBySiteId` and, when it returned null, fell back to `ViewOrderList` instead of opening the order details.

The branch contains:

- **Skip site switch on push notification for ApplicationPasswords sites** — guards the site-switch path with a `SiteConnectionType` check so site-credential sites handle notifications directly against the current site.
- **Open order detail for new order notifications even for unknown sites** — removes the `getSiteBySiteId` guard so the order detail screen opens regardless of whether the notification's site can be resolved locally.
- **Remove unused `remoteNoteId` nav arg from order detail screen** — cleans up an obsolete nav argument threaded through `ViewOrderDetail`, `MainActivity.showOrderDetail`, `MainNavigationRouter`, and the orders nav graphs. It was never read by the destination.

### Test Steps
1. Sign in to a self-hosted site using site credentials (Application Passwords).
2. Trigger a new order push notification on that site.
3. Tap the notification and verify the app navigates directly to the order detail screen without attempting a site switch.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.