### PR TITLE
[WOOMOB-2860] Add analytics order date type API support

### DIFF
--- a/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/datasource/StatsRepository.kt
+++ b/WooCommerce-Wear/src/main/java/com/woocommerce/android/wear/ui/stats/datasource/StatsRepository.kt
@@ -64,7 +64,8 @@ class StatsRepository @Inject constructor(
                 granularity = StatsGranularity.DAYS,
                 startDate = todayRange.start.formatToYYYYmmDDhhmmss(),
                 endDate = todayRange.end.formatToYYYYmmDDhhmmss(),
-                revenueRangeId = StatsTimeRange(todayRange.start, todayRange.end).toRevenueRangeId("Wear")
+                revenueRangeId = StatsTimeRange(todayRange.start, todayRange.end).toRevenueRangeId("Wear"),
+                orderDateType = null
             )
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/StatsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/StatsRepository.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.model.WCBundleStats
 import org.wordpress.android.fluxc.model.WCGiftCardStats
 import org.wordpress.android.fluxc.model.WCProductBundleItemReport
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.model.settings.WCAnalyticsOrderDateType
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType.GENERIC_ERROR
@@ -58,6 +59,8 @@ class StatsRepository @Inject constructor(
         // /wc-analytics/leaderboards. More info https://github.com/woocommerce/woocommerce-android/issues/6688
         private const val PRODUCT_ONLY_LEADERBOARD_REPORT_MIN_WC_VERSION = "6.7.0"
         private const val AN_HOUR_IN_MILLIS = 3600000
+
+        private fun genericWooError() = WooError(GENERIC_ERROR, UNKNOWN)
     }
 
     suspend fun fetchRevenueStats(
@@ -65,11 +68,13 @@ class StatsRepository @Inject constructor(
         granularity: StatsGranularity,
         forced: Boolean,
         revenueRangeId: String,
+        orderDateType: WCAnalyticsOrderDateType? = null,
     ): Result<WCRevenueStatsModel?> = fetchRevenueStats(
         range = range,
         granularity = granularity,
         forced = forced,
         revenueRangeId = revenueRangeId,
+        orderDateType = orderDateType,
         site = selectedSite.get()
     )
 
@@ -78,6 +83,7 @@ class StatsRepository @Inject constructor(
         granularity: StatsGranularity,
         forced: Boolean,
         revenueRangeId: String,
+        orderDateType: WCAnalyticsOrderDateType? = null,
         site: SiteModel
     ): Result<WCRevenueStatsModel?> {
         val result = wcStatsStore.fetchRevenueStats(
@@ -87,17 +93,16 @@ class StatsRepository @Inject constructor(
                 startDate = range.start.formatToYYYYmmDDhhmmss(),
                 endDate = range.end.formatToYYYYmmDDhhmmss(),
                 forced = forced,
-                revenueRangeId = revenueRangeId
+                revenueRangeId = revenueRangeId,
+                orderDateType = orderDateType
             )
         )
 
         return if (!result.isError) {
             val revenueStatsModel = withContext(dispatchers.io) {
-                wcStatsStore.getRawRevenueStats(
+                wcStatsStore.getRawRevenueStatsFromRangeId(
                     site,
-                    result.granularity,
-                    result.startDate!!,
-                    result.endDate!!
+                    revenueRangeId
                 )
             }
             Result.success(revenueStatsModel)
@@ -121,6 +126,26 @@ class StatsRepository @Inject constructor(
                 revenueRangeId
             )
         )
+    }
+
+    suspend fun fetchAnalyticsOrderDateType(): Result<WCAnalyticsOrderDateType> {
+        val result = wooCommerceStore.fetchAnalyticsOrderDateType(selectedSite.get())
+        return if (result.isError) {
+            Result.failure(WooException(result.error ?: genericWooError()))
+        } else {
+            result.model?.let { Result.success(it) } ?: Result.failure(WooException(genericWooError()))
+        }
+    }
+
+    suspend fun updateAnalyticsOrderDateType(
+        orderDateType: WCAnalyticsOrderDateType
+    ): Result<WCAnalyticsOrderDateType> {
+        val result = wooCommerceStore.updateAnalyticsOrderDateType(selectedSite.get(), orderDateType)
+        return if (result.isError) {
+            Result.failure(WooException(result.error ?: genericWooError()))
+        } else {
+            result.model?.let { Result.success(it) } ?: Result.failure(WooException(genericWooError()))
+        }
     }
 
     suspend fun fetchVisitorStats(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/GetStats.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stats/GetStats.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.model.settings.WCAnalyticsOrderDateType
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.days
@@ -41,13 +42,17 @@ class GetStats @Inject constructor(
     private val coroutineDispatchers: CoroutineDispatchers,
     private val analyticsUpdateDataStore: AnalyticsUpdateDataStore,
 ) {
-    suspend operator fun invoke(refresh: Boolean, selectedRange: StatsTimeRangeSelection): Flow<LoadStatsResult> {
+    suspend operator fun invoke(
+        refresh: Boolean,
+        selectedRange: StatsTimeRangeSelection,
+        orderDateType: WCAnalyticsOrderDateType? = null
+    ): Flow<LoadStatsResult> {
         val shouldRefreshRevenue =
             shouldUpdateStats(selectedRange, refresh, AnalyticsUpdateDataStore.AnalyticData.REVENUE)
         val shouldRefreshVisitors =
             shouldUpdateStats(selectedRange, refresh, AnalyticsUpdateDataStore.AnalyticData.VISITORS)
         return merge(
-            revenueStats(selectedRange, shouldRefreshRevenue),
+            revenueStats(selectedRange, shouldRefreshRevenue, orderDateType),
             visitorStats(selectedRange, shouldRefreshVisitors)
         ).onEach { result ->
             if (result is RevenueStatsSuccess && shouldRefreshRevenue && result.isOutdated.not()) {
@@ -67,12 +72,13 @@ class GetStats @Inject constructor(
 
     private fun revenueStats(
         rangeSelection: StatsTimeRangeSelection,
-        forceRefresh: Boolean
+        forceRefresh: Boolean,
+        orderDateType: WCAnalyticsOrderDateType?
     ): Flow<LoadStatsResult> = flow {
         val revenueRangeId = rangeSelection.selectionType.identifier.asRevenueRangeId(
             startDate = rangeSelection.currentRange.start,
             endDate = rangeSelection.currentRange.end
-        )
+        ).withOrderDateType(orderDateType)
 
         statsRepository.getRevenueStatsById(revenueRangeId)
             .takeIf { it.isSuccess && it.getOrNull() != null }
@@ -94,7 +100,8 @@ class GetStats @Inject constructor(
             range = rangeSelection.currentRange,
             granularity = rangeSelection.revenueStatsGranularity,
             forced = forceRefresh,
-            revenueRangeId = revenueRangeId
+            revenueRangeId = revenueRangeId,
+            orderDateType = orderDateType
         ).let { result ->
             result.fold(
                 onSuccess = { stats ->
@@ -204,6 +211,9 @@ class GetStats @Inject constructor(
 
     private fun isPluginNotActiveError(error: Throwable): Boolean =
         (error as? StatsException)?.error?.type == OrderStatsErrorType.PLUGIN_NOT_ACTIVE
+
+    private fun String.withOrderDateType(orderDateType: WCAnalyticsOrderDateType?): String =
+        orderDateType?.let { "$this-${it.value}" } ?: this
 
     private suspend fun shouldUpdateStats(
         selectionRange: StatsTimeRangeSelection,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/background/BackgroundUpdateAnalyticsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/background/BackgroundUpdateAnalyticsRepositoryTest.kt
@@ -11,6 +11,7 @@ import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -63,7 +64,7 @@ class BackgroundUpdateAnalyticsRepositoryTest : BaseUnitTest() {
         val mockCurrentResult: Result<WCRevenueStatsModel?> = Result.success(mock())
         val mockPreviousResult: Result<WCRevenueStatsModel?> = Result.success(mock())
 
-        whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
+        whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), anyOrNull()))
             .thenReturn(mockCurrentResult, mockPreviousResult)
 
         val result = backgroundUpdateAnalyticsRepository.fetchRevenueStats(testSelectionData)
@@ -76,7 +77,7 @@ class BackgroundUpdateAnalyticsRepositoryTest : BaseUnitTest() {
         val mockError = Exception("Error fetching revenue stats")
         val mockCurrentResult: Result<WCRevenueStatsModel?> = Result.failure(mockError)
 
-        whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
+        whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), anyOrNull()))
             .thenReturn(mockCurrentResult, Result.success(mock()))
 
         val result = backgroundUpdateAnalyticsRepository.fetchRevenueStats(testSelectionData)
@@ -96,7 +97,7 @@ class BackgroundUpdateAnalyticsRepositoryTest : BaseUnitTest() {
         val mockCurrentResult: Result<WCRevenueStatsModel?> = Result.failure(mockError1)
         val mockPreviousResult: Result<WCRevenueStatsModel?> = Result.failure(mockError2)
 
-        whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
+        whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), anyOrNull()))
             .thenReturn(mockCurrentResult, mockPreviousResult)
 
         val result = backgroundUpdateAnalyticsRepository.fetchRevenueStats(testSelectionData)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/analytics/AnalyticsRepositoryTest.kt
@@ -26,6 +26,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -103,10 +104,14 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
     fun `given no currentPeriodRevenue, when fetchRevenueData, then result is RevenueError`() = runTest {
         // Given
         val previousPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-        whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+        whenever(
+            statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+        )
             .thenReturn(Result.success(previousPeriodRevenue))
 
-        whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+        whenever(
+            statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+        )
             .thenReturn(Result.failure(StatsRepository.StatsException(null)))
 
         // When
@@ -123,10 +128,14 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
     fun `given no currentPeriodRevenue when fetchOrderData result is RevenueError`() = runTest {
         // Given
         val previousPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-        whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+        whenever(
+            statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+        )
             .thenReturn(Result.success(previousPeriodOrdersStats))
 
-        whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+        whenever(
+            statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+        )
             .thenReturn(Result.failure(StatsRepository.StatsException(null)))
 
         // When
@@ -143,10 +152,14 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
     fun `given no previousRevenuePeriod, when fetchRevenueData, then result is RevenueError`() = runTest {
         // Given
         val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-        whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+        whenever(
+            statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+        )
             .thenReturn(Result.success(currentPeriodRevenue))
 
-        whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+        whenever(
+            statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+        )
             .thenReturn(Result.failure(StatsRepository.StatsException(null)))
 
         // When
@@ -164,10 +177,14 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val currentPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(currentPeriodOrdersStats))
 
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.failure(StatsRepository.StatsException(null)))
 
             // When
@@ -194,10 +211,14 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 netValue = 100.0,
                 itemsSold = 12
             )
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(currentRevenue))
 
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(previousRevenue))
 
             // When
@@ -236,10 +257,14 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 netValue = 159.4,
                 itemsSold = 12
             )
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(currentRevenue))
 
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(previousRevenue))
 
             // When
@@ -269,11 +294,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(ZERO_VALUE, ZERO_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(revenue))
 
             val previousRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(previousRevenue))
 
             // When
@@ -295,11 +324,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(revenue))
 
             val previousRevenue = givenARevenue(ZERO_VALUE, ZERO_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(previousRevenue))
 
             // When
@@ -318,10 +351,14 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val ordersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(ordersStats))
 
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(ordersStats))
 
             // When
@@ -343,10 +380,14 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val ordersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(ordersStats))
 
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(ordersStats))
 
             // When
@@ -366,11 +407,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(ZERO_VALUE, ZERO_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(previousPeriodRevenue))
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue))
 
             // When
@@ -391,11 +436,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodOrdersStats = givenRevenueOrderStats(ZERO_VALUE.toInt(), ZERO_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(previousPeriodOrdersStats))
 
             val currentPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(currentPeriodOrdersStats))
 
             // When
@@ -417,11 +466,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, ZERO_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(previousPeriodRevenue))
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue))
 
             // When
@@ -441,11 +494,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), ZERO_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(previousPeriodOrdersStats))
 
             val currentPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(currentPeriodOrdersStats))
 
             // When
@@ -465,11 +522,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(null, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(previousPeriodRevenue))
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue))
 
             // When
@@ -488,11 +549,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodOrdersStats = givenRevenueOrderStats(null, TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(previousPeriodOrdersStats))
 
             val currentPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(currentPeriodOrdersStats))
 
             // When
@@ -512,11 +577,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, null, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(previousPeriodRevenue))
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue))
 
             // When
@@ -536,11 +605,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), null)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(previousPeriodOrdersStats))
 
             val currentPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(currentPeriodOrdersStats))
 
             // When
@@ -559,11 +632,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(previousPeriodRevenue))
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue))
 
             // When
@@ -583,11 +660,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodOrdersStats = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(previousPeriodOrdersStats))
 
             val currentPeriodRevenue = givenRevenueOrderStats(TEN_VALUE.toInt(), TEN_VALUE)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success<WCRevenueStatsModel?>(currentPeriodRevenue))
 
             // When
@@ -607,10 +688,14 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(previousPeriodRevenue))
 
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null)))
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -634,11 +719,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
     fun `given no previousPeriodRevenue, when fetchProductsData, then result is ProductsError`() =
         runTest {
             // Given
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null)))
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(currentPeriodRevenue))
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -663,10 +752,14 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(previousPeriodRevenue))
 
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.failure<WCRevenueStatsModel?>(StatsRepository.StatsException(null)))
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -691,11 +784,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val previousPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.previousRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(previousPeriodRevenue))
 
             val currentPeriodRevenue = givenARevenue(TEN_VALUE, TEN_VALUE, null)
-            whenever(statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any()))
+            whenever(
+                statsRepository.fetchRevenueStats(eq(testSelectionData.currentRange), any(), any(), any(), anyOrNull())
+            )
                 .thenReturn(Result.success(currentPeriodRevenue))
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -720,7 +817,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), anyOrNull()))
                 .thenReturn(Result.success(revenue))
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -741,7 +838,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), anyOrNull()))
                 .thenReturn(Result.success(revenue))
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -769,7 +866,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), anyOrNull()))
                 .thenReturn(Result.success(revenue))
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -792,8 +889,8 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 eq(testSelectionData.previousRange),
                 any(),
                 any(),
-
-                any()
+                any(),
+                anyOrNull()
             )
         }
 
@@ -829,7 +926,7 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
         runTest {
             // Given
             val revenue = givenARevenue(TEN_VALUE, TEN_VALUE, TEN_VALUE.toInt())
-            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
+            whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), anyOrNull()))
                 .thenReturn(Result.success(revenue))
 
             whenever(statsRepository.fetchTopPerformerProducts(any(), any(), any(), any()))
@@ -858,13 +955,15 @@ class AnalyticsRepositoryTest : BaseUnitTest() {
                 eq(testSelectionData.previousRange),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
             verify(statsRepository, times(2)).fetchRevenueStats(
                 eq(testSelectionData.currentRange),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
         }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/StatsRepositoryTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/StatsRepositoryTests.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito.lenient
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -20,6 +21,7 @@ import org.wordpress.android.fluxc.model.WCBundleStats
 import org.wordpress.android.fluxc.model.WCGiftCardStats
 import org.wordpress.android.fluxc.model.WCProductBundleItemReport
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.model.settings.WCAnalyticsOrderDateType
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
@@ -66,6 +68,52 @@ class StatsRepositoryTests : BaseUnitTest() {
     }
 
     @Test
+    fun `when fetching analytics order date type succeeds then a success response is returned`() = testBlocking {
+        whenever(selectedSite.get()).thenReturn(defaultSiteModel)
+        whenever(wooCommerceStore.fetchAnalyticsOrderDateType(defaultSiteModel))
+            .thenReturn(WooResult(WCAnalyticsOrderDateType.CREATED))
+
+        val result = sut.fetchAnalyticsOrderDateType()
+
+        assertThat(result.getOrNull()).isEqualTo(WCAnalyticsOrderDateType.CREATED)
+    }
+
+    @Test
+    fun `when fetching analytics order date type fails then a failure response is returned`() = testBlocking {
+        whenever(selectedSite.get()).thenReturn(defaultSiteModel)
+        whenever(wooCommerceStore.fetchAnalyticsOrderDateType(defaultSiteModel))
+            .thenReturn(WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)))
+
+        val result = sut.fetchAnalyticsOrderDateType()
+
+        assertThat(result.isFailure).isTrue
+    }
+
+    @Test
+    fun `when updating analytics order date type succeeds then a success response is returned`() = testBlocking {
+        whenever(selectedSite.get()).thenReturn(defaultSiteModel)
+        whenever(
+            wooCommerceStore.updateAnalyticsOrderDateType(defaultSiteModel, WCAnalyticsOrderDateType.COMPLETED)
+        ).thenReturn(WooResult(WCAnalyticsOrderDateType.COMPLETED))
+
+        val result = sut.updateAnalyticsOrderDateType(WCAnalyticsOrderDateType.COMPLETED)
+
+        assertThat(result.getOrNull()).isEqualTo(WCAnalyticsOrderDateType.COMPLETED)
+    }
+
+    @Test
+    fun `when updating analytics order date type fails then a failure response is returned`() = testBlocking {
+        whenever(selectedSite.get()).thenReturn(defaultSiteModel)
+        whenever(
+            wooCommerceStore.updateAnalyticsOrderDateType(defaultSiteModel, WCAnalyticsOrderDateType.COMPLETED)
+        ).thenReturn(WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)))
+
+        val result = sut.updateAnalyticsOrderDateType(WCAnalyticsOrderDateType.COMPLETED)
+
+        assertThat(result.isFailure).isTrue
+    }
+
+    @Test
     fun `when visitors and revenue requests succeed then a success response is returned containing both value`() =
         testBlocking {
             val granularity = WCStatsStore.StatsGranularity.DAYS
@@ -90,7 +138,7 @@ class StatsRepositoryTests : BaseUnitTest() {
             whenever(wcStatsStore.getNewVisitorStats(defaultSiteModel, granularity, quantity, startDate))
                 .thenReturn(emptyMap())
             whenever(wcStatsStore.fetchRevenueStats(any())).thenReturn(revenueStatsResponse)
-            whenever(wcStatsStore.getRawRevenueStats(eq(defaultSiteModel), eq(granularity), eq(startDate), eq(endDate)))
+            whenever(wcStatsStore.getRawRevenueStatsFromRangeId(eq(defaultSiteModel), any()))
                 .thenReturn(WCRevenueStatsModel(LocalId(1), "", "", "", "", "", ""))
 
             val result = sut.fetchStats(
@@ -129,7 +177,7 @@ class StatsRepositoryTests : BaseUnitTest() {
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(null)
         whenever(wcStatsStore.fetchNewVisitorStats(any())).thenReturn(visitorStatsResponse)
         whenever(wcStatsStore.fetchRevenueStats(any())).thenReturn(revenueStatsResponse)
-        whenever(wcStatsStore.getRawRevenueStats(eq(defaultSiteModel), eq(granularity), eq(startDate), eq(endDate)))
+        whenever(wcStatsStore.getRawRevenueStatsFromRangeId(eq(defaultSiteModel), any()))
             .thenReturn(WCRevenueStatsModel(LocalId(1), "", "", "", "", "", ""))
 
         val result = sut.fetchStats(
@@ -146,6 +194,38 @@ class StatsRepositoryTests : BaseUnitTest() {
         assertThat(model).isNotNull
         assertThat(model!!.revenue).isNotNull
         assertThat(model.visitors).isNull()
+    }
+
+    @Test
+    fun `when fetching revenue stats succeeds then stats are read by revenue range id`() = testBlocking {
+        val granularity = WCStatsStore.StatsGranularity.DAYS
+        val startDate = "2024-01-25 00:00:00"
+        val endDate = "2024-01-25 23:59:59"
+        val revenueRangeId = "today-date_created"
+        val wrongStats = WCRevenueStatsModel(LocalId(1), "", "", "", "", "", "today-date_paid")
+        val expectedStats = WCRevenueStatsModel(LocalId(1), "", "", "", "", "", revenueRangeId)
+        val revenueStatsResponse = WCStatsStore.OnWCRevenueStatsChanged(
+            granularity = granularity,
+            startDate = startDate,
+            endDate = endDate
+        )
+
+        whenever(selectedSite.get()).thenReturn(defaultSiteModel)
+        whenever(wcStatsStore.fetchRevenueStats(any())).thenReturn(revenueStatsResponse)
+        lenient().doReturn(wrongStats).whenever(wcStatsStore)
+            .getRawRevenueStats(eq(defaultSiteModel), eq(granularity), eq(startDate), eq(endDate))
+        whenever(wcStatsStore.getRawRevenueStatsFromRangeId(defaultSiteModel, revenueRangeId))
+            .thenReturn(expectedStats)
+
+        val result = sut.fetchRevenueStats(
+            range = defaultRange,
+            granularity = granularity,
+            forced = true,
+            revenueRangeId = revenueRangeId,
+            orderDateType = WCAnalyticsOrderDateType.CREATED
+        )
+
+        assertThat(result.getOrNull()).isEqualTo(expectedStats)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/StatsRepositoryTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/StatsRepositoryTests.kt
@@ -68,7 +68,7 @@ class StatsRepositoryTests : BaseUnitTest() {
     }
 
     @Test
-    fun `when fetching analytics order date type succeeds then a success response is returned`() = testBlocking {
+    fun `when fetching analytics order date type succeeds, then a success response is returned`() = testBlocking {
         whenever(selectedSite.get()).thenReturn(defaultSiteModel)
         whenever(wooCommerceStore.fetchAnalyticsOrderDateType(defaultSiteModel))
             .thenReturn(WooResult(WCAnalyticsOrderDateType.CREATED))
@@ -79,7 +79,7 @@ class StatsRepositoryTests : BaseUnitTest() {
     }
 
     @Test
-    fun `when fetching analytics order date type fails then a failure response is returned`() = testBlocking {
+    fun `when fetching analytics order date type fails, then a failure response is returned`() = testBlocking {
         whenever(selectedSite.get()).thenReturn(defaultSiteModel)
         whenever(wooCommerceStore.fetchAnalyticsOrderDateType(defaultSiteModel))
             .thenReturn(WooResult(WooError(WooErrorType.GENERIC_ERROR, BaseRequest.GenericErrorType.UNKNOWN)))
@@ -90,7 +90,7 @@ class StatsRepositoryTests : BaseUnitTest() {
     }
 
     @Test
-    fun `when updating analytics order date type succeeds then a success response is returned`() = testBlocking {
+    fun `when updating analytics order date type succeeds, then a success response is returned`() = testBlocking {
         whenever(selectedSite.get()).thenReturn(defaultSiteModel)
         whenever(
             wooCommerceStore.updateAnalyticsOrderDateType(defaultSiteModel, WCAnalyticsOrderDateType.COMPLETED)
@@ -102,7 +102,7 @@ class StatsRepositoryTests : BaseUnitTest() {
     }
 
     @Test
-    fun `when updating analytics order date type fails then a failure response is returned`() = testBlocking {
+    fun `when updating analytics order date type fails, then a failure response is returned`() = testBlocking {
         whenever(selectedSite.get()).thenReturn(defaultSiteModel)
         whenever(
             wooCommerceStore.updateAnalyticsOrderDateType(defaultSiteModel, WCAnalyticsOrderDateType.COMPLETED)
@@ -197,7 +197,7 @@ class StatsRepositoryTests : BaseUnitTest() {
     }
 
     @Test
-    fun `when fetching revenue stats succeeds then stats are read by revenue range id`() = testBlocking {
+    fun `when fetching revenue stats succeeds, then stats are read by revenue range id`() = testBlocking {
         val granularity = WCStatsStore.StatsGranularity.DAYS
         val startDate = "2024-01-25 00:00:00"
         val endDate = "2024-01-25 23:59:59"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/DashboardStatsViewModelTest.kt
@@ -31,6 +31,7 @@ import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
@@ -55,7 +56,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     }
 
     private val getStats: GetStats = mock {
-        on { invoke(any(), any()) } doReturn flowOf(GetStats.LoadStatsResult.RevenueStatsSuccess(null))
+        on { invoke(any(), any(), anyOrNull()) } doReturn flowOf(GetStats.LoadStatsResult.RevenueStatsSuccess(null))
     }
     private val networkStatus: NetworkStatus = mock {
         on { isConnected() } doReturn true
@@ -129,7 +130,11 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
                 whenever(networkStatus.isConnected()).thenReturn(true)
             }
 
-            verify(getStats).invoke(refresh = ArgumentMatchers.eq(false), selectedRange = any())
+            verify(getStats).invoke(
+                refresh = ArgumentMatchers.eq(false),
+                selectedRange = any(),
+                orderDateType = anyOrNull()
+            )
         }
 
     @Test
@@ -139,7 +144,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
                 whenever(networkStatus.isConnected()).thenReturn(false)
             }
 
-            verify(getStats, never()).invoke(any(), any())
+            verify(getStats, never()).invoke(any(), any(), anyOrNull())
         }
 
     @Test
@@ -151,7 +156,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
 
             viewModel.onRangeChanged(ANY_SELECTION_TYPE)
 
-            verify(getStats, never()).invoke(any(), any())
+            verify(getStats, never()).invoke(any(), any(), anyOrNull())
         }
 
     @Test
@@ -167,7 +172,8 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
 
         verify(getStats, times(2)).invoke(
             refresh = ArgumentMatchers.eq(false),
-            selectedRange = getStatsArgumentCaptor.capture()
+            selectedRange = getStatsArgumentCaptor.capture(),
+            orderDateType = anyOrNull()
         )
         Assertions.assertThat(getStatsArgumentCaptor.firstValue.selectionType)
             .isEqualTo(DEFAULT_SELECTION_TYPE)
@@ -189,7 +195,8 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
                 refresh = eq(true),
                 selectedRange = argThat {
                     selectionType == DEFAULT_SELECTION_TYPE
-                }
+                },
+                orderDateType = anyOrNull()
             )
         }
 
@@ -197,7 +204,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given success loading revenue, when stats granularity changes, then UI is updated for new selection type`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(flow { emit(GetStats.LoadStatsResult.RevenueStatsSuccess(null)) })
                 whenever(appPrefsWrapper.getActiveStoreStatsTab())
                     .doReturn(DEFAULT_SELECTION_TYPE.name)
@@ -244,7 +251,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
                 rangeId = "",
             )
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(flowOf(GetStats.LoadStatsResult.RevenueStatsSuccess(revenueStats)))
             }
 
@@ -317,7 +324,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given error loading revenue, when screen starts, then UI is updated with error`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(flowOf(GetStats.LoadStatsResult.RevenueStatsError("")))
             }
 
@@ -329,7 +336,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given stats plugin not active, when screen starts, then UI is updated with jetpack error`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(flowOf(GetStats.LoadStatsResult.PluginNotActive))
             }
 
@@ -342,7 +349,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given success loading visitor stats, when screen starts, then UI is updated with visitor stats`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(flowOf(GetStats.LoadStatsResult.VisitorsStatsSuccess(emptyMap(), 0)))
             }
 
@@ -355,7 +362,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given error loading visitor stats, when screen starts, then UI is updated with error`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(flowOf(GetStats.LoadStatsResult.VisitorsStatsError))
             }
 
@@ -368,7 +375,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given jetpack CP connected, when screen starts, then show jetpack CP connected state`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(flowOf(GetStats.LoadStatsResult.VisitorStatUnavailable))
             }
 
@@ -397,7 +404,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given several outdated visitor stats is returned then refreshing indicator is called only once`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(
                         flowOf(
                             GetStats.LoadStatsResult.VisitorsStatsSuccess(mapOf("test" to 3), 2, true),
@@ -413,7 +420,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given up to date visitor stats is returned after outdated stats then hide refreshing indicator`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(
                         flowOf(
                             GetStats.LoadStatsResult.VisitorsStatsSuccess(mapOf("test" to 3), 2, true),
@@ -429,7 +436,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given an error is returned after outdated visitor stats then hide refreshing indicator`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(
                         flowOf(
                             GetStats.LoadStatsResult.VisitorsStatsSuccess(mapOf("test" to 3), 2, true),
@@ -445,7 +452,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given a visitor stats unavailable is returned after outdated data then hide refreshing indicator`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(
                         flowOf(
                             GetStats.LoadStatsResult.VisitorsStatsSuccess(mapOf("test" to 3), 2, true),
@@ -461,7 +468,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given several outdated revenue stats is returned then refreshing indicator is called only once`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(
                         flowOf(
                             GetStats.LoadStatsResult.RevenueStatsSuccess(ANY_REVENUE_STATS, true),
@@ -477,7 +484,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given up to date revenue stats is returned after outdated stats then hide refreshing indicator`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(
                         flowOf(
                             GetStats.LoadStatsResult.RevenueStatsSuccess(ANY_REVENUE_STATS, true),
@@ -493,7 +500,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given revenue error is returned after outdated revenue stats then hide refreshing indicator`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(
                         flowOf(
                             GetStats.LoadStatsResult.RevenueStatsSuccess(ANY_REVENUE_STATS, true),
@@ -509,7 +516,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     fun `given plugin not active error is returned after outdated revenue stats then hide refreshing indicator`() =
         testBlocking {
             setup {
-                whenever(getStats.invoke(any(), any()))
+                whenever(getStats.invoke(any(), any(), anyOrNull()))
                     .thenReturn(
                         flowOf(
                             GetStats.LoadStatsResult.RevenueStatsSuccess(ANY_REVENUE_STATS, true),
@@ -524,7 +531,7 @@ class DashboardStatsViewModelTest : BaseUnitTest() {
     @Test
     fun `given site is WPCom suspended, when visitor stats placeholder, then hide Jetpack icon`() = testBlocking {
         setup {
-            whenever(getStats.invoke(any(), any()))
+            whenever(getStats.invoke(any(), any(), anyOrNull()))
                 .thenReturn(flowOf(GetStats.LoadStatsResult.VisitorStatUnavailable))
             whenever(appPrefsWrapper.isSiteWPComSuspended).thenReturn(true)
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/GetStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/GetStatsTest.kt
@@ -344,7 +344,7 @@ class GetStatsTest : BaseUnitTest() {
         }
 
     @Test
-    fun `Given order date type, when get stats, then fetches revenue stats with date type cache key`() =
+    fun `given order date type, when get stats, then fetches revenue stats with date type cache key`() =
         testBlocking {
             givenGetRevenueStats(Result.success(null))
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/GetStatsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/stats/GetStatsTest.kt
@@ -19,6 +19,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -27,6 +29,7 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.model.settings.WCAnalyticsOrderDateType
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsError
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.WCStatsStore.OrderStatsErrorType.PLUGIN_NOT_ACTIVE
@@ -255,7 +258,7 @@ class GetStatsTest : BaseUnitTest() {
 
             getStats(refresh = false, selectedRange = ANY_STATS_RANGE_SELECTION).collect()
 
-            verify(statsRepository, never()).fetchRevenueStats(any(), any(), any(), any())
+            verify(statsRepository, never()).fetchRevenueStats(any(), any(), any(), any(), anyOrNull())
         }
 
     @Test
@@ -266,7 +269,7 @@ class GetStatsTest : BaseUnitTest() {
 
             getStats(refresh = false, selectedRange = ANY_STATS_RANGE_SELECTION).collect()
 
-            verify(statsRepository).fetchRevenueStats(any(), any(), eq(false), any())
+            verify(statsRepository).fetchRevenueStats(any(), any(), eq(false), any(), anyOrNull())
         }
 
     @Test
@@ -340,8 +343,29 @@ class GetStatsTest : BaseUnitTest() {
             assertThat(result).isNotNull
         }
 
+    @Test
+    fun `Given order date type, when get stats, then fetches revenue stats with date type cache key`() =
+        testBlocking {
+            givenGetRevenueStats(Result.success(null))
+
+            getStats(
+                refresh = false,
+                selectedRange = ANY_STATS_RANGE_SELECTION,
+                orderDateType = WCAnalyticsOrderDateType.COMPLETED
+            ).collect()
+
+            verify(statsRepository).getRevenueStatsById(argThat { endsWith("-date_completed") })
+            verify(statsRepository).fetchRevenueStats(
+                range = any(),
+                granularity = any(),
+                forced = eq(true),
+                revenueRangeId = argThat { endsWith("-date_completed") },
+                orderDateType = eq(WCAnalyticsOrderDateType.COMPLETED)
+            )
+        }
+
     private suspend fun givenFetchRevenueStats(result: Result<WCRevenueStatsModel?>) {
-        whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any()))
+        whenever(statsRepository.fetchRevenueStats(any(), any(), any(), any(), anyOrNull()))
             .thenReturn(result)
     }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/settings/WCAnalyticsOrderDateType.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/settings/WCAnalyticsOrderDateType.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.fluxc.model.settings
+
+enum class WCAnalyticsOrderDateType(val value: String) {
+    PAID("date_paid"),
+    CREATED("date_created"),
+    COMPLETED("date_completed");
+
+    companion object {
+        fun fromValue(value: String?): WCAnalyticsOrderDateType =
+            entries.find { it.value == value } ?: PAID
+    }
+}

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.fluxc.network.rest.wpcom.wc
 
 import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.settings.WCAnalyticsOrderDateType
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.discovery.RootWPAPIRestResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpacktunnel.JetpackTunnelGsonRequest
@@ -17,6 +18,8 @@ class WooCommerceRestClient @Inject constructor(private val wooNetwork: WooNetwo
         const val TAX_SETTING_GROUP = "tax"
         const val TAX_SETTING_ID = "woocommerce_tax_based_on"
         const val ROUND_TAX_AT_SUBTOTAL_SETTING_ID = "woocommerce_tax_round_at_subtotal"
+        const val ANALYTICS_SETTING_GROUP = "wc_admin"
+        const val ANALYTICS_DATE_TYPE_SETTING_ID = "woocommerce_date_type"
 
         private const val ROOT_ENDPOINT_TIMEOUT_MS = 15000
     }
@@ -102,5 +105,32 @@ class WooCommerceRestClient @Inject constructor(private val wooNetwork: WooNetwo
             clazz = SiteSettingOptionResponse::class.java,
         )
         return response.toWooPayload { it.value == "yes" }
+    }
+
+    suspend fun fetchAnalyticsOrderDateType(site: SiteModel): WooPayload<WCAnalyticsOrderDateType> {
+        val url = WOOCOMMERCE.settings.group(ANALYTICS_SETTING_GROUP).id(ANALYTICS_DATE_TYPE_SETTING_ID).pathV3
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = url,
+            clazz = SiteSettingOptionResponse::class.java,
+        )
+        return response.toWooPayload { WCAnalyticsOrderDateType.fromValue(it.value) }
+    }
+
+    suspend fun updateAnalyticsOrderDateType(
+        site: SiteModel,
+        orderDateType: WCAnalyticsOrderDateType
+    ): WooPayload<WCAnalyticsOrderDateType> {
+        val url = WOOCOMMERCE.settings.group(ANALYTICS_SETTING_GROUP).id(ANALYTICS_DATE_TYPE_SETTING_ID).pathV3
+        val param = mapOf("value" to orderDateType.value)
+
+        val response = wooNetwork.executePutGsonRequest(
+            site = site,
+            path = url,
+            clazz = SiteSettingOptionResponse::class.java,
+            body = param
+        )
+
+        return response.toWooPayload { WCAnalyticsOrderDateType.fromValue(it.value) }
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClient.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.fluxc.generated.endpoint.WPCOMREST
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCNewVisitorStatsModel
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
+import org.wordpress.android.fluxc.model.settings.WCAnalyticsOrderDateType
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.WPComGsonRequest.WPComGsonNetworkError
@@ -54,9 +55,8 @@ class OrderStatsRestClient @Inject constructor(
      * Makes a GET call to `/wc-analytics/reports/revenue/stats`, retrieving data for the given
      * WooCommerce [SiteModel].
      *
-     * Does not send a `date_type` parameter, allowing the server to use the store's configured
-     * `woocommerce_date_type` setting (default: `date_paid`). This matches the behavior of the
-     * wp-admin Analytics dashboard, which also relies on the server-side default.
+     * Sends a `date_type` parameter when one is provided. Otherwise, the server uses the store's configured
+     * `woocommerce_date_type` setting (default: `date_paid`).
      *
      * @param[site] the site to fetch stats data for
      * @param[granularity] one of 'hour', 'day', 'week', 'month', or 'year'
@@ -65,6 +65,7 @@ class OrderStatsRestClient @Inject constructor(
      * @param[perPage] the number of items to return in a paginated response
      * @param[forceRefresh] a boolean value indicating whether we should avoid cached data
      * @param[revenueRangeId] a unique id for this request. We will use this id to save the response in the local db.
+     * @param[orderDateType] the order date field to use when grouping revenue stats.
      *
      * Possible non-generic errors:
      * [OrderStatsErrorType.INVALID_PARAM] if [granularity], [startDate], or [endDate] are invalid or incompatible
@@ -78,16 +79,18 @@ class OrderStatsRestClient @Inject constructor(
         perPage: Int,
         forceRefresh: Boolean = false,
         revenueRangeId: String,
+        orderDateType: WCAnalyticsOrderDateType? = null,
     ): FetchRevenueStatsResponsePayload {
         val url = WOOCOMMERCE.reports.revenue.stats.pathV4Analytics
-        val params = mapOf(
-            "interval" to OrderStatsApiUnit.fromStatsGranularity(granularity).toString(),
-            "after" to startDate,
-            "before" to endDate,
-            "per_page" to perPage.toString(),
-            "order" to "asc",
-            "force_cache_refresh" to forceRefresh.toString(),
-        )
+        val params = buildMap {
+            put("interval", OrderStatsApiUnit.fromStatsGranularity(granularity).toString())
+            put("after", startDate)
+            put("before", endDate)
+            put("per_page", perPage.toString())
+            put("order", "asc")
+            put("force_cache_refresh", forceRefresh.toString())
+            orderDateType?.let { put("date_type", it.value) }
+        }
 
         val response = wooNetwork.executeGetGsonRequest(
             site = site,
@@ -101,23 +104,24 @@ class OrderStatsRestClient @Inject constructor(
         return when (response) {
             is WPAPIResponse.Success -> {
                 response.data?.let {
-                        val model = WCRevenueStatsModel(
-                            localSiteId = site.localId(),
-                            interval = granularity.toString(),
-                            data = it.intervals.toString(),
-                            total = it.totals.toString(),
-                            startDate = startDate,
-                            endDate = endDate,
-                            rangeId = revenueRangeId,
-                        )
+                    val model = WCRevenueStatsModel(
+                        localSiteId = site.localId(),
+                        interval = granularity.toString(),
+                        data = it.intervals.toString(),
+                        total = it.totals.toString(),
+                        startDate = startDate,
+                        endDate = endDate,
+                        rangeId = revenueRangeId,
+                    )
 
                     FetchRevenueStatsResponsePayload(site, granularity, model)
                 } ?: FetchRevenueStatsResponsePayload(
-                        OrderStatsError(type = OrderStatsErrorType.GENERIC_ERROR,
-                                message = "Success response with empty data"
-                        ),
-                        site,
-                        granularity
+                    OrderStatsError(
+                        type = OrderStatsErrorType.GENERIC_ERROR,
+                        message = "Success response with empty data"
+                    ),
+                    site,
+                    granularity
                 )
             }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.model.WCNewVisitorStatsModel
 import org.wordpress.android.fluxc.model.WCProductBundleItemReport
 import org.wordpress.android.fluxc.model.WCRevenueStatsModel
 import org.wordpress.android.fluxc.model.WCVisitorStatsSummary
+import org.wordpress.android.fluxc.model.settings.WCAnalyticsOrderDateType
 import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -87,6 +88,7 @@ class WCStatsStore @Inject internal constructor(
         val endDate: String,
         val forced: Boolean = false,
         val revenueRangeId: String,
+        val orderDateType: WCAnalyticsOrderDateType? = null,
     ) : Payload<BaseNetworkError>()
 
     class FetchRevenueStatsResponsePayload(
@@ -409,7 +411,8 @@ class WCStatsStore @Inject internal constructor(
                 endDate = endDate,
                 perPage = ORDER_REVENUE_QUANTITY,
                 forceRefresh = payload.forced,
-                revenueRangeId = payload.revenueRangeId
+                revenueRangeId = payload.revenueRangeId,
+                orderDateType = payload.orderDateType
             )
 
             with(result) {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCStatsStore.kt
@@ -88,7 +88,7 @@ class WCStatsStore @Inject internal constructor(
         val endDate: String,
         val forced: Boolean = false,
         val revenueRangeId: String,
-        val orderDateType: WCAnalyticsOrderDateType? = null,
+        val orderDateType: WCAnalyticsOrderDateType?,
     ) : Payload<BaseNetworkError>()
 
     class FetchRevenueStatsResponsePayload(

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.model.settings.CurrencyPosition.LEFT_SPACE
 import org.wordpress.android.fluxc.model.settings.CurrencyPosition.RIGHT
 import org.wordpress.android.fluxc.model.settings.CurrencyPosition.RIGHT_SPACE
 import org.wordpress.android.fluxc.model.settings.Settings
+import org.wordpress.android.fluxc.model.settings.WCAnalyticsOrderDateType
 import org.wordpress.android.fluxc.model.settings.WCSettingsMapper
 import org.wordpress.android.fluxc.model.taxes.TaxBasedOnSettingEntity
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
@@ -423,6 +424,21 @@ open class WooCommerceStore @Inject internal constructor(
                     WooResult(WooError(GENERIC_ERROR, UNKNOWN))
                 }
             }
+        }
+    }
+
+    suspend fun fetchAnalyticsOrderDateType(site: SiteModel): WooResult<WCAnalyticsOrderDateType> {
+        return coroutineEngine.withDefaultContext(T.API, this, "fetchAnalyticsOrderDateType") {
+            wcCoreRestClient.fetchAnalyticsOrderDateType(site).asWooResult()
+        }
+    }
+
+    suspend fun updateAnalyticsOrderDateType(
+        site: SiteModel,
+        orderDateType: WCAnalyticsOrderDateType
+    ): WooResult<WCAnalyticsOrderDateType> {
+        return coroutineEngine.withDefaultContext(T.API, this, "updateAnalyticsOrderDateType") {
+            wcCoreRestClient.updateAnalyticsOrderDateType(site, orderDateType).asWooResult()
         }
     }
 

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/orderstats/OrderStatsRestClientTest.kt
@@ -1,0 +1,116 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.orderstats
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.settings.WCAnalyticsOrderDateType
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.WPComNetwork
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+import org.wordpress.android.fluxc.store.WCStatsStore.StatsGranularity
+import org.wordpress.android.fluxc.utils.initCoroutineEngine
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OrderStatsRestClientTest {
+    private val site = SiteModel()
+    private val wooNetwork: WooNetwork = mock()
+    private val wpComNetwork: WPComNetwork = mock()
+
+    private lateinit var sut: OrderStatsRestClient
+
+    @Before
+    fun setUp() {
+        sut = OrderStatsRestClient(
+            dispatcher = mock<Dispatcher>(),
+            wooNetwork = wooNetwork,
+            wpComNetwork = wpComNetwork,
+            coroutineEngine = initCoroutineEngine()
+        )
+    }
+
+    @Test
+    fun `when order date type is provided, then date type parameter is sent to API`() = runTest {
+        stubRevenueStatsResponse()
+
+        sut.fetchRevenueStats(
+            site = site,
+            granularity = StatsGranularity.DAYS,
+            startDate = START_DATE,
+            endDate = END_DATE,
+            perPage = PER_PAGE,
+            forceRefresh = true,
+            revenueRangeId = REVENUE_RANGE_ID,
+            orderDateType = WCAnalyticsOrderDateType.CREATED
+        )
+
+        assertThat(captureRevenueStatsParams())
+            .containsEntry("date_type", WCAnalyticsOrderDateType.CREATED.value)
+            .containsEntry("force_cache_refresh", "true")
+    }
+
+    @Test
+    fun `when order date type is not provided, then date type parameter is not sent to API`() = runTest {
+        stubRevenueStatsResponse()
+
+        sut.fetchRevenueStats(
+            site = site,
+            granularity = StatsGranularity.DAYS,
+            startDate = START_DATE,
+            endDate = END_DATE,
+            perPage = PER_PAGE,
+            revenueRangeId = REVENUE_RANGE_ID
+        )
+
+        assertThat(captureRevenueStatsParams()).doesNotContainKey("date_type")
+    }
+
+    private suspend fun stubRevenueStatsResponse() {
+        whenever(
+            wooNetwork.executeGetGsonRequest(
+                site = any(),
+                path = any(),
+                clazz = eq(RevenueStatsApiResponse::class.java),
+                params = any(),
+                enableCaching = any(),
+                cacheTimeToLive = any(),
+                forced = any(),
+                requestTimeout = any(),
+                retries = any()
+            )
+        ).thenReturn(WPAPIResponse.Success(null, emptyList()))
+    }
+
+    private suspend fun captureRevenueStatsParams(): Map<String, String> {
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(wooNetwork).executeGetGsonRequest(
+            site = eq(site),
+            path = eq(WOOCOMMERCE.reports.revenue.stats.pathV4Analytics),
+            clazz = eq(RevenueStatsApiResponse::class.java),
+            params = paramsCaptor.capture(),
+            enableCaching = eq(true),
+            cacheTimeToLive = any(),
+            forced = any(),
+            requestTimeout = any(),
+            retries = any()
+        )
+        return paramsCaptor.firstValue
+    }
+
+    private companion object {
+        const val START_DATE = "2026-01-01T00:00:00"
+        const val END_DATE = "2026-12-31T23:59:59"
+        const val PER_PAGE = 100
+        const val REVENUE_RANGE_ID = "year-date_created"
+    }
+}

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/WCStatsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/WCStatsStoreTest.kt
@@ -580,6 +580,7 @@ class WCStatsStoreTest {
                 startDate = currentDayStatsModel.startDate,
                 endDate = currentDayStatsModel.endDate,
                 revenueRangeId = "${currentDayStatsModel.startDate}${currentDayStatsModel.endDate}",
+                orderDateType = null,
             )
         )
 
@@ -628,6 +629,7 @@ class WCStatsStoreTest {
                 startDate = currentWeekStatsModel.startDate,
                 endDate = currentWeekStatsModel.endDate,
                 revenueRangeId = "${currentDayStatsModel.startDate}${currentDayStatsModel.endDate}",
+                orderDateType = null,
             )
         )
 
@@ -676,6 +678,7 @@ class WCStatsStoreTest {
                 startDate = currentMonthStatsModel.startDate,
                 endDate = currentMonthStatsModel.endDate,
                 revenueRangeId = "${currentDayStatsModel.startDate}${currentDayStatsModel.endDate}",
+                orderDateType = null,
             )
         )
 
@@ -724,6 +727,7 @@ class WCStatsStoreTest {
                 startDate = altSiteOrderStatsModel.startDate,
                 endDate = altSiteOrderStatsModel.endDate,
                 revenueRangeId = "${currentDayStatsModel.startDate}${currentDayStatsModel.endDate}",
+                orderDateType = null,
             )
         )
 
@@ -765,6 +769,7 @@ class WCStatsStoreTest {
                 startDate = altSiteOrderStatsModel.startDate,
                 endDate = altSiteOrderStatsModel.endDate,
                 revenueRangeId = "${currentDayStatsModel.startDate}${currentDayStatsModel.endDate}",
+                orderDateType = null,
             )
         )
 
@@ -805,6 +810,7 @@ class WCStatsStoreTest {
                 startDate = "2019-01-01",
                 endDate = "2019-01-07",
                 revenueRangeId = "${currentDayStatsModel.startDate}${currentDayStatsModel.endDate}",
+                orderDateType = null,
             )
         )
 
@@ -1206,6 +1212,7 @@ class WCStatsStoreTest {
             startDate = startDate,
             endDate = endDate,
             revenueRangeId = "$startDate$endDate",
+            orderDateType = null,
         )
     }
 

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/WCStatsStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/store/WCStatsStoreTest.kt
@@ -10,6 +10,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
@@ -373,7 +374,8 @@ class WCStatsStoreTest {
                     any(),
                     any(),
                     any(),
-                    any()
+                    any(),
+                    anyOrNull()
                 )
             ).thenReturn(
                 FetchRevenueStatsResponsePayload(
@@ -395,7 +397,8 @@ class WCStatsStoreTest {
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
@@ -413,7 +416,8 @@ class WCStatsStoreTest {
                     any(),
                     any(),
                     any(),
-                    any()
+                    any(),
+                    anyOrNull()
                 )
             ).thenReturn(
                 FetchRevenueStatsResponsePayload(
@@ -435,7 +439,8 @@ class WCStatsStoreTest {
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
@@ -461,7 +466,8 @@ class WCStatsStoreTest {
                     any(),
                     any(),
                     any(),
-                    any()
+                    any(),
+                    anyOrNull()
                 )
             ).thenReturn(
                 FetchRevenueStatsResponsePayload(
@@ -482,7 +488,8 @@ class WCStatsStoreTest {
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
@@ -500,7 +507,8 @@ class WCStatsStoreTest {
                     any(),
                     any(),
                     any(),
-                    any()
+                    any(),
+                    anyOrNull()
                 )
             ).thenReturn(
                 FetchRevenueStatsResponsePayload(
@@ -521,7 +529,8 @@ class WCStatsStoreTest {
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
             val siteDate = dateArgument.firstValue
             assertEquals(timeOnSite, siteDate)
@@ -554,7 +563,8 @@ class WCStatsStoreTest {
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
         ).thenReturn(
             FetchRevenueStatsResponsePayload(
@@ -607,7 +617,8 @@ class WCStatsStoreTest {
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
         ).thenReturn(currentWeekPayload)
         wcStatsStore.fetchRevenueStats(
@@ -654,7 +665,8 @@ class WCStatsStoreTest {
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
         ).thenReturn(currentMonthPayload)
         wcStatsStore.fetchRevenueStats(
@@ -701,7 +713,8 @@ class WCStatsStoreTest {
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
         ).thenReturn(allSiteCurrentDayPayload)
         wcStatsStore.fetchRevenueStats(
@@ -741,7 +754,8 @@ class WCStatsStoreTest {
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
         ).thenReturn(nonExistentPayload)
         wcStatsStore.fetchRevenueStats(
@@ -780,7 +794,8 @@ class WCStatsStoreTest {
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                anyOrNull()
             )
         ).thenReturn(nonExistentPayload)
         wcStatsStore.fetchRevenueStats(

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -298,7 +298,7 @@ class WooCommerceStoreTest {
     }
 
     @Test
-    fun `when fetch analytics order date type fails, the error returned`() {
+    fun `when fetch analytics order date type fails, then the error is returned`() {
         runBlocking {
             whenever(wcrestClient.fetchAnalyticsOrderDateType(site)).thenReturn(WooPayload(error))
 
@@ -309,7 +309,7 @@ class WooCommerceStoreTest {
     }
 
     @Test
-    fun `when fetch analytics order date type succeeds, the success returned`() {
+    fun `when fetch analytics order date type succeeds, then the success is returned`() {
         runBlocking {
             whenever(wcrestClient.fetchAnalyticsOrderDateType(site))
                 .thenReturn(WooPayload(WCAnalyticsOrderDateType.CREATED))
@@ -322,7 +322,7 @@ class WooCommerceStoreTest {
     }
 
     @Test
-    fun `when update analytics order date type succeeds, the success returned`() {
+    fun `when update analytics order date type succeeds, then the success is returned`() {
         runBlocking {
             whenever(wcrestClient.updateAnalyticsOrderDateType(site, WCAnalyticsOrderDateType.COMPLETED))
                 .thenReturn(WooPayload(WCAnalyticsOrderDateType.COMPLETED))

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/wc/WooCommerceStoreTest.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.model.WCProductSettingsModel
 import org.wordpress.android.fluxc.model.WCSSRModel
 import org.wordpress.android.fluxc.model.plugin.SitePluginModel
 import org.wordpress.android.fluxc.model.settings.Settings
+import org.wordpress.android.fluxc.model.settings.WCAnalyticsOrderDateType
 import org.wordpress.android.fluxc.model.settings.WCSettingsMapper
 import org.wordpress.android.fluxc.model.taxes.TaxBasedOnSettingEntity
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.NETWORK_ERROR
@@ -293,6 +294,43 @@ class WooCommerceStoreTest {
                 assertThat(it?.localSiteId).isEqualTo(expectedModel.localSiteId)
                 assertThat(it?.selectedOption).isEqualTo(expectedModel.selectedOption)
             }
+        }
+    }
+
+    @Test
+    fun `when fetch analytics order date type fails, the error returned`() {
+        runBlocking {
+            whenever(wcrestClient.fetchAnalyticsOrderDateType(site)).thenReturn(WooPayload(error))
+
+            val result = wooCommerceStore.fetchAnalyticsOrderDateType(site)
+
+            assertThat(result.error).isEqualTo(error)
+        }
+    }
+
+    @Test
+    fun `when fetch analytics order date type succeeds, the success returned`() {
+        runBlocking {
+            whenever(wcrestClient.fetchAnalyticsOrderDateType(site))
+                .thenReturn(WooPayload(WCAnalyticsOrderDateType.CREATED))
+
+            val result = wooCommerceStore.fetchAnalyticsOrderDateType(site)
+
+            assertThat(result.isError).isFalse
+            assertThat(result.model).isEqualTo(WCAnalyticsOrderDateType.CREATED)
+        }
+    }
+
+    @Test
+    fun `when update analytics order date type succeeds, the success returned`() {
+        runBlocking {
+            whenever(wcrestClient.updateAnalyticsOrderDateType(site, WCAnalyticsOrderDateType.COMPLETED))
+                .thenReturn(WooPayload(WCAnalyticsOrderDateType.COMPLETED))
+
+            val result = wooCommerceStore.updateAnalyticsOrderDateType(site, WCAnalyticsOrderDateType.COMPLETED)
+
+            assertThat(result.isError).isFalse
+            assertThat(result.model).isEqualTo(WCAnalyticsOrderDateType.COMPLETED)
         }
     }
 


### PR DESCRIPTION
⚠️ Do not merge until base branch is trunk

Fixes WOOMOB-2860

### Description

Adds network and repository support for the WooCommerce analytics order date-type setting. The app can now fetch and update `woocommerce_date_type`, represent the supported values as a typed enum, send `date_type` to revenue stats requests when selected, and isolate cached revenue stats by order date type.

Stacked on the WOOMOB-2861 revenue selector PR.

### Test Steps
1. Launch the app and open the Dashboard.
2. Confirm the Performance card still loads revenue and visitor stats normally.
3. Pull to refresh the dashboard and confirm the Performance card refreshes without error.
