### PR TITLE
[WOOMOB-2843] Step 2: QR login — token exchange REST client

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -1,6 +1,110 @@
 package com.woocommerce.android.network.qrlogin
 
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
 import com.woocommerce.android.ui.login.qrlogin.Secret
+import com.woocommerce.android.util.CoroutineDispatchers
+import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import javax.inject.Inject
+import javax.inject.Named
+
+/**
+ * Calls the QR login token-exchange endpoint on the merchant's WordPress site.
+ *
+ * The endpoint is unauthenticated — possession of a valid, unexpired, single-use token is the
+ * authorization.
+ */
+class QrLoginRestClient @Inject constructor(
+    @Named("custom-ssl") private val okHttpClient: OkHttpClient,
+    private val gson: Gson,
+    private val dispatchers: CoroutineDispatchers
+) {
+
+    suspend fun exchange(siteUrl: String, token: String): Result<QrLoginCredentials> =
+        withContext(dispatchers.io) {
+            try {
+                Result.success(performExchange(siteUrl, token))
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+                Result.failure(t)
+            }
+        }
+
+    private fun performExchange(siteUrl: String, token: String): QrLoginCredentials {
+        val request = buildExchangeRequest(siteUrl, token)
+        okHttpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw QrLoginExchangeException.HttpError(response.code)
+            return parseExchangeBody(response.body.string())
+                ?: throw QrLoginExchangeException.MalformedResponse
+        }
+    }
+
+    private fun buildExchangeRequest(siteUrl: String, token: String): Request {
+        // The parser only hands us URLs that survived HttpUrl validation, so this should never
+        // be null in practice — fall through to the generic catch if it ever is.
+        val baseUrl = siteUrl.toHttpUrlOrNull()
+            ?: throw IllegalArgumentException("siteUrl could not be parsed by HttpUrl")
+        val exchangeUrl = baseUrl.newBuilder()
+            .addPathSegments(EXCHANGE_PATH_SEGMENTS)
+            .build()
+        val payload = gson.toJson(ExchangeRequest(token))
+        return Request.Builder()
+            .url(exchangeUrl)
+            .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+    }
+
+    private fun parseExchangeBody(body: String): QrLoginCredentials? {
+        val response = gson.fromJson(body, ExchangeResponse::class.java)
+        val credentials = response?.toCredentials()
+        if (credentials == null) {
+            WooLog.w(
+                WooLog.T.LOGIN,
+                "QR login exchange response missing required fields: ${response.missingFields()}"
+            )
+        }
+        return credentials
+    }
+
+    private data class ExchangeRequest(val token: String)
+
+    private data class ExchangeResponse(
+        @SerializedName("user_login") val userLogin: String?,
+        @SerializedName("site_url") val siteUrl: String?,
+        @SerializedName("application_password") val applicationPassword: String?,
+        @SerializedName("uuid") val uuid: String?
+    ) {
+        fun toCredentials(): QrLoginCredentials? {
+            val user = userLogin?.takeIf { it.isNotBlank() } ?: return null
+            if (siteUrl.isNullOrBlank()) return null
+            val password = applicationPassword?.takeIf { it.isNotBlank() } ?: return null
+            return QrLoginCredentials(
+                userLogin = user,
+                applicationPassword = Secret(password),
+                uuid = uuid?.takeIf { it.isNotBlank() }
+            )
+        }
+
+        fun missingFields(): String = buildList {
+            if (userLogin.isNullOrBlank()) add("user_login")
+            if (siteUrl.isNullOrBlank()) add("site_url")
+            if (applicationPassword.isNullOrBlank()) add("application_password")
+        }.joinToString(",").ifEmpty { "(none)" }
+    }
+
+    private companion object {
+        const val EXCHANGE_PATH_SEGMENTS = "wp-json/wc-admin/mobile-app/qr-login-exchange"
+        val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+    }
+}
 
 data class QrLoginCredentials(
     val userLogin: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -7,3 +7,14 @@ data class QrLoginCredentials(
     val applicationPassword: Secret,
     val uuid: String?
 )
+
+sealed class QrLoginExchangeException(message: String) : Exception(message) {
+    data object TokenRejected : QrLoginExchangeException("Token was rejected by the site")
+    data object EndpointMissing : QrLoginExchangeException("Exchange endpoint not available on the site")
+    data object RateLimited : QrLoginExchangeException("Rate limit hit on the exchange endpoint")
+    data object Network : QrLoginExchangeException("Network failure during exchange")
+    data object MalformedResponse : QrLoginExchangeException("Exchange response was malformed")
+    data class HttpError(val code: Int) : QrLoginExchangeException("HTTP $code from exchange endpoint")
+    data class Unknown(val original: Throwable) :
+        QrLoginExchangeException("Unknown exchange failure: ${original.javaClass.simpleName}")
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.network.qrlogin
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
 import com.google.gson.annotations.SerializedName
-import com.woocommerce.android.ui.login.qrlogin.Secret
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.CancellationException
@@ -90,15 +89,18 @@ class QrLoginRestClient @Inject constructor(
     private fun mapException(throwable: Throwable): Throwable = when (throwable) {
         is QrLoginExchangeException -> throwable
         is IOException -> {
-            WooLog.w(WooLog.T.LOGIN, "QR login exchange network failure: ${throwable.message}")
+            WooLog.w(WooLog.T.LOGIN, "QR login exchange network failure")
             QrLoginExchangeException.Network
         }
         is JsonSyntaxException -> {
-            WooLog.w(WooLog.T.LOGIN, "QR login exchange response was not valid JSON: ${throwable.message}")
+            WooLog.w(WooLog.T.LOGIN, "QR login exchange response was not valid JSON")
             QrLoginExchangeException.MalformedResponse
         }
         else -> {
-            WooLog.e(WooLog.T.LOGIN, "QR login exchange unexpected failure: $throwable")
+            WooLog.e(
+                WooLog.T.LOGIN,
+                "QR login exchange unexpected failure: ${throwable.javaClass.simpleName}"
+            )
             QrLoginExchangeException.Unknown(throwable)
         }
     }
@@ -108,18 +110,13 @@ class QrLoginRestClient @Inject constructor(
     private data class ExchangeResponse(
         @SerializedName("user_login") val userLogin: String?,
         @SerializedName("site_url") val siteUrl: String?,
-        @SerializedName("application_password") val applicationPassword: String?,
-        @SerializedName("uuid") val uuid: String?
+        @SerializedName("application_password") val applicationPassword: String?
     ) {
         fun toCredentials(): QrLoginCredentials? {
             val user = userLogin?.takeIf { it.isNotBlank() } ?: return null
             if (siteUrl.isNullOrBlank()) return null
             val password = applicationPassword?.takeIf { it.isNotBlank() } ?: return null
-            return QrLoginCredentials(
-                userLogin = user,
-                applicationPassword = Secret(password),
-                uuid = uuid?.takeIf { it.isNotBlank() }
-            )
+            return QrLoginCredentials(userLogin = user, applicationPassword = password)
         }
 
         fun missingFields(): String = buildList {
@@ -138,9 +135,11 @@ class QrLoginRestClient @Inject constructor(
 
 data class QrLoginCredentials(
     val userLogin: String,
-    val applicationPassword: Secret,
-    val uuid: String?
-)
+    val applicationPassword: String,
+) {
+    override fun toString(): String =
+        "QrLoginCredentials(userLogin=$userLogin, applicationPassword=***)"
+}
 
 sealed class QrLoginExchangeException(message: String) : Exception(message) {
     data object TokenRejected : QrLoginExchangeException("Token was rejected by the site")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.network.qrlogin
 
 import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
 import com.google.gson.annotations.SerializedName
 import com.woocommerce.android.ui.login.qrlogin.Secret
 import com.woocommerce.android.util.CoroutineDispatchers
@@ -12,6 +13,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
 import java.net.HttpURLConnection.HTTP_FORBIDDEN
 import java.net.HttpURLConnection.HTTP_NOT_FOUND
 import java.net.HttpURLConnection.HTTP_UNAUTHORIZED
@@ -37,7 +39,7 @@ class QrLoginRestClient @Inject constructor(
             } catch (ce: CancellationException) {
                 throw ce
             } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
-                Result.failure(t)
+                Result.failure(mapException(t))
             }
         }
 
@@ -66,6 +68,7 @@ class QrLoginRestClient @Inject constructor(
     }
 
     private fun parseExchangeBody(body: String): QrLoginCredentials? {
+        // Let JsonSyntaxException propagate so mapException converts it to MalformedResponse.
         val response = gson.fromJson(body, ExchangeResponse::class.java)
         val credentials = response?.toCredentials()
         if (credentials == null) {
@@ -82,6 +85,22 @@ class QrLoginRestClient @Inject constructor(
         HTTP_NOT_FOUND -> QrLoginExchangeException.EndpointMissing
         HTTP_TOO_MANY_REQUESTS -> QrLoginExchangeException.RateLimited
         else -> QrLoginExchangeException.HttpError(code)
+    }
+
+    private fun mapException(throwable: Throwable): Throwable = when (throwable) {
+        is QrLoginExchangeException -> throwable
+        is IOException -> {
+            WooLog.w(WooLog.T.LOGIN, "QR login exchange network failure: ${throwable.message}")
+            QrLoginExchangeException.Network
+        }
+        is JsonSyntaxException -> {
+            WooLog.w(WooLog.T.LOGIN, "QR login exchange response was not valid JSON: ${throwable.message}")
+            QrLoginExchangeException.MalformedResponse
+        }
+        else -> {
+            WooLog.e(WooLog.T.LOGIN, "QR login exchange unexpected failure: $throwable")
+            QrLoginExchangeException.Unknown(throwable)
+        }
     }
 
     private data class ExchangeRequest(val token: String)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -68,8 +68,8 @@ class QrLoginRestClient @Inject constructor(
 
     private fun parseExchangeBody(body: String): QrLoginCredentials? {
         // Let JsonSyntaxException propagate so mapException converts it to MalformedResponse.
-        val response = gson.fromJson(body, ExchangeResponse::class.java)
-        val credentials = response?.toCredentials()
+        val response = gson.fromJson(body, ExchangeResponse::class.java) ?: return null
+        val credentials = response.toCredentials()
         if (credentials == null) {
             WooLog.w(
                 WooLog.T.LOGIN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -12,6 +12,9 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.net.HttpURLConnection.HTTP_FORBIDDEN
+import java.net.HttpURLConnection.HTTP_NOT_FOUND
+import java.net.HttpURLConnection.HTTP_UNAUTHORIZED
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -41,7 +44,7 @@ class QrLoginRestClient @Inject constructor(
     private fun performExchange(siteUrl: String, token: String): QrLoginCredentials {
         val request = buildExchangeRequest(siteUrl, token)
         okHttpClient.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) throw QrLoginExchangeException.HttpError(response.code)
+            if (!response.isSuccessful) throw mapHttpStatus(response.code)
             return parseExchangeBody(response.body.string())
                 ?: throw QrLoginExchangeException.MalformedResponse
         }
@@ -74,6 +77,13 @@ class QrLoginRestClient @Inject constructor(
         return credentials
     }
 
+    private fun mapHttpStatus(code: Int): QrLoginExchangeException = when (code) {
+        HTTP_UNAUTHORIZED, HTTP_FORBIDDEN -> QrLoginExchangeException.TokenRejected
+        HTTP_NOT_FOUND -> QrLoginExchangeException.EndpointMissing
+        HTTP_TOO_MANY_REQUESTS -> QrLoginExchangeException.RateLimited
+        else -> QrLoginExchangeException.HttpError(code)
+    }
+
     private data class ExchangeRequest(val token: String)
 
     private data class ExchangeResponse(
@@ -102,6 +112,7 @@ class QrLoginRestClient @Inject constructor(
 
     private companion object {
         const val EXCHANGE_PATH_SEGMENTS = "wp-json/wc-admin/mobile-app/qr-login-exchange"
+        const val HTTP_TOO_MANY_REQUESTS = 429
         val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.network.qrlogin
+
+import com.woocommerce.android.ui.login.qrlogin.Secret
+
+data class QrLoginCredentials(
+    val userLogin: String,
+    val applicationPassword: Secret,
+    val uuid: String?
+)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.network.qrlogin
 
 import com.google.gson.Gson
-import com.woocommerce.android.ui.login.qrlogin.Secret
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -49,11 +48,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
         val result = client.exchange("https://store.example", "tok")
 
         assertThat(result.getOrNull()).isEqualTo(
-            QrLoginCredentials(
-                userLogin = "admin",
-                applicationPassword = Secret("ap-secret"),
-                uuid = "uuid-1"
-            )
+            QrLoginCredentials(userLogin = "admin", applicationPassword = "ap-secret")
         )
     }
 
@@ -62,7 +57,6 @@ class QrLoginRestClientTest : BaseUnitTest() {
         val credentials = requireNotNull(client.exchange("https://store.example", "tok").getOrNull())
 
         assertThat(credentials.toString()).doesNotContain("ap-secret")
-        assertThat(credentials.applicationPassword.toString()).doesNotContain("ap-secret")
     }
 
     @Test
@@ -168,17 +162,6 @@ class QrLoginRestClientTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given 200 without uuid, when exchange, then credentials have null uuid`() = testBlocking {
-        responder = {
-            ok(it, body = """{"user_login":"admin","site_url":"https://x","application_password":"ap"}""")
-        }
-
-        val result = client.exchange("https://store.example", "tok")
-
-        assertThat(result.getOrNull()?.uuid).isNull()
-    }
-
-    @Test
     fun `given unexpected RuntimeException, when exchange, then wraps in Unknown preserving cause`() = testBlocking {
         val boom = RuntimeException("oops")
         responder = { throw boom }
@@ -223,7 +206,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     private companion object {
         const val DEFAULT_SUCCESS_BODY =
             """{"user_login":"admin","site_url":"https://store.example",""" +
-                """"application_password":"ap-secret","uuid":"uuid-1"}"""
+                """"application_password":"ap-secret"}"""
         val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
@@ -151,6 +151,24 @@ class QrLoginRestClientTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given 200 with null JSON literal body, when exchange, then MalformedResponse`() = testBlocking {
+        responder = { ok(it, body = "null") }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.MalformedResponse)
+    }
+
+    @Test
+    fun `given 200 with empty body, when exchange, then MalformedResponse`() = testBlocking {
+        responder = { ok(it, body = "") }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.MalformedResponse)
+    }
+
+    @Test
     fun `given 200 with blank application_password, when exchange, then MalformedResponse`() = testBlocking {
         responder = {
             ok(it, body = """{"user_login":"admin","site_url":"https://x","application_password":"  "}""")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
@@ -1,0 +1,229 @@
+package com.woocommerce.android.network.qrlogin
+
+import com.google.gson.Gson
+import com.woocommerce.android.ui.login.qrlogin.Secret
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class QrLoginRestClientTest : BaseUnitTest() {
+
+    private var lastRequest: Request? = null
+    private var responder: (Request) -> Response = { ok(it, DEFAULT_SUCCESS_BODY) }
+
+    private val okHttpClient = OkHttpClient.Builder()
+        .addInterceptor(
+            Interceptor { chain ->
+                lastRequest = chain.request()
+                responder(chain.request())
+            }
+        )
+        .build()
+
+    private lateinit var client: QrLoginRestClient
+
+    @Before
+    fun setUp() {
+        client = QrLoginRestClient(
+            okHttpClient = okHttpClient,
+            gson = Gson(),
+            dispatchers = coroutinesTestRule.testDispatchers
+        )
+    }
+
+    @Test
+    fun `given 200 with valid body, when exchange, then returns credentials`() = testBlocking {
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.getOrNull()).isEqualTo(
+            QrLoginCredentials(
+                userLogin = "admin",
+                applicationPassword = Secret("ap-secret"),
+                uuid = "uuid-1"
+            )
+        )
+    }
+
+    @Test
+    fun `given valid credentials, when toString is called, then password is redacted`() = testBlocking {
+        val credentials = requireNotNull(client.exchange("https://store.example", "tok").getOrNull())
+
+        assertThat(credentials.toString()).doesNotContain("ap-secret")
+        assertThat(credentials.applicationPassword.toString()).doesNotContain("ap-secret")
+    }
+
+    @Test
+    fun `given siteUrl with trailing slash, when exchange, then request path is normalized`() = testBlocking {
+        client.exchange("https://store.example/", "tok")
+
+        assertThat(lastRequest?.url.toString())
+            .isEqualTo("https://store.example/wp-json/wc-admin/mobile-app/qr-login-exchange")
+    }
+
+    @Test
+    fun `given exchange call, when executed, then request is POST with JSON token body`() = testBlocking {
+        client.exchange("https://store.example", "tok-42")
+
+        val request = requireNotNull(lastRequest)
+        assertThat(request.method).isEqualTo("POST")
+        assertThat(request.body?.contentType()?.toString()).startsWith("application/json")
+        val buffer = Buffer().also { requireNotNull(request.body).writeTo(it) }
+        assertThat(buffer.readUtf8()).isEqualTo("""{"token":"tok-42"}""")
+    }
+
+    @Test
+    fun `given 401, when exchange, then TokenRejected`() = testBlocking {
+        responder = { respond(it, code = 401) }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.TokenRejected)
+    }
+
+    @Test
+    fun `given 403, when exchange, then TokenRejected`() = testBlocking {
+        responder = { respond(it, code = 403) }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.TokenRejected)
+    }
+
+    @Test
+    fun `given 404, when exchange, then EndpointMissing`() = testBlocking {
+        responder = { respond(it, code = 404) }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.EndpointMissing)
+    }
+
+    @Test
+    fun `given 429, when exchange, then RateLimited`() = testBlocking {
+        responder = { respond(it, code = 429) }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.RateLimited)
+    }
+
+    @Test
+    fun `given 500, when exchange, then HttpError with status code`() = testBlocking {
+        responder = { respond(it, code = 500) }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.HttpError(500))
+    }
+
+    @Test
+    fun `given network IOException, when exchange, then Network`() = testBlocking {
+        responder = { throw IOException("connection refused") }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.Network)
+    }
+
+    @Test
+    fun `given 200 with non-JSON body, when exchange, then MalformedResponse`() = testBlocking {
+        responder = { ok(it, body = "not json at all") }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.MalformedResponse)
+    }
+
+    @Test
+    fun `given 200 missing user_login, when exchange, then MalformedResponse`() = testBlocking {
+        responder = { ok(it, body = """{"site_url":"https://x","application_password":"ap"}""") }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.MalformedResponse)
+    }
+
+    @Test
+    fun `given 200 with blank application_password, when exchange, then MalformedResponse`() = testBlocking {
+        responder = {
+            ok(it, body = """{"user_login":"admin","site_url":"https://x","application_password":"  "}""")
+        }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.MalformedResponse)
+    }
+
+    @Test
+    fun `given 200 without uuid, when exchange, then credentials have null uuid`() = testBlocking {
+        responder = {
+            ok(it, body = """{"user_login":"admin","site_url":"https://x","application_password":"ap"}""")
+        }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        assertThat(result.getOrNull()?.uuid).isNull()
+    }
+
+    @Test
+    fun `given unexpected RuntimeException, when exchange, then wraps in Unknown preserving cause`() = testBlocking {
+        val boom = RuntimeException("oops")
+        responder = { throw boom }
+
+        val result = client.exchange("https://store.example", "tok")
+
+        val failure = result.exceptionOrNull()
+        assertThat(failure).isInstanceOf(QrLoginExchangeException.Unknown::class.java)
+        assertThat((failure as QrLoginExchangeException.Unknown).original).isEqualTo(boom)
+    }
+
+    @Test
+    fun `given CancellationException during call, when exchange, then it propagates unwrapped`() = testBlocking {
+        responder = { throw CancellationException("cancelled") }
+
+        var thrown: Throwable? = null
+        try {
+            client.exchange("https://store.example", "tok")
+        } catch (t: Throwable) {
+            thrown = t
+        }
+
+        assertThat(thrown).isInstanceOf(CancellationException::class.java)
+    }
+
+    private fun ok(request: Request, body: String): Response = Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .body(body.toResponseBody(JSON_MEDIA_TYPE))
+        .build()
+
+    private fun respond(request: Request, code: Int, body: String = ""): Response = Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(code)
+        .message("status-$code")
+        .body(body.toResponseBody(JSON_MEDIA_TYPE))
+        .build()
+
+    private companion object {
+        const val DEFAULT_SUCCESS_BODY =
+            """{"user_login":"admin","site_url":"https://store.example",""" +
+                """"application_password":"ap-secret","uuid":"uuid-1"}"""
+        val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+    }
+}


### PR DESCRIPTION
Fixes WOOMOB-2843

### Description

Adds `QrLoginRestClient`, a thin networking layer that exchanges a one-time ticket (parsed from the QR payload in step 1) for an Application Password against the merchant's site. Implements every error branch the UI later distinguishes (network, server, rate-limit, token-rejected, endpoint-missing, invalid-payload) so the ViewModel can route them to the right error screen. Fully unit-tested.

This is **Step 2 of 10** in a stacked PR chain — depends on `step-1-qr-login-foundation`.

### Stacked PR chain
- Step 1: #15733 — foundation: payload type, parser, and analytics events
- Step 2: #15734 — token exchange REST client ← **this PR**
- Step 3: #15735 — authenticator orchestrating exchange + site fetch + eligibility
- Step 4: #15736 — scanner ViewModel state machine and feature-flag gate
- Step 5: #15737 — prologue screen with QR icon, URL pill, and camera-permission gate
- Step 6: #15738 — camera viewfinder, scanner screen, and endpoint-missing fallback
- Step 7: #15739 — fullscreen confirm + error screens with retry-eligible mapping
- Step 8: #15740 — prologue and scanner fragments hosting the Compose surfaces
- Step 9: #15741 — activity wiring and `woocommerce://qr-login` deep link
- Step 10: #15742 — detect wp-admin install QR and guide users to the sign-in QR

### Test Steps

N/A — see the PR for `step-10-qr-login-install-qr-detection` for the full feature test plan. This PR is part of a stacked chain (`status: do not merge`) and is unit-test-covered where applicable.

### Images/gif

N/A — no UI in this slice.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.