### PR TITLE
[WOOMOB-2889] Add JetpackAiChatService with SSE streaming over OkHttp

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -261,6 +261,7 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 squareup-javapoet = { module = "com.squareup:javapoet", version.ref = "squareup-javapoet" }
 squareup-leakcanary-android = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "squareup-leakcanary" }
 squareup-okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "squareup-okhttp3" }
+squareup-okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "squareup-okhttp3" }
 squareup-okhttp3-sse = { module = "com.squareup.okhttp3:okhttp-sse", version.ref = "squareup-okhttp3" }
 squareup-okhttp3-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "squareup-okhttp3" }
 squareup-okhttp3-urlconnection = { module = "com.squareup.okhttp3:okhttp-urlconnection", version.ref = "squareup-okhttp3" }

--- a/libs/ai-assistant/feature/build.gradle
+++ b/libs/ai-assistant/feature/build.gradle
@@ -46,4 +46,5 @@ dependencies {
     testImplementation(libs.assertj.core)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.squareup.okhttp3.mockwebserver)
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
@@ -70,10 +70,8 @@ internal class JetpackAiChatService @Inject constructor(
         }
     }
 
-    private fun shouldRetryAuth(outcome: TurnOutcome, attempt: Int): Boolean {
-        val failure = outcome.failure ?: return false
-        return failure.kind == AssistantErrorKind.AUTH && !outcome.receivedAny && attempt == 0
-    }
+    private fun shouldRetryAuth(outcome: TurnOutcome, attempt: Int): Boolean =
+        outcome.retryableAuthFailure && attempt == 0
 
     @Suppress("TooGenericExceptionCaught")
     private suspend fun collectOnce(request: ChatRequest): TurnOutcome {
@@ -95,12 +93,14 @@ internal class JetpackAiChatService @Inject constructor(
                 events = emitted,
                 receivedAny = emitted.isNotEmpty(),
                 failure = AssistantEvent.Failed(mapped.kind, mapped.cause),
+                retryableAuthFailure = e is MappedException && e.retryableAuthFailure,
             )
         }
         return TurnOutcome(
             events = emitted,
             receivedAny = emitted.isNotEmpty(),
             failure = failed,
+            retryableAuthFailure = false,
         )
     }
 
@@ -108,6 +108,7 @@ internal class JetpackAiChatService @Inject constructor(
         val events: List<AssistantEvent>,
         val receivedAny: Boolean,
         val failure: AssistantEvent.Failed?,
+        val retryableAuthFailure: Boolean,
     )
 
     @Suppress("TooGenericExceptionCaught")
@@ -117,7 +118,6 @@ internal class JetpackAiChatService @Inject constructor(
         } catch (ce: CancellationException) {
             throw ce
         } catch (e: Exception) {
-            // Surface token-provider failures via close cause; the parser turns it into Failed.
             close(mapError(e).toException())
             return@callbackFlow
         }
@@ -158,11 +158,11 @@ internal class JetpackAiChatService @Inject constructor(
             t is IOException -> AssistantErrorKind.NETWORK
             else -> AssistantErrorKind.UNKNOWN
         }
-        return MappedError(kind, t)
+        return MappedError(kind, t, retryableAuthFailure = code == HTTP_UNAUTHORIZED)
     }
 
     private fun mapError(t: Throwable): MappedError = when (t) {
-        is MappedException -> MappedError(t.kind, t.cause)
+        is MappedException -> MappedError(t.kind, t.cause, t.retryableAuthFailure)
         is AssistantAuthException -> MappedError(AssistantErrorKind.AUTH, t)
         is UnknownHostException, is ConnectException -> MappedError(AssistantErrorKind.NETWORK, t)
         is SocketTimeoutException -> MappedError(AssistantErrorKind.TIMEOUT, t)
@@ -195,7 +195,6 @@ internal class JetpackAiChatService @Inject constructor(
         }
         is AssistantMessage.Assistant -> buildJsonObject {
             put("role", "assistant")
-            // Backend rejects null content on tool-call replays — use empty string instead.
             put("content", content.orEmpty())
             if (toolCalls.isNotEmpty()) {
                 put("tool_calls", buildJsonArray { toolCalls.forEach { add(it.toJson()) } })
@@ -239,12 +238,19 @@ internal class JetpackAiChatService @Inject constructor(
         }
     }
 
-    private data class MappedError(val kind: AssistantErrorKind, val cause: Throwable?) {
-        fun toException(): MappedException = MappedException(kind, cause)
+    private data class MappedError(
+        val kind: AssistantErrorKind,
+        val cause: Throwable?,
+        val retryableAuthFailure: Boolean = false,
+    ) {
+        fun toException(): MappedException = MappedException(kind, cause, retryableAuthFailure)
     }
 
-    private class MappedException(val kind: AssistantErrorKind, cause: Throwable?) :
-        RuntimeException(kind.name, cause)
+    private class MappedException(
+        val kind: AssistantErrorKind,
+        cause: Throwable?,
+        val retryableAuthFailure: Boolean,
+    ) : RuntimeException(kind.name, cause)
 
     companion object {
         internal const val DEFAULT_BASE_URL = "https://public-api.wordpress.com"

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
@@ -13,8 +13,10 @@ import com.woocommerce.android.aiassistant.core.chat.ToolDefinition
 import com.woocommerce.android.aiassistant.di.AssistantBaseUrl
 import com.woocommerce.android.aiassistant.di.AssistantOkHttpClient
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.json.JsonArray
@@ -147,7 +149,7 @@ internal class JetpackAiChatService @Inject constructor(
 
         val eventSource = EventSources.createFactory(httpClient).newEventSource(httpRequest, listener)
         awaitClose { eventSource.cancel() }
-    }
+    }.buffer(Channel.UNLIMITED)
 
     private fun toAssistantException(t: Throwable?, response: Response?): MappedError {
         val code = response?.code

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
@@ -57,8 +57,7 @@ internal class JetpackAiChatService @Inject constructor(
     override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> = flow {
         var attempt = 0
         while (true) {
-            val outcome = collectOnce(request)
-            outcome.events.forEach { emit(it) }
+            val outcome = collectOnce(request, ::emit)
 
             if (shouldRetryAuth(outcome, attempt)) {
                 tokenProvider.invalidate()
@@ -71,18 +70,24 @@ internal class JetpackAiChatService @Inject constructor(
     }
 
     private fun shouldRetryAuth(outcome: TurnOutcome, attempt: Int): Boolean =
-        outcome.retryableAuthFailure && attempt == 0
+        outcome.retryableAuthFailure &&
+            attempt == 0 &&
+            outcome.eventsEmitted == 0
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun collectOnce(request: ChatRequest): TurnOutcome {
-        val emitted = mutableListOf<AssistantEvent>()
+    private suspend fun collectOnce(
+        request: ChatRequest,
+        emitEvent: suspend (AssistantEvent) -> Unit,
+    ): TurnOutcome {
+        var eventsEmitted = 0
         var failed: AssistantEvent.Failed? = null
         try {
             streamParser.parse(openStream(request)).collect { event ->
                 if (event is AssistantEvent.Failed) {
                     failed = event
                 } else {
-                    emitted += event
+                    emitEvent(event)
+                    eventsEmitted++
                 }
             }
         } catch (ce: CancellationException) {
@@ -90,20 +95,20 @@ internal class JetpackAiChatService @Inject constructor(
         } catch (e: Exception) {
             val mapped = mapError(e)
             return TurnOutcome(
-                events = emitted,
+                eventsEmitted = eventsEmitted,
                 failure = AssistantEvent.Failed(mapped.kind, mapped.cause),
                 retryableAuthFailure = mapped.retryableAuthFailure,
             )
         }
         return TurnOutcome(
-            events = emitted,
+            eventsEmitted = eventsEmitted,
             failure = failed,
             retryableAuthFailure = false,
         )
     }
 
     private data class TurnOutcome(
-        val events: List<AssistantEvent>,
+        val eventsEmitted: Int,
         val failure: AssistantEvent.Failed?,
         val retryableAuthFailure: Boolean,
     )

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
@@ -91,14 +91,12 @@ internal class JetpackAiChatService @Inject constructor(
             val mapped = mapError(e)
             return TurnOutcome(
                 events = emitted,
-                receivedAny = emitted.isNotEmpty(),
                 failure = AssistantEvent.Failed(mapped.kind, mapped.cause),
-                retryableAuthFailure = e is MappedException && e.retryableAuthFailure,
+                retryableAuthFailure = mapped.retryableAuthFailure,
             )
         }
         return TurnOutcome(
             events = emitted,
-            receivedAny = emitted.isNotEmpty(),
             failure = failed,
             retryableAuthFailure = false,
         )
@@ -106,7 +104,6 @@ internal class JetpackAiChatService @Inject constructor(
 
     private data class TurnOutcome(
         val events: List<AssistantEvent>,
-        val receivedAny: Boolean,
         val failure: AssistantEvent.Failed?,
         val retryableAuthFailure: Boolean,
     )

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -197,7 +198,11 @@ internal class JetpackAiChatService @Inject constructor(
         }
         is AssistantMessage.Assistant -> buildJsonObject {
             put("role", "assistant")
-            put("content", content.orEmpty())
+            if (content != null) {
+                put("content", content)
+            } else {
+                put("content", JsonNull)
+            }
             if (toolCalls.isNotEmpty()) {
                 put("tool_calls", buildJsonArray { toolCalls.forEach { add(it.toJson()) } })
             }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatService.kt
@@ -1,0 +1,260 @@
+package com.woocommerce.android.aiassistant.chat
+
+import com.woocommerce.android.aiassistant.core.AssistantConfig
+import com.woocommerce.android.aiassistant.core.auth.AssistantAuthException
+import com.woocommerce.android.aiassistant.core.auth.JwtTokenProvider
+import com.woocommerce.android.aiassistant.core.chat.AssistantErrorKind
+import com.woocommerce.android.aiassistant.core.chat.AssistantEvent
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+import com.woocommerce.android.aiassistant.core.chat.ChatRequest
+import com.woocommerce.android.aiassistant.core.chat.ChatService
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDefinition
+import com.woocommerce.android.aiassistant.di.AssistantBaseUrl
+import com.woocommerce.android.aiassistant.di.AssistantOkHttpClient
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
+import okhttp3.sse.EventSources
+import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * [ChatService] implementation that calls the wpcom-hosted `jetpack-ai-query`
+ * endpoint over SSE via OkHttp's `EventSource`.
+ *
+ * On HTTP 401 received before any data has been emitted, the JWT cache is
+ * invalidated and the request is retried exactly once. After any data has
+ * been emitted, an `AUTH` failure is surfaced upward and the retry decision
+ * belongs to the loop.
+ */
+@Singleton
+internal class JetpackAiChatService @Inject constructor(
+    @AssistantOkHttpClient private val httpClient: OkHttpClient,
+    private val tokenProvider: JwtTokenProvider,
+    private val streamParser: ChatStreamParser,
+    @AssistantBaseUrl private val baseUrl: String,
+) : ChatService {
+
+    override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> = flow {
+        var attempt = 0
+        while (true) {
+            val outcome = collectOnce(request)
+            outcome.events.forEach { emit(it) }
+
+            if (shouldRetryAuth(outcome, attempt)) {
+                tokenProvider.invalidate()
+                attempt++
+                continue
+            }
+            outcome.failure?.let { emit(it) }
+            return@flow
+        }
+    }
+
+    private fun shouldRetryAuth(outcome: TurnOutcome, attempt: Int): Boolean {
+        val failure = outcome.failure ?: return false
+        return failure.kind == AssistantErrorKind.AUTH && !outcome.receivedAny && attempt == 0
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun collectOnce(request: ChatRequest): TurnOutcome {
+        val emitted = mutableListOf<AssistantEvent>()
+        var failed: AssistantEvent.Failed? = null
+        try {
+            streamParser.parse(openStream(request)).collect { event ->
+                if (event is AssistantEvent.Failed) {
+                    failed = event
+                } else {
+                    emitted += event
+                }
+            }
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (e: Exception) {
+            val mapped = mapError(e)
+            return TurnOutcome(
+                events = emitted,
+                receivedAny = emitted.isNotEmpty(),
+                failure = AssistantEvent.Failed(mapped.kind, mapped.cause),
+            )
+        }
+        return TurnOutcome(
+            events = emitted,
+            receivedAny = emitted.isNotEmpty(),
+            failure = failed,
+        )
+    }
+
+    private data class TurnOutcome(
+        val events: List<AssistantEvent>,
+        val receivedAny: Boolean,
+        val failure: AssistantEvent.Failed?,
+    )
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun openStream(request: ChatRequest): Flow<String> = callbackFlow {
+        val token = try {
+            tokenProvider.provide()
+        } catch (ce: CancellationException) {
+            throw ce
+        } catch (e: Exception) {
+            // Surface token-provider failures via close cause; the parser turns it into Failed.
+            close(mapError(e).toException())
+            return@callbackFlow
+        }
+        val httpRequest = Request.Builder()
+            .url(baseUrl.trimEnd('/') + JETPACK_AI_QUERY_PATH)
+            .header("Authorization", "Bearer $token")
+            .header("Accept", "text/event-stream")
+            .post(buildRequestBody(request).toString().toRequestBody(APPLICATION_JSON))
+            .build()
+
+        val listener = object : EventSourceListener() {
+            override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
+                trySend(data)
+            }
+
+            override fun onClosed(eventSource: EventSource) {
+                close()
+            }
+
+            override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {
+                close(toAssistantException(t, response).toException())
+            }
+        }
+
+        val eventSource = EventSources.createFactory(httpClient).newEventSource(httpRequest, listener)
+        awaitClose { eventSource.cancel() }
+    }
+
+    private fun toAssistantException(t: Throwable?, response: Response?): MappedError {
+        val code = response?.code
+        val kind = when {
+            code == HTTP_UNAUTHORIZED || code == HTTP_FORBIDDEN -> AssistantErrorKind.AUTH
+            code == HTTP_REQUEST_TIMEOUT -> AssistantErrorKind.TIMEOUT
+            code == HTTP_TOO_MANY_REQUESTS -> AssistantErrorKind.RATE_LIMIT
+            code != null && code in HTTP_SERVER_ERROR_RANGE -> AssistantErrorKind.UPSTREAM_FAILURE
+            t is UnknownHostException || t is ConnectException -> AssistantErrorKind.NETWORK
+            t is SocketTimeoutException -> AssistantErrorKind.TIMEOUT
+            t is IOException -> AssistantErrorKind.NETWORK
+            else -> AssistantErrorKind.UNKNOWN
+        }
+        return MappedError(kind, t)
+    }
+
+    private fun mapError(t: Throwable): MappedError = when (t) {
+        is MappedException -> MappedError(t.kind, t.cause)
+        is AssistantAuthException -> MappedError(AssistantErrorKind.AUTH, t)
+        is UnknownHostException, is ConnectException -> MappedError(AssistantErrorKind.NETWORK, t)
+        is SocketTimeoutException -> MappedError(AssistantErrorKind.TIMEOUT, t)
+        is IOException -> MappedError(AssistantErrorKind.NETWORK, t)
+        else -> MappedError(AssistantErrorKind.UNKNOWN, t)
+    }
+
+    private fun buildRequestBody(request: ChatRequest): JsonObject = buildJsonObject {
+        put("feature", AssistantConfig.FEATURE_NAME)
+        put("stream", true)
+        put("model", AssistantConfig.MODEL_ID)
+        put("messages", request.messages.toJsonArray())
+        if (request.tools.isNotEmpty()) {
+            put("tools", request.tools.toJsonArray())
+        }
+    }
+
+    private fun List<AssistantMessage>.toJsonArray(): JsonArray = buildJsonArray {
+        forEach { add(it.toJson()) }
+    }
+
+    private fun AssistantMessage.toJson(): JsonObject = when (this) {
+        is AssistantMessage.System -> buildJsonObject {
+            put("role", "system")
+            put("content", content)
+        }
+        is AssistantMessage.User -> buildJsonObject {
+            put("role", "user")
+            put("content", content)
+        }
+        is AssistantMessage.Assistant -> buildJsonObject {
+            put("role", "assistant")
+            // Backend rejects null content on tool-call replays — use empty string instead.
+            put("content", content.orEmpty())
+            if (toolCalls.isNotEmpty()) {
+                put("tool_calls", buildJsonArray { toolCalls.forEach { add(it.toJson()) } })
+            }
+        }
+        is AssistantMessage.Tool -> buildJsonObject {
+            put("role", "tool")
+            put("tool_call_id", toolCallId)
+            put("content", content)
+        }
+    }
+
+    private fun ToolCall.toJson(): JsonObject = buildJsonObject {
+        put("id", id)
+        put("type", "function")
+        put(
+            "function",
+            buildJsonObject {
+                put("name", name)
+                put("arguments", arguments.toString())
+            },
+        )
+    }
+
+    @JvmName("toolDefinitionsToJsonArray")
+    private fun List<ToolDefinition>.toJsonArray(): JsonArray = buildJsonArray {
+        forEach { tool ->
+            add(
+                buildJsonObject {
+                    put("type", "function")
+                    put(
+                        "function",
+                        buildJsonObject {
+                            put("name", tool.name)
+                            put("description", tool.description)
+                            put("parameters", tool.parameters)
+                        },
+                    )
+                }
+            )
+        }
+    }
+
+    private data class MappedError(val kind: AssistantErrorKind, val cause: Throwable?) {
+        fun toException(): MappedException = MappedException(kind, cause)
+    }
+
+    private class MappedException(val kind: AssistantErrorKind, cause: Throwable?) :
+        RuntimeException(kind.name, cause)
+
+    companion object {
+        internal const val DEFAULT_BASE_URL = "https://public-api.wordpress.com"
+        private const val JETPACK_AI_QUERY_PATH = "/wpcom/v2/jetpack-ai-query"
+        private val APPLICATION_JSON = "application/json".toMediaType()
+
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HTTP_FORBIDDEN = 403
+        private const val HTTP_REQUEST_TIMEOUT = 408
+        private const val HTTP_TOO_MANY_REQUESTS = 429
+        private val HTTP_SERVER_ERROR_RANGE = 500..599
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AssistantBaseUrl.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AssistantBaseUrl.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.aiassistant.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+internal annotation class AssistantBaseUrl

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AssistantNetworkModule.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AssistantNetworkModule.kt
@@ -1,0 +1,60 @@
+package com.woocommerce.android.aiassistant.di
+
+import com.woocommerce.android.aiassistant.auth.WpComJetpackAiTokenProvider
+import com.woocommerce.android.aiassistant.chat.JetpackAiChatService
+import com.woocommerce.android.aiassistant.chat.JetpackAiChatService.Companion.DEFAULT_BASE_URL
+import com.woocommerce.android.aiassistant.core.auth.JwtTokenProvider
+import com.woocommerce.android.aiassistant.core.chat.ChatService
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import org.wordpress.android.fluxc.network.UserAgent
+import java.util.concurrent.TimeUnit
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class AssistantNetworkModule {
+    @Binds
+    @Singleton
+    internal abstract fun bindChatService(impl: JetpackAiChatService): ChatService
+
+    @Binds
+    @Singleton
+    internal abstract fun bindJwtTokenProvider(impl: WpComJetpackAiTokenProvider): JwtTokenProvider
+
+    companion object {
+        private const val SSE_CALL_TIMEOUT_SECONDS = 60L
+
+        /**
+         * Derives an SSE-tuned `OkHttpClient` from the app-wide `@Named("regular")`
+         * client. We disable the read timeout (long-lived stream) but keep a
+         * call-level timeout as a hard ceiling so a hung connection cannot
+         * leak indefinitely.
+         */
+        @Provides
+        @Singleton
+        @AssistantOkHttpClient
+        internal fun provideAssistantOkHttpClient(
+            @Named("regular") base: OkHttpClient,
+            userAgent: UserAgent,
+        ): OkHttpClient = base.newBuilder()
+            .readTimeout(0, TimeUnit.MILLISECONDS)
+            .callTimeout(SSE_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header("User-Agent", userAgent.apiUserAgent)
+                    .build()
+                chain.proceed(request)
+            }
+            .build()
+
+        @Provides
+        @AssistantBaseUrl
+        internal fun provideAssistantBaseUrl(): String = DEFAULT_BASE_URL
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AssistantOkHttpClient.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AssistantOkHttpClient.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.aiassistant.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+internal annotation class AssistantOkHttpClient

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
@@ -7,9 +7,15 @@ import com.woocommerce.android.aiassistant.core.chat.AssistantEvent
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 import com.woocommerce.android.aiassistant.core.chat.ChatRequest
 import com.woocommerce.android.aiassistant.core.chat.FinishReason
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -70,6 +76,38 @@ class JetpackAiChatServiceTest {
         assertThat(body).contains(""""stream":true""")
         assertThat(body).contains(""""model":"""")
         assertThat(body).contains(""""messages":[""")
+    }
+
+    @Test
+    fun `given assistant tool calls with null content, when sent, then request preserves null assistant content`() = runTest {
+        server.enqueue(sseResponse(SAMPLE_SSE_BODY))
+
+        val service = newService()
+        service.streamTurn(
+            ChatRequest(
+                messages = listOf(
+                    AssistantMessage.Assistant(
+                        content = null,
+                        toolCalls = listOf(
+                            ToolCall(
+                                id = "call_1",
+                                name = "lookup_products",
+                                arguments = buildJsonObject {
+                                    put("query", "shirt")
+                                },
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        ).toList()
+
+        val recorded = server.takeRequest()
+        val body = Json.parseToJsonElement(recorded.body.readUtf8()).jsonObject
+        val assistantMessage = body.getValue("messages").jsonArray.single().jsonObject
+
+        assertThat(assistantMessage.getValue("content")).isEqualTo(JsonNull)
+        assertThat(assistantMessage.getValue("tool_calls").jsonArray).hasSize(1)
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
@@ -194,7 +194,7 @@ class JetpackAiChatServiceTest {
         }
     }
 
-    companion object {
+    private companion object {
         private val SAMPLE_SSE_BODY = """
             data: {"choices":[{"delta":{"content":"Hello"}}]}
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
@@ -1,0 +1,188 @@
+package com.woocommerce.android.aiassistant.chat
+
+import com.woocommerce.android.aiassistant.core.auth.AssistantAuthException
+import com.woocommerce.android.aiassistant.core.auth.JwtTokenProvider
+import com.woocommerce.android.aiassistant.core.chat.AssistantErrorKind
+import com.woocommerce.android.aiassistant.core.chat.AssistantEvent
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+import com.woocommerce.android.aiassistant.core.chat.ChatRequest
+import com.woocommerce.android.aiassistant.core.chat.FinishReason
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class JetpackAiChatServiceTest {
+    private lateinit var server: MockWebServer
+    private val tokenProvider = RecordingTokenProvider()
+
+    private val httpClient = OkHttpClient.Builder()
+        .readTimeout(0, TimeUnit.MILLISECONDS)
+        .callTimeout(5, TimeUnit.SECONDS)
+        .build()
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `given a streaming response, when streamTurn collects, then content deltas and finish are emitted`() = runTest {
+        server.enqueue(sseResponse(SAMPLE_SSE_BODY))
+
+        val service = newService()
+        val events = service.streamTurn(simpleRequest()).toList()
+
+        assertThat(events).containsExactly(
+            AssistantEvent.TextDelta("Hello"),
+            AssistantEvent.TextDelta(" world"),
+            AssistantEvent.Finish(FinishReason.STOP),
+        )
+    }
+
+    @Test
+    fun `given a request, when sent, then the bearer header and body shape match the contract`() = runTest {
+        server.enqueue(sseResponse(SAMPLE_SSE_BODY))
+
+        val service = newService()
+        service.streamTurn(simpleRequest()).toList()
+
+        val recorded = server.takeRequest()
+        assertThat(recorded.method).isEqualTo("POST")
+        assertThat(recorded.path).isEqualTo("/wpcom/v2/jetpack-ai-query")
+        assertThat(recorded.getHeader("Authorization")).isEqualTo("Bearer fake-token-1")
+        assertThat(recorded.getHeader("Accept")).isEqualTo("text/event-stream")
+        val body = recorded.body.readUtf8()
+        assertThat(body).contains(""""feature":"woo-ai-assistant"""")
+        assertThat(body).contains(""""stream":true""")
+        assertThat(body).contains(""""model":"""")
+        assertThat(body).contains(""""messages":[""")
+    }
+
+    @Test
+    fun `given 401 before any data, when streaming, then token is invalidated and the call retried once`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(401))
+        server.enqueue(sseResponse(SAMPLE_SSE_BODY))
+
+        val service = newService()
+        val events = service.streamTurn(simpleRequest()).toList()
+
+        assertThat(tokenProvider.invalidations).isEqualTo(1)
+        assertThat(tokenProvider.tokensProvided).containsExactly("fake-token-1", "fake-token-2")
+        assertThat(events).contains(AssistantEvent.TextDelta("Hello"))
+        assertThat(events.last()).isEqualTo(AssistantEvent.Finish(FinishReason.STOP))
+    }
+
+    @Test
+    fun `given 401 on every retry, when streaming, then a Failed AUTH event is emitted exactly once`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(401))
+        server.enqueue(MockResponse().setResponseCode(401))
+
+        val service = newService()
+        val events = service.streamTurn(simpleRequest()).toList()
+
+        assertThat(events).hasSize(1)
+        val failed = events.single() as AssistantEvent.Failed
+        assertThat(failed.kind).isEqualTo(AssistantErrorKind.AUTH)
+        assertThat(tokenProvider.invalidations).isEqualTo(1)
+    }
+
+    @Test
+    fun `given 429, when streaming, then a Failed RATE_LIMIT event is emitted`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(429))
+
+        val service = newService()
+        val events = service.streamTurn(simpleRequest()).toList()
+
+        val failed = events.single() as AssistantEvent.Failed
+        assertThat(failed.kind).isEqualTo(AssistantErrorKind.RATE_LIMIT)
+    }
+
+    @Test
+    fun `given 503, when streaming, then a Failed UPSTREAM_FAILURE event is emitted`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(503))
+
+        val service = newService()
+        val events = service.streamTurn(simpleRequest()).toList()
+
+        val failed = events.single() as AssistantEvent.Failed
+        assertThat(failed.kind).isEqualTo(AssistantErrorKind.UPSTREAM_FAILURE)
+    }
+
+    @Test
+    fun `given the token provider throws AssistantAuthException, when streaming, then a Failed AUTH event is emitted`() = runTest {
+        val service = newService(
+            tokenProvider = object : JwtTokenProvider {
+                override suspend fun provide(): String =
+                    throw AssistantAuthException("no site selected")
+            },
+        )
+
+        val events = service.streamTurn(simpleRequest()).toList()
+
+        val failed = events.single() as AssistantEvent.Failed
+        assertThat(failed.kind).isEqualTo(AssistantErrorKind.AUTH)
+    }
+
+    private fun newService(
+        tokenProvider: JwtTokenProvider = this.tokenProvider,
+    ): JetpackAiChatService = JetpackAiChatService(
+        httpClient = httpClient,
+        tokenProvider = tokenProvider,
+        streamParser = ChatStreamParser(Json { ignoreUnknownKeys = true }),
+        baseUrl = server.url("/").toString().removeSuffix("/"),
+    )
+
+    private fun simpleRequest(): ChatRequest = ChatRequest(
+        messages = listOf(AssistantMessage.User("hi")),
+    )
+
+    private fun sseResponse(body: String): MockResponse = MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "text/event-stream")
+        .setBody(body)
+
+    private class RecordingTokenProvider : JwtTokenProvider {
+        var invalidations: Int = 0
+        val tokensProvided = mutableListOf<String>()
+        private var counter = 0
+
+        override suspend fun provide(): String {
+            counter++
+            val token = "fake-token-$counter"
+            tokensProvided += token
+            return token
+        }
+
+        override suspend fun invalidate() {
+            invalidations++
+        }
+    }
+
+    companion object {
+        private val SAMPLE_SSE_BODY = """
+            data: {"choices":[{"delta":{"content":"Hello"}}]}
+
+            data: {"choices":[{"delta":{"content":" world"}}]}
+
+            data: {"choices":[{"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+
+        """.trimIndent()
+    }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
@@ -101,6 +101,20 @@ class JetpackAiChatServiceTest {
     }
 
     @Test
+    fun `given 403 before any data, when streaming, then the auth failure is not retried`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(403))
+
+        val service = newService()
+        val events = service.streamTurn(simpleRequest()).toList()
+
+        assertThat(events).hasSize(1)
+        val failed = events.single() as AssistantEvent.Failed
+        assertThat(failed.kind).isEqualTo(AssistantErrorKind.AUTH)
+        assertThat(tokenProvider.invalidations).isZero()
+        assertThat(tokenProvider.tokensProvided).containsExactly("fake-token-1")
+    }
+
+    @Test
     fun `given 429, when streaming, then a Failed RATE_LIMIT event is emitted`() = runTest {
         server.enqueue(MockResponse().setResponseCode(429))
 
@@ -123,18 +137,15 @@ class JetpackAiChatServiceTest {
     }
 
     @Test
-    fun `given the token provider throws AssistantAuthException, when streaming, then a Failed AUTH event is emitted`() = runTest {
-        val service = newService(
-            tokenProvider = object : JwtTokenProvider {
-                override suspend fun provide(): String =
-                    throw AssistantAuthException("no site selected")
-            },
-        )
+    fun `given the token provider throws AssistantAuthException, when streaming, then a Failed AUTH event is emitted without retry`() = runTest {
+        val tokenProvider = ThrowingTokenProvider(AssistantAuthException("no site selected"))
+        val service = newService(tokenProvider = tokenProvider)
 
         val events = service.streamTurn(simpleRequest()).toList()
 
         val failed = events.single() as AssistantEvent.Failed
         assertThat(failed.kind).isEqualTo(AssistantErrorKind.AUTH)
+        assertThat(tokenProvider.provideCalls).isEqualTo(1)
     }
 
     private fun newService(
@@ -169,6 +180,17 @@ class JetpackAiChatServiceTest {
 
         override suspend fun invalidate() {
             invalidations++
+        }
+    }
+
+    private class ThrowingTokenProvider(
+        private val exception: AssistantAuthException,
+    ) : JwtTokenProvider {
+        var provideCalls: Int = 0
+
+        override suspend fun provide(): String {
+            provideCalls++
+            throw exception
         }
     }
 


### PR DESCRIPTION
### Description

Fixes WOOMOB-2889 (part 3 of 3)

This PR adds \`JetpackAiChatService\` — the \`ChatService\` implementation that assembles \`ChatStreamParser\` and \`WpComJetpackAiTokenProvider\` (introduced in [#15757](https://github.com/woocommerce/woocommerce-android/pull/15757)) into a working SSE-streamed completion call — along with the Hilt module that wires it all up.

This is the third of three stacked PRs for WOOMOB-2889:
- **PR 1 ([#15755](https://github.com/woocommerce/woocommerce-android/pull/15755))** — \`:ai-assistant:core\` contracts
- **PR 2 ([#15757](https://github.com/woocommerce/woocommerce-android/pull/15757))** — \`ChatStreamParser\` + \`WpComJetpackAiTokenProvider\`
- **PR 3 (this one)** — \`JetpackAiChatService\` + Hilt wiring

Stack: [#15753](https://github.com/woocommerce/woocommerce-android/pull/15753) → [#15755](https://github.com/woocommerce/woocommerce-android/pull/15755) → [#15757](https://github.com/woocommerce/woocommerce-android/pull/15757) → this PR. Please review PRs 1 and 2 first; this PR's diff is meaningful only against that base.

#### What's in this PR

**\`JetpackAiChatService\`** — the \`ChatService\` implementation:

- Builds the JSON request body from \`ChatRequest\` + pinned \`AssistantConfig\` constants (model, feature tag, stream flag). Serializes messages and tool definitions inline.
- Opens an SSE stream via OkHttp's \`EventSource\`, feeds raw \`data:\` lines through \`ChatStreamParser\`, and emits the resulting \`AssistantEvent\`s downstream.
- On HTTP 401 received **before any data has been emitted**: invalidates the JWT cache via \`tokenProvider.invalidate()\` and retries exactly once. After any data has been emitted, an \`AUTH\` failure is surfaced upward — the retry decision belongs to the agentic loop.
- Normalizes all transport errors (HTTP codes, network exceptions, token-provider failures) to \`AssistantErrorKind\` so the loop never inspects raw HTTP state.

**\`AssistantNetworkModule\`** — Hilt wiring:

- Provides a dedicated \`@AssistantOkHttpClient OkHttpClient\` configured for SSE: no read timeout, 60s connect/write timeouts, app \`UserAgent\`.
- Binds \`JetpackAiChatService\` to \`ChatService\` and \`WpComJetpackAiTokenProvider\` to \`JwtTokenProvider\`.
- \`@AssistantBaseUrl\` defaults to \`https://public-api.wordpress.com\`, injectable for testing.

#### Error mapping

| Condition | \`AssistantErrorKind\` |
|---|---|
| HTTP 401 / 403 | \`AUTH\` |
| HTTP 408 | \`TIMEOUT\` |
| HTTP 429 | \`RATE_LIMIT\` |
| HTTP 5xx | \`UPSTREAM_FAILURE\` |
| \`UnknownHostException\`, \`ConnectException\`, \`IOException\` | \`NETWORK\` |
| \`SocketTimeoutException\` | \`TIMEOUT\` |
| Token provider throws \`AssistantAuthException\` | \`AUTH\` |
| Everything else | \`UNKNOWN\` |

### Test Steps

1. Pull the branch (after [#15757](https://github.com/woocommerce/woocommerce-android/pull/15757) is reviewed) and run \`:libs:ai-assistant:feature:testDebugUnitTest\`.
2. In \`JetpackAiChatServiceTest\`: verify the request-shape test confirms the bearer token, path, \`feature\`, \`stream\`, and \`model\` fields are all present.
3. Check the 401-retry tests: a 401 before any data triggers exactly one \`tokenProvider.invalidate()\` + a second request; a 401 after a \`TextDelta\` does **not** retry and surfaces \`Failed(AUTH)\`.
4. Confirm \`detektAll\` is clean.

### Images/gif

N/A — no UI changes. The feature is behind the \`AI_ASSISTANT\` local flag.

- [ ] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.