### PR TITLE
[WOOMOB-2891] Define AssistantError sealed class and normalized error model

### DIFF
--- a/config/gradle/jacoco.gradle
+++ b/config/gradle/jacoco.gradle
@@ -19,7 +19,7 @@ rootProject.afterEvaluate {
                 ':libs:apifaker:testDebugUnitTest',
                 ':libs:commons:testDebugUnitTest',
                 ':libs:pos:testDebugUnitTest',
-                ':libs:ai-assistant:core:test',
+                ':libs:ai-assistant:core:jacocoTestReport',
                 ':libs:ai-assistant:feature:testDebugUnitTest',
         )
 

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/auth/JwtTokenProvider.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/auth/JwtTokenProvider.kt
@@ -16,9 +16,9 @@ interface JwtTokenProvider {
 
 /**
  * Raised by [JwtTokenProvider] implementations when a JWT cannot be obtained.
- * [com.woocommerce.android.aiassistant.core.chat.ChatService] maps this to
- * [com.woocommerce.android.aiassistant.core.chat.AssistantErrorKind.AUTH] before
- * surfacing it to the loop.
+ * The chat service maps this to [com.woocommerce.android.aiassistant.core.chat.AssistantErrorKind.AUTH]
+ * at the stream layer; [com.woocommerce.android.aiassistant.core.chat.toAssistantError] maps it to
+ * [com.woocommerce.android.aiassistant.core.chat.AssistantError.Auth] at the loop layer.
  */
 class AssistantAuthException(
     message: String = "Failed to obtain Jetpack AI JWT",

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantError.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantError.kt
@@ -1,0 +1,25 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+/**
+ * Loop-level normalized error vocabulary surfaced to the agentic loop and any
+ * UI layer that consumes the AI assistant. Service-boundary code maps raw
+ * exceptions and HTTP status codes into one of these variants so callers never
+ * branch on transport types.
+ *
+ * [OutcomeUnknown] is intentionally separate from [Network] and [Timeout]: it
+ * means a write tool was dispatched but the response was lost, so the server
+ * may or may not have applied it. That ambiguity drives different retry and
+ * UX decisions than a clean transport failure.
+ */
+sealed class AssistantError {
+    data object Network : AssistantError()
+    data object Auth : AssistantError()
+    data object RateLimit : AssistantError()
+    data object Timeout : AssistantError()
+    data object UpstreamFailure : AssistantError()
+    data class ToolFailed(val toolName: String, val cause: Throwable? = null) : AssistantError()
+    data class InvalidToolCall(val toolName: String) : AssistantError()
+    data object OutcomeUnknown : AssistantError()
+    data object Cancelled : AssistantError()
+    data class Unknown(val cause: Throwable? = null) : AssistantError()
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantError.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantError.kt
@@ -19,7 +19,7 @@ sealed class AssistantError {
     data object UpstreamFailure : AssistantError()
     data class ToolFailed(val toolName: String, val cause: Throwable? = null) : AssistantError()
     data class InvalidToolCall(val toolName: String) : AssistantError()
-    data object OutcomeUnknown : AssistantError()
+    data class OutcomeUnknown(val toolName: String) : AssistantError()
     data object Cancelled : AssistantError()
     data class Unknown(val cause: Throwable? = null) : AssistantError()
 }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorMapper.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorMapper.kt
@@ -1,0 +1,46 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+import com.woocommerce.android.aiassistant.core.auth.AssistantAuthException
+import kotlinx.coroutines.CancellationException
+import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+/**
+ * Normalize a raw [Throwable] into the loop-level [AssistantError] vocabulary.
+ *
+ * Order matters: specific subtypes must be matched before their supertypes.
+ * [SocketTimeoutException] is a subtype of [IOException] so it appears first.
+ * [CancellationException] is preserved as [AssistantError.Cancelled] rather
+ * than rethrown — callers that need to honor structured concurrency should
+ * rethrow it before delegating to this helper.
+ */
+fun Throwable.toAssistantError(): AssistantError = when (this) {
+    is AssistantAuthException -> AssistantError.Auth
+    is CancellationException -> AssistantError.Cancelled
+    is SocketTimeoutException -> AssistantError.Timeout
+    is UnknownHostException -> AssistantError.Network
+    is ConnectException -> AssistantError.Network
+    is IOException -> AssistantError.Network
+    else -> AssistantError.Unknown(cause = this)
+}
+
+/**
+ * Normalize an HTTP status [code] into the loop-level [AssistantError]
+ * vocabulary. Codes outside the documented ranges fall back to
+ * [AssistantError.Unknown] with no cause attached.
+ */
+fun assistantErrorFromHttpCode(code: Int): AssistantError = when (code) {
+    HTTP_UNAUTHORIZED, HTTP_FORBIDDEN -> AssistantError.Auth
+    HTTP_REQUEST_TIMEOUT -> AssistantError.Timeout
+    HTTP_TOO_MANY_REQUESTS -> AssistantError.RateLimit
+    in HTTP_SERVER_ERROR_RANGE -> AssistantError.UpstreamFailure
+    else -> AssistantError.Unknown()
+}
+
+private const val HTTP_UNAUTHORIZED = 401
+private const val HTTP_FORBIDDEN = 403
+private const val HTTP_REQUEST_TIMEOUT = 408
+private const val HTTP_TOO_MANY_REQUESTS = 429
+private val HTTP_SERVER_ERROR_RANGE = 500..599

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorMapperTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorMapperTest.kt
@@ -1,0 +1,138 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+import com.woocommerce.android.aiassistant.core.auth.AssistantAuthException
+import kotlinx.coroutines.CancellationException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+class AssistantErrorMapperTest {
+    @Test
+    fun `given AssistantAuthException, when mapped, then returns Auth`() {
+        val throwable: Throwable = AssistantAuthException()
+
+        val error = throwable.toAssistantError()
+
+        assertThat(error).isEqualTo(AssistantError.Auth)
+    }
+
+    @Test
+    fun `given SocketTimeoutException, when mapped, then returns Timeout`() {
+        val throwable: Throwable = SocketTimeoutException("read timed out")
+
+        val error = throwable.toAssistantError()
+
+        assertThat(error).isEqualTo(AssistantError.Timeout)
+    }
+
+    @Test
+    fun `given SocketTimeoutException as IOException subtype, when mapped, then resolves to Timeout not Network`() {
+        // SocketTimeoutException extends IOException — the mapper must check
+        // it FIRST, otherwise the IOException branch would swallow it.
+        val throwable: IOException = SocketTimeoutException()
+
+        val error = throwable.toAssistantError()
+
+        assertThat(error).isEqualTo(AssistantError.Timeout)
+    }
+
+    @Test
+    fun `given UnknownHostException, when mapped, then returns Network`() {
+        val throwable: Throwable = UnknownHostException("no dns")
+
+        val error = throwable.toAssistantError()
+
+        assertThat(error).isEqualTo(AssistantError.Network)
+    }
+
+    @Test
+    fun `given ConnectException, when mapped, then returns Network`() {
+        val throwable: Throwable = ConnectException("refused")
+
+        val error = throwable.toAssistantError()
+
+        assertThat(error).isEqualTo(AssistantError.Network)
+    }
+
+    @Test
+    fun `given generic IOException, when mapped, then returns Network`() {
+        val throwable: Throwable = IOException("broken pipe")
+
+        val error = throwable.toAssistantError()
+
+        assertThat(error).isEqualTo(AssistantError.Network)
+    }
+
+    @Test
+    fun `given CancellationException, when mapped, then returns Cancelled`() {
+        val throwable: Throwable = CancellationException("user navigated away")
+
+        val error = throwable.toAssistantError()
+
+        assertThat(error).isEqualTo(AssistantError.Cancelled)
+    }
+
+    @Test
+    fun `given arbitrary RuntimeException, when mapped, then returns Unknown carrying the cause`() {
+        val throwable: Throwable = IllegalStateException("oops")
+
+        val error = throwable.toAssistantError()
+
+        assertThat(error).isInstanceOf(AssistantError.Unknown::class.java)
+        assertThat((error as AssistantError.Unknown).cause).isSameAs(throwable)
+    }
+
+    @Test
+    fun `given HTTP 401, when mapped, then returns Auth`() {
+        assertThat(assistantErrorFromHttpCode(401)).isEqualTo(AssistantError.Auth)
+    }
+
+    @Test
+    fun `given HTTP 403, when mapped, then returns Auth`() {
+        assertThat(assistantErrorFromHttpCode(403)).isEqualTo(AssistantError.Auth)
+    }
+
+    @Test
+    fun `given HTTP 408, when mapped, then returns Timeout`() {
+        assertThat(assistantErrorFromHttpCode(408)).isEqualTo(AssistantError.Timeout)
+    }
+
+    @Test
+    fun `given HTTP 429, when mapped, then returns RateLimit`() {
+        assertThat(assistantErrorFromHttpCode(429)).isEqualTo(AssistantError.RateLimit)
+    }
+
+    @Test
+    fun `given HTTP 500, when mapped, then returns UpstreamFailure`() {
+        assertThat(assistantErrorFromHttpCode(500)).isEqualTo(AssistantError.UpstreamFailure)
+    }
+
+    @Test
+    fun `given HTTP 503, when mapped, then returns UpstreamFailure`() {
+        assertThat(assistantErrorFromHttpCode(503)).isEqualTo(AssistantError.UpstreamFailure)
+    }
+
+    @Test
+    fun `given HTTP 599 boundary, when mapped, then returns UpstreamFailure`() {
+        assertThat(assistantErrorFromHttpCode(599)).isEqualTo(AssistantError.UpstreamFailure)
+    }
+
+    @Test
+    fun `given HTTP 400, when mapped, then returns Unknown without cause`() {
+        val error = assistantErrorFromHttpCode(400)
+
+        assertThat(error).isInstanceOf(AssistantError.Unknown::class.java)
+        assertThat((error as AssistantError.Unknown).cause).isNull()
+    }
+
+    @Test
+    fun `given HTTP 200 success code, when mapped, then returns Unknown`() {
+        // Defensive: callers shouldn't ask, but if they do we must not crash.
+        val error = assistantErrorFromHttpCode(200)
+
+        assertThat(error).isInstanceOf(AssistantError.Unknown::class.java)
+    }
+}

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorTest.kt
@@ -14,7 +14,7 @@ class AssistantErrorTest {
             AssistantError.UpstreamFailure,
             AssistantError.ToolFailed(toolName = "create_order"),
             AssistantError.InvalidToolCall(toolName = "create_order"),
-            AssistantError.OutcomeUnknown,
+            AssistantError.OutcomeUnknown(toolName = "create_order"),
             AssistantError.Cancelled,
             AssistantError.Unknown(),
         )
@@ -25,12 +25,19 @@ class AssistantErrorTest {
 
     @Test
     fun `given OutcomeUnknown, when compared to Network and Timeout, then it is a distinct type`() {
-        val outcomeUnknown: AssistantError = AssistantError.OutcomeUnknown
+        val outcomeUnknown: AssistantError = AssistantError.OutcomeUnknown(toolName = "create_order")
 
         assertThat(outcomeUnknown).isNotEqualTo(AssistantError.Network)
         assertThat(outcomeUnknown).isNotEqualTo(AssistantError.Timeout)
         assertThat(outcomeUnknown::class).isNotEqualTo(AssistantError.Network::class)
         assertThat(outcomeUnknown::class).isNotEqualTo(AssistantError.Timeout::class)
+    }
+
+    @Test
+    fun `given OutcomeUnknown, when constructed, then carries tool name`() {
+        val error = AssistantError.OutcomeUnknown(toolName = "create_order")
+
+        assertThat(error.toolName).isEqualTo("create_order")
     }
 
     @Test

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorTest.kt
@@ -24,7 +24,7 @@ class AssistantErrorTest {
     }
 
     @Test
-    fun `given outcome_unknown, when compared to network and timeout, then it is a distinct type`() {
+    fun `given OutcomeUnknown, when compared to Network and Timeout, then it is a distinct type`() {
         val outcomeUnknown: AssistantError = AssistantError.OutcomeUnknown
 
         assertThat(outcomeUnknown).isNotEqualTo(AssistantError.Network)

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantErrorTest.kt
@@ -1,0 +1,61 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AssistantErrorTest {
+    @Test
+    fun `given each variant, when listed, then all ten kinds are present and distinct`() {
+        val variants: List<AssistantError> = listOf(
+            AssistantError.Network,
+            AssistantError.Auth,
+            AssistantError.RateLimit,
+            AssistantError.Timeout,
+            AssistantError.UpstreamFailure,
+            AssistantError.ToolFailed(toolName = "create_order"),
+            AssistantError.InvalidToolCall(toolName = "create_order"),
+            AssistantError.OutcomeUnknown,
+            AssistantError.Cancelled,
+            AssistantError.Unknown(),
+        )
+
+        assertThat(variants).hasSize(10)
+        assertThat(variants.map { it::class }.toSet()).hasSize(10)
+    }
+
+    @Test
+    fun `given outcome_unknown, when compared to network and timeout, then it is a distinct type`() {
+        val outcomeUnknown: AssistantError = AssistantError.OutcomeUnknown
+
+        assertThat(outcomeUnknown).isNotEqualTo(AssistantError.Network)
+        assertThat(outcomeUnknown).isNotEqualTo(AssistantError.Timeout)
+        assertThat(outcomeUnknown::class).isNotEqualTo(AssistantError.Network::class)
+        assertThat(outcomeUnknown::class).isNotEqualTo(AssistantError.Timeout::class)
+    }
+
+    @Test
+    fun `given ToolFailed with cause, when constructed, then carries tool name and cause`() {
+        val cause = IllegalStateException("boom")
+
+        val error = AssistantError.ToolFailed(toolName = "update_product", cause = cause)
+
+        assertThat(error.toolName).isEqualTo("update_product")
+        assertThat(error.cause).isSameAs(cause)
+    }
+
+    @Test
+    fun `given InvalidToolCall, when constructed, then carries tool name`() {
+        val error = AssistantError.InvalidToolCall(toolName = "set_status")
+
+        assertThat(error.toolName).isEqualTo("set_status")
+    }
+
+    @Test
+    fun `given Unknown with cause, when constructed, then carries cause`() {
+        val cause = RuntimeException("???")
+
+        val error = AssistantError.Unknown(cause = cause)
+
+        assertThat(error.cause).isSameAs(cause)
+    }
+}


### PR DESCRIPTION
Fixes WOOMOB-2891

### Description

The agentic loop, retry policy, and any UI that consumes the AI assistant need a single, finite error vocabulary. Until now the codebase had only `AssistantErrorKind` — a stream-level enum scoped to transport errors surfaced by `ChatService`. This PR introduces the loop-level counterpart: `AssistantError`.

`AssistantError` is a sealed class with 10 variants covering the full error surface:

| Variant | Meaning |
|---|---|
| `Network` | Connectivity / IO failure |
| `Auth` | JWT acquisition or HTTP 401/403 |
| `RateLimit` | HTTP 429 |
| `Timeout` | Request timed out (SocketTimeoutException or HTTP 408) |
| `UpstreamFailure` | HTTP 5xx from the backend |
| `ToolFailed(toolName, cause?)` | Tool execution threw an exception |
| `InvalidToolCall(toolName)` | Model emitted an unparseable or unknown tool call |
| `OutcomeUnknown` | Write tool was dispatched but no response was ever received |
| `Cancelled` | Coroutine was cancelled |
| `Unknown(cause?)` | Catch-all for unclassified failures |

`OutcomeUnknown` is deliberately separate from `Network` and `Timeout`. It means a write tool was sent but the response was lost, so the server may or may not have applied it — that ambiguity requires different retry and UX treatment than a clean transport failure.

Two top-level mapping helpers normalise raw inputs into `AssistantError`:

- **`Throwable.toAssistantError()`** — maps `AssistantAuthException`, `SocketTimeoutException`, `UnknownHostException`, `ConnectException`, `IOException`, and `CancellationException`. Branch order in the `when` expression is load-bearing (`SocketTimeoutException` must precede its `IOException` supertype); this is documented in the KDoc and guarded by a dedicated test.
- **`assistantErrorFromHttpCode(code: Int)`** — maps 401/403 → `Auth`, 408 → `Timeout`, 429 → `RateLimit`, 500–599 → `UpstreamFailure`, anything else → `Unknown`.

Both live in `libs/ai-assistant/core` (pure Kotlin/JVM). `AssistantErrorKind` is intentionally unchanged — it stays scoped to `AssistantEvent.Failed` for stream events. The two types coexist by design: the agentic loop (WOOMOB-2893) will use these helpers at the service boundary so callers above it never observe raw exception types.

> [!IMPORTANT]
>  **Note on apparent duplication with `JetpackAiChatService`:** reviewers familiar with [#15756](https://github.com/woocommerce/woocommerce-android/pull/15756) will notice that `JetpackAiChatService` already contains similar inline exception-to-`AssistantErrorKind` mapping (`toAssistantException` / `mapError`). That mapping operates at the stream layer — it converts OkHttp/SSE failures into `AssistantEvent.Failed` events. The helpers introduced here operate at the loop layer — they convert those same raw inputs into `AssistantError`, the type the loop and UI will consume. The mapping rules are intentionally parallel (same exception → same semantic outcome), but the output types are different because the two layers serve different consumers. The inline mapping in `JetpackAiChatService` will be cleaned up or delegated to these helpers once the agentic loop (WOOMOB-2893) is in place and wires everything together.

22 unit tests written TDD (full branch coverage on both helpers).

### Test Steps

This is a pure library change in `libs/ai-assistant/core` with no user-visible surface yet.

1. Run `./gradlew :libs:ai-assistant:core:test` — 22 tests should pass.
2. Open `AssistantError.kt` and confirm it has exactly 10 sealed subclasses.
3. Open `AssistantErrorKind.kt` and confirm it is unchanged (stream-level enum stays as-is).

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.