### PR TITLE
[WOOMOB-2737] Add CompositeConnectionTokenProvider for Stripe SDK

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.cardreader.connection.CompositeConnectionTokenProvider
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
@@ -64,6 +65,8 @@ class MockCardReaderManagerModule {
             get() = emptyFlow()
         override val displayBluetoothCardReaderMessages: Flow<BluetoothCardReaderMessages>
             get() = emptyFlow()
+        override val connectionTokenProvider: CompositeConnectionTokenProvider
+            get() = error("connectionTokenProvider is not used in instrumented tests")
 
         override fun initialize(updateFrequency: SimulatorUpdateFrequency, useInterac: Boolean, isDebug: Boolean) {}
         override fun reinitializeSimulatedTerminal(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.cardreader.connection.CompositeConnectionTokenProvider
 import com.woocommerce.android.cardreader.connection.event.BluetoothCardReaderMessages
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
@@ -29,6 +30,7 @@ interface CardReaderManager {
     val softwareUpdateAvailability: Flow<SoftwareUpdateAvailability>
     val batteryStatus: Flow<CardReaderBatteryStatus>
     val displayBluetoothCardReaderMessages: Flow<BluetoothCardReaderMessages>
+    val connectionTokenProvider: CompositeConnectionTokenProvider
 
     fun initialize(
         updateFrequency: SimulatorUpdateFrequency,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.cardreader
 
 import android.app.Application
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
+import com.woocommerce.android.cardreader.connection.CompositeConnectionTokenProvider
 import com.woocommerce.android.cardreader.internal.CardReaderManagerImpl
 import com.woocommerce.android.cardreader.internal.TokenProvider
 import com.woocommerce.android.cardreader.internal.connection.BluetoothReaderListenerImpl
@@ -43,11 +44,12 @@ object CardReaderManagerFactory {
         val tapToPayReaderListener = TapToPayReaderListenerImpl(logWrapper, terminalListener)
         val cardReaderConfigFactory = CardReaderConfigFactory()
         val paymentUtils = PaymentUtils(logWrapper)
+        val compositeTokenProvider = CompositeConnectionTokenProvider(TokenProvider(cardReaderStore))
 
         return CardReaderManagerImpl(
             application,
             terminal,
-            TokenProvider(cardReaderStore),
+            compositeTokenProvider,
             logWrapper,
             PaymentManager(
                 terminal,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProvider.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProvider.kt
@@ -12,15 +12,16 @@ import java.util.concurrent.atomic.AtomicReference
  *
  * Intended caller lifecycle:
  * - On Card Reader Mode activity `onCreate`: build a `RemoteTokenChannelProvider`, then call
- *   [use]`(remoteProvider)`.
- * - On Card Reader Mode activity `onDestroy`: call [useDefault] first, then `remoteProvider.close()`.
+ *   [useRemote].
+ * - On Card Reader Mode activity `onDestroy`: call [useDefault] first, then
+ *   `remoteProvider.close()`.
  *
  * The atomic swap guarantees a single `fetchConnectionToken` call always routes to whichever
  * provider was active at the moment the SDK read the reference. A call that is already in flight
  * when the mode changes completes on the previous delegate.
  *
- * Treat this as a narrow lifecycle hook for Card Reader Mode. Do not call [use] from any other
- * place — swapping mid-transaction will surface token failures in the existing BT / self-tap flows.
+ * The public API intentionally only accepts [RemoteTokenChannelProvider] so Stripe SDK types never
+ * leak into consumers of this library.
  */
 class CompositeConnectionTokenProvider internal constructor(
     private val defaultProvider: ConnectionTokenProvider,
@@ -31,7 +32,7 @@ class CompositeConnectionTokenProvider internal constructor(
         active.set(defaultProvider)
     }
 
-    fun use(provider: ConnectionTokenProvider) {
+    fun useRemote(provider: RemoteTokenChannelProvider) {
         active.set(provider)
     }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProvider.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProvider.kt
@@ -4,6 +4,24 @@ import com.stripe.stripeterminal.external.callable.ConnectionTokenCallback
 import com.stripe.stripeterminal.external.callable.ConnectionTokenProvider
 import java.util.concurrent.atomic.AtomicReference
 
+/**
+ * Delegates `fetchConnectionToken` to whichever provider is currently active. Lets the Stripe
+ * Terminal SDK singleton serve both the existing backend-fetched flows (self-tap TTP, BT reader)
+ * and the new Card Reader Mode flow (token supplied over a local TLS socket) without ever being
+ * re-initialized.
+ *
+ * Intended caller lifecycle:
+ * - On Card Reader Mode activity `onCreate`: build a `RemoteTokenChannelProvider`, then call
+ *   [use]`(remoteProvider)`.
+ * - On Card Reader Mode activity `onDestroy`: call [useDefault] first, then `remoteProvider.close()`.
+ *
+ * The atomic swap guarantees a single `fetchConnectionToken` call always routes to whichever
+ * provider was active at the moment the SDK read the reference. A call that is already in flight
+ * when the mode changes completes on the previous delegate.
+ *
+ * Treat this as a narrow lifecycle hook for Card Reader Mode. Do not call [use] from any other
+ * place — swapping mid-transaction will surface token failures in the existing BT / self-tap flows.
+ */
 class CompositeConnectionTokenProvider internal constructor(
     private val defaultProvider: ConnectionTokenProvider,
 ) : ConnectionTokenProvider {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProvider.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProvider.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.cardreader.connection
+
+import com.stripe.stripeterminal.external.callable.ConnectionTokenCallback
+import com.stripe.stripeterminal.external.callable.ConnectionTokenProvider
+import java.util.concurrent.atomic.AtomicReference
+
+class CompositeConnectionTokenProvider internal constructor(
+    private val defaultProvider: ConnectionTokenProvider,
+) : ConnectionTokenProvider {
+    private val active: AtomicReference<ConnectionTokenProvider> = AtomicReference(defaultProvider)
+
+    fun useDefault() {
+        active.set(defaultProvider)
+    }
+
+    fun use(provider: ConnectionTokenProvider) {
+        active.set(provider)
+    }
+
+    override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
+        active.get().fetchConnectionToken(callback)
+    }
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/RemoteTokenChannelProvider.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/RemoteTokenChannelProvider.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 class RemoteTokenChannelProvider : ConnectionTokenProvider, AutoCloseable {
@@ -19,6 +20,10 @@ class RemoteTokenChannelProvider : ConnectionTokenProvider, AutoCloseable {
     }
 
     override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
+        if (!scope.isActive) {
+            callback.onFailure(ConnectionTokenException("Remote token provider is closed"))
+            return
+        }
         scope.launch {
             runCatching { tokens.receive() }
                 .onSuccess { callback.onSuccess(it) }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/RemoteTokenChannelProvider.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/RemoteTokenChannelProvider.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
 
 class RemoteTokenChannelProvider : ConnectionTokenProvider, AutoCloseable {
     private val tokens = Channel<String>(Channel.RENDEZVOUS)
@@ -20,18 +20,27 @@ class RemoteTokenChannelProvider : ConnectionTokenProvider, AutoCloseable {
     }
 
     override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
-        if (!scope.isActive) {
-            callback.onFailure(ConnectionTokenException("Remote token provider is closed"))
-            return
-        }
-        scope.launch {
+        val delivered = AtomicBoolean(false)
+        val job = scope.launch {
             runCatching { tokens.receive() }
-                .onSuccess { callback.onSuccess(it) }
-                .onFailure { err ->
-                    callback.onFailure(
-                        ConnectionTokenException(err.message.orEmpty(), err)
-                    )
+                .onSuccess { token ->
+                    if (delivered.compareAndSet(false, true)) callback.onSuccess(token)
                 }
+                .onFailure { err ->
+                    if (delivered.compareAndSet(false, true)) {
+                        callback.onFailure(ConnectionTokenException(err.message.orEmpty(), err))
+                    }
+                }
+        }
+        job.invokeOnCompletion { cause ->
+            if (cause != null && delivered.compareAndSet(false, true)) {
+                callback.onFailure(
+                    ConnectionTokenException(
+                        cause.message ?: "Remote token provider is closed",
+                        cause
+                    )
+                )
+            }
         }
     }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/RemoteTokenChannelProvider.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/RemoteTokenChannelProvider.kt
@@ -1,0 +1,37 @@
+package com.woocommerce.android.cardreader.connection
+
+import com.stripe.stripeterminal.external.callable.ConnectionTokenCallback
+import com.stripe.stripeterminal.external.callable.ConnectionTokenProvider
+import com.stripe.stripeterminal.external.models.ConnectionTokenException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+
+class RemoteTokenChannelProvider : ConnectionTokenProvider, AutoCloseable {
+    private val tokens = Channel<String>(Channel.RENDEZVOUS)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    suspend fun supply(token: String) {
+        tokens.send(token)
+    }
+
+    override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
+        scope.launch {
+            runCatching { tokens.receive() }
+                .onSuccess { callback.onSuccess(it) }
+                .onFailure { err ->
+                    callback.onFailure(
+                        ConnectionTokenException(err.message.orEmpty(), err)
+                    )
+                }
+        }
+    }
+
+    override fun close() {
+        tokens.close()
+        scope.cancel()
+    }
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.cardreader.connection.CompositeConnectionTokenProvider
 import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.connection.TerminalListenerImpl
 import com.woocommerce.android.cardreader.internal.firmware.SoftwareUpdateManager
@@ -28,7 +29,7 @@ import kotlinx.coroutines.flow.Flow
 internal class CardReaderManagerImpl(
     private var application: Application,
     private val terminal: TerminalWrapper,
-    private val tokenProvider: TokenProvider,
+    private val tokenProvider: CompositeConnectionTokenProvider,
     private val logWrapper: LogWrapper,
     private val paymentManager: PaymentManager,
     private val interacRefundManager: InteracRefundManager,
@@ -54,6 +55,8 @@ internal class CardReaderManagerImpl(
     override val batteryStatus = connectionManager.batteryStatus
 
     override val displayBluetoothCardReaderMessages = connectionManager.displayBluetoothCardReaderMessages
+
+    override val connectionTokenProvider: CompositeConnectionTokenProvider = tokenProvider
 
     override fun initialize(
         updateFrequency: CardReaderManager.SimulatorUpdateFrequency,

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProviderTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProviderTest.kt
@@ -9,7 +9,7 @@ import org.mockito.kotlin.verifyNoInteractions
 
 class CompositeConnectionTokenProviderTest {
     private val defaultDelegate: ConnectionTokenProvider = mock()
-    private val altDelegate: ConnectionTokenProvider = mock()
+    private val remoteDelegate: RemoteTokenChannelProvider = mock()
     private val callback: ConnectionTokenCallback = mock()
 
     private val sut = CompositeConnectionTokenProvider(defaultDelegate)
@@ -24,26 +24,26 @@ class CompositeConnectionTokenProviderTest {
 
         // THEN
         verify(defaultDelegate).fetchConnectionToken(callback)
-        verifyNoInteractions(altDelegate)
+        verifyNoInteractions(remoteDelegate)
     }
 
     @Test
-    fun `given use(alt) was called, when fetchConnectionToken is called, then alt delegate receives it`() {
+    fun `given useRemote was called, when fetchConnectionToken is called, then remote delegate receives it`() {
         // GIVEN
-        sut.use(altDelegate)
+        sut.useRemote(remoteDelegate)
 
         // WHEN
         sut.fetchConnectionToken(callback)
 
         // THEN
-        verify(altDelegate).fetchConnectionToken(callback)
+        verify(remoteDelegate).fetchConnectionToken(callback)
         verifyNoInteractions(defaultDelegate)
     }
 
     @Test
-    fun `given alt was active, when useDefault is called, then default delegate receives fetch`() {
+    fun `given remote was active, when useDefault is called, then default delegate receives fetch`() {
         // GIVEN
-        sut.use(altDelegate)
+        sut.useRemote(remoteDelegate)
         sut.useDefault()
 
         // WHEN
@@ -51,6 +51,6 @@ class CompositeConnectionTokenProviderTest {
 
         // THEN
         verify(defaultDelegate).fetchConnectionToken(callback)
-        verifyNoInteractions(altDelegate)
+        verifyNoInteractions(remoteDelegate)
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProviderTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProviderTest.kt
@@ -1,0 +1,56 @@
+package com.woocommerce.android.cardreader.connection
+
+import com.stripe.stripeterminal.external.callable.ConnectionTokenCallback
+import com.stripe.stripeterminal.external.callable.ConnectionTokenProvider
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+class CompositeConnectionTokenProviderTest {
+    private val defaultDelegate: ConnectionTokenProvider = mock()
+    private val altDelegate: ConnectionTokenProvider = mock()
+    private val callback: ConnectionTokenCallback = mock()
+
+    private val sut = CompositeConnectionTokenProvider(defaultDelegate)
+
+    @Test
+    fun `given default mode, when fetchConnectionToken is called, then default delegate receives it`() {
+        // GIVEN
+        // new composite with default delegate
+
+        // WHEN
+        sut.fetchConnectionToken(callback)
+
+        // THEN
+        verify(defaultDelegate).fetchConnectionToken(callback)
+        verifyNoInteractions(altDelegate)
+    }
+
+    @Test
+    fun `given use(alt) was called, when fetchConnectionToken is called, then alt delegate receives it`() {
+        // GIVEN
+        sut.use(altDelegate)
+
+        // WHEN
+        sut.fetchConnectionToken(callback)
+
+        // THEN
+        verify(altDelegate).fetchConnectionToken(callback)
+        verifyNoInteractions(defaultDelegate)
+    }
+
+    @Test
+    fun `given alt was active, when useDefault is called, then default delegate receives fetch`() {
+        // GIVEN
+        sut.use(altDelegate)
+        sut.useDefault()
+
+        // WHEN
+        sut.fetchConnectionToken(callback)
+
+        // THEN
+        verify(defaultDelegate).fetchConnectionToken(callback)
+        verifyNoInteractions(altDelegate)
+    }
+}

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.cardreader.connection.CompositeConnectionTokenProvider
 import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
 import com.woocommerce.android.cardreader.internal.connection.TerminalListenerImpl
@@ -35,7 +36,7 @@ class CardReaderManagerImplTest : CardReaderBaseUnitTest() {
     private val terminalWrapper: TerminalWrapper = mock {
         on { getLifecycleObserver() }.thenReturn(terminalApplicationDelegateWrapper)
     }
-    private val tokenProvider: TokenProvider = mock()
+    private val tokenProvider: CompositeConnectionTokenProvider = mock()
     private val application: Application = mock()
     private val logWrapper: LogWrapper = mock()
     private val paymentManager: PaymentManager = mock()


### PR DESCRIPTION
### Description

Fixes WOOMOB-2737

Adds a `CompositeConnectionTokenProvider` that delegates the Stripe Terminal SDK's `fetchConnectionToken` call to one of two underlying providers at runtime. The SDK singleton is never re-initialized — only the active delegate swaps atomically.

This is the single most important non-regression component of the Remote Tap-to-Pay project: it lets the new Card Reader Mode flow share the same SDK singleton with the existing self-tap TTP and BT reader flows without any changes to those flows.

**Components:**
- `CompositeConnectionTokenProvider` — atomic delegate swap via `AtomicReference`. Exposes `use(provider)` and `useDefault()` on a narrow lifecycle contract documented in the class KDoc.
- `RemoteTokenChannelProvider` — a `ConnectionTokenProvider` backed by a rendezvous `Channel<String>`. Used later by Card Reader Mode to feed tokens received over the local TLS socket. Fail-fasts on `fetchConnectionToken` after `close()` so teardown doesn't silently hang the SDK.
- Wiring: `CardReaderManagerFactory` constructs the composite wrapping the existing `TokenProvider`. `CardReaderManager.connectionTokenProvider` exposes the composite so Card Reader Mode can swap delegates from its activity lifecycle.

**Non-regression:** with the feature flag off on both surfaces, the composite always points at the default (backend-fetched) provider, and the existing self-tap TTP and BT reader flows are byte-identical to trunk.

Target: \`feature/remote-tap-to-pay\` (long-lived integration branch; final merge to trunk ships everything behind the \`REMOTE_TAP_TO_PAY\` flag from WOOMOB-2735).

### Test Steps

1. Build: \`./gradlew :libs:cardreader:assembleDebug\` — BUILD SUCCESSFUL.
2. Tests: \`./gradlew :libs:cardreader:testDebugUnitTest\` — 3 new tests on `CompositeConnectionTokenProvider` (default routes to default delegate; `use(alt)` routes to alt; `useDefault()` restores default) must pass.
3. Non-regression smoke (manual): run the existing self-tap TTP flow on a debug build — payment should work identically to trunk (the composite transparently delegates to the backend provider).

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.