### PR TITLE
[WOOMOB-2859] Support dashboard revenue sales type data

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModel.kt
@@ -344,6 +344,8 @@ class DashboardStatsViewModel @AssistedInject constructor(
         return RevenueStatsUiModel(
             intervalList = getIntervalList().toStatsIntervalUiModelList(),
             totalOrdersCount = totals?.ordersCount,
+            grossSales = totals?.grossSales,
+            netSales = totals?.netRevenue,
             totalSales = totals?.totalSales,
             currencyCode = wooCommerceStore.getSiteSettings(selectedSite.get())?.currencyCode,
             rangeId = rangeId
@@ -355,7 +357,9 @@ class DashboardStatsViewModel @AssistedInject constructor(
             StatsIntervalUiModel(
                 it.interval,
                 it.subtotals?.ordersCount,
-                it.subtotals?.totalSales
+                it.subtotals?.totalSales,
+                it.subtotals?.grossSales,
+                it.subtotals?.netRevenue
             )
         }
 
@@ -399,6 +403,8 @@ class DashboardStatsViewModel @AssistedInject constructor(
     data class RevenueStatsUiModel(
         val intervalList: List<StatsIntervalUiModel> = emptyList(),
         val totalOrdersCount: Int? = null,
+        val grossSales: Double? = null,
+        val netSales: Double? = null,
         val totalSales: Double? = null,
         val currencyCode: String?,
         val rangeId: String
@@ -407,7 +413,9 @@ class DashboardStatsViewModel @AssistedInject constructor(
     data class StatsIntervalUiModel(
         val interval: String? = null,
         val ordersCount: Long? = null,
-        val sales: Double? = null
+        val sales: Double? = null,
+        val grossSales: Double? = null,
+        val netSales: Double? = null
     )
 
     data class OpenDatePicker(val fromDate: Date, val toDate: Date) : MultiLiveEvent.Event()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
@@ -206,6 +206,53 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given revenue stats with all sales types, when screen starts, then UI model exposes all sales types`() =
+        testBlocking {
+            val revenueStats = WCRevenueStatsModel(
+                localSiteId = LocalId(1),
+                interval = "",
+                startDate = "",
+                endDate = "",
+                data = """
+                    [
+                        {
+                            "interval": "2026-04-27",
+                            "subtotals": {
+                                "orders_count": 3,
+                                "gross_sales": 45.25,
+                                "net_revenue": 30.15,
+                                "total_sales": 50.35
+                            }
+                        }
+                    ]
+                """.trimIndent(),
+                total = """
+                    {
+                        "orders_count": 6,
+                        "gross_sales": 150.25,
+                        "net_revenue": 120.15,
+                        "total_sales": 170.35
+                    }
+                """.trimIndent(),
+                rangeId = "",
+            )
+            setup {
+                whenever(getStats.invoke(any(), any()))
+                    .thenReturn(flowOf(GetStats.LoadStatsResult.RevenueStatsSuccess(revenueStats)))
+            }
+
+            val content = viewModel.revenueStatsState.value as DashboardStatsViewModel.RevenueStatsViewState.Content
+            val uiModel = content.revenueStats!!
+
+            Assertions.assertThat(uiModel.grossSales).isEqualTo(150.25)
+            Assertions.assertThat(uiModel.netSales).isEqualTo(120.15)
+            Assertions.assertThat(uiModel.totalSales).isEqualTo(170.35)
+            Assertions.assertThat(uiModel.intervalList.first().grossSales).isEqualTo(45.25)
+            Assertions.assertThat(uiModel.intervalList.first().netSales).isEqualTo(30.15)
+            Assertions.assertThat(uiModel.intervalList.first().sales).isEqualTo(50.35)
+        }
+
+    @Test
     fun `when stats granularity changes, then selected option is saved into prefs`() =
         testBlocking {
             setup()

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/WCRevenueStatsModel.kt
@@ -35,6 +35,8 @@ data class WCRevenueStatsModel(
     class SubTotal {
         @SerializedName("orders_count")
         val ordersCount: Long? = null
+        @SerializedName("gross_sales")
+        val grossSales: Double? = null
         @SerializedName("total_sales")
         val totalSales: Double? = null
         @SerializedName("net_revenue")
@@ -54,6 +56,8 @@ data class WCRevenueStatsModel(
     class Total {
         @SerializedName("orders_count")
         val ordersCount: Int? = null
+        @SerializedName("gross_sales")
+        val grossSales: Double? = null
         @SerializedName("total_sales")
         val totalSales: Double? = null
         @SerializedName("net_revenue")

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/model/WCRevenueStatsModelTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/model/WCRevenueStatsModelTest.kt
@@ -57,4 +57,57 @@ class WCRevenueStatsModelTest {
 
         assertThat(total?.itemsSold).isEqualTo(123456)
     }
+
+    @Test
+    fun `should parse revenue sales types from total`() {
+        val sut = WCRevenueStatsModel(
+            localSiteId = LocalId(1),
+            interval = "",
+            startDate = "",
+            endDate = "",
+            data = "",
+            total = json {
+                "gross_sales" To "150.25"
+                "net_revenue" To "120.15"
+                "total_sales" To "170.35"
+            }.toString(),
+            rangeId = "",
+        )
+
+        val total = sut.parseTotal()
+
+        assertThat(total?.grossSales).isEqualTo(150.25)
+        assertThat(total?.netRevenue).isEqualTo(120.15)
+        assertThat(total?.totalSales).isEqualTo(170.35)
+    }
+
+    @Test
+    fun `should parse revenue sales types from intervals`() {
+        val sut = WCRevenueStatsModel(
+            localSiteId = LocalId(1),
+            interval = "",
+            startDate = "",
+            endDate = "",
+            data = """
+                [
+                    {
+                        "interval": "2026-04-27",
+                        "subtotals": {
+                            "gross_sales": 45.25,
+                            "net_revenue": 30.15,
+                            "total_sales": 50.35
+                        }
+                    }
+                ]
+            """.trimIndent(),
+            total = "",
+            rangeId = "",
+        )
+
+        val interval = sut.getIntervalList().first()
+
+        assertThat(interval.subtotals?.grossSales).isEqualTo(45.25)
+        assertThat(interval.subtotals?.netRevenue).isEqualTo(30.15)
+        assertThat(interval.subtotals?.totalSales).isEqualTo(50.35)
+    }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2859

Adds dashboard stats data-layer support for the three revenue sales types needed by the updated Performance card design. FluxC now parses gross sales from revenue stats totals and intervals, and the dashboard stats UI model exposes gross, net, and total sales while preserving the existing total-sales behavior for the current UI.

This is the first PR in the WOOMOB-2773 stack.

### Test Steps
1. Launch the app and open the Dashboard.
2. Confirm the Performance card still loads revenue, orders, visitors, and conversion data.
3. Change dashboard date ranges and confirm the Performance card continues to load stats normally.

