### PR TITLE
[WOOMOB-2846] Step 5: QR login — prologue screen with QR icon, URL pill, and camera-permission gate

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -13,12 +14,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.colorResource
@@ -28,6 +34,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
 fun QrLoginPrologueScreen(
@@ -62,6 +72,7 @@ fun QrLoginPrologueScreen(
             verticalArrangement = Arrangement.SpaceBetween
         ) {
             Hero()
+            Buttons(onScanClicked = onScanClicked, onFallbackClicked = onFallbackClicked)
         }
     }
 }
@@ -74,6 +85,8 @@ private fun Hero() {
             .padding(top = dimensionResource(id = R.dimen.major_300)),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        QrIconBadge()
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_200)))
         Text(
             text = stringResource(id = R.string.login_qr_prologue_title),
             style = MaterialTheme.typography.headlineMedium,
@@ -89,11 +102,89 @@ private fun Hero() {
             textAlign = TextAlign.Center
         )
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_125)))
+        UrlBadge()
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_125)))
         Text(
             text = stringResource(id = R.string.login_qr_prologue_step_hint),
             style = MaterialTheme.typography.bodyMedium,
             color = colorResource(id = R.color.prologue_login_on_background_tertiary),
             textAlign = TextAlign.Center
         )
+    }
+}
+
+@Composable
+private fun QrIconBadge() {
+    Box(
+        modifier = Modifier
+            .size(dimensionResource(id = R.dimen.image_major_72))
+            .clip(CircleShape)
+            .background(colorResource(id = R.color.prologue_login_url_badge_background)),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_baseline_qr_code_scanner),
+            contentDescription = null,
+            tint = colorResource(id = R.color.prologue_login_on_background),
+            modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_100))
+        )
+    }
+}
+
+@Composable
+private fun UrlBadge() {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(dimensionResource(id = R.dimen.major_75)))
+            .background(colorResource(id = R.color.prologue_login_url_badge_background))
+            .padding(
+                horizontal = dimensionResource(id = R.dimen.major_125),
+                vertical = dimensionResource(id = R.dimen.major_85)
+            )
+    ) {
+        Text(
+            text = stringResource(id = R.string.login_qr_prologue_url),
+            style = MaterialTheme.typography.titleLarge,
+            color = colorResource(id = R.color.prologue_login_on_background),
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun Buttons(
+    onScanClicked: () -> Unit,
+    onFallbackClicked: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        WCColoredButton(
+            onClick = onScanClicked,
+            text = stringResource(id = R.string.login_qr_prologue_scan_button),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
+        WCTextButton(
+            onClick = onFallbackClicked,
+            contentPadding = PaddingValues(vertical = dimensionResource(id = R.dimen.major_75)),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = stringResource(id = R.string.login_qr_prologue_fallback_link),
+                color = colorResource(id = R.color.prologue_login_on_background),
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun QrLoginPrologueScreenPreview() {
+    WooThemeWithBackground {
+        QrLoginPrologueScreen(onScanClicked = {}, onFallbackClicked = {})
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
@@ -1,0 +1,99 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import com.woocommerce.android.R
+
+@Composable
+fun QrLoginPrologueScreen(
+    onScanClicked: () -> Unit,
+    onFallbackClicked: () -> Unit,
+) {
+    val systemBarsPadding = WindowInsets.systemBars.asPaddingValues()
+    val navBarsPadding = WindowInsets.navigationBars.asPaddingValues()
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colorResource(id = R.color.prologue_login_background_color))
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.img_prologue_bg_white),
+            contentDescription = null,
+            modifier = Modifier.fillMaxSize(),
+            colorFilter = ColorFilter.tint(colorResource(id = R.color.prologue_login_shape_color)),
+            contentScale = ContentScale.Crop
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = dimensionResource(id = R.dimen.major_150))
+                .padding(top = systemBarsPadding.calculateTopPadding())
+                .padding(
+                    bottom = navBarsPadding.calculateBottomPadding()
+                        + dimensionResource(id = R.dimen.major_100)
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Hero()
+        }
+    }
+}
+
+@Composable
+private fun Hero() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = dimensionResource(id = R.dimen.major_300)),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = stringResource(id = R.string.login_qr_prologue_title),
+            style = MaterialTheme.typography.headlineMedium,
+            color = colorResource(id = R.color.prologue_login_on_background),
+            textAlign = TextAlign.Center,
+            fontWeight = FontWeight.SemiBold
+        )
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
+        Text(
+            text = stringResource(id = R.string.login_qr_prologue_subtitle),
+            style = MaterialTheme.typography.bodyLarge,
+            color = colorResource(id = R.color.prologue_login_on_background_secondary),
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_125)))
+        Text(
+            text = stringResource(id = R.string.login_qr_prologue_step_hint),
+            style = MaterialTheme.typography.bodyMedium,
+            color = colorResource(id = R.color.prologue_login_on_background_tertiary),
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
@@ -1,5 +1,9 @@
 package com.woocommerce.android.ui.login.qrlogin
 
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -27,12 +31,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.core.content.ContextCompat
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
@@ -44,6 +50,30 @@ fun QrLoginPrologueScreen(
     onScanClicked: () -> Unit,
     onFallbackClicked: () -> Unit,
 ) {
+    val context = LocalContext.current
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = { granted ->
+            // The scanner asks for the permission again on first composition; if the user just
+            // granted it here, that follow-up returns immediately with no extra dialog.
+            // If the user denied, we stay on the prologue — they can tap again to retry, or
+            // pick the site-URL fallback. We don't navigate to a black scanner-with-permission-
+            // prompt screen.
+            if (granted) onScanClicked()
+        }
+    )
+    val handleScanClicked: () -> Unit = {
+        val alreadyGranted = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.CAMERA
+        ) == PackageManager.PERMISSION_GRANTED
+        if (alreadyGranted) {
+            onScanClicked()
+        } else {
+            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
     val systemBarsPadding = WindowInsets.systemBars.asPaddingValues()
     val navBarsPadding = WindowInsets.navigationBars.asPaddingValues()
     Box(
@@ -72,7 +102,7 @@ fun QrLoginPrologueScreen(
             verticalArrangement = Arrangement.SpaceBetween
         ) {
             Hero()
-            Buttons(onScanClicked = onScanClicked, onFallbackClicked = onFallbackClicked)
+            Buttons(onScanClicked = handleScanClicked, onFallbackClicked = onFallbackClicked)
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
@@ -6,7 +6,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -20,7 +19,9 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -99,9 +100,18 @@ fun QrLoginPrologueScreen(
                         + dimensionResource(id = R.dimen.major_100)
                 ),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.SpaceBetween
         ) {
-            Hero()
+            // Hero scrolls so the fallback link below stays visible in landscape on phones
+            // where the static layout would otherwise push it off the bottom edge.
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState()),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Hero()
+            }
             Buttons(onScanClicked = handleScanClicked, onFallbackClicked = onFallbackClicked)
         }
     }

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -69,6 +69,10 @@
     <color name="prologue_login_background_color">@color/color_surface</color>
     <color name="prologue_login_shape_color">@color/woo_gray_80</color>
     <color name="prologue_login_button_color">@color/color_primary</color>
+    <color name="prologue_login_on_background">@color/woo_white</color>
+    <color name="prologue_login_on_background_secondary">@color/woo_white_alpha_087</color>
+    <color name="prologue_login_on_background_tertiary">@color/woo_white_alpha_060</color>
+    <color name="prologue_login_url_badge_background">#2EFFFFFF</color>
 
     <!--
         Rating widget colors

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -108,6 +108,10 @@
     <color name="prologue_login_background_color">@color/woo_purple_70</color>
     <color name="prologue_login_shape_color">@color/woo_purple_40</color>
     <color name="prologue_login_button_color">@color/white</color>
+    <color name="prologue_login_on_background">@color/woo_white</color>
+    <color name="prologue_login_on_background_secondary">@color/woo_white_alpha_087</color>
+    <color name="prologue_login_on_background_tertiary">@color/woo_white_alpha_060</color>
+    <color name="prologue_login_url_badge_background">#2EFFFFFF</color>
 
     <!--
         Rating widget colors

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -212,6 +212,14 @@
 
     <string name="login_prologue_start_new_store">Starting a new store?</string>
 
+    <!-- QR login prologue -->
+    <string name="login_qr_prologue_title">Scan to sign in</string>
+    <string name="login_qr_prologue_subtitle">On a device where you\'re already signed in, visit:</string>
+    <string name="login_qr_prologue_url" translatable="false">woo.com/mobilelogin</string>
+    <string name="login_qr_prologue_step_hint">Then scan the QR code that appears.</string>
+    <string name="login_qr_prologue_scan_button">Scan QR code</string>
+    <string name="login_qr_prologue_fallback_link">Sign in with site address instead</string>
+
     <string name="login_pick_store">Select store to connect</string>
     <string name="login_non_woo_stores_label">Other sites</string>
     <string name="login_verifying_site">Verifying site…</string>


### PR DESCRIPTION
Fixes WOOMOB-2846

### Description

Adds `QrLoginPrologueScreen` — the first screen the merchant sees when they tap "Log In" on a fresh install: a QR icon, hero copy explaining what's about to happen, the `woo.com/mobilelogin` URL pill so they know where to find the QR on desktop, and a "Sign in with site address instead" fallback link. The camera permission is requested *here*, while the prologue is on screen, so the system permission prompt overlays the purple background instead of the black scanner surface that briefly appeared in earlier iterations. The hero is wrapped in a scrollable column so the fallback link stays visible in landscape on phones.

This is **Step 5 of 10** in a stacked PR chain — depends on `step-4-qr-login-availability-and-viewmodel`.

### Stacked PR chain
- Step 1: #15733 — foundation: payload type, parser, and analytics events
- Step 2: #15734 — token exchange REST client
- Step 3: #15735 — authenticator orchestrating exchange + site fetch + eligibility
- Step 4: #15736 — scanner ViewModel state machine and feature-flag gate
- Step 5: #15737 — prologue screen with QR icon, URL pill, and camera-permission gate ← **this PR**
- Step 6: #15738 — camera viewfinder, scanner screen, and endpoint-missing fallback
- Step 7: #15739 — fullscreen confirm + error screens with retry-eligible mapping
- Step 8: #15740 — prologue and scanner fragments hosting the Compose surfaces
- Step 9: #15741 — activity wiring and `woocommerce://qr-login` deep link
- Step 10: #15742 — detect wp-admin install QR and guide users to the sign-in QR

### Test Steps

N/A — see the PR for `step-10-qr-login-install-qr-detection` for the full feature test plan. This PR is part of a stacked chain (`status: do not merge`) and is unit-test-covered where applicable.

### Images/gif

See test plan in step-10 PR — prologue screen is exercised end-to-end there.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.