### PR TITLE
[WOOMOB-2886] POS card reader: fixes from remote TTP integration bug-bash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -119,6 +119,8 @@ class WooPosCardPaymentViewModel @Inject constructor(
                             _state.value = buildPreparingState()
                             collectPayment()
                         }
+                        // Keep current state during a transient reconnect so an in-flight BT
+                        // payment is not cancelled when the reader briefly drops to Reconnecting.
                         WooPosEffectiveReaderStatus.Reconnecting -> Unit
                         WooPosEffectiveReaderStatus.Connecting,
                         WooPosEffectiveReaderStatus.Disconnected -> {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -119,8 +119,8 @@ class WooPosCardPaymentViewModel @Inject constructor(
                             _state.value = buildPreparingState()
                             collectPayment()
                         }
+                        WooPosEffectiveReaderStatus.Reconnecting -> Unit
                         WooPosEffectiveReaderStatus.Connecting,
-                        WooPosEffectiveReaderStatus.Reconnecting,
                         WooPosEffectiveReaderStatus.Disconnected -> {
                             _state.value = buildReaderDisconnectedState()
                             cancelPayment()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -322,9 +322,11 @@ class WooPosCardReaderConnectionController(
                 is CardReaderStatus.Connected -> Unit
                 is CardReaderStatus.Reconnecting ->
                     runCatching { cardReaderManager.cancelReconnection() }
+                        .onFailure { logger.e("startDiscovery(): cancelReconnection() failed - ${it.message}") }
                 is CardReaderStatus.Connecting,
                 is CardReaderStatus.NotConnected ->
                     runCatching { cardReaderManager.disconnectReader() }
+                        .onFailure { logger.e("startDiscovery(): disconnectReader() failed - ${it.message}") }
             }
             unifiedDiscoveryStream
                 .discover(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -319,6 +319,7 @@ class WooPosCardReaderConnectionController(
     private fun startDiscovery() {
         discoveryJob?.cancel()
         discoveryJob = scope.launch {
+            runCatching { cardReaderManager.disconnectReader() }
             unifiedDiscoveryStream
                 .discover(
                     isSimulated = developerOptionsRepository.isSimulatedCardReaderEnabled(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Suppress("LongParameterList")
 class WooPosCardReaderConnectionController(
@@ -290,10 +291,19 @@ class WooPosCardReaderConnectionController(
     }
 
     suspend fun disconnect() {
-        appPrefsWrapper.removeLastConnectedCardReaderId()
-        appPrefsWrapper.removeLastConnectedPhoneName()
-        remoteReaderSession.disconnect()
-        cardReaderManager.disconnectReader()
+        withContext(dispatchers.io) {
+            logger.d("disconnect(): clearing prefs")
+            appPrefsWrapper.removeLastConnectedCardReaderId()
+            appPrefsWrapper.removeLastConnectedPhoneName()
+
+            logger.d("disconnect(): stopping remote session")
+            runCatching { remoteReaderSession.disconnect() }
+                .onFailure { logger.e("disconnect(): remoteReaderSession.disconnect() failed - ${it.message}") }
+
+            logger.d("disconnect(): calling cardReaderManager.disconnectReader()")
+            val result = cardReaderManager.disconnectReader()
+            logger.d("disconnect(): cardReaderManager.disconnectReader() returned $result")
+        }
     }
 
     private fun initializeCardReaderManagerIfNeeded() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -319,8 +319,13 @@ class WooPosCardReaderConnectionController(
     private fun startDiscovery() {
         discoveryJob?.cancel()
         discoveryJob = scope.launch {
-            if (cardReaderManager.readerStatus.value !is CardReaderStatus.Connected) {
-                runCatching { cardReaderManager.disconnectReader() }
+            when (cardReaderManager.readerStatus.value) {
+                is CardReaderStatus.Connected -> Unit
+                is CardReaderStatus.Reconnecting ->
+                    runCatching { cardReaderManager.cancelReconnection() }
+                is CardReaderStatus.Connecting,
+                is CardReaderStatus.NotConnected ->
+                    runCatching { cardReaderManager.disconnectReader() }
             }
             unifiedDiscoveryStream
                 .discover(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -477,6 +477,7 @@ class WooPosCardReaderConnectionController(
             is WooPosRemoteReaderSession.State.Failed -> {
                 logger.e("Remote reader connection failed: ${result.message}")
                 tracker.trackConnectionFailed()
+                appPrefsWrapper.removeLastConnectedPhoneName()
                 _state.value = WooPosCardReaderConnectionState.ConnectingFailed(
                     errorMessage = result.message,
                     onRetryClicked = { onPhoneConnectClicked(phone) },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -286,7 +286,6 @@ class WooPosCardReaderConnectionController(
             scope.launch { remoteReaderSession.disconnect() }
         }
         enterScanningState()
-        startDiscovery()
         emitEvent(ControllerEvent.Cancelled)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -319,7 +319,9 @@ class WooPosCardReaderConnectionController(
     private fun startDiscovery() {
         discoveryJob?.cancel()
         discoveryJob = scope.launch {
-            runCatching { cardReaderManager.disconnectReader() }
+            if (cardReaderManager.readerStatus.value !is CardReaderStatus.Connected) {
+                runCatching { cardReaderManager.disconnectReader() }
+            }
             unifiedDiscoveryStream
                 .discover(
                     isSimulated = developerOptionsRepository.isSimulatedCardReaderEnabled(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
@@ -26,9 +26,12 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val appPrefs: AppPrefs = AppPrefs,
 ) {
-    suspend fun collect(order: Order): Result {
+    suspend fun collect(order: Order, onCaptureStarting: suspend () -> Unit = {}): Result {
         val connected = remoteReaderSession.state.value as? WooPosRemoteReaderSession.State.Connected
-        if (connected?.reader?.isSimulated == true) return simulatePayment()
+        if (connected?.reader?.isSimulated == true) {
+            onCaptureStarting()
+            return simulatePayment()
+        }
 
         val site = selectedSite.get()
         val countryCode = wooStore.getStoreCountryCode(site)
@@ -60,7 +63,10 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
         )
 
         return when (val outcome = remoteReaderSession.sendCollectPayment(paymentInfo)) {
-            is CollectPaymentOutcome.Success -> capture(order.id, outcome.paymentIntentId)
+            is CollectPaymentOutcome.Success -> {
+                onCaptureStarting()
+                capture(order.id, outcome.paymentIntentId)
+            }
             is CollectPaymentOutcome.Rejected -> Result.Failed(genericFailureMessage())
             CollectPaymentOutcome.TimedOut -> Result.Failed(genericFailureMessage())
             is CollectPaymentOutcome.Failed -> Result.Failed(mapFailureToUserMessage(outcome.cause))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentOrderHelper
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
+import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.delay
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -24,6 +25,7 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
     private val paymentReceiptHelper: PaymentReceiptHelper,
     private val wooStore: WooCommerceStore,
     private val resourceProvider: ResourceProvider,
+    private val logger: WooPosLogWrapper,
     private val appPrefs: AppPrefs = AppPrefs,
 ) {
     suspend fun collect(order: Order, onCaptureStarting: suspend () -> Unit = {}): Result {
@@ -67,9 +69,18 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
                 onCaptureStarting()
                 capture(order.id, outcome.paymentIntentId)
             }
-            is CollectPaymentOutcome.Rejected -> Result.Failed(genericFailureMessage())
-            CollectPaymentOutcome.TimedOut -> Result.Failed(genericFailureMessage())
-            is CollectPaymentOutcome.Failed -> Result.Failed(mapFailureToUserMessage(outcome.cause))
+            is CollectPaymentOutcome.Rejected -> {
+                logger.e("Remote payment rejected: ${outcome.code} - ${outcome.description}")
+                Result.Failed(genericFailureMessage())
+            }
+            CollectPaymentOutcome.TimedOut -> {
+                logger.e("Remote payment timed out waiting for phone reader")
+                Result.Failed(genericFailureMessage())
+            }
+            is CollectPaymentOutcome.Failed -> {
+                logger.e("Remote payment failed - ${outcome.cause.message}", outcome.cause)
+                Result.Failed(mapFailureToUserMessage(outcome.cause))
+            }
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
@@ -36,8 +36,10 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
         }
 
         val site = selectedSite.get()
-        val countryCode = wooStore.getStoreCountryCode(site)
-            ?: return Result.Failed("Store country code unavailable")
+        val countryCode = wooStore.getStoreCountryCode(site) ?: run {
+            logger.e("Remote payment aborted: store country code unavailable")
+            return Result.Failed(genericFailureMessage())
+        }
 
         val paymentInfo = PaymentInfo(
             paymentDescription = cardReaderPaymentOrderHelper.getPaymentDescription(order),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.cardreader.remote
 
 import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.R
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.payments.PaymentInfo
@@ -10,6 +11,7 @@ import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentOrderHelper
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
+import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.delay
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import javax.inject.Inject
@@ -21,6 +23,7 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
     private val cardReaderPaymentOrderHelper: CardReaderPaymentOrderHelper,
     private val paymentReceiptHelper: PaymentReceiptHelper,
     private val wooStore: WooCommerceStore,
+    private val resourceProvider: ResourceProvider,
     private val appPrefs: AppPrefs = AppPrefs,
 ) {
     suspend fun collect(order: Order): Result {
@@ -58,13 +61,23 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
 
         return when (val outcome = remoteReaderSession.sendCollectPayment(paymentInfo)) {
             is CollectPaymentOutcome.Success -> capture(order.id, outcome.paymentIntentId)
-            is CollectPaymentOutcome.Rejected -> Result.Failed("${outcome.code}: ${outcome.description}")
-            CollectPaymentOutcome.TimedOut -> Result.Failed("Timed out waiting for phone reader")
-            is CollectPaymentOutcome.Failed -> Result.Failed(
-                outcome.cause.message ?: "Remote collection failed"
-            )
+            is CollectPaymentOutcome.Rejected -> Result.Failed(genericFailureMessage())
+            CollectPaymentOutcome.TimedOut -> Result.Failed(genericFailureMessage())
+            is CollectPaymentOutcome.Failed -> Result.Failed(mapFailureToUserMessage(outcome.cause))
         }
     }
+
+    private fun mapFailureToUserMessage(cause: Throwable): String {
+        val message = cause.message.orEmpty()
+        return if (cause is IllegalStateException && message.contains(CONNECTION_LOST_MARKER, ignoreCase = true)) {
+            resourceProvider.getString(R.string.woopos_remote_payment_failed_connection_lost)
+        } else {
+            genericFailureMessage()
+        }
+    }
+
+    private fun genericFailureMessage(): String =
+        resourceProvider.getString(R.string.woopos_remote_payment_failed_generic)
 
     private suspend fun capture(orderId: Long, paymentIntentId: String): Result =
         when (val response = cardReaderStore.capturePaymentIntent(orderId, paymentIntentId)) {
@@ -86,5 +99,6 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
         const val CANADA_COUNTRY_CODE = "CA"
         const val CANADA_FEE_FLAT_IN_CENTS = 15L
         const val SIMULATED_PAYMENT_DELAY_MS = 1_500L
+        const val CONNECTION_LOST_MARKER = "Connection to phone reader was lost"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
@@ -136,9 +136,13 @@ class WooPosRemoteReaderSession @Inject constructor(
     suspend fun sendCollectPayment(
         paymentInfo: PaymentInfo,
         timeoutMillis: Long = CardReaderRemoteTabletClient.DEFAULT_COLLECT_PAYMENT_TIMEOUT_MILLIS,
-    ): CollectPaymentOutcome =
-        client?.collectPayment(paymentInfo, timeoutMillis)
-            ?: CollectPaymentOutcome.Failed(IllegalStateException("Remote session is not connected"))
+    ): CollectPaymentOutcome {
+        val activeClient = mutex.withLock {
+            if (_state.value !is State.Connected) return@withLock null
+            client
+        } ?: return CollectPaymentOutcome.Failed(IllegalStateException("Reader not connected"))
+        return activeClient.collectPayment(paymentInfo, timeoutMillis)
+    }
 
     private fun disconnectInternal() {
         monitorScope?.cancel()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 
 @Singleton
 class WooPosRemoteReaderSession @Inject constructor(
@@ -59,12 +60,16 @@ class WooPosRemoteReaderSession @Inject constructor(
         return connected
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun fetchToken(): String? {
-        val token = runCatching { cardReaderStore.fetchConnectionToken() }
-            .getOrElse {
-                fail("Failed to fetch connection token: ${it.message}")
-                return null
-            }
+        val token = try {
+            cardReaderStore.fetchConnectionToken()
+        } catch (cancel: CancellationException) {
+            throw cancel
+        } catch (cause: Throwable) {
+            fail("Failed to fetch connection token: ${cause.message}")
+            return null
+        }
         if (token.isBlank()) {
             fail("Empty connection token")
             return null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
@@ -111,6 +111,19 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
     ) {
         mutex.withLock {
             val fingerprint = phone.fingerprintBase64
+
+            // The phone may have re-registered with a new fingerprint+name without us
+            // receiving the Lost event for the previous one (Android NSD goodbye is
+            // unreliable). Drop any earlier entries from the same host so we don't show
+            // the same device twice.
+            val staleNames = state.phonesByFingerprint.values
+                .filter { it.host == phone.host && it.fingerprintBase64 != fingerprint }
+                .map { it.name }
+            staleNames.forEach { name ->
+                val staleFp = state.fingerprintByName.remove(name)
+                if (staleFp != null) state.phonesByFingerprint.remove(staleFp)
+            }
+
             val isUpdate = state.phonesByFingerprint.containsKey(fingerprint)
             if (isUpdate || state.phonesByFingerprint.size < MAX_DISCOVERED_PHONES) {
                 state.phonesByFingerprint[fingerprint] = phone

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -401,7 +401,11 @@ class WooPosTotalsViewModel @Inject constructor(
                 )
                 childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentCollecting)
             }
-            when (val result = remoteReaderPaymentFlow.collect(order)) {
+            val result = remoteReaderPaymentFlow.collect(
+                order = order,
+                onCaptureStarting = { handleCapturingPaymentState() },
+            )
+            when (result) {
                 WooPosRemoteReaderPaymentFlow.Result.Completed -> {
                     childrenToParentEventSender.sendToParent(OrderSuccessfullyPaidByCard)
                 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3803,6 +3803,9 @@
     <string name="woo_pos_payment_failed_go_back_to_checkout">Go back to checkout</string>
     <string name="woo_pos_payment_failed_go_back">Go back</string>
 
+    <string name="woopos_remote_payment_failed_connection_lost">Connection to the phone reader was lost. Please reconnect and try again.</string>
+    <string name="woopos_remote_payment_failed_generic">Something went wrong. Please try again.</string>
+
     <string name="woopos_card_payment_done_button">Done</string>
 
     <string name="woopos_floating_toolbar_overlay_menu_content_description">Dimmed background. Tap to close the menu.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -665,7 +665,7 @@ class WooPosCardPaymentViewModelTest {
             reader = simulatedRemoteReader(),
             readerSerial = "SIM-1",
         )
-        whenever(remoteReaderPaymentFlow.collect(any()))
+        whenever(remoteReaderPaymentFlow.collect(any(), any()))
             .doSuspendableAnswer { awaitCancellation() }
 
         viewModel = createViewModel(source = CardPaymentSource.CHECKOUT)
@@ -688,7 +688,7 @@ class WooPosCardPaymentViewModelTest {
             reader = simulatedRemoteReader(),
             readerSerial = "SIM-1",
         )
-        whenever(remoteReaderPaymentFlow.collect(any()))
+        whenever(remoteReaderPaymentFlow.collect(any(), any()))
             .doSuspendableAnswer { awaitCancellation() }
 
         viewModel = createViewModel(source = CardPaymentSource.CHECKOUT)
@@ -711,7 +711,7 @@ class WooPosCardPaymentViewModelTest {
             reader = simulatedRemoteReader(),
             readerSerial = "SIM-1",
         )
-        whenever(remoteReaderPaymentFlow.collect(any()))
+        whenever(remoteReaderPaymentFlow.collect(any(), any()))
             .thenReturn(WooPosRemoteReaderPaymentFlow.Result.Failed("error"))
 
         viewModel = createViewModel(source = CardPaymentSource.CHECKOUT)
@@ -723,7 +723,7 @@ class WooPosCardPaymentViewModelTest {
         advanceUntilIdle()
 
         // THEN
-        verify(remoteReaderPaymentFlow, times(2)).collect(any())
+        verify(remoteReaderPaymentFlow, times(2)).collect(any(), any())
     }
 
     private fun simulatedRemoteReader() =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.woopos.cardreader.remote
 
 import com.woocommerce.android.cardreader.CardReaderStore
+import com.woocommerce.android.cardreader.payments.PaymentInfo
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteTabletClient
+import com.woocommerce.android.cardreader.remote.CollectPaymentOutcome
 import com.woocommerce.android.cardreader.remote.ConnectOutcome
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderLocationRepository
 import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderLocationRepository.LocationIdFetchingResult
@@ -19,6 +21,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.net.InetAddress
 import kotlin.coroutines.cancellation.CancellationException
@@ -107,6 +111,21 @@ class WooPosRemoteReaderSessionTest {
             } catch (e: CancellationException) {
                 assertThat(e.message).isEqualTo("cancelled")
             }
+        }
+
+    @Test
+    fun `given session is not connected, when sendCollectPayment, then returns Failed without calling client`() =
+        runTest {
+            // GIVEN
+            val session = createSession()
+            val paymentInfo: PaymentInfo = mock()
+
+            // WHEN
+            val outcome = session.sendCollectPayment(paymentInfo)
+
+            // THEN
+            assertThat(outcome).isInstanceOf(CollectPaymentOutcome.Failed::class.java)
+            verify(client, never()).collectPayment(any(), any())
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
@@ -21,6 +21,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.net.InetAddress
+import kotlin.coroutines.cancellation.CancellationException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WooPosRemoteReaderSessionTest {
@@ -91,6 +92,22 @@ class WooPosRemoteReaderSessionTest {
         // THEN
         assertThat(state).isInstanceOf(WooPosRemoteReaderSession.State.Connected::class.java)
     }
+
+    @Test
+    fun `given fetchConnectionToken throws CancellationException, when connect, then exception is rethrown`() =
+        runTest {
+            // GIVEN
+            whenever(cardReaderStore.fetchConnectionToken()).thenThrow(CancellationException("cancelled"))
+            val session = createSession()
+
+            // WHEN / THEN
+            try {
+                session.connect(phone(isSimulated = false))
+                assertThat(false).withFailMessage("Expected CancellationException").isTrue()
+            } catch (e: CancellationException) {
+                assertThat(e.message).isEqualTo("cancelled")
+            }
+        }
 
     @Test
     fun `when disconnect, then state is Idle`() = runTest {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.cardreader.remote
 
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.payments.PaymentInfo
+import com.woocommerce.android.cardreader.payments.StatementDescriptor
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteTabletClient
 import com.woocommerce.android.cardreader.remote.CollectPaymentOutcome
 import com.woocommerce.android.cardreader.remote.ConnectOutcome
@@ -24,6 +25,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.math.BigDecimal
 import java.net.InetAddress
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -118,7 +120,21 @@ class WooPosRemoteReaderSessionTest {
         runTest {
             // GIVEN
             val session = createSession()
-            val paymentInfo: PaymentInfo = mock()
+            val paymentInfo = PaymentInfo(
+                paymentDescription = "desc",
+                statementDescriptor = StatementDescriptor(null),
+                orderId = 1L,
+                amount = BigDecimal.ONE,
+                currency = "USD",
+                customerEmail = null,
+                isPluginCanSendReceipt = false,
+                customerName = null,
+                storeName = null,
+                siteUrl = null,
+                orderKey = null,
+                feeAmount = null,
+                channel = null,
+            )
 
             // WHEN
             val outcome = session.sendCollectPayment(paymentInfo)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1965,7 +1965,7 @@ class WooPosTotalsViewModelTest {
                 )
             )
             whenever(remoteReaderSession.state).thenReturn(remoteState)
-            whenever(remoteReaderPaymentFlow.collect(any()))
+            whenever(remoteReaderPaymentFlow.collect(any(), any()))
                 .thenReturn(WooPosRemoteReaderPaymentFlow.Result.Failed("error"))
 
             val vm = createViewModelAndSetupForSuccessfulOrderCreation()
@@ -1977,7 +1977,7 @@ class WooPosTotalsViewModelTest {
             advanceUntilIdle()
 
             // THEN
-            verify(remoteReaderPaymentFlow, org.mockito.kotlin.times(2)).collect(any())
+            verify(remoteReaderPaymentFlow, org.mockito.kotlin.times(2)).collect(any(), any())
         }
 
     private fun simulatedRemoteReader() =

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManagerFactory.kt
@@ -27,6 +27,7 @@ import com.woocommerce.android.cardreader.internal.wrappers.PaymentMethodTypeMap
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 
 object CardReaderManagerFactory {
+    @Suppress("LongMethod")
     fun createCardReaderManager(
         application: Application,
         cardReaderStore: CardReaderStore,
@@ -44,7 +45,10 @@ object CardReaderManagerFactory {
         val tapToPayReaderListener = TapToPayReaderListenerImpl(logWrapper, terminalListener)
         val cardReaderConfigFactory = CardReaderConfigFactory()
         val paymentUtils = PaymentUtils(logWrapper)
-        val compositeTokenProvider = CompositeConnectionTokenProvider(TokenProvider(cardReaderStore))
+        val compositeTokenProvider = CompositeConnectionTokenProvider(
+            defaultProvider = TokenProvider(cardReaderStore),
+            logWrapper = logWrapper,
+        )
 
         return CardReaderManagerImpl(
             application,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProvider.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CompositeConnectionTokenProvider.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.cardreader.connection
 
 import com.stripe.stripeterminal.external.callable.ConnectionTokenCallback
 import com.stripe.stripeterminal.external.callable.ConnectionTokenProvider
+import com.woocommerce.android.cardreader.LogWrapper
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -25,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReference
  */
 class CompositeConnectionTokenProvider internal constructor(
     private val defaultProvider: ConnectionTokenProvider,
+    private val logWrapper: LogWrapper? = null,
 ) : ConnectionTokenProvider {
     private val active: AtomicReference<ConnectionTokenProvider> = AtomicReference(defaultProvider)
 
@@ -37,6 +39,12 @@ class CompositeConnectionTokenProvider internal constructor(
     }
 
     override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
-        active.get().fetchConnectionToken(callback)
+        val current = active.get()
+        logWrapper?.d(LOG_TAG, "fetchConnectionToken via ${current::class.java.simpleName}")
+        current.fetchConnectionToken(callback)
+    }
+
+    private companion object {
+        const val LOG_TAG = "CompositeConnectionTokenProvider"
     }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -106,7 +106,11 @@ internal class CardReaderManagerImpl(
     override suspend fun disconnectReader(): Boolean {
         if (!terminal.isInitialized()) error("Terminal not initialized")
         if (terminal.getConnectedReader() == null) {
-            terminalListener.updateReaderStatus(CardReaderStatus.NotConnected())
+            // Don't clobber Reconnecting — that's a legit transient state where Stripe's
+            // auto-reconnect is in flight and connectedReader is null by design.
+            if (terminalListener.readerStatus.value is CardReaderStatus.Connected) {
+                terminalListener.updateReaderStatus(CardReaderStatus.NotConnected())
+            }
             return false
         }
         return connectionManager.disconnectReader()

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
+import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.connection.CompositeConnectionTokenProvider
 import com.woocommerce.android.cardreader.internal.connection.ConnectionManager
@@ -104,7 +105,10 @@ internal class CardReaderManagerImpl(
 
     override suspend fun disconnectReader(): Boolean {
         if (!terminal.isInitialized()) error("Terminal not initialized")
-        if (terminal.getConnectedReader() == null) return false
+        if (terminal.getConnectedReader() == null) {
+            terminalListener.updateReaderStatus(CardReaderStatus.NotConnected())
+            return false
+        }
         return connectionManager.disconnectReader()
     }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -186,6 +186,7 @@ class CardReaderRemoteSession internal constructor(
         val supplyJob = launch { tokenProvider.supply(request.connectionToken) }
         try {
             runCatching {
+                runCatching { cardReaderManager.disconnectReader() }
                 val reader = discoverFirstTapToPayReader()
                 logWrapper.d(LOG_TAG, "Discovered ${reader.id}, connecting...")
                 cardReaderManager.startConnectionToReader(reader, request.locationId)
@@ -199,6 +200,7 @@ class CardReaderRemoteSession internal constructor(
                 _state.value = CardReaderRemoteSessionState.WaitingForPayment(tabletName = null)
             }.onFailure { err ->
                 logWrapper.e(LOG_TAG, "Connect failed: ${err::class.java.simpleName}: ${err.message}")
+                runCatching { cardReaderManager.disconnectReader() }
                 accepted.send(
                     ErrorMessage(
                         requestId = request.requestId,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.net.SocketException
 import java.net.SocketTimeoutException
 
 class CardReaderRemoteSession internal constructor(
@@ -102,7 +103,22 @@ class CardReaderRemoteSession internal constructor(
     fun stop() {
         val scope = sessionScope ?: return
         sessionScope = null
+
+        // Capture and clear transport before close so a racing start() can't have its new
+        // resources clobbered by the old session's async cleanupSync().
+        val nsd = nsdRegistration
+        val tls = tlsServer
+        nsdRegistration = null
+        tlsServer = null
+
         scope.cancel()
+
+        // Close synchronously: scope.cancel() does not interrupt the blocking socket.accept()
+        // inside withContext(ioDispatcher), so without an explicit close NSD stays advertising
+        // until ACCEPT_TIMEOUT_MILLIS expires.
+        runCatching { nsd?.close() }
+        runCatching { tls?.close() }
+
         if (readerWasConnected) {
             readerWasConnected = false
             disconnectScope.launch {
@@ -137,6 +153,11 @@ class CardReaderRemoteSession internal constructor(
                 _state.value = readyToPairState(server)
             } catch (e: SocketTimeoutException) {
                 logWrapper.d(LOG_TAG, "Waiting for tablet to connect: ${e.message}")
+            } catch (e: SocketException) {
+                // Server socket was closed externally (typically stop() during shutdown).
+                // Exit the loop gracefully so cleanup runs without an Error state.
+                logWrapper.d(LOG_TAG, "Server socket closed: ${e.message}")
+                return
             }
         }
     }
@@ -311,15 +332,22 @@ class CardReaderRemoteSession internal constructor(
     }
 
     private fun cleanupSync() {
-        runCatching { connection?.close() }
+        // Capture locals first: a racing start() may have already overwritten the fields with
+        // new resources, and we must close only what this session owned.
+        val conn = connection
+        val tokenProv = remoteTokenProvider
+        val nsd = nsdRegistration
+        val tls = tlsServer
         connection = null
-        runCatching { cardReaderManager.connectionTokenProvider.useDefault() }
-        runCatching { remoteTokenProvider?.close() }
         remoteTokenProvider = null
-        runCatching { nsdRegistration?.close() }
         nsdRegistration = null
-        runCatching { tlsServer?.close() }
         tlsServer = null
+
+        runCatching { conn?.close() }
+        runCatching { cardReaderManager.connectionTokenProvider.useDefault() }
+        runCatching { tokenProv?.close() }
+        runCatching { nsd?.close() }
+        runCatching { tls?.close() }
         if (readerWasConnected) {
             readerWasConnected = false
             disconnectScope.launch {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteTabletClient.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteTabletClient.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import java.io.IOException
 import java.util.UUID
 
 interface CardReaderRemoteTabletClient {
@@ -123,6 +124,9 @@ internal class DefaultCardReaderRemoteTabletClient(
         } catch (cancel: CancellationException) {
             disconnect()
             throw cancel
+        } catch (cause: IOException) {
+            disconnect()
+            ConnectOutcome.Failed(IllegalStateException(CONNECTION_LOST_MESSAGE, cause))
         } catch (@Suppress("TooGenericExceptionCaught") cause: Exception) {
             disconnect()
             ConnectOutcome.Failed(cause)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteTabletClient.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteTabletClient.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import java.util.UUID
@@ -93,7 +93,9 @@ internal class DefaultCardReaderRemoteTabletClient(
                 logWrapper.d(TAG, "Sending ConnectRequest requestId=$requestId")
                 opened.send(ConnectRequest(requestId, connectionToken, locationId))
                 logWrapper.d(TAG, "ConnectRequest sent, awaiting reply")
-                when (val reply = opened.receive().first { it.requestId == requestId }) {
+                val reply = opened.receive().firstOrNull { it.requestId == requestId }
+                    ?: throw IllegalStateException(CONNECTION_LOST_MESSAGE)
+                when (reply) {
                     is ConnectAck -> {
                         bridgeClosedSignal(opened)
                         startHeartbeat(opened)
@@ -152,7 +154,8 @@ internal class DefaultCardReaderRemoteTabletClient(
             val requestId = UUID.randomUUID().toString()
             active.send(paymentInfo.toCollectPaymentRequest(requestId))
             val reply = withTimeout(timeoutMillis) {
-                active.receive().first { it.requestId == requestId }
+                active.receive().firstOrNull { it.requestId == requestId }
+                    ?: throw IllegalStateException(CONNECTION_LOST_MESSAGE)
             }
             when (reply) {
                 is PaymentIntentResult -> CollectPaymentOutcome.Success(reply.paymentIntentId, reply.status)
@@ -188,6 +191,7 @@ internal class DefaultCardReaderRemoteTabletClient(
     private companion object {
         const val CODE_UNEXPECTED_REPLY = "unexpected_reply"
         const val TAG = "CardReaderRemoteTabletClient"
+        const val CONNECTION_LOST_MESSAGE = "Connection to phone reader was lost"
     }
 }
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.cardreader.internal
 import android.app.Application
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.LogWrapper
+import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.connection.CompositeConnectionTokenProvider
 import com.woocommerce.android.cardreader.connection.ReaderType
@@ -16,6 +17,7 @@ import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import com.woocommerce.android.cardreader.payments.RefundConfig
 import com.woocommerce.android.cardreader.payments.RefundParams
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.Before
@@ -43,7 +45,9 @@ class CardReaderManagerImplTest : CardReaderBaseUnitTest() {
     private val interacRefundManager: InteracRefundManager = mock()
     private val connectionManager: ConnectionManager = mock()
     private val softwareUpdateManager: SoftwareUpdateManager = mock()
-    private val terminalListener: TerminalListenerImpl = mock()
+    private val terminalListener: TerminalListenerImpl = mock {
+        on { readerStatus }.thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+    }
 
     private val supportedReaders =
         CardReaderTypesToDiscover.SpecificReaders.ExternalReaders(

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/DefaultCardReaderRemoteTabletClientTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/DefaultCardReaderRemoteTabletClientTest.kt
@@ -8,13 +8,18 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import kotlin.concurrent.thread
 
 @ExperimentalCoroutinesApi
 class DefaultCardReaderRemoteTabletClientTest : CardReaderBaseUnitTest() {
@@ -22,6 +27,35 @@ class DefaultCardReaderRemoteTabletClientTest : CardReaderBaseUnitTest() {
     private val logWrapper: LogWrapper = mock()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
     private val client = DefaultCardReaderRemoteTabletClient(tlsClient, logWrapper, scope)
+
+    private var serverSocket: ServerSocket? = null
+    private var clientSocket: Socket? = null
+    private var acceptedSocket: Socket? = null
+
+    @After
+    fun closeSockets() {
+        runCatching { clientSocket?.close() }
+        runCatching { acceptedSocket?.close() }
+        runCatching { serverSocket?.close() }
+    }
+
+    @Test
+    fun `given remote closes mid-connect, when connect, then Failed cause carries connection-lost message`() {
+        runBlocking {
+            // GIVEN
+            val openedConnection = openConnectionPair()
+            whenever(tlsClient.connect(any(), any(), any())).thenAnswer { openedConnection.first }
+            openedConnection.second.close()
+
+            // WHEN
+            val outcome = client.connect(reader = aReader(), connectionToken = "tok", locationId = "loc")
+
+            // THEN
+            assertThat(outcome).isInstanceOf(ConnectOutcome.Failed::class.java)
+            assertThat((outcome as ConnectOutcome.Failed).cause)
+                .hasMessage("Connection to phone reader was lost")
+        }
+    }
 
     @Test
     fun `given tls handshake throws, when connect, then returns Failed with the cause`() = testBlocking {
@@ -44,6 +78,17 @@ class DefaultCardReaderRemoteTabletClientTest : CardReaderBaseUnitTest() {
 
         // THEN
         assertThat(outcome).isInstanceOf(CollectPaymentOutcome.Failed::class.java)
+    }
+
+    private fun openConnectionPair(): Pair<CardReaderRemoteConnection, CardReaderRemoteConnection> {
+        val server = ServerSocket(0).also { serverSocket = it }
+        val acceptThread = thread { acceptedSocket = server.accept() }
+        val client = Socket("127.0.0.1", server.localPort).also { clientSocket = it }
+        acceptThread.join()
+        val accepted = requireNotNull(acceptedSocket)
+        val openedClient = CardReaderRemoteConnection(client, mock<LogWrapper>(), ioDispatcher = Dispatchers.IO)
+        val openedServer = CardReaderRemoteConnection(accepted, mock<LogWrapper>(), ioDispatcher = Dispatchers.IO)
+        return openedClient to openedServer
     }
 
     private fun aReader() = DiscoveredRemoteReader(


### PR DESCRIPTION
### Description
Fixes WOOMOB-2886.

Bug-fix-only PR on top of #15745. Issues surfaced while integration-testing the remote Tap-to-Pay stack (lib + phone + tablet PRs merged together) — most affect the regular BT card reader flow as well, so they're worth fixing before the stack lands.

Grouped by area:

**POS card reader connect / disconnect / discovery**
- `disconnect()` now runs on `Dispatchers.IO` (was on Main → `StrictMode NetworkViolation` from SSL close) and survives a failing `remoteReaderSession.disconnect()` so the BT disconnect always reaches the SDK.
- `disconnectReader()` in the lib now syncs `readerStatus` to `NotConnected` only when our cached state is `Connected` (don't clobber `Reconnecting`, where Stripe SDK's `connectedReader` is null by design).
- `startDiscovery()` cancels Stripe's auto-reconnect (`cancelReconnection()`) when status is `Reconnecting`; defensively disconnects only when `Connecting`/`NotConnected`; no-op when `Connected` (preserves a live connection through dialog dismiss).
- `cancel()` no longer restarts discovery on dismiss (matches trunk) — the leftover discovery job was getting cancelled mid-flight by the next discovery start, leaving Stripe in a bad state where it never reported the BT reader.

**Remote TTP session & state**
- Phone-side `handleConnectRequest` defensively disconnects any leftover reader before TTP discovery (Stripe SDK refuses discovery while a reader is bound).
- `WooPosRemoteReaderSession.fetchToken` now rethrows `CancellationException` instead of misreporting it as a token fetch failure.
- `sendCollectPayment` checks state under the mutex and returns `Failed` if not `Connected`, so we don't run a payment on a stale client.
- `LAST_CONNECTED_PHONE_NAME` is cleared on remote connect failure, so auto-reconnect doesn't keep targeting an unreachable phone.

**Payment UX**
- `CardReaderRemoteTabletClient` now throws a typed connection-lost error when the receive flow ends without a matching reply (was leaking `NoSuchElementException("Expected at least one element matching the predicate")` to the user).
- `WooPosRemoteReaderPaymentFlow.collect` now exposes friendly error strings and an `onCaptureStarting` callback.
- Tablet now transitions to the same full-screen "Processing payment" state as BT once the phone returns from collect (used to stay on totals + "Ready for payment" until success).
- `WooPosCardPaymentViewModel` no longer cancels in-flight BT payments when the reader briefly drops to `Reconnecting` (was a regression vs trunk).

**Diagnostics**
- One log line in `CompositeConnectionTokenProvider.fetchConnectionToken` printing the active delegate, to make root-causing the BT-vs-remote token routing easier next time.

### Test Steps
1. **POS BT reader basic flow**: connect a BT reader, take a payment, disconnect from the toolbar chip and from Settings → Hardware → Card Reader. All three should work end-to-end.
2. **POS BT reconnect during payment**: start a card payment, briefly toggle Bluetooth/move the reader to force a transient disconnect. Payment should keep going (no "Reader disconnected" cancel).
3. **POS BT reconnect after a stuck Stripe state**: disconnect from a BT reader, immediately try to connect again. Discovery should find the reader (was failing with "Unexpected operation in progress: ReconnectBluetoothReaderOperation").
4. **Remote TTP happy path**: pair tablet ↔ phone, take a payment from the tablet by tapping a (simulated) card on the phone. Tablet should briefly show "Ready for payment" then transition to full-screen "Processing payment", then success.
5. **Remote TTP error UX**: drop the phone connection mid-payment (turn screen off / close Card Reader Mode). Tablet should show a friendly "Connection to the phone reader was lost" message instead of the raw Kotlin exception.
6. **Remote TTP retry after connectivity issue**: trigger a phone connect failure, then dismiss + reopen the connect dialog. Should not auto-reconnect to the same unreachable phone forever.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.