### PR TITLE
[WOOMOB-2849] Step 8: QR login — prologue and scanner fragments hosting the Compose surfaces

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueFragment.kt
@@ -1,0 +1,84 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.login.DynamicEdgeToEdgeActivity
+import com.woocommerce.android.ui.login.UnifiedLoginTracker
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+/**
+ * QR-first login prologue shown after the merchant taps "Login to Store" when
+ * [com.woocommerce.android.util.FeatureFlag.QR_LOGIN] is on.
+ *
+ * Offers a single primary action ("Scan QR code") and a fallback link into the existing
+ * credentials flow for merchants without access to their computer.
+ */
+@AndroidEntryPoint
+class QrLoginPrologueFragment : Fragment() {
+    companion object {
+        const val TAG = "qr-login-prologue-fragment"
+    }
+
+    interface Listener {
+        fun onQrLoginScanClicked()
+        fun onQrLoginFallbackClicked()
+    }
+
+    @Inject
+    lateinit var unifiedLoginTracker: UnifiedLoginTracker
+
+    @Inject
+    lateinit var analyticsTracker: AnalyticsTrackerWrapper
+
+    private var listener: Listener? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = composeView {
+        QrLoginPrologueScreen(
+            onScanClicked = {
+                analyticsTracker.track(AnalyticsEvent.LOGIN_QR_PROLOGUE_SCAN_TAPPED)
+                unifiedLoginTracker.trackClick(UnifiedLoginTracker.Click.LOGIN_QR_SCAN)
+                listener?.onQrLoginScanClicked()
+            },
+            onFallbackClicked = {
+                analyticsTracker.track(AnalyticsEvent.LOGIN_QR_PROLOGUE_FALLBACK_TAPPED)
+                unifiedLoginTracker.trackClick(UnifiedLoginTracker.Click.LOGIN_QR_FALLBACK)
+                listener?.onQrLoginFallbackClicked()
+            }
+        )
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        (activity as? DynamicEdgeToEdgeActivity)?.enableDynamicEdgeToEdge(forceDarkStatusBar = true)
+        if (savedInstanceState == null) {
+            analyticsTracker.track(AnalyticsEvent.LOGIN_QR_PROLOGUE_SHOWN)
+            unifiedLoginTracker.track(UnifiedLoginTracker.Flow.LOGIN_QR, UnifiedLoginTracker.Step.QR_PROLOGUE)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        unifiedLoginTracker.setFlowAndStep(UnifiedLoginTracker.Flow.LOGIN_QR, UnifiedLoginTracker.Step.QR_PROLOGUE)
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        listener = context as? Listener
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        listener = null
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -14,12 +14,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
-import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import org.wordpress.android.login.LoginListener
 
 /**
  * Hosts [QrLoginScannerScreen] for the QR-first login flow. Plumbs camera permissions, the
@@ -36,7 +34,9 @@ class QrLoginScannerFragment : Fragment() {
         /**
          * Creates an instance that skips the camera preview and feeds [rawPayload] (a
          * `woocommerce://qr-login?...` URI) straight into the login pipeline — used when the
-         * user opens the deep link from a browser.
+         * user opens the deep link from a browser. The payload is held in [arguments] only
+         * briefly: the fragment moves it into a transient field and clears [arguments] in
+         * [onCreate] so the single-use token is never parcelled into fragment instance state.
          */
         fun forDeepLink(rawPayload: String): QrLoginScannerFragment = QrLoginScannerFragment().apply {
             arguments = Bundle().apply { putString(ARG_DEEP_LINK_PAYLOAD, rawPayload) }
@@ -51,11 +51,10 @@ class QrLoginScannerFragment : Fragment() {
     private val scannerViewModel: BarcodeScanningViewModel by viewModels()
     private val qrLoginViewModel: QrLoginScannerViewModel by viewModels()
 
-    private val deepLinkPayload: String?
-        get() = arguments?.getString(ARG_DEEP_LINK_PAYLOAD)
-
-    // Captured once at fragment creation so subsequent reads survive `arguments?.remove(...)`.
-    // Stays false on process-death recovery so the user falls back to the scanner.
+    // Captured once at fragment creation. Kept in memory only — never persisted to
+    // saved-instance-state — and consumed in onViewCreated. On process-death recovery this
+    // stays null so the user falls back to the scanner instead of replaying a stale token.
+    private var pendingDeepLinkPayload: String? = null
     private var isDeepLinkEntry: Boolean = false
 
     @Inject
@@ -65,7 +64,13 @@ class QrLoginScannerFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        isDeepLinkEntry = savedInstanceState == null && deepLinkPayload != null
+        val payload = arguments?.getString(ARG_DEEP_LINK_PAYLOAD)
+        // Strip the payload from arguments before any save-state cycle can persist it.
+        arguments = null
+        if (savedInstanceState == null && payload != null) {
+            pendingDeepLinkPayload = payload
+            isDeepLinkEntry = true
+        }
     }
 
     override fun onCreateView(
@@ -76,16 +81,10 @@ class QrLoginScannerFragment : Fragment() {
         val permissionState = scannerViewModel.permissionState.observeAsState(
             initial = BarcodeScanningViewModel.PermissionState.Unknown
         )
-        val authenticating by qrLoginViewModel.isAuthenticating.collectAsStateWithLifecycle()
-        val endpointMissing by qrLoginViewModel.endpointMissing.collectAsStateWithLifecycle()
-        val pendingConfirmation by qrLoginViewModel.pendingConfirmation.collectAsStateWithLifecycle()
-        val currentError by qrLoginViewModel.currentError.collectAsStateWithLifecycle()
+        val uiState by qrLoginViewModel.uiState.collectAsStateWithLifecycle()
         QrLoginScannerScreen(
             permissionState = permissionState,
-            authenticating = authenticating,
-            endpointMissing = endpointMissing,
-            pendingConfirmation = pendingConfirmation,
-            currentError = currentError,
+            uiState = uiState,
             showCamera = !isDeepLinkEntry,
             onNewFrame = scannerViewModel::onNewFrame,
             onBindingException = scannerViewModel::onBindingException,
@@ -108,13 +107,8 @@ class QrLoginScannerFragment : Fragment() {
         observeQrLoginEvents()
         if (savedInstanceState == null) {
             unifiedLoginTracker.track(UnifiedLoginTracker.Flow.LOGIN_QR, UnifiedLoginTracker.Step.QR_SCAN)
-            deepLinkPayload?.let { payload ->
-                qrLoginViewModel.onDeepLinkPayload(payload)
-                // Drop the raw deep link from fragment arguments so it isn't parcelled into
-                // saved-instance-state / recents, and so a state-loss recovery falls back to the
-                // scanner instead of replaying a single-use token.
-                arguments?.remove(ARG_DEEP_LINK_PAYLOAD)
-            }
+            pendingDeepLinkPayload?.let { qrLoginViewModel.onDeepLinkPayload(it) }
+            pendingDeepLinkPayload = null
         }
     }
 
@@ -191,20 +185,8 @@ class QrLoginScannerFragment : Fragment() {
     private fun handleLoggedIn(localSiteId: Int) {
         // Stop the camera before handing off so the preview doesn't leak.
         scannerViewModel.stopCodesRecognition()
-        val activeListener = listener
-        if (activeListener != null) {
-            activeListener.onQrLoginCompleted(localSiteId)
-            return
-        }
-        val activity = requireActivity()
-        val loginListener = activity as? LoginListener
-        if (loginListener == null) {
-            WooLog.e(
-                WooLog.T.LOGIN,
-                "QR login finished but ${activity.javaClass.simpleName} is not a Listener or LoginListener"
-            )
-            return
-        }
-        loginListener.loggedInViaUsernamePassword(arrayListOf(localSiteId))
+        requireNotNull(listener) {
+            "${requireActivity().javaClass.simpleName} must implement QrLoginScannerFragment.Listener"
+        }.onQrLoginCompleted(localSiteId)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -98,6 +98,7 @@ class QrLoginScannerFragment : Fragment() {
             onConfirmSite = qrLoginViewModel::onConfirmSite,
             onCancelSite = ::handleCancelSite,
             onStartOver = ::handleStartOver,
+            onRetryExchange = qrLoginViewModel::onRetryExchange,
             onFallbackClicked = { listener?.onQrLoginFallbackClicked() },
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -1,0 +1,209 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import android.Manifest
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel
+import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.login.UnifiedLoginTracker
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooPermissionUtils
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import org.wordpress.android.login.LoginListener
+
+/**
+ * Hosts [QrLoginScannerScreen] for the QR-first login flow. Plumbs camera permissions, the
+ * deep-link payload, and the post-login handoff back to the activity; the conditional UI lives
+ * in the screen composable.
+ */
+@AndroidEntryPoint
+class QrLoginScannerFragment : Fragment() {
+    companion object {
+        const val TAG = "qr-login-scanner-fragment"
+        const val KEY_CAMERA_PERMISSION = Manifest.permission.CAMERA
+        private const val ARG_DEEP_LINK_PAYLOAD = "arg-deep-link-payload"
+
+        /**
+         * Creates an instance that skips the camera preview and feeds [rawPayload] (a
+         * `woocommerce://qr-login?...` URI) straight into the login pipeline — used when the
+         * user opens the deep link from a browser.
+         */
+        fun forDeepLink(rawPayload: String): QrLoginScannerFragment = QrLoginScannerFragment().apply {
+            arguments = Bundle().apply { putString(ARG_DEEP_LINK_PAYLOAD, rawPayload) }
+        }
+    }
+
+    interface Listener {
+        fun onQrLoginCompleted(localSiteId: Int)
+        fun onQrLoginFallbackClicked()
+    }
+
+    private val scannerViewModel: BarcodeScanningViewModel by viewModels()
+    private val qrLoginViewModel: QrLoginScannerViewModel by viewModels()
+
+    private val deepLinkPayload: String?
+        get() = arguments?.getString(ARG_DEEP_LINK_PAYLOAD)
+
+    // Captured once at fragment creation so subsequent reads survive `arguments?.remove(...)`.
+    // Stays false on process-death recovery so the user falls back to the scanner.
+    private var isDeepLinkEntry: Boolean = false
+
+    @Inject
+    lateinit var unifiedLoginTracker: UnifiedLoginTracker
+
+    private var listener: Listener? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        isDeepLinkEntry = savedInstanceState == null && deepLinkPayload != null
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = composeView {
+        val permissionState = scannerViewModel.permissionState.observeAsState(
+            initial = BarcodeScanningViewModel.PermissionState.Unknown
+        )
+        val authenticating by qrLoginViewModel.isAuthenticating.collectAsStateWithLifecycle()
+        val endpointMissing by qrLoginViewModel.endpointMissing.collectAsStateWithLifecycle()
+        val pendingConfirmation by qrLoginViewModel.pendingConfirmation.collectAsStateWithLifecycle()
+        val currentError by qrLoginViewModel.currentError.collectAsStateWithLifecycle()
+        QrLoginScannerScreen(
+            permissionState = permissionState,
+            authenticating = authenticating,
+            endpointMissing = endpointMissing,
+            pendingConfirmation = pendingConfirmation,
+            currentError = currentError,
+            showCamera = !isDeepLinkEntry,
+            onNewFrame = scannerViewModel::onNewFrame,
+            onBindingException = scannerViewModel::onBindingException,
+            onPermissionResult = { granted ->
+                scannerViewModel.updatePermissionState(
+                    granted,
+                    shouldShowRequestPermissionRationale(KEY_CAMERA_PERMISSION)
+                )
+            },
+            onConfirmSite = qrLoginViewModel::onConfirmSite,
+            onCancelSite = ::handleCancelSite,
+            onStartOver = ::handleStartOver,
+            onFallbackClicked = { listener?.onQrLoginFallbackClicked() },
+        )
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        observeScannerEvents()
+        observeQrLoginEvents()
+        if (savedInstanceState == null) {
+            unifiedLoginTracker.track(UnifiedLoginTracker.Flow.LOGIN_QR, UnifiedLoginTracker.Step.QR_SCAN)
+            deepLinkPayload?.let { payload ->
+                qrLoginViewModel.onDeepLinkPayload(payload)
+                // Drop the raw deep link from fragment arguments so it isn't parcelled into
+                // saved-instance-state / recents, and so a state-loss recovery falls back to the
+                // scanner instead of replaying a single-use token.
+                arguments?.remove(ARG_DEEP_LINK_PAYLOAD)
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (!isDeepLinkEntry) {
+            scannerViewModel.startCodesRecognition()
+        }
+        unifiedLoginTracker.setFlowAndStep(UnifiedLoginTracker.Flow.LOGIN_QR, UnifiedLoginTracker.Step.QR_SCAN)
+    }
+
+    override fun onPause() {
+        if (!isDeepLinkEntry) {
+            scannerViewModel.stopCodesRecognition()
+        }
+        super.onPause()
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        listener = context as? Listener
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        listener = null
+    }
+
+    private fun observeScannerEvents() {
+        scannerViewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is BarcodeScanningViewModel.ScanningEvents.LaunchCameraPermission ->
+                    event.cameraLauncher.launch(KEY_CAMERA_PERMISSION)
+
+                is BarcodeScanningViewModel.ScanningEvents.OpenAppSettings ->
+                    WooPermissionUtils.showAppSettings(requireContext(), false)
+
+                is BarcodeScanningViewModel.ScanningEvents.OnScanningResult ->
+                    qrLoginViewModel.onScanResult(event.status)
+
+                is Exit -> requireActivity().onBackPressedDispatcher.onBackPressed()
+            }
+        }
+    }
+
+    private fun observeQrLoginEvents() {
+        qrLoginViewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is QrLoginScannerViewModel.Dispatch.LoggedIn -> handleLoggedIn(event.localSiteId)
+            }
+        }
+    }
+
+    /**
+     * In camera mode, dismissing confirm just clears the overlay and the camera resumes.
+     * In deep-link mode there is no camera underneath, so the same dismissal would leave the
+     * user on a blank surface — exit the fragment instead.
+     */
+    private fun handleCancelSite() {
+        qrLoginViewModel.onCancelSite()
+        if (isDeepLinkEntry) requireActivity().onBackPressedDispatcher.onBackPressed()
+    }
+
+    /**
+     * Same reasoning as [handleCancelSite]: error/endpoint-missing screens in deep-link mode
+     * have nothing to fall back to once dismissed, so we exit. In camera mode the scanner
+     * resumes underneath as soon as the overlay is cleared.
+     */
+    private fun handleStartOver() {
+        qrLoginViewModel.onStartOver()
+        if (isDeepLinkEntry) requireActivity().onBackPressedDispatcher.onBackPressed()
+    }
+
+    private fun handleLoggedIn(localSiteId: Int) {
+        // Stop the camera before handing off so the preview doesn't leak.
+        scannerViewModel.stopCodesRecognition()
+        val activeListener = listener
+        if (activeListener != null) {
+            activeListener.onQrLoginCompleted(localSiteId)
+            return
+        }
+        val activity = requireActivity()
+        val loginListener = activity as? LoginListener
+        if (loginListener == null) {
+            WooLog.e(
+                WooLog.T.LOGIN,
+                "QR login finished but ${activity.javaClass.simpleName} is not a Listener or LoginListener"
+            )
+            return
+        }
+        loginListener.loggedInViaUsernamePassword(arrayListOf(localSiteId))
+    }
+}


### PR DESCRIPTION
Fixes WOOMOB-2849

### Description

Adds `QrLoginPrologueFragment` and `QrLoginScannerFragment` — the Fragment hosts that wire the Compose screens (steps 5–7) into the existing login navigation. Plumbs the post-login handoff back to the listener, handles deep-link entry vs camera entry differently for back-press / cancel (deep-link entry exits the QR flow on cancel; camera entry returns to the prologue), and passes the ViewModel callbacks into the screens including the `onRetryExchange` retry-with-same-ticket wiring.

This is **Step 8 of 10** in a stacked PR chain — depends on `step-7-qr-login-confirm-and-error-screens`.

### Stacked PR chain
- Step 1: #15733 — foundation: payload type, parser, and analytics events
- Step 2: #15734 — token exchange REST client
- Step 3: #15735 — authenticator orchestrating exchange + site fetch + eligibility
- Step 4: #15736 — scanner ViewModel state machine and feature-flag gate
- Step 5: #15737 — prologue screen with QR icon, URL pill, and camera-permission gate
- Step 6: #15738 — camera viewfinder, scanner screen, and endpoint-missing fallback
- Step 7: #15739 — fullscreen confirm + error screens with retry-eligible mapping
- Step 8: #15740 — prologue and scanner fragments hosting the Compose surfaces ← **this PR**
- Step 9: #15741 — activity wiring and `woocommerce://qr-login` deep link
- Step 10: #15742 — detect wp-admin install QR and guide users to the sign-in QR

### Test Steps

N/A — see the PR for `step-10-qr-login-install-qr-detection` for the full feature test plan. This PR is part of a stacked chain (`status: do not merge`) and is unit-test-covered where applicable.

### Images/gif

See test plan in step-10 PR — fragments are exercised end-to-end there.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.