### PR TITLE
Gate unread filter on Product Reviews

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsFragment.kt
@@ -130,6 +130,7 @@ class ProductReviewsFragment :
             }
             new.isLoadingMore?.takeIfNotEqualTo(old?.isLoadingMore) { showLoadMoreProgress(it) }
             new.isEmptyViewVisible?.takeIfNotEqualTo(old?.isEmptyViewVisible) { showEmptyView(it) }
+            new.isUnreadFilterVisible.takeIfNotEqualTo(old?.isUnreadFilterVisible) { showUnreadFilter(it) }
         }
 
         viewModel.event.observe(viewLifecycleOwner) { event ->
@@ -173,16 +174,22 @@ class ProductReviewsFragment :
     private fun showEmptyView(show: Boolean) {
         if (show) {
             if (binding.unreadFilterSwitch.isChecked) {
-                binding.unreadReviewsFilterLayout.show()
                 binding.emptyView.show(EmptyViewType.UNREAD_FILTERED_REVIEW_LIST)
             } else {
                 binding.emptyView.show(EmptyViewType.REVIEW_LIST) {
                     ChromeCustomTabUtils.launchUrl(requireActivity(), AppUrls.URL_LEARN_MORE_REVIEWS)
                 }
-                binding.unreadReviewsFilterLayout.hide()
             }
         } else {
             binding.emptyView.hide()
+        }
+    }
+
+    private fun showUnreadFilter(show: Boolean) {
+        if (show) {
+            binding.unreadReviewsFilterLayout.show()
+        } else {
+            binding.unreadReviewsFilterLayout.hide()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModel.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.tools.NetworkStatus
 import com.woocommerce.android.ui.reviews.ReviewListRepository
 import com.woocommerce.android.ui.reviews.ReviewModerationConsumer
 import com.woocommerce.android.ui.reviews.ReviewModerationHandler
+import com.woocommerce.android.ui.reviews.domain.SupportsReviewsReadStatus
 import com.woocommerce.android.ui.reviews.observeModerationEvents
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooLog.T.PRODUCTS
@@ -39,7 +40,8 @@ class ProductReviewsViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val networkStatus: NetworkStatus,
     private val reviewModerationHandler: ReviewModerationHandler,
-    private val reviewListRepository: ReviewListRepository
+    private val reviewListRepository: ReviewListRepository,
+    private val supportsReviewsReadStatus: SupportsReviewsReadStatus
 ) : ScopedViewModel(savedState), ReviewModerationConsumer {
     private val _reviewList = MutableLiveData<List<ProductReview>>()
 
@@ -117,8 +119,9 @@ class ProductReviewsViewModel @Inject constructor(
             } else {
                 productReviewsViewState = productReviewsViewState.copy(isSkeletonShown = true)
             }
+            syncUnreadFilterAvailability()
+            fetchProductReviews(navArgs.remoteProductId, loadMore = false)
         }
-        fetchProductReviews(navArgs.remoteProductId, loadMore = false)
     }
 
     private fun fetchProductReviews(
@@ -138,6 +141,7 @@ class ProductReviewsViewModel @Inject constructor(
                             ReviewListRepository.FetchReviewsResult.NothingFetched -> {
                                 // No action needed
                             }
+
                             is ReviewListRepository.FetchReviewsResult.NotificationsFetched -> {
                                 if (result.requestResult == SUCCESS) {
                                     val reviews = reviewListRepository.getCachedProductReviews()
@@ -146,6 +150,7 @@ class ProductReviewsViewModel @Inject constructor(
                                     }
                                 }
                             }
+
                             is ReviewListRepository.FetchReviewsResult.ReviewsFetched -> {
                                 trackFetchProductReviewsResult(result.requestResult, loadMore)
                                 when (result.requestResult) {
@@ -219,12 +224,24 @@ class ProductReviewsViewModel @Inject constructor(
         )
     }
 
+    private suspend fun syncUnreadFilterAvailability() {
+        val isUnreadFilterSupported = supportsReviewsReadStatus()
+        productReviewsViewState = productReviewsViewState.copy(
+            isUnreadFilterSupported = isUnreadFilterSupported,
+            isUnreadFilterEnabled = productReviewsViewState.isUnreadFilterEnabled && isUnreadFilterSupported
+        )
+    }
+
     @Parcelize
     data class ProductReviewsViewState(
         val isSkeletonShown: Boolean? = null,
         val isLoadingMore: Boolean? = null,
         val isRefreshing: Boolean? = null,
         val isEmptyViewVisible: Boolean? = null,
+        val isUnreadFilterSupported: Boolean = true,
         val isUnreadFilterEnabled: Boolean = false
-    ) : Parcelable
+    ) : Parcelable {
+        val isUnreadFilterVisible: Boolean
+            get() = isUnreadFilterSupported && (isEmptyViewVisible != true || isUnreadFilterEnabled)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/products/reviews/ProductReviewsViewModelTest.kt
@@ -1,0 +1,79 @@
+package com.woocommerce.android.ui.products.reviews
+
+import com.woocommerce.android.model.ProductReview
+import com.woocommerce.android.tools.NetworkStatus
+import com.woocommerce.android.ui.reviews.ProductReviewTestUtils
+import com.woocommerce.android.ui.reviews.ReviewListRepository
+import com.woocommerce.android.ui.reviews.ReviewModerationHandler
+import com.woocommerce.android.ui.reviews.domain.SupportsReviewsReadStatus
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProductReviewsViewModelTest : BaseUnitTest() {
+    private val networkStatus: NetworkStatus = mock()
+    private val reviewModerationHandler: ReviewModerationHandler = mock {
+        on { pendingModerationStatus } doReturn emptyFlow()
+    }
+    private val reviewListRepository: ReviewListRepository = mock()
+    private val supportsReviewsReadStatus: SupportsReviewsReadStatus = mock()
+
+    private lateinit var viewModel: ProductReviewsViewModel
+
+    @Before
+    fun setup() = testBlocking {
+        doReturn(true).whenever(networkStatus).isConnected()
+        whenever(supportsReviewsReadStatus.invoke()).thenReturn(true)
+        doReturn(emptyList<ProductReview>()).whenever(reviewListRepository).getCachedProductReviews(anyOrNull())
+        doReturn(emptyFlow<ReviewListRepository.FetchReviewsResult>())
+            .whenever(reviewListRepository).fetchProductReviews(loadMore = false, remoteProductId = REMOTE_PRODUCT_ID)
+    }
+
+    @Test
+    fun `given read-status is unsupported, when view model is created, then unread filter is hidden`() = testBlocking {
+        whenever(supportsReviewsReadStatus.invoke()).thenReturn(false)
+
+        createViewModel()
+
+        assertThat(viewModel.productReviewsViewStateData.liveData.value?.isUnreadFilterSupported).isFalse()
+        assertThat(viewModel.productReviewsViewStateData.liveData.value?.isUnreadFilterVisible).isFalse()
+    }
+
+    @Test
+    fun `given read-status is supported and reviews are available, when view model is created, then unread filter is visible`() =
+        testBlocking {
+            doReturn(ProductReviewTestUtils.generateProductReviewList())
+                .whenever(reviewListRepository).getCachedProductReviews(anyOrNull())
+            whenever(supportsReviewsReadStatus.invoke()).thenReturn(true)
+
+            createViewModel()
+
+            assertThat(viewModel.productReviewsViewStateData.liveData.value?.isUnreadFilterSupported).isTrue()
+            assertThat(viewModel.productReviewsViewStateData.liveData.value?.isUnreadFilterVisible).isTrue()
+        }
+
+    private fun createViewModel(
+        savedState: androidx.lifecycle.SavedStateHandle =
+            ProductReviewsFragmentArgs(remoteProductId = REMOTE_PRODUCT_ID).toSavedStateHandle()
+    ) {
+        viewModel = ProductReviewsViewModel(
+            savedState = savedState,
+            networkStatus = networkStatus,
+            reviewModerationHandler = reviewModerationHandler,
+            reviewListRepository = reviewListRepository,
+            supportsReviewsReadStatus = supportsReviewsReadStatus
+        )
+    }
+
+    private companion object {
+        const val REMOTE_PRODUCT_ID = 100L
+    }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-2750

This updates the Product Reviews screen so the \"Unread reviews only\" filter is hidden for Jetpack-connected sites with Woo-driven push and for site-credentials (application passwords) sites.

Unread review state is only supported while reviews are still backed by WP.com notifications. On the Product Reviews screen, the unread filter remains visible on Jetpack-connected sites that still use WP.com push (the default Jetpack setup).

### Test Steps
1. Use a Jetpack-connected site with Woo-driven push and a product with reviews.
2. Open **Product Reviews**.
3. Verify the \"Unread reviews only\" filter is hidden.

4. Use a site-credentials (application passwords) site and a product with reviews.
5. Open **Product Reviews**.
6. Verify the \"Unread reviews only\" filter is hidden.

7. Use a Jetpack-connected site with WP.com push (default Jetpack setup) and a product with reviews.
8. Open **Product Reviews**.
9. Verify the \"Unread reviews only\" filter is visible.

10. Use a Jetpack-connected site with WP.com push (default Jetpack setup) and a product with no reviews.
11. Open **Product Reviews**.
12. Verify the regular empty state is shown and the \"Unread reviews only\" filter row is not shown.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.