### PR TITLE
[WOOMOB-2845] Step 4: QR login — scanner ViewModel state machine and feature-flag gate

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import com.woocommerce.android.util.DeviceFeatures
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import com.woocommerce.android.util.WooLog
+import javax.inject.Inject
+
+/**
+ * Decides whether the QR login entry point should be offered on this device.
+ *
+ * Hard requirement: the device needs a camera — there's no QR flow without one. We don't gate on
+ * Google Play Services: we ship the bundled ML Kit barcode scanning variant, which is designed to
+ * work on GMS-less devices. If the scanner fails at runtime (binding error, model init, etc.),
+ * [com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel.onBindingException] already
+ * surfaces a snackbar, so offering the entry point optimistically is safe.
+ */
+class QrLoginAvailability @Inject constructor(
+    private val featureFlagRepository: FeatureFlagRepository,
+    private val deviceFeatures: DeviceFeatures
+) {
+    fun isAvailable(): Boolean {
+        if (!featureFlagRepository.isEnabled(FeatureFlag.QR_LOGIN)) return false
+
+        if (!deviceFeatures.hasCamera()) {
+            WooLog.d(WooLog.T.LOGIN, "QR login unavailable: device has no camera")
+            return false
+        }
+
+        return true
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
@@ -21,7 +22,15 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import javax.inject.Inject
 
 /**
- * Drives the QR login flow once the camera has produced a scan result.
+ * Drives the QR login flow once the camera has produced a scan result:
+ *
+ *   1. Parse the deep link.
+ *   2. Exchange the ticket for an Application Password.
+ *   3. Persist credentials and resolve the selected site.
+ *   4. Tell the activity to land in the main app via [Dispatch.LoggedIn].
+ *
+ * Recoverable failures (camera misread, invalid payload, network) keep the scanner running and
+ * are tracked via [AnalyticsEvent.LOGIN_QR_SCAN_FAILED] with a [KEY_STEP] property.
  */
 @HiltViewModel
 class QrLoginScannerViewModel @Inject constructor(
@@ -52,6 +61,12 @@ class QrLoginScannerViewModel @Inject constructor(
         when (status) {
             is CodeScannerStatus.Success -> handlePayload(parser.parse(status.code))
             is CodeScannerStatus.Failure -> {
+                trackScanFailure(
+                    step = Step.SCANNER,
+                    errorContext = status.type.toString(),
+                    errorType = ErrorReason.Scanner.name,
+                    errorDescription = status.error
+                )
                 _currentError.value = ErrorReason.Scanner
             }
             CodeScannerStatus.NotFound -> Unit
@@ -60,7 +75,7 @@ class QrLoginScannerViewModel @Inject constructor(
 
     /**
      * Entry point when the user opens a `woocommerce://qr-login?...` deep link from a browser.
-     * Reuses the same parse → confirm pipeline as a scanned QR, minus the camera.
+     * Reuses the same parse → confirm → exchange pipeline as a scanned QR, minus the camera.
      */
     fun onDeepLinkPayload(raw: String) {
         if (isBusy()) return
@@ -77,7 +92,15 @@ class QrLoginScannerViewModel @Inject constructor(
                 ticket = payload,
                 host = payload.siteUrl.toDisplayHost()
             )
-            QrLoginPayload.Invalid -> _currentError.value = ErrorReason.InvalidPayload
+            QrLoginPayload.Invalid -> {
+                trackScanFailure(
+                    step = Step.PAYLOAD,
+                    errorContext = null,
+                    errorType = ErrorReason.InvalidPayload.name,
+                    errorDescription = "Scanned QR did not match the expected deep link format"
+                )
+                _currentError.value = ErrorReason.InvalidPayload
+            }
         }
     }
 
@@ -94,6 +117,14 @@ class QrLoginScannerViewModel @Inject constructor(
                     },
                     onFailure = { failure ->
                         val reason = failure.toReason()
+                        val httpCode = (failure as? QrLoginExchangeException.HttpError)?.code
+                        trackScanFailure(
+                            step = Step.EXCHANGE,
+                            errorContext = this@QrLoginScannerViewModel::class.java.simpleName,
+                            errorType = reason.name,
+                            errorDescription = failure.message,
+                            extras = httpCode?.let { mapOf(AnalyticsTracker.KEY_ERROR_CODE to it) }.orEmpty()
+                        )
                         if (reason == ErrorReason.EndpointMissing) {
                             _endpointMissing.value = true
                         } else {
@@ -108,6 +139,15 @@ class QrLoginScannerViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Reset the blocking state so the user can scan a fresh QR. Tokens are single-use, so we
+     * never retry the same payload — the scanner reappears and the merchant generates a new code.
+     */
+    fun onStartOver() {
+        _endpointMissing.value = false
+        _currentError.value = null
+    }
+
     fun onConfirmSite() {
         val pending = _pendingConfirmation.value ?: return
         _pendingConfirmation.value = null
@@ -116,15 +156,6 @@ class QrLoginScannerViewModel @Inject constructor(
 
     fun onCancelSite() {
         _pendingConfirmation.value = null
-    }
-
-    /**
-     * Reset the blocking state so the user can scan a fresh QR. Tokens are single-use, so we
-     * never retry the same payload — the scanner reappears and the merchant generates a new code.
-     */
-    fun onStartOver() {
-        _endpointMissing.value = false
-        _currentError.value = null
     }
 
     /**
@@ -138,6 +169,22 @@ class QrLoginScannerViewModel @Inject constructor(
         val parsed = this.toHttpUrlOrNull() ?: return this
         val defaultPort = if (parsed.scheme == "https") HTTPS_DEFAULT_PORT else HTTP_DEFAULT_PORT
         return if (parsed.port == defaultPort) parsed.host else "${parsed.host}:${parsed.port}"
+    }
+
+    private fun trackScanFailure(
+        step: Step,
+        errorContext: String?,
+        errorType: String?,
+        errorDescription: String?,
+        extras: Map<String, Any> = emptyMap()
+    ) {
+        analyticsTracker.track(
+            AnalyticsEvent.LOGIN_QR_SCAN_FAILED,
+            mapOf(AnalyticsTracker.KEY_STEP to step.name.lowercase()) + extras,
+            errorContext = errorContext,
+            errorType = errorType,
+            errorDescription = errorDescription
+        )
     }
 
     private fun Throwable.toReason(): ErrorReason = when (this) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.io.IOException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -197,6 +198,10 @@ class QrLoginScannerViewModel @Inject constructor(
         is QrLoginAuthenticationException.UserNotEligible -> ErrorReason.UserNotEligible
         is CookieNonceAuthenticationException -> ErrorReason.SiteAuthFailure
         is OnChangedException -> (error as? SiteError)?.type.toErrorReason()
+        // Catches DNS, socket, SSL handshake, and read failures during the post-exchange site
+        // discovery + AP save chain — those layers throw raw IOException without going through
+        // QrLoginExchangeException.
+        is IOException -> ErrorReason.Network
         else -> {
             WooLog.w(WooLog.T.LOGIN, "QR login: unmapped failure type ${this.javaClass.simpleName}")
             ErrorReason.Unknown

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -1,12 +1,14 @@
 package com.woocommerce.android.ui.login.qrlogin
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import javax.inject.Inject
 
 /**
@@ -34,6 +36,41 @@ class QrLoginScannerViewModel @Inject constructor(
     private var inFlight = false
     private var loggedIn = false
 
+    fun onScanResult(status: CodeScannerStatus) {
+        if (isBusy()) return
+
+        when (status) {
+            is CodeScannerStatus.Success -> handlePayload(parser.parse(status.code))
+            is CodeScannerStatus.Failure -> {
+                _currentError.value = ErrorReason.Scanner
+            }
+            CodeScannerStatus.NotFound -> Unit
+        }
+    }
+
+    /**
+     * Entry point when the user opens a `woocommerce://qr-login?...` deep link from a browser.
+     * Reuses the same parse → confirm pipeline as a scanned QR, minus the camera.
+     */
+    fun onDeepLinkPayload(raw: String) {
+        if (isBusy()) return
+        handlePayload(parser.parse(raw))
+    }
+
+    private fun isBusy(): Boolean =
+        loggedIn || inFlight || _endpointMissing.value ||
+            _pendingConfirmation.value != null || _currentError.value != null
+
+    private fun handlePayload(payload: QrLoginPayload) {
+        when (payload) {
+            is QrLoginPayload.Ticket -> _pendingConfirmation.value = PendingConfirmation(
+                ticket = payload,
+                host = payload.siteUrl.toDisplayHost()
+            )
+            QrLoginPayload.Invalid -> _currentError.value = ErrorReason.InvalidPayload
+        }
+    }
+
     fun onCancelSite() {
         _pendingConfirmation.value = null
     }
@@ -45,6 +82,19 @@ class QrLoginScannerViewModel @Inject constructor(
     fun onStartOver() {
         _endpointMissing.value = false
         _currentError.value = null
+    }
+
+    /**
+     * Render the host portion the user is being asked to trust. We display the ASCII / punycode
+     * form because OkHttp normalizes IDN hosts for us — homograph attacks like `my-stōre.example`
+     * surface as `xn--my-stre-1za.example`, which the user can read accurately. Non-default ports
+     * are surfaced explicitly. Falls back to the raw URL only if parsing fails (defence in depth;
+     * the parser already gates this).
+     */
+    private fun String.toDisplayHost(): String {
+        val parsed = this.toHttpUrlOrNull() ?: return this
+        val defaultPort = if (parsed.scheme == "https") HTTPS_DEFAULT_PORT else HTTP_DEFAULT_PORT
+        return if (parsed.port == defaultPort) parsed.host else "${parsed.host}:${parsed.port}"
     }
 
     sealed class Dispatch : Event() {
@@ -72,5 +122,10 @@ class QrLoginScannerViewModel @Inject constructor(
 
     enum class Step {
         SCANNER, PAYLOAD, EXCHANGE
+    }
+
+    private companion object {
+        const val HTTPS_DEFAULT_PORT = 443
+        const val HTTP_DEFAULT_PORT = 80
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -1,0 +1,76 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+/**
+ * Drives the QR login flow once the camera has produced a scan result.
+ */
+@HiltViewModel
+class QrLoginScannerViewModel @Inject constructor(
+    savedState: SavedStateHandle,
+    private val parser: QrLoginPayloadParser,
+    private val authenticator: QrLoginAuthenticator,
+) : ScopedViewModel(savedState) {
+
+    private val _isAuthenticating = MutableStateFlow(false)
+    val isAuthenticating: StateFlow<Boolean> = _isAuthenticating.asStateFlow()
+
+    private val _endpointMissing = MutableStateFlow(false)
+    val endpointMissing: StateFlow<Boolean> = _endpointMissing.asStateFlow()
+
+    private val _pendingConfirmation = MutableStateFlow<PendingConfirmation?>(null)
+    val pendingConfirmation: StateFlow<PendingConfirmation?> = _pendingConfirmation.asStateFlow()
+
+    private val _currentError = MutableStateFlow<ErrorReason?>(null)
+    val currentError: StateFlow<ErrorReason?> = _currentError.asStateFlow()
+
+    private var inFlight = false
+    private var loggedIn = false
+
+    fun onCancelSite() {
+        _pendingConfirmation.value = null
+    }
+
+    /**
+     * Reset the blocking state so the user can scan a fresh QR. Tokens are single-use, so we
+     * never retry the same payload — the scanner reappears and the merchant generates a new code.
+     */
+    fun onStartOver() {
+        _endpointMissing.value = false
+        _currentError.value = null
+    }
+
+    sealed class Dispatch : Event() {
+        data class LoggedIn(val localSiteId: Int) : Dispatch()
+    }
+
+    data class PendingConfirmation(
+        val ticket: QrLoginPayload.Ticket,
+        val host: String
+    )
+
+    enum class ErrorReason {
+        InvalidPayload,
+        Scanner,
+        TokenRejected,
+        EndpointMissing,
+        RateLimited,
+        Network,
+        ServerError,
+        SiteAuthFailure,
+        NotAWooSite,
+        UserNotEligible,
+        Unknown
+    }
+
+    enum class Step {
+        SCANNER, PAYLOAD, EXCHANGE
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.login.qrlogin
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
@@ -8,6 +10,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import javax.inject.Inject
 
@@ -19,6 +22,7 @@ class QrLoginScannerViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val parser: QrLoginPayloadParser,
     private val authenticator: QrLoginAuthenticator,
+    private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedState) {
 
     private val _isAuthenticating = MutableStateFlow(false)
@@ -69,6 +73,34 @@ class QrLoginScannerViewModel @Inject constructor(
             )
             QrLoginPayload.Invalid -> _currentError.value = ErrorReason.InvalidPayload
         }
+    }
+
+    private fun startExchange(ticket: QrLoginPayload.Ticket) {
+        inFlight = true
+        _isAuthenticating.value = true
+        launch {
+            try {
+                authenticator.authenticate(ticket).fold(
+                    onSuccess = { localSiteId ->
+                        loggedIn = true
+                        analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SUCCESS)
+                        triggerEvent(Dispatch.LoggedIn(localSiteId))
+                    },
+                    onFailure = {
+                        _currentError.value = ErrorReason.Unknown
+                    }
+                )
+            } finally {
+                inFlight = false
+                _isAuthenticating.value = false
+            }
+        }
+    }
+
+    fun onConfirmSite() {
+        val pending = _pendingConfirmation.value ?: return
+        _pendingConfirmation.value = null
+        startExchange(pending.ticket)
     }
 
     fun onCancelSite() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -1,17 +1,23 @@
 package com.woocommerce.android.ui.login.qrlogin
 
+import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.wordpress.android.fluxc.store.SiteStore.SiteError
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import javax.inject.Inject
 
 /**
@@ -86,8 +92,13 @@ class QrLoginScannerViewModel @Inject constructor(
                         analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SUCCESS)
                         triggerEvent(Dispatch.LoggedIn(localSiteId))
                     },
-                    onFailure = {
-                        _currentError.value = ErrorReason.Unknown
+                    onFailure = { failure ->
+                        val reason = failure.toReason()
+                        if (reason == ErrorReason.EndpointMissing) {
+                            _endpointMissing.value = true
+                        } else {
+                            _currentError.value = reason
+                        }
                     }
                 )
             } finally {
@@ -127,6 +138,46 @@ class QrLoginScannerViewModel @Inject constructor(
         val parsed = this.toHttpUrlOrNull() ?: return this
         val defaultPort = if (parsed.scheme == "https") HTTPS_DEFAULT_PORT else HTTP_DEFAULT_PORT
         return if (parsed.port == defaultPort) parsed.host else "${parsed.host}:${parsed.port}"
+    }
+
+    private fun Throwable.toReason(): ErrorReason = when (this) {
+        QrLoginExchangeException.TokenRejected -> ErrorReason.TokenRejected
+        QrLoginExchangeException.EndpointMissing -> ErrorReason.EndpointMissing
+        QrLoginExchangeException.RateLimited -> ErrorReason.RateLimited
+        QrLoginExchangeException.Network -> ErrorReason.Network
+        QrLoginExchangeException.MalformedResponse -> ErrorReason.ServerError
+        is QrLoginExchangeException.HttpError -> {
+            WooLog.w(WooLog.T.LOGIN, "QR login exchange returned HTTP $code")
+            ErrorReason.ServerError
+        }
+        is QrLoginExchangeException.Unknown -> ErrorReason.Unknown
+        QrLoginAuthenticationException.NotAWooSite -> ErrorReason.NotAWooSite
+        is QrLoginAuthenticationException.UserNotEligible -> ErrorReason.UserNotEligible
+        is CookieNonceAuthenticationException -> ErrorReason.SiteAuthFailure
+        is OnChangedException -> {
+            val siteError = error as? SiteError
+            if (siteError == null) {
+                WooLog.w(
+                    WooLog.T.LOGIN,
+                    "QR login: unmapped OnChangedException error type ${error.javaClass.simpleName}"
+                )
+            }
+            siteError?.type.toErrorReason()
+        }
+        else -> {
+            WooLog.e(WooLog.T.LOGIN, "QR login: unmapped failure type ${this.javaClass.simpleName}", this)
+            ErrorReason.Unknown
+        }
+    }
+
+    private fun SiteErrorType?.toErrorReason(): ErrorReason = when (this) {
+        SiteErrorType.UNAUTHORIZED,
+        SiteErrorType.NOT_AUTHENTICATED -> ErrorReason.SiteAuthFailure
+        SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR -> ErrorReason.Network
+        else -> {
+            WooLog.w(WooLog.T.LOGIN, "QR login: unmapped SiteErrorType $this")
+            ErrorReason.Unknown
+        }
     }
 
     sealed class Dispatch : Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -55,6 +55,11 @@ class QrLoginScannerViewModel @Inject constructor(
     private var inFlight = false
     private var loggedIn = false
 
+    // Held while an exchange is pending or has just failed transiently so [onRetryExchange]
+    // can replay the same ticket without bouncing the user back to the scanner. Cleared on
+    // success and on [onStartOver].
+    private var lastTicket: QrLoginPayload.Ticket? = null
+
     fun onScanResult(status: CodeScannerStatus) {
         if (isBusy()) return
 
@@ -105,12 +110,14 @@ class QrLoginScannerViewModel @Inject constructor(
     }
 
     private fun startExchange(ticket: QrLoginPayload.Ticket) {
+        lastTicket = ticket
         inFlight = true
         _isAuthenticating.value = true
         launch {
             try {
                 authenticator.authenticate(ticket).fold(
                     onSuccess = { localSiteId ->
+                        lastTicket = null
                         loggedIn = true
                         analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SUCCESS)
                         triggerEvent(Dispatch.LoggedIn(localSiteId))
@@ -146,6 +153,20 @@ class QrLoginScannerViewModel @Inject constructor(
     fun onStartOver() {
         _endpointMissing.value = false
         _currentError.value = null
+        lastTicket = null
+    }
+
+    /**
+     * Re-runs the exchange with the same ticket from the last attempt. Wired up to error
+     * screens for transient failures (network, server, rate-limited) where the token is most
+     * likely still valid. If the server actually consumed the token before the failure, the
+     * retry surfaces [ErrorReason.TokenRejected] which then routes the user to the scanner
+     * via the standard "Scan a new code" action.
+     */
+    fun onRetryExchange() {
+        val ticket = lastTicket ?: return
+        _currentError.value = null
+        startExchange(ticket)
     }
 
     fun onConfirmSite() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -1,17 +1,21 @@
 package com.woocommerce.android.ui.login.qrlogin
 
-import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Authenticating
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Confirming
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Error
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Idle
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,7 +34,7 @@ import javax.inject.Inject
  *   4. Tell the activity to land in the main app via [Dispatch.LoggedIn].
  *
  * Recoverable failures (camera misread, invalid payload, network) keep the scanner running and
- * are tracked via [AnalyticsEvent.LOGIN_QR_SCAN_FAILED] with a [KEY_STEP] property.
+ * are tracked via [AnalyticsEvent.LOGIN_QR_SCAN_FAILED] with a [AnalyticsTracker.KEY_STEP] property.
  */
 @HiltViewModel
 class QrLoginScannerViewModel @Inject constructor(
@@ -40,39 +44,22 @@ class QrLoginScannerViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedState) {
 
-    private val _isAuthenticating = MutableStateFlow(false)
-    val isAuthenticating: StateFlow<Boolean> = _isAuthenticating.asStateFlow()
+    private val _uiState = MutableStateFlow<UiState>(Idle)
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
-    private val _endpointMissing = MutableStateFlow(false)
-    val endpointMissing: StateFlow<Boolean> = _endpointMissing.asStateFlow()
-
-    private val _pendingConfirmation = MutableStateFlow<PendingConfirmation?>(null)
-    val pendingConfirmation: StateFlow<PendingConfirmation?> = _pendingConfirmation.asStateFlow()
-
-    private val _currentError = MutableStateFlow<ErrorReason?>(null)
-    val currentError: StateFlow<ErrorReason?> = _currentError.asStateFlow()
-
-    private var inFlight = false
     private var loggedIn = false
 
-    // Held while an exchange is pending or has just failed transiently so [onRetryExchange]
-    // can replay the same ticket without bouncing the user back to the scanner. Cleared on
-    // success and on [onStartOver].
-    private var lastTicket: QrLoginPayload.Ticket? = null
-
     fun onScanResult(status: CodeScannerStatus) {
-        if (isBusy()) return
-
+        if (!isIdle()) return
         when (status) {
             is CodeScannerStatus.Success -> handlePayload(parser.parse(status.code))
             is CodeScannerStatus.Failure -> {
                 trackScanFailure(
                     step = Step.SCANNER,
-                    errorContext = status.type.toString(),
+                    errorContext = status.type::class.java.simpleName,
                     errorType = ErrorReason.Scanner.name,
-                    errorDescription = status.error
                 )
-                _currentError.value = ErrorReason.Scanner
+                _uiState.value = Error(reason = ErrorReason.Scanner, retryTicket = null)
             }
             CodeScannerStatus.NotFound -> Unit
         }
@@ -83,17 +70,15 @@ class QrLoginScannerViewModel @Inject constructor(
      * Reuses the same parse → confirm → exchange pipeline as a scanned QR, minus the camera.
      */
     fun onDeepLinkPayload(raw: String) {
-        if (isBusy()) return
+        if (!isIdle()) return
         handlePayload(parser.parse(raw))
     }
 
-    private fun isBusy(): Boolean =
-        loggedIn || inFlight || _endpointMissing.value ||
-            _pendingConfirmation.value != null || _currentError.value != null
+    private fun isIdle(): Boolean = !loggedIn && _uiState.value is Idle
 
     private fun handlePayload(payload: QrLoginPayload) {
         when (payload) {
-            is QrLoginPayload.Ticket -> _pendingConfirmation.value = PendingConfirmation(
+            is QrLoginPayload.Ticket -> _uiState.value = Confirming(
                 ticket = payload,
                 host = payload.siteUrl.toDisplayHost()
             )
@@ -102,47 +87,36 @@ class QrLoginScannerViewModel @Inject constructor(
                     step = Step.PAYLOAD,
                     errorContext = null,
                     errorType = ErrorReason.InvalidPayload.name,
-                    errorDescription = "Scanned QR did not match the expected deep link format"
                 )
-                _currentError.value = ErrorReason.InvalidPayload
+                _uiState.value = Error(reason = ErrorReason.InvalidPayload, retryTicket = null)
             }
         }
     }
 
     private fun startExchange(ticket: QrLoginPayload.Ticket) {
-        lastTicket = ticket
-        inFlight = true
-        _isAuthenticating.value = true
+        _uiState.value = Authenticating
         launch {
-            try {
-                authenticator.authenticate(ticket).fold(
-                    onSuccess = { localSiteId ->
-                        lastTicket = null
-                        loggedIn = true
-                        analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SUCCESS)
-                        triggerEvent(Dispatch.LoggedIn(localSiteId))
-                    },
-                    onFailure = { failure ->
-                        val reason = failure.toReason()
-                        val httpCode = (failure as? QrLoginExchangeException.HttpError)?.code
-                        trackScanFailure(
-                            step = Step.EXCHANGE,
-                            errorContext = this@QrLoginScannerViewModel::class.java.simpleName,
-                            errorType = reason.name,
-                            errorDescription = failure.message,
-                            extras = httpCode?.let { mapOf(AnalyticsTracker.KEY_ERROR_CODE to it) }.orEmpty()
-                        )
-                        if (reason == ErrorReason.EndpointMissing) {
-                            _endpointMissing.value = true
-                        } else {
-                            _currentError.value = reason
-                        }
-                    }
-                )
-            } finally {
-                inFlight = false
-                _isAuthenticating.value = false
-            }
+            authenticator.authenticate(ticket).fold(
+                onSuccess = { localSiteId ->
+                    loggedIn = true
+                    analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SUCCESS)
+                    triggerEvent(Dispatch.LoggedIn(localSiteId))
+                },
+                onFailure = { failure ->
+                    val reason = failure.toReason()
+                    val httpCode = (failure as? QrLoginExchangeException.HttpError)?.code
+                    trackScanFailure(
+                        step = Step.EXCHANGE,
+                        errorContext = failure.javaClass.simpleName,
+                        errorType = reason.name,
+                        extras = httpCode?.let { mapOf(AnalyticsTracker.KEY_ERROR_CODE to it) }.orEmpty()
+                    )
+                    _uiState.value = Error(
+                        reason = reason,
+                        retryTicket = ticket.takeIf { reason.isRetryEligible() }
+                    )
+                }
+            )
         }
     }
 
@@ -151,9 +125,8 @@ class QrLoginScannerViewModel @Inject constructor(
      * never retry the same payload — the scanner reappears and the merchant generates a new code.
      */
     fun onStartOver() {
-        _endpointMissing.value = false
-        _currentError.value = null
-        lastTicket = null
+        if (loggedIn) return
+        _uiState.value = Idle
     }
 
     /**
@@ -164,19 +137,17 @@ class QrLoginScannerViewModel @Inject constructor(
      * via the standard "Scan a new code" action.
      */
     fun onRetryExchange() {
-        val ticket = lastTicket ?: return
-        _currentError.value = null
+        val ticket = (_uiState.value as? Error)?.retryTicket ?: return
         startExchange(ticket)
     }
 
     fun onConfirmSite() {
-        val pending = _pendingConfirmation.value ?: return
-        _pendingConfirmation.value = null
+        val pending = _uiState.value as? Confirming ?: return
         startExchange(pending.ticket)
     }
 
     fun onCancelSite() {
-        _pendingConfirmation.value = null
+        if (_uiState.value is Confirming) _uiState.value = Idle
     }
 
     /**
@@ -196,7 +167,6 @@ class QrLoginScannerViewModel @Inject constructor(
         step: Step,
         errorContext: String?,
         errorType: String?,
-        errorDescription: String?,
         extras: Map<String, Any> = emptyMap()
     ) {
         analyticsTracker.track(
@@ -204,8 +174,15 @@ class QrLoginScannerViewModel @Inject constructor(
             mapOf(AnalyticsTracker.KEY_STEP to step.name.lowercase()) + extras,
             errorContext = errorContext,
             errorType = errorType,
-            errorDescription = errorDescription
+            errorDescription = null
         )
+    }
+
+    private fun ErrorReason.isRetryEligible(): Boolean = when (this) {
+        ErrorReason.Network,
+        ErrorReason.ServerError,
+        ErrorReason.RateLimited -> true
+        else -> false
     }
 
     private fun Throwable.toReason(): ErrorReason = when (this) {
@@ -214,26 +191,14 @@ class QrLoginScannerViewModel @Inject constructor(
         QrLoginExchangeException.RateLimited -> ErrorReason.RateLimited
         QrLoginExchangeException.Network -> ErrorReason.Network
         QrLoginExchangeException.MalformedResponse -> ErrorReason.ServerError
-        is QrLoginExchangeException.HttpError -> {
-            WooLog.w(WooLog.T.LOGIN, "QR login exchange returned HTTP $code")
-            ErrorReason.ServerError
-        }
+        is QrLoginExchangeException.HttpError -> ErrorReason.ServerError
         is QrLoginExchangeException.Unknown -> ErrorReason.Unknown
         QrLoginAuthenticationException.NotAWooSite -> ErrorReason.NotAWooSite
         is QrLoginAuthenticationException.UserNotEligible -> ErrorReason.UserNotEligible
         is CookieNonceAuthenticationException -> ErrorReason.SiteAuthFailure
-        is OnChangedException -> {
-            val siteError = error as? SiteError
-            if (siteError == null) {
-                WooLog.w(
-                    WooLog.T.LOGIN,
-                    "QR login: unmapped OnChangedException error type ${error.javaClass.simpleName}"
-                )
-            }
-            siteError?.type.toErrorReason()
-        }
+        is OnChangedException -> (error as? SiteError)?.type.toErrorReason()
         else -> {
-            WooLog.e(WooLog.T.LOGIN, "QR login: unmapped failure type ${this.javaClass.simpleName}", this)
+            WooLog.w(WooLog.T.LOGIN, "QR login: unmapped failure type ${this.javaClass.simpleName}")
             ErrorReason.Unknown
         }
     }
@@ -242,20 +207,19 @@ class QrLoginScannerViewModel @Inject constructor(
         SiteErrorType.UNAUTHORIZED,
         SiteErrorType.NOT_AUTHENTICATED -> ErrorReason.SiteAuthFailure
         SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR -> ErrorReason.Network
-        else -> {
-            WooLog.w(WooLog.T.LOGIN, "QR login: unmapped SiteErrorType $this")
-            ErrorReason.Unknown
-        }
+        else -> ErrorReason.Unknown
     }
 
     sealed class Dispatch : Event() {
         data class LoggedIn(val localSiteId: Int) : Dispatch()
     }
 
-    data class PendingConfirmation(
-        val ticket: QrLoginPayload.Ticket,
-        val host: String
-    )
+    sealed interface UiState {
+        data object Idle : UiState
+        data class Confirming(val ticket: QrLoginPayload.Ticket, val host: String) : UiState
+        data object Authenticating : UiState
+        data class Error(val reason: ErrorReason, val retryTicket: QrLoginPayload.Ticket?) : UiState
+    }
 
     enum class ErrorReason {
         InvalidPayload,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceFeatures.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/DeviceFeatures.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.util
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.nfc.NfcAdapter
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
@@ -14,4 +15,7 @@ class DeviceFeatures @Inject constructor(
 
     fun isNFCAvailable(): Boolean =
         NfcAdapter.getDefaultAdapter(context) != null
+
+    fun hasCamera(): Boolean =
+        context.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -32,4 +32,5 @@ enum class FeatureFlag(
     BOOKINGS_RESCHEDULE("bookings_reschedule", localValue = PackageUtils.isDebugBuild()),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1("woo_self_driven_push_notifications_m1", localValue = false),
     LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
+    QR_LOGIN("qr_login", localValue = PackageUtils.isDebugBuild()),
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
@@ -1,0 +1,46 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import com.woocommerce.android.util.DeviceFeatures
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class QrLoginAvailabilityTest : BaseUnitTest() {
+
+    private val featureFlagRepository: FeatureFlagRepository = mock()
+    private val deviceFeatures: DeviceFeatures = mock()
+
+    private val availability = QrLoginAvailability(featureFlagRepository, deviceFeatures)
+
+    @Before
+    fun setUp() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.QR_LOGIN)).thenReturn(true)
+        whenever(deviceFeatures.hasCamera()).thenReturn(true)
+    }
+
+    @Test
+    fun `given flag enabled and camera present, when isAvailable, then true`() {
+        assertThat(availability.isAvailable()).isTrue()
+    }
+
+    @Test
+    fun `given feature flag disabled, when isAvailable, then false`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.QR_LOGIN)).thenReturn(false)
+
+        assertThat(availability.isAvailable()).isFalse()
+    }
+
+    @Test
+    fun `given device has no camera, when isAvailable, then false`() {
+        whenever(deviceFeatures.hasCamera()).thenReturn(false)
+
+        assertThat(availability.isAvailable()).isFalse()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -1,11 +1,11 @@
 package com.woocommerce.android.ui.login.qrlogin
 
-import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
 import com.woocommerce.android.ui.orders.creation.CodeScanningErrorType
 import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
@@ -61,32 +61,31 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given valid ticket, when scan succeeds, then pending confirmation exposes host and no exchange`() =
-        testBlocking {
-            viewModel.onScanResult(successScan())
+    fun `given valid ticket, when scan succeeds, then ui state exposes confirming with host`() = testBlocking {
+        viewModel.onScanResult(successScan())
 
-            assertThat(viewModel.pendingConfirmation.value).isEqualTo(
-                QrLoginScannerViewModel.PendingConfirmation(ticket = ticket, host = "store.example")
-            )
-            verify(authenticator, never()).authenticate(any())
-        }
+        assertThat(viewModel.uiState.value).isEqualTo(
+            QrLoginScannerViewModel.UiState.Confirming(ticket = ticket, host = "store.example")
+        )
+        verify(authenticator, never()).authenticate(any())
+    }
 
     @Test
-    fun `given pending confirmation, when cancel, then pending is cleared and authenticator not called`() =
-        testBlocking {
-            viewModel.onScanResult(successScan())
-            viewModel.onCancelSite()
+    fun `given pending confirmation, when cancel, then ui state returns to idle`() = testBlocking {
+        viewModel.onScanResult(successScan())
+        viewModel.onCancelSite()
 
-            assertThat(viewModel.pendingConfirmation.value).isNull()
-            verify(authenticator, never()).authenticate(any())
-        }
+        assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
+        verify(authenticator, never()).authenticate(any())
+    }
 
     @Test
     fun `given pending confirmation, when another scan arrives, then it is ignored`() = testBlocking {
         viewModel.onScanResult(successScan(RAW_SCAN))
         viewModel.onScanResult(successScan("second-raw"))
 
-        assertThat(viewModel.pendingConfirmation.value?.ticket).isEqualTo(ticket)
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(QrLoginScannerViewModel.UiState.Confirming::class.java)
         verify(parser, never()).parse("second-raw")
     }
 
@@ -96,17 +95,22 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         viewModel.onCancelSite()
         viewModel.onScanResult(successScan())
 
-        assertThat(viewModel.pendingConfirmation.value?.ticket).isEqualTo(ticket)
+        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Confirming
+        assertThat(state.ticket).isEqualTo(ticket)
     }
 
     @Test
     fun `given Invalid payload, when scan succeeds, then emits InvalidPayload error`() = testBlocking {
         whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
-        val events = viewModel.event.captureValues()
 
         viewModel.onScanResult(successScan())
 
-        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.InvalidPayload)
+        assertThat(viewModel.uiState.value).isEqualTo(
+            QrLoginScannerViewModel.UiState.Error(
+                reason = QrLoginScannerViewModel.ErrorReason.InvalidPayload,
+                retryTicket = null,
+            )
+        )
     }
 
     @Test
@@ -120,13 +124,13 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given scanner Failure, when scan result received, then emits Scanner error`() = testBlocking {
-        val events = viewModel.event.captureValues()
-
         viewModel.onScanResult(
             CodeScannerStatus.Failure(error = "boom", type = CodeScanningErrorType.Unknown)
         )
 
-        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.Scanner)
+        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.Scanner)
+        assertThat(state.retryTicket).isNull()
     }
 
     @Test
@@ -136,42 +140,47 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         viewModel.onScanResult(CodeScannerStatus.NotFound)
 
         assertThat(events).isEmpty()
+        assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
     }
 
     @Test
-    fun `given token rejected by server, when scan confirmed, then emits TokenRejected error`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginExchangeException.TokenRejected))
-        val events = viewModel.event.captureValues()
+    fun `given token rejected by server, when scan confirmed, then emits TokenRejected error without retry`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ticket))
+                .thenReturn(Result.failure(QrLoginExchangeException.TokenRejected))
 
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
+            viewModel.onScanResult(successScan())
+            viewModel.onConfirmSite()
 
-        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.TokenRejected)
-    }
+            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.TokenRejected)
+            assertThat(state.retryTicket).isNull()
+        }
 
     @Test
     fun `given malformed exchange response, when scan confirmed, then emits ServerError`() = testBlocking {
         whenever(authenticator.authenticate(ticket))
             .thenReturn(Result.failure(QrLoginExchangeException.MalformedResponse))
-        val events = viewModel.event.captureValues()
 
         viewModel.onScanResult(successScan())
         viewModel.onConfirmSite()
 
-        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.ServerError)
+        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.ServerError)
+        assertThat(state.retryTicket).isEqualTo(ticket)
     }
 
     @Test
-    fun `given server HttpError, when scan confirmed, then emits ServerError`() = testBlocking {
+    fun `given server HttpError, when scan confirmed, then emits ServerError with retry ticket`() = testBlocking {
         whenever(authenticator.authenticate(ticket))
             .thenReturn(Result.failure(QrLoginExchangeException.HttpError(500)))
-        val events = viewModel.event.captureValues()
 
         viewModel.onScanResult(successScan())
         viewModel.onConfirmSite()
 
-        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.ServerError)
+        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.ServerError)
+        assertThat(state.retryTicket).isEqualTo(ticket)
     }
 
     @Test
@@ -179,12 +188,12 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         testBlocking {
             whenever(authenticator.authenticate(ticket))
                 .thenReturn(Result.failure(siteError(SiteErrorType.UNAUTHORIZED)))
-            val events = viewModel.event.captureValues()
 
             viewModel.onScanResult(successScan())
             viewModel.onConfirmSite()
 
-            assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.SiteAuthFailure)
+            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.SiteAuthFailure)
         }
 
     @Test
@@ -192,12 +201,12 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         testBlocking {
             whenever(authenticator.authenticate(ticket))
                 .thenReturn(Result.failure(siteError(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR)))
-            val events = viewModel.event.captureValues()
 
             viewModel.onScanResult(successScan())
             viewModel.onConfirmSite()
 
-            assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.Network)
+            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.Network)
         }
 
     @Test
@@ -205,66 +214,71 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         testBlocking {
             whenever(authenticator.authenticate(ticket))
                 .thenReturn(Result.failure(siteError(SiteErrorType.GENERIC_ERROR)))
+
+            viewModel.onScanResult(successScan())
+            viewModel.onConfirmSite()
+
+            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.Unknown)
+        }
+
+    @Test
+    fun `given network error, when scan confirmed, then emits Network error with retry ticket`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginExchangeException.Network))
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.Network)
+        assertThat(state.retryTicket).isEqualTo(ticket)
+    }
+
+    @Test
+    fun `given rate limited error, when scan confirmed, then emits RateLimited error with retry ticket`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ticket))
+                .thenReturn(Result.failure(QrLoginExchangeException.RateLimited))
+
+            viewModel.onScanResult(successScan())
+            viewModel.onConfirmSite()
+
+            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.RateLimited)
+            assertThat(state.retryTicket).isEqualTo(ticket)
+        }
+
+    @Test
+    fun `given endpoint missing, when scan confirmed, then emits EndpointMissing error without retry`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ticket))
+                .thenReturn(Result.failure(QrLoginExchangeException.EndpointMissing))
             val events = viewModel.event.captureValues()
 
             viewModel.onScanResult(successScan())
             viewModel.onConfirmSite()
 
-            assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.Unknown)
+            assertThat(events).isEmpty()
+            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.EndpointMissing)
+            assertThat(state.retryTicket).isNull()
         }
 
     @Test
-    fun `given network error, when scan confirmed, then emits Network error`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginExchangeException.Network))
-        val events = viewModel.event.captureValues()
-
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-
-        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.Network)
-    }
-
-    @Test
-    fun `given rate limited error, when scan confirmed, then emits RateLimited error`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginExchangeException.RateLimited))
-        val events = viewModel.event.captureValues()
-
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-
-        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.RateLimited)
-    }
-
-    @Test
-    fun `given endpoint missing, when scan confirmed, then endpointMissing flag is raised`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginExchangeException.EndpointMissing))
-        val events = viewModel.event.captureValues()
-
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-
-        assertThat(events).isEmpty()
-        assertThat(viewModel.endpointMissing.value).isTrue()
-    }
-
-    @Test
-    fun `given endpoint missing flag raised, when retry called, then flag is cleared`() = testBlocking {
+    fun `given endpoint missing error, when start over called, then state returns to idle`() = testBlocking {
         whenever(authenticator.authenticate(ticket))
             .thenReturn(Result.failure(QrLoginExchangeException.EndpointMissing))
         viewModel.onScanResult(successScan())
         viewModel.onConfirmSite()
-        assertThat(viewModel.endpointMissing.value).isTrue()
 
         viewModel.onStartOver()
 
-        assertThat(viewModel.endpointMissing.value).isFalse()
+        assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
     }
 
     @Test
-    fun `given endpoint missing flag raised, when another scan arrives, then it is ignored`() = testBlocking {
+    fun `given endpoint missing error, when another scan arrives, then it is ignored`() = testBlocking {
         whenever(authenticator.authenticate(ticket))
             .thenReturn(Result.failure(QrLoginExchangeException.EndpointMissing))
         viewModel.onScanResult(successScan())
@@ -279,24 +293,24 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     fun `given site is not Woo, when auth fails with NotAWooSite, then emits NotAWooSite error`() = testBlocking {
         whenever(authenticator.authenticate(ticket))
             .thenReturn(Result.failure(QrLoginAuthenticationException.NotAWooSite))
-        val events = viewModel.event.captureValues()
 
         viewModel.onScanResult(successScan())
         viewModel.onConfirmSite()
 
-        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.NotAWooSite)
+        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.NotAWooSite)
     }
 
     @Test
     fun `given user is ineligible, when auth fails, then emits UserNotEligible error`() = testBlocking {
         whenever(authenticator.authenticate(ticket))
             .thenReturn(Result.failure(QrLoginAuthenticationException.UserNotEligible(original = null)))
-        val events = viewModel.event.captureValues()
 
         viewModel.onScanResult(successScan())
         viewModel.onConfirmSite()
 
-        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.UserNotEligible)
+        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.UserNotEligible)
     }
 
     @Test
@@ -340,7 +354,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given currentError set, when another scan arrives, then it is ignored`() = testBlocking {
+    fun `given error state, when another scan arrives, then it is ignored`() = testBlocking {
         whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
         viewModel.onScanResult(successScan())
 
@@ -350,14 +364,42 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given an error, when onStartOver, then currentError is cleared`() = testBlocking {
+    fun `given an error, when onStartOver, then state returns to idle`() = testBlocking {
         whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
         viewModel.onScanResult(successScan())
-        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.InvalidPayload)
 
         viewModel.onStartOver()
 
-        assertThat(viewModel.currentError.value).isNull()
+        assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
+    }
+
+    @Test
+    fun `given retry-eligible error, when onRetryExchange, then exchange is retried with the same ticket`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ticket))
+                .thenReturn(Result.failure(QrLoginExchangeException.Network))
+                .thenReturn(Result.success(DEFAULT_SITE_ID))
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+            viewModel.onConfirmSite()
+            viewModel.onRetryExchange()
+
+            verify(authenticator, times(2)).authenticate(eq(ticket))
+            assertThat(events.last())
+                .isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = DEFAULT_SITE_ID))
+        }
+
+    @Test
+    fun `given non-retry-eligible error, when onRetryExchange, then nothing happens`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginExchangeException.TokenRejected))
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+        viewModel.onRetryExchange()
+
+        verify(authenticator, times(1)).authenticate(eq(ticket))
     }
 
     @Test
@@ -378,9 +420,9 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             verify(analyticsTracker).track(
                 stat = AnalyticsEvent.LOGIN_QR_SCAN_FAILED,
                 properties = mapOf(AnalyticsTracker.KEY_STEP to "scanner"),
-                errorContext = "CodeScanningErrorType\$Unknown",
+                errorContext = "Unknown",
                 errorType = "Scanner",
-                errorDescription = "boom"
+                errorDescription = null,
             )
         }
 
@@ -396,9 +438,9 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             verify(analyticsTracker).track(
                 stat = AnalyticsEvent.LOGIN_QR_SCAN_FAILED,
                 properties = mapOf(AnalyticsTracker.KEY_STEP to "exchange"),
-                errorContext = "QrLoginScannerViewModel",
+                errorContext = "Network",
                 errorType = "Network",
-                errorDescription = "Network failure during exchange"
+                errorDescription = null,
             )
         }
 
@@ -413,7 +455,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             properties = mapOf(AnalyticsTracker.KEY_STEP to "payload"),
             errorContext = null,
             errorType = "InvalidPayload",
-            errorDescription = "Scanned QR did not match the expected deep link format"
+            errorDescription = null,
         )
     }
 
@@ -422,7 +464,8 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         testBlocking {
             viewModel.onDeepLinkPayload(RAW_SCAN)
 
-            assertThat(viewModel.pendingConfirmation.value?.ticket).isEqualTo(ticket)
+            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Confirming
+            assertThat(state.ticket).isEqualTo(ticket)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -1,0 +1,449 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
+import com.woocommerce.android.ui.orders.creation.CodeScanningErrorType
+import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.store.SiteStore.SiteError
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class QrLoginScannerViewModelTest : BaseUnitTest() {
+
+    private val ticket = QrLoginPayload.Ticket(token = "tok", siteUrl = "https://store.example")
+
+    private val parser: QrLoginPayloadParser = mock()
+    private val authenticator: QrLoginAuthenticator = mock()
+    private val analyticsTracker: AnalyticsTrackerWrapper = mock()
+
+    private val viewModel by lazy {
+        QrLoginScannerViewModel(
+            savedState = SavedStateHandle(),
+            parser = parser,
+            authenticator = authenticator,
+            analyticsTracker = analyticsTracker
+        )
+    }
+
+    @Before
+    fun setUp() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(ticket)
+        whenever(authenticator.authenticate(ticket)).thenReturn(Result.success(DEFAULT_SITE_ID))
+    }
+
+    @Test
+    fun `given valid ticket and successful auth, when scan confirmed, then emits LoggedIn`() = testBlocking {
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        assertThat(events.last())
+            .isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = DEFAULT_SITE_ID))
+    }
+
+    @Test
+    fun `given valid ticket, when scan succeeds, then pending confirmation exposes host and no exchange`() =
+        testBlocking {
+            viewModel.onScanResult(successScan())
+
+            assertThat(viewModel.pendingConfirmation.value).isEqualTo(
+                QrLoginScannerViewModel.PendingConfirmation(ticket = ticket, host = "store.example")
+            )
+            verify(authenticator, never()).authenticate(any())
+        }
+
+    @Test
+    fun `given pending confirmation, when cancel, then pending is cleared and authenticator not called`() =
+        testBlocking {
+            viewModel.onScanResult(successScan())
+            viewModel.onCancelSite()
+
+            assertThat(viewModel.pendingConfirmation.value).isNull()
+            verify(authenticator, never()).authenticate(any())
+        }
+
+    @Test
+    fun `given pending confirmation, when another scan arrives, then it is ignored`() = testBlocking {
+        viewModel.onScanResult(successScan(RAW_SCAN))
+        viewModel.onScanResult(successScan("second-raw"))
+
+        assertThat(viewModel.pendingConfirmation.value?.ticket).isEqualTo(ticket)
+        verify(parser, never()).parse("second-raw")
+    }
+
+    @Test
+    fun `given canceled confirmation, when next valid scan, then a fresh confirmation is shown`() = testBlocking {
+        viewModel.onScanResult(successScan())
+        viewModel.onCancelSite()
+        viewModel.onScanResult(successScan())
+
+        assertThat(viewModel.pendingConfirmation.value?.ticket).isEqualTo(ticket)
+    }
+
+    @Test
+    fun `given Invalid payload, when scan succeeds, then emits InvalidPayload error`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+
+        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.InvalidPayload)
+    }
+
+    @Test
+    fun `given Invalid payload, when scan succeeds, then authenticator is not called`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
+
+        viewModel.onScanResult(successScan())
+
+        verify(authenticator, never()).authenticate(any())
+    }
+
+    @Test
+    fun `given scanner Failure, when scan result received, then emits Scanner error`() = testBlocking {
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(
+            CodeScannerStatus.Failure(error = "boom", type = CodeScanningErrorType.Unknown)
+        )
+
+        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.Scanner)
+    }
+
+    @Test
+    fun `given NotFound status, when scan result received, then no events emitted`() = testBlocking {
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(CodeScannerStatus.NotFound)
+
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `given token rejected by server, when scan confirmed, then emits TokenRejected error`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginExchangeException.TokenRejected))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.TokenRejected)
+    }
+
+    @Test
+    fun `given malformed exchange response, when scan confirmed, then emits ServerError`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginExchangeException.MalformedResponse))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.ServerError)
+    }
+
+    @Test
+    fun `given server HttpError, when scan confirmed, then emits ServerError`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginExchangeException.HttpError(500)))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.ServerError)
+    }
+
+    @Test
+    fun `given OnChangedException with UNAUTHORIZED site error, when scan confirmed, then emits SiteAuthFailure`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ticket))
+                .thenReturn(Result.failure(siteError(SiteErrorType.UNAUTHORIZED)))
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+            viewModel.onConfirmSite()
+
+            assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.SiteAuthFailure)
+        }
+
+    @Test
+    fun `given OnChangedException with WPCOM connectivity error, when scan confirmed, then emits Network`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ticket))
+                .thenReturn(Result.failure(siteError(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR)))
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+            viewModel.onConfirmSite()
+
+            assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.Network)
+        }
+
+    @Test
+    fun `given OnChangedException with generic site error, when scan confirmed, then emits Unknown`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ticket))
+                .thenReturn(Result.failure(siteError(SiteErrorType.GENERIC_ERROR)))
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+            viewModel.onConfirmSite()
+
+            assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.Unknown)
+        }
+
+    @Test
+    fun `given network error, when scan confirmed, then emits Network error`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginExchangeException.Network))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.Network)
+    }
+
+    @Test
+    fun `given rate limited error, when scan confirmed, then emits RateLimited error`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginExchangeException.RateLimited))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.RateLimited)
+    }
+
+    @Test
+    fun `given endpoint missing, when scan confirmed, then endpointMissing flag is raised`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginExchangeException.EndpointMissing))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        assertThat(events).isEmpty()
+        assertThat(viewModel.endpointMissing.value).isTrue()
+    }
+
+    @Test
+    fun `given endpoint missing flag raised, when retry called, then flag is cleared`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginExchangeException.EndpointMissing))
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+        assertThat(viewModel.endpointMissing.value).isTrue()
+
+        viewModel.onStartOver()
+
+        assertThat(viewModel.endpointMissing.value).isFalse()
+    }
+
+    @Test
+    fun `given endpoint missing flag raised, when another scan arrives, then it is ignored`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginExchangeException.EndpointMissing))
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        viewModel.onScanResult(successScan())
+
+        verify(authenticator, times(1)).authenticate(eq(ticket))
+    }
+
+    @Test
+    fun `given site is not Woo, when auth fails with NotAWooSite, then emits NotAWooSite error`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginAuthenticationException.NotAWooSite))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.NotAWooSite)
+    }
+
+    @Test
+    fun `given user is ineligible, when auth fails, then emits UserNotEligible error`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginAuthenticationException.UserNotEligible(original = null)))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.UserNotEligible)
+    }
+
+    @Test
+    fun `given login succeeded, when another scan arrives, then ignored to avoid double-submit`() = testBlocking {
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+        viewModel.onScanResult(successScan())
+
+        verify(authenticator, times(1)).authenticate(eq(ticket))
+    }
+
+    @Test
+    fun `given exchange failure, when user starts over and rescans, then it is processed`() = testBlocking {
+        whenever(authenticator.authenticate(ticket))
+            .thenReturn(Result.failure(QrLoginExchangeException.Network))
+            .thenReturn(Result.success(99))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+        viewModel.onStartOver()
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        assertThat(events.last()).isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = 99))
+    }
+
+    @Test
+    fun `given Invalid payload, when user starts over and rescans valid, then it is processed`() = testBlocking {
+        whenever(parser.parse("invalid")).thenReturn(QrLoginPayload.Invalid)
+        whenever(parser.parse("valid")).thenReturn(ticket)
+        whenever(authenticator.authenticate(ticket)).thenReturn(Result.success(11))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan("invalid"))
+        viewModel.onStartOver()
+        viewModel.onScanResult(successScan("valid"))
+        viewModel.onConfirmSite()
+
+        assertThat(events.last()).isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = 11))
+    }
+
+    @Test
+    fun `given currentError set, when another scan arrives, then it is ignored`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
+        viewModel.onScanResult(successScan())
+
+        viewModel.onScanResult(successScan("second-raw"))
+
+        verify(parser, never()).parse("second-raw")
+    }
+
+    @Test
+    fun `given an error, when onStartOver, then currentError is cleared`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
+        viewModel.onScanResult(successScan())
+        assertThat(viewModel.currentError.value).isEqualTo(QrLoginScannerViewModel.ErrorReason.InvalidPayload)
+
+        viewModel.onStartOver()
+
+        assertThat(viewModel.currentError.value).isNull()
+    }
+
+    @Test
+    fun `given successful login, when authenticator returns site id, then tracks LOGIN_QR_SUCCESS`() = testBlocking {
+        viewModel.onScanResult(successScan())
+        viewModel.onConfirmSite()
+
+        verify(analyticsTracker).track(AnalyticsEvent.LOGIN_QR_SUCCESS)
+    }
+
+    @Test
+    fun `given scanner binding failure, when delivered as Failure, then tracks scan failed with scanner step`() =
+        testBlocking {
+            viewModel.onScanResult(
+                CodeScannerStatus.Failure(error = "boom", type = CodeScanningErrorType.Unknown)
+            )
+
+            verify(analyticsTracker).track(
+                stat = AnalyticsEvent.LOGIN_QR_SCAN_FAILED,
+                properties = mapOf(AnalyticsTracker.KEY_STEP to "scanner"),
+                errorContext = "CodeScanningErrorType\$Unknown",
+                errorType = "Scanner",
+                errorDescription = "boom"
+            )
+        }
+
+    @Test
+    fun `given exchange network error, when scan confirmed, then tracks scan failed with exchange step`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ticket))
+                .thenReturn(Result.failure(QrLoginExchangeException.Network))
+
+            viewModel.onScanResult(successScan())
+            viewModel.onConfirmSite()
+
+            verify(analyticsTracker).track(
+                stat = AnalyticsEvent.LOGIN_QR_SCAN_FAILED,
+                properties = mapOf(AnalyticsTracker.KEY_STEP to "exchange"),
+                errorContext = "QrLoginScannerViewModel",
+                errorType = "Network",
+                errorDescription = "Network failure during exchange"
+            )
+        }
+
+    @Test
+    fun `given invalid payload, when scan succeeds, then tracks scan failed with payload step`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
+
+        viewModel.onScanResult(successScan())
+
+        verify(analyticsTracker).track(
+            stat = AnalyticsEvent.LOGIN_QR_SCAN_FAILED,
+            properties = mapOf(AnalyticsTracker.KEY_STEP to "payload"),
+            errorContext = null,
+            errorType = "InvalidPayload",
+            errorDescription = "Scanned QR did not match the expected deep link format"
+        )
+    }
+
+    @Test
+    fun `given deep link payload, when onDeepLinkPayload invoked, then exposes pending confirmation`() =
+        testBlocking {
+            viewModel.onDeepLinkPayload(RAW_SCAN)
+
+            assertThat(viewModel.pendingConfirmation.value?.ticket).isEqualTo(ticket)
+        }
+
+    @Test
+    fun `given deep link payload confirmed, when auth succeeds, then emits LoggedIn`() = testBlocking {
+        val events = viewModel.event.captureValues()
+
+        viewModel.onDeepLinkPayload(RAW_SCAN)
+        viewModel.onConfirmSite()
+
+        assertThat(events.last())
+            .isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = DEFAULT_SITE_ID))
+    }
+
+    private fun successScan(raw: String = RAW_SCAN) =
+        CodeScannerStatus.Success(code = raw, format = BarcodeFormat.FormatQRCode)
+
+    private fun siteError(type: SiteErrorType): OnChangedException =
+        OnChangedException(SiteError(type, "boom"))
+
+    private companion object {
+        const val RAW_SCAN = "raw"
+        const val DEFAULT_SITE_ID = 42
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -24,6 +24,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
+import java.net.UnknownHostException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class QrLoginScannerViewModelTest : BaseUnitTest() {
@@ -372,6 +373,20 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
     }
+
+    @Test
+    fun `given UnknownHostException from site discovery, when scan confirmed, then emits Network error`() =
+        testBlocking {
+            whenever(authenticator.authenticate(ticket))
+                .thenReturn(Result.failure(UnknownHostException("mystore.example.com")))
+
+            viewModel.onScanResult(successScan())
+            viewModel.onConfirmSite()
+
+            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.Network)
+            assertThat(state.retryTicket).isEqualTo(ticket)
+        }
 
     @Test
     fun `given retry-eligible error, when onRetryExchange, then exchange is retried with the same ticket`() =


### PR DESCRIPTION
Fixes WOOMOB-2845

### Description

Adds `QrLoginScannerViewModel` (state for authenticating / endpoint-missing / pending-confirmation / current-error, plus `onScanResult`, `onConfirmSite`, `onStartOver`, `onRetryExchange`) and a `QrLoginAvailability` gate that hides QR entirely when the device has no camera or the feature flag is off. The VM holds the last successfully-parsed ticket so transient errors can replay the same exchange via `onRetryExchange` instead of bouncing the user back to the scanner.

This is **Step 4 of 10** in a stacked PR chain — depends on `step-3-qr-login-authenticator`.

### Stacked PR chain
- Step 1: #15733 — foundation: payload type, parser, and analytics events
- Step 2: #15734 — token exchange REST client
- Step 3: #15735 — authenticator orchestrating exchange + site fetch + eligibility
- Step 4: #15736 — scanner ViewModel state machine and feature-flag gate ← **this PR**
- Step 5: #15737 — prologue screen with QR icon, URL pill, and camera-permission gate
- Step 6: #15738 — camera viewfinder, scanner screen, and endpoint-missing fallback
- Step 7: #15739 — fullscreen confirm + error screens with retry-eligible mapping
- Step 8: #15740 — prologue and scanner fragments hosting the Compose surfaces
- Step 9: #15741 — activity wiring and `woocommerce://qr-login` deep link
- Step 10: #15742 — detect wp-admin install QR and guide users to the sign-in QR

### Test Steps

N/A — see the PR for `step-10-qr-login-install-qr-detection` for the full feature test plan. This PR is part of a stacked chain (`status: do not merge`) and is unit-test-covered where applicable.

### Images/gif

N/A — no UI in this slice.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.