### PR TITLE
[WOOMOB-2739] Card Reader Mode session (NSD + TLS + protocol loop)

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -1,0 +1,243 @@
+package com.woocommerce.android.cardreader.remote
+
+import android.content.Context
+import android.os.Build
+import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.cardreader.LogWrapper
+import com.woocommerce.android.cardreader.connection.CardReader
+import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.connection.RemoteTokenChannelProvider
+import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.CollectPaymentRequest
+import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.ConnectAck
+import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.ConnectRequest
+import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.ErrorMessage
+import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.PaymentIntentResult
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.net.SocketTimeoutException
+
+class CardReaderRemoteSession internal constructor(
+    private val context: Context,
+    private val cardReaderManager: CardReaderManager,
+    private val logWrapper: LogWrapper,
+    private val tlsServerFactory: TlsServerFactory,
+    private val nsdFactory: NsdFactory,
+    private val remoteTokenProviderFactory: RemoteTokenProviderFactory,
+    private val disconnectScope: CoroutineScope = defaultDisconnectScope(),
+) {
+    constructor(
+        context: Context,
+        cardReaderManager: CardReaderManager,
+        logWrapper: LogWrapper,
+    ) : this(
+        context = context,
+        cardReaderManager = cardReaderManager,
+        logWrapper = logWrapper,
+        tlsServerFactory = TlsServerFactory { CardReaderRemoteTlsServer() },
+        nsdFactory = NsdFactory { ctx -> CardReaderRemoteNsd(ctx) },
+        remoteTokenProviderFactory = RemoteTokenProviderFactory { RemoteTokenChannelProvider() },
+    )
+
+    private val _state = MutableStateFlow<CardReaderRemoteSessionState>(CardReaderRemoteSessionState.Idle)
+    val state: StateFlow<CardReaderRemoteSessionState> = _state.asStateFlow()
+
+    private var sessionScope: CoroutineScope? = null
+    private var tlsServer: CardReaderRemoteTlsServer? = null
+    private var nsdRegistration: CardReaderRemoteNsdRegistration? = null
+    private var remoteTokenProvider: RemoteTokenChannelProvider? = null
+    private var connection: CardReaderRemoteConnection? = null
+    private var readerWasConnected: Boolean = false
+
+    fun start(parentScope: CoroutineScope) {
+        if (sessionScope != null) return
+        val parentJob = parentScope.coroutineContext[Job]
+        val scope = CoroutineScope(parentScope.coroutineContext + SupervisorJob(parentJob))
+        sessionScope = scope
+        scope.launch {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                runSession()
+            } catch (c: CancellationException) {
+                throw c
+            } catch (t: Throwable) {
+                logWrapper.e(LOG_TAG, "Session ended with error: ${t.message}")
+            } finally {
+                cleanupSync()
+            }
+        }
+    }
+
+    fun stop() {
+        val scope = sessionScope ?: return
+        sessionScope = null
+        scope.cancel()
+        if (readerWasConnected) {
+            readerWasConnected = false
+            disconnectScope.launch {
+                runCatching { cardReaderManager.disconnectReader() }
+            }
+        }
+    }
+
+    private suspend fun runSession() {
+        _state.value = CardReaderRemoteSessionState.Starting
+
+        val server = tlsServerFactory.create().also { tlsServer = it }
+        server.start()
+
+        val registration = nsdFactory.create(context).advertise(server.port, server.fingerprint)
+        nsdRegistration = registration
+
+        _state.value = readyToPairState(server)
+
+        while (currentCoroutineContext().isActive) {
+            try {
+                acceptAndRunProtocolLoop(server)
+                break
+            } catch (e: SocketTimeoutException) {
+                logWrapper.d(LOG_TAG, "Waiting for tablet to connect: ${e.message}")
+            }
+        }
+    }
+
+    private suspend fun acceptAndRunProtocolLoop(server: CardReaderRemoteTlsServer) {
+        val accepted = server.acceptOne()
+        connection = accepted
+
+        val tokenProvider = remoteTokenProviderFactory.create()
+        remoteTokenProvider = tokenProvider
+        cardReaderManager.connectionTokenProvider.useRemote(tokenProvider)
+
+        accepted.receive().collect { message ->
+            handleMessage(message, accepted, tokenProvider)
+        }
+    }
+
+    internal suspend fun handleMessage(
+        message: CardReaderRemoteMessage,
+        accepted: CardReaderRemoteConnection,
+        tokenProvider: RemoteTokenChannelProvider,
+    ) {
+        when (message) {
+            is ConnectRequest -> handleConnectRequest(message, accepted, tokenProvider)
+            is CollectPaymentRequest -> handleCollectPaymentRequest(message, accepted)
+            is ConnectAck,
+            is PaymentIntentResult,
+            is ErrorMessage -> Unit
+        }
+    }
+
+    private suspend fun handleConnectRequest(
+        request: ConnectRequest,
+        accepted: CardReaderRemoteConnection,
+        tokenProvider: RemoteTokenChannelProvider,
+    ) = coroutineScope {
+        val supplyJob = launch { tokenProvider.supply(request.connectionToken) }
+        try {
+            runCatching {
+                val reader = discoverFirstTapToPayReader()
+                cardReaderManager.startConnectionToReader(reader, request.locationId)
+                reader
+            }.onSuccess { reader ->
+                readerWasConnected = true
+                accepted.send(ConnectAck(requestId = request.requestId, readerSerial = reader.id))
+                _state.value = CardReaderRemoteSessionState.WaitingForPayment(tabletName = null)
+            }.onFailure { err ->
+                accepted.send(
+                    ErrorMessage(
+                        requestId = request.requestId,
+                        code = CODE_CONNECT_FAILED,
+                        description = err.message.orEmpty(),
+                    )
+                )
+                tlsServer?.let { _state.value = readyToPairState(it) }
+            }
+        } finally {
+            supplyJob.cancel()
+        }
+    }
+
+    private suspend fun discoverFirstTapToPayReader(): CardReader {
+        val found = cardReaderManager.discoverReaders(
+            isSimulated = false,
+            cardReaderTypesToDiscover = CardReaderTypesToDiscover.SpecificReaders.BuiltInReaders(
+                listOf(ReaderType.BuildInReader.TapToPayDevice)
+            )
+        ).filterIsInstance<CardReaderDiscoveryEvents.ReadersFound>()
+            .first { it.list.isNotEmpty() }
+        return found.list.first()
+    }
+
+    @Suppress("ForbiddenComment")
+    private suspend fun handleCollectPaymentRequest(
+        request: CollectPaymentRequest,
+        accepted: CardReaderRemoteConnection,
+    ) {
+        // TODO: real Stripe retrieve/collect/confirm against request.paymentIntentClientSecret.
+        //  Deferred as WOOMOB-2739-b until a cardreader-owned API is in place.
+        accepted.send(
+            ErrorMessage(
+                requestId = request.requestId,
+                code = CODE_NOT_IMPLEMENTED,
+                description = "Payment collection deferred to WOOMOB-2739-b",
+            )
+        )
+        _state.value = CardReaderRemoteSessionState.WaitingForPayment(tabletName = null)
+    }
+
+    private fun readyToPairState(server: CardReaderRemoteTlsServer) =
+        CardReaderRemoteSessionState.ReadyToPair(
+            deviceName = Build.MODEL ?: DEFAULT_DEVICE_NAME,
+            fingerprintSuffix = CardReaderRemoteFingerprint.pairingCodeFromBase64(server.fingerprint),
+        )
+
+    private fun cleanupSync() {
+        runCatching { connection?.close() }
+        connection = null
+        runCatching { cardReaderManager.connectionTokenProvider.useDefault() }
+        runCatching { remoteTokenProvider?.close() }
+        remoteTokenProvider = null
+        runCatching { nsdRegistration?.close() }
+        nsdRegistration = null
+        runCatching { tlsServer?.close() }
+        tlsServer = null
+        _state.value = CardReaderRemoteSessionState.Idle
+    }
+
+    internal fun interface TlsServerFactory {
+        fun create(): CardReaderRemoteTlsServer
+    }
+
+    internal fun interface NsdFactory {
+        fun create(context: Context): CardReaderRemoteNsd
+    }
+
+    internal fun interface RemoteTokenProviderFactory {
+        fun create(): RemoteTokenChannelProvider
+    }
+
+    companion object {
+        private const val LOG_TAG = "CardReaderRemoteSession"
+        private const val CODE_CONNECT_FAILED = "connect_failed"
+        private const val CODE_NOT_IMPLEMENTED = "not_implemented"
+        private const val DEFAULT_DEVICE_NAME = "Android"
+
+        private fun defaultDisconnectScope(): CoroutineScope =
+            CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    }
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -219,6 +219,12 @@ class CardReaderRemoteSession internal constructor(
         nsdRegistration = null
         runCatching { tlsServer?.close() }
         tlsServer = null
+        if (readerWasConnected) {
+            readerWasConnected = false
+            disconnectScope.launch {
+                runCatching { cardReaderManager.disconnectReader() }
+            }
+        }
         _state.value = CardReaderRemoteSessionState.Idle
     }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -75,7 +75,7 @@ class CardReaderRemoteSession internal constructor(
             } catch (c: CancellationException) {
                 throw c
             } catch (t: Throwable) {
-                logWrapper.e(LOG_TAG, "Session ended with error: ${t.message}")
+                logWrapper.e(LOG_TAG, "Session ended with error: ${t::class.java.name}: ${t.message}")
             } finally {
                 cleanupSync()
                 if (sessionScope === scope) {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -78,6 +78,9 @@ class CardReaderRemoteSession internal constructor(
                 logWrapper.e(LOG_TAG, "Session ended with error: ${t.message}")
             } finally {
                 cleanupSync()
+                if (sessionScope === scope) {
+                    sessionScope = null
+                }
             }
         }
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSessionState.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSessionState.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.cardreader.remote
+
+sealed class CardReaderRemoteSessionState {
+    object Idle : CardReaderRemoteSessionState()
+
+    object Starting : CardReaderRemoteSessionState()
+
+    data class ReadyToPair(
+        val deviceName: String,
+        val fingerprintSuffix: String,
+    ) : CardReaderRemoteSessionState()
+
+    data class WaitingForPayment(
+        val tabletName: String?,
+    ) : CardReaderRemoteSessionState()
+}

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSessionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSessionTest.kt
@@ -1,0 +1,60 @@
+package com.woocommerce.android.cardreader.remote
+
+import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.cardreader.LogWrapper
+import com.woocommerce.android.cardreader.connection.CardReader
+import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
+import com.woocommerce.android.cardreader.connection.RemoteTokenChannelProvider
+import com.woocommerce.android.cardreader.internal.CardReaderBaseUnitTest
+import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.ConnectRequest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class CardReaderRemoteSessionTest : CardReaderBaseUnitTest() {
+
+    private val cardReaderManager: CardReaderManager = mock()
+    private val logWrapper: LogWrapper = mock()
+
+    @Test
+    fun `given ConnectRequest arrives, when reader connect succeeds, then state transitions to WaitingForPayment`() =
+        testBlocking {
+            // GIVEN
+            val reader: CardReader = mock { on { id } doReturn "reader-serial" }
+            whenever(
+                cardReaderManager.discoverReaders(any(), any())
+            ).thenReturn(flowOf(CardReaderDiscoveryEvents.ReadersFound(listOf(reader))))
+
+            val tokenProvider: RemoteTokenChannelProvider = mock()
+            val connection: CardReaderRemoteConnection = mock()
+            val session = CardReaderRemoteSession(
+                context = mock(),
+                cardReaderManager = cardReaderManager,
+                logWrapper = logWrapper,
+                tlsServerFactory = mock(),
+                nsdFactory = mock(),
+                remoteTokenProviderFactory = { tokenProvider },
+            )
+
+            // WHEN
+            session.handleMessage(
+                message = ConnectRequest(
+                    requestId = "req-1",
+                    connectionToken = "tok",
+                    locationId = "loc-xyz",
+                ),
+                accepted = connection,
+                tokenProvider = tokenProvider,
+            )
+
+            // THEN
+            assertThat(session.state.value)
+                .isInstanceOf(CardReaderRemoteSessionState.WaitingForPayment::class.java)
+        }
+}


### PR DESCRIPTION
### Description

Fixes WOOMOB-2739.

Adds the phone-side session for Woo POS Card Reader Mode in `libs/cardreader`. Advertises the phone via NSD, serves a TLS socket, runs the JSON protocol loop, and exposes a `StateFlow<CardReaderRemoteSessionState>` (`Idle` → `Starting` → `ReadyToPair` → `WaitingForPayment`) for a UI layer to render. UI wiring (activity, state bridge, Payments Hub entry) is in the follow-up PR #15717.

**Base:** #15703. Also carries #15704 in the diff - drops out once that dependency merges into `feature/remote-tap-to-pay`.

**Known gaps:**

- `CollectPaymentRequest` replies `ErrorMessage("not_implemented")`. Real `retrievePaymentIntent → collectPaymentMethod → confirmPaymentIntent` is deferred to **WOOMOB-2739-b**.

### Test Steps

No UI to exercise in this PR - see #15717 for end-to-end steps and video.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.