### PR TITLE
[WOOMOB-2844] Step 3: QR login — authenticator orchestrating exchange + site fetch + eligibility

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -163,11 +163,6 @@ class WPApiSiteRepository @Inject constructor(
         dispatcher.dispatchAndAwait<SiteModel, OnSiteChanged>(SiteActionBuilder.newUpdateSiteAction(site))
     }
 
-    suspend fun deleteApplicationPassword(localSiteId: Int) {
-        val site = getSiteByLocalId(localSiteId) ?: return
-        applicationPasswordsStore.deleteCredentials(site)
-    }
-
     private fun Error.mapToException(): CookieNonceAuthenticationException {
         val networkStatusCode = extractNetworkStatusCode()
         val networkErrorMessage by lazy {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/WPApiSiteRepository.kt
@@ -163,6 +163,11 @@ class WPApiSiteRepository @Inject constructor(
         dispatcher.dispatchAndAwait<SiteModel, OnSiteChanged>(SiteActionBuilder.newUpdateSiteAction(site))
     }
 
+    suspend fun deleteApplicationPassword(localSiteId: Int) {
+        val site = getSiteByLocalId(localSiteId) ?: return
+        applicationPasswordsStore.deleteCredentials(site)
+    }
+
     private fun Error.mapToException(): CookieNonceAuthenticationException {
         val networkStatusCode = extractNetworkStatusCode()
         val networkErrorMessage by lazy {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
@@ -48,7 +48,15 @@ class QrLoginAuthenticator @Inject constructor(
             username = credentials.userLogin,
             password = credentials.applicationPassword.reveal()
         )
-        ensureUserEligible(site)
+        try {
+            ensureUserEligible(site)
+        } catch (ce: CancellationException) {
+            wpApiSiteRepository.deleteApplicationPassword(site.id)
+            throw ce
+        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+            wpApiSiteRepository.deleteApplicationPassword(site.id)
+            throw t
+        }
         selectedSite.set(site)
         return site.id
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
@@ -1,0 +1,51 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import com.woocommerce.android.network.qrlogin.QrLoginCredentials
+import com.woocommerce.android.network.qrlogin.QrLoginRestClient
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.WPApiSiteRepository
+import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+
+/**
+ * Glue layer that turns a scanned QR ticket into a logged-in [SelectedSite].
+ *
+ * Steps:
+ *   1. Exchange the QR ticket for an Application Password (unauthenticated POST to the merchant site).
+ *   2. Discover and persist the [SiteModel] using the AP credentials.
+ *   3. Save the AP into encrypted shared preferences so subsequent REST calls authenticate.
+ *   4. Promote the site to the selected site.
+ *
+ * Returns the local site id so the caller can drive `loggedInViaUsernamePassword(localSiteId)`.
+ */
+class QrLoginAuthenticator @Inject constructor(
+    private val exchangeClient: QrLoginRestClient,
+    private val wpApiSiteRepository: WPApiSiteRepository,
+    private val selectedSite: SelectedSite
+) {
+    suspend fun authenticate(ticket: QrLoginPayload.Ticket): Result<Int> {
+        val credentials = exchangeClient.exchange(ticket.siteUrl, ticket.token)
+            .getOrElse { return Result.failure(it) }
+
+        return try {
+            val site = wpApiSiteRepository.fetchSite(
+                url = ticket.siteUrl,
+                username = credentials.userLogin,
+                password = credentials.applicationPassword.reveal()
+            ).getOrThrow()
+            wpApiSiteRepository.saveApplicationPassword(
+                localSiteId = site.id,
+                username = credentials.userLogin,
+                password = credentials.applicationPassword.reveal()
+            )
+            selectedSite.set(site)
+            Result.success(site.id)
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+            WooLog.e(WooLog.T.LOGIN, "QR login authentication failed", t)
+            Result.failure(t)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
@@ -46,7 +46,7 @@ class QrLoginAuthenticator @Inject constructor(
         wpApiSiteRepository.saveApplicationPassword(
             localSiteId = site.id,
             username = credentials.userLogin,
-            password = credentials.applicationPassword.reveal()
+            password = credentials.applicationPassword
         )
         try {
             ensureUserEligible(site)
@@ -68,7 +68,7 @@ class QrLoginAuthenticator @Inject constructor(
         val site = wpApiSiteRepository.fetchSite(
             url = siteUrl,
             username = credentials.userLogin,
-            password = credentials.applicationPassword.reveal()
+            password = credentials.applicationPassword
         ).getOrThrow()
 
         if (!site.hasWooCommerce) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
@@ -16,7 +16,7 @@ import javax.inject.Inject
  *   1. Exchange the QR ticket for an Application Password (unauthenticated POST to the merchant site).
  *   2. Discover and persist the [SiteModel] using the AP credentials.
  *   3. Save the AP into encrypted shared preferences so subsequent REST calls authenticate.
- *   4. Promote the site to the selected site.
+ *   4. Verify the user is eligible to use the app, then promote the site to the selected site.
  *
  * Returns the local site id so the caller can drive `loggedInViaUsernamePassword(localSiteId)`.
  */
@@ -48,6 +48,7 @@ class QrLoginAuthenticator @Inject constructor(
             username = credentials.userLogin,
             password = credentials.applicationPassword.reveal()
         )
+        ensureUserEligible(site)
         selectedSite.set(site)
         return site.id
     }
@@ -68,8 +69,19 @@ class QrLoginAuthenticator @Inject constructor(
         }
         return site
     }
+
+    private suspend fun ensureUserEligible(site: SiteModel) {
+        val isEligible = wpApiSiteRepository.checkIfUserIsEligible(site)
+            .getOrElse { cause ->
+                WooLog.e(WooLog.T.LOGIN, "QR login: eligibility check failed for ${site.url}", cause)
+                throw QrLoginAuthenticationException.UserNotEligible(cause)
+            }
+        if (!isEligible) throw QrLoginAuthenticationException.UserNotEligible(original = null)
+    }
 }
 
 sealed class QrLoginAuthenticationException(message: String) : Exception(message) {
     data object NotAWooSite : QrLoginAuthenticationException("Site is not a WooCommerce store")
+    data class UserNotEligible(val original: Throwable?) :
+        QrLoginAuthenticationException("User is not eligible to use the app")
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.CancellationException
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
 
 /**
@@ -23,6 +24,7 @@ import javax.inject.Inject
 class QrLoginAuthenticator @Inject constructor(
     private val exchangeClient: QrLoginRestClient,
     private val wpApiSiteRepository: WPApiSiteRepository,
+    private val siteStore: SiteStore,
     private val selectedSite: SelectedSite
 ) {
     suspend fun authenticate(ticket: QrLoginPayload.Ticket): Result<Int> {
@@ -51,14 +53,25 @@ class QrLoginAuthenticator @Inject constructor(
         try {
             ensureUserEligible(site)
         } catch (ce: CancellationException) {
-            wpApiSiteRepository.deleteApplicationPassword(site.id)
+            revokeApplicationPassword(site)
             throw ce
         } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
-            wpApiSiteRepository.deleteApplicationPassword(site.id)
+            revokeApplicationPassword(site)
             throw t
         }
         selectedSite.set(site)
         return site.id
+    }
+
+    private suspend fun revokeApplicationPassword(site: SiteModel) {
+        val result = siteStore.deleteApplicationPassword(site)
+        if (result.isError) {
+            WooLog.e(
+                WooLog.T.LOGIN,
+                "QR login: failed to revoke application password server-side: " +
+                    "${result.error?.errorCode} ${result.error?.message}"
+            )
+        }
     }
 
     private suspend fun fetchAndValidateSite(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.login.qrlogin
 import com.woocommerce.android.network.qrlogin.QrLoginCredentials
 import com.woocommerce.android.network.qrlogin.QrLoginRestClient
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.CancellationException
@@ -25,7 +26,8 @@ class QrLoginAuthenticator @Inject constructor(
     private val exchangeClient: QrLoginRestClient,
     private val wpApiSiteRepository: WPApiSiteRepository,
     private val siteStore: SiteStore,
-    private val selectedSite: SelectedSite
+    private val selectedSite: SelectedSite,
+    private val accountRepository: AccountRepository
 ) {
     suspend fun authenticate(ticket: QrLoginPayload.Ticket): Result<Int> {
         val credentials = exchangeClient.exchange(ticket.siteUrl, ticket.token)
@@ -53,17 +55,22 @@ class QrLoginAuthenticator @Inject constructor(
         try {
             ensureUserEligible(site)
         } catch (ce: CancellationException) {
-            revokeApplicationPassword(site)
+            revokeAndLogOut(site)
             throw ce
         } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
-            revokeApplicationPassword(site)
+            revokeAndLogOut(site)
             throw t
         }
         selectedSite.set(site)
         return site.id
     }
 
-    private suspend fun revokeApplicationPassword(site: SiteModel) {
+    /**
+     * On post-exchange QR login failure, revoke the just-minted Application Password and tear down
+     * any existing session. The app does not support multi-login, so a failed QR attempt must leave
+     * the user fully logged out rather than in a half-state.
+     */
+    private suspend fun revokeAndLogOut(site: SiteModel) {
         val result = siteStore.deleteApplicationPassword(site)
         if (result.isError) {
             WooLog.e(
@@ -72,6 +79,7 @@ class QrLoginAuthenticator @Inject constructor(
                     "${result.error?.errorCode} ${result.error?.message}"
             )
         }
+        accountRepository.logout()
     }
 
     private suspend fun fetchAndValidateSite(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.CancellationException
+import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 
 /**
@@ -29,23 +30,46 @@ class QrLoginAuthenticator @Inject constructor(
             .getOrElse { return Result.failure(it) }
 
         return try {
-            val site = wpApiSiteRepository.fetchSite(
-                url = ticket.siteUrl,
-                username = credentials.userLogin,
-                password = credentials.applicationPassword.reveal()
-            ).getOrThrow()
-            wpApiSiteRepository.saveApplicationPassword(
-                localSiteId = site.id,
-                username = credentials.userLogin,
-                password = credentials.applicationPassword.reveal()
-            )
-            selectedSite.set(site)
-            Result.success(site.id)
+            Result.success(authenticateWithCredentials(ticket.siteUrl, credentials))
         } catch (ce: CancellationException) {
             throw ce
+        } catch (e: QrLoginAuthenticationException) {
+            Result.failure(e)
         } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
             WooLog.e(WooLog.T.LOGIN, "QR login authentication failed", t)
             Result.failure(t)
         }
     }
+
+    private suspend fun authenticateWithCredentials(siteUrl: String, credentials: QrLoginCredentials): Int {
+        val site = fetchAndValidateSite(siteUrl, credentials)
+        wpApiSiteRepository.saveApplicationPassword(
+            localSiteId = site.id,
+            username = credentials.userLogin,
+            password = credentials.applicationPassword.reveal()
+        )
+        selectedSite.set(site)
+        return site.id
+    }
+
+    private suspend fun fetchAndValidateSite(
+        siteUrl: String,
+        credentials: QrLoginCredentials
+    ): SiteModel {
+        val site = wpApiSiteRepository.fetchSite(
+            url = siteUrl,
+            username = credentials.userLogin,
+            password = credentials.applicationPassword.reveal()
+        ).getOrThrow()
+
+        if (!site.hasWooCommerce) {
+            WooLog.w(WooLog.T.LOGIN, "QR login: site ${site.url} does not have WooCommerce installed")
+            throw QrLoginAuthenticationException.NotAWooSite
+        }
+        return site
+    }
+}
+
+sealed class QrLoginAuthenticationException(message: String) : Exception(message) {
+    data object NotAWooSite : QrLoginAuthenticationException("Site is not a WooCommerce store")
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticatorTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.network.qrlogin.QrLoginCredentials
 import com.woocommerce.android.network.qrlogin.QrLoginRestClient
 import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.CancellationException
@@ -45,8 +46,10 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
     private val repo: WPApiSiteRepository = mock()
     private val siteStore: SiteStore = mock()
     private val selectedSite: SelectedSite = mock()
+    private val accountRepository: AccountRepository = mock()
 
-    private val authenticator = QrLoginAuthenticator(exchangeClient, repo, siteStore, selectedSite)
+    private val authenticator =
+        QrLoginAuthenticator(exchangeClient, repo, siteStore, selectedSite, accountRepository)
 
     @Before
     fun setUp() = testBlocking {
@@ -107,27 +110,31 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given user is not eligible, when authenticate, then saved AP is revoked`() = testBlocking {
-        whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.success(false))
+    fun `given user is not eligible, when authenticate, then saved AP is revoked and user logged out`() =
+        testBlocking {
+            whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.success(false))
 
-        authenticator.authenticate(ticket)
+            authenticator.authenticate(ticket)
 
-        verify(repo).saveApplicationPassword(
-            localSiteId = site.id,
-            username = credentials.userLogin,
-            password = credentials.applicationPassword
-        )
-        verify(siteStore).deleteApplicationPassword(site)
-    }
+            verify(repo).saveApplicationPassword(
+                localSiteId = site.id,
+                username = credentials.userLogin,
+                password = credentials.applicationPassword
+            )
+            verify(siteStore).deleteApplicationPassword(site)
+            verify(accountRepository).logout()
+        }
 
     @Test
-    fun `given eligibility check fails, when authenticate, then saved AP is revoked`() = testBlocking {
-        whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.failure(IOException("offline")))
+    fun `given eligibility check fails, when authenticate, then saved AP is revoked and user logged out`() =
+        testBlocking {
+            whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.failure(IOException("offline")))
 
-        authenticator.authenticate(ticket)
+            authenticator.authenticate(ticket)
 
-        verify(siteStore).deleteApplicationPassword(site)
-    }
+            verify(siteStore).deleteApplicationPassword(site)
+            verify(accountRepository).logout()
+        }
 
     @Test
     fun `given fetchSite fails, when authenticate, then failure propagates and AP not saved`() = testBlocking {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticatorTest.kt
@@ -26,8 +26,7 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
     private val ticket = QrLoginPayload.Ticket(token = "tok", siteUrl = "https://store.example")
     private val credentials = QrLoginCredentials(
         userLogin = "admin",
-        applicationPassword = Secret("ap-secret"),
-        uuid = "uuid-1"
+        applicationPassword = "ap-secret",
     )
     private val site = SiteModel().apply {
         id = 42
@@ -50,7 +49,7 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
     fun setUp() = testBlocking {
         whenever(exchangeClient.exchange(ticket.siteUrl, ticket.token))
             .thenReturn(Result.success(credentials))
-        whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword.reveal()))
+        whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword))
             .thenReturn(Result.success(site))
         whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.success(true))
     }
@@ -63,7 +62,7 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
         verify(repo).saveApplicationPassword(
             localSiteId = 42,
             username = credentials.userLogin,
-            password = credentials.applicationPassword.reveal()
+            password = credentials.applicationPassword
         )
         verify(selectedSite).set(site)
     }
@@ -82,7 +81,7 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
 
     @Test
     fun `given site has no WooCommerce, when authenticate, then NotAWooSite and AP not saved`() = testBlocking {
-        whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword.reveal()))
+        whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword))
             .thenReturn(Result.success(nonWooSite))
 
         val result = authenticator.authenticate(ticket)
@@ -112,7 +111,7 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
         verify(repo).saveApplicationPassword(
             localSiteId = site.id,
             username = credentials.userLogin,
-            password = credentials.applicationPassword.reveal()
+            password = credentials.applicationPassword
         )
         verify(repo).deleteApplicationPassword(site.id)
     }
@@ -128,7 +127,7 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
 
     @Test
     fun `given fetchSite fails, when authenticate, then failure propagates and AP not saved`() = testBlocking {
-        whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword.reveal()))
+        whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword))
             .thenReturn(Result.failure(IllegalStateException("nope")))
 
         val result = authenticator.authenticate(ticket)
@@ -141,7 +140,7 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
     @Test
     fun `given fetchSite throws CancellationException, when authenticate, then it propagates unwrapped`() =
         testBlocking {
-            whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword.reveal()))
+            whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword))
                 .thenAnswer { throw CancellationException("cancelled") }
 
             var thrown: Throwable? = null

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticatorTest.kt
@@ -1,0 +1,169 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import com.woocommerce.android.network.qrlogin.QrLoginCredentials
+import com.woocommerce.android.network.qrlogin.QrLoginRestClient
+import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.login.WPApiSiteRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import java.io.IOException
+import org.wordpress.android.fluxc.model.SiteModel
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class QrLoginAuthenticatorTest : BaseUnitTest() {
+
+    private val ticket = QrLoginPayload.Ticket(token = "tok", siteUrl = "https://store.example")
+    private val credentials = QrLoginCredentials(
+        userLogin = "admin",
+        applicationPassword = Secret("ap-secret"),
+        uuid = "uuid-1"
+    )
+    private val site = SiteModel().apply {
+        id = 42
+        url = "https://store.example"
+        hasWooCommerce = true
+    }
+    private val nonWooSite = SiteModel().apply {
+        id = 7
+        url = "https://blog.example"
+        hasWooCommerce = false
+    }
+
+    private val exchangeClient: QrLoginRestClient = mock()
+    private val repo: WPApiSiteRepository = mock()
+    private val selectedSite: SelectedSite = mock()
+
+    private val authenticator = QrLoginAuthenticator(exchangeClient, repo, selectedSite)
+
+    @Before
+    fun setUp() = testBlocking {
+        whenever(exchangeClient.exchange(ticket.siteUrl, ticket.token))
+            .thenReturn(Result.success(credentials))
+        whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword.reveal()))
+            .thenReturn(Result.success(site))
+        whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.success(true))
+    }
+
+    @Test
+    fun `given happy path, when authenticate, then returns site id and persists credentials`() = testBlocking {
+        val result = authenticator.authenticate(ticket)
+
+        assertThat(result).isEqualTo(Result.success(42))
+        verify(repo).saveApplicationPassword(
+            localSiteId = 42,
+            username = credentials.userLogin,
+            password = credentials.applicationPassword.reveal()
+        )
+        verify(selectedSite).set(site)
+    }
+
+    @Test
+    fun `given exchange fails, when authenticate, then propagates exchange exception`() = testBlocking {
+        whenever(exchangeClient.exchange(ticket.siteUrl, ticket.token))
+            .thenReturn(Result.failure(QrLoginExchangeException.RateLimited))
+
+        val result = authenticator.authenticate(ticket)
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.RateLimited)
+        verify(repo, never()).saveApplicationPassword(any(), any(), any())
+        verifyNoInteractions(selectedSite)
+    }
+
+    @Test
+    fun `given site has no WooCommerce, when authenticate, then NotAWooSite and AP not saved`() = testBlocking {
+        whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword.reveal()))
+            .thenReturn(Result.success(nonWooSite))
+
+        val result = authenticator.authenticate(ticket)
+
+        assertThat(result.exceptionOrNull()).isInstanceOf(QrLoginAuthenticationException.NotAWooSite::class.java)
+        verify(repo, never()).saveApplicationPassword(any(), any(), any())
+        verifyNoInteractions(selectedSite)
+    }
+
+    @Test
+    fun `given user is not eligible, when authenticate, then UserNotEligible and site not selected`() = testBlocking {
+        whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.success(false))
+
+        val result = authenticator.authenticate(ticket)
+
+        assertThat(result.exceptionOrNull())
+            .isInstanceOf(QrLoginAuthenticationException.UserNotEligible::class.java)
+        verifyNoInteractions(selectedSite)
+    }
+
+    @Test
+    fun `given user is not eligible, when authenticate, then saved AP is revoked`() = testBlocking {
+        whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.success(false))
+
+        authenticator.authenticate(ticket)
+
+        verify(repo).saveApplicationPassword(
+            localSiteId = site.id,
+            username = credentials.userLogin,
+            password = credentials.applicationPassword.reveal()
+        )
+        verify(repo).deleteApplicationPassword(site.id)
+    }
+
+    @Test
+    fun `given eligibility check fails, when authenticate, then saved AP is revoked`() = testBlocking {
+        whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.failure(IOException("offline")))
+
+        authenticator.authenticate(ticket)
+
+        verify(repo).deleteApplicationPassword(site.id)
+    }
+
+    @Test
+    fun `given fetchSite fails, when authenticate, then failure propagates and AP not saved`() = testBlocking {
+        whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword.reveal()))
+            .thenReturn(Result.failure(IllegalStateException("nope")))
+
+        val result = authenticator.authenticate(ticket)
+
+        assertThat(result.isFailure).isTrue()
+        verify(repo, never()).saveApplicationPassword(any(), any(), any())
+        verifyNoInteractions(selectedSite)
+    }
+
+    @Test
+    fun `given fetchSite throws CancellationException, when authenticate, then it propagates unwrapped`() =
+        testBlocking {
+            whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword.reveal()))
+                .thenAnswer { throw CancellationException("cancelled") }
+
+            var thrown: Throwable? = null
+            try {
+                authenticator.authenticate(ticket)
+            } catch (t: Throwable) {
+                thrown = t
+            }
+
+            assertThat(thrown).isInstanceOf(CancellationException::class.java)
+        }
+
+    @Test
+    fun `given eligibility check fails with IO error, when authenticate, then UserNotEligible carries the cause`() =
+        testBlocking {
+            val cause = IOException("offline")
+            whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.failure(cause))
+
+            val result = authenticator.authenticate(ticket)
+
+            val failure = result.exceptionOrNull()
+            assertThat(failure).isInstanceOf(QrLoginAuthenticationException.UserNotEligible::class.java)
+            assertThat((failure as QrLoginAuthenticationException.UserNotEligible).original).isEqualTo(cause)
+        }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticatorTest.kt
@@ -19,6 +19,8 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import java.io.IOException
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.OnApplicationPasswordDeleted
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class QrLoginAuthenticatorTest : BaseUnitTest() {
@@ -41,9 +43,10 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
 
     private val exchangeClient: QrLoginRestClient = mock()
     private val repo: WPApiSiteRepository = mock()
+    private val siteStore: SiteStore = mock()
     private val selectedSite: SelectedSite = mock()
 
-    private val authenticator = QrLoginAuthenticator(exchangeClient, repo, selectedSite)
+    private val authenticator = QrLoginAuthenticator(exchangeClient, repo, siteStore, selectedSite)
 
     @Before
     fun setUp() = testBlocking {
@@ -52,6 +55,7 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
         whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword))
             .thenReturn(Result.success(site))
         whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.success(true))
+        whenever(siteStore.deleteApplicationPassword(site)).thenReturn(OnApplicationPasswordDeleted(site))
     }
 
     @Test
@@ -113,7 +117,7 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
             username = credentials.userLogin,
             password = credentials.applicationPassword
         )
-        verify(repo).deleteApplicationPassword(site.id)
+        verify(siteStore).deleteApplicationPassword(site)
     }
 
     @Test
@@ -122,7 +126,7 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
 
         authenticator.authenticate(ticket)
 
-        verify(repo).deleteApplicationPassword(site.id)
+        verify(siteStore).deleteApplicationPassword(site)
     }
 
     @Test


### PR DESCRIPTION
Fixes WOOMOB-2844

### Description

Adds `QrLoginAuthenticator`, which sequences the moving parts behind a single `Result<LocalSiteId>`: ticket exchange (via the rest client from step 2) → site lookup → eligibility check → Application Password persistence. On any post-exchange failure the AP is revoked so the merchant isn't left with a stranded credential on their site. Unit-tested including the AP-revocation paths.

This is **Step 3 of 10** in a stacked PR chain — depends on `step-2-qr-login-exchange-client`.

### Stacked PR chain
- Step 1: #15733 — foundation: payload type, parser, and analytics events
- Step 2: #15734 — token exchange REST client
- Step 3: #15735 — authenticator orchestrating exchange + site fetch + eligibility ← **this PR**
- Step 4: #15736 — scanner ViewModel state machine and feature-flag gate
- Step 5: #15737 — prologue screen with QR icon, URL pill, and camera-permission gate
- Step 6: #15738 — camera viewfinder, scanner screen, and endpoint-missing fallback
- Step 7: #15739 — fullscreen confirm + error screens with retry-eligible mapping
- Step 8: #15740 — prologue and scanner fragments hosting the Compose surfaces
- Step 9: #15741 — activity wiring and `woocommerce://qr-login` deep link
- Step 10: #15742 — detect wp-admin install QR and guide users to the sign-in QR

### Test Steps

N/A — see the PR for `step-10-qr-login-install-qr-detection` for the full feature test plan. This PR is part of a stacked chain (`status: do not merge`) and is unit-test-covered where applicable.

### Images/gif

N/A — no UI in this slice.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.