### PR TITLE
[WOOMOB-2787] Remote payment flow — fixes and improvements

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/RemoteTapToPayPaymentViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/RemoteTapToPayPaymentViewState.kt
@@ -14,6 +14,15 @@ data class RemoteTapToPayStarting(
     primaryActionLabel = R.string.card_reader_mode_cancel,
 )
 
+data class RemoteTapToPayLocationPermissionExplainer(
+    override val onPrimaryActionClicked: (() -> Unit),
+) : ViewState(
+    headerLabel = R.string.card_reader_mode_location_permission_header,
+    paymentStateLabel = UiStringRes(R.string.card_reader_mode_location_permission_subtitle),
+    illustration = R.drawable.img_card_reader_tpp_connecting,
+    primaryActionLabel = R.string.card_reader_mode_location_permission_continue,
+)
+
 data class RemoteTapToPayReadyToPair(
     val deviceName: String,
     val fingerprintSuffix: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeActivity.kt
@@ -38,20 +38,20 @@ class CardReaderModeActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.events.collect { finish() }
+                viewModel.events.collect { event ->
+                    when (event) {
+                        CardReaderModeEvent.Exit -> finish()
+                        CardReaderModeEvent.RequestLocationPermission ->
+                            locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                    }
+                }
             }
         }
 
-        ensureLocationPermission(isFirstCreate = savedInstanceState == null)
-    }
-
-    private fun ensureLocationPermission(isFirstCreate: Boolean) {
-        when {
-            WooPermissionUtils.hasFineLocationPermission(this) ->
-                viewModel.onLocationPermissionResult(true)
-
-            isFirstCreate ->
-                locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        if (WooPermissionUtils.hasFineLocationPermission(this)) {
+            viewModel.onLocationPermissionResult(true)
+        } else {
+            viewModel.onLocationPermissionMissing()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeEvent.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.ui.payments.cardreader.readermode
+
+sealed class CardReaderModeEvent {
+    data object Exit : CardReaderModeEvent()
+    data object RequestLocationPermission : CardReaderModeEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeExit.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeExit.kt
@@ -1,3 +1,0 @@
-package com.woocommerce.android.ui.payments.cardreader.readermode
-
-object CardReaderModeExit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSession
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSessionState
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayError
+import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionExplainer
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayReadyToPair
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayStarting
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayWaitingForPayment
@@ -35,10 +36,17 @@ class CardReaderModeViewModel @Inject constructor(
     private val _viewState = MutableStateFlow<ViewState?>(null)
     val viewState: StateFlow<ViewState?> = _viewState.asStateFlow()
 
-    private val _events = Channel<CardReaderModeExit>(capacity = Channel.BUFFERED)
-    val events: Flow<CardReaderModeExit> = _events.receiveAsFlow()
+    private val _events = Channel<CardReaderModeEvent>(capacity = Channel.BUFFERED)
+    val events: Flow<CardReaderModeEvent> = _events.receiveAsFlow()
 
     private var sessionStarted = false
+
+    fun onLocationPermissionMissing() {
+        if (sessionStarted) return
+        _viewState.value = RemoteTapToPayLocationPermissionExplainer(
+            onPrimaryActionClicked = { _events.trySend(CardReaderModeEvent.RequestLocationPermission) },
+        )
+    }
 
     fun onLocationPermissionResult(granted: Boolean) {
         when (granted) {
@@ -96,6 +104,6 @@ class CardReaderModeViewModel @Inject constructor(
     }
 
     private fun exit() {
-        _events.trySend(CardReaderModeExit)
+        _events.trySend(CardReaderModeEvent.Exit)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -4,9 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
@@ -15,8 +13,9 @@ import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardRea
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.woopos.bookings.BOOKING_PAYMENT_FLOW_FINISHED_KEY
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatus
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
 import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderPaymentFlow
-import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderSession
 import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
 import com.woocommerce.android.ui.woopos.home.totals.TTPPaymentProgressDelegate
 import com.woocommerce.android.ui.woopos.home.totals.WooPosCardReaderPaymentControllerFactory
@@ -34,8 +33,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -51,8 +48,8 @@ class WooPosCardPaymentViewModel @Inject constructor(
     private val analyticsTracker: WooPosCardPaymentAnalyticsTracker,
     private val cardPaymentRepository: WooPosCardPaymentRepository,
     private val priceFormat: WooPosFormatPrice,
-    private val remoteReaderSession: WooPosRemoteReaderSession,
     private val remoteReaderPaymentFlow: WooPosRemoteReaderPaymentFlow,
+    private val effectiveReaderStatusProvider: WooPosEffectiveReaderStatusProvider,
 ) : ViewModel() {
 
     private val orderId: Long = requireNotNull(savedState[CARD_PAYMENT_ROUTE_ORDER_ID_KEY])
@@ -106,44 +103,30 @@ class WooPosCardPaymentViewModel @Inject constructor(
 
     private fun observeReaderStatus() {
         viewModelScope.launch {
-            combine(
-                cardReaderFacade.readerStatus,
-                remoteReaderSession.state,
-            ) { bt, remote -> toEffectiveReaderStatus(bt, remote) }
-                .distinctUntilChanged()
+            effectiveReaderStatusProvider.flow
                 .collect { effective ->
                     val currentState = _state.value
                     if (currentState is WooPosCardPaymentState.PaymentInProgress) {
                         return@collect
                     }
                     when (effective) {
-                        EffectiveReaderStatus.RemoteConnected -> {
+                        WooPosEffectiveReaderStatus.RemoteConnected -> {
                             _state.value = buildPreparingState()
                             collectPaymentRemote()
                         }
-                        EffectiveReaderStatus.BluetoothConnected -> {
+                        WooPosEffectiveReaderStatus.BluetoothConnected -> {
                             _state.value = buildPreparingState()
                             collectPayment()
                         }
-                        EffectiveReaderStatus.Connecting,
-                        EffectiveReaderStatus.Disconnected -> {
+                        WooPosEffectiveReaderStatus.Connecting,
+                        WooPosEffectiveReaderStatus.Reconnecting,
+                        WooPosEffectiveReaderStatus.Disconnected -> {
                             _state.value = buildReaderDisconnectedState()
                             cancelPayment()
                         }
                     }
                 }
         }
-    }
-
-    private fun toEffectiveReaderStatus(
-        bt: CardReaderStatus,
-        remote: WooPosRemoteReaderSession.State,
-    ): EffectiveReaderStatus = when {
-        remote is WooPosRemoteReaderSession.State.Connected -> EffectiveReaderStatus.RemoteConnected
-        bt is Connected -> EffectiveReaderStatus.BluetoothConnected
-        bt is Connecting || remote is WooPosRemoteReaderSession.State.Connecting ->
-            EffectiveReaderStatus.Connecting
-        else -> EffectiveReaderStatus.Disconnected
     }
 
     private fun collectPaymentRemote() {
@@ -343,10 +326,12 @@ class WooPosCardPaymentViewModel @Inject constructor(
 
     fun onScreenResumed() {
         if (_state.value is WooPosCardPaymentState.Collecting) {
-            if (remoteReaderSession.state.value is WooPosRemoteReaderSession.State.Connected) {
-                collectPaymentRemote()
-            } else {
-                collectPayment()
+            when (effectiveReaderStatusProvider.current()) {
+                WooPosEffectiveReaderStatus.RemoteConnected -> collectPaymentRemote()
+                WooPosEffectiveReaderStatus.BluetoothConnected -> collectPayment()
+                WooPosEffectiveReaderStatus.Connecting,
+                WooPosEffectiveReaderStatus.Reconnecting,
+                WooPosEffectiveReaderStatus.Disconnected -> Unit
             }
         }
     }
@@ -431,13 +416,6 @@ class WooPosCardPaymentViewModel @Inject constructor(
         remotePaymentJob = null
         cardReaderPaymentController?.onBackPressed()
         cardReaderPaymentController?.stop()
-    }
-
-    private enum class EffectiveReaderStatus {
-        RemoteConnected,
-        BluetoothConnected,
-        Connecting,
-        Disconnected,
     }
 
     override fun onCleared() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosEffectiveReaderStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosEffectiveReaderStatus.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.ui.woopos.cardreader
+
+import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderSession
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import javax.inject.Inject
+import javax.inject.Singleton
+
+enum class WooPosEffectiveReaderStatus {
+    RemoteConnected,
+    BluetoothConnected,
+    Reconnecting,
+    Connecting,
+    Disconnected,
+}
+
+@Singleton
+class WooPosEffectiveReaderStatusProvider @Inject constructor(
+    private val cardReaderFacade: WooPosCardReaderFacade,
+    private val remoteReaderSession: WooPosRemoteReaderSession,
+) {
+    val flow: Flow<WooPosEffectiveReaderStatus> = combine(
+        cardReaderFacade.readerStatus,
+        remoteReaderSession.state,
+    ) { bt, remote -> toEffective(bt, remote) }.distinctUntilChanged()
+
+    fun current(): WooPosEffectiveReaderStatus = toEffective(
+        cardReaderFacade.readerStatus.value,
+        remoteReaderSession.state.value,
+    )
+
+    private fun toEffective(
+        bt: CardReaderStatus,
+        remote: WooPosRemoteReaderSession.State,
+    ): WooPosEffectiveReaderStatus = when {
+        remote is WooPosRemoteReaderSession.State.Connected -> WooPosEffectiveReaderStatus.RemoteConnected
+        bt is CardReaderStatus.Connected -> WooPosEffectiveReaderStatus.BluetoothConnected
+        bt is CardReaderStatus.Reconnecting -> WooPosEffectiveReaderStatus.Reconnecting
+        bt is CardReaderStatus.Connecting || remote is WooPosRemoteReaderSession.State.Connecting ->
+            WooPosEffectiveReaderStatus.Connecting
+        else -> WooPosEffectiveReaderStatus.Disconnected
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
@@ -11,10 +11,15 @@ import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderLocation
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -33,6 +38,8 @@ class WooPosRemoteReaderSession @Inject constructor(
 
     private var client: CardReaderRemoteTabletClient? = null
     private val mutex = Mutex()
+    private val monitorScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var closeWatcherJob: Job? = null
 
     suspend fun connect(reader: WooPosDiscoveredReader.Phone): State = mutex.withLock {
         disconnectInternal()
@@ -90,11 +97,27 @@ class WooPosRemoteReaderSession @Inject constructor(
         )
         return when (val outcome = newClient.connect(discovered, token, locationId)) {
             is ConnectOutcome.Success -> State.Connected(reader, outcome.readerSerial)
-                .also { _state.value = it }
+                .also {
+                    _state.value = it
+                    watchForRemoteClose(newClient)
+                }
             is ConnectOutcome.Rejected -> fail("${outcome.code}: ${outcome.description}")
             is ConnectOutcome.Failed -> fail(
                 "${outcome.cause::class.java.simpleName}: ${outcome.cause.message ?: "Connection failed"}"
             )
+        }
+    }
+
+    private fun watchForRemoteClose(watchedClient: CardReaderRemoteTabletClient) {
+        closeWatcherJob?.cancel()
+        closeWatcherJob = monitorScope.launch {
+            watchedClient.connectionClosed.collect { isClosed ->
+                if (isClosed && client === watchedClient && _state.value is State.Connected) {
+                    logger.d("Remote reader connection closed by the phone")
+                    disconnectInternal()
+                    _state.value = State.Idle
+                }
+            }
         }
     }
 
@@ -111,6 +134,8 @@ class WooPosRemoteReaderSession @Inject constructor(
             ?: CollectPaymentOutcome.Failed(IllegalStateException("Remote session is not connected"))
 
     private fun disconnectInternal() {
+        closeWatcherJob?.cancel()
+        closeWatcherJob = null
         client?.disconnect()
         client = null
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
@@ -3,17 +3,13 @@ package com.woocommerce.android.ui.woopos.home.toolbar
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.cardreader.connection.CardReaderStatus
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Reconnecting
 import com.woocommerce.android.cardreader.connection.event.BatteryStatus
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatus
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionController
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionControllerFactory
-import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderSession
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarUIEvent.MenuItemClicked
@@ -29,8 +25,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -45,7 +39,7 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
     private val networkStatus: WooPosNetworkStatus,
     private val resourceProvider: ResourceProvider,
     private val analyticsTracker: WooPosAnalyticsTracker,
-    private val remoteReaderSession: WooPosRemoteReaderSession,
+    private val effectiveReaderStatusProvider: WooPosEffectiveReaderStatusProvider,
     controllerFactory: WooPosCardReaderConnectionControllerFactory,
 ) : ViewModel() {
 
@@ -63,30 +57,26 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            combine(
-                cardReaderFacade.readerStatus,
-                remoteReaderSession.state,
-            ) { bt, remote -> toEffectiveReaderStatus(bt, remote) }
-                .distinctUntilChanged()
+            effectiveReaderStatusProvider.flow
                 .flatMapLatest { effective ->
                     when (effective) {
-                        EffectiveReaderStatus.RemoteConnected -> flowOf(
+                        WooPosEffectiveReaderStatus.RemoteConnected -> flowOf(
                             WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected(
                                 batteryState = WooPosHomeFloatingToolbarState.BatteryState.NOMINAL
                             )
                         )
-                        EffectiveReaderStatus.BluetoothConnected ->
+                        WooPosEffectiveReaderStatus.BluetoothConnected ->
                             cardReaderFacade.batteryStatus
                                 .map { batteryStatus ->
                                     WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected(
                                         batteryState = mapBatteryState(batteryStatus)
                                     )
                                 }
-                        EffectiveReaderStatus.Reconnecting -> flowOf(
+                        WooPosEffectiveReaderStatus.Reconnecting -> flowOf(
                             WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Reconnecting
                         )
-                        EffectiveReaderStatus.Connecting,
-                        EffectiveReaderStatus.Disconnected -> flowOf(
+                        WooPosEffectiveReaderStatus.Connecting,
+                        WooPosEffectiveReaderStatus.Disconnected -> flowOf(
                             WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.NotConnected
                         )
                     }
@@ -95,18 +85,6 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
                     _state.value = _state.value.copy(cardReaderStatus = cardReaderStatus)
                 }
         }
-    }
-
-    private fun toEffectiveReaderStatus(
-        bt: CardReaderStatus,
-        remote: WooPosRemoteReaderSession.State,
-    ): EffectiveReaderStatus = when {
-        remote is WooPosRemoteReaderSession.State.Connected -> EffectiveReaderStatus.RemoteConnected
-        bt is Connected -> EffectiveReaderStatus.BluetoothConnected
-        bt is Reconnecting -> EffectiveReaderStatus.Reconnecting
-        bt is Connecting || remote is WooPosRemoteReaderSession.State.Connecting ->
-            EffectiveReaderStatus.Connecting
-        else -> EffectiveReaderStatus.Disconnected
     }
 
     fun onUiEvent(event: WooPosHomeFloatingToolbarUIEvent) {
@@ -223,13 +201,5 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
                 )
             )
         }
-    }
-
-    private enum class EffectiveReaderStatus {
-        RemoteConnected,
-        BluetoothConnected,
-        Reconnecting,
-        Connecting,
-        Disconnected,
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -7,15 +7,15 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.WooException
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Reconnecting
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatus
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderPaymentFlow
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
@@ -53,6 +53,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import java.math.BigDecimal
 import javax.inject.Inject
 
+@Suppress("LargeClass")
 @HiltViewModel
 class WooPosTotalsViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
@@ -67,6 +68,8 @@ class WooPosTotalsViewModel @Inject constructor(
     private val totalsAnalyticsTracker: WooPosTotalsAnalyticsTracker,
     private val wooPosLogWrapper: WooPosLogWrapper,
     private val performIncrementalSyncUseCase: WooPosPerformLocalCatalogIncrementalSync,
+    private val remoteReaderPaymentFlow: WooPosRemoteReaderPaymentFlow,
+    private val effectiveReaderStatusProvider: WooPosEffectiveReaderStatusProvider,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -98,6 +101,7 @@ class WooPosTotalsViewModel @Inject constructor(
     private var isTTPPaymentInProgress: Boolean by TTPPaymentProgressDelegate(savedState)
 
     private var cardReaderPaymentController: CardReaderPaymentController? = null
+    private var remotePaymentJob: Job? = null
 
     private fun createCardReaderPaymentController(orderId: Long) {
         cardReaderPaymentController = cardReaderPaymentControllerFactory.create(
@@ -114,31 +118,42 @@ class WooPosTotalsViewModel @Inject constructor(
 
     private fun observeCardReaderStatus() {
         viewModelScope.launch {
-            cardReaderFacade.readerStatus.combine(
-                dataState
-            ) { status, data -> Pair(status, data) }.collect { (status, data) ->
-                when (status) {
-                    is NotConnected, is Connecting -> {
-                        val state = uiState.value
-                        if (state !is WooPosTotalsViewState.Checkout) return@collect
-                        uiState.value = state.copy(readerStatus = buildTotalsReaderNotConnectedError())
-                        cancelPaymentAction()
-                    }
+            effectiveReaderStatusProvider.flow
+                .combine(dataState) { effective, data -> effective to data }
+                .collect { (effective, data) ->
+                    when (effective) {
+                        WooPosEffectiveReaderStatus.RemoteConnected -> {
+                            val state = uiState.value
+                            if (state !is WooPosTotalsViewState.Checkout) return@collect
+                            if (state.readerStatus !is WooPosTotalsViewState.ReaderStatus.ReadyForPayment) {
+                                uiState.value = state.copy(readerStatus = buildPreparingReaderStatusState())
+                            }
+                            if (data.orderId != EMPTY_ORDER_ID) collectPaymentRemote()
+                        }
 
-                    Reconnecting -> {
-                        // We start payment right away so this state not worth handling
-                    }
+                        WooPosEffectiveReaderStatus.BluetoothConnected -> {
+                            val state = uiState.value
+                            if (state !is WooPosTotalsViewState.Checkout) return@collect
+                            if (state.readerStatus !is WooPosTotalsViewState.ReaderStatus.ReadyForPayment) {
+                                uiState.value = state.copy(readerStatus = buildPreparingReaderStatusState())
+                            }
+                            if (data.orderId != EMPTY_ORDER_ID) collectPayment()
+                        }
 
-                    is Connected -> {
-                        val state = uiState.value
-                        if (state !is WooPosTotalsViewState.Checkout) return@collect
-                        uiState.value = state.copy(readerStatus = buildPreparingReaderStatusState())
-                        if (data.orderId != EMPTY_ORDER_ID) {
-                            collectPayment()
+                        WooPosEffectiveReaderStatus.Reconnecting -> {
+                            // We start payment right away so this state not worth handling
+                        }
+
+                        WooPosEffectiveReaderStatus.Connecting,
+                        WooPosEffectiveReaderStatus.Disconnected -> {
+                            val state = uiState.value
+                            if (state !is WooPosTotalsViewState.Checkout) return@collect
+                            uiState.value = state.copy(readerStatus = buildTotalsReaderNotConnectedError())
+                            cancelPaymentAction()
+                            cancelRemotePaymentAction()
                         }
                     }
                 }
-            }
         }
     }
 
@@ -325,6 +340,67 @@ class WooPosTotalsViewModel @Inject constructor(
         }
     }
 
+    private fun collectPaymentRemote(orderOverride: Order? = null) {
+        if (remotePaymentJob?.isActive == true) return
+        if (!networkStatus.isConnected()) {
+            viewModelScope.launch {
+                childrenToParentEventSender.sendToParent(
+                    ToastMessageDisplayed(
+                        message = resourceProvider.getString(R.string.woopos_no_internet_message)
+                    )
+                )
+            }
+            return
+        }
+        val orderId = dataState.value.orderId
+        if (orderId == EMPTY_ORDER_ID) return
+        if (dataState.value.orderTotal?.compareTo(BigDecimal.ZERO) != 1) return
+
+        remotePaymentJob = viewModelScope.launch {
+            val order = orderOverride ?: totalsRepository.getOrderById(orderId) ?: run {
+                wooPosLogWrapper.e("Remote payment: order $orderId not found")
+                return@launch
+            }
+            val state = uiState.value
+            if (state is WooPosTotalsViewState.Checkout) {
+                uiState.value = state.copy(
+                    readerStatus = WooPosTotalsViewState.ReaderStatus.ReadyForPayment(
+                        title = resourceProvider.getString(
+                            R.string.woopos_totals_reader_ready_for_payment_title
+                        ),
+                        subtitle = resourceProvider.getString(
+                            R.string.woopos_totals_reader_ready_for_payment_subtitle
+                        ),
+                    )
+                )
+                childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentCollecting)
+            }
+            when (val result = remoteReaderPaymentFlow.collect(order)) {
+                WooPosRemoteReaderPaymentFlow.Result.Completed -> {
+                    childrenToParentEventSender.sendToParent(OrderSuccessfullyPaidByCard)
+                }
+                is WooPosRemoteReaderPaymentFlow.Result.Failed -> {
+                    uiState.value = PaymentFailed(
+                        title = resourceProvider.getString(
+                            R.string.woopos_success_totals_payment_failed_title
+                        ),
+                        subtitle = result.message,
+                        retryPaymentButtonLabel = resourceProvider.getString(
+                            R.string.woo_pos_payment_failed_try_again
+                        ),
+                        isReturnToCheckoutButtonVisible = true,
+                    )
+                    childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentFailed)
+                }
+            }
+        }
+    }
+
+    private fun cancelRemotePaymentAction() {
+        remotePaymentJob?.cancel()
+        remotePaymentJob = null
+    }
+
     private fun listenUpEvents() {
         viewModelScope.launch {
             parentToChildrenEventReceiver.events.collect { event ->
@@ -502,6 +578,7 @@ class WooPosTotalsViewModel @Inject constructor(
 
     override fun onCleared() {
         cardReaderPaymentController?.stop()
+        cancelRemotePaymentAction()
     }
 
     private fun createOrderDraft(itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData>) {
@@ -590,7 +667,11 @@ class WooPosTotalsViewModel @Inject constructor(
             orderTotal = order.total
         )
         uiState.value = buildWooPosTotalsViewState(order)
-        collectPayment()
+        if (effectiveReaderStatusProvider.current() == WooPosEffectiveReaderStatus.RemoteConnected) {
+            collectPaymentRemote(orderOverride = order)
+        } else {
+            collectPayment()
+        }
     }
 
     private fun getProductsIdsMissingFromOrder(order: Order): List<Long> {
@@ -706,9 +787,12 @@ class WooPosTotalsViewModel @Inject constructor(
         val readerStatus = if (totalAmount.compareTo(BigDecimal.ZERO) == 0) {
             WooPosTotalsViewState.ReaderStatus.Unavailable
         } else {
-            when (cardReaderFacade.readerStatus.value) {
-                is Connected -> buildPreparingReaderStatusState()
-                else -> buildTotalsReaderNotConnectedError()
+            when (effectiveReaderStatusProvider.current()) {
+                WooPosEffectiveReaderStatus.RemoteConnected,
+                WooPosEffectiveReaderStatus.BluetoothConnected -> buildPreparingReaderStatusState()
+                WooPosEffectiveReaderStatus.Connecting,
+                WooPosEffectiveReaderStatus.Reconnecting,
+                WooPosEffectiveReaderStatus.Disconnected -> buildTotalsReaderNotConnectedError()
             }
         }
         return WooPosTotalsViewState.Checkout(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -150,7 +150,6 @@ class WooPosTotalsViewModel @Inject constructor(
                             if (state !is WooPosTotalsViewState.Checkout) return@collect
                             uiState.value = state.copy(readerStatus = buildTotalsReaderNotConnectedError())
                             cancelPaymentAction()
-                            cancelRemotePaymentAction()
                         }
                     }
                 }
@@ -165,6 +164,7 @@ class WooPosTotalsViewModel @Inject constructor(
     private fun cancelPaymentAction() {
         cardReaderPaymentController?.onBackPressed()
         cardReaderPaymentController?.stop()
+        cancelRemotePaymentAction()
     }
 
     private fun cancelCreateOrderDraftAction() {
@@ -311,7 +311,11 @@ class WooPosTotalsViewModel @Inject constructor(
         val order = totalsRepository.getOrderById(dataState.value.orderId)
         checkNotNull(order)
         uiState.value = buildWooPosTotalsViewState(order)
-        collectPayment()
+        if (effectiveReaderStatusProvider.current() == WooPosEffectiveReaderStatus.RemoteConnected) {
+            collectPaymentRemote(orderOverride = order)
+        } else {
+            collectPayment()
+        }
     }
 
     private fun collectPayment() {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1533,6 +1533,9 @@
     <string name="card_reader_mode_error_subtitle">Check your Wi-Fi connection and try again.</string>
     <string name="card_reader_mode_error_close">Close</string>
     <string name="card_reader_mode_location_permission_required">Location permission is required to connect with the tablet.</string>
+    <string name="card_reader_mode_location_permission_header">Location permission required</string>
+    <string name="card_reader_mode_location_permission_subtitle">Android requires location access to use tap-to-pay on this phone. Your location stays on this device.</string>
+    <string name="card_reader_mode_location_permission_continue">Continue</string>
 
     <string name="card_reader_payment_failed_nfc_disabled">The app could not enable the card reader, because the NFC chip is disabled</string>
     <string name="card_reader_payment_failed_nfc_disabled_enable_nfc">Enable NFC</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
@@ -168,7 +168,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         (viewModel.viewState.value as RemoteTapToPayStarting).onPrimaryActionClicked.invoke()
 
         // THEN
-        assertThat(viewModel.events.first()).isEqualTo(CardReaderModeExit)
+        assertThat(viewModel.events.first()).isEqualTo(CardReaderModeEvent.Exit)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardRea
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.woopos.bookings.BOOKING_PAYMENT_FLOW_FINISHED_KEY
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
 import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderPaymentFlow
 import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderSession
 import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
@@ -121,8 +122,8 @@ class WooPosCardPaymentViewModelTest {
             analyticsTracker = analyticsTracker,
             cardPaymentRepository = cardPaymentRepository,
             priceFormat = priceFormat,
-            remoteReaderSession = remoteReaderSession,
             remoteReaderPaymentFlow = remoteReaderPaymentFlow,
+            effectiveReaderStatusProvider = WooPosEffectiveReaderStatusProvider(cardReaderFacade, remoteReaderSession),
         )
     }
 
@@ -412,8 +413,8 @@ class WooPosCardPaymentViewModelTest {
             analyticsTracker = analyticsTracker,
             cardPaymentRepository = cardPaymentRepository,
             priceFormat = priceFormat,
-            remoteReaderSession = remoteReaderSession,
             remoteReaderPaymentFlow = remoteReaderPaymentFlow,
+            effectiveReaderStatusProvider = WooPosEffectiveReaderStatusProvider(cardReaderFacade, remoteReaderSession),
         )
         advanceUntilIdle()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.event.BatteryStatus
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionController
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionControllerFactory
 import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosDiscoveredReader
@@ -409,7 +410,7 @@ class WooPosHomeFloatingToolbarViewModelTest {
         networkStatus,
         resourceProvider,
         analyticsTracker,
-        remoteReaderSession,
+        WooPosEffectiveReaderStatusProvider(cardReaderFacade, remoteReaderSession),
         controllerFactory
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -32,6 +32,9 @@ import com.woocommerce.android.ui.payments.receipt.PaymentReceiptShare
 import com.woocommerce.android.ui.payments.tracking.CardReaderTrackingInfoKeeper
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderPaymentFlow
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderSession
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.BackFromCheckoutToCartClicked
@@ -159,6 +162,10 @@ class WooPosTotalsViewModelTest {
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val performIncrementalSyncUseCase: WooPosPerformLocalCatalogIncrementalSync = mock()
     private val productsDataSource: WooPosProductsDataSource = mock()
+    private val remoteReaderSession: WooPosRemoteReaderSession = mock {
+        on { state }.thenReturn(MutableStateFlow(WooPosRemoteReaderSession.State.Idle))
+    }
+    private val remoteReaderPaymentFlow: WooPosRemoteReaderPaymentFlow = mock()
 
     private companion object {
         private const val EMPTY_ORDER_ID = -1L
@@ -2093,5 +2100,7 @@ class WooPosTotalsViewModelTest {
         ),
         wooPosLogWrapper = wooPosLogWrapper,
         performIncrementalSyncUseCase = performIncrementalSyncUseCase,
+        remoteReaderPaymentFlow = remoteReaderPaymentFlow,
+        effectiveReaderStatusProvider = WooPosEffectiveReaderStatusProvider(cardReaderFacade, remoteReaderSession),
     )
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteConnection.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteConnection.kt
@@ -8,6 +8,9 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -31,6 +34,8 @@ internal class CardReaderRemoteConnection internal constructor(
 
     private val readerScope = CoroutineScope(SupervisorJob() + ioDispatcher)
     private val messages = Channel<CardReaderRemoteMessage>(capacity = MESSAGE_BUFFER_CAPACITY)
+    private val _closed = MutableStateFlow(false)
+    val closed: StateFlow<Boolean> = _closed.asStateFlow()
 
     private val readerJob: Job = readerScope.launch {
         var fatalError: Throwable? = null
@@ -46,6 +51,7 @@ internal class CardReaderRemoteConnection internal constructor(
             }
         } finally {
             messages.close(fatalError)
+            _closed.value = true
         }
     }
 
@@ -64,6 +70,7 @@ internal class CardReaderRemoteConnection internal constructor(
         readerJob.cancel()
         readerScope.cancel()
         messages.close()
+        _closed.value = true
     }
 
     private companion object {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteHeartbeat.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteHeartbeat.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.remote
 
+import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -13,5 +14,10 @@ internal fun CoroutineScope.launchHeartbeat(connection: CardReaderRemoteConnecti
     while (isActive) {
         delay(HEARTBEAT_INTERVAL_MILLIS)
         runCatching { connection.send(CardReaderRemoteMessage.Ping(UUID.randomUUID().toString())) }
+            .onFailure { err ->
+                Log.w("CardReaderRemoteHeartbeat", "Ping failed, closing connection: ${err::class.java.simpleName}")
+                runCatching { connection.close() }
+                return@launch
+            }
     }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteHeartbeat.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteHeartbeat.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.cardreader.remote
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+internal const val HEARTBEAT_INTERVAL_MILLIS = 30_000L
+
+internal fun CoroutineScope.launchHeartbeat(connection: CardReaderRemoteConnection): Job = launch {
+    while (isActive) {
+        delay(HEARTBEAT_INTERVAL_MILLIS)
+        runCatching { connection.send(CardReaderRemoteMessage.Ping(UUID.randomUUID().toString())) }
+    }
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteMessage.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteMessage.kt
@@ -44,4 +44,8 @@ internal sealed class CardReaderRemoteMessage {
         val code: String,
         val description: String,
     ) : CardReaderRemoteMessage()
+
+    data class Ping(
+        override val requestId: String,
+    ) : CardReaderRemoteMessage()
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteProtocol.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteProtocol.kt
@@ -67,6 +67,7 @@ internal class CardReaderRemoteProtocol {
         private const val TYPE_COLLECT_PAYMENT = "collect_payment"
         private const val TYPE_PAYMENT_INTENT_RESULT = "payment_intent_result"
         private const val TYPE_ERROR = "error"
+        private const val TYPE_PING = "ping"
 
         private fun typeLabelFor(clazz: Class<out CardReaderRemoteMessage>): String = when (clazz) {
             CardReaderRemoteMessage.ConnectRequest::class.java -> TYPE_CONNECT_REQUEST
@@ -74,6 +75,7 @@ internal class CardReaderRemoteProtocol {
             CardReaderRemoteMessage.CollectPaymentRequest::class.java -> TYPE_COLLECT_PAYMENT
             CardReaderRemoteMessage.PaymentIntentResult::class.java -> TYPE_PAYMENT_INTENT_RESULT
             CardReaderRemoteMessage.ErrorMessage::class.java -> TYPE_ERROR
+            CardReaderRemoteMessage.Ping::class.java -> TYPE_PING
             else -> error("Unknown CardReaderRemoteMessage subtype: $clazz")
         }
 
@@ -83,6 +85,7 @@ internal class CardReaderRemoteProtocol {
             TYPE_COLLECT_PAYMENT -> CardReaderRemoteMessage.CollectPaymentRequest::class.java
             TYPE_PAYMENT_INTENT_RESULT -> CardReaderRemoteMessage.PaymentIntentResult::class.java
             TYPE_ERROR -> CardReaderRemoteMessage.ErrorMessage::class.java
+            TYPE_PING -> CardReaderRemoteMessage.Ping::class.java
             else -> error("Unknown message type label: $label")
         }
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -297,7 +297,7 @@ class CardReaderRemoteSession internal constructor(
 
     private fun deviceName(): String = Build.MODEL ?: DEFAULT_DEVICE_NAME
 
-    private fun cleanupConnectionOnly() {
+    private suspend fun cleanupConnectionOnly() {
         runCatching { connection?.close() }
         connection = null
         runCatching { cardReaderManager.connectionTokenProvider.useDefault() }
@@ -305,18 +305,26 @@ class CardReaderRemoteSession internal constructor(
         remoteTokenProvider = null
         if (readerWasConnected) {
             readerWasConnected = false
-            disconnectScope.launch {
-                runCatching { cardReaderManager.disconnectReader() }
-            }
+            runCatching { cardReaderManager.disconnectReader() }
         }
     }
 
     private fun cleanupSync() {
-        cleanupConnectionOnly()
+        runCatching { connection?.close() }
+        connection = null
+        runCatching { cardReaderManager.connectionTokenProvider.useDefault() }
+        runCatching { remoteTokenProvider?.close() }
+        remoteTokenProvider = null
         runCatching { nsdRegistration?.close() }
         nsdRegistration = null
         runCatching { tlsServer?.close() }
         tlsServer = null
+        if (readerWasConnected) {
+            readerWasConnected = false
+            disconnectScope.launch {
+                runCatching { cardReaderManager.disconnectReader() }
+            }
+        }
     }
 
     internal fun interface TlsServerFactory {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.Connect
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.ConnectRequest
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.ErrorMessage
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.PaymentIntentResult
+import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.Ping
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -131,14 +132,17 @@ class CardReaderRemoteSession internal constructor(
         while (currentCoroutineContext().isActive) {
             try {
                 acceptAndRunProtocolLoop(server)
-                break
+                // Tablet disconnected — reset per-connection state and wait for the next one
+                logWrapper.d(LOG_TAG, "Tablet disconnected, resetting to ready-to-pair")
+                cleanupConnectionOnly()
+                _state.value = readyToPairState(server)
             } catch (e: SocketTimeoutException) {
                 logWrapper.d(LOG_TAG, "Waiting for tablet to connect: ${e.message}")
             }
         }
     }
 
-    private suspend fun acceptAndRunProtocolLoop(server: CardReaderRemoteTlsServer) {
+    private suspend fun acceptAndRunProtocolLoop(server: CardReaderRemoteTlsServer) = coroutineScope {
         logWrapper.d(LOG_TAG, "Waiting for TLS accept...")
         val accepted = server.acceptOne()
         logWrapper.d(LOG_TAG, "TLS accepted, starting protocol loop")
@@ -148,9 +152,14 @@ class CardReaderRemoteSession internal constructor(
         remoteTokenProvider = tokenProvider
         cardReaderManager.connectionTokenProvider.useRemote(tokenProvider)
 
-        accepted.receive().collect { message ->
-            logWrapper.d(LOG_TAG, "Received message: ${message::class.java.simpleName}")
-            handleMessage(message, accepted, tokenProvider)
+        val pingJob = launchHeartbeat(accepted)
+        try {
+            accepted.receive().collect { message ->
+                logWrapper.d(LOG_TAG, "Received message: ${message::class.java.simpleName}")
+                handleMessage(message, accepted, tokenProvider)
+            }
+        } finally {
+            pingJob.cancel()
         }
     }
 
@@ -162,6 +171,7 @@ class CardReaderRemoteSession internal constructor(
         when (message) {
             is ConnectRequest -> handleConnectRequest(message, accepted, tokenProvider)
             is CollectPaymentRequest -> handleCollectPaymentRequest(message, accepted)
+            is Ping,
             is ConnectAck,
             is PaymentIntentResult,
             is ErrorMessage -> Unit
@@ -287,22 +297,26 @@ class CardReaderRemoteSession internal constructor(
 
     private fun deviceName(): String = Build.MODEL ?: DEFAULT_DEVICE_NAME
 
-    private fun cleanupSync() {
+    private fun cleanupConnectionOnly() {
         runCatching { connection?.close() }
         connection = null
         runCatching { cardReaderManager.connectionTokenProvider.useDefault() }
         runCatching { remoteTokenProvider?.close() }
         remoteTokenProvider = null
-        runCatching { nsdRegistration?.close() }
-        nsdRegistration = null
-        runCatching { tlsServer?.close() }
-        tlsServer = null
         if (readerWasConnected) {
             readerWasConnected = false
             disconnectScope.launch {
                 runCatching { cardReaderManager.disconnectReader() }
             }
         }
+    }
+
+    private fun cleanupSync() {
+        cleanupConnectionOnly()
+        runCatching { nsdRegistration?.close() }
+        nsdRegistration = null
+        runCatching { tlsServer?.close() }
+        tlsServer = null
     }
 
     internal fun interface TlsServerFactory {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteTabletClient.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteTabletClient.kt
@@ -8,12 +8,22 @@ import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.Connect
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.ErrorMessage
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteMessage.PaymentIntentResult
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import java.util.UUID
 
 interface CardReaderRemoteTabletClient {
+    val connectionClosed: StateFlow<Boolean>
+
     suspend fun connect(
         reader: DiscoveredRemoteReader,
         connectionToken: String,
@@ -31,7 +41,10 @@ interface CardReaderRemoteTabletClient {
         const val DEFAULT_COLLECT_PAYMENT_TIMEOUT_MILLIS: Long = 90_000
 
         fun create(): CardReaderRemoteTabletClient =
-            DefaultCardReaderRemoteTabletClient(CardReaderRemoteTlsClient())
+            DefaultCardReaderRemoteTabletClient(
+                tlsClient = CardReaderRemoteTlsClient(),
+                scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+            )
     }
 }
 
@@ -50,8 +63,13 @@ sealed class CollectPaymentOutcome {
 
 internal class DefaultCardReaderRemoteTabletClient(
     private val tlsClient: CardReaderRemoteTlsClient,
+    private val scope: CoroutineScope,
 ) : CardReaderRemoteTabletClient {
     private var connection: CardReaderRemoteConnection? = null
+    private var closedBridgeJob: Job? = null
+    private var heartbeatJob: Job? = null
+    private val _connectionClosed = MutableStateFlow(true)
+    override val connectionClosed: StateFlow<Boolean> = _connectionClosed.asStateFlow()
 
     override suspend fun connect(
         reader: DiscoveredRemoteReader,
@@ -59,6 +77,7 @@ internal class DefaultCardReaderRemoteTabletClient(
         locationId: String,
     ): ConnectOutcome {
         disconnect()
+        _connectionClosed.value = false
         return try {
             Log.d(TAG, "Opening TLS connection")
             val opened = tlsClient.connect(reader.host, reader.port, reader.fingerprintBase64)
@@ -68,10 +87,15 @@ internal class DefaultCardReaderRemoteTabletClient(
             opened.send(ConnectRequest(requestId, connectionToken, locationId))
             Log.d(TAG, "ConnectRequest sent, awaiting reply")
             when (val reply = opened.receive().first { it.requestId == requestId }) {
-                is ConnectAck -> ConnectOutcome.Success(reply.readerSerial)
+                is ConnectAck -> {
+                    bridgeClosedSignal(opened)
+                    startHeartbeat(opened)
+                    ConnectOutcome.Success(reply.readerSerial)
+                }
                 is ErrorMessage -> ConnectOutcome.Rejected(reply.code, reply.description)
                 is ConnectRequest,
                 is CollectPaymentRequest,
+                is CardReaderRemoteMessage.Ping,
                 is PaymentIntentResult -> ConnectOutcome.Rejected(
                     CODE_UNEXPECTED_REPLY,
                     "Unexpected reply type: ${reply::class.simpleName}",
@@ -84,6 +108,20 @@ internal class DefaultCardReaderRemoteTabletClient(
             disconnect()
             ConnectOutcome.Failed(cause)
         }
+    }
+
+    private fun bridgeClosedSignal(connection: CardReaderRemoteConnection) {
+        closedBridgeJob?.cancel()
+        closedBridgeJob = scope.launch {
+            connection.closed.collect { isClosed ->
+                _connectionClosed.value = isClosed
+            }
+        }
+    }
+
+    private fun startHeartbeat(connection: CardReaderRemoteConnection) {
+        heartbeatJob?.cancel()
+        heartbeatJob = scope.launchHeartbeat(connection)
     }
 
     override suspend fun collectPayment(
@@ -104,6 +142,7 @@ internal class DefaultCardReaderRemoteTabletClient(
                 is ErrorMessage -> CollectPaymentOutcome.Rejected(reply.code, reply.description)
                 is ConnectAck,
                 is ConnectRequest,
+                is CardReaderRemoteMessage.Ping,
                 is CollectPaymentRequest -> CollectPaymentOutcome.Rejected(
                     CODE_UNEXPECTED_REPLY,
                     "Unexpected reply type: ${reply::class.simpleName}",
@@ -120,8 +159,13 @@ internal class DefaultCardReaderRemoteTabletClient(
     }
 
     override fun disconnect() {
+        closedBridgeJob?.cancel()
+        closedBridgeJob = null
+        heartbeatJob?.cancel()
+        heartbeatJob = null
         connection?.close()
         connection = null
+        _connectionClosed.value = true
     }
 
     private companion object {


### PR DESCRIPTION
### Description

Fixes WOOMOB-2787

Polish pass on the remote Tap to Pay payment flow between the phone (acting as a card reader) and the tablet (running POS). Covers a few connection-handling bugs, an idle-timeout fix, a permissions UX cleanup, and a small refactor that removes duplication.

**Fixes**
- Phone re-accepts new tablet connections after a disconnect. Previously the session ended the moment the first tablet closed the socket and the phone was stuck on "Starting Card Reader Mode".
- Tablet detects when the phone cancels Card Reader Mode. A new `closed: StateFlow<Boolean>` on `CardReaderRemoteConnection` is bridged through `CardReaderRemoteTabletClient.connectionClosed` into `WooPosRemoteReaderSession`, which flips the state back to `Idle` so the toolbar and totals screens update.
- Application-level heartbeat `Ping` every 30s in both directions prevents the TLS socket from hitting its 90s read timeout during idle periods.
- Totals screen observes the remote reader state. When a phone reader is connected and an order is ready, it now kicks off `WooPosRemoteReaderPaymentFlow` instead of only considering the local Bluetooth/TTP reader — no more stuck "Checking order".

**UX**
- Location permission: show an explainer screen with a Continue button before opening the system dialog, matching the pattern used elsewhere in POS.
- `CardReaderModeExit` (object) → `CardReaderModeEvent` sealed class so the activity can handle both `Exit` and `RequestLocationPermission`.

**Refactor**
- Extracted `combine(cardReaderFacade.readerStatus, remoteReaderSession.state)` into a new `WooPosEffectiveReaderStatusProvider`. Toolbar, card payment and totals VMs all use it (was duplicated in three places).
- Heartbeat loop extracted to a shared `CoroutineScope.launchHeartbeat(connection)` extension used by both sides.

### Test Steps

1. On the phone, open **Menu → Payments → Card Reader Mode**. Verify the explainer screen shows before the system permission dialog. Tap Continue → system dialog appears.
2. Grant permission. Phone should land on "Ready to pair" with the device name and 4-char code.
3. On the tablet open POS → tap the reader status in the toolbar → pick the phone. Toolbar flips to "Reader connected" (green dot).
4. On the phone, tap **Cancel**. Within ~5s the tablet toolbar should flip to "Reader not connected".
5. Reconnect. Leave the pair idle for ~2 minutes without doing anything. Connection should stay alive — the heartbeat keeps it warm.
6. While paired, add a product to the cart on the tablet and tap **Checkout**. The totals screen should show "Ready for payment" (not stuck on "Checking order") and the phone should prompt for a card tap.
7. Close the Card Reader Mode screen on the phone mid-session. Tablet should drop to a disconnected state and the totals should flip back to "Reader not connected".

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.