### PR TITLE
[RSM] Adapt POS dialogs for phone screens

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionDialog.kt
@@ -434,7 +434,7 @@ private fun CardReaderDialogContent(
             color = MaterialTheme.colorScheme.onSurface,
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
-            maxLines = 1,
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
@@ -27,12 +27,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
@@ -63,8 +63,10 @@ fun WooPosDialogWrapper(
         WooPosBreakpoint.SmallTablet,
         WooPosBreakpoint.Tablet -> widthFraction
     }
+    val density = LocalDensity.current
+    val containerHeight = with(density) { LocalWindowInfo.current.containerSize.height.toDp() }
     val phoneMaxHeight = if (breakpoint == WooPosBreakpoint.Phone) {
-        (LocalConfiguration.current.screenHeightDp * PHONE_MAX_HEIGHT_FRACTION).dp
+        containerHeight * PHONE_MAX_HEIGHT_FRACTION
     } else {
         null
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
@@ -63,9 +63,9 @@ fun WooPosDialogWrapper(
         WooPosBreakpoint.SmallTablet,
         WooPosBreakpoint.Tablet -> widthFraction
     }
-    val density = LocalDensity.current
-    val containerHeight = with(density) { LocalWindowInfo.current.containerSize.height.toDp() }
     val phoneMaxHeight = if (breakpoint == WooPosBreakpoint.Phone) {
+        val density = LocalDensity.current
+        val containerHeight = with(density) { LocalWindowInfo.current.containerSize.height.toDp() }
         containerHeight * PHONE_MAX_HEIGHT_FRACTION
     } else {
         null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosDialogWrapper.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -26,17 +27,23 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIconSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
 
 private const val DEFAULT_WIDTH_FRACTION = 0.75f
+private const val PHONE_WIDTH_FRACTION = 0.95f
+private const val PHONE_MAX_HEIGHT_FRACTION = 0.9f
 private const val ENTER_EXIT_DURATION_MS = 300
 
 @Composable
@@ -50,6 +57,17 @@ fun WooPosDialogWrapper(
     content: @Composable AnimatedVisibilityScope.() -> Unit
 ) {
     val closeContentDescription = stringResource(R.string.close)
+    val breakpoint = currentWooPosBreakpoint()
+    val adaptiveWidthFraction = when (breakpoint) {
+        WooPosBreakpoint.Phone -> PHONE_WIDTH_FRACTION
+        WooPosBreakpoint.SmallTablet,
+        WooPosBreakpoint.Tablet -> widthFraction
+    }
+    val phoneMaxHeight = if (breakpoint == WooPosBreakpoint.Phone) {
+        (LocalConfiguration.current.screenHeightDp * PHONE_MAX_HEIGHT_FRACTION).dp
+    } else {
+        null
+    }
 
     BackHandler(enabled = isVisible) { onDismissRequest() }
 
@@ -87,7 +105,14 @@ fun WooPosDialogWrapper(
                 modifier = modifier
                     .statusBarsPadding()
                     .navigationBarsPadding()
-                    .fillMaxWidth(widthFraction),
+                    .fillMaxWidth(adaptiveWidthFraction)
+                    .then(
+                        if (phoneMaxHeight != null) {
+                            Modifier.heightIn(max = phoneMaxHeight)
+                        } else {
+                            Modifier
+                        }
+                    ),
             ) {
                 Column(
                     modifier = Modifier.padding(WooPosSpacing.XLarge.value)


### PR DESCRIPTION
### Description

POS dialogs (exit confirmation, card reader connection, scanning setup, refund dialogs, etc.) use a fixed width fraction via `WooPosDialogWrapper` — 75% by default, 55% for the card reader dialog. This looks great on tablets but results in narrow, cramped dialogs on phones where titles get truncated and content doesn't use enough screen space.

This PR makes `WooPosDialogWrapper` breakpoint-aware using the existing `WooPosBreakpoint` system:
- **Phone**: dialogs use 95% screen width and are capped at 90% screen height to prevent overflow
- **SmallTablet / Tablet**: behavior is unchanged — the caller's `widthFraction` is used as before

Additionally, the card reader connection dialog title is changed from `maxLines = 1` to `maxLines = 2` with ellipsis, so longer titles (like reader serial numbers) can wrap instead of being truncated on a single line.

All 7+ POS dialogs benefit automatically since they all go through `WooPosDialogWrapper`.

### Test Steps

1. Open POS on a **phone-sized device** (or fold a foldable)
2. Press back to trigger the **exit confirmation dialog** — verify the title is fully visible and the dialog takes up most of the screen width
3. Add a product, check out, and tap "Connect to reader" to see the **card reader connection dialog** — verify the title is not truncated
4. Repeat on a **tablet** and verify dialogs look the same as before (unchanged width)

### Images/gif

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0d8569ab-f3e3-495c-a8ea-25f623ad955d" />
<img width="300"  alt="Screenshot_20260429_144055" src="https://github.com/user-attachments/assets/a798c127-beae-484e-ac17-9ecca16bf3c2" />
<img width="300" alt="Screenshot_20260429_144108" src="https://github.com/user-attachments/assets/0fec6676-83ca-4105-8065-df1b485e4565" />
<img width="300"  alt="Screenshot_20260429_144113" src="https://github.com/user-attachments/assets/a27067b4-3848-46f8-aa7f-6ba794a2d8af" />



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.