### PR TITLE
[WOOMOB-2850] Step 9: QR login — activity wiring and woocommerce://qr-login deep link

### DIFF
--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -102,6 +102,7 @@
                 <data android:scheme="woocommerce" />
                 <data android:host="jetpack-connected" />
                 <data android:host="app-login" />
+                <data android:host="qr-login" />
             </intent-filter>
         </activity>
         <activity

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -210,10 +210,10 @@ class LoginActivity :
                 intent?.action == Intent.ACTION_VIEW &&
                 intent.data?.authority == QR_LOGIN_AUTHORITY -> {
                 intent.data?.let { uri -> handleQrLoginUri(uri) }
-                // Drop the deep-link payload so a config change or process restart doesn't
-                // re-push the scanner fragment with the same (now-invalid) token.
-                intent.data = null
-                intent.action = null
+                // Replace the activity intent so a process restart from recents cannot replay
+                // the single-use token. Mutating fields on the in-memory Intent is not enough —
+                // Android restores getIntent() from the originally launched intent on cold start.
+                setIntent(Intent())
             }
 
             hasJetpackConnectedIntent() -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -53,6 +53,9 @@ import com.woocommerce.android.ui.login.error.LoginNotWPDialogFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginEmailPasswordFragment
 import com.woocommerce.android.ui.login.overrides.WooLoginSiteAddressFragment
+import com.woocommerce.android.ui.login.qrlogin.QrLoginAvailability
+import com.woocommerce.android.ui.login.qrlogin.QrLoginPrologueFragment
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerFragment
 import com.woocommerce.android.ui.login.sitecredentials.LoginSiteCredentialsFragment
 import com.woocommerce.android.ui.login.sitecredentials.applicationpassword.ApplicationPasswordTutorialFragment
 import com.woocommerce.android.ui.main.MainActivity
@@ -110,7 +113,9 @@ class LoginActivity :
     LoginNoJetpackListener,
     LoginEmailHelpDialogFragment.Listener,
     WooLoginEmailFragment.Listener,
-    LoginSiteCredentialsFragment.Listener {
+    LoginSiteCredentialsFragment.Listener,
+    QrLoginPrologueFragment.Listener,
+    QrLoginScannerFragment.Listener {
     companion object {
         private const val FORGOT_PASSWORD_URL_SUFFIX = "wp-login.php?action=lostpassword"
         private const val JETPACK_CONNECT_URL = "https://wordpress.com/jetpack/connect"
@@ -127,6 +132,7 @@ class LoginActivity :
         const val SITE_URL_PARAMETER = "siteUrl"
         const val WP_COM_EMAIL_PARAMETER = "wpcomEmail"
         const val APP_LOGIN_AUTHORITY = "app-login"
+        const val QR_LOGIN_AUTHORITY = "qr-login"
         const val USERNAME_PARAMETER = "username"
     }
 
@@ -159,6 +165,9 @@ class LoginActivity :
 
     @Inject
     internal lateinit var registerDevice: RegisterDevice
+
+    @Inject
+    internal lateinit var qrLoginAvailability: QrLoginAvailability
 
     private var loginMode: LoginMode? = null
     private lateinit var binding: ActivityLoginBinding
@@ -195,6 +204,16 @@ class LoginActivity :
 
             intent?.action == Intent.ACTION_VIEW && intent.data?.authority == APP_LOGIN_AUTHORITY -> {
                 intent.data?.let { uri -> handleAppLoginUri(uri) }
+            }
+
+            savedInstanceState == null &&
+                intent?.action == Intent.ACTION_VIEW &&
+                intent.data?.authority == QR_LOGIN_AUTHORITY -> {
+                intent.data?.let { uri -> handleQrLoginUri(uri) }
+                // Drop the deep-link payload so a config change or process restart doesn't
+                // re-push the scanner fragment with the same (now-invalid) token.
+                intent.data = null
+                intent.action = null
             }
 
             hasJetpackConnectedIntent() -> {
@@ -268,6 +287,25 @@ class LoginActivity :
         } else {
             showPrologueFragment()
         }
+    }
+
+    private fun showQrLoginPrologueFragment() {
+        val existing = supportFragmentManager.findFragmentByTag(QrLoginPrologueFragment.TAG)
+            as? QrLoginPrologueFragment
+        changeFragment(existing ?: QrLoginPrologueFragment(), true, QrLoginPrologueFragment.TAG)
+    }
+
+    override fun onQrLoginScanClicked() {
+        changeFragment(QrLoginScannerFragment(), true, QrLoginScannerFragment.TAG)
+    }
+
+    override fun onQrLoginFallbackClicked() {
+        disableDynamicEdgeToEdge()
+        loginViaSiteAddress()
+    }
+
+    override fun onQrLoginCompleted(localSiteId: Int) {
+        loggedInViaUsernamePassword(arrayListOf(localSiteId))
     }
 
     private fun hasJetpackConnectedIntent(): Boolean {
@@ -355,7 +393,11 @@ class LoginActivity :
     override fun onPrimaryButtonClicked() {
         unifiedLoginTracker.trackClick(Click.LOGIN_WITH_SITE_ADDRESS)
         disableDynamicEdgeToEdge()
-        loginViaSiteAddress()
+        if (qrLoginAvailability.isAvailable()) {
+            showQrLoginPrologueFragment()
+        } else {
+            loginViaSiteAddress()
+        }
     }
 
     override fun onSecondaryButtonClicked() {
@@ -1016,6 +1058,11 @@ class LoginActivity :
         // Sometimes, the same website could be fetched from different APIs (WPCom or WPApi), and if cached twice
         // during successive login attempts, it leads to some issues later
         dispatcher.dispatch(SiteActionBuilder.newRemoveAllSitesAction())
+    }
+
+    private fun handleQrLoginUri(uri: Uri) {
+        unifiedLoginTracker.setFlow(Flow.LOGIN_QR.value)
+        changeFragment(QrLoginScannerFragment.forDeepLink(uri.toString()), true, QrLoginScannerFragment.TAG)
     }
 
     private fun handleAppLoginUri(uri: Uri) {


### PR DESCRIPTION
Fixes WOOMOB-2850

### Description

Wires the QR flow into `LoginActivity`: gates entry on `QrLoginAvailability` (camera + feature flag), hooks up the prologue's "Scan QR code" / fallback listeners, and registers the `woocommerce://qr-login?token=…&siteUrl=…` deep link so wp-admin's QR can launch the merchant straight into the confirm screen on a freshly installed app. With this PR, the feature is wired together end-to-end.

This is **Step 9 of 10** in the QR login stacked PR chain. The follow-up step (`step-10-qr-login-install-qr-detection`) detects the wp-admin onboarding *install* QR and is the final step of the chain — its PR carries the full end-to-end test plan. The `status: do not merge` label is applied so this lands only after PRs 1–8 are reviewed and ready.

### Stacked PR chain
- Step 1: #15733 — foundation: payload type, parser, and analytics events
- Step 2: #15734 — token exchange REST client
- Step 3: #15735 — authenticator orchestrating exchange + site fetch + eligibility
- Step 4: #15736 — scanner ViewModel state machine and feature-flag gate
- Step 5: #15737 — prologue screen with QR icon, URL pill, and camera-permission gate
- Step 6: #15738 — camera viewfinder, scanner screen, and endpoint-missing fallback
- Step 7: #15739 — fullscreen confirm + error screens with retry-eligible mapping
- Step 8: #15740 — prologue and scanner fragments hosting the Compose surfaces
- Step 9: #15741 — activity wiring and `woocommerce://qr-login` deep link ← **this PR**
- Step 10: #15742 — detect wp-admin install QR and guide users to the sign-in QR

### Test Steps

N/A — see the PR for `step-10-qr-login-install-qr-detection` for the full feature test plan. This PR is part of a stacked chain (`status: do not merge`) and is unit-test-covered where applicable.

### Images/gif

See test plan in step-10 PR — the full QR login flow is exercised end-to-end there.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.