### PR TITLE
[WOOMOB-2787] Tablet-side remote payment flow and floating toolbar status

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -4,10 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
+import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
@@ -15,6 +13,9 @@ import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardRea
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.woopos.bookings.BOOKING_PAYMENT_FLOW_FINISHED_KEY
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatus
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderPaymentFlow
 import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
 import com.woocommerce.android.ui.woopos.home.totals.TTPPaymentProgressDelegate
 import com.woocommerce.android.ui.woopos.home.totals.WooPosCardReaderPaymentControllerFactory
@@ -47,6 +48,8 @@ class WooPosCardPaymentViewModel @Inject constructor(
     private val analyticsTracker: WooPosCardPaymentAnalyticsTracker,
     private val cardPaymentRepository: WooPosCardPaymentRepository,
     private val priceFormat: WooPosFormatPrice,
+    private val remoteReaderPaymentFlow: WooPosRemoteReaderPaymentFlow,
+    private val effectiveReaderStatusProvider: WooPosEffectiveReaderStatusProvider,
 ) : ViewModel() {
 
     private val orderId: Long = requireNotNull(savedState[CARD_PAYMENT_ROUTE_ORDER_ID_KEY])
@@ -63,69 +66,96 @@ class WooPosCardPaymentViewModel @Inject constructor(
     val navigationEvent: SharedFlow<WooPosNavigationEvent> = _navigationEvent.asSharedFlow()
 
     private lateinit var orderTotals: WooPosOrderTotalsViewState
+    private var order: Order? = null
 
     private var cardReaderPaymentController: CardReaderPaymentController? = null
     private var paymentListenerJob: Job? = null
     private var controllerEventJob: Job? = null
+    private var remotePaymentJob: Job? = null
     private var isTTPPaymentInProgress: Boolean by TTPPaymentProgressDelegate(savedState)
     private var analyticsTrackerJob: Job? = null
 
     init {
         viewModelScope.launch {
-            val totals = loadOrderTotals()
-            if (totals != null) {
-                orderTotals = totals
-                observeCardReaderStatus()
+            val loaded = cardPaymentRepository.fetchOrGetOrder(orderId)
+            if (loaded == null) {
+                _state.value = WooPosCardPaymentState.PaymentFailed(
+                    title = resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title),
+                    subtitle = resourceProvider.getString(R.string.woopos_products_loading_error_message),
+                    isDismissButtonVisible = true,
+                )
+            } else {
+                order = loaded
+                orderTotals = WooPosOrderTotalsViewState(
+                    subtotal = priceFormat(loaded.productsTotal),
+                    discount = if (loaded.discountTotal > BigDecimal.ZERO) {
+                        "-${priceFormat(loaded.discountTotal)}"
+                    } else {
+                        null
+                    },
+                    taxes = priceFormat(loaded.totalTax),
+                    total = priceFormat(loaded.total),
+                )
+                observeReaderStatus()
             }
         }
     }
 
-    private suspend fun loadOrderTotals(): WooPosOrderTotalsViewState? {
-        val order = cardPaymentRepository.fetchOrGetOrder(orderId)
-        if (order == null) {
-            _state.value = WooPosCardPaymentState.PaymentFailed(
-                title = resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title),
-                subtitle = resourceProvider.getString(R.string.woopos_products_loading_error_message),
-                isDismissButtonVisible = true,
-            )
-            return null
+    private fun observeReaderStatus() {
+        viewModelScope.launch {
+            effectiveReaderStatusProvider.flow
+                .collect { effective ->
+                    val currentState = _state.value
+                    if (currentState is WooPosCardPaymentState.PaymentInProgress) {
+                        return@collect
+                    }
+                    when (effective) {
+                        WooPosEffectiveReaderStatus.RemoteConnected -> {
+                            _state.value = buildPreparingState()
+                            collectPaymentRemote()
+                        }
+                        WooPosEffectiveReaderStatus.BluetoothConnected -> {
+                            _state.value = buildPreparingState()
+                            collectPayment()
+                        }
+                        WooPosEffectiveReaderStatus.Connecting,
+                        WooPosEffectiveReaderStatus.Reconnecting,
+                        WooPosEffectiveReaderStatus.Disconnected -> {
+                            _state.value = buildReaderDisconnectedState()
+                            cancelPayment()
+                        }
+                    }
+                }
         }
-
-        return WooPosOrderTotalsViewState(
-            subtotal = priceFormat(order.productsTotal),
-            discount = if (order.discountTotal > BigDecimal.ZERO) {
-                "-${priceFormat(order.discountTotal)}"
-            } else {
-                null
-            },
-            taxes = priceFormat(order.totalTax),
-            total = priceFormat(order.total),
-        )
     }
 
-    private fun observeCardReaderStatus() {
-        viewModelScope.launch {
-            cardReaderFacade.readerStatus.collect { status ->
-                when (status) {
-                    is NotConnected, is Connecting -> {
-                        val currentState = _state.value
-                        if (currentState is WooPosCardPaymentState.PaymentInProgress) {
-                            return@collect
-                        }
-                        _state.value = buildReaderDisconnectedState()
-                        cancelPayment()
-                    }
+    private fun collectPaymentRemote() {
+        if (!networkStatus.isConnected()) {
+            _state.value = WooPosCardPaymentState.PaymentFailed(
+                title = resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title),
+                subtitle = resourceProvider.getString(R.string.woopos_no_internet_message),
+                actionButtonLabel = resourceProvider.getString(R.string.woo_pos_payment_failed_try_again),
+                isDismissButtonVisible = true,
+            )
+            return
+        }
+        val order = this.order ?: return
 
-                    is Connected -> {
-                        val currentState = _state.value
-                        if (currentState is WooPosCardPaymentState.PaymentInProgress) {
-                            return@collect
-                        }
-                        _state.value = buildPreparingState()
-                        collectPayment()
-                    }
-
-                    is CardReaderStatus.Reconnecting -> Unit
+        remotePaymentJob?.cancel()
+        remotePaymentJob = viewModelScope.launch {
+            _state.value = WooPosCardPaymentState.PaymentInProgress(
+                title = resourceProvider.getString(R.string.woopos_success_totals_payment_processing_title),
+                subtitle = resourceProvider.getString(R.string.woopos_success_totals_payment_processing_subtitle),
+            )
+            when (val result = remoteReaderPaymentFlow.collect(order)) {
+                WooPosRemoteReaderPaymentFlow.Result.Completed -> handlePaymentSuccessful()
+                is WooPosRemoteReaderPaymentFlow.Result.Failed -> {
+                    _state.value = WooPosCardPaymentState.PaymentFailed(
+                        title = resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title),
+                        subtitle = result.message,
+                        actionButtonLabel = resourceProvider.getString(R.string.woo_pos_payment_failed_try_again),
+                        isDismissButtonVisible = true,
+                    )
                 }
             }
         }
@@ -296,7 +326,13 @@ class WooPosCardPaymentViewModel @Inject constructor(
 
     fun onScreenResumed() {
         if (_state.value is WooPosCardPaymentState.Collecting) {
-            collectPayment()
+            when (effectiveReaderStatusProvider.current()) {
+                WooPosEffectiveReaderStatus.RemoteConnected -> collectPaymentRemote()
+                WooPosEffectiveReaderStatus.BluetoothConnected -> collectPayment()
+                WooPosEffectiveReaderStatus.Connecting,
+                WooPosEffectiveReaderStatus.Reconnecting,
+                WooPosEffectiveReaderStatus.Disconnected -> Unit
+            }
         }
     }
 
@@ -376,6 +412,8 @@ class WooPosCardPaymentViewModel @Inject constructor(
         controllerEventJob = null
         analyticsTrackerJob?.cancel()
         analyticsTrackerJob = null
+        remotePaymentJob?.cancel()
+        remotePaymentJob = null
         cardReaderPaymentController?.onBackPressed()
         cardReaderPaymentController?.stop()
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -74,6 +74,7 @@ class WooPosCardPaymentViewModel @Inject constructor(
     private var remotePaymentJob: Job? = null
     private var isTTPPaymentInProgress: Boolean by TTPPaymentProgressDelegate(savedState)
     private var analyticsTrackerJob: Job? = null
+    private var activePaymentMode: PaymentMode? = null
 
     init {
         viewModelScope.launch {
@@ -142,6 +143,7 @@ class WooPosCardPaymentViewModel @Inject constructor(
         val order = this.order ?: return
 
         remotePaymentJob?.cancel()
+        activePaymentMode = PaymentMode.REMOTE
         remotePaymentJob = viewModelScope.launch {
             _state.value = WooPosCardPaymentState.PaymentInProgress(
                 title = resourceProvider.getString(R.string.woopos_success_totals_payment_processing_title),
@@ -174,6 +176,7 @@ class WooPosCardPaymentViewModel @Inject constructor(
         if (cardReaderFacade.readerStatus.value !is Connected) return
 
         cardReaderPaymentController?.stop()
+        activePaymentMode = PaymentMode.BLUETOOTH
         cardReaderPaymentController = cardReaderPaymentControllerFactory.create(
             orderId = orderId,
             paymentType = PaymentOrRefund.Payment.PaymentType.WOO_POS,
@@ -343,6 +346,14 @@ class WooPosCardPaymentViewModel @Inject constructor(
     }
 
     fun onRetryClicked() {
+        when (activePaymentMode) {
+            PaymentMode.REMOTE -> collectPaymentRemote()
+            PaymentMode.BLUETOOTH -> retryBluetoothPayment()
+            null -> error("Retry clicked but no active payment mode")
+        }
+    }
+
+    private fun retryBluetoothPayment() {
         val paymentState = cardReaderPaymentController?.paymentState?.value
         check(paymentState != null) {
             "Retry clicked but payment controller is null"
@@ -359,19 +370,27 @@ class WooPosCardPaymentViewModel @Inject constructor(
     }
 
     fun onBackClicked() {
-        val paymentState = cardReaderPaymentController?.paymentState?.value
-        if (paymentState is CardReaderPaymentState.ProcessingPayment ||
-            paymentState is CardReaderPaymentState.PaymentCapturing
-        ) {
-            return
-        }
+        if (isPaymentInFlight()) return
         cancelPayment()
         navigateBack()
     }
 
     fun onDismissClicked() {
+        if (isPaymentInFlight()) return
         cancelPayment()
         navigateBack()
+    }
+
+    private fun isPaymentInFlight(): Boolean {
+        return when (activePaymentMode) {
+            PaymentMode.BLUETOOTH -> {
+                val paymentState = cardReaderPaymentController?.paymentState?.value
+                paymentState is CardReaderPaymentState.ProcessingPayment ||
+                    paymentState is CardReaderPaymentState.PaymentCapturing
+            }
+            PaymentMode.REMOTE -> _state.value is WooPosCardPaymentState.PaymentInProgress
+            null -> false
+        }
     }
 
     private fun navigateBack() {
@@ -416,9 +435,15 @@ class WooPosCardPaymentViewModel @Inject constructor(
         remotePaymentJob = null
         cardReaderPaymentController?.onBackPressed()
         cardReaderPaymentController?.stop()
+        activePaymentMode = null
     }
 
     override fun onCleared() {
         cancelPayment()
+    }
+
+    private enum class PaymentMode {
+        BLUETOOTH,
+        REMOTE,
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -131,6 +131,7 @@ class WooPosCardPaymentViewModel @Inject constructor(
     }
 
     private fun collectPaymentRemote() {
+        activePaymentMode = PaymentMode.REMOTE
         if (!networkStatus.isConnected()) {
             _state.value = WooPosCardPaymentState.PaymentFailed(
                 title = resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title),
@@ -143,7 +144,6 @@ class WooPosCardPaymentViewModel @Inject constructor(
         val order = this.order ?: return
 
         remotePaymentJob?.cancel()
-        activePaymentMode = PaymentMode.REMOTE
         remotePaymentJob = viewModelScope.launch {
             _state.value = WooPosCardPaymentState.PaymentInProgress(
                 title = resourceProvider.getString(R.string.woopos_success_totals_payment_processing_title),
@@ -164,6 +164,7 @@ class WooPosCardPaymentViewModel @Inject constructor(
     }
 
     private fun collectPayment() {
+        activePaymentMode = PaymentMode.BLUETOOTH
         if (!networkStatus.isConnected()) {
             _state.value = WooPosCardPaymentState.PaymentFailed(
                 title = resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title),
@@ -176,7 +177,6 @@ class WooPosCardPaymentViewModel @Inject constructor(
         if (cardReaderFacade.readerStatus.value !is Connected) return
 
         cardReaderPaymentController?.stop()
-        activePaymentMode = PaymentMode.BLUETOOTH
         cardReaderPaymentController = cardReaderPaymentControllerFactory.create(
             orderId = orderId,
             paymentType = PaymentOrRefund.Payment.PaymentType.WOO_POS,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosEffectiveReaderStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosEffectiveReaderStatus.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.ui.woopos.cardreader
+
+import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderSession
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import javax.inject.Inject
+import javax.inject.Singleton
+
+enum class WooPosEffectiveReaderStatus {
+    RemoteConnected,
+    BluetoothConnected,
+    Reconnecting,
+    Connecting,
+    Disconnected,
+}
+
+@Singleton
+class WooPosEffectiveReaderStatusProvider @Inject constructor(
+    private val cardReaderFacade: WooPosCardReaderFacade,
+    private val remoteReaderSession: WooPosRemoteReaderSession,
+) {
+    val flow: Flow<WooPosEffectiveReaderStatus> = combine(
+        cardReaderFacade.readerStatus,
+        remoteReaderSession.state,
+    ) { bt, remote -> toEffective(bt, remote) }.distinctUntilChanged()
+
+    fun current(): WooPosEffectiveReaderStatus = toEffective(
+        cardReaderFacade.readerStatus.value,
+        remoteReaderSession.state.value,
+    )
+
+    private fun toEffective(
+        bt: CardReaderStatus,
+        remote: WooPosRemoteReaderSession.State,
+    ): WooPosEffectiveReaderStatus = when {
+        remote is WooPosRemoteReaderSession.State.Connected -> WooPosEffectiveReaderStatus.RemoteConnected
+        bt is CardReaderStatus.Connected -> WooPosEffectiveReaderStatus.BluetoothConnected
+        bt is CardReaderStatus.Reconnecting -> WooPosEffectiveReaderStatus.Reconnecting
+        bt is CardReaderStatus.Connecting || remote is WooPosRemoteReaderSession.State.Connecting ->
+            WooPosEffectiveReaderStatus.Connecting
+        else -> WooPosEffectiveReaderStatus.Disconnected
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -297,6 +297,7 @@ fun WooPosCardReaderConnectionDialogContent(
                 is WooPosCardReaderConnectionState.ReaderFound -> {
                     ReaderFoundContent(
                         readerName = currentState.reader.name,
+                        fingerprintSuffix = currentState.reader.fingerprintSuffix,
                         onConnectClicked = currentState.reader.onConnectClicked,
                         onKeepSearchingClicked = currentState.onKeepSearchingClicked,
                     )
@@ -508,11 +509,17 @@ private fun ScanningDialogBody() {
 @Composable
 private fun ReaderFoundContent(
     readerName: String,
+    fingerprintSuffix: String?,
     onConnectClicked: () -> Unit,
     onKeepSearchingClicked: () -> Unit,
 ) {
+    val title = if (fingerprintSuffix != null) {
+        stringResource(R.string.woopos_card_reader_found_title, "$readerName · $fingerprintSuffix")
+    } else {
+        stringResource(R.string.woopos_card_reader_found_title, readerName)
+    }
     CardReaderDialogContent(
-        title = stringResource(R.string.woopos_card_reader_found_title, readerName),
+        title = title,
         icon = WooPosIcons.CardReaderFound,
     ) {
         WooPosButton(
@@ -1039,6 +1046,7 @@ fun WooPosCardReaderConnectionDialogReaderFoundPreview() {
     WooPosTheme {
         ReaderFoundContent(
             readerName = "STRM261380012691",
+            fingerprintSuffix = null,
             onConnectClicked = {},
             onKeepSearchingClicked = {},
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
@@ -30,7 +30,7 @@ class WooPosRemoteReaderDiscovery @Inject constructor(
             when (event) {
                 is RemoteReaderDiscoveryEvent.Added -> WooPosPhoneDiscoveryEvent.Added(
                     WooPosDiscoveredReader.Phone(
-                        name = event.reader.name,
+                        name = event.reader.deviceName?.takeIf { it.isNotBlank() } ?: event.reader.name,
                         host = event.reader.host,
                         port = event.reader.port,
                         fingerprintBase64 = event.reader.fingerprintBase64,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
@@ -1,0 +1,90 @@
+package com.woocommerce.android.ui.woopos.cardreader.remote
+
+import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.cardreader.CardReaderStore
+import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
+import com.woocommerce.android.cardreader.payments.PaymentInfo
+import com.woocommerce.android.cardreader.payments.StatementDescriptor
+import com.woocommerce.android.cardreader.remote.CollectPaymentOutcome
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentOrderHelper
+import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
+import kotlinx.coroutines.delay
+import org.wordpress.android.fluxc.store.WooCommerceStore
+import javax.inject.Inject
+
+class WooPosRemoteReaderPaymentFlow @Inject constructor(
+    private val cardReaderStore: CardReaderStore,
+    private val remoteReaderSession: WooPosRemoteReaderSession,
+    private val selectedSite: SelectedSite,
+    private val cardReaderPaymentOrderHelper: CardReaderPaymentOrderHelper,
+    private val paymentReceiptHelper: PaymentReceiptHelper,
+    private val wooStore: WooCommerceStore,
+    private val appPrefs: AppPrefs = AppPrefs,
+) {
+    suspend fun collect(order: Order): Result {
+        val connected = remoteReaderSession.state.value as? WooPosRemoteReaderSession.State.Connected
+        if (connected?.reader?.isSimulated == true) return simulatePayment()
+
+        val site = selectedSite.get()
+        val countryCode = wooStore.getStoreCountryCode(site)
+            ?: return Result.Failed("Store country code unavailable")
+
+        val paymentInfo = PaymentInfo(
+            paymentDescription = cardReaderPaymentOrderHelper.getPaymentDescription(order),
+            statementDescriptor = StatementDescriptor(
+                appPrefs.getCardReaderStatementDescriptor(
+                    localSiteId = site.id,
+                    remoteSiteId = site.siteId,
+                    selfHostedSiteId = site.selfHostedSiteId,
+                )
+            ),
+            orderId = order.id,
+            amount = order.total,
+            currency = order.currency,
+            orderKey = order.orderKey,
+            customerEmail = order.billingAddress.email.ifEmpty { null },
+            isPluginCanSendReceipt = paymentReceiptHelper.isPluginCanSendReceipt(site),
+            customerName = "${order.billingAddress.firstName} ${order.billingAddress.lastName}"
+                .trim()
+                .ifBlank { null },
+            storeName = site.name.ifEmpty { null },
+            siteUrl = site.url.ifEmpty { null },
+            countryCode = countryCode,
+            feeAmount = if (countryCode == CANADA_COUNTRY_CODE) CANADA_FEE_FLAT_IN_CENTS else null,
+            channel = PaymentInfo.PaymentChannel.Pos,
+        )
+
+        return when (val outcome = remoteReaderSession.sendCollectPayment(paymentInfo)) {
+            is CollectPaymentOutcome.Success -> capture(order.id, outcome.paymentIntentId)
+            is CollectPaymentOutcome.Rejected -> Result.Failed("${outcome.code}: ${outcome.description}")
+            CollectPaymentOutcome.TimedOut -> Result.Failed("Timed out waiting for phone reader")
+            is CollectPaymentOutcome.Failed -> Result.Failed(
+                outcome.cause.message ?: "Remote collection failed"
+            )
+        }
+    }
+
+    private suspend fun capture(orderId: Long, paymentIntentId: String): Result =
+        when (val response = cardReaderStore.capturePaymentIntent(orderId, paymentIntentId)) {
+            is CapturePaymentResponse.Successful -> Result.Completed
+            is CapturePaymentResponse.Error -> Result.Failed(response.message)
+        }
+
+    private suspend fun simulatePayment(): Result {
+        delay(SIMULATED_PAYMENT_DELAY_MS)
+        return Result.Completed
+    }
+
+    sealed class Result {
+        data object Completed : Result()
+        data class Failed(val message: String) : Result()
+    }
+
+    private companion object {
+        const val CANADA_COUNTRY_CODE = "CA"
+        const val CANADA_FEE_FLAT_IN_CENTS = 15L
+        const val SIMULATED_PAYMENT_DELAY_MS = 1_500L
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
@@ -118,10 +118,13 @@ class WooPosRemoteReaderSession @Inject constructor(
         monitorScope = scope
         scope.launch {
             watchedClient.connectionClosed.collect { isClosed ->
-                if (isClosed && client === watchedClient && _state.value is State.Connected) {
-                    logger.d("Remote reader connection closed by the phone")
-                    disconnectInternal()
-                    _state.value = State.Idle
+                if (!isClosed) return@collect
+                mutex.withLock {
+                    if (client === watchedClient && _state.value is State.Connected) {
+                        logger.d("Remote reader connection closed by the phone")
+                        disconnectInternal()
+                        _state.value = State.Idle
+                    }
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
@@ -14,8 +14,8 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -39,8 +39,7 @@ class WooPosRemoteReaderSession @Inject constructor(
 
     private var client: CardReaderRemoteTabletClient? = null
     private val mutex = Mutex()
-    private val monitorScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private var closeWatcherJob: Job? = null
+    private var monitorScope: CoroutineScope? = null
 
     suspend fun connect(reader: WooPosDiscoveredReader.Phone): State = mutex.withLock {
         disconnectInternal()
@@ -110,8 +109,10 @@ class WooPosRemoteReaderSession @Inject constructor(
     }
 
     private fun watchForRemoteClose(watchedClient: CardReaderRemoteTabletClient) {
-        closeWatcherJob?.cancel()
-        closeWatcherJob = monitorScope.launch {
+        monitorScope?.cancel()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        monitorScope = scope
+        scope.launch {
             watchedClient.connectionClosed.collect { isClosed ->
                 if (isClosed && client === watchedClient && _state.value is State.Connected) {
                     logger.d("Remote reader connection closed by the phone")
@@ -135,8 +136,8 @@ class WooPosRemoteReaderSession @Inject constructor(
             ?: CollectPaymentOutcome.Failed(IllegalStateException("Remote session is not connected"))
 
     private fun disconnectInternal() {
-        closeWatcherJob?.cancel()
-        closeWatcherJob = null
+        monitorScope?.cancel()
+        monitorScope = null
         client?.disconnect()
         client = null
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
@@ -12,10 +12,15 @@ import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderLocation
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -34,6 +39,8 @@ class WooPosRemoteReaderSession @Inject constructor(
 
     private var client: CardReaderRemoteTabletClient? = null
     private val mutex = Mutex()
+    private val monitorScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var closeWatcherJob: Job? = null
 
     suspend fun connect(reader: WooPosDiscoveredReader.Phone): State = mutex.withLock {
         disconnectInternal()
@@ -91,18 +98,33 @@ class WooPosRemoteReaderSession @Inject constructor(
         )
         return when (val outcome = newClient.connect(discovered, token, locationId)) {
             is ConnectOutcome.Success -> State.Connected(reader, outcome.readerSerial)
-                .also { _state.value = it }
+                .also {
+                    _state.value = it
+                    watchForRemoteClose(newClient)
+                }
             is ConnectOutcome.Rejected -> fail("${outcome.code}: ${outcome.description}")
-            is ConnectOutcome.Failed -> fail(outcome.cause.message ?: "Connection failed")
+            is ConnectOutcome.Failed -> fail(
+                "${outcome.cause::class.java.simpleName}: ${outcome.cause.message ?: "Connection failed"}"
+            )
         }
     }
 
-    suspend fun disconnect() {
-        client?.disconnect()
-        mutex.withLock {
-            disconnectInternal()
-            _state.value = State.Idle
+    private fun watchForRemoteClose(watchedClient: CardReaderRemoteTabletClient) {
+        closeWatcherJob?.cancel()
+        closeWatcherJob = monitorScope.launch {
+            watchedClient.connectionClosed.collect { isClosed ->
+                if (isClosed && client === watchedClient && _state.value is State.Connected) {
+                    logger.d("Remote reader connection closed by the phone")
+                    disconnectInternal()
+                    _state.value = State.Idle
+                }
+            }
         }
+    }
+
+    suspend fun disconnect() = mutex.withLock {
+        disconnectInternal()
+        _state.value = State.Idle
     }
 
     suspend fun sendCollectPayment(
@@ -113,6 +135,8 @@ class WooPosRemoteReaderSession @Inject constructor(
             ?: CollectPaymentOutcome.Failed(IllegalStateException("Remote session is not connected"))
 
     private fun disconnectInternal() {
+        closeWatcherJob?.cancel()
+        closeWatcherJob = null
         client?.disconnect()
         client = null
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.cardreader.remote
 
+import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.payments.PaymentInfo
@@ -12,6 +13,7 @@ import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderLocation
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
+import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -33,6 +35,7 @@ class WooPosRemoteReaderSession @Inject constructor(
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker,
     private val clientProvider: WooPosRemoteReaderClientProvider,
     private val logger: WooPosLogWrapper,
+    private val resourceProvider: ResourceProvider,
 ) {
     private val _state = MutableStateFlow<State>(State.Idle)
     val state: StateFlow<State> = _state.asStateFlow()
@@ -107,7 +110,7 @@ class WooPosRemoteReaderSession @Inject constructor(
                     "Remote reader connect failed: ${outcome.cause::class.java.simpleName}",
                     outcome.cause
                 )
-                fail(outcome.cause.message ?: "Connection failed")
+                fail(resourceProvider.getString(R.string.woopos_remote_reader_connect_failed_generic))
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
@@ -102,9 +102,13 @@ class WooPosRemoteReaderSession @Inject constructor(
                     watchForRemoteClose(newClient)
                 }
             is ConnectOutcome.Rejected -> fail("${outcome.code}: ${outcome.description}")
-            is ConnectOutcome.Failed -> fail(
-                "${outcome.cause::class.java.simpleName}: ${outcome.cause.message ?: "Connection failed"}"
-            )
+            is ConnectOutcome.Failed -> {
+                logger.e(
+                    "Remote reader connect failed: ${outcome.cause::class.java.simpleName}",
+                    outcome.cause
+                )
+                fail(outcome.cause.message ?: "Connection failed")
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModel.kt
@@ -3,13 +3,11 @@ package com.woocommerce.android.ui.woopos.home.toolbar
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Reconnecting
 import com.woocommerce.android.cardreader.connection.event.BatteryStatus
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatus
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionController
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionControllerFactory
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
@@ -41,6 +39,7 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
     private val networkStatus: WooPosNetworkStatus,
     private val resourceProvider: ResourceProvider,
     private val analyticsTracker: WooPosAnalyticsTracker,
+    private val effectiveReaderStatusProvider: WooPosEffectiveReaderStatusProvider,
     controllerFactory: WooPosCardReaderConnectionControllerFactory,
 ) : ViewModel() {
 
@@ -58,21 +57,33 @@ class WooPosHomeFloatingToolbarViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            cardReaderFacade.readerStatus.flatMapLatest { readerStatus ->
-                when (readerStatus) {
-                    is Connected -> cardReaderFacade.batteryStatus.map { batteryStatus ->
-                        WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected(
-                            batteryState = mapBatteryState(batteryStatus)
+            effectiveReaderStatusProvider.flow
+                .flatMapLatest { effective ->
+                    when (effective) {
+                        WooPosEffectiveReaderStatus.RemoteConnected -> flowOf(
+                            WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected(
+                                batteryState = WooPosHomeFloatingToolbarState.BatteryState.NOMINAL
+                            )
+                        )
+                        WooPosEffectiveReaderStatus.BluetoothConnected ->
+                            cardReaderFacade.batteryStatus
+                                .map { batteryStatus ->
+                                    WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected(
+                                        batteryState = mapBatteryState(batteryStatus)
+                                    )
+                                }
+                        WooPosEffectiveReaderStatus.Reconnecting -> flowOf(
+                            WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Reconnecting
+                        )
+                        WooPosEffectiveReaderStatus.Connecting,
+                        WooPosEffectiveReaderStatus.Disconnected -> flowOf(
+                            WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.NotConnected
                         )
                     }
-                    is NotConnected, Connecting -> flowOf(
-                        WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.NotConnected
-                    )
-                    Reconnecting -> flowOf(WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Reconnecting)
                 }
-            }.collect { cardReaderStatus ->
-                _state.value = _state.value.copy(cardReaderStatus = cardReaderStatus)
-            }
+                .collect { cardReaderStatus ->
+                    _state.value = _state.value.copy(cardReaderStatus = cardReaderStatus)
+                }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -288,7 +288,7 @@ class WooPosTotalsViewModel @Inject constructor(
                 paymentState is CardReaderPaymentState.ProcessingPayment ||
                     paymentState is CardReaderPaymentState.PaymentCapturing
             }
-            PaymentMode.REMOTE -> uiState.value is PaymentInProgress
+            PaymentMode.REMOTE -> remotePaymentJob?.isActive == true
             null -> false
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -102,6 +102,7 @@ class WooPosTotalsViewModel @Inject constructor(
 
     private var cardReaderPaymentController: CardReaderPaymentController? = null
     private var remotePaymentJob: Job? = null
+    private var activePaymentMode: PaymentMode? = null
 
     private fun createCardReaderPaymentController(orderId: Long) {
         cardReaderPaymentController = cardReaderPaymentControllerFactory.create(
@@ -165,6 +166,7 @@ class WooPosTotalsViewModel @Inject constructor(
         cardReaderPaymentController?.onBackPressed()
         cardReaderPaymentController?.stop()
         cancelRemotePaymentAction()
+        activePaymentMode = null
     }
 
     private fun cancelCreateOrderDraftAction() {
@@ -233,19 +235,30 @@ class WooPosTotalsViewModel @Inject constructor(
 
     private fun handleRetryFailedTransactionClicked() {
         viewModelScope.launch {
-            val paymentState = cardReaderPaymentController?.paymentState?.value
-            check(paymentState != null) {
-                "Retry failed transaction clicked but payment controller is null"
-            }
-            check(paymentState is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment) {
-                "Retry failed transaction clicked but payment state is not PaymentFailed"
-            }
-            when {
-                paymentState.onRetry != null -> paymentState.onRetry!!()
-                else -> {
+            when (activePaymentMode) {
+                PaymentMode.REMOTE -> {
                     childrenToParentEventSender.sendToParent(ChildToParentEvent.ReturnedFromCardReaderPaymentToCheckout)
                     retryPaymentCollectionFromScratch()
                 }
+                PaymentMode.BLUETOOTH -> retryBluetoothFailedTransaction()
+                null -> error("Retry failed transaction clicked but no active payment mode")
+            }
+        }
+    }
+
+    private suspend fun retryBluetoothFailedTransaction() {
+        val paymentState = cardReaderPaymentController?.paymentState?.value
+        check(paymentState != null) {
+            "Retry failed transaction clicked but payment controller is null"
+        }
+        check(paymentState is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment) {
+            "Retry failed transaction clicked but payment state is not PaymentFailed"
+        }
+        when {
+            paymentState.onRetry != null -> paymentState.onRetry!!()
+            else -> {
+                childrenToParentEventSender.sendToParent(ChildToParentEvent.ReturnedFromCardReaderPaymentToCheckout)
+                retryPaymentCollectionFromScratch()
             }
         }
     }
@@ -254,12 +267,7 @@ class WooPosTotalsViewModel @Inject constructor(
         viewModelScope.launch {
             when (state.value) {
                 is PaymentFailed, is PaymentInProgress -> {
-                    val paymentState = cardReaderPaymentController?.paymentState?.value
-                    if (paymentState is CardReaderPaymentState.ProcessingPayment ||
-                        paymentState is CardReaderPaymentState.PaymentCapturing
-                    ) {
-                        return@launch
-                    }
+                    if (isPaymentInFlight()) return@launch
 
                     childrenToParentEventSender.sendToParent(ChildToParentEvent.ReturnedFromCardReaderPaymentToCheckout)
                     retryPaymentCollectionFromScratch()
@@ -270,6 +278,18 @@ class WooPosTotalsViewModel @Inject constructor(
                     childrenToParentEventSender.sendToParent(ChildToParentEvent.BackFromCheckoutToCartClicked)
                 }
             }
+        }
+    }
+
+    private fun isPaymentInFlight(): Boolean {
+        return when (activePaymentMode) {
+            PaymentMode.BLUETOOTH -> {
+                val paymentState = cardReaderPaymentController?.paymentState?.value
+                paymentState is CardReaderPaymentState.ProcessingPayment ||
+                    paymentState is CardReaderPaymentState.PaymentCapturing
+            }
+            PaymentMode.REMOTE -> uiState.value is PaymentInProgress
+            null -> false
         }
     }
 
@@ -337,6 +357,7 @@ class WooPosTotalsViewModel @Inject constructor(
                 val state = uiState.value
                 check(state is WooPosTotalsViewState.Checkout)
                 check(uiState.value is WooPosTotalsViewState.Checkout)
+                activePaymentMode = PaymentMode.BLUETOOTH
                 createCardReaderPaymentController(dataState.value.orderId)
                 cardReaderPaymentController?.start()
                 listenToPaymentState()
@@ -360,6 +381,7 @@ class WooPosTotalsViewModel @Inject constructor(
         if (orderId == EMPTY_ORDER_ID) return
         if (dataState.value.orderTotal?.compareTo(BigDecimal.ZERO) != 1) return
 
+        activePaymentMode = PaymentMode.REMOTE
         remotePaymentJob = viewModelScope.launch {
             val order = orderOverride ?: totalsRepository.getOrderById(orderId) ?: run {
                 wooPosLogWrapper.e("Remote payment: order $orderId not found")
@@ -829,4 +851,9 @@ class WooPosTotalsViewModel @Inject constructor(
         val orderTotal: BigDecimal? = null,
         val itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData> = emptyList()
     ) : Parcelable
+
+    private enum class PaymentMode {
+        BLUETOOTH,
+        REMOTE,
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -7,15 +7,15 @@ import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
 import com.woocommerce.android.WooException
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
-import com.woocommerce.android.cardreader.connection.CardReaderStatus.Reconnecting
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatus
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderPaymentFlow
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
@@ -53,6 +53,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import java.math.BigDecimal
 import javax.inject.Inject
 
+@Suppress("LargeClass")
 @HiltViewModel
 class WooPosTotalsViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
@@ -67,6 +68,8 @@ class WooPosTotalsViewModel @Inject constructor(
     private val totalsAnalyticsTracker: WooPosTotalsAnalyticsTracker,
     private val wooPosLogWrapper: WooPosLogWrapper,
     private val performIncrementalSyncUseCase: WooPosPerformLocalCatalogIncrementalSync,
+    private val remoteReaderPaymentFlow: WooPosRemoteReaderPaymentFlow,
+    private val effectiveReaderStatusProvider: WooPosEffectiveReaderStatusProvider,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -98,6 +101,7 @@ class WooPosTotalsViewModel @Inject constructor(
     private var isTTPPaymentInProgress: Boolean by TTPPaymentProgressDelegate(savedState)
 
     private var cardReaderPaymentController: CardReaderPaymentController? = null
+    private var remotePaymentJob: Job? = null
 
     private fun createCardReaderPaymentController(orderId: Long) {
         cardReaderPaymentController = cardReaderPaymentControllerFactory.create(
@@ -114,31 +118,41 @@ class WooPosTotalsViewModel @Inject constructor(
 
     private fun observeCardReaderStatus() {
         viewModelScope.launch {
-            cardReaderFacade.readerStatus.combine(
-                dataState
-            ) { status, data -> Pair(status, data) }.collect { (status, data) ->
-                when (status) {
-                    is NotConnected, is Connecting -> {
-                        val state = uiState.value
-                        if (state !is WooPosTotalsViewState.Checkout) return@collect
-                        uiState.value = state.copy(readerStatus = buildTotalsReaderNotConnectedError())
-                        cancelPaymentAction()
-                    }
+            effectiveReaderStatusProvider.flow
+                .combine(dataState) { effective, data -> effective to data }
+                .collect { (effective, data) ->
+                    when (effective) {
+                        WooPosEffectiveReaderStatus.RemoteConnected -> {
+                            val state = uiState.value
+                            if (state !is WooPosTotalsViewState.Checkout) return@collect
+                            if (state.readerStatus !is WooPosTotalsViewState.ReaderStatus.ReadyForPayment) {
+                                uiState.value = state.copy(readerStatus = buildPreparingReaderStatusState())
+                            }
+                            if (data.orderId != EMPTY_ORDER_ID) collectPaymentRemote()
+                        }
 
-                    Reconnecting -> {
-                        // We start payment right away so this state not worth handling
-                    }
+                        WooPosEffectiveReaderStatus.BluetoothConnected -> {
+                            val state = uiState.value
+                            if (state !is WooPosTotalsViewState.Checkout) return@collect
+                            if (state.readerStatus !is WooPosTotalsViewState.ReaderStatus.ReadyForPayment) {
+                                uiState.value = state.copy(readerStatus = buildPreparingReaderStatusState())
+                            }
+                            if (data.orderId != EMPTY_ORDER_ID) collectPayment()
+                        }
 
-                    is Connected -> {
-                        val state = uiState.value
-                        if (state !is WooPosTotalsViewState.Checkout) return@collect
-                        uiState.value = state.copy(readerStatus = buildPreparingReaderStatusState())
-                        if (data.orderId != EMPTY_ORDER_ID) {
-                            collectPayment()
+                        WooPosEffectiveReaderStatus.Reconnecting -> {
+                            // We start payment right away so this state not worth handling
+                        }
+
+                        WooPosEffectiveReaderStatus.Connecting,
+                        WooPosEffectiveReaderStatus.Disconnected -> {
+                            val state = uiState.value
+                            if (state !is WooPosTotalsViewState.Checkout) return@collect
+                            uiState.value = state.copy(readerStatus = buildTotalsReaderNotConnectedError())
+                            cancelPaymentAction()
                         }
                     }
                 }
-            }
         }
     }
 
@@ -150,6 +164,7 @@ class WooPosTotalsViewModel @Inject constructor(
     private fun cancelPaymentAction() {
         cardReaderPaymentController?.onBackPressed()
         cardReaderPaymentController?.stop()
+        cancelRemotePaymentAction()
     }
 
     private fun cancelCreateOrderDraftAction() {
@@ -296,7 +311,11 @@ class WooPosTotalsViewModel @Inject constructor(
         val order = totalsRepository.getOrderById(dataState.value.orderId)
         checkNotNull(order)
         uiState.value = buildWooPosTotalsViewState(order)
-        collectPayment()
+        if (effectiveReaderStatusProvider.current() == WooPosEffectiveReaderStatus.RemoteConnected) {
+            collectPaymentRemote(orderOverride = order)
+        } else {
+            collectPayment()
+        }
     }
 
     private fun collectPayment() {
@@ -323,6 +342,67 @@ class WooPosTotalsViewModel @Inject constructor(
                 listenToPaymentState()
             }
         }
+    }
+
+    private fun collectPaymentRemote(orderOverride: Order? = null) {
+        if (remotePaymentJob?.isActive == true) return
+        if (!networkStatus.isConnected()) {
+            viewModelScope.launch {
+                childrenToParentEventSender.sendToParent(
+                    ToastMessageDisplayed(
+                        message = resourceProvider.getString(R.string.woopos_no_internet_message)
+                    )
+                )
+            }
+            return
+        }
+        val orderId = dataState.value.orderId
+        if (orderId == EMPTY_ORDER_ID) return
+        if (dataState.value.orderTotal?.compareTo(BigDecimal.ZERO) != 1) return
+
+        remotePaymentJob = viewModelScope.launch {
+            val order = orderOverride ?: totalsRepository.getOrderById(orderId) ?: run {
+                wooPosLogWrapper.e("Remote payment: order $orderId not found")
+                return@launch
+            }
+            val state = uiState.value
+            if (state is WooPosTotalsViewState.Checkout) {
+                uiState.value = state.copy(
+                    readerStatus = WooPosTotalsViewState.ReaderStatus.ReadyForPayment(
+                        title = resourceProvider.getString(
+                            R.string.woopos_totals_reader_ready_for_payment_title
+                        ),
+                        subtitle = resourceProvider.getString(
+                            R.string.woopos_totals_reader_ready_for_payment_subtitle
+                        ),
+                    )
+                )
+                childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentCollecting)
+            }
+            when (val result = remoteReaderPaymentFlow.collect(order)) {
+                WooPosRemoteReaderPaymentFlow.Result.Completed -> {
+                    childrenToParentEventSender.sendToParent(OrderSuccessfullyPaidByCard)
+                }
+                is WooPosRemoteReaderPaymentFlow.Result.Failed -> {
+                    uiState.value = PaymentFailed(
+                        title = resourceProvider.getString(
+                            R.string.woopos_success_totals_payment_failed_title
+                        ),
+                        subtitle = result.message,
+                        retryPaymentButtonLabel = resourceProvider.getString(
+                            R.string.woo_pos_payment_failed_try_again
+                        ),
+                        isReturnToCheckoutButtonVisible = true,
+                    )
+                    childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentFailed)
+                }
+            }
+        }
+    }
+
+    private fun cancelRemotePaymentAction() {
+        remotePaymentJob?.cancel()
+        remotePaymentJob = null
     }
 
     private fun listenUpEvents() {
@@ -502,6 +582,7 @@ class WooPosTotalsViewModel @Inject constructor(
 
     override fun onCleared() {
         cardReaderPaymentController?.stop()
+        cancelRemotePaymentAction()
     }
 
     private fun createOrderDraft(itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData>) {
@@ -590,7 +671,11 @@ class WooPosTotalsViewModel @Inject constructor(
             orderTotal = order.total
         )
         uiState.value = buildWooPosTotalsViewState(order)
-        collectPayment()
+        if (effectiveReaderStatusProvider.current() == WooPosEffectiveReaderStatus.RemoteConnected) {
+            collectPaymentRemote(orderOverride = order)
+        } else {
+            collectPayment()
+        }
     }
 
     private fun getProductsIdsMissingFromOrder(order: Order): List<Long> {
@@ -706,9 +791,12 @@ class WooPosTotalsViewModel @Inject constructor(
         val readerStatus = if (totalAmount.compareTo(BigDecimal.ZERO) == 0) {
             WooPosTotalsViewState.ReaderStatus.Unavailable
         } else {
-            when (cardReaderFacade.readerStatus.value) {
-                is Connected -> buildPreparingReaderStatusState()
-                else -> buildTotalsReaderNotConnectedError()
+            when (effectiveReaderStatusProvider.current()) {
+                WooPosEffectiveReaderStatus.RemoteConnected,
+                WooPosEffectiveReaderStatus.BluetoothConnected -> buildPreparingReaderStatusState()
+                WooPosEffectiveReaderStatus.Connecting,
+                WooPosEffectiveReaderStatus.Reconnecting,
+                WooPosEffectiveReaderStatus.Disconnected -> buildTotalsReaderNotConnectedError()
             }
         }
         return WooPosTotalsViewState.Checkout(

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3627,6 +3627,7 @@
     <string name="woopos_reader_connected">Reader connected</string>
     <string name="woopos_reader_disconnected">Connect your reader</string>
     <string name="woopos_reader_reconnecting">Reconnecting…</string>
+    <string name="woopos_remote_reader_connect_failed_generic">Connection failed</string>
     <string name="woopos_battery_low">Card reader battery low</string>
     <string name="woopos_battery_critical">Card reader battery critical</string>
     <string name="woopos_checkout_button">Check out</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -11,6 +11,9 @@ import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardRea
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.woopos.bookings.BOOKING_PAYMENT_FLOW_FINISHED_KEY
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderPaymentFlow
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderSession
 import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
 import com.woocommerce.android.ui.woopos.home.totals.WooPosCardReaderPaymentControllerFactory
 import com.woocommerce.android.ui.woopos.paymentsuccess.PaymentSuccessSource
@@ -74,6 +77,12 @@ class WooPosCardPaymentViewModelTest {
     private val priceFormat: WooPosFormatPrice = mock {
         on { invoke(any<BigDecimal>()) } doReturn "$0.00"
     }
+    private val remoteReaderSessionStateFlow =
+        MutableStateFlow<WooPosRemoteReaderSession.State>(WooPosRemoteReaderSession.State.Idle)
+    private val remoteReaderSession: WooPosRemoteReaderSession = mock {
+        on { state }.thenReturn(remoteReaderSessionStateFlow)
+    }
+    private val remoteReaderPaymentFlow: WooPosRemoteReaderPaymentFlow = mock()
 
     private val testOrder: Order = Order.getEmptyOrder(Date(), Date()).copy(
         productsTotal = BigDecimal.TEN,
@@ -113,6 +122,8 @@ class WooPosCardPaymentViewModelTest {
             analyticsTracker = analyticsTracker,
             cardPaymentRepository = cardPaymentRepository,
             priceFormat = priceFormat,
+            remoteReaderPaymentFlow = remoteReaderPaymentFlow,
+            effectiveReaderStatusProvider = WooPosEffectiveReaderStatusProvider(cardReaderFacade, remoteReaderSession),
         )
     }
 
@@ -402,6 +413,8 @@ class WooPosCardPaymentViewModelTest {
             analyticsTracker = analyticsTracker,
             cardPaymentRepository = cardPaymentRepository,
             priceFormat = priceFormat,
+            remoteReaderPaymentFlow = remoteReaderPaymentFlow,
+            effectiveReaderStatusProvider = WooPosEffectiveReaderStatusProvider(cardReaderFacade, remoteReaderSession),
         )
         advanceUntilIdle()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardRea
 import com.woocommerce.android.ui.woopos.bookings.BOOKING_PAYMENT_FLOW_FINISHED_KEY
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosDiscoveredReader
 import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderPaymentFlow
 import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderSession
 import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
@@ -24,6 +25,7 @@ import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.util.UiStringParser
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
@@ -35,10 +37,13 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
+import java.net.InetAddress
 import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -651,4 +656,82 @@ class WooPosCardPaymentViewModelTest {
         val failedState = viewModel.state.value as WooPosCardPaymentState.PaymentFailed
         assertThat(failedState.isDismissButtonVisible).isTrue()
     }
+
+    @Test
+    fun `given remote payment in progress, when onBackClicked, then no GoBack emitted`() = runTest {
+        // GIVEN
+        readerStatusFlow.value = CardReaderStatus.NotConnected()
+        remoteReaderSessionStateFlow.value = WooPosRemoteReaderSession.State.Connected(
+            reader = simulatedRemoteReader(),
+            readerSerial = "SIM-1",
+        )
+        whenever(remoteReaderPaymentFlow.collect(any()))
+            .doSuspendableAnswer { awaitCancellation() }
+
+        viewModel = createViewModel(source = CardPaymentSource.CHECKOUT)
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.navigationEvent.test {
+            viewModel.onBackClicked()
+
+            // THEN
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `given remote payment in progress, when onDismissClicked, then no GoBack emitted`() = runTest {
+        // GIVEN
+        readerStatusFlow.value = CardReaderStatus.NotConnected()
+        remoteReaderSessionStateFlow.value = WooPosRemoteReaderSession.State.Connected(
+            reader = simulatedRemoteReader(),
+            readerSerial = "SIM-1",
+        )
+        whenever(remoteReaderPaymentFlow.collect(any()))
+            .doSuspendableAnswer { awaitCancellation() }
+
+        viewModel = createViewModel(source = CardPaymentSource.CHECKOUT)
+        advanceUntilIdle()
+
+        // WHEN
+        viewModel.navigationEvent.test {
+            viewModel.onDismissClicked()
+
+            // THEN
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `given remote payment failed, when onRetryClicked, then remote flow is invoked again`() = runTest {
+        // GIVEN
+        readerStatusFlow.value = CardReaderStatus.NotConnected()
+        remoteReaderSessionStateFlow.value = WooPosRemoteReaderSession.State.Connected(
+            reader = simulatedRemoteReader(),
+            readerSerial = "SIM-1",
+        )
+        whenever(remoteReaderPaymentFlow.collect(any()))
+            .thenReturn(WooPosRemoteReaderPaymentFlow.Result.Failed("error"))
+
+        viewModel = createViewModel(source = CardPaymentSource.CHECKOUT)
+        advanceUntilIdle()
+        assertThat(viewModel.state.value).isInstanceOf(WooPosCardPaymentState.PaymentFailed::class.java)
+
+        // WHEN
+        viewModel.onRetryClicked()
+        advanceUntilIdle()
+
+        // THEN
+        verify(remoteReaderPaymentFlow, times(2)).collect(any())
+    }
+
+    private fun simulatedRemoteReader() =
+        WooPosDiscoveredReader.Phone(
+            name = "phone",
+            host = InetAddress.getByName("127.0.0.1"),
+            port = 1234,
+            fingerprintBase64 = "fp",
+            isSimulated = true,
+        )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -29,7 +30,9 @@ class WooPosRemoteReaderSessionTest {
     private val cardReaderStore: CardReaderStore = mock()
     private val locationRepository: CardReaderLocationRepository = mock()
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker = mock()
-    private val client: CardReaderRemoteTabletClient = mock()
+    private val client: CardReaderRemoteTabletClient = mock {
+        on { connectionClosed }.thenReturn(MutableStateFlow(false))
+    }
     private val clientProvider: WooPosRemoteReaderClientProvider = mock {
         on { create() }.thenReturn(client)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboa
 import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -37,6 +38,9 @@ class WooPosRemoteReaderSessionTest {
         on { create() }.thenReturn(client)
     }
     private val logger: WooPosLogWrapper = mock()
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) }.thenReturn("")
+    }
 
     @Test
     fun `given simulated reader, when connect, then state is Connected`() = runTest {
@@ -110,6 +114,7 @@ class WooPosRemoteReaderSessionTest {
         cardReaderOnboardingChecker = cardReaderOnboardingChecker,
         clientProvider = clientProvider,
         logger = logger,
+        resourceProvider = resourceProvider,
     )
 
     private fun phone(isSimulated: Boolean) = WooPosDiscoveredReader.Phone(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -5,8 +5,11 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.event.BatteryStatus
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionController
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionControllerFactory
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosDiscoveredReader
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderSession
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosHomeFloatingToolbarState.BatteryState
@@ -27,6 +30,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.net.InetAddress
 
 @ExperimentalCoroutinesApi
 class WooPosHomeFloatingToolbarViewModelTest {
@@ -45,6 +49,9 @@ class WooPosHomeFloatingToolbarViewModelTest {
     private val controller: WooPosCardReaderConnectionController = mock()
     private val controllerFactory: WooPosCardReaderConnectionControllerFactory = mock {
         on { create(any()) }.thenReturn(controller)
+    }
+    private val remoteReaderSession: WooPosRemoteReaderSession = mock {
+        on { state }.thenReturn(MutableStateFlow(WooPosRemoteReaderSession.State.Idle))
     }
 
     @Test
@@ -376,12 +383,34 @@ class WooPosHomeFloatingToolbarViewModelTest {
             .isEqualTo(BatteryState.NOMINAL)
     }
 
+    @Test
+    fun `given remote session is Connected, when initialized, then state should be Connected`() = runTest {
+        // GIVEN
+        val phone = WooPosDiscoveredReader.Phone(
+            name = "Andrey's phone",
+            host = InetAddress.getByName("127.0.0.1"),
+            port = 0,
+            fingerprintBase64 = "fp",
+        )
+        whenever(remoteReaderSession.state).thenReturn(
+            MutableStateFlow(WooPosRemoteReaderSession.State.Connected(phone, readerSerial = "serial"))
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        assertThat(viewModel.state.value.cardReaderStatus)
+            .isInstanceOf(WooPosHomeFloatingToolbarState.WooPosCardReaderStatus.Connected::class.java)
+    }
+
     private fun createViewModel() = WooPosHomeFloatingToolbarViewModel(
         cardReaderFacade,
         childrenToParentEventSender,
         networkStatus,
         resourceProvider,
         analyticsTracker,
+        WooPosEffectiveReaderStatusProvider(cardReaderFacade, remoteReaderSession),
         controllerFactory
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -32,6 +32,9 @@ import com.woocommerce.android.ui.payments.receipt.PaymentReceiptShare
 import com.woocommerce.android.ui.payments.tracking.CardReaderTrackingInfoKeeper
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosEffectiveReaderStatusProvider
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderPaymentFlow
+import com.woocommerce.android.ui.woopos.cardreader.remote.WooPosRemoteReaderSession
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.BackFromCheckoutToCartClicked
@@ -159,6 +162,10 @@ class WooPosTotalsViewModelTest {
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val performIncrementalSyncUseCase: WooPosPerformLocalCatalogIncrementalSync = mock()
     private val productsDataSource: WooPosProductsDataSource = mock()
+    private val remoteReaderSession: WooPosRemoteReaderSession = mock {
+        on { state }.thenReturn(MutableStateFlow(WooPosRemoteReaderSession.State.Idle))
+    }
+    private val remoteReaderPaymentFlow: WooPosRemoteReaderPaymentFlow = mock()
 
     private companion object {
         private const val EMPTY_ORDER_ID = -1L
@@ -2093,5 +2100,7 @@ class WooPosTotalsViewModelTest {
         ),
         wooPosLogWrapper = wooPosLogWrapper,
         performIncrementalSyncUseCase = performIncrementalSyncUseCase,
+        remoteReaderPaymentFlow = remoteReaderPaymentFlow,
+        effectiveReaderStatusProvider = WooPosEffectiveReaderStatusProvider(cardReaderFacade, remoteReaderSession),
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1949,6 +1949,46 @@ class WooPosTotalsViewModelTest {
             )
         }
 
+    @Test
+    fun `given remote payment failed, when RetryFailedTransactionClicked, then remote flow is invoked again`() =
+        runTest {
+            // GIVEN
+            mockPaymentFailedTexts()
+            givenCardReaderConnectedAndNetworkAvailable()
+            whenever(cardReaderFacade.readerStatus).thenReturn(
+                MutableStateFlow(CardReaderStatus.NotConnected())
+            )
+            val remoteState = MutableStateFlow<WooPosRemoteReaderSession.State>(
+                WooPosRemoteReaderSession.State.Connected(
+                    reader = simulatedRemoteReader(),
+                    readerSerial = "SIM-1",
+                )
+            )
+            whenever(remoteReaderSession.state).thenReturn(remoteState)
+            whenever(remoteReaderPaymentFlow.collect(any()))
+                .thenReturn(WooPosRemoteReaderPaymentFlow.Result.Failed("error"))
+
+            val vm = createViewModelAndSetupForSuccessfulOrderCreation()
+            advanceUntilIdle()
+            assertThat(vm.state.value).isInstanceOf(WooPosTotalsViewState.PaymentFailed::class.java)
+
+            // WHEN
+            vm.onUIEvent(WooPosTotalsUIEvent.RetryFailedTransactionClicked)
+            advanceUntilIdle()
+
+            // THEN
+            verify(remoteReaderPaymentFlow, org.mockito.kotlin.times(2)).collect(any())
+        }
+
+    private fun simulatedRemoteReader() =
+        com.woocommerce.android.ui.woopos.cardreader.remote.WooPosDiscoveredReader.Phone(
+            name = "phone",
+            host = java.net.InetAddress.getByName("127.0.0.1"),
+            port = 1234,
+            fingerprintBase64 = "fp",
+            isSimulated = true,
+        )
+
     private fun mockPaymentFailedTexts() {
         whenever(resourceProvider.getString(R.string.woopos_success_totals_payment_processing_title))
             .thenReturn("Processing payment")


### PR DESCRIPTION
Fixes WOOMOB-2787

Wires the tablet side of the Woo POS Remote Tap-to-Pay flow. The tablet drives the payment: it builds a `PaymentInfo` from the order, sends `CollectPaymentRequest` to the connected phone, and captures the resulting `PaymentIntent` via WCPay once the phone reports back. The floating toolbar and totals screen reflect the connected phone's status.

**Notable**

- `WooPosRemoteReaderPaymentFlow`: build PaymentInfo → send to phone → wait for `PaymentIntentResult` → capture via WCPay. Simulated phones short-circuit to `Result.Completed` so the flow can be exercised without a signed TTP APK.
- `WooPosEffectiveReaderStatus`: collapses BT (`CardReaderStatus`) and remote (`WooPosRemoteReaderSession.State`) into one enum so VMs only depend on a single signal.
- `WooPosCardPaymentViewModel`, `WooPosTotalsViewModel`, `WooPosHomeFloatingToolbarViewModel`: route through the effective status. Previously they only watched BT, so a connected phone never flipped them to "Connected" / "Ready for payment".
- `WooPosRemoteReaderSession`: subscribes to the lib's `connectionClosed` signal so when the phone drops the session the tablet returns to Idle.
- `WooPosCardReaderConnectionDialog`: ReaderFound screen shows the 4-char pairing-code suffix next to the phone name (`CPH2747 · 2846`).
- `WooPosRemoteReaderDiscovery`: prefers the device's broadcast `deviceName` over the NSD service name.

### Test Steps

1. Open POS on the tablet, open the reader status in the toolbar, pick a phone broadcasting Remote TTP, tap Connect.
2. Reader Found screen shows `device-name · 4-char-suffix`. Toolbar flips to **Connected**.
3. Add a product, tap **Checkout**. Totals shows "Ready for payment". On a simulated phone, the payment completes via the short-circuit. On a real phone, the phone prompts for a card tap and the tablet captures.
4. Drop the connection from the phone side — tablet returns to Idle within ~5s and the toolbar status updates.
5. With a Bluetooth reader connected instead of a phone, take a card payment and confirm it still routes through the local controller (no regression on the BT path).


test better on this branch - https://github.com/woocommerce/woocommerce-android/pull/15754 many bugs fixed there

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.