### PR TITLE
[WOOMOB-2854] Step 10: QR login — detect wp-admin install QR and guide users to the sign-in QR

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -209,7 +209,14 @@ class LoginActivity :
             savedInstanceState == null &&
                 intent?.action == Intent.ACTION_VIEW &&
                 intent.data?.authority == QR_LOGIN_AUTHORITY -> {
-                intent.data?.let { uri -> handleQrLoginUri(uri) }
+                // Gate the deep link on the same availability check as the in-app entry, so
+                // the system camera / 3rd-party scanner path cannot bypass the feature flag.
+                if (qrLoginAvailability.isAvailable()) {
+                    intent.data?.let { uri -> handleQrLoginUri(uri) }
+                } else {
+                    loginAnalyticsListener.trackLoginAccessed()
+                    showPrologue()
+                }
                 // Replace the activity intent so a process restart from recents cannot replay
                 // the single-use token. Mutating fields on the in-memory Intent is not enough —
                 // Android restores getIntent() from the originally launched intent on cold start.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCOutlinedButton
+import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -74,9 +74,10 @@ fun QrLoginErrorScreen(
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
-        WCOutlinedButton(
+        WCTextButton(
             onClick = onSecondaryClicked,
             text = stringResource(id = content.secondaryAction),
+            allCaps = false,
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
@@ -19,7 +19,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
@@ -58,7 +62,7 @@ fun QrLoginErrorScreen(
         )
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_100)))
         Text(
-            text = stringResource(id = content.body),
+            text = bodyAnnotatedString(content),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center
@@ -91,5 +95,31 @@ private fun QrLoginErrorScreenPreview() {
             onPrimaryClicked = {},
             onSecondaryClicked = {},
         )
+    }
+}
+
+/**
+ * Resolves the body text for an error. When [QrLoginErrorContent.bodyHighlightedArgs] is empty
+ * we just return the body string as-is. Otherwise we treat the body as a `%1$s, %2$s, …`
+ * template, substitute each arg in order, and apply a SemiBold span to each substituted run.
+ * This pattern keeps `<b>…</b>` markup out of strings.xml so translators can't accidentally
+ * drop or break it.
+ */
+@Composable
+private fun bodyAnnotatedString(content: QrLoginErrorContent): AnnotatedString {
+    val template = stringResource(id = content.body)
+    if (content.bodyHighlightedArgs.isEmpty()) return AnnotatedString(template)
+    val args = content.bodyHighlightedArgs.map { stringResource(id = it) }
+    return buildAnnotatedString {
+        var cursor = 0
+        args.forEachIndexed { index, value ->
+            val placeholder = "%${index + 1}\$s"
+            val placeholderStart = template.indexOf(placeholder, startIndex = cursor)
+            if (placeholderStart < 0) return@forEachIndexed
+            append(template.substring(cursor, placeholderStart))
+            withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) { append(value) }
+            cursor = placeholderStart + placeholder.length
+        }
+        append(template.substring(cursor))
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.login.qrlogin
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -10,7 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.background
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,14 +19,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.annotatedStringRes
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
@@ -61,8 +58,12 @@ fun QrLoginErrorScreen(
             textAlign = TextAlign.Center
         )
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        @Suppress("SpreadOperator")
         Text(
-            text = bodyAnnotatedString(content),
+            text = annotatedStringRes(
+                content.body,
+                *content.bodyArgs.map { stringResource(id = it) }.toTypedArray(),
+            ),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center
@@ -96,31 +97,5 @@ private fun QrLoginErrorScreenPreview() {
             onPrimaryClicked = {},
             onSecondaryClicked = {},
         )
-    }
-}
-
-/**
- * Resolves the body text for an error. When [QrLoginErrorContent.bodyHighlightedArgs] is empty
- * we just return the body string as-is. Otherwise we treat the body as a `%1$s, %2$s, …`
- * template, substitute each arg in order, and apply a SemiBold span to each substituted run.
- * This pattern keeps `<b>…</b>` markup out of strings.xml so translators can't accidentally
- * drop or break it.
- */
-@Composable
-private fun bodyAnnotatedString(content: QrLoginErrorContent): AnnotatedString {
-    val template = stringResource(id = content.body)
-    if (content.bodyHighlightedArgs.isEmpty()) return AnnotatedString(template)
-    val args = content.bodyHighlightedArgs.map { stringResource(id = it) }
-    return buildAnnotatedString {
-        var cursor = 0
-        args.forEachIndexed { index, value ->
-            val placeholder = "%${index + 1}\$s"
-            val placeholderStart = template.indexOf(placeholder, startIndex = cursor)
-            if (placeholderStart < 0) return@forEachIndexed
-            append(template.substring(cursor, placeholderStart))
-            withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) { append(value) }
-            cursor = placeholderStart + placeholder.length
-        }
-        append(template.substring(cursor))
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
@@ -19,5 +19,13 @@ sealed interface QrLoginPayload {
         val siteUrl: String
     ) : QrLoginPayload
 
+    /**
+     * The merchant scanned the wp-admin onboarding QR that links to the App Store / Play Store
+     * install pages (`https://woocommerce.com/mobile/?utm_source=wc_onboarding_mobile_task`).
+     * The app is already installed, so the install QR is useless here — surfaced as a dedicated
+     * error so we can explain the situation instead of falling back to "Not a WooCommerce code".
+     */
+    data object InstallQrCode : QrLoginPayload
+
     data object Invalid : QrLoginPayload
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
@@ -42,7 +42,6 @@ class QrLoginPayloadParser @Inject constructor() {
      */
     private fun looksLikeInstallQr(raw: String?): Boolean {
         val parsed = raw?.trim()?.takeIf { it.isNotEmpty() }?.toHttpUrlOrNull() ?: return false
-        if (parsed.scheme != "https") return false
         if (!parsed.host.equals(INSTALL_QR_HOST, ignoreCase = true)) return false
         val pathSegments = parsed.encodedPathSegments.filter { it.isNotEmpty() }
         return pathSegments.firstOrNull()?.equals(INSTALL_QR_PATH_FIRST_SEGMENT, ignoreCase = true) == true

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
@@ -22,10 +22,30 @@ import javax.inject.Inject
 class QrLoginPayloadParser @Inject constructor() {
 
     fun parse(raw: String?): QrLoginPayload {
-        val uri = parseDeepLink(raw) ?: return QrLoginPayload.Invalid
-        val token = uri.queryParam(PARAM_TOKEN)?.takeIf { it.isNotBlank() } ?: return QrLoginPayload.Invalid
-        val siteUrl = uri.queryParam(PARAM_SITE_URL)?.let(::normalizeSiteUrl) ?: return QrLoginPayload.Invalid
+        if (looksLikeInstallQr(raw)) return QrLoginPayload.InstallQrCode
+        return parseTicket(raw) ?: QrLoginPayload.Invalid
+    }
+
+    private fun parseTicket(raw: String?): QrLoginPayload.Ticket? {
+        val uri = parseDeepLink(raw) ?: return null
+        val token = uri.queryParam(PARAM_TOKEN)?.takeIf { it.isNotBlank() } ?: return null
+        val siteUrl = uri.queryParam(PARAM_SITE_URL)?.let(::normalizeSiteUrl) ?: return null
         return QrLoginPayload.Ticket(token = token, siteUrl = siteUrl)
+    }
+
+    /**
+     * The wp-admin onboarding flow renders a QR that points to
+     * `https://woocommerce.com/mobile/...` — its purpose is to land users on the App Store /
+     * Play Store install pages. If we see one of those URLs we know the merchant scanned the
+     * install QR rather than the sign-in QR; the app is already installed, so we can surface
+     * a helpful explanation instead of "Not a WooCommerce code".
+     */
+    private fun looksLikeInstallQr(raw: String?): Boolean {
+        val parsed = raw?.trim()?.takeIf { it.isNotEmpty() }?.toHttpUrlOrNull() ?: return false
+        if (parsed.scheme != "https") return false
+        if (!parsed.host.equals(INSTALL_QR_HOST, ignoreCase = true)) return false
+        val pathSegments = parsed.encodedPathSegments.filter { it.isNotEmpty() }
+        return pathSegments.firstOrNull()?.equals(INSTALL_QR_PATH_FIRST_SEGMENT, ignoreCase = true) == true
     }
 
     private fun parseDeepLink(raw: String?): URI? {
@@ -71,5 +91,7 @@ class QrLoginPayloadParser @Inject constructor() {
         const val PARAM_TOKEN = "token"
         const val PARAM_SITE_URL = "siteUrl"
         const val HTTPS_PREFIX = "https://"
+        const val INSTALL_QR_HOST = "woocommerce.com"
+        const val INSTALL_QR_PATH_FIRST_SEGMENT = "mobile"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
@@ -128,6 +128,11 @@ fun QrLoginPrologueScreen(
 @Composable
 private fun Hero() {
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+    if (isLandscape) HeroLandscape() else HeroPortrait()
+}
+
+@Composable
+private fun HeroPortrait() {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -144,35 +149,14 @@ private fun Hero() {
             fontWeight = FontWeight.SemiBold
         )
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
-        if (isLandscape) {
-            // In landscape the stacked subtitle + URL pill push the bottom CTAs off-screen.
-            // Render them side-by-side instead so the screen fits without scrolling.
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(
-                    dimensionResource(id = R.dimen.major_100),
-                    Alignment.CenterHorizontally
-                ),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(id = R.string.login_qr_prologue_subtitle),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = colorResource(id = R.color.prologue_login_on_background_secondary),
-                    textAlign = TextAlign.End
-                )
-                UrlBadge()
-            }
-        } else {
-            Text(
-                text = stringResource(id = R.string.login_qr_prologue_subtitle),
-                style = MaterialTheme.typography.bodyLarge,
-                color = colorResource(id = R.color.prologue_login_on_background_secondary),
-                textAlign = TextAlign.Center
-            )
-            Spacer(Modifier.height(dimensionResource(id = R.dimen.major_125)))
-            UrlBadge()
-        }
+        Text(
+            text = stringResource(id = R.string.login_qr_prologue_subtitle),
+            style = MaterialTheme.typography.bodyLarge,
+            color = colorResource(id = R.color.prologue_login_on_background_secondary),
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_125)))
+        UrlBadge()
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_125)))
         Text(
             text = stringResource(id = R.string.login_qr_prologue_step_hint),
@@ -180,6 +164,54 @@ private fun Hero() {
             color = colorResource(id = R.color.prologue_login_on_background_tertiary),
             textAlign = TextAlign.Center
         )
+    }
+}
+
+/**
+ * Landscape phones only have ~400dp of vertical space, so the portrait hero pushes the bottom
+ * CTAs off-screen. Lay out QR icon on the left and text content on the right so everything
+ * fits without scrolling and the URL pill is visible alongside the "On your computer, visit:"
+ * label as Jorge requested.
+ */
+@Composable
+private fun HeroLandscape() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = dimensionResource(id = R.dimen.major_100)),
+        horizontalArrangement = Arrangement.spacedBy(
+            dimensionResource(id = R.dimen.major_150),
+            Alignment.CenterHorizontally
+        ),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        QrIconBadge()
+        Column(horizontalAlignment = Alignment.Start) {
+            Text(
+                text = stringResource(id = R.string.login_qr_prologue_title),
+                style = MaterialTheme.typography.headlineSmall,
+                color = colorResource(id = R.color.prologue_login_on_background),
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(id = R.string.login_qr_prologue_subtitle),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = colorResource(id = R.color.prologue_login_on_background_secondary)
+                )
+                UrlBadge()
+            }
+            Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
+            Text(
+                text = stringResource(id = R.string.login_qr_prologue_step_hint),
+                style = MaterialTheme.typography.bodyMedium,
+                color = colorResource(id = R.color.prologue_login_on_background_tertiary)
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
@@ -2,13 +2,16 @@ package com.woocommerce.android.ui.login.qrlogin
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -33,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
@@ -120,6 +124,7 @@ fun QrLoginPrologueScreen(
 
 @Composable
 private fun Hero() {
+    val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -136,14 +141,35 @@ private fun Hero() {
             fontWeight = FontWeight.SemiBold
         )
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
-        Text(
-            text = stringResource(id = R.string.login_qr_prologue_subtitle),
-            style = MaterialTheme.typography.bodyLarge,
-            color = colorResource(id = R.color.prologue_login_on_background_secondary),
-            textAlign = TextAlign.Center
-        )
-        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_125)))
-        UrlBadge()
+        if (isLandscape) {
+            // In landscape the stacked subtitle + URL pill push the bottom CTAs off-screen.
+            // Render them side-by-side instead so the screen fits without scrolling.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(
+                    dimensionResource(id = R.dimen.major_100),
+                    Alignment.CenterHorizontally
+                ),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(id = R.string.login_qr_prologue_subtitle),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = colorResource(id = R.color.prologue_login_on_background_secondary),
+                    textAlign = TextAlign.End
+                )
+                UrlBadge()
+            }
+        } else {
+            Text(
+                text = stringResource(id = R.string.login_qr_prologue_subtitle),
+                style = MaterialTheme.typography.bodyLarge,
+                color = colorResource(id = R.color.prologue_login_on_background_secondary),
+                textAlign = TextAlign.Center
+            )
+            Spacer(Modifier.height(dimensionResource(id = R.dimen.major_125)))
+            UrlBadge()
+        }
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_125)))
         Text(
             text = stringResource(id = R.string.login_qr_prologue_step_hint),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
@@ -46,9 +46,12 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.core.content.ContextCompat
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.WindowSizeClass
 import com.woocommerce.android.extensions.copyToClipboard
+import com.woocommerce.android.extensions.windowHeightSizeClass
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
@@ -128,7 +131,10 @@ fun QrLoginPrologueScreen(
 @Composable
 private fun Hero() {
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
-    if (isLandscape) HeroLandscape() else HeroPortrait()
+    // Tablets have enough vertical room for the portrait stack in landscape too — only the
+    // compact height bucket (phones in landscape) needs the compacted hero.
+    val isCompactHeight = LocalContext.current.windowHeightSizeClass == WindowSizeClass.Compact
+    if (isLandscape && isCompactHeight) HeroLandscape() else HeroPortrait()
 }
 
 @Composable
@@ -169,57 +175,64 @@ private fun HeroPortrait() {
 
 /**
  * Landscape phones only have ~400dp of vertical space, so the portrait hero pushes the bottom
- * CTAs off-screen. Lay out QR icon on the left and text content on the right so everything
- * fits without scrolling and the URL pill is visible alongside the "On your computer, visit:"
- * label as Jorge requested.
+ * CTAs off-screen. Pair the QR icon with the title on a single row and keep the URL line and
+ * step hint horizontally centered below — everything fits without scrolling and reads as a
+ * single centered block.
  */
 @Composable
 private fun HeroLandscape() {
-    Row(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = dimensionResource(id = R.dimen.major_100)),
-        horizontalArrangement = Arrangement.spacedBy(
-            dimensionResource(id = R.dimen.major_150),
-            Alignment.CenterHorizontally
-        ),
-        verticalAlignment = Alignment.CenterVertically
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        QrIconBadge()
-        Column(horizontalAlignment = Alignment.Start) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            QrIconBadge(
+                size = dimensionResource(id = R.dimen.image_major_50),
+                iconSize = dimensionResource(id = R.dimen.image_minor_80),
+            )
             Text(
                 text = stringResource(id = R.string.login_qr_prologue_title),
                 style = MaterialTheme.typography.headlineSmall,
                 color = colorResource(id = R.color.prologue_login_on_background),
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(id = R.string.login_qr_prologue_subtitle),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = colorResource(id = R.color.prologue_login_on_background_secondary)
-                )
-                UrlBadge()
-            }
-            Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
-            Text(
-                text = stringResource(id = R.string.login_qr_prologue_step_hint),
-                style = MaterialTheme.typography.bodyMedium,
-                color = colorResource(id = R.color.prologue_login_on_background_tertiary)
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1
             )
         }
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_100)),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(id = R.string.login_qr_prologue_subtitle),
+                style = MaterialTheme.typography.bodyLarge,
+                color = colorResource(id = R.color.prologue_login_on_background_secondary)
+            )
+            UrlBadge()
+        }
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
+        Text(
+            text = stringResource(id = R.string.login_qr_prologue_step_hint),
+            style = MaterialTheme.typography.bodyMedium,
+            color = colorResource(id = R.color.prologue_login_on_background_tertiary),
+            textAlign = TextAlign.Center
+        )
     }
 }
 
 @Composable
-private fun QrIconBadge() {
+private fun QrIconBadge(
+    size: Dp = dimensionResource(id = R.dimen.image_major_72),
+    iconSize: Dp = dimensionResource(id = R.dimen.image_minor_100),
+) {
     Box(
         modifier = Modifier
-            .size(dimensionResource(id = R.dimen.image_major_72))
+            .size(size)
             .clip(CircleShape)
             .background(colorResource(id = R.color.prologue_login_url_badge_background)),
         contentAlignment = Alignment.Center
@@ -228,7 +241,7 @@ private fun QrIconBadge() {
             painter = painterResource(id = R.drawable.ic_baseline_qr_code_scanner),
             contentDescription = null,
             tint = colorResource(id = R.color.prologue_login_on_background),
-            modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_100))
+            modifier = Modifier.size(iconSize)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
@@ -3,10 +3,12 @@ package com.woocommerce.android.ui.login.qrlogin
 import android.Manifest
 import android.content.pm.PackageManager
 import android.content.res.Configuration
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -46,6 +48,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.core.content.ContextCompat
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.copyToClipboard
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
@@ -200,17 +203,25 @@ private fun QrIconBadge() {
 
 @Composable
 private fun UrlBadge() {
+    val context = LocalContext.current
+    val url = stringResource(id = R.string.login_qr_prologue_url)
+    val clipboardLabel = stringResource(id = R.string.login_qr_prologue_url_clipboard_label)
+    val copiedMessage = stringResource(id = R.string.login_qr_prologue_url_copied)
     Box(
         modifier = Modifier
             .clip(RoundedCornerShape(dimensionResource(id = R.dimen.major_75)))
             .background(colorResource(id = R.color.prologue_login_url_badge_background))
+            .clickable {
+                context.copyToClipboard(clipboardLabel, url)
+                Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
+            }
             .padding(
                 horizontal = dimensionResource(id = R.dimen.major_125),
                 vertical = dimensionResource(id = R.dimen.major_85)
             )
     ) {
         Text(
-            text = stringResource(id = R.string.login_qr_prologue_url),
+            text = url,
             style = MaterialTheme.typography.titleLarge,
             color = colorResource(id = R.color.prologue_login_on_background),
             fontWeight = FontWeight.Bold,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -201,9 +202,17 @@ private fun Buttons(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        // White-on-purple to stand out from the purple prologue background. The default
+        // WCColoredButton uses the primary purple as its container, which blends into the
+        // background in light mode. Mirrors the existing legacy prologue's
+        // `Woo.Button.Colored.White` style.
         WCColoredButton(
             onClick = onScanClicked,
             text = stringResource(id = R.string.login_qr_prologue_scan_button),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = colorResource(id = R.color.prologue_login_button_color),
+                contentColor = colorResource(id = R.color.color_on_surface),
+            ),
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -163,13 +163,13 @@ class QrLoginScannerFragment : Fragment() {
     }
 
     /**
-     * In camera mode, dismissing confirm just clears the overlay and the camera resumes.
-     * In deep-link mode there is no camera underneath, so the same dismissal would leave the
-     * user on a blank surface — exit the fragment instead.
+     * Cancel always exits to the previous destination (the prologue in camera mode, the launcher
+     * caller in deep-link mode). Resuming the camera underneath would re-scan the same QR if it
+     * is still framed, which loops the user back into the same confirm screen.
      */
     private fun handleCancelSite() {
         qrLoginViewModel.onCancelSite()
-        if (isDeepLinkEntry) requireActivity().onBackPressedDispatcher.onBackPressed()
+        requireActivity().onBackPressedDispatcher.onBackPressed()
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
@@ -73,6 +73,7 @@ data class QrLoginErrorContent(
     @StringRes val body: Int,
     @StringRes val primaryAction: Int,
     @StringRes val secondaryAction: Int = R.string.login_qr_endpoint_missing_enter_url,
+    val bodyHighlightedArgs: List<Int> = emptyList(),
 )
 
 private fun ErrorReason.toErrorContent(): QrLoginErrorContent = when (this) {
@@ -81,11 +82,7 @@ private fun ErrorReason.toErrorContent(): QrLoginErrorContent = when (this) {
         body = R.string.login_qr_scanner_error_payload_body,
         primaryAction = R.string.login_qr_error_primary_scan,
     )
-    ErrorReason.InstallQrCode -> QrLoginErrorContent(
-        title = R.string.login_qr_scanner_error_install_qr_title,
-        body = R.string.login_qr_scanner_error_install_qr_body,
-        primaryAction = R.string.login_qr_error_primary_scan,
-    )
+    ErrorReason.InstallQrCode -> installQrErrorContent()
     ErrorReason.TokenRejected -> QrLoginErrorContent(
         title = R.string.login_qr_scanner_error_token_title,
         body = R.string.login_qr_scanner_error_token_body,
@@ -133,3 +130,13 @@ private fun ErrorReason.toErrorContent(): QrLoginErrorContent = when (this) {
         primaryAction = R.string.login_qr_error_primary_retry,
     )
 }
+
+private fun installQrErrorContent() = QrLoginErrorContent(
+    title = R.string.login_qr_scanner_error_install_qr_title,
+    body = R.string.login_qr_scanner_error_install_qr_body,
+    primaryAction = R.string.login_qr_error_primary_scan,
+    bodyHighlightedArgs = listOf(
+        R.string.login_qr_scanner_error_install_qr_body_button,
+        R.string.login_qr_prologue_url,
+    ),
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
@@ -73,7 +73,7 @@ data class QrLoginErrorContent(
     @StringRes val body: Int,
     @StringRes val primaryAction: Int,
     @StringRes val secondaryAction: Int = R.string.login_qr_endpoint_missing_enter_url,
-    val bodyHighlightedArgs: List<Int> = emptyList(),
+    val bodyArgs: List<Int> = emptyList(),
 )
 
 private fun ErrorReason.toErrorContent(): QrLoginErrorContent = when (this) {
@@ -135,7 +135,7 @@ private fun installQrErrorContent() = QrLoginErrorContent(
     title = R.string.login_qr_scanner_error_install_qr_title,
     body = R.string.login_qr_scanner_error_install_qr_body,
     primaryAction = R.string.login_qr_error_primary_scan,
-    bodyHighlightedArgs = listOf(
+    bodyArgs = listOf(
         R.string.login_qr_scanner_error_install_qr_body_button,
         R.string.login_qr_prologue_url,
     ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
@@ -81,10 +81,10 @@ private fun ErrorReason.toErrorContent(): QrLoginErrorContent = when (this) {
         body = R.string.login_qr_scanner_error_payload_body,
         primaryAction = R.string.login_qr_error_primary_scan,
     )
-    ErrorReason.Scanner -> QrLoginErrorContent(
-        title = R.string.login_qr_scanner_error_generic_title,
-        body = R.string.login_qr_scanner_error_generic_body,
-        primaryAction = R.string.login_qr_error_primary_retry,
+    ErrorReason.InstallQrCode -> QrLoginErrorContent(
+        title = R.string.login_qr_scanner_error_install_qr_title,
+        body = R.string.login_qr_scanner_error_install_qr_body,
+        primaryAction = R.string.login_qr_error_primary_scan,
     )
     ErrorReason.TokenRejected -> QrLoginErrorContent(
         title = R.string.login_qr_scanner_error_token_title,
@@ -126,6 +126,7 @@ private fun ErrorReason.toErrorContent(): QrLoginErrorContent = when (this) {
         body = R.string.login_qr_scanner_error_user_role_body,
         primaryAction = R.string.login_qr_error_primary_retry,
     )
+    ErrorReason.Scanner,
     ErrorReason.Unknown -> QrLoginErrorContent(
         title = R.string.login_qr_scanner_error_generic_title,
         body = R.string.login_qr_scanner_error_generic_body,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -83,6 +83,14 @@ class QrLoginScannerViewModel @Inject constructor(
                 ticket = payload,
                 host = payload.siteUrl.toDisplayHost()
             )
+            QrLoginPayload.InstallQrCode -> {
+                trackScanFailure(
+                    step = Step.PAYLOAD,
+                    errorContext = null,
+                    errorType = ErrorReason.InstallQrCode.name,
+                )
+                _uiState.value = Error(reason = ErrorReason.InstallQrCode, retryTicket = null)
+            }
             QrLoginPayload.Invalid -> {
                 trackScanFailure(
                     step = Step.PAYLOAD,
@@ -228,6 +236,7 @@ class QrLoginScannerViewModel @Inject constructor(
 
     enum class ErrorReason {
         InvalidPayload,
+        InstallQrCode,
         Scanner,
         TokenRejected,
         EndpointMissing,

--- a/WooCommerce/src/main/res/values-night/colors_base.xml
+++ b/WooCommerce/src/main/res/values-night/colors_base.xml
@@ -72,7 +72,7 @@
     <color name="prologue_login_on_background">@color/woo_white</color>
     <color name="prologue_login_on_background_secondary">@color/woo_white_alpha_087</color>
     <color name="prologue_login_on_background_tertiary">@color/woo_white_alpha_060</color>
-    <color name="prologue_login_url_badge_background">#2EFFFFFF</color>
+    <color name="prologue_login_url_badge_background">@color/woo_white_alpha_012</color>
 
     <!--
         Rating widget colors

--- a/WooCommerce/src/main/res/values/colors_base.xml
+++ b/WooCommerce/src/main/res/values/colors_base.xml
@@ -111,7 +111,7 @@
     <color name="prologue_login_on_background">@color/woo_white</color>
     <color name="prologue_login_on_background_secondary">@color/woo_white_alpha_087</color>
     <color name="prologue_login_on_background_tertiary">@color/woo_white_alpha_060</color>
-    <color name="prologue_login_url_badge_background">#2EFFFFFF</color>
+    <color name="prologue_login_url_badge_background">@color/woo_white_alpha_012</color>
 
     <!--
         Rating widget colors

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -214,7 +214,7 @@
 
     <!-- QR login prologue -->
     <string name="login_qr_prologue_title">Scan to sign in</string>
-    <string name="login_qr_prologue_subtitle">On a device where you\'re already signed in, visit:</string>
+    <string name="login_qr_prologue_subtitle">On your computer, visit:</string>
     <string name="login_qr_prologue_url" translatable="false">woo.com/mobilelogin</string>
     <string name="login_qr_prologue_step_hint">Then scan the QR code that appears.</string>
     <string name="login_qr_prologue_scan_button">Scan QR code</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -237,6 +237,8 @@
     <string name="login_qr_scanner_error_generic_body">We couldn\'t read that QR code. Please try again.</string>
     <string name="login_qr_scanner_error_payload_title">Not a WooCommerce code</string>
     <string name="login_qr_scanner_error_payload_body">This QR isn\'t a WooCommerce login code. Generate a new one from your store and try again.</string>
+    <string name="login_qr_scanner_error_install_qr_title">That\'s the install QR</string>
+    <string name="login_qr_scanner_error_install_qr_body">You scanned the QR that installs the app — but it\'s already installed. Tap <b>App is installed</b> in your wp-admin onboarding to reveal the sign-in QR. Don\'t see that button? Visit <b>woo.com/mobilelogin</b> on your computer.</string>
     <string name="login_qr_scanner_error_token_title">Code expired</string>
     <string name="login_qr_scanner_error_token_body">That code expired or has already been used. Generate a new one in your store.</string>
     <string name="login_qr_scanner_error_rate_limited_title">Too many attempts</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -238,7 +238,8 @@
     <string name="login_qr_scanner_error_payload_title">Not a WooCommerce code</string>
     <string name="login_qr_scanner_error_payload_body">This QR isn\'t a WooCommerce login code. Generate a new one from your store and try again.</string>
     <string name="login_qr_scanner_error_install_qr_title">That\'s the install QR</string>
-    <string name="login_qr_scanner_error_install_qr_body">You scanned the QR that installs the app — but it\'s already installed. Tap <b>App is installed</b> in your wp-admin onboarding to reveal the sign-in QR. Don\'t see that button? Visit <b>woo.com/mobilelogin</b> on your computer.</string>
+    <string name="login_qr_scanner_error_install_qr_body">The app\'s already installed — this QR installs it. In wp-admin, tap the %1$s button to reveal the sign-in QR. Or visit %2$s on your computer.</string>
+    <string name="login_qr_scanner_error_install_qr_body_button">App is installed</string>
     <string name="login_qr_scanner_error_token_title">Code expired</string>
     <string name="login_qr_scanner_error_token_body">That code expired or has already been used. Generate a new one in your store.</string>
     <string name="login_qr_scanner_error_rate_limited_title">Too many attempts</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -240,7 +240,7 @@
     <string name="login_qr_scanner_error_payload_title">Not a WooCommerce code</string>
     <string name="login_qr_scanner_error_payload_body">This QR isn\'t a WooCommerce login code. Generate a new one from your store and try again.</string>
     <string name="login_qr_scanner_error_install_qr_title">That\'s the install QR</string>
-    <string name="login_qr_scanner_error_install_qr_body">The app\'s already installed — this QR installs it. In wp-admin, tap the %1$s button to reveal the sign-in QR. Or visit %2$s on your computer.</string>
+    <string name="login_qr_scanner_error_install_qr_body"><![CDATA[The app\'s already installed — this QR installs it. In wp-admin, tap the <b>%1$s</b> button to reveal the sign-in QR. Or visit <b>%2$s</b> on your computer.]]></string>
     <string name="login_qr_scanner_error_install_qr_body_button">App is installed</string>
     <string name="login_qr_scanner_error_token_title">Code expired</string>
     <string name="login_qr_scanner_error_token_body">That code expired or has already been used. Generate a new one in your store.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -216,6 +216,8 @@
     <string name="login_qr_prologue_title">Scan to sign in</string>
     <string name="login_qr_prologue_subtitle">On your computer, visit:</string>
     <string name="login_qr_prologue_url" translatable="false">woo.com/mobilelogin</string>
+    <string name="login_qr_prologue_url_clipboard_label">WooCommerce login URL</string>
+    <string name="login_qr_prologue_url_copied">Link copied to clipboard</string>
     <string name="login_qr_prologue_step_hint">Then scan the QR code that appears.</string>
     <string name="login_qr_prologue_scan_button">Scan QR code</string>
     <string name="login_qr_prologue_fallback_link">Sign in with site address instead</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
@@ -113,6 +113,35 @@ class QrLoginPayloadParserTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given install QR url with utm source, when parsed, then returns InstallQrCode`() {
+        val raw = "https://woocommerce.com/mobile/?utm_source=wc_onboarding_mobile_task"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.InstallQrCode)
+    }
+
+    @Test
+    fun `given install QR url without query, when parsed, then returns InstallQrCode`() {
+        assertThat(parser.parse("https://woocommerce.com/mobile/")).isEqualTo(QrLoginPayload.InstallQrCode)
+        assertThat(parser.parse("https://woocommerce.com/mobile")).isEqualTo(QrLoginPayload.InstallQrCode)
+    }
+
+    @Test
+    fun `given install QR url with mixed case host, when parsed, then returns InstallQrCode`() {
+        assertThat(parser.parse("https://WooCommerce.com/mobile/")).isEqualTo(QrLoginPayload.InstallQrCode)
+    }
+
+    @Test
+    fun `given other woocommerce com path, when parsed, then returns Invalid`() {
+        assertThat(parser.parse("https://woocommerce.com/")).isEqualTo(QrLoginPayload.Invalid)
+        assertThat(parser.parse("https://woocommerce.com/blog")).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given http install QR url, when parsed, then returns Invalid`() {
+        assertThat(parser.parse("http://woocommerce.com/mobile/")).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
     fun `given long real-world token, when parsed, then returns Ticket with full token`() {
         val token = "8a3f5b9e2c4d7168f0a2b4c6e8f1a3b5c7d9e1f3a5b7c9d1e3f5a7b9c1d3e5f7"
         val raw = "woocommerce://qr-login?token=$token&siteUrl=https%3A%2F%2Feasyclothes.example"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
@@ -137,8 +137,8 @@ class QrLoginPayloadParserTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given http install QR url, when parsed, then returns Invalid`() {
-        assertThat(parser.parse("http://woocommerce.com/mobile/")).isEqualTo(QrLoginPayload.Invalid)
+    fun `given http install QR url, when parsed, then returns InstallQrCode`() {
+        assertThat(parser.parse("http://woocommerce.com/mobile/")).isEqualTo(QrLoginPayload.InstallQrCode)
     }
 
     @Test


### PR DESCRIPTION
Fixes WOOMOB-2854

### Description

Final step of the stacked QR login PR series. The wp-admin onboarding flow displays a QR that links to `https://woocommerce.com/mobile/?utm_source=wc_onboarding_mobile_task` so users can install the app from the App Store / Play Store. If a merchant who already has the app installed scans that install QR, the chain (steps 1–9) currently surfaces the generic **"Not a WooCommerce code"** error, which doesn't explain why or what to do next.

This PR detects the install QR specifically and shows a dedicated, actionable error: **"That's the install QR — the app is already installed. Tap _App is installed_ in your wp-admin onboarding to reveal the sign-in QR. Don't see that button? Visit *woo.com/mobilelogin* on your computer."**

This PR also folds in three small follow-ups across the chain that surfaced during review on the previous round:
- Detekt fix for `QrLoginPayloadParser.queryParam` (loop-with-too-many-jumps refactor).
- Landscape scrolling fixes on `QrLoginPrologueScreen` and `QrLoginConfirmSiteScreen` so the bottom CTAs stay reachable on phones.
- Light-mode polish on the prologue: the **Scan QR code** button now uses an explicit white-on-purple style instead of the default purple-on-purple that blended into the background; the URL pill's hardcoded `#2EFFFFFF` is replaced with the existing `@color/woo_white_alpha_012` token. Subtitle reworded from *"On a device where you're already signed in, visit:"* → *"On your computer, visit:"* to remove the phone-vs-computer ambiguity.

Implementation:
- Adds `QrLoginPayload.InstallQrCode` to the parser sealed hierarchy.
- Parser detects `https://woocommerce.com/mobile[/...]` (case-insensitive host, https only) — utm parameters are accepted, unrelated paths are rejected.
- New `ErrorReason.InstallQrCode` routed to a dedicated `QrLoginErrorContent` mapping with install-QR-specific copy.
- New strings: `login_qr_scanner_error_install_qr_title` / `_body`.
- Unit tests cover the install URL with utm parameters, without query, mixed-case host, and rejection of unrelated paths / http URLs.

This is **Step 10 of 10** in the QR login stacked PR chain — depends on `step-9-qr-login-activity-wiring`. Test plan below covers the full feature end-to-end since this is the final PR before the chain is ready to merge.

### Stacked PR chain
- Step 1: #15733 — foundation: payload type, parser, and analytics events
- Step 2: #15734 — token exchange REST client
- Step 3: #15735 — authenticator orchestrating exchange + site fetch + eligibility
- Step 4: #15736 — scanner ViewModel state machine and feature-flag gate
- Step 5: #15737 — prologue screen with QR icon, URL pill, and camera-permission gate
- Step 6: #15738 — camera viewfinder, scanner screen, and endpoint-missing fallback
- Step 7: #15739 — fullscreen confirm + error screens with retry-eligible mapping
- Step 8: #15740 — prologue and scanner fragments hosting the Compose surfaces
- Step 9: #15741 — activity wiring and `woocommerce://qr-login` deep link
- Step 10: #15742 — detect wp-admin install QR and guide users to the sign-in QR ← **this PR**


https://github.com/user-attachments/assets/2ceffa07-0cb2-49ed-9023-133750d453b3





### Test Steps

#### Manual test steps (for a human reviewer)

These cover the main paths and don't require apifaker / mock-server setup.

- [x] **Happy path** — open the app on a fresh install, tap *Log In* → *Scan QR code* → grant camera → scan a real sign-in QR from your own wp-admin → the *Sign in to this store?* screen appears with your store host in a purple pill → tap *Continue* → *Signing you in…* → land in the store dashboard.
- [x] **Cancel** — repeat the above but tap *Cancel* on the confirm screen → returns to the prologue (NOT a black screen).
- [x] **Install QR (this PR's main scenario)** — point the camera at the wp-admin onboarding install QR, OR open `https://woocommerce.com/mobile/?utm_source=wc_onboarding_mobile_task` from a desktop browser as a printed QR → fullscreen *"That's the install QR"* with body explaining how to find the sign-in QR (the *App is installed* button) and the `woo.com/mobilelogin` fallback. Tap *Scan a new code* → returns to scanner cleanly.
- [x] **Wrong / non-Woo QR** — scan any random QR (e.g. a URL QR for `google.com`) → fullscreen *"Not a WooCommerce code"* → *Scan a new code* → exits cleanly.
- [x] **No camera / feature flag off** — the QR_LOGIN feature flag is debug-only in this build; on a release build (or with the flag flipped off) tap *Log In* → it should route directly to the legacy site-URL flow, skipping the QR prologue. (You can simulate by flipping the flag locally.)
- [x] **Landscape on phone** — rotate the device on the prologue and on the confirm screen; the hero scrolls and the fallback / Cancel CTAs stay visible at the bottom edge.
- [x] **Light + dark mode chrome** — toggle the system theme on the prologue; the *Scan QR code* button is clearly visible in both themes (NOT purple-on-purple), and the *Visit `woo.com/mobilelogin`* pill is readable in both.

#### AI testing (the error-state coverage)

The exchange-error states (`401`, `5xx`, `429`, `404`, network unreachable, malformed deep link, retry-with-same-ticket) need apifaker rules and an emulator with the `verify-on-device` skill to exercise reliably. Paste the prompt below into Claude (or your AI agent of choice) — it should pick up from there.

<details>
<summary><strong>Prompt for the AI agent</strong></summary>

```
Verify the QR login error-state coverage for PR #15742 on the running emulator.

Setup:
- App is already installed and on the login prologue. Don't rebuild if it's already running.
- Use the apifaker library (libs/apifaker) to mock responses for the
  /wp-json/wc-admin/mobile-app/qr-login-exchange endpoint.
- For each scenario below: trigger via the deep link template
  `adb shell 'am start -a android.intent.action.VIEW -p com.woocommerce.android.dev     -d "woocommerce://qr-login?token=tok&siteUrl=https%3A%2F%2Fmystore.example"'`
  unless otherwise specified, then use the verify-on-device skill (element list +
  logcat — no screenshots needed for the assertion itself) to confirm each expected
  state, and finally take ONE screenshot per scenario for the PR write-up.

Scenarios:
1. 401 token rejected → fullscreen "Code expired" → tap "Scan a new code" exits
   cleanly. Verify the error reason is `TokenRejected` (NOT retry-eligible — there
   should be no "Try again" path back to the same exchange).
2. 5xx server error → fullscreen "Something went wrong" → tap "Try again" replays
   the exchange with the same ticket (NOT the scanner). Confirm the second call
   uses the same token (apifaker request log).
3. 429 rate limited → fullscreen "Too many attempts" → "Try again" retries.
4. 404 endpoint missing → fullscreen "This store can't complete QR login" → tap
   "Try scanning again" exits cleanly. "Enter site URL instead" switches to the
   legacy URL flow.
5. Network unreachable host (siteUrl that won't resolve, no apifaker rule needed)
   → fullscreen "Couldn't reach your store" → "Try again" retries.
6. Malformed deep link (`woocommerce://qr-login?invalid=true`) → "Not a WooCommerce
   code" → "Scan a new code" exits cleanly.
7. Process restart from recents AFTER deep-link entry → confirm that re-launching
   from recents does NOT replay the single-use token (the scanner should NOT
   restart the exchange on cold start; verify via logcat that no second exchange
   request fires).
8. Authenticating state UX → trigger any successful exchange and verify the
   "Signing you in…" view fills the screen (centered spinner on the surface
   color, NOT a small ProgressDialog on a black scrim).

Report: a table with one row per scenario (status, observed state, screenshot
path, any deviations).
```

</details>

### Images/gif

Screenshots captured during local verification on emulator-5554 are attached to the Linear issue. The AI run above (when it lands) will produce per-error-state screenshots.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.