### PR TITLE
Add 2.7% percentage and split Canada/Interac flat application fees

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -83,6 +83,7 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.util.Currency
 import kotlin.reflect.KMutableProperty0
 
 private const val ARTIFICIAL_RETRY_DELAY = 500L
@@ -299,7 +300,7 @@ class CardReaderPaymentController(
                 storeName = selectedSite.get().name.ifEmpty { null },
                 siteUrl = selectedSite.get().url.ifEmpty { null },
                 countryCode = countryCode,
-                feeAmount = calculateFeeInCents(countryCode, order.total),
+                feeAmount = calculateFeeInCents(countryCode, order.total, order.currency),
                 channel = determinePaymentChannel(paymentOrRefund)
             )
         ).collect { paymentStatus ->
@@ -860,11 +861,12 @@ class CardReaderPaymentController(
         }
     }
 
-    private fun calculateFeeInCents(countryCode: String, orderTotal: BigDecimal): Long? =
+    private fun calculateFeeInCents(countryCode: String, orderTotal: BigDecimal, currencyCode: String): Long? =
         if (countryCode == "CA") {
+            val fractionDigits = Currency.getInstance(currencyCode).defaultFractionDigits
             val percentageInCents = orderTotal
                 .multiply(CANADA_FEE_PERCENTAGE)
-                .movePointRight(2)
+                .movePointRight(fractionDigits)
                 .setScale(0, RoundingMode.HALF_UP)
                 .toLong()
             percentageInCents + CANADA_FEE_FLAT_IN_CENTS + INTERAC_FEE_FLAT_IN_CENTS

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -81,10 +81,18 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.math.BigDecimal
+import java.math.RoundingMode
 import kotlin.reflect.KMutableProperty0
 
 private const val ARTIFICIAL_RETRY_DELAY = 500L
-private const val CANADA_FEE_FLAT_IN_CENTS = 15L
+
+// The base Canada fee and percentage are overwritten by Transact Server at the capture
+// step for non-Interac payments. Interac payments have no capture step, so the full
+// combined fee (base + Interac + percentage) is what Stripe charges.
+private const val CANADA_FEE_FLAT_IN_CENTS = 5L
+private const val INTERAC_FEE_FLAT_IN_CENTS = 15L
+private val CANADA_FEE_PERCENTAGE = BigDecimal("0.027")
 
 @Suppress("LongParameterList", "LargeClass")
 class CardReaderPaymentController(
@@ -291,7 +299,7 @@ class CardReaderPaymentController(
                 storeName = selectedSite.get().name.ifEmpty { null },
                 siteUrl = selectedSite.get().url.ifEmpty { null },
                 countryCode = countryCode,
-                feeAmount = calculateFeeInCents(countryCode),
+                feeAmount = calculateFeeInCents(countryCode, order.total),
                 channel = determinePaymentChannel(paymentOrRefund)
             )
         ).collect { paymentStatus ->
@@ -852,9 +860,14 @@ class CardReaderPaymentController(
         }
     }
 
-    private fun calculateFeeInCents(countryCode: String) =
+    private fun calculateFeeInCents(countryCode: String, orderTotal: BigDecimal): Long? =
         if (countryCode == "CA") {
-            CANADA_FEE_FLAT_IN_CENTS
+            val percentageInCents = orderTotal
+                .multiply(CANADA_FEE_PERCENTAGE)
+                .multiply(BigDecimal(100))
+                .setScale(0, RoundingMode.HALF_UP)
+                .toLong()
+            percentageInCents + CANADA_FEE_FLAT_IN_CENTS + INTERAC_FEE_FLAT_IN_CENTS
         } else {
             null
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -864,7 +864,7 @@ class CardReaderPaymentController(
         if (countryCode == "CA") {
             val percentageInCents = orderTotal
                 .multiply(CANADA_FEE_PERCENTAGE)
-                .multiply(BigDecimal(100))
+                .movePointRight(2)
                 .setScale(0, RoundingMode.HALF_UP)
                 .toLong()
             percentageInCents + CANADA_FEE_FLAT_IN_CENTS + INTERAC_FEE_FLAT_IN_CENTS

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -2666,7 +2666,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given canada and total 0,58, when flow started, then fee set to 15`() =
+    fun `given canada and total 0,58, when flow started, then fee set to 22`() =
         testBlocking {
             // Given
             whenever(wooStore.getStoreCountryCode(any())).thenReturn("CA")
@@ -2678,12 +2678,13 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             controller.start()
 
             // Then
+            // 0.58 * 0.027 * 100 = 1.566 -> 2 cents, + 5 (Canada base) + 15 (Interac) = 22
             verify(cardReaderManager).collectPayment(captor.capture())
-            assertThat(captor.firstValue.feeAmount).isEqualTo(15)
+            assertThat(captor.firstValue.feeAmount).isEqualTo(22)
         }
 
     @Test
-    fun `given canada and total 135,6, when flow started, then fee set to 15`() =
+    fun `given canada and total 145,6, when flow started, then fee set to 413`() =
         testBlocking {
             // Given
             whenever(wooStore.getStoreCountryCode(any())).thenReturn("CA")
@@ -2695,8 +2696,9 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             controller.start()
 
             // Then
+            // 145.6 * 0.027 * 100 = 393.12 -> 393 cents, + 5 (Canada base) + 15 (Interac) = 413
             verify(cardReaderManager).collectPayment(captor.capture())
-            assertThat(captor.firstValue.feeAmount).isEqualTo(15)
+            assertThat(captor.firstValue.feeAmount).isEqualTo(413)
         }
 
     @Test


### PR DESCRIPTION
## Description
TRAPLAT-3863

Updates the hardcoded Canadian card-present application fee. Previously the app applied a flat 15 cents on every CA card-present payment. This PR splits that into three components and adds a 2.7% element:

- `CANADA_FEE_FLAT_IN_CENTS` — 5 (was 15)
- `INTERAC_FEE_FLAT_IN_CENTS` — 15 (new)
- `CANADA_FEE_PERCENTAGE` — 2.7% (new)

The full combined fee (base + Interac + percentage) is what Stripe charges for Interac payments, since Interac has no capture step. For non-Interac card-present payments, Transact Server overwrites these values at the capture step, so the code here is effectively an Interac pricing change.

## Test Steps
On a CA-configured test store, connect a WisePad3 and take a payment
- [x] Using an Interac card, confirm the `application_fee_amount` on the Stripe PaymentIntent equals `orderTotal × 0.027 + 0.20` (rounded to 2dp).
- [x] Using a normal card, confirm the `application_fee_amount` on the Stripe PaymentIntent equals `orderTotal × 0.027 + 0.05` (rounded to 2dp).
- [x] Check the order notes match the fee in WCPay ~(n.b. known issue with this for Interac fees https://linear.app/a8c/issue/TRAPLAT-3863/interac-transactions-not-charging-the-full-fee#comment-6f8fa098)~ Resolved.