### PR TITLE
[WOOMOB-2847] Step 6: QR login — camera viewfinder, scanner screen, and endpoint-missing fallback

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScanner.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.barcodescanner
 
 import android.content.res.Configuration
 import android.util.Size
+import androidx.annotation.StringRes
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.FocusMeteringAction
 import androidx.camera.core.ImageAnalysis
@@ -45,6 +46,8 @@ import androidx.camera.core.Preview as CameraPreview
 fun BarcodeScanner(
     onNewFrame: (ImageProxy) -> Unit,
     onBindingException: (Exception) -> Unit,
+    @StringRes overlayLabel: Int = R.string.barcode_scanning_scan_product_barcode_label,
+    overlayContent: (@Composable () -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -132,12 +135,16 @@ fun BarcodeScanner(
             factory = { previewView },
             modifier = Modifier.fillMaxSize()
         )
-        ScannerOverlay()
+        if (overlayContent != null) {
+            overlayContent()
+        } else {
+            ScannerOverlay(overlayLabel = overlayLabel)
+        }
     }
 }
 
 @Composable
-private fun ScannerOverlay() {
+private fun ScannerOverlay(@StringRes overlayLabel: Int) {
     Column {
         Box(
             modifier = Modifier
@@ -155,7 +162,7 @@ private fun ScannerOverlay() {
         ) {
             Text(
                 modifier = Modifier.padding(dimensionResource(id = R.dimen.major_100)),
-                text = stringResource(R.string.barcode_scanning_scan_product_barcode_label)
+                text = stringResource(overlayLabel)
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScanner.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScanner.kt
@@ -47,7 +47,7 @@ fun BarcodeScanner(
     onNewFrame: (ImageProxy) -> Unit,
     onBindingException: (Exception) -> Unit,
     @StringRes overlayLabel: Int = R.string.barcode_scanning_scan_product_barcode_label,
-    overlayContent: (@Composable () -> Unit)? = null,
+    overlayContent: @Composable () -> Unit = { DefaultScannerOverlay(overlayLabel = overlayLabel) },
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -135,16 +135,12 @@ fun BarcodeScanner(
             factory = { previewView },
             modifier = Modifier.fillMaxSize()
         )
-        if (overlayContent != null) {
-            overlayContent()
-        } else {
-            ScannerOverlay(overlayLabel = overlayLabel)
-        }
+        overlayContent()
     }
 }
 
 @Composable
-private fun ScannerOverlay(@StringRes overlayLabel: Int) {
+internal fun DefaultScannerOverlay(@StringRes overlayLabel: Int) {
     Column {
         Box(
             modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScannerScreen.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.barcodescanner
 import android.content.res.Configuration
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.StringRes
 import androidx.camera.core.ImageProxy
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
@@ -25,11 +26,15 @@ fun BarcodeScannerScreen(
     onBindingException: (Exception) -> Unit,
     permissionState: State<BarcodeScanningViewModel.PermissionState>,
     onResult: (Boolean) -> Unit,
+    @StringRes overlayLabel: Int = R.string.barcode_scanning_scan_product_barcode_label,
+    overlayContent: (@Composable () -> Unit)? = null,
 ) = BarcodeScannerScreen(
     onNewFrame = onNewFrame,
     onBindingException = onBindingException,
     permissionState = permissionState.value,
     onResult = onResult,
+    overlayLabel = overlayLabel,
+    overlayContent = overlayContent,
 )
 
 @Composable
@@ -38,6 +43,8 @@ fun BarcodeScannerScreen(
     onBindingException: (Exception) -> Unit,
     permissionState: BarcodeScanningViewModel.PermissionState,
     onResult: (Boolean) -> Unit,
+    @StringRes overlayLabel: Int = R.string.barcode_scanning_scan_product_barcode_label,
+    overlayContent: (@Composable () -> Unit)? = null,
 ) {
     val cameraPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
@@ -53,6 +60,8 @@ fun BarcodeScannerScreen(
             BarcodeScanner(
                 onNewFrame = onNewFrame,
                 onBindingException = onBindingException,
+                overlayLabel = overlayLabel,
+                overlayContent = overlayContent,
             )
         }
         is BarcodeScanningViewModel.PermissionState.ShouldShowRationale -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/barcodescanner/BarcodeScannerScreen.kt
@@ -27,7 +27,7 @@ fun BarcodeScannerScreen(
     permissionState: State<BarcodeScanningViewModel.PermissionState>,
     onResult: (Boolean) -> Unit,
     @StringRes overlayLabel: Int = R.string.barcode_scanning_scan_product_barcode_label,
-    overlayContent: (@Composable () -> Unit)? = null,
+    overlayContent: @Composable () -> Unit = { DefaultScannerOverlay(overlayLabel = overlayLabel) },
 ) = BarcodeScannerScreen(
     onNewFrame = onNewFrame,
     onBindingException = onBindingException,
@@ -44,7 +44,7 @@ fun BarcodeScannerScreen(
     permissionState: BarcodeScanningViewModel.PermissionState,
     onResult: (Boolean) -> Unit,
     @StringRes overlayLabel: Int = R.string.barcode_scanning_scan_product_barcode_label,
-    overlayContent: (@Composable () -> Unit)? = null,
+    overlayContent: @Composable () -> Unit = { DefaultScannerOverlay(overlayLabel = overlayLabel) },
 ) {
     val cameraPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginEndpointMissingScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginEndpointMissingScreen.kt
@@ -1,0 +1,82 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun QrLoginEndpointMissingScreen(
+    onEnterUrlClicked: () -> Unit,
+    onRetryClicked: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+            .padding(horizontal = dimensionResource(id = R.dimen.major_150)),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.img_woo_generic_error),
+            contentDescription = null,
+            modifier = Modifier.size(120.dp)
+        )
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_150)))
+        Text(
+            text = stringResource(id = R.string.login_qr_endpoint_missing_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        Text(
+            text = stringResource(id = R.string.login_qr_endpoint_missing_body),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_200)))
+        WCColoredButton(
+            onClick = onEnterUrlClicked,
+            text = stringResource(id = R.string.login_qr_endpoint_missing_enter_url),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
+        WCOutlinedButton(
+            onClick = onRetryClicked,
+            text = stringResource(id = R.string.login_qr_endpoint_missing_retry),
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun QrLoginEndpointMissingScreenPreview() {
+    WooThemeWithBackground {
+        QrLoginEndpointMissingScreen(onEnterUrlClicked = {}, onRetryClicked = {})
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
@@ -14,6 +14,8 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.barcodescanner.BarcodeScannerScreen
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel
 import com.woocommerce.android.ui.compose.component.ProgressDialog
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.ErrorReason
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState
 
 /**
  * Renders the QR-first login screen. Routes between the camera scanner, the endpoint-missing
@@ -23,8 +25,7 @@ import com.woocommerce.android.ui.compose.component.ProgressDialog
 @Composable
 fun QrLoginScannerScreen(
     permissionState: State<BarcodeScanningViewModel.PermissionState>,
-    authenticating: Boolean,
-    endpointMissing: Boolean,
+    uiState: UiState,
     showCamera: Boolean,
     onNewFrame: (ImageProxy) -> Unit,
     onBindingException: (Exception) -> Unit,
@@ -48,14 +49,14 @@ fun QrLoginScannerScreen(
             )
         }
 
-        if (endpointMissing) {
+        if (uiState is UiState.Error && uiState.reason == ErrorReason.EndpointMissing) {
             QrLoginEndpointMissingScreen(
                 onEnterUrlClicked = onFallbackClicked,
                 onRetryClicked = onStartOver,
             )
         }
 
-        if (authenticating) {
+        if (uiState is UiState.Authenticating) {
             ProgressDialog(
                 title = "",
                 subtitle = stringResource(id = R.string.login_qr_scanner_authenticating),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
@@ -1,0 +1,69 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import androidx.camera.core.ImageProxy
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.window.DialogProperties
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.barcodescanner.BarcodeScannerScreen
+import com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel
+import com.woocommerce.android.ui.compose.component.ProgressDialog
+
+/**
+ * Renders the QR-first login screen. Routes between the camera scanner, the endpoint-missing
+ * fallback, and the signing-in progress dialog. The fragment plumbs camera permissions and the
+ * post-login handoff; this composable is purely UI routing.
+ */
+@Composable
+fun QrLoginScannerScreen(
+    permissionState: State<BarcodeScanningViewModel.PermissionState>,
+    authenticating: Boolean,
+    endpointMissing: Boolean,
+    showCamera: Boolean,
+    onNewFrame: (ImageProxy) -> Unit,
+    onBindingException: (Exception) -> Unit,
+    onPermissionResult: (Boolean) -> Unit,
+    onStartOver: () -> Unit,
+    onFallbackClicked: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        if (showCamera) {
+            BarcodeScannerScreen(
+                onNewFrame = onNewFrame,
+                onBindingException = onBindingException,
+                permissionState = permissionState,
+                onResult = onPermissionResult,
+                overlayLabel = R.string.login_qr_scanner_hint,
+                overlayContent = { QrLoginViewfinder() }
+            )
+        }
+
+        if (endpointMissing) {
+            QrLoginEndpointMissingScreen(
+                onEnterUrlClicked = onFallbackClicked,
+                onRetryClicked = onStartOver,
+            )
+        }
+
+        if (authenticating) {
+            ProgressDialog(
+                title = "",
+                subtitle = stringResource(id = R.string.login_qr_scanner_authenticating),
+                properties = DialogProperties(
+                    dismissOnBackPress = false,
+                    dismissOnClickOutside = false
+                )
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginViewfinder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginViewfinder.kt
@@ -1,23 +1,21 @@
 package com.woocommerce.android.ui.login.qrlogin
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -29,7 +27,6 @@ import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import kotlin.math.min
@@ -43,98 +40,91 @@ private val FrameRadius = 24.dp
 
 @Composable
 fun QrLoginViewfinder() {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .drawWithContent {
-                drawContent()
-                val side = min(size.width, size.height) * FRAME_FRACTION
-                val left = (size.width - side) / 2f
-                val top = (size.height - side) / 2f
-                val radiusPx = FrameRadius.toPx()
-                val cornerStrokePx = CornerStroke.toPx()
-                val arm = CornerArm.toPx()
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Layer 1 (bottom): scrim + brackets, drawn directly on the camera preview.
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val side = min(size.width, size.height) * FRAME_FRACTION
+            val left = (size.width - side) / 2f
+            val top = (size.height - side) / 2f
+            val radiusPx = FrameRadius.toPx()
+            val cornerStrokePx = CornerStroke.toPx()
+            val arm = CornerArm.toPx()
 
-                // Scrim with a rounded-rect hole. EvenOdd fill creates the cutout: the outer
-                // rectangle is filled, the inner rounded rect punches through.
-                val scrim = Path().apply {
-                    fillType = PathFillType.EvenOdd
-                    addRect(Rect(Offset.Zero, size))
-                    addRoundRect(
-                        RoundRect(
-                            rect = Rect(Offset(left, top), Size(side, side)),
-                            cornerRadius = CornerRadius(radiusPx)
-                        )
+            // Scrim with a rounded-rect hole. EvenOdd fill creates the cutout: the outer
+            // rectangle is filled, the inner rounded rect punches through.
+            val scrim = Path().apply {
+                fillType = PathFillType.EvenOdd
+                addRect(Rect(Offset.Zero, size))
+                addRoundRect(
+                    RoundRect(
+                        rect = Rect(Offset(left, top), Size(side, side)),
+                        cornerRadius = CornerRadius(radiusPx)
                     )
-                }
-                drawPath(path = scrim, color = ScrimColor)
-
-                // Bold corner brackets
-                val r = left + side
-                val b = top + side
-                val corners = Path().apply {
-                    // top-left
-                    moveTo(left, top + arm)
-                    lineTo(left, top + radiusPx)
-                    quadraticTo(left, top, left + radiusPx, top)
-                    lineTo(left + arm, top)
-                    // top-right
-                    moveTo(r - arm, top)
-                    lineTo(r - radiusPx, top)
-                    quadraticTo(r, top, r, top + radiusPx)
-                    lineTo(r, top + arm)
-                    // bottom-right
-                    moveTo(r, b - arm)
-                    lineTo(r, b - radiusPx)
-                    quadraticTo(r, b, r - radiusPx, b)
-                    lineTo(r - arm, b)
-                    // bottom-left
-                    moveTo(left + arm, b)
-                    lineTo(left + radiusPx, b)
-                    quadraticTo(left, b, left, b - radiusPx)
-                    lineTo(left, b - arm)
-                }
-                drawPath(
-                    path = corners,
-                    color = CornerColor,
-                    style = Stroke(width = cornerStrokePx)
                 )
             }
-    ) {
+            drawPath(path = scrim, color = ScrimColor)
+
+            // Bold corner brackets
+            val r = left + side
+            val b = top + side
+            val corners = Path().apply {
+                // top-left
+                moveTo(left, top + arm)
+                lineTo(left, top + radiusPx)
+                quadraticTo(left, top, left + radiusPx, top)
+                lineTo(left + arm, top)
+                // top-right
+                moveTo(r - arm, top)
+                lineTo(r - radiusPx, top)
+                quadraticTo(r, top, r, top + radiusPx)
+                lineTo(r, top + arm)
+                // bottom-right
+                moveTo(r, b - arm)
+                lineTo(r, b - radiusPx)
+                quadraticTo(r, b, r - radiusPx, b)
+                lineTo(r - arm, b)
+                // bottom-left
+                moveTo(left + arm, b)
+                lineTo(left + radiusPx, b)
+                quadraticTo(left, b, left, b - radiusPx)
+                lineTo(left, b - arm)
+            }
+            drawPath(
+                path = corners,
+                color = CornerColor,
+                style = Stroke(width = cornerStrokePx)
+            )
+        }
+
+        // Layer 2 (top): the URL pill, rendered on top of the scrim so its background isn't
+        // dimmed by the overlay.
         Column(
             modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Bottom
         ) {
-            UrlPill()
-            Spacer(Modifier.height(16.dp))
-            Text(
-                text = stringResource(id = R.string.login_qr_scanner_hint),
-                color = Color.White.copy(alpha = 0.85f),
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 32.dp)
-            )
+            VisitUrlPill()
             Spacer(Modifier.height(48.dp))
         }
     }
 }
 
 @Composable
-private fun UrlPill() {
+private fun VisitUrlPill() {
     Box(
         modifier = Modifier
             .clip(RoundedCornerShape(20.dp))
-            .background(Color.Black.copy(alpha = 0.55f))
-            .padding(horizontal = 20.dp, vertical = 10.dp)
+            .background(Color.Black.copy(alpha = 0.85f))
+            .padding(horizontal = 24.dp, vertical = 14.dp)
     ) {
         Text(
-            text = stringResource(id = R.string.login_qr_prologue_url),
+            text = stringResource(
+                id = R.string.login_qr_scanner_visit_url,
+                stringResource(id = R.string.login_qr_prologue_url)
+            ),
             color = Color.White,
             fontWeight = FontWeight.SemiBold,
-            style = MaterialTheme.typography.titleSmall
+            style = MaterialTheme.typography.titleMedium
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginViewfinder.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginViewfinder.kt
@@ -1,0 +1,140 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import kotlin.math.min
+
+private val ScrimColor = Color(0xB3000000)
+private val CornerColor = Color(0xFFB475F0)
+private const val FRAME_FRACTION = 0.62f
+private val CornerStroke = 4.dp
+private val CornerArm = 28.dp
+private val FrameRadius = 24.dp
+
+@Composable
+fun QrLoginViewfinder() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .drawWithContent {
+                drawContent()
+                val side = min(size.width, size.height) * FRAME_FRACTION
+                val left = (size.width - side) / 2f
+                val top = (size.height - side) / 2f
+                val radiusPx = FrameRadius.toPx()
+                val cornerStrokePx = CornerStroke.toPx()
+                val arm = CornerArm.toPx()
+
+                // Scrim with a rounded-rect hole. EvenOdd fill creates the cutout: the outer
+                // rectangle is filled, the inner rounded rect punches through.
+                val scrim = Path().apply {
+                    fillType = PathFillType.EvenOdd
+                    addRect(Rect(Offset.Zero, size))
+                    addRoundRect(
+                        RoundRect(
+                            rect = Rect(Offset(left, top), Size(side, side)),
+                            cornerRadius = CornerRadius(radiusPx)
+                        )
+                    )
+                }
+                drawPath(path = scrim, color = ScrimColor)
+
+                // Bold corner brackets
+                val r = left + side
+                val b = top + side
+                val corners = Path().apply {
+                    // top-left
+                    moveTo(left, top + arm)
+                    lineTo(left, top + radiusPx)
+                    quadraticTo(left, top, left + radiusPx, top)
+                    lineTo(left + arm, top)
+                    // top-right
+                    moveTo(r - arm, top)
+                    lineTo(r - radiusPx, top)
+                    quadraticTo(r, top, r, top + radiusPx)
+                    lineTo(r, top + arm)
+                    // bottom-right
+                    moveTo(r, b - arm)
+                    lineTo(r, b - radiusPx)
+                    quadraticTo(r, b, r - radiusPx, b)
+                    lineTo(r - arm, b)
+                    // bottom-left
+                    moveTo(left + arm, b)
+                    lineTo(left + radiusPx, b)
+                    quadraticTo(left, b, left, b - radiusPx)
+                    lineTo(left, b - arm)
+                }
+                drawPath(
+                    path = corners,
+                    color = CornerColor,
+                    style = Stroke(width = cornerStrokePx)
+                )
+            }
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Bottom
+        ) {
+            UrlPill()
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = stringResource(id = R.string.login_qr_scanner_hint),
+                color = Color.White.copy(alpha = 0.85f),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp)
+            )
+            Spacer(Modifier.height(48.dp))
+        }
+    }
+}
+
+@Composable
+private fun UrlPill() {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(Color.Black.copy(alpha = 0.55f))
+            .padding(horizontal = 20.dp, vertical = 10.dp)
+    ) {
+        Text(
+            text = stringResource(id = R.string.login_qr_prologue_url),
+            color = Color.White,
+            fontWeight = FontWeight.SemiBold,
+            style = MaterialTheme.typography.titleSmall
+        )
+    }
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -220,6 +220,7 @@
     <string name="login_qr_prologue_scan_button">Scan QR code</string>
     <string name="login_qr_prologue_fallback_link">Sign in with site address instead</string>
     <string name="login_qr_scanner_hint">Center the QR code in the frame</string>
+    <string name="login_qr_scanner_visit_url">Visit %1$s</string>
     <string name="login_qr_scanner_authenticating">Signing you in…</string>
     <string name="login_qr_endpoint_missing_title">This store can\'t complete QR login</string>
     <string name="login_qr_endpoint_missing_body">Your WooCommerce plugin doesn\'t support QR login. Please update WooCommerce on your store and try again, or sign in by entering your site URL.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -219,6 +219,12 @@
     <string name="login_qr_prologue_step_hint">Then scan the QR code that appears.</string>
     <string name="login_qr_prologue_scan_button">Scan QR code</string>
     <string name="login_qr_prologue_fallback_link">Sign in with site address instead</string>
+    <string name="login_qr_scanner_hint">Center the QR code in the frame</string>
+    <string name="login_qr_scanner_authenticating">Signing you in…</string>
+    <string name="login_qr_endpoint_missing_title">This store can\'t complete QR login</string>
+    <string name="login_qr_endpoint_missing_body">Your WooCommerce plugin doesn\'t support QR login. Please update WooCommerce on your store and try again, or sign in by entering your site URL.</string>
+    <string name="login_qr_endpoint_missing_enter_url">Enter site URL instead</string>
+    <string name="login_qr_endpoint_missing_retry">Try scanning again</string>
 
     <string name="login_pick_store">Select store to connect</string>
     <string name="login_non_woo_stores_label">Other sites</string>


### PR DESCRIPTION
Fixes WOOMOB-2847

### Description

Adds the camera-side UI: `QrLoginViewfinder` (centered cutout, corner brackets, "Visit woo.com/mobilelogin" pill rendered above the scrim with high-contrast styling so it's readable on light camera previews), `QrLoginScannerScreen` routing camera + endpoint-missing + signing-in states inside a single Box so a non-black background is always visible, and the fullscreen "This store can't complete QR login" screen for stores whose WooCommerce plugin doesn't expose the QR endpoint.

This is **Step 6 of 10** in a stacked PR chain — depends on `step-5-qr-login-prologue-screen`.

### Stacked PR chain
- Step 1: #15733 — foundation: payload type, parser, and analytics events
- Step 2: #15734 — token exchange REST client
- Step 3: #15735 — authenticator orchestrating exchange + site fetch + eligibility
- Step 4: #15736 — scanner ViewModel state machine and feature-flag gate
- Step 5: #15737 — prologue screen with QR icon, URL pill, and camera-permission gate
- Step 6: #15738 — camera viewfinder, scanner screen, and endpoint-missing fallback ← **this PR**
- Step 7: #15739 — fullscreen confirm + error screens with retry-eligible mapping
- Step 8: #15740 — prologue and scanner fragments hosting the Compose surfaces
- Step 9: #15741 — activity wiring and `woocommerce://qr-login` deep link
- Step 10: #15742 — detect wp-admin install QR and guide users to the sign-in QR

### Test Steps

N/A — see the PR for `step-10-qr-login-install-qr-detection` for the full feature test plan. This PR is part of a stacked chain (`status: do not merge`) and is unit-test-covered where applicable.

### Images/gif

See test plan in step-10 PR — viewfinder + scanner screen are exercised end-to-end there.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.