### PR TITLE
[WOOMOB-2787] Log discovered phone NSD events with name, fingerprint, pairing code

### DIFF
--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.cardreader.remote
 
 import android.content.Context
+import android.util.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.net.InetAddress
@@ -33,7 +34,17 @@ internal class DefaultCardReaderRemoteDiscovery(
     override fun discover(): Flow<RemoteReaderDiscoveryEvent> =
         nsd.discover().map { event ->
             when (event) {
-                is CardReaderRemoteNsdEvent.Found -> RemoteReaderDiscoveryEvent.Added(event.host.toPublic())
+                is CardReaderRemoteNsdEvent.Found -> {
+                    val pairingCode = CardReaderRemoteFingerprint.pairingCodeFromBase64OrNull(
+                        event.host.fingerprintBase64
+                    )
+                    Log.d(
+                        "CardReaderRemoteDiscovery",
+                        "Discovered phone ${event.host.name} fp=${event.host.fingerprintBase64} " +
+                            "pairingCode=$pairingCode"
+                    )
+                    RemoteReaderDiscoveryEvent.Added(event.host.toPublic())
+                }
                 is CardReaderRemoteNsdEvent.Lost -> RemoteReaderDiscoveryEvent.Removed(event.serviceName)
             }
         }


### PR DESCRIPTION
Fixes WOOMOB-2787

### Description
Adds a debug log line on each NSD `Found` event in `CardReaderRemoteDiscovery`, printing the discovered phone's display name, full fingerprint, and short pairing code. This makes it easy to confirm — from logcat alone — that the tablet sees the right phone and that the pairing code shown to the merchant matches the certificate the phone advertised.

The log uses the tolerant `pairingCodeFromBase64OrNull` helper, so a malformed or short fingerprint just prints `pairingCode=null` instead of breaking discovery.

### Test Steps
1. Run the tablet build with this branch on a phone that already has another phone advertising remote tap-to-pay on the same network.
2. Open Woo POS → Settings → Hardware → connect a card reader → start scanning.
3. Filter logcat by tag `CardReaderRemoteDiscovery`.
4. Confirm a `Discovered phone <name> fp=<base64> pairingCode=<XXXX>` line appears for each phone that shows up in the picker, and that the printed pairing code matches what the phone displays in its Card Reader Mode prologue.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.