### PR TITLE
[WOOMOB-2889] Define :ai-assistant:core contracts for chat service

### DIFF
--- a/config/gradle/jacoco.gradle
+++ b/config/gradle/jacoco.gradle
@@ -19,6 +19,7 @@ rootProject.afterEvaluate {
                 ':libs:apifaker:testDebugUnitTest',
                 ':libs:commons:testDebugUnitTest',
                 ':libs:pos:testDebugUnitTest',
+                ':libs:ai-assistant:core:test',
                 ':libs:ai-assistant:feature:testDebugUnitTest',
         )
 

--- a/libs/ai-assistant/README.md
+++ b/libs/ai-assistant/README.md
@@ -1,0 +1,48 @@
+# `:libs:ai-assistant`
+
+Assistant feature modules for WooCommerce Android. All assistant implementation lives here;
+`:WooCommerce` owns only host integration (entry point, navigation, DI bootstrap).
+
+## Module layout
+
+```
+:WooCommerce  ──depends on──►  :libs:ai-assistant:feature  ──depends on──►  :libs:ai-assistant:core
+```
+
+### `:libs:ai-assistant:feature`
+
+Android library. The implementation home for the assistant:
+
+- Chat UI and screen-level state (Compose)
+- ViewModel and agentic loop orchestration
+- `ChatService` implementation (`JetpackAiChatService` over OkHttp SSE)
+- JWT token provider (WP.com Jetpack AI)
+- Tool adapters and assistant-specific repository/wiring
+- Result cards and assistant UI components
+- Telemetry hooks
+- Navigation targets or host callbacks emitted outward to `:WooCommerce`
+
+### `:libs:ai-assistant:core`
+
+Pure Kotlin/JVM library. The contract layer consumed by `:feature`:
+
+- `ChatService` and completion-facing interfaces
+- `AssistantEvent`, `AssistantMessage`, `ChatRequest`, `AssistantErrorKind`
+- `JwtTokenProvider`
+- `AssistantConfig` (pinned model / prompt / tool-catalog version triple)
+
+No Android, Compose, Hilt, or OkHttp dependencies. Tests run as plain JVM tests.
+
+### `:WooCommerce`
+
+Owns only host/app concerns — no assistant feature logic:
+
+- Entry point into the existing app surface
+- Host-side navigation implementation
+- App-specific DI bootstrap and feature flags
+- Supplying the runtime environment the assistant module expects
+
+## Future splits
+
+New concerns stay inside the assistant module family, not in `:WooCommerce`. Candidates
+when the time comes: `:libs:ai-assistant:cards`, `:libs:ai-assistant:tools`.

--- a/libs/ai-assistant/core/build.gradle
+++ b/libs/ai-assistant/core/build.gradle
@@ -8,3 +8,12 @@ java {
     sourceCompatibility = libs.versions.java.get()
     targetCompatibility = libs.versions.java.get()
 }
+
+dependencies {
+    api(libs.kotlinx.coroutines.core)
+    api(libs.kotlinx.serialization.json)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/AssistantConfig.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/AssistantConfig.kt
@@ -1,0 +1,29 @@
+package com.woocommerce.android.aiassistant.core
+
+/**
+ * Pins the completion stack used at runtime: model id, system prompt version,
+ * and tool catalog version. Collapsing the triple into one named-constant
+ * object makes a version bump reviewable in a single diff.
+ *
+ * Release rules:
+ *  - Bumping [MODEL_ID] is release-blocking and gated on the regression suite
+ *    (see Linear ticket WOOMOB-2922).
+ *  - Bumping [PROMPT_VERSION] or [TOOL_CATALOG_VERSION] triggers the same
+ *    regression suite. Prompt and catalog edits change model behavior as much
+ *    as a model swap can.
+ *
+ * Only [MODEL_ID] is consumed by the runtime. The other two constants are
+ * carried into telemetry tags via [completionStack] and exist to make changes
+ * diffable.
+ */
+object AssistantConfig {
+    const val MODEL_ID: String = "gpt-4o-mini"
+    const val PROMPT_VERSION: String = "v1.0.0"
+    const val TOOL_CATALOG_VERSION: String = "v1.0.0"
+
+    /** Billing/metering hook sent on every request. Pinned, not per-call, to keep accounting changes in one place. */
+    const val FEATURE_NAME: String = "woo-ai-assistant"
+
+    const val completionStack: String =
+        "model=$MODEL_ID;prompt=$PROMPT_VERSION;catalog=$TOOL_CATALOG_VERSION"
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/auth/JwtTokenProvider.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/auth/JwtTokenProvider.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.aiassistant.core.auth
+
+/**
+ * Supplies a Jetpack AI JWT to [com.woocommerce.android.aiassistant.core.chat.ChatService].
+ * Implementations may mint on demand or cache-and-refresh; the contract only
+ * requires that [provide] returns a token good for one streaming call.
+ *
+ * [invalidate] is called by the chat service after a 401 so the next [provide]
+ * mints a fresh token. Implementations with no cache can leave the default
+ * no-op.
+ */
+interface JwtTokenProvider {
+    suspend fun provide(): String
+    suspend fun invalidate() {}
+}
+
+/**
+ * Raised by [JwtTokenProvider] implementations when a JWT cannot be obtained.
+ * [com.woocommerce.android.aiassistant.core.chat.ChatService] maps this to
+ * [com.woocommerce.android.aiassistant.core.chat.AssistantErrorKind.AUTH] before
+ * surfacing it to the loop.
+ */
+class AssistantAuthException(
+    message: String = "Failed to obtain Jetpack AI JWT",
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorKind.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorKind.kt
@@ -1,0 +1,22 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+/**
+ * Closed vocabulary for transport-level errors surfaced by [ChatService].
+ * Transport-specific exceptions (IOException, HTTP status codes, JSON parse
+ * failures) are normalized to one of these values at the service boundary so
+ * the loop and UI speak a single error vocabulary.
+ *
+ * The full assistant error model (loop / tool / safety failures) lives
+ * elsewhere; this enum only covers the failure modes a chat stream can
+ * produce.
+ */
+enum class AssistantErrorKind {
+    NETWORK,
+    TIMEOUT,
+    AUTH,
+    RATE_LIMIT,
+    UPSTREAM_FAILURE,
+    INVALID_STREAM,
+    CANCELLED,
+    UNKNOWN,
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantEvent.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantEvent.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+/**
+ * Stream events emitted by [ChatService]. The agentic loop consumes this
+ * vocabulary directly; transport-level details (HTTP status codes, SSE
+ * framing) never escape the [ChatService] implementation.
+ */
+sealed interface AssistantEvent {
+    data class TextDelta(val text: String) : AssistantEvent
+
+    /**
+     * One delta of a streaming tool call. [index] stays stable across deltas
+     * for the same call so the loop can join them. [id] and [name] arrive on
+     * the first delta; [argumentsDelta] arrives in JSON fragments that
+     * concatenate into a complete object.
+     */
+    data class ToolCallDelta(
+        val index: Int,
+        val id: String? = null,
+        val name: String? = null,
+        val argumentsDelta: String? = null,
+    ) : AssistantEvent
+
+    /** Stream completed cleanly. The loop uses [reason] to decide between continuation and exit. */
+    data class Finish(val reason: FinishReason) : AssistantEvent
+
+    /** Stream failed. [cause] is preserved for telemetry but never inspected by UI code. */
+    data class Failed(
+        val kind: AssistantErrorKind,
+        val cause: Throwable? = null,
+    ) : AssistantEvent
+}
+
+enum class FinishReason { STOP, TOOL_CALLS, LENGTH, CONTENT_FILTER, OTHER }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantMessage.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantMessage.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * A single message in the conversation passed to [ChatService]. The runtime
+ * keeps these as a pure-Kotlin sealed hierarchy so the loop can append turns
+ * without depending on transport-level JSON shapes.
+ */
+sealed interface AssistantMessage {
+    val role: String
+
+    data class System(val content: String) : AssistantMessage {
+        override val role: String = "system"
+    }
+
+    data class User(val content: String) : AssistantMessage {
+        override val role: String = "user"
+    }
+
+    data class Assistant(
+        val content: String?,
+        val toolCalls: List<ToolCall> = emptyList(),
+    ) : AssistantMessage {
+        override val role: String = "assistant"
+    }
+
+    data class Tool(
+        val toolCallId: String,
+        val content: String,
+    ) : AssistantMessage {
+        override val role: String = "tool"
+    }
+}
+
+/**
+ * One assembled tool call returned by the model. The agentic loop concatenates
+ * streamed [AssistantEvent.ToolCallDelta] fragments into this shape before
+ * dispatching to the registry.
+ */
+data class ToolCall(
+    val id: String,
+    val name: String,
+    val arguments: JsonObject,
+)

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/ChatRequest.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/ChatRequest.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+/** Single chat turn submitted to [ChatService]. */
+data class ChatRequest(
+    val messages: List<AssistantMessage>,
+    val tools: List<ToolDefinition> = emptyList(),
+)

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/ChatService.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/ChatService.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Single seam for AI completions. Concrete implementations own the transport,
+ * JWT auth, and JSON shape so the loop can be swapped onto a different backend
+ * without upstream changes.
+ *
+ * Implementations must:
+ *  - emit [AssistantEvent]s and terminate the flow when the stream ends
+ *  - normalize transport errors to [AssistantEvent.Failed] with the appropriate [AssistantErrorKind]
+ *  - support coroutine cancellation: cancelling the collector aborts the underlying HTTP call
+ */
+interface ChatService {
+    fun streamTurn(request: ChatRequest): Flow<AssistantEvent>
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/ToolDefinition.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/ToolDefinition.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * OpenAI-style function definition for the tools the model is allowed to call.
+ * `parameters` is the JSON Schema describing the call shape.
+ */
+data class ToolDefinition(
+    val name: String,
+    val description: String,
+    val parameters: JsonObject,
+)


### PR DESCRIPTION
### Description

Part of WOOMOB-2889 (part 1 of 3)

This PR adds the pure-JVM contracts that the AI assistant chat layer is built on. It introduces the `:libs:ai-assistant:core` source set with no Android, Hilt, or transport dependencies — only the types the agentic loop and any `ChatService` adapter must agree on.

This is the first of three stacked PRs for WOOMOB-2889:
- **PR 1 (this one)**: contracts + pinned config + module README
- **PR 2 ([#15757](https://github.com/woocommerce/woocommerce-android/pull/15757))**: `ChatStreamParser` + `WpComJetpackAiTokenProvider`
- **PR 3 ([#15756](https://github.com/woocommerce/woocommerce-android/pull/15756))**: `JetpackAiChatService` + Hilt wiring

All three stack on top of [#15753](https://github.com/woocommerce/woocommerce-android/pull/15753) (WOOMOB-2887, skeleton modules). The split is along the `:core` / `:feature` module boundary so the contract is reviewable independently of the SSE adapter that implements it.

#### What's in this PR

- **`AssistantConfig`** — pinned triple (model id, prompt version, tool-catalog version) plus the `feature` billing tag. Bumping any of these is release-blocking and gated on the regression suite (WOOMOB-2922). Collapsing the triple into one object makes a version bump reviewable as a single diff and makes telemetry (`completionStack`) consistent across call sites.
- **`ChatService`** — single seam between the agentic loop and the completion backend. Concrete adapters own JWT auth, transport, and JSON shape; the loop only sees `Flow<AssistantEvent>`.
- **`AssistantEvent`** sealed hierarchy — `TextDelta`, `ToolCallDelta`, `Finish` (with `FinishReason`), `Failed` (with `AssistantErrorKind`). Transport-level details (HTTP status, SSE framing) never escape the adapter.
- **`AssistantMessage`** sealed hierarchy — `System`, `User`, `Assistant`, `Tool`. Pure-Kotlin so the loop can append turns without depending on transport-level JSON shapes. Mapping to the on-the-wire DTO (OpenAI-style for now, anything OpenAI-compatible later) is the adapter's job, captured forward-looking in WOOMOB-2890.
- **`ChatRequest`** — the loop's input to a turn: messages + optional tools. Deliberately minimal (no `model`/`feature`/`temperature`/`stream` overrides) — Android's posture is to pin the completion stack in code and bump it via release-gated edits to `AssistantConfig`, not per-call config.
- **`ToolDefinition`** — name, description, and JSON-schema parameters block, kept transport-agnostic.
- **`JwtTokenProvider`** + **`AssistantAuthException`** — the auth port that adapters depend on (the WP.com implementation lands in PR 2).
- **Module README** — documents the intended module layout and ownership boundaries for the assistant module family.

#### Why pure JVM

`:core` has zero Android / Hilt / OkHttp dependencies. That keeps the contract reviewable in isolation, lets its tests run as fast pure-JVM tests, and prevents transport details from leaking into the seam the loop consumes.

### Test Steps

1. Pull the branch and confirm `:libs:ai-assistant:core:test` passes locally.
2. Skim `AssistantConfig.kt` and confirm the pinned triple matches what telemetry should report (`completionStack`).
3. Confirm `:core` has no `android.*`, `dagger.*`, or `okhttp3.*` imports anywhere — this is a hard property of the module, not just a convention.

### Images/gif

N/A — no UI changes. The feature is behind the `AI_ASSISTANT` local flag added in a prior PR.

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.