### PR TITLE
[WOOMOB-2747] Format order total in Percentage custom amount label

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
@@ -106,13 +106,17 @@ class CustomAmountsFragment : BaseFragment(R.layout.dialog_custom_amounts) {
     }
 
     private fun bindPercentageLabel(binding: DialogCustomAmountsBinding) {
-        with(binding.percentageLabel) {
-            val orderTotal = arguments.orderTotal.orEmpty()
-            val formattedOrderTotal = arguments.customAmountUIModel.currencyCode?.value
-                ?.let { currencyFormatter.formatCurrency(orderTotal, it) }
-                ?: currencyFormatter.formatCurrency(orderTotal)
-            text = context.getString(R.string.custom_amounts_percentage_label, formattedOrderTotal)
-        }
+        binding.percentageLabel.text = getString(
+            R.string.custom_amounts_percentage_label,
+            formatOrderTotal()
+        )
+    }
+
+    private fun formatOrderTotal(): String {
+        val orderTotal = arguments.orderTotal?.toBigDecimalOrNull() ?: BigDecimal.ZERO
+        return arguments.customAmountUIModel.currencyCode?.value
+            ?.let { currencyFormatter.formatCurrency(orderTotal, it) }
+            ?: currencyFormatter.formatCurrency(orderTotal)
     }
 
     private fun bindAmountsView(binding: DialogCustomAmountsBinding) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/customamounts/CustomAmountsFragment.kt
@@ -107,7 +107,11 @@ class CustomAmountsFragment : BaseFragment(R.layout.dialog_custom_amounts) {
 
     private fun bindPercentageLabel(binding: DialogCustomAmountsBinding) {
         with(binding.percentageLabel) {
-            text = context.getString(R.string.custom_amounts_percentage_label, arguments.orderTotal)
+            val orderTotal = arguments.orderTotal.orEmpty()
+            val formattedOrderTotal = arguments.customAmountUIModel.currencyCode?.value
+                ?.let { currencyFormatter.formatCurrency(orderTotal, it) }
+                ?: currencyFormatter.formatCurrency(orderTotal)
+            text = context.getString(R.string.custom_amounts_percentage_label, formattedOrderTotal)
         }
     }
 


### PR DESCRIPTION
Closes [WOOMOB-2747](https://linear.app/a8c/issue/WOOMOB-2747/order-creation-percentage-of-order-total-label-shows-unformatted)

### Description
When adding/editing a custom amount of type _Percentage of order total_ during order creation, the helper label under the title rendered the order total as a raw decimal string with the full precision coming from the API (e.g. `Percentage of order total (116.60000000)`).

The `CustomAmountsFragment` was passing `arguments.orderTotal` (a plain `String` from the nav args) straight into the formatted string resource without running it through the `CurrencyFormatter`. This PR formats that value using the injected `CurrencyFormatter` and the currency code associated with the order so the label now shows something like `Percentage of order total ($116.60)` — with the proper currency symbol, thousand separator and decimal places configured for the store.

https://github.com/user-attachments/assets/f7c300d2-0da3-48e8-a1dc-6b170111d76c


### Test Steps
1. Open the Woo Android app and sign in on a store that has non-zero orders.
2. Create a new order (or edit an existing one) with at least one product so the order total is non-zero.
3. Tap _Add custom amount_ and choose _Percentage of order total_.
4. Verify the helper label under the title reads `Percentage of order total (<formatted total>)`, using the store's currency symbol, thousand separators and decimal places (no long trailing zeros).
5. Repeat with a store configured for a different currency/locale and confirm the formatting matches.

### Images/gif

https://github.com/user-attachments/assets/7dae6830-2d98-489b-a7fc-98c445acd762

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.