### PR TITLE
[Woo POS] [Remote TTP] Unified BT + NSD discovery stream

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
-import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover.SpecificReaders.ExternalReaders
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.Chipper2X
@@ -23,6 +22,9 @@ import com.woocommerce.android.ui.payments.tracking.CardReaderTrackingInfoKeeper
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.prefs.developer.DeveloperOptionsRepository
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionState.Connected
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosDiscoveredReader
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosUnifiedDiscoveryEvent
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosUnifiedDiscoveryStream
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.FeatureFlag
@@ -55,6 +57,7 @@ class WooPosCardReaderConnectionController(
     private val tracker: PaymentsFlowTracker,
     private val cardReaderTrackingInfoKeeper: CardReaderTrackingInfoKeeper,
     private val onboardingErrorMapper: WooPosOnboardingErrorMapper,
+    private val unifiedDiscoveryStream: WooPosUnifiedDiscoveryStream,
     featureFlagRepository: FeatureFlagRepository,
 ) {
     private val isRemoteTapToPayEnabled = featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)
@@ -286,8 +289,8 @@ class WooPosCardReaderConnectionController(
     private fun startDiscovery() {
         discoveryJob?.cancel()
         discoveryJob = scope.launch {
-            cardReaderManager
-                .discoverReaders(
+            unifiedDiscoveryStream
+                .discover(
                     isSimulated = developerOptionsRepository.isSimulatedCardReaderEnabled(),
                     cardReaderTypesToDiscover = ExternalReaders(
                         listOf(Chipper2X, StripeM2, WisePade3)
@@ -300,17 +303,20 @@ class WooPosCardReaderConnectionController(
         }
     }
 
-    private fun handleDiscoveryEvent(event: CardReaderDiscoveryEvents) {
+    private fun handleDiscoveryEvent(event: WooPosUnifiedDiscoveryEvent) {
         when (event) {
-            is CardReaderDiscoveryEvents.Started -> {
+            is WooPosUnifiedDiscoveryEvent.Started -> {
                 logger.d("Discovery started")
                 enterScanningState()
             }
-            is CardReaderDiscoveryEvents.ReadersFound -> {
-                logger.d("Found ${event.list.size} readers")
-                handleReadersFound(event.list)
+            is WooPosUnifiedDiscoveryEvent.ReadersFound -> {
+                val bluetoothReaders = event.readers
+                    .filterIsInstance<WooPosDiscoveredReader.Bluetooth>()
+                    .map { it.cardReader }
+                logger.d("Found ${bluetoothReaders.size} bluetooth readers (of ${event.readers.size} total)")
+                handleReadersFound(bluetoothReaders)
             }
-            is CardReaderDiscoveryEvents.Failed -> {
+            is WooPosUnifiedDiscoveryEvent.Failed -> {
                 logger.e("Discovery failed - ${event.msg}")
                 tracker.trackReaderDiscoveryFailed(event.msg)
                 _state.value = WooPosCardReaderConnectionState.ScanningFailed(
@@ -319,7 +325,7 @@ class WooPosCardReaderConnectionController(
                     onCancelClicked = { cancel() }
                 )
             }
-            is CardReaderDiscoveryEvents.Succeeded -> {
+            is WooPosUnifiedDiscoveryEvent.Succeeded -> {
                 logger.d("Discovery succeeded")
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -313,7 +313,7 @@ class WooPosCardReaderConnectionController(
                 val bluetoothReaders = event.readers
                     .filterIsInstance<WooPosDiscoveredReader.Bluetooth>()
                     .map { it.cardReader }
-                logger.d("Found ${bluetoothReaders.size} bluetooth readers (of ${event.readers.size} total)")
+                logger.d("Found ${bluetoothReaders.size} readers")
                 handleReadersFound(bluetoothReaders)
             }
             is WooPosUnifiedDiscoveryEvent.Failed -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionControllerFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionControllerFactory.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboa
 import com.woocommerce.android.ui.payments.tracking.CardReaderTrackingInfoKeeper
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.prefs.developer.DeveloperOptionsRepository
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosUnifiedDiscoveryStream
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.FeatureFlagRepository
@@ -30,6 +31,7 @@ class WooPosCardReaderConnectionControllerFactory @Inject constructor(
     @PointOfSaleMode private val tracker: PaymentsFlowTracker,
     private val cardReaderTrackingInfoKeeper: CardReaderTrackingInfoKeeper,
     private val onboardingErrorMapper: WooPosOnboardingErrorMapper,
+    private val unifiedDiscoveryStream: WooPosUnifiedDiscoveryStream,
     private val featureFlagRepository: FeatureFlagRepository,
 ) {
     fun create(scope: CoroutineScope): WooPosCardReaderConnectionController {
@@ -47,6 +49,7 @@ class WooPosCardReaderConnectionControllerFactory @Inject constructor(
             tracker = tracker,
             cardReaderTrackingInfoKeeper = cardReaderTrackingInfoKeeper,
             onboardingErrorMapper = onboardingErrorMapper,
+            unifiedDiscoveryStream = unifiedDiscoveryStream,
             featureFlagRepository = featureFlagRepository,
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
@@ -18,10 +18,14 @@ sealed class WooPosPhoneDiscoveryEvent {
     data class Removed(val name: String) : WooPosPhoneDiscoveryEvent()
 }
 
+interface WooPosPhoneDiscoverySource {
+    fun discover(): Flow<WooPosPhoneDiscoveryEvent>
+}
+
 class WooPosRemoteReaderDiscovery @Inject constructor(
     private val remoteDiscovery: CardReaderRemoteDiscovery,
-) {
-    fun discover(): Flow<WooPosPhoneDiscoveryEvent> =
+) : WooPosPhoneDiscoverySource {
+    override fun discover(): Flow<WooPosPhoneDiscoveryEvent> =
         remoteDiscovery.discover().map { event ->
             when (event) {
                 is RemoteReaderDiscoveryEvent.Added -> WooPosPhoneDiscoveryEvent.Added(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
@@ -1,0 +1,37 @@
+package com.woocommerce.android.ui.woopos.cardreader.remote
+
+import android.content.Context
+import com.woocommerce.android.cardreader.remote.CardReaderRemoteDiscovery
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+class WooPosRemoteReaderDiscovery @Inject constructor(
+    private val remoteDiscovery: CardReaderRemoteDiscovery,
+) {
+    fun discover(): Flow<WooPosDiscoveredReader.Phone> =
+        remoteDiscovery.discover().map { reader ->
+            WooPosDiscoveredReader.Phone(
+                name = reader.name,
+                host = reader.host,
+                port = reader.port,
+                fingerprintBase64 = reader.fingerprintBase64,
+            )
+        }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object WooPosRemoteReaderDiscoveryModule {
+    @Provides
+    @Singleton
+    fun provideCardReaderRemoteDiscovery(
+        @ApplicationContext context: Context,
+    ): CardReaderRemoteDiscovery = CardReaderRemoteDiscovery.create(context)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.cardreader.remote
 
 import android.content.Context
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteDiscovery
+import com.woocommerce.android.cardreader.remote.RemoteReaderDiscoveryEvent
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -12,17 +13,27 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
+sealed class WooPosPhoneDiscoveryEvent {
+    data class Added(val phone: WooPosDiscoveredReader.Phone) : WooPosPhoneDiscoveryEvent()
+    data class Removed(val name: String) : WooPosPhoneDiscoveryEvent()
+}
+
 class WooPosRemoteReaderDiscovery @Inject constructor(
     private val remoteDiscovery: CardReaderRemoteDiscovery,
 ) {
-    fun discover(): Flow<WooPosDiscoveredReader.Phone> =
-        remoteDiscovery.discover().map { reader ->
-            WooPosDiscoveredReader.Phone(
-                name = reader.name,
-                host = reader.host,
-                port = reader.port,
-                fingerprintBase64 = reader.fingerprintBase64,
-            )
+    fun discover(): Flow<WooPosPhoneDiscoveryEvent> =
+        remoteDiscovery.discover().map { event ->
+            when (event) {
+                is RemoteReaderDiscoveryEvent.Added -> WooPosPhoneDiscoveryEvent.Added(
+                    WooPosDiscoveredReader.Phone(
+                        name = event.reader.name,
+                        host = event.reader.host,
+                        port = event.reader.port,
+                        fingerprintBase64 = event.reader.fingerprintBase64,
+                    )
+                )
+                is RemoteReaderDiscoveryEvent.Removed -> WooPosPhoneDiscoveryEvent.Removed(event.name)
+            }
         }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
@@ -1,0 +1,36 @@
+package com.woocommerce.android.ui.woopos.cardreader.remote
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.net.InetAddress
+import javax.inject.Inject
+
+class WooPosSimulatedRemoteReaderDiscovery @Inject constructor() : WooPosPhoneDiscoverySource {
+    override fun discover(): Flow<WooPosPhoneDiscoveryEvent> = flow {
+        delay(FIRST_PHONE_DELAY_MS)
+        emit(WooPosPhoneDiscoveryEvent.Added(simulatedPhones[0]))
+        delay(SECOND_PHONE_DELAY_MS)
+        emit(WooPosPhoneDiscoveryEvent.Added(simulatedPhones[1]))
+    }
+
+    private companion object {
+        const val FIRST_PHONE_DELAY_MS = 500L
+        const val SECOND_PHONE_DELAY_MS = 1_000L
+
+        val simulatedPhones = listOf(
+            WooPosDiscoveredReader.Phone(
+                name = "Simulated Pixel 7",
+                host = InetAddress.getLoopbackAddress(),
+                port = 9000,
+                fingerprintBase64 = "SIM1",
+            ),
+            WooPosDiscoveredReader.Phone(
+                name = "Simulated Galaxy S24",
+                host = InetAddress.getLoopbackAddress(),
+                port = 9001,
+                fingerprintBase64 = "SIM2",
+            ),
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -61,8 +62,7 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
                 when (event) {
                     is CardReaderDiscoveryEvents.Started -> send(WooPosUnifiedDiscoveryEvent.Started)
                     is CardReaderDiscoveryEvents.ReadersFound -> {
-                        mutex.withLock { state.bluetoothReaders = event.list }
-                        sendSnapshot(mutex, state)
+                        updateBluetoothAndSendSnapshot(mutex, state, event.list)
                     }
                     is CardReaderDiscoveryEvents.Failed -> send(WooPosUnifiedDiscoveryEvent.Failed(event.msg))
                     is CardReaderDiscoveryEvents.Succeeded -> send(WooPosUnifiedDiscoveryEvent.Succeeded)
@@ -72,26 +72,51 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
 
         if (featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)) {
             launch {
-                remoteDiscovery.discover().collect { phone ->
-                    mutex.withLock { state.phonesByName[phone.name] = phone }
-                    sendSnapshot(mutex, state)
-                }
+                remoteDiscovery.discover()
+                    // NSD failures must not tear down BT discovery — degrade to BT-only silently.
+                    .catch { }
+                    .collect { phone ->
+                        addPhoneAndSendSnapshot(mutex, state, phone)
+                    }
             }
         }
     }
 
-    private suspend fun ProducerScope<WooPosUnifiedDiscoveryEvent>.sendSnapshot(
+    private suspend fun ProducerScope<WooPosUnifiedDiscoveryEvent>.updateBluetoothAndSendSnapshot(
         mutex: Mutex,
         state: DiscoveryState,
+        readers: List<CardReader>,
     ) {
-        val snapshot = mutex.withLock {
-            state.bluetoothReaders.map(WooPosDiscoveredReader::Bluetooth) + state.phonesByName.values
+        mutex.withLock {
+            state.bluetoothReaders = readers
+            send(WooPosUnifiedDiscoveryEvent.ReadersFound(state.snapshot()))
         }
-        send(WooPosUnifiedDiscoveryEvent.ReadersFound(snapshot))
+    }
+
+    private suspend fun ProducerScope<WooPosUnifiedDiscoveryEvent>.addPhoneAndSendSnapshot(
+        mutex: Mutex,
+        state: DiscoveryState,
+        phone: WooPosDiscoveredReader.Phone,
+    ) {
+        mutex.withLock {
+            val key = phone.fingerprintBase64
+            val isUpdate = state.phonesByFingerprint.containsKey(key)
+            if (isUpdate || state.phonesByFingerprint.size < MAX_DISCOVERED_PHONES) {
+                state.phonesByFingerprint[key] = phone
+                send(WooPosUnifiedDiscoveryEvent.ReadersFound(state.snapshot()))
+            }
+        }
     }
 
     private class DiscoveryState {
         var bluetoothReaders: List<CardReader> = emptyList()
-        val phonesByName: LinkedHashMap<String, WooPosDiscoveredReader.Phone> = linkedMapOf()
+        val phonesByFingerprint: LinkedHashMap<String, WooPosDiscoveredReader.Phone> = linkedMapOf()
+
+        fun snapshot(): List<WooPosDiscoveredReader> =
+            bluetoothReaders.map(WooPosDiscoveredReader::Bluetooth) + phonesByFingerprint.values
+    }
+
+    private companion object {
+        const val MAX_DISCOVERED_PHONES = 32
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
 import kotlinx.coroutines.channels.ProducerScope
@@ -49,6 +50,7 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
     private val cardReaderManager: CardReaderManager,
     private val remoteDiscovery: WooPosRemoteReaderDiscovery,
     private val featureFlagRepository: FeatureFlagRepository,
+    private val logger: WooPosLogWrapper,
 ) {
     fun discover(
         isSimulated: Boolean,
@@ -73,10 +75,15 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
         if (featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)) {
             launch {
                 remoteDiscovery.discover()
-                    // NSD failures must not tear down BT discovery — degrade to BT-only silently.
-                    .catch { }
-                    .collect { phone ->
-                        addPhoneAndSendSnapshot(mutex, state, phone)
+                    // NSD failures must not tear down BT discovery — degrade to BT-only.
+                    .catch { throwable -> logger.e("NSD discovery failed, degrading to BT-only", throwable) }
+                    .collect { event ->
+                        when (event) {
+                            is WooPosPhoneDiscoveryEvent.Added ->
+                                addPhoneAndSendSnapshot(mutex, state, event.phone)
+                            is WooPosPhoneDiscoveryEvent.Removed ->
+                                removePhoneAndSendSnapshot(mutex, state, event.name)
+                        }
                     }
             }
         }
@@ -99,18 +106,32 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
         phone: WooPosDiscoveredReader.Phone,
     ) {
         mutex.withLock {
-            val key = phone.fingerprintBase64
-            val isUpdate = state.phonesByFingerprint.containsKey(key)
+            val fingerprint = phone.fingerprintBase64
+            val isUpdate = state.phonesByFingerprint.containsKey(fingerprint)
             if (isUpdate || state.phonesByFingerprint.size < MAX_DISCOVERED_PHONES) {
-                state.phonesByFingerprint[key] = phone
+                state.phonesByFingerprint[fingerprint] = phone
+                state.fingerprintByName[phone.name] = fingerprint
                 send(WooPosUnifiedDiscoveryEvent.ReadersFound(state.snapshot()))
             }
+        }
+    }
+
+    private suspend fun ProducerScope<WooPosUnifiedDiscoveryEvent>.removePhoneAndSendSnapshot(
+        mutex: Mutex,
+        state: DiscoveryState,
+        serviceName: String,
+    ) {
+        mutex.withLock {
+            val fingerprint = state.fingerprintByName.remove(serviceName) ?: return@withLock
+            state.phonesByFingerprint.remove(fingerprint)
+            send(WooPosUnifiedDiscoveryEvent.ReadersFound(state.snapshot()))
         }
     }
 
     private class DiscoveryState {
         var bluetoothReaders: List<CardReader> = emptyList()
         val phonesByFingerprint: LinkedHashMap<String, WooPosDiscoveredReader.Phone> = linkedMapOf()
+        val fingerprintByName: MutableMap<String, String> = mutableMapOf()
 
         fun snapshot(): List<WooPosDiscoveredReader> =
             bluetoothReaders.map(WooPosDiscoveredReader::Bluetooth) + phonesByFingerprint.values

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
@@ -1,0 +1,97 @@
+package com.woocommerce.android.ui.woopos.cardreader.remote
+
+import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.cardreader.connection.CardReader
+import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.net.InetAddress
+import javax.inject.Inject
+
+sealed class WooPosDiscoveredReader {
+    abstract val transport: WooPosDiscoveryTransport
+
+    data class Bluetooth(val cardReader: CardReader) : WooPosDiscoveredReader() {
+        override val transport = WooPosDiscoveryTransport.Bluetooth
+    }
+
+    data class Phone(
+        val name: String,
+        val host: InetAddress,
+        val port: Int,
+        val fingerprintBase64: String,
+    ) : WooPosDiscoveredReader() {
+        override val transport = WooPosDiscoveryTransport.WifiLan
+    }
+}
+
+sealed interface WooPosDiscoveryTransport {
+    data object Bluetooth : WooPosDiscoveryTransport
+    data object WifiLan : WooPosDiscoveryTransport
+}
+
+sealed class WooPosUnifiedDiscoveryEvent {
+    data object Started : WooPosUnifiedDiscoveryEvent()
+    data class ReadersFound(val readers: List<WooPosDiscoveredReader>) : WooPosUnifiedDiscoveryEvent()
+    data class Failed(val msg: String) : WooPosUnifiedDiscoveryEvent()
+    data object Succeeded : WooPosUnifiedDiscoveryEvent()
+}
+
+class WooPosUnifiedDiscoveryStream @Inject constructor(
+    private val cardReaderManager: CardReaderManager,
+    private val remoteDiscovery: WooPosRemoteReaderDiscovery,
+    private val featureFlagRepository: FeatureFlagRepository,
+) {
+    fun discover(
+        isSimulated: Boolean,
+        cardReaderTypesToDiscover: CardReaderTypesToDiscover,
+    ): Flow<WooPosUnifiedDiscoveryEvent> = channelFlow {
+        val mutex = Mutex()
+        val state = DiscoveryState()
+
+        launch {
+            cardReaderManager.discoverReaders(isSimulated, cardReaderTypesToDiscover).collect { event ->
+                when (event) {
+                    is CardReaderDiscoveryEvents.Started -> send(WooPosUnifiedDiscoveryEvent.Started)
+                    is CardReaderDiscoveryEvents.ReadersFound -> {
+                        mutex.withLock { state.bluetoothReaders = event.list }
+                        sendSnapshot(mutex, state)
+                    }
+                    is CardReaderDiscoveryEvents.Failed -> send(WooPosUnifiedDiscoveryEvent.Failed(event.msg))
+                    is CardReaderDiscoveryEvents.Succeeded -> send(WooPosUnifiedDiscoveryEvent.Succeeded)
+                }
+            }
+        }
+
+        if (featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)) {
+            launch {
+                remoteDiscovery.discover().collect { phone ->
+                    mutex.withLock { state.phonesByName[phone.name] = phone }
+                    sendSnapshot(mutex, state)
+                }
+            }
+        }
+    }
+
+    private suspend fun ProducerScope<WooPosUnifiedDiscoveryEvent>.sendSnapshot(
+        mutex: Mutex,
+        state: DiscoveryState,
+    ) {
+        val snapshot = mutex.withLock {
+            state.bluetoothReaders.map(WooPosDiscoveredReader::Bluetooth) + state.phonesByName.values
+        }
+        send(WooPosUnifiedDiscoveryEvent.ReadersFound(snapshot))
+    }
+
+    private class DiscoveryState {
+        var bluetoothReaders: List<CardReader> = emptyList()
+        val phonesByName: LinkedHashMap<String, WooPosDiscoveredReader.Phone> = linkedMapOf()
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
@@ -49,6 +49,7 @@ sealed class WooPosUnifiedDiscoveryEvent {
 class WooPosUnifiedDiscoveryStream @Inject constructor(
     private val cardReaderManager: CardReaderManager,
     private val remoteDiscovery: WooPosRemoteReaderDiscovery,
+    private val simulatedRemoteDiscovery: WooPosSimulatedRemoteReaderDiscovery,
     private val featureFlagRepository: FeatureFlagRepository,
     private val logger: WooPosLogWrapper,
 ) {
@@ -73,8 +74,10 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
         }
 
         if (featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)) {
+            val phoneSource: WooPosPhoneDiscoverySource =
+                if (isSimulated) simulatedRemoteDiscovery else remoteDiscovery
             launch {
-                remoteDiscovery.discover()
+                phoneSource.discover()
                     // NSD failures must not tear down BT discovery — degrade to BT-only.
                     .catch { throwable -> logger.e("NSD discovery failed, degrading to BT-only", throwable) }
                     .collect { event ->
@@ -138,6 +141,6 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
     }
 
     private companion object {
-        const val MAX_DISCOVERED_PHONES = 32
+        const val MAX_DISCOVERED_PHONES = 8
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover.SpecificReaders.ExternalReaders
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.Chipper2X
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -23,6 +24,7 @@ class WooPosUnifiedDiscoveryStreamTest {
     private val cardReaderManager: CardReaderManager = mock()
     private val remoteDiscovery: WooPosRemoteReaderDiscovery = mock()
     private val featureFlagRepository: FeatureFlagRepository = mock()
+    private val logger: WooPosLogWrapper = mock()
 
     private val types: CardReaderTypesToDiscover = ExternalReaders(listOf(Chipper2X))
 
@@ -38,10 +40,10 @@ class WooPosUnifiedDiscoveryStreamTest {
             )
         )
         whenever(remoteDiscovery.discover()).thenReturn(
-            flowOf(phone(name = "Pixel 7"))
+            flowOf(WooPosPhoneDiscoveryEvent.Added(phone(name = "Pixel 7")))
         )
         whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(false)
-        val sut = WooPosUnifiedDiscoveryStream(cardReaderManager, remoteDiscovery, featureFlagRepository)
+        val sut = WooPosUnifiedDiscoveryStream(cardReaderManager, remoteDiscovery, featureFlagRepository, logger)
 
         // WHEN / THEN
         sut.discover(isSimulated = false, cardReaderTypesToDiscover = types).test {
@@ -64,9 +66,9 @@ class WooPosUnifiedDiscoveryStreamTest {
             )
         )
         val phone = phone(name = "Pixel 7")
-        whenever(remoteDiscovery.discover()).thenReturn(flowOf(phone))
+        whenever(remoteDiscovery.discover()).thenReturn(flowOf(WooPosPhoneDiscoveryEvent.Added(phone)))
         whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(true)
-        val sut = WooPosUnifiedDiscoveryStream(cardReaderManager, remoteDiscovery, featureFlagRepository)
+        val sut = WooPosUnifiedDiscoveryStream(cardReaderManager, remoteDiscovery, featureFlagRepository, logger)
 
         // WHEN / THEN
         sut.discover(isSimulated = false, cardReaderTypesToDiscover = types).test {
@@ -78,6 +80,33 @@ class WooPosUnifiedDiscoveryStreamTest {
                 WooPosDiscoveredReader.Bluetooth(bluetoothReader),
                 phone,
             )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `given flag on, when nsd reports a phone lost, then the phone is removed from the snapshot`() = runTest {
+        // GIVEN
+        whenever(cardReaderManager.discoverReaders(false, types)).thenReturn(
+            flowOf(CardReaderDiscoveryEvents.Started)
+        )
+        val phone = phone(name = "Pixel 7")
+        whenever(remoteDiscovery.discover()).thenReturn(
+            flowOf(
+                WooPosPhoneDiscoveryEvent.Added(phone),
+                WooPosPhoneDiscoveryEvent.Removed(phone.name),
+            )
+        )
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(true)
+        val sut = WooPosUnifiedDiscoveryStream(cardReaderManager, remoteDiscovery, featureFlagRepository, logger)
+
+        // WHEN / THEN
+        sut.discover(isSimulated = false, cardReaderTypesToDiscover = types).test {
+            assertThat(awaitItem()).isEqualTo(WooPosUnifiedDiscoveryEvent.Started)
+            val withPhone = awaitItem() as WooPosUnifiedDiscoveryEvent.ReadersFound
+            assertThat(withPhone.readers).containsExactly(phone)
+            val withoutPhone = awaitItem() as WooPosUnifiedDiscoveryEvent.ReadersFound
+            assertThat(withoutPhone.readers).isEmpty()
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
@@ -23,6 +23,7 @@ import java.net.InetAddress
 class WooPosUnifiedDiscoveryStreamTest {
     private val cardReaderManager: CardReaderManager = mock()
     private val remoteDiscovery: WooPosRemoteReaderDiscovery = mock()
+    private val simulatedRemoteDiscovery: WooPosSimulatedRemoteReaderDiscovery = mock()
     private val featureFlagRepository: FeatureFlagRepository = mock()
     private val logger: WooPosLogWrapper = mock()
 
@@ -43,7 +44,13 @@ class WooPosUnifiedDiscoveryStreamTest {
             flowOf(WooPosPhoneDiscoveryEvent.Added(phone(name = "Pixel 7")))
         )
         whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(false)
-        val sut = WooPosUnifiedDiscoveryStream(cardReaderManager, remoteDiscovery, featureFlagRepository, logger)
+        val sut = WooPosUnifiedDiscoveryStream(
+            cardReaderManager,
+            remoteDiscovery,
+            simulatedRemoteDiscovery,
+            featureFlagRepository,
+            logger,
+        )
 
         // WHEN / THEN
         sut.discover(isSimulated = false, cardReaderTypesToDiscover = types).test {
@@ -68,7 +75,13 @@ class WooPosUnifiedDiscoveryStreamTest {
         val phone = phone(name = "Pixel 7")
         whenever(remoteDiscovery.discover()).thenReturn(flowOf(WooPosPhoneDiscoveryEvent.Added(phone)))
         whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(true)
-        val sut = WooPosUnifiedDiscoveryStream(cardReaderManager, remoteDiscovery, featureFlagRepository, logger)
+        val sut = WooPosUnifiedDiscoveryStream(
+            cardReaderManager,
+            remoteDiscovery,
+            simulatedRemoteDiscovery,
+            featureFlagRepository,
+            logger,
+        )
 
         // WHEN / THEN
         sut.discover(isSimulated = false, cardReaderTypesToDiscover = types).test {
@@ -98,7 +111,13 @@ class WooPosUnifiedDiscoveryStreamTest {
             )
         )
         whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(true)
-        val sut = WooPosUnifiedDiscoveryStream(cardReaderManager, remoteDiscovery, featureFlagRepository, logger)
+        val sut = WooPosUnifiedDiscoveryStream(
+            cardReaderManager,
+            remoteDiscovery,
+            simulatedRemoteDiscovery,
+            featureFlagRepository,
+            logger,
+        )
 
         // WHEN / THEN
         sut.discover(isSimulated = false, cardReaderTypesToDiscover = types).test {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
@@ -1,0 +1,91 @@
+package com.woocommerce.android.ui.woopos.cardreader.remote
+
+import app.cash.turbine.test
+import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.cardreader.connection.CardReader
+import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover.SpecificReaders.ExternalReaders
+import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.Chipper2X
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.net.InetAddress
+
+@ExperimentalCoroutinesApi
+class WooPosUnifiedDiscoveryStreamTest {
+    private val cardReaderManager: CardReaderManager = mock()
+    private val remoteDiscovery: WooPosRemoteReaderDiscovery = mock()
+    private val featureFlagRepository: FeatureFlagRepository = mock()
+
+    private val types: CardReaderTypesToDiscover = ExternalReaders(listOf(Chipper2X))
+
+    @Test
+    fun `given flag off, when bluetooth and nsd emit, then only bluetooth readers surface`() = runTest {
+        // GIVEN
+        val bluetoothReader: CardReader = mock { on { id }.thenReturn("chipper-1") }
+        whenever(cardReaderManager.discoverReaders(false, types)).thenReturn(
+            flowOf(
+                CardReaderDiscoveryEvents.Started,
+                CardReaderDiscoveryEvents.ReadersFound(listOf(bluetoothReader)),
+                CardReaderDiscoveryEvents.Succeeded,
+            )
+        )
+        whenever(remoteDiscovery.discover()).thenReturn(
+            flowOf(phone(name = "Pixel 7"))
+        )
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(false)
+        val sut = WooPosUnifiedDiscoveryStream(cardReaderManager, remoteDiscovery, featureFlagRepository)
+
+        // WHEN / THEN
+        sut.discover(isSimulated = false, cardReaderTypesToDiscover = types).test {
+            assertThat(awaitItem()).isEqualTo(WooPosUnifiedDiscoveryEvent.Started)
+            val found = awaitItem() as WooPosUnifiedDiscoveryEvent.ReadersFound
+            assertThat(found.readers).containsExactly(WooPosDiscoveredReader.Bluetooth(bluetoothReader))
+            assertThat(awaitItem()).isEqualTo(WooPosUnifiedDiscoveryEvent.Succeeded)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `given flag on, when bluetooth and nsd emit, then both readers surface in the snapshot`() = runTest {
+        // GIVEN
+        val bluetoothReader: CardReader = mock { on { id }.thenReturn("chipper-1") }
+        whenever(cardReaderManager.discoverReaders(false, types)).thenReturn(
+            flowOf(
+                CardReaderDiscoveryEvents.Started,
+                CardReaderDiscoveryEvents.ReadersFound(listOf(bluetoothReader)),
+            )
+        )
+        val phone = phone(name = "Pixel 7")
+        whenever(remoteDiscovery.discover()).thenReturn(flowOf(phone))
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(true)
+        val sut = WooPosUnifiedDiscoveryStream(cardReaderManager, remoteDiscovery, featureFlagRepository)
+
+        // WHEN / THEN
+        sut.discover(isSimulated = false, cardReaderTypesToDiscover = types).test {
+            assertThat(awaitItem()).isEqualTo(WooPosUnifiedDiscoveryEvent.Started)
+            val btOnly = awaitItem() as WooPosUnifiedDiscoveryEvent.ReadersFound
+            assertThat(btOnly.readers).containsExactly(WooPosDiscoveredReader.Bluetooth(bluetoothReader))
+            val combined = awaitItem() as WooPosUnifiedDiscoveryEvent.ReadersFound
+            assertThat(combined.readers).containsExactly(
+                WooPosDiscoveredReader.Bluetooth(bluetoothReader),
+                phone,
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun phone(name: String) = WooPosDiscoveredReader.Phone(
+        name = name,
+        host = InetAddress.getLoopbackAddress(),
+        port = 9000,
+        fingerprintBase64 = "AB4F",
+    )
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
@@ -6,12 +6,17 @@ import kotlinx.coroutines.flow.map
 import java.net.InetAddress
 
 interface CardReaderRemoteDiscovery {
-    fun discover(): Flow<DiscoveredRemoteReader>
+    fun discover(): Flow<RemoteReaderDiscoveryEvent>
 
     companion object {
         fun create(context: Context): CardReaderRemoteDiscovery =
             DefaultCardReaderRemoteDiscovery(CardReaderRemoteNsd(context))
     }
+}
+
+sealed class RemoteReaderDiscoveryEvent {
+    data class Added(val reader: DiscoveredRemoteReader) : RemoteReaderDiscoveryEvent()
+    data class Removed(val name: String) : RemoteReaderDiscoveryEvent()
 }
 
 data class DiscoveredRemoteReader(
@@ -24,8 +29,13 @@ data class DiscoveredRemoteReader(
 internal class DefaultCardReaderRemoteDiscovery(
     private val nsd: CardReaderRemoteNsd,
 ) : CardReaderRemoteDiscovery {
-    override fun discover(): Flow<DiscoveredRemoteReader> =
-        nsd.discover().map { it.toPublic() }
+    override fun discover(): Flow<RemoteReaderDiscoveryEvent> =
+        nsd.discover().map { event ->
+            when (event) {
+                is CardReaderRemoteNsdEvent.Found -> RemoteReaderDiscoveryEvent.Added(event.host.toPublic())
+                is CardReaderRemoteNsdEvent.Lost -> RemoteReaderDiscoveryEvent.Removed(event.serviceName)
+            }
+        }
 }
 
 private fun CardReaderRemoteResolvedHost.toPublic() =

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
@@ -1,0 +1,37 @@
+package com.woocommerce.android.cardreader.remote
+
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.net.InetAddress
+
+interface CardReaderRemoteDiscovery {
+    fun discover(): Flow<DiscoveredRemoteReader>
+
+    companion object {
+        fun create(context: Context): CardReaderRemoteDiscovery =
+            DefaultCardReaderRemoteDiscovery(CardReaderRemoteNsd(context))
+    }
+}
+
+data class DiscoveredRemoteReader(
+    val name: String,
+    val host: InetAddress,
+    val port: Int,
+    val fingerprintBase64: String,
+)
+
+internal class DefaultCardReaderRemoteDiscovery(
+    private val nsd: CardReaderRemoteNsd,
+) : CardReaderRemoteDiscovery {
+    override fun discover(): Flow<DiscoveredRemoteReader> =
+        nsd.discover().map { it.toPublic() }
+}
+
+private fun CardReaderRemoteResolvedHost.toPublic() =
+    DiscoveredRemoteReader(
+        name = name,
+        host = host,
+        port = port,
+        fingerprintBase64 = fingerprintBase64,
+    )

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
@@ -83,7 +83,7 @@ internal class CardReaderRemoteNsd(
             }
         }
 
-    fun discover(): Flow<CardReaderRemoteResolvedHost> = callbackFlow {
+    fun discover(): Flow<CardReaderRemoteNsdEvent> = callbackFlow {
         val discoveryListener = object : NsdManager.DiscoveryListener {
             override fun onDiscoveryStarted(serviceType: String) {
                 Log.d(TAG, "NSD discovery started: $serviceType")
@@ -102,11 +102,11 @@ internal class CardReaderRemoteNsd(
             }
 
             override fun onServiceFound(service: NsdServiceInfo) {
-                resolve(service) { resolved -> trySend(resolved) }
+                resolve(service) { resolved -> trySend(CardReaderRemoteNsdEvent.Found(resolved)) }
             }
 
             override fun onServiceLost(service: NsdServiceInfo) {
-                Log.d(TAG, "NSD service lost: ${service.serviceName}")
+                trySend(CardReaderRemoteNsdEvent.Lost(service.serviceName))
             }
         }
 
@@ -235,3 +235,8 @@ internal data class CardReaderRemoteResolvedHost(
     val fingerprintBase64: String,
     val version: String,
 )
+
+internal sealed class CardReaderRemoteNsdEvent {
+    data class Found(val host: CardReaderRemoteResolvedHost) : CardReaderRemoteNsdEvent()
+    data class Lost(val serviceName: String) : CardReaderRemoteNsdEvent()
+}


### PR DESCRIPTION
Fixes WOOMOB-2740.

### Description

Adds a unified discovery stream for the Woo POS connect dialog that merges the existing Bluetooth reader scan with a new NSD-based scan that finds phones running Card Reader Mode. The NSD branch is gated on `FeatureFlag.REMOTE_TAP_TO_PAY` — with the flag off, the stream is byte-identical to today's BT-only discovery.

- Introduces `CardReaderRemoteDiscovery` (public) in `libs/cardreader` so the main app can browse NSD without leaking Stripe or internal NSD types.
- Adds `WooPosRemoteReaderDiscovery` adapter and `WooPosUnifiedDiscoveryStream` merger in `ui/woopos/cardreader/remote/`.
- Rewires `WooPosCardReaderConnectionController.startDiscovery()` onto the unified stream. Phone rows are present in the event payload but not rendered yet — that lands with WOOMOB-2742 (Task 4.4).
- Phones are keyed by TLS fingerprint (stable, cert-bound) and the map is capped at 32 entries to bound memory against LAN floods. NSD failures are absorbed so a broken listener cannot tear down Bluetooth discovery.

### Test Steps

1. With `REMOTE_TAP_TO_PAY` **off**, open Woo POS → Settings → Card Readers → Connect. Bluetooth discovery behaves exactly as on trunk.
2. With the flag **on**, open the same dialog. No visible difference in the list yet — this PR only wires the stream. Verify no crash, no new permission prompts, existing BT readers still appear and connect normally.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
