### PR TITLE
Bump push notifications min WC version to 10.8.0

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/CheckWooPluginPushNotificationsSupport.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/CheckWooPluginPushNotificationsSupport.kt
@@ -10,7 +10,7 @@ class CheckWooPluginPushNotificationsSupport @Inject constructor(
     private val getWooCorePluginCachedVersion: GetWooCorePluginCachedVersion
 ) {
     companion object {
-        const val PUSH_NOTIFICATIONS_MIN_WC_VERSION = "10.6.0"
+        const val PUSH_NOTIFICATIONS_MIN_WC_VERSION = "10.8.0"
     }
 
     suspend operator fun invoke(forceRefresh: Boolean): Result {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/CheckWooPluginPushNotificationsSupportTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/CheckWooPluginPushNotificationsSupportTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.whenever
 class CheckWooPluginPushNotificationsSupportTest : BaseUnitTest() {
     private val fetchActiveWCPluginVersion: FetchActiveWCPluginVersion = mock()
     private val getWooCorePluginCachedVersion: GetWooCorePluginCachedVersion = mock()
+    private val minSupportedWooVersion = CheckWooPluginPushNotificationsSupport.PUSH_NOTIFICATIONS_MIN_WC_VERSION
 
     private val sut = CheckWooPluginPushNotificationsSupport(
         fetchActiveWCPluginVersion,
@@ -24,7 +25,7 @@ class CheckWooPluginPushNotificationsSupportTest : BaseUnitTest() {
 
     @Test
     fun `given compatible version, when invoked, then returns Compatible`() = testBlocking {
-        whenever(fetchActiveWCPluginVersion()).thenReturn("10.6.0")
+        whenever(fetchActiveWCPluginVersion()).thenReturn(minSupportedWooVersion)
 
         val result = sut(forceRefresh = true)
 
@@ -61,7 +62,7 @@ class CheckWooPluginPushNotificationsSupportTest : BaseUnitTest() {
     @Test
     fun `given compatible cached version, when invoked with forceRefresh=false, then returns Compatible`() =
         testBlocking {
-            whenever(getWooCorePluginCachedVersion()).thenReturn("10.6.0")
+            whenever(getWooCorePluginCachedVersion()).thenReturn(minSupportedWooVersion)
 
             val result = sut(forceRefresh = false)
 
@@ -89,7 +90,7 @@ class CheckWooPluginPushNotificationsSupportTest : BaseUnitTest() {
 
     @Test
     fun `given forceRefresh=false, when invoked, then does not call fetchActiveWCPluginVersion`() = testBlocking {
-        whenever(getWooCorePluginCachedVersion()).thenReturn("10.6.0")
+        whenever(getWooCorePluginCachedVersion()).thenReturn(minSupportedWooVersion)
 
         sut(forceRefresh = false)
 


### PR DESCRIPTION
### Description

Updates `PUSH_NOTIFICATIONS_MIN_WC_VERSION` from `10.6.0` to `10.8.0` to align with the final Woo Core release that ships the self-driven push notifications endpoint.

Context: the `POST /wp-json/wc-push-notifications/push-tokens` endpoint (core send path) is merged in Woo Core and scheduled for the 10.8.0 release. The previous `10.6.0` bound was a placeholder from an earlier milestone and would let incompatible stores through the `CheckWooPluginPushNotificationsSupport` gate.

### Test Steps

1. Install the app on a site running WooCommerce **< 10.8.0**.
2. Enable the `WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M2` feature flag override (Settings → Beta Features → Override Feature Flags).
3. On the dashboard, tap the "Never miss a new order" card.
4. **Verify:** the "Check plugin compatibility" step fails with the outdated-plugin error and the action button shows "Update plugin".
5. Upgrade the site to Woo **10.8.0** (or a `10.8.0-dev` build) and repeat steps 3–4.
6. **Verify:** the "Check plugin compatibility" step succeeds and the flow continues to the next step.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.