### PR TITLE
[WOOMOB-2470] Fix stale POS list row after refund when selection changes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersCoordinator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersCoordinator.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.orders
 
 import dagger.hilt.android.scopes.ActivityRetainedScoped
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -14,14 +15,17 @@ class WooPosOrdersCoordinator @Inject constructor() {
     private val _selectedOrderId = MutableStateFlow<Long?>(null)
     val selectedOrderId: StateFlow<Long?> = _selectedOrderId.asStateFlow()
 
-    private val _orderRefreshed = MutableSharedFlow<Long>()
+    private val _orderRefreshed = MutableSharedFlow<Long>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     val orderRefreshed: SharedFlow<Long> = _orderRefreshed.asSharedFlow()
 
     fun selectOrder(orderId: Long?) {
         _selectedOrderId.value = orderId
     }
 
-    suspend fun notifyOrderRefreshed(orderId: Long) {
-        _orderRefreshed.emit(orderId)
+    fun notifyOrderRefreshed(orderId: Long) {
+        _orderRefreshed.tryEmit(orderId)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
@@ -103,7 +103,8 @@ class WooPosOrderDetailsViewModel @Inject constructor(
     fun loadOrder(orderId: Long) {
         lastRequestedOrderId = orderId
         sideLoadJob?.cancel()
-        refreshOrderJob?.cancel()
+        // Do not cancel refreshOrderJob: a pending refresh must complete so the list row
+        // for the previously selected order is updated even after selection changes.
 
         viewModelScope.launch {
             _state.value = WooPosOrderDetailsState.Loading
@@ -314,11 +315,11 @@ class WooPosOrderDetailsViewModel @Inject constructor(
 
         val newDetailsViewState = orderDetailsMapper.mapOrderDetails(updated, historicalRefundsResult)
 
-        val current = _state.value as? WooPosOrderDetailsState.Loaded ?: return
-        if (current.details.id == updated.id) {
+        val current = _state.value as? WooPosOrderDetailsState.Loaded
+        if (current != null && current.details.id == updated.id) {
             _state.value = current.copy(details = newDetailsViewState)
-            coordinator.notifyOrderRefreshed(updated.id)
         }
+        coordinator.notifyOrderRefreshed(updated.id)
     }
 
     private fun cacheRefundData(orderId: Long, refundRows: List<RefundRowData>, order: Order) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -34,6 +35,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import javax.inject.Inject
 
@@ -103,8 +105,7 @@ class WooPosOrderDetailsViewModel @Inject constructor(
     fun loadOrder(orderId: Long) {
         lastRequestedOrderId = orderId
         sideLoadJob?.cancel()
-        // Do not cancel refreshOrderJob: a pending refresh must complete so the list row
-        // for the previously selected order is updated even after selection changes.
+        refreshOrderJob?.cancel()
 
         viewModelScope.launch {
             _state.value = WooPosOrderDetailsState.Loading
@@ -299,8 +300,15 @@ class WooPosOrderDetailsViewModel @Inject constructor(
         sideLoadJob?.cancel()
         refreshOrderJob?.cancel()
         refreshOrderJob = viewModelScope.launch {
-            ordersDataSource.refreshOrderById(selectedOrderId)
-                .onSuccess { applyOrderUpdate(it) }
+            // Fetch + notify run atomically so the list row is always refreshed when the cache
+            // is updated, even if the user has already selected a different order. Only the
+            // detail-pane work below is cancellable and skipped on selection change.
+            val updated = withContext(NonCancellable) {
+                ordersDataSource.refreshOrderById(selectedOrderId).getOrNull()?.also {
+                    coordinator.notifyOrderRefreshed(it.id)
+                }
+            } ?: return@launch
+            applyOrderUpdate(updated)
         }
     }
 
@@ -315,11 +323,10 @@ class WooPosOrderDetailsViewModel @Inject constructor(
 
         val newDetailsViewState = orderDetailsMapper.mapOrderDetails(updated, historicalRefundsResult)
 
-        val current = _state.value as? WooPosOrderDetailsState.Loaded
-        if (current != null && current.details.id == updated.id) {
+        val current = _state.value as? WooPosOrderDetailsState.Loaded ?: return
+        if (current.details.id == updated.id) {
             _state.value = current.copy(details = newDetailsViewState)
         }
-        coordinator.notifyOrderRefreshed(updated.id)
     }
 
     private fun cacheRefundData(orderId: Long, refundRows: List<RefundRowData>, order: Order) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModel.kt
@@ -102,7 +102,7 @@ class WooPosOrderDetailsViewModel @Inject constructor(
         loadOrder(orderId)
     }
 
-    fun loadOrder(orderId: Long) {
+    private fun loadOrder(orderId: Long) {
         lastRequestedOrderId = orderId
         sideLoadJob?.cancel()
         refreshOrderJob?.cancel()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsViewModelTest.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -464,6 +465,33 @@ class WooPosOrderDetailsViewModelTest {
         // THEN
         verify(dataSource).refreshOrderById(1L)
     }
+
+    @Test
+    fun `given refresh in flight, when user selects different order, then coordinator notifies for original order`() =
+        runTest {
+            // GIVEN
+            val refreshedIds = mutableListOf<Long>()
+            val collectorJob = launch {
+                coordinator.orderRefreshed.collect { refreshedIds.add(it) }
+            }
+            doReturn(Result.success(order(2L))).whenever(dataSource).getOrderById(2L)
+            viewModel = createViewModel()
+            advanceUntilIdle()
+            coordinator.selectOrder(1L)
+            advanceUntilIdle()
+
+            // WHEN
+            viewModel.onBackFromSuccessfullySendingEmailReceipt()
+            coordinator.selectOrder(2L)
+            advanceUntilIdle()
+
+            // THEN
+            assertThat(refreshedIds).contains(1L)
+            val loaded = viewModel.state.value as WooPosOrderDetailsState.Loaded
+            assertThat(loaded.details.id).isEqualTo(2L)
+
+            collectorJob.cancel()
+        }
 
     @Test
     fun `given issue refund dialog open, when dismissed, then order is refreshed`() = runTest {


### PR DESCRIPTION
Fixes WOOMOB-2470

### Description

Fixes a regression introduced by #15683 (the VM split).

**The bug:** after issuing a refund (or returning from the email-receipt flow), the detail VM refreshes the order in the background and updates both the detail pane and the corresponding list row. If the user tapped a different order before that refresh finished, the original order's list row was left showing pre-refund data — status, totals, etc. — until the next pull-to-refresh. Trunk did not have this problem; #15683 accidentally tied the list-row refresh to the "detail pane still shows this order" condition.

**The fix** is in two commits:

1. **Refresh list row after order update even if selection has changed.** Decouples the list-row notify from the detail-state update so the list row is refreshed whenever the cache is updated, regardless of what the detail pane is showing.
2. **Skip stale detail-pane work when selection changes during refresh.** The fetch + list-row notify are now wrapped in `withContext(NonCancellable)`, guaranteeing they run to completion even when the user moves on. The expensive detail-pane work that follows (refund re-fetch, view-state mapping) is cancellable, so it's skipped when it would be discarded anyway. `notifyOrderRefreshed` switches to a non-suspending `tryEmit` on a buffered `SharedFlow`, which also removes a latent risk of events being dropped if a collector wasn't immediately ready.

### Test Steps

1. Install on a tablet and open POS → historical orders.
2. Pick an order that shows **Issue refund** (typically a Completed order with line items). Issue a refund and dismiss the dialog.
3. Before the list row visibly updates, tap a different order in the list.
4. Confirm the first order's row now reflects the refund (status / total updated). Without the fix it stays on the pre-refund values until pull-to-refresh.
5. Repeat the same pattern with **Email receipt**: send a receipt, return to the screen, then quickly select a different order. The original order's row should still reflect any changes.


### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.