### PR TITLE
[WOOMOB-2750] Hide unread reviews filter for Woo-registered sites

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListScreen.kt
@@ -75,10 +75,12 @@ private fun ReviewListScreen(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier.fillMaxSize()) {
-        UnreadFilterRow(
-            isChecked = viewState.isUnreadFilterEnabled,
-            onCheckedChange = onUnreadFilterChanged
-        )
+        if (viewState.isUnreadFilterVisible) {
+            UnreadFilterRow(
+                isChecked = viewState.isUnreadFilterEnabled,
+                onCheckedChange = onUnreadFilterChanged
+            )
+        }
         if (viewState.isSkeletonShown == true) {
             ReviewListSkeleton()
         } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModel.kt
@@ -16,7 +16,9 @@ import com.woocommerce.android.model.RequestResult.NO_ACTION_NEEDED
 import com.woocommerce.android.model.RequestResult.SUCCESS
 import com.woocommerce.android.network.ConnectionChangeReceiver.ConnectionChangeEvent
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
+import com.woocommerce.android.notifications.push.PushNotificationRegistrationStatus
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.reviews.ReviewListViewModel.ReviewListEvent.MarkAllAsRead
 import com.woocommerce.android.ui.reviews.domain.MarkAllReviewsAsSeen
 import com.woocommerce.android.ui.reviews.domain.MarkAllReviewsAsSeen.Fail
@@ -48,6 +50,8 @@ class ReviewListViewModel @Inject constructor(
     private val unseenReviewsCountHandler: UnseenReviewsCountHandler,
     private val reviewModerationHandler: ReviewModerationHandler,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val selectedSite: SelectedSite,
+    private val pushNotificationRegistrationStatus: PushNotificationRegistrationStatus,
     savedState: SavedStateHandle
 ) : ScopedViewModel(savedState), ReviewModerationConsumer {
     companion object {
@@ -104,6 +108,7 @@ class ReviewListViewModel @Inject constructor(
             }
             // Fetch after cache check to avoid race where fetchReviewList sets
             // isSkeletonShown = false before the cache check sets it to true.
+            syncUnreadFilterAvailability()
             fetchReviewList(loadMore = false)
         }
     }
@@ -177,6 +182,7 @@ class ReviewListViewModel @Inject constructor(
                             ReviewListRepository.FetchReviewsResult.NothingFetched -> {
                                 // No action needed
                             }
+
                             is ReviewListRepository.FetchReviewsResult.NotificationsFetched -> {
                                 if (result.requestResult == SUCCESS) {
                                     val reviews = reviewRepository.getCachedProductReviews()
@@ -246,6 +252,16 @@ class ReviewListViewModel @Inject constructor(
         fetchReviewList(loadMore = false)
     }
 
+    private suspend fun syncUnreadFilterAvailability() {
+        val registrationStatus = pushNotificationRegistrationStatus(selectedSite.getIfExists()?.siteId)
+        val isUnreadFilterVisible = !registrationStatus.isWooRegistered
+
+        viewState = viewState.copy(
+            isUnreadFilterVisible = isUnreadFilterVisible,
+            isUnreadFilterEnabled = viewState.isUnreadFilterEnabled && isUnreadFilterVisible
+        )
+    }
+
     @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ConnectionChangeEvent) {
@@ -261,6 +277,7 @@ class ReviewListViewModel @Inject constructor(
         val isLoadingMore: Boolean? = null,
         val isRefreshing: Boolean? = null,
         val hasUnreadReviews: Boolean? = null,
+        val isUnreadFilterVisible: Boolean = true,
         val isUnreadFilterEnabled: Boolean = false
     ) : Parcelable
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModelTest.kt
@@ -8,7 +8,9 @@ import com.woocommerce.android.model.ActionStatus
 import com.woocommerce.android.model.ProductReview
 import com.woocommerce.android.model.RequestResult
 import com.woocommerce.android.notifications.UnseenReviewsCountHandler
+import com.woocommerce.android.notifications.push.PushNotificationRegistrationStatus
 import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.reviews.ReviewListViewModel.ReviewListEvent.MarkAllAsRead
 import com.woocommerce.android.ui.reviews.domain.MarkAllReviewsAsSeen
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -27,6 +29,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.SiteModel
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -35,19 +38,36 @@ class ReviewListViewModelTest : BaseUnitTest() {
     private val networkStatus: NetworkStatus = mock()
     private val reviewListRepository: ReviewListRepository = mock()
     private val dispatcher: Dispatcher = mock()
-    private val savedState: SavedStateHandle = SavedStateHandle()
     private val markAllReviewsAsSeen: MarkAllReviewsAsSeen = mock()
     private val unseenReviewsCountHandler: UnseenReviewsCountHandler = mock()
     private val reviewModerationHandler: ReviewModerationHandler = mock {
         on { pendingModerationStatus } doReturn emptyFlow()
     }
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val siteModel: SiteModel = mock {
+        on { siteId } doReturn SITE_ID
+    }
+    private val selectedSite: SelectedSite = mock {
+        on { getIfExists() } doReturn siteModel
+    }
+    private val pushNotificationRegistrationStatus: PushNotificationRegistrationStatus = mock()
 
     private val reviews = ProductReviewTestUtils.generateProductReviewList()
+    private lateinit var savedState: SavedStateHandle
     private lateinit var viewModel: ReviewListViewModel
 
     @Before
     fun setup() {
+        doReturn(true).whenever(networkStatus).isConnected()
+        testBlocking {
+            whenever(pushNotificationRegistrationStatus.invoke(SITE_ID))
+                .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
+        }
+        createViewModel()
+    }
+
+    private fun createViewModel(savedState: SavedStateHandle = SavedStateHandle()) {
+        this.savedState = savedState
         viewModel = spy(
             ReviewListViewModel(
                 networkStatus,
@@ -57,11 +77,11 @@ class ReviewListViewModelTest : BaseUnitTest() {
                 unseenReviewsCountHandler,
                 reviewModerationHandler,
                 analyticsTrackerWrapper,
+                selectedSite,
+                pushNotificationRegistrationStatus,
                 savedState
             )
         )
-
-        doReturn(true).whenever(networkStatus).isConnected()
     }
 
     /**
@@ -430,5 +450,49 @@ class ReviewListViewModelTest : BaseUnitTest() {
 
         verify(reviewListRepository, times(1)).fetchOnlyUnreadProductReviews(loadMore = false)
         verify(reviewListRepository, times(1)).getCachedUnreadProductReviews()
+    }
+
+    @Test
+    fun `given site is Woo registered only, when view model started, then unread filter is hidden`() = testBlocking {
+        whenever(pushNotificationRegistrationStatus.invoke(SITE_ID))
+            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_WOO_ONLY)
+        doReturn(emptyList<ProductReview>()).whenever(reviewListRepository).getCachedProductReviews()
+        doReturn(false).whenever(networkStatus).isConnected()
+
+        createViewModel()
+        viewModel.start()
+
+        assertThat(viewModel.viewStateData.liveData.value?.isUnreadFilterVisible).isFalse()
+    }
+
+    @Test
+    fun `given site is WPCom registered only, when view model started, then unread filter is visible`() = testBlocking {
+        whenever(pushNotificationRegistrationStatus.invoke(SITE_ID))
+            .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_WPCOM_ONLY)
+        doReturn(emptyList<ProductReview>()).whenever(reviewListRepository).getCachedProductReviews()
+        doReturn(false).whenever(networkStatus).isConnected()
+
+        createViewModel()
+        viewModel.start()
+
+        assertThat(viewModel.viewStateData.liveData.value?.isUnreadFilterVisible).isTrue()
+    }
+
+    @Test
+    fun `given site is registered in both systems, when view model started, then unread filter is hidden`() =
+        testBlocking {
+            whenever(pushNotificationRegistrationStatus.invoke(SITE_ID))
+                .thenReturn(PushNotificationRegistrationStatus.Status.REGISTERED_BOTH)
+            doReturn(emptyList<ProductReview>()).whenever(reviewListRepository).getCachedProductReviews()
+            doReturn(false).whenever(networkStatus).isConnected()
+
+            createViewModel()
+            viewModel.start()
+
+            assertThat(viewModel.viewStateData.liveData.value?.isUnreadFilterVisible).isFalse()
+        }
+
+    private companion object {
+        const val SITE_ID = 123L
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModelTest.kt
@@ -55,7 +55,6 @@ class ReviewListViewModelTest : BaseUnitTest() {
     }
 
     private val reviews = ProductReviewTestUtils.generateProductReviewList()
-    private lateinit var savedState: SavedStateHandle
     private lateinit var viewModel: ReviewListViewModel
 
     @Before
@@ -65,7 +64,6 @@ class ReviewListViewModelTest : BaseUnitTest() {
     }
 
     private fun createViewModel(savedState: SavedStateHandle = SavedStateHandle()) {
-        this.savedState = savedState
         viewModel = spy(
             ReviewListViewModel(
                 networkStatus,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/reviews/ReviewListViewModelTest.kt
@@ -50,7 +50,9 @@ class ReviewListViewModelTest : BaseUnitTest() {
     private val selectedSite: SelectedSite = mock {
         on { getIfExists() } doReturn siteModel
     }
-    private val pushNotificationRegistrationStatus: PushNotificationRegistrationStatus = mock()
+    private val pushNotificationRegistrationStatus: PushNotificationRegistrationStatus = mock {
+        on { invoke(SITE_ID) } doReturn PushNotificationRegistrationStatus.Status.UNREGISTERED
+    }
 
     private val reviews = ProductReviewTestUtils.generateProductReviewList()
     private lateinit var savedState: SavedStateHandle
@@ -59,10 +61,6 @@ class ReviewListViewModelTest : BaseUnitTest() {
     @Before
     fun setup() {
         doReturn(true).whenever(networkStatus).isConnected()
-        testBlocking {
-            whenever(pushNotificationRegistrationStatus.invoke(SITE_ID))
-                .thenReturn(PushNotificationRegistrationStatus.Status.UNREGISTERED)
-        }
         createViewModel()
     }
 


### PR DESCRIPTION
### Description
Fixes WOOMOB-2750

This updates the Reviews screen so the \"Unread reviews only\" filter is hidden for Woo-registered sites.

Unread review state is only supported while reviews are still backed by WP.com notifications. Once a site is Woo-registered, the unread filter is not supported and the screen falls back to the regular reviews list.

### Test Steps
1. Use a site that is registered in Woo only.
2. Open Reviews.
3. Verify the \"Unread reviews only\" filter is hidden.

4. Use a site that is registered in WP.com only.
5. Open Reviews.
6. Verify the \"Unread reviews only\" filter is visible.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the \"[Internal]\" label for non-user-facing changes.