### PR TITLE
[WOOMOB-2889] Add ChatStreamParser and WpComJetpackAiTokenProvider

### DIFF
--- a/libs/ai-assistant/feature/build.gradle
+++ b/libs/ai-assistant/feature/build.gradle
@@ -20,6 +20,12 @@ android {
         sourceCompatibility = libs.versions.java.get()
         targetCompatibility = libs.versions.java.get()
     }
+
+    lint {
+        // The lint detector expects metadata version 2.0.0 but the project uses 2.1.0
+        // This can be re-enabled once the compose lint library supports newer metadata versions
+        disable "FlowOperatorInvokedInComposition"
+    }
 }
 
 dependencies {

--- a/libs/ai-assistant/feature/build.gradle
+++ b/libs/ai-assistant/feature/build.gradle
@@ -23,6 +23,8 @@ android {
 }
 
 dependencies {
+    implementation(project(":libs:ai-assistant:core"))
+
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.squareup.okhttp3)
@@ -33,4 +35,5 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.assertj.core)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/libs/ai-assistant/feature/build.gradle
+++ b/libs/ai-assistant/feature/build.gradle
@@ -25,6 +25,9 @@ android {
 dependencies {
     implementation(project(":libs:ai-assistant:core"))
 
+    implementation(project(":libs:commons"))
+    implementation(project(":libs:fluxc"))
+
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.squareup.okhttp3)
@@ -35,5 +38,6 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.assertj.core)
+    testImplementation(libs.mockito.kotlin)
     testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/auth/WpComJetpackAiTokenProvider.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/auth/WpComJetpackAiTokenProvider.kt
@@ -1,0 +1,68 @@
+package com.woocommerce.android.aiassistant.auth
+
+import com.woocommerce.android.aiassistant.core.auth.AssistantAuthException
+import com.woocommerce.android.aiassistant.core.auth.JwtTokenProvider
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.wordpress.android.fluxc.model.JWTToken
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAIJWTTokenResponse
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * [JwtTokenProvider] that mints and caches a Jetpack AI JWT for the currently
+ * selected WP.com site.
+ *
+ * Behavior:
+ *  - Caches one [JWTToken] in memory; reuses it until it expires or its
+ *    embedded `blog_id` no longer matches the active site (e.g. after a site
+ *    switch).
+ *  - Single-flights concurrent callers via [Mutex] so a token storm produces
+ *    one mint, not N.
+ *  - Throws [AssistantAuthException] for every recoverable failure surface
+ *    (no selected site, missing/invalid token, REST error). The chat layer
+ *    converts that to `AssistantErrorKind.AUTH`.
+ */
+@Singleton
+internal class WpComJetpackAiTokenProvider @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val restClient: JetpackAIRestClient,
+) : JwtTokenProvider {
+
+    private val mutex = Mutex()
+
+    @Volatile
+    private var cached: JWTToken? = null
+
+    override suspend fun provide(): String = mutex.withLock {
+        val site = selectedSite.getOrNull()
+            ?: throw AssistantAuthException("No selected site; cannot mint Jetpack AI JWT")
+
+        cached?.takeIf { it.matchesSite(site) }
+            ?.validateExpiryDate()
+            ?.let { return@withLock it.value }
+
+        val fresh = mintToken(site)
+        cached = fresh
+        fresh.value
+    }
+
+    override suspend fun invalidate() = mutex.withLock {
+        cached = null
+    }
+
+    private suspend fun mintToken(site: SiteModel): JWTToken =
+        when (val response = restClient.fetchJetpackAIJWTToken(site)) {
+            is JetpackAIJWTTokenResponse.Success -> response.token.validateExpiryDate()
+                ?: throw AssistantAuthException("Jetpack AI JWT was returned already expired")
+            is JetpackAIJWTTokenResponse.Error -> throw AssistantAuthException(
+                "Failed to mint Jetpack AI JWT: ${response.type} ${response.message.orEmpty()}".trim()
+            )
+        }
+
+    private fun JWTToken.matchesSite(site: SiteModel): Boolean =
+        getPayloadItem("blog_id")?.toLongOrNull() == site.siteId
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/auth/WpComJetpackAiTokenProvider.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/auth/WpComJetpackAiTokenProvider.kt
@@ -42,7 +42,7 @@ internal class WpComJetpackAiTokenProvider @Inject constructor(
             ?: throw AssistantAuthException("No selected site; cannot mint Jetpack AI JWT")
 
         cached?.takeIf { it.matchesSite(site) }
-            ?.validateExpiryDate()
+            ?.validateOrThrow()
             ?.let { return@withLock it.value }
 
         val fresh = mintToken(site)
@@ -56,13 +56,18 @@ internal class WpComJetpackAiTokenProvider @Inject constructor(
 
     private suspend fun mintToken(site: SiteModel): JWTToken =
         when (val response = restClient.fetchJetpackAIJWTToken(site)) {
-            is JetpackAIJWTTokenResponse.Success -> response.token.validateExpiryDate()
+            is JetpackAIJWTTokenResponse.Success -> response.token.validateOrThrow()
                 ?: throw AssistantAuthException("Jetpack AI JWT was returned already expired")
             is JetpackAIJWTTokenResponse.Error -> throw AssistantAuthException(
                 "Failed to mint Jetpack AI JWT: ${response.type} ${response.message.orEmpty()}".trim()
             )
         }
 
-    private fun JWTToken.matchesSite(site: SiteModel): Boolean =
+    private fun JWTToken.validateOrThrow(): JWTToken? = runCatching {
+        validateExpiryDate()
+    }.getOrElse { throw AssistantAuthException("Invalid Jetpack AI JWT", it) }
+
+    private fun JWTToken.matchesSite(site: SiteModel): Boolean = runCatching {
         getPayloadItem("blog_id")?.toLongOrNull() == site.siteId
+    }.getOrElse { throw AssistantAuthException("Invalid Jetpack AI JWT", it) }
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/ChatStreamParser.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/ChatStreamParser.kt
@@ -1,0 +1,127 @@
+package com.woocommerce.android.aiassistant.chat
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantErrorKind
+import com.woocommerce.android.aiassistant.core.chat.AssistantEvent
+import com.woocommerce.android.aiassistant.core.chat.FinishReason
+import com.woocommerce.android.aiassistant.di.AiAssistantJson
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Parses an OpenAI-compatible chat-completion SSE stream into a flow of
+ * [AssistantEvent]s.
+ *
+ * The caller is expected to have already peeled the transport envelope: each
+ * item in the input flow is the body of one `data: <payload>` line with the
+ * `data: ` prefix stripped and empty lines filtered out. The sentinel line
+ * `[DONE]` terminates the stream.
+ *
+ * The parser stays stateless with respect to tool-call assembly — each
+ * streamed `tool_calls[*]` fragment becomes one [AssistantEvent.ToolCallDelta]
+ * with its `argumentsDelta` kept verbatim. Higher layers (the agentic loop)
+ * concatenate deltas by index into final tool calls; doing the merge here
+ * would hide the raw stream from anything that wants to display partial
+ * progress.
+ */
+@Singleton
+internal class ChatStreamParser @Inject constructor(
+    @AiAssistantJson private val json: Json,
+) {
+    fun parse(lines: Flow<String>): Flow<AssistantEvent> = flow {
+        var done = false
+        lines.collect { raw ->
+            if (done) return@collect
+            val payload = raw.trim()
+            if (payload.isEmpty()) return@collect
+            if (payload == DONE_SENTINEL) {
+                done = true
+                return@collect
+            }
+
+            val chunk = runCatching { json.parseToJsonElement(payload).jsonObject }
+                .getOrElse {
+                    emit(AssistantEvent.Failed(AssistantErrorKind.INVALID_STREAM, MalformedChunkException(payload, it)))
+                    done = true
+                    return@collect
+                }
+
+            runCatching { emitChunk(chunk) }
+                .onFailure {
+                    emit(AssistantEvent.Failed(AssistantErrorKind.INVALID_STREAM, it))
+                    done = true
+                }
+        }
+    }
+
+    private suspend fun FlowCollector<AssistantEvent>.emitChunk(chunk: JsonObject) {
+        val choice = chunk["choices"]?.jsonArray?.firstOrNull()?.jsonObject ?: return
+        val delta = choice["delta"]?.jsonObject
+
+        if (delta != null) {
+            delta["content"]?.stringOrNull()
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { emit(AssistantEvent.TextDelta(it)) }
+
+            delta["tool_calls"]?.jsonArray?.forEach { element ->
+                val toolCall = element.jsonObject
+                val index = toolCall["index"]?.jsonPrimitive?.int ?: return@forEach
+                val id = toolCall["id"]?.stringOrNull()
+                val function = toolCall["function"]?.jsonObject
+                val name = function?.get("name")?.stringOrNull()
+                val argumentsDelta = function?.get("arguments")?.stringOrNull()
+                emit(
+                    AssistantEvent.ToolCallDelta(
+                        index = index,
+                        id = id,
+                        name = name,
+                        argumentsDelta = argumentsDelta,
+                    )
+                )
+            }
+        }
+
+        val finish = choice["finish_reason"]?.stringOrNull()
+        if (finish != null) {
+            emit(AssistantEvent.Finish(finish.toFinishReason()))
+        }
+    }
+
+    private fun JsonElement.stringOrNull(): String? {
+        if (this is JsonNull) return null
+        val primitive = this as? JsonPrimitive ?: return null
+        return primitive.content
+    }
+
+    private fun String.toFinishReason(): FinishReason = when (this) {
+        "stop" -> FinishReason.STOP
+        "tool_calls" -> FinishReason.TOOL_CALLS
+        "length" -> FinishReason.LENGTH
+        "content_filter" -> FinishReason.CONTENT_FILTER
+        else -> FinishReason.OTHER
+    }
+
+    companion object {
+        private const val DONE_SENTINEL = "[DONE]"
+    }
+}
+
+internal class MalformedChunkException(
+    val payload: String,
+    cause: Throwable,
+) : RuntimeException("Malformed SSE chunk: ${payload.take(MAX_PAYLOAD_PREVIEW_CHARS)}", cause) {
+    companion object {
+        private const val MAX_PAYLOAD_PREVIEW_CHARS = 200
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/ChatStreamParser.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/ChatStreamParser.kt
@@ -6,7 +6,7 @@ import com.woocommerce.android.aiassistant.core.chat.FinishReason
 import com.woocommerce.android.aiassistant.di.AiAssistantJson
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.transformWhile
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -39,29 +39,28 @@ import javax.inject.Singleton
 internal class ChatStreamParser @Inject constructor(
     @AiAssistantJson private val json: Json,
 ) {
-    fun parse(lines: Flow<String>): Flow<AssistantEvent> = flow {
-        var done = false
-        lines.collect { raw ->
-            if (done) return@collect
-            val payload = raw.trim()
-            if (payload.isEmpty()) return@collect
-            if (payload == DONE_SENTINEL) {
-                done = true
-                return@collect
+    fun parse(lines: Flow<String>): Flow<AssistantEvent> = lines.transformWhile { raw ->
+        val payload = raw.trim()
+        when {
+            payload.isEmpty() -> true
+            payload == DONE_SENTINEL -> false
+            else -> parsePayload(payload)
+        }
+    }
+
+    private suspend fun FlowCollector<AssistantEvent>.parsePayload(payload: String): Boolean {
+        val chunk = runCatching { json.parseToJsonElement(payload).jsonObject }
+            .getOrElse {
+                emit(AssistantEvent.Failed(AssistantErrorKind.INVALID_STREAM, MalformedChunkException(payload, it)))
+                return false
             }
 
-            val chunk = runCatching { json.parseToJsonElement(payload).jsonObject }
-                .getOrElse {
-                    emit(AssistantEvent.Failed(AssistantErrorKind.INVALID_STREAM, MalformedChunkException(payload, it)))
-                    done = true
-                    return@collect
-                }
-
-            runCatching { emitChunk(chunk) }
-                .onFailure {
-                    emit(AssistantEvent.Failed(AssistantErrorKind.INVALID_STREAM, it))
-                    done = true
-                }
+        return runCatching {
+            emitChunk(chunk)
+            true
+        }.getOrElse {
+            emit(AssistantEvent.Failed(AssistantErrorKind.INVALID_STREAM, it))
+            false
         }
     }
 
@@ -112,7 +111,7 @@ internal class ChatStreamParser @Inject constructor(
         else -> FinishReason.OTHER
     }
 
-    companion object {
+    private companion object {
         private const val DONE_SENTINEL = "[DONE]"
     }
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/auth/WpComJetpackAiTokenProviderTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/auth/WpComJetpackAiTokenProviderTest.kt
@@ -12,10 +12,12 @@ import org.mockito.kotlin.stub
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.JWTToken
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAIJWTTokenResponse
+import java.util.Base64
 
 class WpComJetpackAiTokenProviderTest {
     private val selectedSite: SelectedSite = mock()
@@ -41,7 +43,7 @@ class WpComJetpackAiTokenProviderTest {
 
     @Test
     fun `given REST returns error, when provide is called, then AssistantAuthException carries the error type`() = runTest {
-        val site = SiteModel().apply { siteId = 42L }
+        val site = SiteModel().apply { siteId = SITE_ID }
         selectedSite.stub { on { getOrNull() } doReturn site }
         whenever(restClient.fetchJetpackAIJWTToken(site)).thenReturn(
             JetpackAIJWTTokenResponse.Error(
@@ -59,7 +61,7 @@ class WpComJetpackAiTokenProviderTest {
 
     @Test
     fun `given REST returns error, when provide is called twice, then both calls hit the network`() = runTest {
-        val site = SiteModel().apply { siteId = 42L }
+        val site = SiteModel().apply { siteId = SITE_ID }
         selectedSite.stub { on { getOrNull() } doReturn site }
         whenever(restClient.fetchJetpackAIJWTToken(site)).thenReturn(
             JetpackAIJWTTokenResponse.Error(
@@ -75,7 +77,52 @@ class WpComJetpackAiTokenProviderTest {
     }
 
     @Test
+    fun `given REST returns malformed JWT, when provide is called, then AssistantAuthException is thrown`() = runTest {
+        val site = SiteModel().apply { siteId = SITE_ID }
+        selectedSite.stub { on { getOrNull() } doReturn site }
+        whenever(restClient.fetchJetpackAIJWTToken(site)).thenReturn(
+            JetpackAIJWTTokenResponse.Success(malformedJwtToken())
+        )
+
+        val error = runCatching { provider.provide() }.exceptionOrNull()
+
+        assertThat(error)
+            .isInstanceOf(AssistantAuthException::class.java)
+            .hasMessageContaining(INVALID_JWT_MESSAGE)
+    }
+
+    @Test
+    fun `given cached JWT is malformed, when provide is called, then AssistantAuthException is thrown`() = runTest {
+        val site = SiteModel().apply { siteId = SITE_ID }
+        selectedSite.stub { on { getOrNull() } doReturn site }
+        givenCachedToken(malformedJwtToken())
+
+        val error = runCatching { provider.provide() }.exceptionOrNull()
+
+        assertThat(error)
+            .isInstanceOf(AssistantAuthException::class.java)
+            .hasMessageContaining(INVALID_JWT_MESSAGE)
+        verify(restClient, times(0)).fetchJetpackAIJWTToken(site)
+    }
+
+    @Test
     fun `given no token has been minted, when invalidate is called, then nothing is thrown`() = runTest {
         provider.invalidate()
+    }
+
+    private fun givenCachedToken(token: JWTToken) {
+        val field = provider.javaClass.getDeclaredField("cached")
+        field.isAccessible = true
+        field.set(provider, token.value)
+    }
+
+    private fun malformedJwtToken(): JWTToken {
+        val malformedPayload = Base64.getEncoder().encodeToString("not-json".toByteArray())
+        return JWTToken("ignored.$malformedPayload.ignored")
+    }
+
+    companion object {
+        private const val SITE_ID = 42L
+        private const val INVALID_JWT_MESSAGE = "Invalid Jetpack AI JWT"
     }
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/auth/WpComJetpackAiTokenProviderTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/auth/WpComJetpackAiTokenProviderTest.kt
@@ -1,0 +1,81 @@
+package com.woocommerce.android.aiassistant.auth
+
+import com.woocommerce.android.aiassistant.core.auth.AssistantAuthException
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAICompletionsErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.jetpackai.JetpackAIRestClient.JetpackAIJWTTokenResponse
+
+class WpComJetpackAiTokenProviderTest {
+    private val selectedSite: SelectedSite = mock()
+    private val restClient: JetpackAIRestClient = mock()
+
+    private lateinit var provider: WpComJetpackAiTokenProvider
+
+    @Before
+    fun setUp() {
+        provider = WpComJetpackAiTokenProvider(selectedSite, restClient)
+    }
+
+    @Test
+    fun `given no selected site, when provide is called, then AssistantAuthException is thrown`() = runTest {
+        whenever(selectedSite.getOrNull()).thenReturn(null)
+
+        val error = runCatching { provider.provide() }.exceptionOrNull()
+
+        assertThat(error)
+            .isInstanceOf(AssistantAuthException::class.java)
+            .hasMessageContaining("No selected site")
+    }
+
+    @Test
+    fun `given REST returns error, when provide is called, then AssistantAuthException carries the error type`() = runTest {
+        val site = SiteModel().apply { siteId = 42L }
+        selectedSite.stub { on { getOrNull() } doReturn site }
+        whenever(restClient.fetchJetpackAIJWTToken(site)).thenReturn(
+            JetpackAIJWTTokenResponse.Error(
+                type = JetpackAICompletionsErrorType.AUTH_ERROR,
+                message = "expired",
+            )
+        )
+
+        val error = runCatching { provider.provide() }.exceptionOrNull()
+
+        assertThat(error)
+            .isInstanceOf(AssistantAuthException::class.java)
+            .hasMessageContaining("AUTH_ERROR")
+    }
+
+    @Test
+    fun `given REST returns error, when provide is called twice, then both calls hit the network`() = runTest {
+        val site = SiteModel().apply { siteId = 42L }
+        selectedSite.stub { on { getOrNull() } doReturn site }
+        whenever(restClient.fetchJetpackAIJWTToken(site)).thenReturn(
+            JetpackAIJWTTokenResponse.Error(
+                type = JetpackAICompletionsErrorType.GENERIC_ERROR,
+                message = null,
+            )
+        )
+
+        runCatching { provider.provide() }
+        runCatching { provider.provide() }
+
+        verify(restClient, times(2)).fetchJetpackAIJWTToken(site)
+    }
+
+    @Test
+    fun `given no token has been minted, when invalidate is called, then nothing is thrown`() = runTest {
+        provider.invalidate()
+    }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/ChatStreamParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/ChatStreamParserTest.kt
@@ -3,9 +3,12 @@ package com.woocommerce.android.aiassistant.chat
 import com.woocommerce.android.aiassistant.core.chat.AssistantErrorKind
 import com.woocommerce.android.aiassistant.core.chat.AssistantEvent
 import com.woocommerce.android.aiassistant.core.chat.FinishReason
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -33,11 +36,7 @@ class ChatStreamParserTest {
 
     @Test
     fun `given a tool-call fragment, when parsed, then a ToolCallDelta is emitted with verbatim arguments`() = runTest {
-        val payload = """
-            {"choices":[{"delta":{"tool_calls":[
-              {"index":0,"id":"call_1","function":{"name":"show_cards","arguments":"{\"a\":"}}
-            ]}}]}
-        """.trimIndent()
+        val payload = """{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"show_cards","arguments":"{\"a\":"}}]}}]}"""
 
         val events = parser.parse(flowOf(payload)).toList()
 
@@ -94,6 +93,24 @@ class ChatStreamParserTest {
         val later = """{"choices":[{"delta":{"content":"ignored"}}]}"""
 
         val events = parser.parse(flowOf(payload1, done, later)).toList()
+
+        assertThat(events).containsExactly(AssistantEvent.TextDelta("Hi"))
+    }
+
+    @Test
+    fun `given the DONE sentinel, when upstream stays open, then parsing completes immediately`() = runTest {
+        val payload = """{"choices":[{"delta":{"content":"Hi"}}]}"""
+        val done = "[DONE]"
+
+        val events = withTimeout(1_000) {
+            parser.parse(
+                flow {
+                    emit(payload)
+                    emit(done)
+                    awaitCancellation()
+                }
+            ).toList()
+        }
 
         assertThat(events).containsExactly(AssistantEvent.TextDelta("Hi"))
     }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/ChatStreamParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/ChatStreamParserTest.kt
@@ -1,0 +1,133 @@
+package com.woocommerce.android.aiassistant.chat
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantErrorKind
+import com.woocommerce.android.aiassistant.core.chat.AssistantEvent
+import com.woocommerce.android.aiassistant.core.chat.FinishReason
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ChatStreamParserTest {
+    private val parser = ChatStreamParser(Json { ignoreUnknownKeys = true })
+
+    @Test
+    fun `given a content delta payload, when parsed, then a TextDelta is emitted`() = runTest {
+        val payload = """{"choices":[{"delta":{"content":"Hello"}}]}"""
+
+        val events = parser.parse(flowOf(payload)).toList()
+
+        assertThat(events).containsExactly(AssistantEvent.TextDelta("Hello"))
+    }
+
+    @Test
+    fun `given an empty content delta, when parsed, then no event is emitted`() = runTest {
+        val payload = """{"choices":[{"delta":{"content":""}}]}"""
+
+        val events = parser.parse(flowOf(payload)).toList()
+
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `given a tool-call fragment, when parsed, then a ToolCallDelta is emitted with verbatim arguments`() = runTest {
+        val payload = """
+            {"choices":[{"delta":{"tool_calls":[
+              {"index":0,"id":"call_1","function":{"name":"show_cards","arguments":"{\"a\":"}}
+            ]}}]}
+        """.trimIndent()
+
+        val events = parser.parse(flowOf(payload)).toList()
+
+        assertThat(events).containsExactly(
+            AssistantEvent.ToolCallDelta(
+                index = 0,
+                id = "call_1",
+                name = "show_cards",
+                argumentsDelta = """{"a":""",
+            )
+        )
+    }
+
+    @Test
+    fun `given a tool-call delta without index, when parsed, then it is skipped silently`() = runTest {
+        val payload = """{"choices":[{"delta":{"tool_calls":[{"function":{"name":"x"}}]}}]}"""
+
+        val events = parser.parse(flowOf(payload)).toList()
+
+        assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `given finish_reason stop, when parsed, then Finish Stop is emitted`() = runTest {
+        val payload = """{"choices":[{"delta":{},"finish_reason":"stop"}]}"""
+
+        val events = parser.parse(flowOf(payload)).toList()
+
+        assertThat(events).containsExactly(AssistantEvent.Finish(FinishReason.STOP))
+    }
+
+    @Test
+    fun `given finish_reason tool_calls, when parsed, then Finish ToolCalls is emitted`() = runTest {
+        val payload = """{"choices":[{"finish_reason":"tool_calls"}]}"""
+
+        val events = parser.parse(flowOf(payload)).toList()
+
+        assertThat(events).containsExactly(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
+    }
+
+    @Test
+    fun `given an unknown finish reason, when parsed, then Finish Other is emitted`() = runTest {
+        val payload = """{"choices":[{"finish_reason":"refusal"}]}"""
+
+        val events = parser.parse(flowOf(payload)).toList()
+
+        assertThat(events).containsExactly(AssistantEvent.Finish(FinishReason.OTHER))
+    }
+
+    @Test
+    fun `given the DONE sentinel, when parsed, then no further events are emitted`() = runTest {
+        val payload1 = """{"choices":[{"delta":{"content":"Hi"}}]}"""
+        val done = "[DONE]"
+        val later = """{"choices":[{"delta":{"content":"ignored"}}]}"""
+
+        val events = parser.parse(flowOf(payload1, done, later)).toList()
+
+        assertThat(events).containsExactly(AssistantEvent.TextDelta("Hi"))
+    }
+
+    @Test
+    fun `given a malformed payload, when parsed, then a Failed INVALID_STREAM event is emitted`() = runTest {
+        val payload = "not json at all"
+
+        val events = parser.parse(flowOf(payload)).toList()
+
+        assertThat(events).hasSize(1)
+        val failure = events.single() as AssistantEvent.Failed
+        assertThat(failure.kind).isEqualTo(AssistantErrorKind.INVALID_STREAM)
+        assertThat(failure.cause).isInstanceOf(MalformedChunkException::class.java)
+    }
+
+    @Test
+    fun `given empty and blank lines, when parsed, then they are ignored`() = runTest {
+        val flow = flowOf("", "   ", """{"choices":[{"delta":{"content":"x"}}]}""")
+
+        val events = parser.parse(flow).toList()
+
+        assertThat(events).containsExactly(AssistantEvent.TextDelta("x"))
+    }
+
+    @Test
+    fun `given content and finish in the same chunk, when parsed, then both events are emitted in order`() = runTest {
+        val payload = """{"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}"""
+
+        val events = parser.parse(flowOf(payload)).toList()
+
+        assertThat(events).containsExactly(
+            AssistantEvent.TextDelta("done"),
+            AssistantEvent.Finish(FinishReason.STOP),
+        )
+    }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/ChatStreamParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/ChatStreamParserTest.kt
@@ -36,7 +36,8 @@ class ChatStreamParserTest {
 
     @Test
     fun `given a tool-call fragment, when parsed, then a ToolCallDelta is emitted with verbatim arguments`() = runTest {
-        val payload = """{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"show_cards","arguments":"{\"a\":"}}]}}]}"""
+        val payload = """{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1",""" +
+            """"function":{"name":"show_cards","arguments":"{\"a\":"}}]}}]}"""
 
         val events = parser.parse(flowOf(payload)).toList()
 


### PR DESCRIPTION
### Description

Part of WOOMOB-2889 (part 2 of 3)

This PR adds the two primitive components that `JetpackAiChatService` depends on — the SSE stream parser and the WP.com JWT token provider. Both are independently testable with no dependency on each other.

This is the second of three stacked PRs for WOOMOB-2889:
- **PR 1 ([#15755](https://github.com/woocommerce/woocommerce-android/pull/15755))** — `:ai-assistant:core` contracts
- **PR 2 (this one)** — `ChatStreamParser` + `WpComJetpackAiTokenProvider`
- **PR 3 ([#15756](https://github.com/woocommerce/woocommerce-android/pull/15756))** — `JetpackAiChatService` + Hilt wiring

Stack: [#15753](https://github.com/woocommerce/woocommerce-android/pull/15753) → [#15755](https://github.com/woocommerce/woocommerce-android/pull/15755) → this PR → [#15756](https://github.com/woocommerce/woocommerce-android/pull/15756).

#### What's in this PR

**`ChatStreamParser`** — parses incoming SSE `data:` lines (emitted by `JetpackAiChatService`) into `AssistantEvent`s. Key behaviors:

- Skips empty/blank lines and the `[DONE]` sentinel, then stops.
- Extracts `choices[0].delta.content` into `TextDelta`, tool-call fragments into `ToolCallDelta` (index required; missing-index entries are silently dropped).
- Maps `finish_reason` strings to `FinishReason`; unknown values map to `OTHER`.
- Handles content and finish_reason in the same chunk by emitting both in order.
- Malformed JSON is surfaced as `Failed(INVALID_STREAM)` rather than throwing, so the loop can decide whether to retry.
- Injectable `@Singleton` reusing the shared `@AiAssistantJson Json` instance.

**`WpComJetpackAiTokenProvider`** — WP.com implementation of `JwtTokenProvider`:

- Pulls the active site from `SelectedSite`; throws `AssistantAuthException` if none is selected.
- Calls `JetpackAIRestClient.fetchJetpackAIJWTToken`; wraps REST errors into `AssistantAuthException` with the `JetpackAICompletionsErrorType` embedded in the message for diagnostics.
- Caches the JWT under a `Mutex`; only successful tokens are cached — errors never fill the cache, so a transient failure doesn't permanently poison subsequent calls.
- Exposes `invalidate()` so the service's 401-retry path can clear the cache and force a fresh token fetch.

### Test Steps

1. Pull the branch (after [#15755](https://github.com/woocommerce/woocommerce-android/pull/15755) is reviewed) and run `:libs:ai-assistant:feature:testDebugUnitTest`.
2. In `ChatStreamParserTest`: pay particular attention to the `[DONE]` sentinel test (ensures lines after `[DONE]` are discarded) and the malformed-payload test (ensures the parser emits `Failed` rather than crashing the flow).
3. In `WpComJetpackAiTokenProviderTest`: check that the error-path test confirms two calls both hit the network (no caching of failures).

### Images/gif

N/A — no UI changes.

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.