### PR TITLE
[WOOMOB-2787] Phone-side Card Reader Mode: location permission and simulated reader

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
@@ -15,10 +15,12 @@ import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailab
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
 import com.woocommerce.android.cardreader.payments.CardInteracRefundStatus
 import com.woocommerce.android.cardreader.payments.CardPaymentStatus
+import com.woocommerce.android.cardreader.payments.CreatePaymentIntentResult
 import com.woocommerce.android.cardreader.payments.PaymentData
 import com.woocommerce.android.cardreader.payments.PaymentInfo
 import com.woocommerce.android.cardreader.payments.RefundConfig
 import com.woocommerce.android.cardreader.payments.RefundParams
+import com.woocommerce.android.cardreader.payments.RetrieveAndCollectResult
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
@@ -89,6 +91,12 @@ class MockCardReaderManagerModule {
 
         override suspend fun collectPayment(paymentInfo: PaymentInfo): Flow<CardPaymentStatus> =
             flowOf(CardPaymentStatus.ProcessingPayment)
+
+        override suspend fun createPaymentIntent(paymentInfo: PaymentInfo): CreatePaymentIntentResult =
+            CreatePaymentIntentResult.Failed(IllegalStateException("Not used in instrumented tests"))
+
+        override suspend fun retrieveAndCollectPayment(clientSecret: String): RetrieveAndCollectResult =
+            RetrieveAndCollectResult.Failed(IllegalStateException("Not used in instrumented tests"))
 
         override suspend fun refundInteracPayment(
             refundParams: RefundParams,

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
         android:name="com.google.android.gms.permission.AD_ID"
         tools:node="remove" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <queries>
         <package android:name="com.whatsapp" />

--- a/WooCommerce/src/main/AndroidManifest.xml
+++ b/WooCommerce/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         android:name="com.google.android.gms.permission.AD_ID"
         tools:node="remove" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <queries>
         <package android:name="com.whatsapp" />

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/RemoteTapToPayPaymentViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/RemoteTapToPayPaymentViewState.kt
@@ -23,6 +23,15 @@ data class RemoteTapToPayLocationPermissionExplainer(
     primaryActionLabel = R.string.card_reader_mode_location_permission_continue,
 )
 
+data class RemoteTapToPayLocationPermissionDenied(
+    override val onPrimaryActionClicked: (() -> Unit),
+) : ViewState(
+    headerLabel = R.string.card_reader_mode_location_permission_header,
+    paymentStateLabel = UiStringRes(R.string.card_reader_mode_location_permission_denied_subtitle),
+    illustration = R.drawable.img_card_reader_tpp_connecting,
+    primaryActionLabel = R.string.card_reader_mode_location_permission_open_settings,
+)
+
 data class RemoteTapToPayReadyToPair(
     val deviceName: String,
     val fingerprintSuffix: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/RemoteTapToPayPaymentViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/RemoteTapToPayPaymentViewState.kt
@@ -14,6 +14,15 @@ data class RemoteTapToPayStarting(
     primaryActionLabel = R.string.card_reader_mode_cancel,
 )
 
+data class RemoteTapToPayLocationPermissionExplainer(
+    override val onPrimaryActionClicked: (() -> Unit),
+) : ViewState(
+    headerLabel = R.string.card_reader_mode_location_permission_header,
+    paymentStateLabel = UiStringRes(R.string.card_reader_mode_location_permission_subtitle),
+    illustration = R.drawable.img_card_reader_tpp_connecting,
+    primaryActionLabel = R.string.card_reader_mode_location_permission_continue,
+)
+
 data class RemoteTapToPayReadyToPair(
     val deviceName: String,
     val fingerprintSuffix: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeActivity.kt
@@ -48,10 +48,12 @@ class CardReaderModeActivity : AppCompatActivity() {
             }
         }
 
-        if (WooPermissionUtils.hasFineLocationPermission(this)) {
-            viewModel.onLocationPermissionResult(true)
-        } else {
-            viewModel.onLocationPermissionMissing()
+        if (savedInstanceState == null) {
+            if (WooPermissionUtils.hasFineLocationPermission(this)) {
+                viewModel.onLocationPermissionResult(true)
+            } else {
+                viewModel.onLocationPermissionMissing()
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeActivity.kt
@@ -1,22 +1,30 @@
 package com.woocommerce.android.ui.payments.cardreader.readermode
 
+import android.Manifest
 import android.os.Bundle
 import android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.util.WooPermissionUtils
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class CardReaderModeActivity : AppCompatActivity() {
 
     private val viewModel: CardReaderModeViewModel by viewModels()
+
+    private val locationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        viewModel.onLocationPermissionResult(granted)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,8 +38,20 @@ class CardReaderModeActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.events.collect { finish() }
+                viewModel.events.collect { event ->
+                    when (event) {
+                        CardReaderModeEvent.Exit -> finish()
+                        CardReaderModeEvent.RequestLocationPermission ->
+                            locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                    }
+                }
             }
+        }
+
+        if (WooPermissionUtils.hasFineLocationPermission(this)) {
+            viewModel.onLocationPermissionResult(true)
+        } else {
+            viewModel.onLocationPermissionMissing()
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeActivity.kt
@@ -23,7 +23,10 @@ class CardReaderModeActivity : AppCompatActivity() {
     private val locationPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { granted ->
-        viewModel.onLocationPermissionResult(granted)
+        viewModel.onLocationPermissionResult(
+            granted = granted,
+            shouldShowRationale = WooPermissionUtils.shouldShowFineLocationPermissionRationale(this),
+        )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -43,6 +46,8 @@ class CardReaderModeActivity : AppCompatActivity() {
                         CardReaderModeEvent.Exit -> finish()
                         CardReaderModeEvent.RequestLocationPermission ->
                             locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                        CardReaderModeEvent.OpenAppSettings ->
+                            WooPermissionUtils.showAppSettings(this@CardReaderModeActivity, openInNewStack = false)
                     }
                 }
             }
@@ -50,7 +55,7 @@ class CardReaderModeActivity : AppCompatActivity() {
 
         if (savedInstanceState == null) {
             if (WooPermissionUtils.hasFineLocationPermission(this)) {
-                viewModel.onLocationPermissionResult(true)
+                viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
             } else {
                 viewModel.onLocationPermissionMissing()
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeEvent.kt
@@ -3,4 +3,5 @@ package com.woocommerce.android.ui.payments.cardreader.readermode
 sealed class CardReaderModeEvent {
     data object Exit : CardReaderModeEvent()
     data object RequestLocationPermission : CardReaderModeEvent()
+    data object OpenAppSettings : CardReaderModeEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeEvent.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.ui.payments.cardreader.readermode
+
+sealed class CardReaderModeEvent {
+    data object Exit : CardReaderModeEvent()
+    data object RequestLocationPermission : CardReaderModeEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeExit.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeExit.kt
@@ -1,3 +1,0 @@
-package com.woocommerce.android.ui.payments.cardreader.readermode
-
-object CardReaderModeExit

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSession
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSessionState
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayError
+import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionDenied
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionExplainer
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayReadyToPair
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayStarting
@@ -45,10 +46,13 @@ class CardReaderModeViewModel @Inject constructor(
         )
     }
 
-    fun onLocationPermissionResult(granted: Boolean) {
-        when (granted) {
-            true -> startSessionIfNeeded()
-            false -> onLocationPermissionMissing()
+    fun onLocationPermissionResult(granted: Boolean, shouldShowRationale: Boolean) {
+        when {
+            granted -> startSessionIfNeeded()
+            !shouldShowRationale -> _viewState.value = RemoteTapToPayLocationPermissionDenied(
+                onPrimaryActionClicked = { _events.trySend(CardReaderModeEvent.OpenAppSettings) },
+            )
+            else -> onLocationPermissionMissing()
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -2,13 +2,19 @@ package com.woocommerce.android.ui.payments.cardreader.readermode
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSession
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSessionState
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayError
+import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionExplainer
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayReadyToPair
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayStarting
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayWaitingForPayment
 import com.woocommerce.android.ui.payments.cardreader.payment.ViewState
+import com.woocommerce.android.ui.prefs.developer.DeveloperOptionsRepository
+import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -22,21 +28,56 @@ import javax.inject.Inject
 @HiltViewModel
 class CardReaderModeViewModel @Inject constructor(
     private val session: CardReaderRemoteSession,
+    private val cardReaderManager: CardReaderManager,
+    private val developerOptionsRepository: DeveloperOptionsRepository,
+    private val resourceProvider: ResourceProvider,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow<ViewState?>(null)
     val viewState: StateFlow<ViewState?> = _viewState.asStateFlow()
 
-    private val _events = Channel<CardReaderModeExit>(capacity = Channel.BUFFERED)
-    val events: Flow<CardReaderModeExit> = _events.receiveAsFlow()
+    private val _events = Channel<CardReaderModeEvent>(capacity = Channel.BUFFERED)
+    val events: Flow<CardReaderModeEvent> = _events.receiveAsFlow()
 
-    init {
+    private var sessionStarted = false
+
+    fun onLocationPermissionMissing() {
+        if (sessionStarted) return
+        _viewState.value = RemoteTapToPayLocationPermissionExplainer(
+            onPrimaryActionClicked = { _events.trySend(CardReaderModeEvent.RequestLocationPermission) },
+        )
+    }
+
+    fun onLocationPermissionResult(granted: Boolean) {
+        when (granted) {
+            true -> startSessionIfNeeded()
+            false -> _viewState.value = RemoteTapToPayError(
+                message = resourceProvider.getString(R.string.card_reader_mode_location_permission_required),
+                onPrimaryActionClicked = ::exit,
+            )
+        }
+    }
+
+    private fun startSessionIfNeeded() {
+        if (sessionStarted) return
+        sessionStarted = true
+
+        if (!cardReaderManager.initialized) {
+            cardReaderManager.initialize(
+                updateFrequency = developerOptionsRepository.getUpdateSimulatedReaderOption(),
+                useInterac = developerOptionsRepository.isInteracPaymentEnabled(),
+                isDebug = BuildConfig.DEBUG,
+            )
+        }
         viewModelScope.launch {
             session.state.collect { sessionState ->
                 _viewState.value = mapToViewState(sessionState)
             }
         }
-        session.start(viewModelScope)
+        session.start(
+            parentScope = viewModelScope,
+            isSimulated = developerOptionsRepository.isSimulatedCardReaderEnabled(),
+        )
     }
 
     override fun onCleared() {
@@ -63,6 +104,6 @@ class CardReaderModeViewModel @Inject constructor(
     }
 
     private fun exit() {
-        _events.trySend(CardReaderModeExit)
+        _events.trySend(CardReaderModeEvent.Exit)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.payments.cardreader.readermode
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.BuildConfig
-import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSession
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSessionState
@@ -14,7 +13,6 @@ import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayStar
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayWaitingForPayment
 import com.woocommerce.android.ui.payments.cardreader.payment.ViewState
 import com.woocommerce.android.ui.prefs.developer.DeveloperOptionsRepository
-import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -30,7 +28,6 @@ class CardReaderModeViewModel @Inject constructor(
     private val session: CardReaderRemoteSession,
     private val cardReaderManager: CardReaderManager,
     private val developerOptionsRepository: DeveloperOptionsRepository,
-    private val resourceProvider: ResourceProvider,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow<ViewState?>(null)
@@ -51,10 +48,7 @@ class CardReaderModeViewModel @Inject constructor(
     fun onLocationPermissionResult(granted: Boolean) {
         when (granted) {
             true -> startSessionIfNeeded()
-            false -> _viewState.value = RemoteTapToPayError(
-                message = resourceProvider.getString(R.string.card_reader_mode_location_permission_required),
-                onPrimaryActionClicked = ::exit,
-            )
+            false -> onLocationPermissionMissing()
         }
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1535,6 +1535,8 @@
     <string name="card_reader_mode_location_permission_header">Location permission required</string>
     <string name="card_reader_mode_location_permission_subtitle">Android requires location access to use tap-to-pay on this phone. Your location stays on this device.</string>
     <string name="card_reader_mode_location_permission_continue">Continue</string>
+    <string name="card_reader_mode_location_permission_denied_subtitle">Location permission is blocked. Open Settings and grant Location to use tap-to-pay on this phone.</string>
+    <string name="card_reader_mode_location_permission_open_settings">Open Settings</string>
 
     <string name="card_reader_payment_failed_nfc_disabled">The app could not enable the card reader, because the NFC chip is disabled</string>
     <string name="card_reader_payment_failed_nfc_disabled_enable_nfc">Enable NFC</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1532,7 +1532,6 @@
     <string name="card_reader_mode_error_header">Card Reader Mode failed to start</string>
     <string name="card_reader_mode_error_subtitle">Check your Wi-Fi connection and try again.</string>
     <string name="card_reader_mode_error_close">Close</string>
-    <string name="card_reader_mode_location_permission_required">Location permission is required to connect with the tablet.</string>
     <string name="card_reader_mode_location_permission_header">Location permission required</string>
     <string name="card_reader_mode_location_permission_subtitle">Android requires location access to use tap-to-pay on this phone. Your location stays on this device.</string>
     <string name="card_reader_mode_location_permission_continue">Continue</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1532,6 +1532,10 @@
     <string name="card_reader_mode_error_header">Card Reader Mode failed to start</string>
     <string name="card_reader_mode_error_subtitle">Check your Wi-Fi connection and try again.</string>
     <string name="card_reader_mode_error_close">Close</string>
+    <string name="card_reader_mode_location_permission_required">Location permission is required to connect with the tablet.</string>
+    <string name="card_reader_mode_location_permission_header">Location permission required</string>
+    <string name="card_reader_mode_location_permission_subtitle">Android requires location access to use tap-to-pay on this phone. Your location stays on this device.</string>
+    <string name="card_reader_mode_location_permission_continue">Continue</string>
 
     <string name="card_reader_payment_failed_nfc_disabled">The app could not enable the card reader, because the NFC chip is disabled</string>
     <string name="card_reader_payment_failed_nfc_disabled_enable_nfc">Enable NFC</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
@@ -3,17 +3,16 @@ package com.woocommerce.android.ui.payments.cardreader.readermode
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
-import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSession
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSessionState
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayError
+import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionExplainer
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayReadyToPair
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayStarting
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayWaitingForPayment
 import com.woocommerce.android.ui.prefs.developer.DeveloperOptionsRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
-import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -24,6 +23,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 
 @ExperimentalCoroutinesApi
@@ -36,10 +36,6 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         on { initialized }.thenReturn(true)
     }
     private val developerOptionsRepository: DeveloperOptionsRepository = mock()
-    private val resourceProvider: ResourceProvider = mock {
-        on { getString(R.string.card_reader_mode_location_permission_required) }
-            .thenReturn("Location permission is required to connect with the tablet.")
-    }
 
     private lateinit var store: ViewModelStore
     private lateinit var viewModel: CardReaderModeViewModel
@@ -54,7 +50,6 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
                     session,
                     cardReaderManager,
                     developerOptionsRepository,
-                    resourceProvider,
                 ) as T
         }
         viewModel = ViewModelProvider(store, factory)[CardReaderModeViewModel::class.java]
@@ -82,18 +77,17 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         viewModel.onLocationPermissionResult(granted = true)
 
         // THEN
-        verify(session).start(any(), any())
+        verify(session, times(1)).start(any(), any())
     }
 
     @Test
-    fun `given location permission denied, when result received, then error state is shown`() = testBlocking {
+    fun `given location permission denied, when result received, then explainer state is shown`() = testBlocking {
         // WHEN
         viewModel.onLocationPermissionResult(granted = false)
         advanceUntilIdle()
 
         // THEN
-        val viewState = viewModel.viewState.value as RemoteTapToPayError
-        assertThat(viewState.message).isEqualTo("Location permission is required to connect with the tablet.")
+        assertThat(viewModel.viewState.value).isInstanceOf(RemoteTapToPayLocationPermissionExplainer::class.java)
         verify(session, never()).start(any(), any())
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
@@ -3,13 +3,17 @@ package com.woocommerce.android.ui.payments.cardreader.readermode
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
+import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSession
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSessionState
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayError
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayReadyToPair
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayStarting
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayWaitingForPayment
+import com.woocommerce.android.ui.prefs.developer.DeveloperOptionsRepository
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -19,6 +23,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 @ExperimentalCoroutinesApi
@@ -26,6 +31,14 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     private val sessionState = MutableStateFlow<CardReaderRemoteSessionState>(CardReaderRemoteSessionState.Idle)
     private val session: CardReaderRemoteSession = mock {
         on { state }.thenReturn(sessionState)
+    }
+    private val cardReaderManager: CardReaderManager = mock {
+        on { initialized }.thenReturn(true)
+    }
+    private val developerOptionsRepository: DeveloperOptionsRepository = mock()
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(R.string.card_reader_mode_location_permission_required) }
+            .thenReturn("Location permission is required to connect with the tablet.")
     }
 
     private lateinit var store: ViewModelStore
@@ -37,19 +50,58 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         val factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T =
-                CardReaderModeViewModel(session) as T
+                CardReaderModeViewModel(
+                    session,
+                    cardReaderManager,
+                    developerOptionsRepository,
+                    resourceProvider,
+                ) as T
         }
         viewModel = ViewModelProvider(store, factory)[CardReaderModeViewModel::class.java]
     }
 
     @Test
-    fun `when view model initialized, then session started`() {
+    fun `when view model initialized, then session is not started yet`() {
         // THEN
-        verify(session).start(any())
+        verify(session, never()).start(any(), any())
+    }
+
+    @Test
+    fun `given location permission granted, when result received, then session started`() {
+        // WHEN
+        viewModel.onLocationPermissionResult(granted = true)
+
+        // THEN
+        verify(session).start(any(), any())
+    }
+
+    @Test
+    fun `given location permission granted twice, when received, then session started only once`() {
+        // WHEN
+        viewModel.onLocationPermissionResult(granted = true)
+        viewModel.onLocationPermissionResult(granted = true)
+
+        // THEN
+        verify(session).start(any(), any())
+    }
+
+    @Test
+    fun `given location permission denied, when result received, then error state is shown`() = testBlocking {
+        // WHEN
+        viewModel.onLocationPermissionResult(granted = false)
+        advanceUntilIdle()
+
+        // THEN
+        val viewState = viewModel.viewState.value as RemoteTapToPayError
+        assertThat(viewState.message).isEqualTo("Location permission is required to connect with the tablet.")
+        verify(session, never()).start(any(), any())
     }
 
     @Test
     fun `given starting session state, when emitted, then starting view state is shown`() = testBlocking {
+        // GIVEN
+        viewModel.onLocationPermissionResult(granted = true)
+
         // WHEN
         sessionState.value = CardReaderRemoteSessionState.Starting
         advanceUntilIdle()
@@ -60,6 +112,9 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given ready to pair session state, when emitted, then ready to pair view state is shown`() = testBlocking {
+        // GIVEN
+        viewModel.onLocationPermissionResult(granted = true)
+
         // WHEN
         sessionState.value = CardReaderRemoteSessionState.ReadyToPair(
             deviceName = "Pixel",
@@ -76,6 +131,9 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     @Test
     fun `given waiting for payment session state, when emitted, then waiting for payment view state is shown`() =
         testBlocking {
+            // GIVEN
+            viewModel.onLocationPermissionResult(granted = true)
+
             // WHEN
             sessionState.value = CardReaderRemoteSessionState.WaitingForPayment(tabletName = "Tablet 1")
             advanceUntilIdle()
@@ -87,6 +145,9 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given error session state, when emitted, then error view state carries the message`() = testBlocking {
+        // GIVEN
+        viewModel.onLocationPermissionResult(granted = true)
+
         // WHEN
         sessionState.value = CardReaderRemoteSessionState.Error(message = "java.net.SocketException: closed")
         advanceUntilIdle()
@@ -99,6 +160,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     @Test
     fun `given starting view state, when cancel clicked, then exit event is emitted`() = testBlocking {
         // GIVEN
+        viewModel.onLocationPermissionResult(granted = true)
         sessionState.value = CardReaderRemoteSessionState.Starting
         advanceUntilIdle()
 
@@ -106,7 +168,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         (viewModel.viewState.value as RemoteTapToPayStarting).onPrimaryActionClicked.invoke()
 
         // THEN
-        assertThat(viewModel.events.first()).isEqualTo(CardReaderModeExit)
+        assertThat(viewModel.events.first()).isEqualTo(CardReaderModeEvent.Exit)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSession
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSessionState
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayError
+import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionDenied
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionExplainer
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayReadyToPair
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayStarting
@@ -64,7 +65,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     @Test
     fun `given location permission granted, when result received, then session started`() {
         // WHEN
-        viewModel.onLocationPermissionResult(granted = true)
+        viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
         // THEN
         verify(session).start(any(), any())
@@ -73,17 +74,17 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     @Test
     fun `given location permission granted twice, when received, then session started only once`() {
         // WHEN
-        viewModel.onLocationPermissionResult(granted = true)
-        viewModel.onLocationPermissionResult(granted = true)
+        viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
+        viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
         // THEN
         verify(session, times(1)).start(any(), any())
     }
 
     @Test
-    fun `given location permission denied, when result received, then explainer state is shown`() = testBlocking {
+    fun `given denied with rationale, when result received, then explainer state is shown`() = testBlocking {
         // WHEN
-        viewModel.onLocationPermissionResult(granted = false)
+        viewModel.onLocationPermissionResult(granted = false, shouldShowRationale = true)
         advanceUntilIdle()
 
         // THEN
@@ -92,9 +93,20 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given permanently denied, when result received, then permission denied state is shown`() = testBlocking {
+        // WHEN
+        viewModel.onLocationPermissionResult(granted = false, shouldShowRationale = false)
+        advanceUntilIdle()
+
+        // THEN
+        assertThat(viewModel.viewState.value).isInstanceOf(RemoteTapToPayLocationPermissionDenied::class.java)
+        verify(session, never()).start(any(), any())
+    }
+
+    @Test
     fun `given starting session state, when emitted, then starting view state is shown`() = testBlocking {
         // GIVEN
-        viewModel.onLocationPermissionResult(granted = true)
+        viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
         // WHEN
         sessionState.value = CardReaderRemoteSessionState.Starting
@@ -107,7 +119,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     @Test
     fun `given ready to pair session state, when emitted, then ready to pair view state is shown`() = testBlocking {
         // GIVEN
-        viewModel.onLocationPermissionResult(granted = true)
+        viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
         // WHEN
         sessionState.value = CardReaderRemoteSessionState.ReadyToPair(
@@ -126,7 +138,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     fun `given waiting for payment session state, when emitted, then waiting for payment view state is shown`() =
         testBlocking {
             // GIVEN
-            viewModel.onLocationPermissionResult(granted = true)
+            viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
             // WHEN
             sessionState.value = CardReaderRemoteSessionState.WaitingForPayment(tabletName = "Tablet 1")
@@ -140,7 +152,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     @Test
     fun `given error session state, when emitted, then error view state carries the message`() = testBlocking {
         // GIVEN
-        viewModel.onLocationPermissionResult(granted = true)
+        viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
         // WHEN
         sessionState.value = CardReaderRemoteSessionState.Error(message = "java.net.SocketException: closed")
@@ -154,7 +166,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     @Test
     fun `given starting view state, when cancel clicked, then exit event is emitted`() = testBlocking {
         // GIVEN
-        viewModel.onLocationPermissionResult(granted = true)
+        viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
         sessionState.value = CardReaderRemoteSessionState.Starting
         advanceUntilIdle()
 


### PR DESCRIPTION
Fixes WOOMOB-2787

The phone runs as a Stripe Tap-to-Pay reader for the Woo POS Remote Tap-to-Pay flow. Stripe Terminal needs `ACCESS_FINE_LOCATION` to discover the built-in TTP reader. The activity now asks for the permission before starting the session, and the ViewModel only kicks off the Stripe SDK once the permission is granted.

**Notable**

- Permission flow: explainer state while the permission is missing → system dialog → either start the session, or show an error if denied.
- `CardReaderModeExit` (object) is replaced by `CardReaderModeEvent` sealed class so the ViewModel can emit both `Exit` and `RequestLocationPermission`.
- Simulated card reader: dev option threaded through `session.start(isSimulated)`. With it enabled, Stripe Terminal uses its simulator instead of real hardware.
- `MockCardReaderManagerModule` (androidTest) gets fakes for the new `createPaymentIntent` / `retrieveAndCollectPayment` API.

### Test Steps

1. Open **Payments → Card Reader Mode** on a TTP-capable phone.
2. If location permission is missing: explainer screen appears with a Continue button. Tap Continue → system permission dialog appears. Deny → error screen with "location required" message. Grant → session starts and Card Reader Mode shows the existing pairing/waiting states.
3. Re-open the screen with permission already granted → session starts immediately.
4. Toggle **Simulated card reader** in developer options → reopen Card Reader Mode → session starts in simulated mode (no real reader needed).

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.