### PR TITLE
[WOOMOB-2924] Add local feature flag for AI Assistant work

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -32,4 +32,5 @@ enum class FeatureFlag(
     BOOKINGS_RESCHEDULE("bookings_reschedule", localValue = PackageUtils.isDebugBuild()),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1("woo_self_driven_push_notifications_m1", localValue = false),
     LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
+    AI_ASSISTANT("ai_assistant", localValue = PackageUtils.isDebugBuild()),
 }


### PR DESCRIPTION
Fixes WOOMOB-2924

### Description

Adds the `AI_ASSISTANT` entry to the `FeatureFlag` enum so that all subsequent AI Assistant work can land behind a feature gate from day one.

The flag uses `localValue = PackageUtils.isDebugBuild()`, so it is on in debug builds and off in release. No production code reads the flag yet — the entry point and DI wiring land in a follow-up ticket (WOOMOB-2918).

> [!NOTE]
> The behavior will be tested later when we add the initial entry point for the feature. 

### Test Steps
Green CI is enough for now.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.