### PR TITLE
Remove unused WellSql processor from fluxc-plugin

### DIFF
--- a/libs/fluxc-plugin/build.gradle
+++ b/libs/fluxc-plugin/build.gradle
@@ -69,8 +69,6 @@ dependencies {
     implementation libs.androidx.core.ktx
 
     implementation libs.wellsql
-    kapt libs.wellsql.processor
-
     // FluxC annotations
     api project(":libs:fluxc-annotations")
     kapt project(":libs:fluxc-processor")


### PR DESCRIPTION
### Description
This removes `kapt libs.wellsql.processor` from `:libs:fluxc-plugin`.

Before this change, `buildHealth` reported:

```text
Advice for :libs:fluxc-plugin

Unused annotation processors that should be removed:
  kapt libs.wellsql.processor
```

`fluxc-plugin` uses WellSql-generated code, but it does not contain source that requires running the WellSql processor in this module, so this `kapt` dependency was unnecessary.

This PR only addresses that single warning. There are still other unused dependency warnings in the report, but they are out of scope for this PR.

### Test Steps
1. On `trunk`, run `./gradlew buildHealth --console=plain`.
2. Open `build/reports/dependency-analysis/build-health-report.txt`.
3. Confirm that under `Advice for :libs:fluxc-plugin` the report contains:
   ```text
   Unused annotation processors that should be removed:
     kapt libs.wellsql.processor
   ```
4. Check out this branch and run `./gradlew buildHealth --console=plain` again.
5. Confirm that the `kapt libs.wellsql.processor` warning is no longer present under `Advice for :libs:fluxc-plugin`.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.