### PR TITLE
[WOOMOB-2853] Verify phone is on the same store before pairing for Remote Tap-to-Pay

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/RemoteTapToPayPaymentViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/RemoteTapToPayPaymentViewState.kt
@@ -35,6 +35,7 @@ data class RemoteTapToPayLocationPermissionDenied(
 data class RemoteTapToPayReadyToPair(
     val deviceName: String,
     val fingerprintSuffix: String,
+    val siteUrl: String?,
     override val onPrimaryActionClicked: (() -> Unit),
 ) : ViewState(
     headerLabel = R.string.card_reader_mode_ready_to_pair_header,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeScreen.kt
@@ -154,6 +154,14 @@ private fun StatefulContent(state: ViewState) {
                     fontWeight = FontWeight.Bold,
                     textAlign = TextAlign.Center,
                 )
+                state.siteUrl?.takeIf { it.isNotBlank() }?.let { url ->
+                    Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.minor_100)))
+                    Text(
+                        text = stringResource(id = R.string.card_reader_mode_ready_to_pair_store, url),
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                }
             }
         }
 
@@ -186,6 +194,7 @@ fun CardReaderModeReadyToPairPreview() {
             state = RemoteTapToPayReadyToPair(
                 deviceName = "Pixel 7",
                 fingerprintSuffix = "AB4F",
+                siteUrl = "example.com",
                 onPrimaryActionClicked = {},
             )
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -15,6 +15,7 @@ import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayStar
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayWaitingForPayment
 import com.woocommerce.android.ui.payments.cardreader.payment.ViewState
 import com.woocommerce.android.ui.prefs.developer.DeveloperOptionsRepository
+import com.woocommerce.android.util.siteIdHash
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -60,7 +61,7 @@ class CardReaderModeViewModel @Inject constructor(
 
     private fun startSessionIfNeeded() {
         if (sessionStarted) return
-        val siteId = selectedSite.getOrNull()?.remoteId()?.value ?: return
+        val siteHash = selectedSite.getOrNull()?.remoteId()?.value?.let(::siteIdHash) ?: return
         sessionStarted = true
 
         if (!cardReaderManager.initialized) {
@@ -77,7 +78,7 @@ class CardReaderModeViewModel @Inject constructor(
         }
         session.start(
             parentScope = viewModelScope,
-            siteId = siteId,
+            siteHash = siteHash,
             isSimulated = developerOptionsRepository.isSimulatedCardReaderEnabled(),
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -77,8 +77,8 @@ class CardReaderModeViewModel @Inject constructor(
         }
         session.start(
             parentScope = viewModelScope,
-            isSimulated = developerOptionsRepository.isSimulatedCardReaderEnabled(),
             siteId = siteId,
+            isSimulated = developerOptionsRepository.isSimulatedCardReaderEnabled(),
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSession
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSessionState
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayError
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionDenied
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionExplainer
@@ -29,6 +30,7 @@ class CardReaderModeViewModel @Inject constructor(
     private val session: CardReaderRemoteSession,
     private val cardReaderManager: CardReaderManager,
     private val developerOptionsRepository: DeveloperOptionsRepository,
+    private val selectedSite: SelectedSite,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow<ViewState?>(null)
@@ -75,6 +77,7 @@ class CardReaderModeViewModel @Inject constructor(
         session.start(
             parentScope = viewModelScope,
             isSimulated = developerOptionsRepository.isSimulatedCardReaderEnabled(),
+            siteId = selectedSite.getOrNull()?.siteId,
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -60,6 +60,7 @@ class CardReaderModeViewModel @Inject constructor(
 
     private fun startSessionIfNeeded() {
         if (sessionStarted) return
+        val siteId = selectedSite.getOrNull()?.siteId ?: return
         sessionStarted = true
 
         if (!cardReaderManager.initialized) {
@@ -77,7 +78,7 @@ class CardReaderModeViewModel @Inject constructor(
         session.start(
             parentScope = viewModelScope,
             isSimulated = developerOptionsRepository.isSimulatedCardReaderEnabled(),
-            siteId = selectedSite.getOrNull()?.siteId,
+            siteId = siteId,
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -60,7 +60,7 @@ class CardReaderModeViewModel @Inject constructor(
 
     private fun startSessionIfNeeded() {
         if (sessionStarted) return
-        val siteId = selectedSite.getOrNull()?.siteId ?: return
+        val siteId = selectedSite.getOrNull()?.remoteId()?.value ?: return
         sessionStarted = true
 
         if (!cardReaderManager.initialized) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 
 @HiltViewModel
@@ -94,6 +95,7 @@ class CardReaderModeViewModel @Inject constructor(
         is CardReaderRemoteSessionState.ReadyToPair -> RemoteTapToPayReadyToPair(
             deviceName = state.deviceName,
             fingerprintSuffix = state.fingerprintSuffix,
+            siteUrl = selectedSiteDisplayUrl(),
             onPrimaryActionClicked = ::exit,
         )
         is CardReaderRemoteSessionState.WaitingForPayment -> RemoteTapToPayWaitingForPayment(
@@ -109,4 +111,10 @@ class CardReaderModeViewModel @Inject constructor(
     private fun exit() {
         _events.trySend(CardReaderModeEvent.Exit)
     }
+
+    private fun selectedSiteDisplayUrl(): String? =
+        selectedSite.getOrNull()?.url
+            ?.takeIf { it.isNotBlank() }
+            ?.let(UrlUtils::removeScheme)
+            ?.trim('/')
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
@@ -35,6 +35,7 @@ class WooPosRemoteReaderDiscovery @Inject constructor(
                         host = event.reader.host,
                         port = event.reader.port,
                         fingerprintBase64 = event.reader.fingerprintBase64,
+                        siteId = event.reader.siteId,
                     )
                 )
                 is RemoteReaderDiscoveryEvent.Removed -> WooPosPhoneDiscoveryEvent.Removed(event.name)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
@@ -35,7 +35,7 @@ class WooPosRemoteReaderDiscovery @Inject constructor(
                         host = event.reader.host,
                         port = event.reader.port,
                         fingerprintBase64 = event.reader.fingerprintBase64,
-                        siteId = event.reader.siteId,
+                        siteHash = event.reader.siteHash,
                     )
                 )
                 is RemoteReaderDiscoveryEvent.Removed -> WooPosPhoneDiscoveryEvent.Removed(event.name)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
@@ -10,7 +10,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -27,20 +27,17 @@ class WooPosRemoteReaderDiscovery @Inject constructor(
     private val remoteDiscovery: CardReaderRemoteDiscovery,
 ) : WooPosPhoneDiscoverySource {
     override fun discover(): Flow<WooPosPhoneDiscoveryEvent> =
-        remoteDiscovery.discover().mapNotNull { event ->
+        remoteDiscovery.discover().map { event ->
             when (event) {
-                is RemoteReaderDiscoveryEvent.Added -> {
-                    val siteId = event.reader.siteId ?: return@mapNotNull null
-                    WooPosPhoneDiscoveryEvent.Added(
-                        WooPosDiscoveredReader.Phone(
-                            name = event.reader.deviceName?.takeIf { it.isNotBlank() } ?: event.reader.name,
-                            host = event.reader.host,
-                            port = event.reader.port,
-                            fingerprintBase64 = event.reader.fingerprintBase64,
-                            siteId = siteId,
-                        )
+                is RemoteReaderDiscoveryEvent.Added -> WooPosPhoneDiscoveryEvent.Added(
+                    WooPosDiscoveredReader.Phone(
+                        name = event.reader.deviceName?.takeIf { it.isNotBlank() } ?: event.reader.name,
+                        host = event.reader.host,
+                        port = event.reader.port,
+                        fingerprintBase64 = event.reader.fingerprintBase64,
+                        siteId = event.reader.siteId,
                     )
-                }
+                )
                 is RemoteReaderDiscoveryEvent.Removed -> WooPosPhoneDiscoveryEvent.Removed(event.name)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
@@ -10,7 +10,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -27,17 +27,20 @@ class WooPosRemoteReaderDiscovery @Inject constructor(
     private val remoteDiscovery: CardReaderRemoteDiscovery,
 ) : WooPosPhoneDiscoverySource {
     override fun discover(): Flow<WooPosPhoneDiscoveryEvent> =
-        remoteDiscovery.discover().map { event ->
+        remoteDiscovery.discover().mapNotNull { event ->
             when (event) {
-                is RemoteReaderDiscoveryEvent.Added -> WooPosPhoneDiscoveryEvent.Added(
-                    WooPosDiscoveredReader.Phone(
-                        name = event.reader.deviceName?.takeIf { it.isNotBlank() } ?: event.reader.name,
-                        host = event.reader.host,
-                        port = event.reader.port,
-                        fingerprintBase64 = event.reader.fingerprintBase64,
-                        siteId = event.reader.siteId,
+                is RemoteReaderDiscoveryEvent.Added -> {
+                    val siteId = event.reader.siteId ?: return@mapNotNull null
+                    WooPosPhoneDiscoveryEvent.Added(
+                        WooPosDiscoveredReader.Phone(
+                            name = event.reader.deviceName?.takeIf { it.isNotBlank() } ?: event.reader.name,
+                            host = event.reader.host,
+                            port = event.reader.port,
+                            fingerprintBase64 = event.reader.fingerprintBase64,
+                            siteId = siteId,
+                        )
                     )
-                )
+                }
                 is RemoteReaderDiscoveryEvent.Removed -> WooPosPhoneDiscoveryEvent.Removed(event.name)
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
@@ -99,6 +99,7 @@ class WooPosRemoteReaderSession @Inject constructor(
             port = reader.port,
             fingerprintBase64 = reader.fingerprintBase64,
             deviceName = reader.name,
+            siteId = reader.siteId,
         )
         return when (val outcome = newClient.connect(discovered, token, locationId)) {
             is ConnectOutcome.Success -> State.Connected(reader, outcome.readerSerial)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
@@ -102,7 +102,7 @@ class WooPosRemoteReaderSession @Inject constructor(
             port = reader.port,
             fingerprintBase64 = reader.fingerprintBase64,
             deviceName = reader.name,
-            siteId = reader.siteId,
+            siteHash = reader.siteHash,
         )
         return when (val outcome = newClient.connect(discovered, token, locationId)) {
             is ConnectOutcome.Success -> State.Connected(reader, outcome.readerSerial)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.cardreader.remote
 
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.siteIdHash
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -11,7 +12,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor(
     private val selectedSite: SelectedSite,
 ) : WooPosPhoneDiscoverySource {
     override fun discover(): Flow<WooPosPhoneDiscoveryEvent> = flow {
-        val siteId = selectedSite.get().remoteId().value
+        val siteHash = siteIdHash(selectedSite.get().remoteId().value)
         delay(FIRST_PHONE_DELAY_MS)
         emit(
             WooPosPhoneDiscoveryEvent.Added(
@@ -20,7 +21,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor(
                     host = InetAddress.getByName("127.0.0.1"),
                     port = 9000,
                     fingerprintBase64 = "SIM1",
-                    siteId = siteId,
+                    siteHash = siteHash,
                     isSimulated = true,
                 )
             )
@@ -33,7 +34,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor(
                     host = InetAddress.getByName("127.0.0.2"),
                     port = 9001,
                     fingerprintBase64 = "SIM2",
-                    siteId = siteId,
+                    siteHash = siteHash,
                     isSimulated = true,
                 )
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
@@ -24,6 +24,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor() : WooPosPhoneDi
                 host = InetAddress.getLoopbackAddress(),
                 port = 9000,
                 fingerprintBase64 = "SIM1",
+                siteId = null,
                 isSimulated = true,
             ),
             WooPosDiscoveredReader.Phone(
@@ -31,6 +32,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor() : WooPosPhoneDi
                 host = InetAddress.getLoopbackAddress(),
                 port = 9001,
                 fingerprintBase64 = "SIM2",
+                siteId = null,
                 isSimulated = true,
             ),
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
@@ -1,40 +1,47 @@
 package com.woocommerce.android.ui.woopos.cardreader.remote
 
+import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.net.InetAddress
 import javax.inject.Inject
 
-class WooPosSimulatedRemoteReaderDiscovery @Inject constructor() : WooPosPhoneDiscoverySource {
+class WooPosSimulatedRemoteReaderDiscovery @Inject constructor(
+    private val selectedSite: SelectedSite,
+) : WooPosPhoneDiscoverySource {
     override fun discover(): Flow<WooPosPhoneDiscoveryEvent> = flow {
+        val siteId = selectedSite.get().siteId
         delay(FIRST_PHONE_DELAY_MS)
-        emit(WooPosPhoneDiscoveryEvent.Added(simulatedPhones[0]))
+        emit(
+            WooPosPhoneDiscoveryEvent.Added(
+                WooPosDiscoveredReader.Phone(
+                    name = "Simulated Pixel 7",
+                    host = InetAddress.getByName("127.0.0.1"),
+                    port = 9000,
+                    fingerprintBase64 = "SIM1",
+                    siteId = siteId,
+                    isSimulated = true,
+                )
+            )
+        )
         delay(SECOND_PHONE_DELAY_MS)
-        emit(WooPosPhoneDiscoveryEvent.Added(simulatedPhones[1]))
+        emit(
+            WooPosPhoneDiscoveryEvent.Added(
+                WooPosDiscoveredReader.Phone(
+                    name = "Simulated Galaxy S24",
+                    host = InetAddress.getByName("127.0.0.2"),
+                    port = 9001,
+                    fingerprintBase64 = "SIM2",
+                    siteId = siteId,
+                    isSimulated = true,
+                )
+            )
+        )
     }
 
     private companion object {
         const val FIRST_PHONE_DELAY_MS = 500L
         const val SECOND_PHONE_DELAY_MS = 1_000L
-
-        val simulatedPhones = listOf(
-            WooPosDiscoveredReader.Phone(
-                name = "Simulated Pixel 7",
-                host = InetAddress.getByName("127.0.0.1"),
-                port = 9000,
-                fingerprintBase64 = "SIM1",
-                siteId = null,
-                isSimulated = true,
-            ),
-            WooPosDiscoveredReader.Phone(
-                name = "Simulated Galaxy S24",
-                host = InetAddress.getByName("127.0.0.2"),
-                port = 9001,
-                fingerprintBase64 = "SIM2",
-                siteId = null,
-                isSimulated = true,
-            ),
-        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
@@ -21,7 +21,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor() : WooPosPhoneDi
         val simulatedPhones = listOf(
             WooPosDiscoveredReader.Phone(
                 name = "Simulated Pixel 7",
-                host = InetAddress.getLoopbackAddress(),
+                host = InetAddress.getByName("127.0.0.1"),
                 port = 9000,
                 fingerprintBase64 = "SIM1",
                 siteId = null,
@@ -29,7 +29,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor() : WooPosPhoneDi
             ),
             WooPosDiscoveredReader.Phone(
                 name = "Simulated Galaxy S24",
-                host = InetAddress.getLoopbackAddress(),
+                host = InetAddress.getByName("127.0.0.2"),
                 port = 9001,
                 fingerprintBase64 = "SIM2",
                 siteId = null,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
@@ -11,7 +11,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor(
     private val selectedSite: SelectedSite,
 ) : WooPosPhoneDiscoverySource {
     override fun discover(): Flow<WooPosPhoneDiscoveryEvent> = flow {
-        val siteId = selectedSite.get().siteId
+        val siteId = selectedSite.get().remoteId().value
         delay(FIRST_PHONE_DELAY_MS)
         emit(
             WooPosPhoneDiscoveryEvent.Added(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
+import com.woocommerce.android.util.siteIdHash
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -30,7 +31,7 @@ sealed class WooPosDiscoveredReader {
         val host: InetAddress,
         val port: Int,
         val fingerprintBase64: String,
-        val siteId: Long,
+        val siteHash: String,
         val isSimulated: Boolean = false,
     ) : WooPosDiscoveredReader() {
         override val transport = WooPosDiscoveryTransport.WifiLan
@@ -113,9 +114,9 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
         phone: WooPosDiscoveredReader.Phone,
     ) {
         mutex.withLock {
-            val expectedSiteId = selectedSite.getOrNull()?.remoteId()?.value
-            if (phone.siteId != expectedSiteId) {
-                logger.d("Dropping NSD phone with site mismatch (got=${phone.siteId}, expected=$expectedSiteId)")
+            val expectedSiteHash = selectedSite.getOrNull()?.remoteId()?.value?.let(::siteIdHash)
+            if (expectedSiteHash == null || phone.siteHash != expectedSiteHash) {
+                logger.d("Dropping NSD phone with site mismatch")
                 return@withLock
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
@@ -113,7 +113,7 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
         phone: WooPosDiscoveredReader.Phone,
     ) {
         mutex.withLock {
-            val expectedSiteId = selectedSite.getOrNull()?.siteId
+            val expectedSiteId = selectedSite.getOrNull()?.remoteId()?.value
             if (phone.siteId != expectedSiteId) {
                 logger.d("Dropping NSD phone with site mismatch (got=${phone.siteId}, expected=$expectedSiteId)")
                 return@withLock

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
@@ -30,7 +30,7 @@ sealed class WooPosDiscoveredReader {
         val host: InetAddress,
         val port: Int,
         val fingerprintBase64: String,
-        val siteId: Long?,
+        val siteId: Long,
         val isSimulated: Boolean = false,
     ) : WooPosDiscoveredReader() {
         override val transport = WooPosDiscoveryTransport.WifiLan
@@ -114,7 +114,7 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
     ) {
         mutex.withLock {
             val expectedSiteId = selectedSite.getOrNull()?.siteId
-            if (phone.siteId != null && phone.siteId != expectedSiteId) {
+            if (phone.siteId != expectedSiteId) {
                 logger.d("Dropping NSD phone with site mismatch (got=${phone.siteId}, expected=$expectedSiteId)")
                 return@withLock
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
@@ -29,6 +30,7 @@ sealed class WooPosDiscoveredReader {
         val host: InetAddress,
         val port: Int,
         val fingerprintBase64: String,
+        val siteId: Long?,
         val isSimulated: Boolean = false,
     ) : WooPosDiscoveredReader() {
         override val transport = WooPosDiscoveryTransport.WifiLan
@@ -52,6 +54,7 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
     private val remoteDiscovery: WooPosRemoteReaderDiscovery,
     private val simulatedRemoteDiscovery: WooPosSimulatedRemoteReaderDiscovery,
     private val featureFlagRepository: FeatureFlagRepository,
+    private val selectedSite: SelectedSite,
     private val logger: WooPosLogWrapper,
 ) {
     fun discover(
@@ -110,6 +113,12 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
         phone: WooPosDiscoveredReader.Phone,
     ) {
         mutex.withLock {
+            val expectedSiteId = selectedSite.getOrNull()?.siteId
+            if (phone.siteId != null && phone.siteId != expectedSiteId) {
+                logger.d("Dropping NSD phone with site mismatch (got=${phone.siteId}, expected=$expectedSiteId)")
+                return@withLock
+            }
+
             val fingerprint = phone.fingerprintBase64
 
             // The phone may have re-registered with a new fingerprint+name without us

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SiteIdHash.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/SiteIdHash.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.util
+
+import java.security.MessageDigest
+
+private const val SITE_HASH_PREFIX = "woopos-site-v1:"
+private const val SITE_HASH_HEX_LENGTH = 32
+
+fun siteIdHash(remoteId: Long): String {
+    val bytes = MessageDigest.getInstance("SHA-256")
+        .digest("$SITE_HASH_PREFIX$remoteId".toByteArray(Charsets.UTF_8))
+    return bytes.joinToString(separator = "") { "%02x".format(it) }.take(SITE_HASH_HEX_LENGTH)
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4137,7 +4137,7 @@
     <string name="woopos_remote_ttp_explainer_setup_heading">Set up your phone</string>
     <string name="woopos_remote_ttp_explainer_setup_body">Open Woo on your phone, then go to Settings → Payments → Card Reader Mode.</string>
     <string name="woopos_remote_ttp_explainer_requirements_heading">Check compatibility</string>
-    <string name="woopos_remote_ttp_explainer_requirements_body">Use the same Wi-Fi and sign in to the same store on both devices. Your phone needs Android 11 or newer, NFC, and Tap-to-Pay support.</string>
+    <string name="woopos_remote_ttp_explainer_requirements_body">Use the same Wi-Fi and sign in to the same store on both devices. Your phone needs Android 13 or newer, NFC, and Tap-to-Pay support.</string>
     <string name="woopos_remote_ttp_explainer_got_it">Got it</string>
 
     <string name="customers_details_customer_section">Customer</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -4137,7 +4137,7 @@
     <string name="woopos_remote_ttp_explainer_setup_heading">Set up your phone</string>
     <string name="woopos_remote_ttp_explainer_setup_body">Open Woo on your phone, then go to Settings → Payments → Card Reader Mode.</string>
     <string name="woopos_remote_ttp_explainer_requirements_heading">Check compatibility</string>
-    <string name="woopos_remote_ttp_explainer_requirements_body">Use the same Wi-Fi as this tablet. Your phone needs Android 11 or newer, NFC, and Tap-to-Pay support.</string>
+    <string name="woopos_remote_ttp_explainer_requirements_body">Use the same Wi-Fi and sign in to the same store on both devices. Your phone needs Android 11 or newer, NFC, and Tap-to-Pay support.</string>
     <string name="woopos_remote_ttp_explainer_got_it">Got it</string>
 
     <string name="customers_details_customer_section">Customer</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -1522,6 +1522,7 @@
 
     <string name="card_reader_mode_ready_to_pair_header">Ready to pair</string>
     <string name="card_reader_mode_ready_to_pair_subtitle">Open Woo POS on your tablet and pick this phone.</string>
+    <string name="card_reader_mode_ready_to_pair_store">Store: %1$s</string>
     <string name="card_reader_mode_waiting_header">Paired with tablet</string>
     <string name="card_reader_mode_waiting_subtitle">Waiting for payment…</string>
     <string name="card_reader_mode_cancel">Cancel</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/RemoteTapToPayPaymentViewStateTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/RemoteTapToPayPaymentViewStateTest.kt
@@ -12,12 +12,14 @@ class RemoteTapToPayPaymentViewStateTest {
         val state = RemoteTapToPayReadyToPair(
             deviceName = "Pixel 7",
             fingerprintSuffix = "AB4F",
+            siteUrl = "example.com",
             onPrimaryActionClicked = {}
         )
 
         // WHEN // THEN
         assertThat(state.deviceName).isEqualTo("Pixel 7")
         assertThat(state.fingerprintSuffix).isEqualTo("AB4F")
+        assertThat(state.siteUrl).isEqualTo("example.com")
         assertThat(state.primaryActionLabel).isEqualTo(R.string.card_reader_mode_cancel)
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelStore
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSession
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSessionState
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayError
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionDenied
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionExplainer
@@ -22,6 +23,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -37,6 +39,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         on { initialized }.thenReturn(true)
     }
     private val developerOptionsRepository: DeveloperOptionsRepository = mock()
+    private val selectedSite: SelectedSite = mock()
 
     private lateinit var store: ViewModelStore
     private lateinit var viewModel: CardReaderModeViewModel
@@ -51,6 +54,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
                     session,
                     cardReaderManager,
                     developerOptionsRepository,
+                    selectedSite,
                 ) as T
         }
         viewModel = ViewModelProvider(store, factory)[CardReaderModeViewModel::class.java]
@@ -59,7 +63,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     @Test
     fun `when view model initialized, then session is not started yet`() {
         // THEN
-        verify(session, never()).start(any(), any())
+        verify(session, never()).start(any(), any(), anyOrNull())
     }
 
     @Test
@@ -68,7 +72,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
         // THEN
-        verify(session).start(any(), any())
+        verify(session).start(any(), any(), anyOrNull())
     }
 
     @Test
@@ -78,7 +82,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
         // THEN
-        verify(session, times(1)).start(any(), any())
+        verify(session, times(1)).start(any(), any(), anyOrNull())
     }
 
     @Test
@@ -89,7 +93,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat(viewModel.viewState.value).isInstanceOf(RemoteTapToPayLocationPermissionExplainer::class.java)
-        verify(session, never()).start(any(), any())
+        verify(session, never()).start(any(), any(), anyOrNull())
     }
 
     @Test
@@ -100,7 +104,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat(viewModel.viewState.value).isInstanceOf(RemoteTapToPayLocationPermissionDenied::class.java)
-        verify(session, never()).start(any(), any())
+        verify(session, never()).start(any(), any(), anyOrNull())
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSession
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSessionState
 import com.woocommerce.android.tools.SelectedSite
-import org.wordpress.android.fluxc.model.SiteModel
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayError
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionDenied
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionExplainer
@@ -28,6 +27,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.wordpress.android.fluxc.model.SiteModel
 
 @ExperimentalCoroutinesApi
 class CardReaderModeViewModelTest : BaseUnitTest() {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
@@ -40,7 +40,12 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     }
     private val developerOptionsRepository: DeveloperOptionsRepository = mock()
     private val selectedSite: SelectedSite = mock {
-        on { getOrNull() }.thenReturn(SiteModel().apply { siteId = 1L })
+        on { getOrNull() }.thenReturn(
+            SiteModel().apply {
+                siteId = 1L
+                url = "https://example.com"
+            }
+        )
     }
 
     private lateinit var store: ViewModelStore
@@ -138,6 +143,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         val viewState = viewModel.viewState.value as RemoteTapToPayReadyToPair
         assertThat(viewState.deviceName).isEqualTo("Pixel")
         assertThat(viewState.fingerprintSuffix).isEqualTo("1234")
+        assertThat(viewState.siteUrl).isEqualTo("example.com")
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSession
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteSessionState
 import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.model.SiteModel
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayError
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionDenied
 import com.woocommerce.android.ui.payments.cardreader.payment.RemoteTapToPayLocationPermissionExplainer
@@ -23,7 +24,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -39,7 +39,9 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         on { initialized }.thenReturn(true)
     }
     private val developerOptionsRepository: DeveloperOptionsRepository = mock()
-    private val selectedSite: SelectedSite = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { getOrNull() }.thenReturn(SiteModel().apply { siteId = 1L })
+    }
 
     private lateinit var store: ViewModelStore
     private lateinit var viewModel: CardReaderModeViewModel
@@ -63,7 +65,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     @Test
     fun `when view model initialized, then session is not started yet`() {
         // THEN
-        verify(session, never()).start(any(), any(), anyOrNull())
+        verify(session, never()).start(any(), any(), any())
     }
 
     @Test
@@ -72,7 +74,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
         // THEN
-        verify(session).start(any(), any(), anyOrNull())
+        verify(session).start(any(), any(), any())
     }
 
     @Test
@@ -82,7 +84,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
         // THEN
-        verify(session, times(1)).start(any(), any(), anyOrNull())
+        verify(session, times(1)).start(any(), any(), any())
     }
 
     @Test
@@ -93,7 +95,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat(viewModel.viewState.value).isInstanceOf(RemoteTapToPayLocationPermissionExplainer::class.java)
-        verify(session, never()).start(any(), any(), anyOrNull())
+        verify(session, never()).start(any(), any(), any())
     }
 
     @Test
@@ -104,7 +106,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat(viewModel.viewState.value).isInstanceOf(RemoteTapToPayLocationPermissionDenied::class.java)
-        verify(session, never()).start(any(), any(), anyOrNull())
+        verify(session, never()).start(any(), any(), any())
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -732,6 +732,7 @@ class WooPosCardPaymentViewModelTest {
             host = InetAddress.getByName("127.0.0.1"),
             port = 1234,
             fingerprintBase64 = "fp",
+            siteId = null,
             isSimulated = true,
         )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -665,7 +665,7 @@ class WooPosCardPaymentViewModelTest {
             reader = simulatedRemoteReader(),
             readerSerial = "SIM-1",
         )
-        whenever(remoteReaderPaymentFlow.collect(any()))
+        whenever(remoteReaderPaymentFlow.collect(any(), any()))
             .doSuspendableAnswer { awaitCancellation() }
 
         viewModel = createViewModel(source = CardPaymentSource.CHECKOUT)
@@ -688,7 +688,7 @@ class WooPosCardPaymentViewModelTest {
             reader = simulatedRemoteReader(),
             readerSerial = "SIM-1",
         )
-        whenever(remoteReaderPaymentFlow.collect(any()))
+        whenever(remoteReaderPaymentFlow.collect(any(), any()))
             .doSuspendableAnswer { awaitCancellation() }
 
         viewModel = createViewModel(source = CardPaymentSource.CHECKOUT)
@@ -711,7 +711,7 @@ class WooPosCardPaymentViewModelTest {
             reader = simulatedRemoteReader(),
             readerSerial = "SIM-1",
         )
-        whenever(remoteReaderPaymentFlow.collect(any()))
+        whenever(remoteReaderPaymentFlow.collect(any(), any()))
             .thenReturn(WooPosRemoteReaderPaymentFlow.Result.Failed("error"))
 
         viewModel = createViewModel(source = CardPaymentSource.CHECKOUT)
@@ -723,7 +723,7 @@ class WooPosCardPaymentViewModelTest {
         advanceUntilIdle()
 
         // THEN
-        verify(remoteReaderPaymentFlow, times(2)).collect(any())
+        verify(remoteReaderPaymentFlow, times(2)).collect(any(), any())
     }
 
     private fun simulatedRemoteReader() =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -732,7 +732,7 @@ class WooPosCardPaymentViewModelTest {
             host = InetAddress.getByName("127.0.0.1"),
             port = 1234,
             fingerprintBase64 = "fp",
-            siteId = 1L,
+            siteHash = "site-hash",
             isSimulated = true,
         )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -732,7 +732,7 @@ class WooPosCardPaymentViewModelTest {
             host = InetAddress.getByName("127.0.0.1"),
             port = 1234,
             fingerprintBase64 = "fp",
-            siteId = null,
+            siteId = 1L,
             isSimulated = true,
         )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
@@ -169,6 +169,7 @@ class WooPosRemoteReaderSessionTest {
         host = InetAddress.getLoopbackAddress(),
         port = 9000,
         fingerprintBase64 = "AB4F",
+        siteId = null,
         isSimulated = isSimulated,
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
@@ -169,7 +169,7 @@ class WooPosRemoteReaderSessionTest {
         host = InetAddress.getLoopbackAddress(),
         port = 9000,
         fingerprintBase64 = "AB4F",
-        siteId = null,
+        siteId = 1L,
         isSimulated = isSimulated,
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
@@ -174,7 +174,7 @@ class WooPosRemoteReaderSessionTest {
         host = InetAddress.getLoopbackAddress(),
         port = 9000,
         fingerprintBase64 = "AB4F",
-        siteId = 1L,
+        siteHash = "site-hash",
         isSimulated = isSimulated,
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
@@ -194,7 +194,7 @@ class WooPosUnifiedDiscoveryStreamTest {
         }
     }
 
-    private fun phone(name: String, siteId: Long? = TABLET_SITE_ID) = WooPosDiscoveredReader.Phone(
+    private fun phone(name: String, siteId: Long = TABLET_SITE_ID) = WooPosDiscoveredReader.Phone(
         name = name,
         host = InetAddress.getLoopbackAddress(),
         port = 9000,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover.SpecificReaders.ExternalReaders
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.Chipper2X
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
@@ -17,6 +18,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
 import java.net.InetAddress
 
 @ExperimentalCoroutinesApi
@@ -25,6 +27,9 @@ class WooPosUnifiedDiscoveryStreamTest {
     private val remoteDiscovery: WooPosRemoteReaderDiscovery = mock()
     private val simulatedRemoteDiscovery: WooPosSimulatedRemoteReaderDiscovery = mock()
     private val featureFlagRepository: FeatureFlagRepository = mock()
+    private val selectedSite: SelectedSite = mock {
+        on { getOrNull() }.thenReturn(SiteModel().apply { siteId = TABLET_SITE_ID })
+    }
     private val logger: WooPosLogWrapper = mock()
 
     private val types: CardReaderTypesToDiscover = ExternalReaders(listOf(Chipper2X))
@@ -49,6 +54,7 @@ class WooPosUnifiedDiscoveryStreamTest {
             remoteDiscovery,
             simulatedRemoteDiscovery,
             featureFlagRepository,
+            selectedSite,
             logger,
         )
 
@@ -80,6 +86,7 @@ class WooPosUnifiedDiscoveryStreamTest {
             remoteDiscovery,
             simulatedRemoteDiscovery,
             featureFlagRepository,
+            selectedSite,
             logger,
         )
 
@@ -116,6 +123,7 @@ class WooPosUnifiedDiscoveryStreamTest {
             remoteDiscovery,
             simulatedRemoteDiscovery,
             featureFlagRepository,
+            selectedSite,
             logger,
         )
 
@@ -130,10 +138,72 @@ class WooPosUnifiedDiscoveryStreamTest {
         }
     }
 
-    private fun phone(name: String) = WooPosDiscoveredReader.Phone(
+    @Test
+    fun `given phone advertises different siteId, when discovered, then phone is not surfaced`() = runTest {
+        // GIVEN
+        whenever(cardReaderManager.discoverReaders(false, types)).thenReturn(
+            flowOf(CardReaderDiscoveryEvents.Started)
+        )
+        val mismatchedPhone = phone(name = "Pixel 7", siteId = OTHER_SITE_ID)
+        whenever(remoteDiscovery.discover()).thenReturn(
+            flowOf(WooPosPhoneDiscoveryEvent.Added(mismatchedPhone))
+        )
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(true)
+        val sut = WooPosUnifiedDiscoveryStream(
+            cardReaderManager,
+            remoteDiscovery,
+            simulatedRemoteDiscovery,
+            featureFlagRepository,
+            selectedSite,
+            logger,
+        )
+
+        // WHEN / THEN
+        sut.discover(isSimulated = false, cardReaderTypesToDiscover = types).test {
+            assertThat(awaitItem()).isEqualTo(WooPosUnifiedDiscoveryEvent.Started)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `given phone advertises matching siteId, when discovered, then phone is surfaced`() = runTest {
+        // GIVEN
+        whenever(cardReaderManager.discoverReaders(false, types)).thenReturn(
+            flowOf(CardReaderDiscoveryEvents.Started)
+        )
+        val matchingPhone = phone(name = "Pixel 7", siteId = TABLET_SITE_ID)
+        whenever(remoteDiscovery.discover()).thenReturn(
+            flowOf(WooPosPhoneDiscoveryEvent.Added(matchingPhone))
+        )
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(true)
+        val sut = WooPosUnifiedDiscoveryStream(
+            cardReaderManager,
+            remoteDiscovery,
+            simulatedRemoteDiscovery,
+            featureFlagRepository,
+            selectedSite,
+            logger,
+        )
+
+        // WHEN / THEN
+        sut.discover(isSimulated = false, cardReaderTypesToDiscover = types).test {
+            assertThat(awaitItem()).isEqualTo(WooPosUnifiedDiscoveryEvent.Started)
+            val found = awaitItem() as WooPosUnifiedDiscoveryEvent.ReadersFound
+            assertThat(found.readers).containsExactly(matchingPhone)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun phone(name: String, siteId: Long? = TABLET_SITE_ID) = WooPosDiscoveredReader.Phone(
         name = name,
         host = InetAddress.getLoopbackAddress(),
         port = 9000,
         fingerprintBase64 = "AB4F",
+        siteId = siteId,
     )
+
+    private companion object {
+        const val TABLET_SITE_ID = 123L
+        const val OTHER_SITE_ID = 456L
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
+import com.woocommerce.android.util.siteIdHash
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -139,12 +140,12 @@ class WooPosUnifiedDiscoveryStreamTest {
     }
 
     @Test
-    fun `given phone advertises different siteId, when discovered, then phone is not surfaced`() = runTest {
+    fun `given phone advertises different site hash, when discovered, then phone is not surfaced`() = runTest {
         // GIVEN
         whenever(cardReaderManager.discoverReaders(false, types)).thenReturn(
             flowOf(CardReaderDiscoveryEvents.Started)
         )
-        val mismatchedPhone = phone(name = "Pixel 7", siteId = OTHER_SITE_ID)
+        val mismatchedPhone = phone(name = "Pixel 7", siteHash = siteIdHash(OTHER_SITE_ID))
         whenever(remoteDiscovery.discover()).thenReturn(
             flowOf(WooPosPhoneDiscoveryEvent.Added(mismatchedPhone))
         )
@@ -166,12 +167,12 @@ class WooPosUnifiedDiscoveryStreamTest {
     }
 
     @Test
-    fun `given phone advertises matching siteId, when discovered, then phone is surfaced`() = runTest {
+    fun `given phone advertises matching site hash, when discovered, then phone is surfaced`() = runTest {
         // GIVEN
         whenever(cardReaderManager.discoverReaders(false, types)).thenReturn(
             flowOf(CardReaderDiscoveryEvents.Started)
         )
-        val matchingPhone = phone(name = "Pixel 7", siteId = TABLET_SITE_ID)
+        val matchingPhone = phone(name = "Pixel 7", siteHash = siteIdHash(TABLET_SITE_ID))
         whenever(remoteDiscovery.discover()).thenReturn(
             flowOf(WooPosPhoneDiscoveryEvent.Added(matchingPhone))
         )
@@ -194,12 +195,12 @@ class WooPosUnifiedDiscoveryStreamTest {
         }
     }
 
-    private fun phone(name: String, siteId: Long = TABLET_SITE_ID) = WooPosDiscoveredReader.Phone(
+    private fun phone(name: String, siteHash: String = siteIdHash(TABLET_SITE_ID)) = WooPosDiscoveredReader.Phone(
         name = name,
         host = InetAddress.getLoopbackAddress(),
         port = 9000,
         fingerprintBase64 = "AB4F",
-        siteId = siteId,
+        siteHash = siteHash,
     )
 
     private companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -391,7 +391,7 @@ class WooPosHomeFloatingToolbarViewModelTest {
             host = InetAddress.getByName("127.0.0.1"),
             port = 0,
             fingerprintBase64 = "fp",
-            siteId = 1L,
+            siteHash = "site-hash",
         )
         whenever(remoteReaderSession.state).thenReturn(
             MutableStateFlow(WooPosRemoteReaderSession.State.Connected(phone, readerSerial = "serial"))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -391,6 +391,7 @@ class WooPosHomeFloatingToolbarViewModelTest {
             host = InetAddress.getByName("127.0.0.1"),
             port = 0,
             fingerprintBase64 = "fp",
+            siteId = null,
         )
         whenever(remoteReaderSession.state).thenReturn(
             MutableStateFlow(WooPosRemoteReaderSession.State.Connected(phone, readerSerial = "serial"))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -391,7 +391,7 @@ class WooPosHomeFloatingToolbarViewModelTest {
             host = InetAddress.getByName("127.0.0.1"),
             port = 0,
             fingerprintBase64 = "fp",
-            siteId = null,
+            siteId = 1L,
         )
         whenever(remoteReaderSession.state).thenReturn(
             MutableStateFlow(WooPosRemoteReaderSession.State.Connected(phone, readerSerial = "serial"))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1986,7 +1986,7 @@ class WooPosTotalsViewModelTest {
             host = java.net.InetAddress.getByName("127.0.0.1"),
             port = 1234,
             fingerprintBase64 = "fp",
-            siteId = 1L,
+            siteHash = "site-hash",
             isSimulated = true,
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1965,7 +1965,7 @@ class WooPosTotalsViewModelTest {
                 )
             )
             whenever(remoteReaderSession.state).thenReturn(remoteState)
-            whenever(remoteReaderPaymentFlow.collect(any()))
+            whenever(remoteReaderPaymentFlow.collect(any(), any()))
                 .thenReturn(WooPosRemoteReaderPaymentFlow.Result.Failed("error"))
 
             val vm = createViewModelAndSetupForSuccessfulOrderCreation()
@@ -1977,7 +1977,7 @@ class WooPosTotalsViewModelTest {
             advanceUntilIdle()
 
             // THEN
-            verify(remoteReaderPaymentFlow, org.mockito.kotlin.times(2)).collect(any())
+            verify(remoteReaderPaymentFlow, org.mockito.kotlin.times(2)).collect(any(), any())
         }
 
     private fun simulatedRemoteReader() =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1986,7 +1986,7 @@ class WooPosTotalsViewModelTest {
             host = java.net.InetAddress.getByName("127.0.0.1"),
             port = 1234,
             fingerprintBase64 = "fp",
-            siteId = null,
+            siteId = 1L,
             isSimulated = true,
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1986,6 +1986,7 @@ class WooPosTotalsViewModelTest {
             host = java.net.InetAddress.getByName("127.0.0.1"),
             port = 1234,
             fingerprintBase64 = "fp",
+            siteId = null,
             isSimulated = true,
         )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/SiteIdHashTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/SiteIdHashTest.kt
@@ -1,0 +1,35 @@
+package com.woocommerce.android.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SiteIdHashTest {
+    @Test
+    fun `given same remote id, when hashed, then produces same result`() {
+        // WHEN
+        val hashA = siteIdHash(123L)
+        val hashB = siteIdHash(123L)
+
+        // THEN
+        assertThat(hashA).isEqualTo(hashB)
+    }
+
+    @Test
+    fun `given different remote ids, when hashed, then produces different results`() {
+        // WHEN
+        val hashA = siteIdHash(123L)
+        val hashB = siteIdHash(456L)
+
+        // THEN
+        assertThat(hashA).isNotEqualTo(hashB)
+    }
+
+    @Test
+    fun `when hashed, then result does not contain raw remote id`() {
+        // WHEN
+        val hash = siteIdHash(987654321L)
+
+        // THEN
+        assertThat(hash).doesNotContain("987654321")
+    }
+}

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
@@ -26,6 +26,7 @@ data class DiscoveredRemoteReader(
     val port: Int,
     val fingerprintBase64: String,
     val deviceName: String?,
+    val siteId: Long?,
 )
 
 internal class DefaultCardReaderRemoteDiscovery(
@@ -64,4 +65,5 @@ private fun CardReaderRemoteResolvedHost.toPublic() =
         port = port,
         fingerprintBase64 = fingerprintBase64,
         deviceName = deviceName,
+        siteId = siteId,
     )

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
@@ -26,7 +26,7 @@ data class DiscoveredRemoteReader(
     val port: Int,
     val fingerprintBase64: String,
     val deviceName: String?,
-    val siteId: Long?,
+    val siteId: Long,
 )
 
 internal class DefaultCardReaderRemoteDiscovery(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
@@ -26,7 +26,7 @@ data class DiscoveredRemoteReader(
     val port: Int,
     val fingerprintBase64: String,
     val deviceName: String?,
-    val siteId: Long,
+    val siteHash: String,
 )
 
 internal class DefaultCardReaderRemoteDiscovery(
@@ -65,5 +65,5 @@ private fun CardReaderRemoteResolvedHost.toPublic() =
         port = port,
         fingerprintBase64 = fingerprintBase64,
         deviceName = deviceName,
-        siteId = siteId,
+        siteHash = siteHash,
     )

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
@@ -33,7 +33,7 @@ internal class CardReaderRemoteNsd(
         port: Int,
         fingerprint: String,
         deviceName: String,
-        siteId: Long,
+        siteHash: String,
     ): CardReaderRemoteNsdRegistration =
         withContext(ioDispatcher) {
             val serviceInfo = NsdServiceInfo().apply {
@@ -43,7 +43,7 @@ internal class CardReaderRemoteNsd(
                 setAttribute(TXT_KEY_FINGERPRINT, fingerprint)
                 setAttribute(TXT_KEY_VERSION, PROTOCOL_VERSION)
                 setAttribute(TXT_KEY_DEVICE_NAME, deviceName)
-                setAttribute(TXT_KEY_SITE_ID, siteId.toString())
+                setAttribute(TXT_KEY_SITE_HASH, siteHash)
             }
 
             val listener = object : NsdManager.RegistrationListener {
@@ -177,13 +177,17 @@ internal class CardReaderRemoteNsd(
         val version = attributes[TXT_KEY_VERSION]?.toString(Charsets.UTF_8)
         val fingerprint = attributes[TXT_KEY_FINGERPRINT]?.toString(Charsets.UTF_8)
         val host = firstHost()
-        val siteId = attributes[TXT_KEY_SITE_ID]?.toString(Charsets.UTF_8)?.toLongOrNull()
-        val isValid = version == PROTOCOL_VERSION && !fingerprint.isNullOrEmpty() && host != null && siteId != null
+        val siteHash = attributes[TXT_KEY_SITE_HASH]?.toString(Charsets.UTF_8)
+        val isValid = version == PROTOCOL_VERSION &&
+            !fingerprint.isNullOrEmpty() &&
+            host != null &&
+            !siteHash.isNullOrEmpty()
         if (!isValid) {
             Log.w(
                 TAG,
                 "Dropping NSD service $serviceName " +
-                    "(version=$version, fingerprintLen=${fingerprint?.length ?: 0}, host=$host, siteId=$siteId)"
+                    "(version=$version, fingerprintLen=${fingerprint?.length ?: 0}, " +
+                    "host=$host, siteHashLen=${siteHash?.length ?: 0})"
             )
             return null
         }
@@ -195,7 +199,7 @@ internal class CardReaderRemoteNsd(
             fingerprintBase64 = fingerprint,
             version = version,
             deviceName = deviceName,
-            siteId = siteId,
+            siteHash = siteHash,
         )
     }
 
@@ -220,7 +224,7 @@ internal class CardReaderRemoteNsd(
         const val TXT_KEY_FINGERPRINT = "fp"
         const val TXT_KEY_VERSION = "ver"
         const val TXT_KEY_DEVICE_NAME = "name"
-        const val TXT_KEY_SITE_ID = "siteId"
+        const val TXT_KEY_SITE_HASH = "siteHash"
         const val PROTOCOL_VERSION = "1"
         private const val SERVICE_NAME_PREFIX = "woopos-remote"
         private const val SUFFIX_RANGE_EXCLUSIVE = 0x10000
@@ -245,7 +249,7 @@ internal data class CardReaderRemoteResolvedHost(
     val fingerprintBase64: String,
     val version: String,
     val deviceName: String?,
-    val siteId: Long,
+    val siteHash: String,
 )
 
 internal sealed class CardReaderRemoteNsdEvent {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
@@ -175,26 +175,19 @@ internal class CardReaderRemoteNsd(
 
     private fun NsdServiceInfo.toResolvedHost(): CardReaderRemoteResolvedHost? {
         val version = attributes[TXT_KEY_VERSION]?.toString(Charsets.UTF_8)
-        if (version != PROTOCOL_VERSION) {
-            Log.w(TAG, "Dropping NSD service with unsupported version: $version")
-            return null
-        }
         val fingerprint = attributes[TXT_KEY_FINGERPRINT]?.toString(Charsets.UTF_8)
-        if (fingerprint.isNullOrEmpty()) {
-            Log.w(TAG, "Dropping NSD service without fingerprint TXT record")
-            return null
-        }
         val host = firstHost()
-        if (host == null) {
-            Log.w(TAG, "Dropping NSD service without resolved host: $serviceName")
+        val siteId = attributes[TXT_KEY_SITE_ID]?.toString(Charsets.UTF_8)?.toLongOrNull()
+        val isValid = version == PROTOCOL_VERSION && !fingerprint.isNullOrEmpty() && host != null && siteId != null
+        if (!isValid) {
+            Log.w(
+                TAG,
+                "Dropping NSD service $serviceName " +
+                    "(version=$version, fingerprintLen=${fingerprint?.length ?: 0}, host=$host, siteId=$siteId)"
+            )
             return null
         }
         val deviceName = attributes[TXT_KEY_DEVICE_NAME]?.toString(Charsets.UTF_8)
-        val siteId = attributes[TXT_KEY_SITE_ID]?.toString(Charsets.UTF_8)?.toLongOrNull()
-        if (siteId == null) {
-            Log.w(TAG, "Dropping NSD service without siteId TXT record: $serviceName")
-            return null
-        }
         return CardReaderRemoteResolvedHost(
             name = serviceName,
             host = host,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
@@ -33,6 +33,7 @@ internal class CardReaderRemoteNsd(
         port: Int,
         fingerprint: String,
         deviceName: String,
+        siteId: Long?,
     ): CardReaderRemoteNsdRegistration =
         withContext(ioDispatcher) {
             val serviceInfo = NsdServiceInfo().apply {
@@ -42,6 +43,9 @@ internal class CardReaderRemoteNsd(
                 setAttribute(TXT_KEY_FINGERPRINT, fingerprint)
                 setAttribute(TXT_KEY_VERSION, PROTOCOL_VERSION)
                 setAttribute(TXT_KEY_DEVICE_NAME, deviceName)
+                if (siteId != null) {
+                    setAttribute(TXT_KEY_SITE_ID, siteId.toString())
+                }
             }
 
             val listener = object : NsdManager.RegistrationListener {
@@ -188,6 +192,7 @@ internal class CardReaderRemoteNsd(
             return null
         }
         val deviceName = attributes[TXT_KEY_DEVICE_NAME]?.toString(Charsets.UTF_8)
+        val siteId = attributes[TXT_KEY_SITE_ID]?.toString(Charsets.UTF_8)?.toLongOrNull()
         return CardReaderRemoteResolvedHost(
             name = serviceName,
             host = host,
@@ -195,6 +200,7 @@ internal class CardReaderRemoteNsd(
             fingerprintBase64 = fingerprint,
             version = version,
             deviceName = deviceName,
+            siteId = siteId,
         )
     }
 
@@ -219,6 +225,7 @@ internal class CardReaderRemoteNsd(
         const val TXT_KEY_FINGERPRINT = "fp"
         const val TXT_KEY_VERSION = "ver"
         const val TXT_KEY_DEVICE_NAME = "name"
+        const val TXT_KEY_SITE_ID = "siteId"
         const val PROTOCOL_VERSION = "1"
         private const val SERVICE_NAME_PREFIX = "woopos-remote"
         private const val SUFFIX_RANGE_EXCLUSIVE = 0x10000
@@ -243,6 +250,7 @@ internal data class CardReaderRemoteResolvedHost(
     val fingerprintBase64: String,
     val version: String,
     val deviceName: String?,
+    val siteId: Long?,
 )
 
 internal sealed class CardReaderRemoteNsdEvent {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
@@ -33,7 +33,7 @@ internal class CardReaderRemoteNsd(
         port: Int,
         fingerprint: String,
         deviceName: String,
-        siteId: Long?,
+        siteId: Long,
     ): CardReaderRemoteNsdRegistration =
         withContext(ioDispatcher) {
             val serviceInfo = NsdServiceInfo().apply {
@@ -43,9 +43,7 @@ internal class CardReaderRemoteNsd(
                 setAttribute(TXT_KEY_FINGERPRINT, fingerprint)
                 setAttribute(TXT_KEY_VERSION, PROTOCOL_VERSION)
                 setAttribute(TXT_KEY_DEVICE_NAME, deviceName)
-                if (siteId != null) {
-                    setAttribute(TXT_KEY_SITE_ID, siteId.toString())
-                }
+                setAttribute(TXT_KEY_SITE_ID, siteId.toString())
             }
 
             val listener = object : NsdManager.RegistrationListener {
@@ -193,6 +191,10 @@ internal class CardReaderRemoteNsd(
         }
         val deviceName = attributes[TXT_KEY_DEVICE_NAME]?.toString(Charsets.UTF_8)
         val siteId = attributes[TXT_KEY_SITE_ID]?.toString(Charsets.UTF_8)?.toLongOrNull()
+        if (siteId == null) {
+            Log.w(TAG, "Dropping NSD service without siteId TXT record: $serviceName")
+            return null
+        }
         return CardReaderRemoteResolvedHost(
             name = serviceName,
             host = host,
@@ -250,7 +252,7 @@ internal data class CardReaderRemoteResolvedHost(
     val fingerprintBase64: String,
     val version: String,
     val deviceName: String?,
-    val siteId: Long?,
+    val siteId: Long,
 )
 
 internal sealed class CardReaderRemoteNsdEvent {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -71,7 +71,7 @@ class CardReaderRemoteSession internal constructor(
     private var useSimulatedReader: Boolean = false
     private var siteId: Long = 0L
 
-    fun start(parentScope: CoroutineScope, isSimulated: Boolean = false, siteId: Long) {
+    fun start(parentScope: CoroutineScope, siteId: Long, isSimulated: Boolean = false) {
         useSimulatedReader = isSimulated
         this.siteId = siteId
         startInternal(parentScope)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -69,9 +69,9 @@ class CardReaderRemoteSession internal constructor(
     private var connection: CardReaderRemoteConnection? = null
     private var readerWasConnected: Boolean = false
     private var useSimulatedReader: Boolean = false
-    private var siteId: Long? = null
+    private var siteId: Long = 0L
 
-    fun start(parentScope: CoroutineScope, isSimulated: Boolean = false, siteId: Long? = null) {
+    fun start(parentScope: CoroutineScope, isSimulated: Boolean = false, siteId: Long) {
         useSimulatedReader = isSimulated
         this.siteId = siteId
         startInternal(parentScope)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -69,11 +69,11 @@ class CardReaderRemoteSession internal constructor(
     private var connection: CardReaderRemoteConnection? = null
     private var readerWasConnected: Boolean = false
     private var useSimulatedReader: Boolean = false
-    private var siteId: Long = 0L
+    private var siteHash: String = ""
 
-    fun start(parentScope: CoroutineScope, siteId: Long, isSimulated: Boolean = false) {
+    fun start(parentScope: CoroutineScope, siteHash: String, isSimulated: Boolean = false) {
         useSimulatedReader = isSimulated
-        this.siteId = siteId
+        this.siteHash = siteHash
         startInternal(parentScope)
     }
 
@@ -136,7 +136,7 @@ class CardReaderRemoteSession internal constructor(
         server.start()
 
         val registration = nsdFactory.create(context)
-            .advertise(server.port, server.fingerprint, deviceName(), siteId)
+            .advertise(server.port, server.fingerprint, deviceName(), siteHash)
         nsdRegistration = registration
 
         logWrapper.d(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -69,9 +69,11 @@ class CardReaderRemoteSession internal constructor(
     private var connection: CardReaderRemoteConnection? = null
     private var readerWasConnected: Boolean = false
     private var useSimulatedReader: Boolean = false
+    private var siteId: Long? = null
 
-    fun start(parentScope: CoroutineScope, isSimulated: Boolean = false) {
+    fun start(parentScope: CoroutineScope, isSimulated: Boolean = false, siteId: Long? = null) {
         useSimulatedReader = isSimulated
+        this.siteId = siteId
         startInternal(parentScope)
     }
 
@@ -134,7 +136,7 @@ class CardReaderRemoteSession internal constructor(
         server.start()
 
         val registration = nsdFactory.create(context)
-            .advertise(server.port, server.fingerprint, deviceName())
+            .advertise(server.port, server.fingerprint, deviceName(), siteId)
         nsdRegistration = registration
 
         logWrapper.d(

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.cardreader.internal
 import android.app.Application
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.LogWrapper
+import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover
 import com.woocommerce.android.cardreader.connection.CompositeConnectionTokenProvider
 import com.woocommerce.android.cardreader.connection.ReaderType
@@ -16,6 +17,7 @@ import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import com.woocommerce.android.cardreader.payments.RefundConfig
 import com.woocommerce.android.cardreader.payments.RefundParams
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.Before
@@ -43,7 +45,9 @@ class CardReaderManagerImplTest : CardReaderBaseUnitTest() {
     private val interacRefundManager: InteracRefundManager = mock()
     private val connectionManager: ConnectionManager = mock()
     private val softwareUpdateManager: SoftwareUpdateManager = mock()
-    private val terminalListener: TerminalListenerImpl = mock()
+    private val terminalListener: TerminalListenerImpl = mock {
+        on { readerStatus }.thenReturn(MutableStateFlow(CardReaderStatus.NotConnected()))
+    }
 
     private val supportedReaders =
         CardReaderTypesToDiscover.SpecificReaders.ExternalReaders(

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/DefaultCardReaderRemoteTabletClientTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/DefaultCardReaderRemoteTabletClientTest.kt
@@ -97,7 +97,7 @@ class DefaultCardReaderRemoteTabletClientTest : CardReaderBaseUnitTest() {
         port = 9000,
         fingerprintBase64 = "AB4F",
         deviceName = "Pixel",
-        siteId = null,
+        siteId = 1L,
     )
 
     private fun aPaymentInfo() = PaymentInfo(

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/DefaultCardReaderRemoteTabletClientTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/DefaultCardReaderRemoteTabletClientTest.kt
@@ -97,6 +97,7 @@ class DefaultCardReaderRemoteTabletClientTest : CardReaderBaseUnitTest() {
         port = 9000,
         fingerprintBase64 = "AB4F",
         deviceName = "Pixel",
+        siteId = null,
     )
 
     private fun aPaymentInfo() = PaymentInfo(

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/DefaultCardReaderRemoteTabletClientTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/DefaultCardReaderRemoteTabletClientTest.kt
@@ -97,7 +97,7 @@ class DefaultCardReaderRemoteTabletClientTest : CardReaderBaseUnitTest() {
         port = 9000,
         fingerprintBase64 = "AB4F",
         deviceName = "Pixel",
-        siteId = 1L,
+        siteHash = "site-hash",
     )
 
     private fun aPaymentInfo() = PaymentInfo(


### PR DESCRIPTION
### Description

Fixes WOOMOB-2853

For Remote Tap-to-Pay (phone-as-reader on POS), the tablet had no way to know whether a discovered phone was signed into the same WP store. Pairing relied on TLS cert pinning + a 4-char pairing code derived from the cert fingerprint — both prove device identity but say nothing about site identity. Defense-in-depth against operator error: a phone signed into a different store shouldn't appear in the tablet's discovery list at all.

The phone now advertises its current `siteId` as an NSD TXT record. The tablet drops phones whose `siteId` doesn't match `selectedSite.get().siteId` before they reach the discovery list. No protocol change, no extra round-trip.

A few non-obvious bits:

- `WooPosDiscoveredReader.Phone.siteId` is non-nullable. Phones whose TXT record is missing a siteId are dropped at the boundary in `WooPosRemoteReaderDiscovery` — past that point, every phone has a real `siteId`.
- The simulated remote-reader source now uses the tablet's own `siteId`, so simulated phones always pass the filter.
- Simulated phones now use distinct loopback IPs (127.0.0.1 / 127.0.0.2) so the dedup-by-host fix from the bug-bash branch doesn't collapse both into one entry.
- Explainer copy in the connect dialog now mentions the same-store requirement.

The threat model here is operator error, not an attacker on the LAN. mDNS broadcasts are unauthenticated and can be spoofed; the real defense against a malicious phone is having the phone fetch its own connection token using its WP credentials — separate, larger change, intentionally out of scope.

### Test Steps

1. Sign two phones into different WP stores (Phone A on store X, Phone B on store Y).
2. On a tablet signed into store X, open POS and start the connect flow with the simulator off.
3. Put both phones into Card Reader Mode (Settings → Payments → Card Reader Mode).
4. Confirm only Phone A appears in the tablet's discovery list. Phone B should be dropped silently (visible in logcat as "Dropping NSD phone with site mismatch").
5. Connect to Phone A and run a test payment end-to-end — should still work.
6. With the simulator on, confirm two simulated phones appear in the list (regression check from bug-bash branch).
7. Tap the "Phone-as-reader?" hint in the connect dialog. The compatibility section should mention "sign in to the same store on both devices."

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.