### PR TITLE
[WOOMOB-2470] POS Orders: Cache paginated orders for instant detail opens (4/4)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSource.kt
@@ -74,7 +74,11 @@ class WooPosOrdersDataSource @Inject constructor(
 
     suspend fun loadMore(searchQuery: String? = null): Result<List<Order>> =
         withContext(Dispatchers.IO) {
-            loadNextPage(searchQuery)
+            loadNextPage(searchQuery).onSuccess { orders ->
+                if (searchQuery == null) {
+                    ordersCache.appendAll(orders)
+                }
+            }
         }
 
     suspend fun getOrderById(orderId: Long): Result<Order> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersInMemoryCache.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersInMemoryCache.kt
@@ -13,6 +13,10 @@ class WooPosOrdersInMemoryCache @Inject constructor() {
         ordersCache.set(orders.toList())
     }
 
+    fun appendAll(orders: List<Order>) {
+        ordersCache.updateAndGet { current -> current + orders }
+    }
+
     fun getAll(): List<Order> = ordersCache.get()
 
     fun clear() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosOrdersInMemoryCacheTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/common/data/WooPosOrdersInMemoryCacheTest.kt
@@ -65,6 +65,58 @@ class WooPosOrdersInMemoryCacheTest {
     }
 
     @Test
+    fun `when appendAll is called, then new orders are added to existing cache`() {
+        // GIVEN
+        val first = listOf(
+            OrderTestUtils.generateTestOrder(1),
+            OrderTestUtils.generateTestOrder(2)
+        )
+        val more = listOf(
+            OrderTestUtils.generateTestOrder(3),
+            OrderTestUtils.generateTestOrder(4)
+        )
+        cache.setAll(first)
+
+        // WHEN
+        cache.appendAll(more)
+
+        // THEN
+        assertThat(cache.getAll()).containsExactlyElementsOf(first + more)
+    }
+
+    @Test
+    fun `given empty cache, when appendAll is called, then orders become the cache`() {
+        // GIVEN
+        val orders = listOf(
+            OrderTestUtils.generateTestOrder(1),
+            OrderTestUtils.generateTestOrder(2)
+        )
+
+        // WHEN
+        cache.appendAll(orders)
+
+        // THEN
+        assertThat(cache.getAll()).containsExactlyElementsOf(orders)
+    }
+
+    @Test
+    fun `when setAll is called after appendAll, then cache is replaced`() {
+        // GIVEN
+        cache.setAll(listOf(OrderTestUtils.generateTestOrder(1)))
+        cache.appendAll(listOf(OrderTestUtils.generateTestOrder(2)))
+
+        // WHEN
+        val replacement = listOf(
+            OrderTestUtils.generateTestOrder(10),
+            OrderTestUtils.generateTestOrder(11)
+        )
+        cache.setAll(replacement)
+
+        // THEN
+        assertThat(cache.getAll()).containsExactlyElementsOf(replacement)
+    }
+
+    @Test
     fun `when cache is cleared, then getAll returns empty list`() {
         // GIVEN
         val orders = listOf(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSourceTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersDataSourceTest.kt
@@ -382,6 +382,71 @@ class WooPosOrdersDataSourceTest {
     }
 
     @Test
+    fun `when loadMore without query succeeds, then new orders appended to cache`() = runTest {
+        // GIVEN
+        whenever(ordersCache.getAll()).thenReturn(emptyList())
+        val firstPayload = WCOrderStore.FetchOrdersResponsePayload(
+            site = siteModel,
+            ordersWithMeta = emptyList(),
+            canLoadMore = true
+        )
+        whenever(orderRestClient.fetchOrders(any(), any(), eq(1), any(), any(), anyOrNull(), any(), isNull(), eq(8)))
+            .thenReturn(firstPayload)
+        sut.loadOrders().toList(mutableListOf())
+
+        val e3 = OrderEntity(LocalOrRemoteId.LocalId(1), 3L)
+        val e4 = OrderEntity(LocalOrRemoteId.LocalId(1), 4L)
+        val mapped3 = OrderTestUtils.generateTestOrder(orderId = 3)
+        val mapped4 = OrderTestUtils.generateTestOrder(orderId = 4)
+        whenever(orderMapper.toAppModel(e3)).thenReturn(mapped3)
+        whenever(orderMapper.toAppModel(e4)).thenReturn(mapped4)
+        val page2Payload = WCOrderStore.FetchOrdersResponsePayload(
+            site = siteModel,
+            ordersWithMeta = listOf(e3 to emptyList(), e4 to emptyList()),
+            canLoadMore = false
+        )
+        whenever(orderRestClient.fetchOrders(any(), any(), eq(2), any(), any(), anyOrNull(), any(), isNull(), eq(8)))
+            .thenReturn(page2Payload)
+
+        // WHEN
+        sut.loadMore()
+
+        // THEN
+        verify(ordersCache).appendAll(listOf(mapped3, mapped4))
+    }
+
+    @Test
+    fun `when loadMore with search query succeeds, then cache is not appended`() = runTest {
+        // GIVEN
+        val query = "abc"
+        whenever(ordersCache.getAll()).thenReturn(emptyList())
+        val firstPayload = WCOrderStore.FetchOrdersResponsePayload(
+            site = siteModel,
+            ordersWithMeta = emptyList(),
+            canLoadMore = true
+        )
+        whenever(orderRestClient.fetchOrders(any(), any(), eq(1), any(), any(), anyOrNull(), any(), eq(query), eq(8)))
+            .thenReturn(firstPayload)
+        sut.searchOrders(query)
+
+        val e1 = OrderEntity(LocalOrRemoteId.LocalId(1), 9L)
+        whenever(orderMapper.toAppModel(e1)).thenReturn(OrderTestUtils.generateTestOrder(orderId = 9))
+        val page2Payload = WCOrderStore.FetchOrdersResponsePayload(
+            site = siteModel,
+            ordersWithMeta = listOf(e1 to emptyList()),
+            canLoadMore = false
+        )
+        whenever(orderRestClient.fetchOrders(any(), any(), eq(2), any(), any(), anyOrNull(), any(), eq(query), eq(8)))
+            .thenReturn(page2Payload)
+
+        // WHEN
+        sut.loadMore(query)
+
+        // THEN
+        verify(ordersCache, never()).appendAll(any())
+    }
+
+    @Test
     fun `when loadMore fails, then page does not advance and hasMorePages unchanged`() = runTest {
         whenever(ordersCache.getAll()).thenReturn(emptyList())
 


### PR DESCRIPTION
### Description

Fixes WOOMOB-2470

Stacks on #15683.

In POS Orders, tapping a row in the first page (≤25 orders) opens the detail instantly, but tapping any row further down the list takes ~hundreds of ms on first tap. The reason: `WooPosOrdersInMemoryCache` is only populated by `WooPosOrdersDataSource.loadOrders()` (first page). Rows loaded via `loadMore()` miss the cache, so `getOrderById` falls through to `fetchSingleOrder` — a network call.

Fix: append the result of `loadMore()` into the same cache so `getOrderById` finds paginated rows too. Added `WooPosOrdersInMemoryCache.appendAll(orders)`, atomic via `AtomicReference.updateAndGet`. The append is skipped for paginated search results (`searchQuery != null`) — they're ephemeral and shouldn't leak into the main orders cache.

Freshness is preserved by the existing invalidation points: `loadOrders()` replaces the whole cache via `setAll`, so re-enter/pull-to-refresh evicts paginated entries; and `refreshOrderById` (called after a refund) updates the matching entry in place. The staleness surface is the same one first-page orders already have.

### Test Steps

1. Open POS → Orders. Scroll until pagination loads page 2 (rows 26+).
2. Tap a row from page 2 → the detail should open instantly (before this PR, it took a visible fraction of a second).
3. Pull-to-refresh and repeat — first tap fetches fresh, subsequent taps within the session are instant.
4. Search for a term, paginate within search results, tap a row — should work. Exit search — the main Orders list should not contain search results.
5. Issue a refund on a page-2 row — both list badge and detail pane should update.


### Images/gif

N/A — performance-only change, no UI differences.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.