### PR TITLE
[WOOMOB-2932] Step 11: QR login — scan WordPress.com magic-login QR codes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -123,6 +123,7 @@ enum class AnalyticsEvent(override val siteless: Boolean = false) : IAnalyticsEv
     LOGIN_QR_PROLOGUE_FALLBACK_TAPPED(siteless = true),
     LOGIN_QR_SCAN_FAILED(siteless = true),
     LOGIN_QR_SUCCESS(siteless = true),
+    LOGIN_QR_HANDED_OFF_WP_COM_MAGIC_LINK(siteless = true),
 
     // -- Site Picker
     SITE_PICKER_STORES_SHOWN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
@@ -27,5 +27,13 @@ sealed interface QrLoginPayload {
      */
     data object InstallQrCode : QrLoginPayload
 
+    /**
+     * The merchant scanned the canonical wp.com magic-login URL
+     * (`https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=…`).
+     * The scanner opens [url] via `ACTION_VIEW` so the system browser bounces through wp.com —
+     * the same end-to-end path that 3rd-party scanners (Google Lens, etc.) use today.
+     */
+    data class WpComMagicLinkUrl(val url: String) : QrLoginPayload
+
     data object Invalid : QrLoginPayload
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
@@ -30,8 +30,8 @@ sealed interface QrLoginPayload {
     /**
      * The merchant scanned the canonical wp.com magic-login URL
      * (`https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=…`).
-     * The scanner opens [url] via `ACTION_VIEW` so the system browser bounces through wp.com —
-     * the same end-to-end path that 3rd-party scanners (Google Lens, etc.) use today.
+     * The scanner hands [url] to the browser; wp.com then redirects to `woocommerce://magic-login`,
+     * mirroring the path a 3rd-party scanner (Google Lens, etc.) takes today.
      */
     data class WpComMagicLinkUrl(val url: String) : QrLoginPayload
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
@@ -18,12 +18,34 @@ import javax.inject.Inject
  * beyond non-blank — that's the server's job during exchange. `siteUrl` is parsed via OkHttp's
  * [okhttp3.HttpUrl] and rejected if it carries userinfo, query, or fragment components — those
  * have no role in a Woo site root and are classic spoofing surfaces in the confirmation prompt.
+ *
+ * Also recognises the WordPress.com magic-login QR
+ * (`https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=…`) and
+ * surfaces it as [QrLoginPayload.WpComMagicLinkUrl] for the scanner to hand off via `ACTION_VIEW`.
  */
 class QrLoginPayloadParser @Inject constructor() {
 
     fun parse(raw: String?): QrLoginPayload {
+        parseWpComMagicLinkUrl(raw)?.let { return it }
         if (looksLikeInstallQr(raw)) return QrLoginPayload.InstallQrCode
         return parseTicket(raw) ?: QrLoginPayload.Invalid
+    }
+
+    /**
+     * Validates the wp.com magic-login URL and returns it verbatim. The `scheme=woocommerce`
+     * requirement is load-bearing: a QR with `scheme=wordpress` is intended for the WordPress
+     * app and we must not silently launch its URL here.
+     */
+    private fun parseWpComMagicLinkUrl(raw: String?): QrLoginPayload.WpComMagicLinkUrl? {
+        val trimmed = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        val parsed = trimmed.toHttpUrlOrNull() ?: return null
+        val matches = parsed.scheme == "https" &&
+            parsed.host.equals(WP_COM_HOST, ignoreCase = true) &&
+            parsed.encodedPath == WP_COM_MAGIC_LINK_PATH &&
+            parsed.queryParameter(PARAM_ACTION)?.lowercase() == ACTION_MAGIC_LOGIN &&
+            parsed.queryParameter(PARAM_SCHEME)?.lowercase() == SCHEME &&
+            !parsed.queryParameter(PARAM_TOKEN).isNullOrBlank()
+        return if (matches) QrLoginPayload.WpComMagicLinkUrl(url = trimmed) else null
     }
 
     private fun parseTicket(raw: String?): QrLoginPayload.Ticket? {
@@ -90,8 +112,13 @@ class QrLoginPayloadParser @Inject constructor() {
         const val HOST = "qr-login"
         const val PARAM_TOKEN = "token"
         const val PARAM_SITE_URL = "siteUrl"
+        const val PARAM_ACTION = "action"
+        const val PARAM_SCHEME = "scheme"
         const val HTTPS_PREFIX = "https://"
         const val INSTALL_QR_HOST = "woocommerce.com"
         const val INSTALL_QR_PATH_FIRST_SEGMENT = "mobile"
+        const val WP_COM_HOST = "wordpress.com"
+        const val WP_COM_MAGIC_LINK_PATH = "/wp-login.php"
+        const val ACTION_MAGIC_LOGIN = "magic-login"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.login.qrlogin
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -158,6 +160,8 @@ class QrLoginScannerFragment : Fragment() {
         qrLoginViewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is QrLoginScannerViewModel.Dispatch.LoggedIn -> handleLoggedIn(event.localSiteId)
+                is QrLoginScannerViewModel.Dispatch.OpenWpComMagicLinkUrl ->
+                    openWpComMagicLinkUrl(event.url)
             }
         }
     }
@@ -188,5 +192,16 @@ class QrLoginScannerFragment : Fragment() {
         requireNotNull(listener) {
             "${requireActivity().javaClass.simpleName} must implement QrLoginScannerFragment.Listener"
         }.onQrLoginCompleted(localSiteId)
+    }
+
+    /**
+     * Open the wp.com magic-login URL via [Intent.ACTION_VIEW]. The system routes it (typically
+     * to Chrome), wp.com 3xx-redirects to `woocommerce://magic-login`, and the existing
+     * intent-filter on `MagicLinkInterceptActivity` picks it up — same end-to-end path as a
+     * 3rd-party scanner.
+     */
+    private fun openWpComMagicLinkUrl(url: String) {
+        scannerViewModel.stopCodesRecognition()
+        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -2,8 +2,6 @@ package com.woocommerce.android.ui.login.qrlogin
 
 import android.Manifest
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -16,6 +14,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
+import com.woocommerce.android.util.ChromeCustomTabUtils
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
@@ -195,13 +194,17 @@ class QrLoginScannerFragment : Fragment() {
     }
 
     /**
-     * Open the wp.com magic-login URL via [Intent.ACTION_VIEW]. The system routes it (typically
-     * to Chrome), wp.com 3xx-redirects to `woocommerce://magic-login`, and the existing
-     * intent-filter on `MagicLinkInterceptActivity` picks it up — same end-to-end path as a
-     * 3rd-party scanner.
+     * Hand the wp.com magic-login URL off to the browser. wp.com 3xx-redirects to
+     * `woocommerce://magic-login`, and the existing intent-filter on `MagicLinkInterceptActivity`
+     * picks it up — same end-to-end path as a 3rd-party scanner.
+     *
+     * [ChromeCustomTabUtils.launchUrl] handles the no-browser edge case for us: it falls back to
+     * a plain external launch and shows a toast on `ActivityNotFoundException`, so we don't need
+     * a try/catch here. Custom Tabs forward non-http schemes (here, the redirect target
+     * `woocommerce://magic-login`) to the OS as Intents, so the deeplink still fires.
      */
     private fun openWpComMagicLinkUrl(url: String) {
         scannerViewModel.stopCodesRecognition()
-        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        ChromeCustomTabUtils.launchUrl(requireContext(), url)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -83,6 +83,14 @@ class QrLoginScannerViewModel @Inject constructor(
                 ticket = payload,
                 host = payload.siteUrl.toDisplayHost()
             )
+            is QrLoginPayload.WpComMagicLinkUrl -> {
+                // Hand the URL off to the system browser, which mirrors the 3rd-party scanner
+                // path: browser → wp.com 3xx → woocommerce://magic-login → MagicLinkInterceptActivity.
+                // Lock the state machine — the user is leaving the scanner and the outcome is no
+                // longer ours to handle.
+                loggedIn = true
+                triggerEvent(Dispatch.OpenWpComMagicLinkUrl(url = payload.url))
+            }
             QrLoginPayload.InstallQrCode -> {
                 trackScanFailure(
                     step = Step.PAYLOAD,
@@ -225,6 +233,14 @@ class QrLoginScannerViewModel @Inject constructor(
 
     sealed class Dispatch : Event() {
         data class LoggedIn(val localSiteId: Int) : Dispatch()
+
+        /**
+         * The merchant scanned a wp.com magic-login URL. Because the wp.com `token` is an opaque
+         * envelope only the server can resolve, the fragment opens [url] in the system browser
+         * via `ACTION_VIEW`; wp.com then 3xx-redirects to `woocommerce://magic-login` which the
+         * existing intent-filter routes to `MagicLinkInterceptActivity`.
+         */
+        data class OpenWpComMagicLinkUrl(val url: String) : Dispatch()
     }
 
     sealed interface UiState {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -84,11 +84,12 @@ class QrLoginScannerViewModel @Inject constructor(
                 host = payload.siteUrl.toDisplayHost()
             )
             is QrLoginPayload.WpComMagicLinkUrl -> {
-                // Hand the URL off to the system browser, which mirrors the 3rd-party scanner
-                // path: browser → wp.com 3xx → woocommerce://magic-login → MagicLinkInterceptActivity.
-                // Lock the state machine — the user is leaving the scanner and the outcome is no
-                // longer ours to handle.
+                // Hand the URL off to the browser; wp.com then 3xx-redirects to
+                // woocommerce://magic-login → MagicLinkInterceptActivity. Lock the state machine
+                // because the user is leaving the scanner and the outcome is no longer ours to
+                // handle. This is the happy path — we track the handoff, not a scan failure.
                 loggedIn = true
+                analyticsTracker.track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_WP_COM_MAGIC_LINK)
                 triggerEvent(Dispatch.OpenWpComMagicLinkUrl(url = payload.url))
             }
             QrLoginPayload.InstallQrCode -> {
@@ -235,10 +236,10 @@ class QrLoginScannerViewModel @Inject constructor(
         data class LoggedIn(val localSiteId: Int) : Dispatch()
 
         /**
-         * The merchant scanned a wp.com magic-login URL. Because the wp.com `token` is an opaque
-         * envelope only the server can resolve, the fragment opens [url] in the system browser
-         * via `ACTION_VIEW`; wp.com then 3xx-redirects to `woocommerce://magic-login` which the
-         * existing intent-filter routes to `MagicLinkInterceptActivity`.
+         * The merchant scanned a wp.com magic-login URL. The fragment hands [url] to the browser;
+         * wp.com then 3xx-redirects to `woocommerce://magic-login` which the existing
+         * intent-filter routes to `MagicLinkInterceptActivity` — the same end-to-end path a
+         * 3rd-party scanner (Google Lens, etc.) takes today.
          */
         data class OpenWpComMagicLinkUrl(val url: String) : Dispatch()
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
@@ -152,4 +152,90 @@ class QrLoginPayloadParserTest : BaseUnitTest() {
             QrLoginPayload.Ticket(token = token, siteUrl = "https://easyclothes.example")
         )
     }
+
+    @Test
+    fun `given wp dot com magic link url, when parsed, then returns WpComMagicLinkUrl with original url`() {
+        val raw = "https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=abc123"
+
+        val result = parser.parse(raw)
+
+        assertThat(result).isEqualTo(QrLoginPayload.WpComMagicLinkUrl(url = raw))
+    }
+
+    @Test
+    fun `given wp dot com magic link url with token containing reserved chars, when parsed, then preserves verbatim`() {
+        // Real wp.com tokens contain percent-encoded reserved characters; the parser must not
+        // transform them — the URL is forwarded to the browser as-is.
+        val raw = "https://wordpress.com/wp-login.php" +
+            "?token=%2Fu5iR4Bv3B%2BGLC5zt1V89A%3D%3D%3AqkpOuOFo9IeVclfMciTlEw%3D%3D" +
+            "&action=magic-login&scheme=woocommerce"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.WpComMagicLinkUrl(url = raw))
+    }
+
+    @Test
+    fun `given wp dot com magic link url with flow, when parsed, then preserves entire url`() {
+        val raw = "https://wordpress.com/wp-login.php" +
+            "?action=magic-login&scheme=woocommerce&token=abc&flow=jetpack-connection"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.WpComMagicLinkUrl(url = raw))
+    }
+
+    @Test
+    fun `given wp dot com magic link url with mixed case host, when parsed, then returns WpComMagicLinkUrl`() {
+        val raw = "https://WordPress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=abc"
+
+        assertThat(parser.parse(raw)).isInstanceOf(QrLoginPayload.WpComMagicLinkUrl::class.java)
+    }
+
+    @Test
+    fun `given wp dot com magic link url with reordered query params, when parsed, then returns WpComMagicLinkUrl`() {
+        val raw = "https://wordpress.com/wp-login.php?token=abc&scheme=woocommerce&action=magic-login"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.WpComMagicLinkUrl(url = raw))
+    }
+
+    @Test
+    fun `given wp dot com url with scheme wordpress, when parsed, then returns Invalid`() {
+        // Intended for the WordPress app — must not be silently consumed by us.
+        val raw = "https://wordpress.com/wp-login.php?action=magic-login&scheme=wordpress&token=abc"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given wp dot com url with non magic-login action, when parsed, then returns Invalid`() {
+        val raw = "https://wordpress.com/wp-login.php?action=lostpassword&scheme=woocommerce&token=abc"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given wp dot com magic link url without token, when parsed, then returns Invalid`() {
+        val raw = "https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given wp dot com magic link url with blank token, when parsed, then returns Invalid`() {
+        val raw = "https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token="
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given http wp dot com magic link url, when parsed, then returns Invalid`() {
+        val raw = "http://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=abc"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given wp dot com url with non wp-login path, when parsed, then returns Invalid`() {
+        val raw = "https://wordpress.com/wp-admin/login.php?action=magic-login&scheme=woocommerce&token=abc"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -494,6 +494,50 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             .isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = DEFAULT_SITE_ID))
     }
 
+    @Test
+    fun `given wp dot com url payload, when scan succeeds, then emits OpenWpComMagicLinkUrl`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.WpComMagicLinkUrl(WP_COM_URL))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+
+        assertThat(events.last()).isEqualTo(
+            QrLoginScannerViewModel.Dispatch.OpenWpComMagicLinkUrl(url = WP_COM_URL)
+        )
+    }
+
+    @Test
+    fun `given wp dot com url payload, when scan succeeds, then ui state stays idle`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.WpComMagicLinkUrl(WP_COM_URL))
+
+        viewModel.onScanResult(successScan())
+
+        assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
+        verify(authenticator, never()).authenticate(any())
+    }
+
+    @Test
+    fun `given wp dot com url via deep link, when received, then emits OpenWpComMagicLinkUrl`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.WpComMagicLinkUrl(WP_COM_URL))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onDeepLinkPayload(RAW_SCAN)
+
+        assertThat(events.last()).isEqualTo(
+            QrLoginScannerViewModel.Dispatch.OpenWpComMagicLinkUrl(url = WP_COM_URL)
+        )
+    }
+
+    @Test
+    fun `given wp dot com url handed off, when another scan arrives, then it is ignored`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.WpComMagicLinkUrl(WP_COM_URL))
+
+        viewModel.onScanResult(successScan(RAW_SCAN))
+        viewModel.onScanResult(successScan("second-raw"))
+
+        verify(parser, never()).parse("second-raw")
+    }
+
     private fun successScan(raw: String = RAW_SCAN) =
         CodeScannerStatus.Success(code = raw, format = BarcodeFormat.FormatQRCode)
 
@@ -503,5 +547,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     private companion object {
         const val RAW_SCAN = "raw"
         const val DEFAULT_SITE_ID = 42
+        const val WP_COM_URL =
+            "https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=abc"
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -538,6 +538,28 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         verify(parser, never()).parse("second-raw")
     }
 
+    @Test
+    fun `given wp dot com url payload, when scan succeeds, then tracks LOGIN_QR_HANDED_OFF_WP_COM_MAGIC_LINK`() =
+        testBlocking {
+            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.WpComMagicLinkUrl(WP_COM_URL))
+
+            viewModel.onScanResult(successScan())
+
+            verify(analyticsTracker).track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_WP_COM_MAGIC_LINK)
+        }
+
+    @Test
+    fun `given wp dot com url payload, when scan succeeds, then does not track LOGIN_QR_SCAN_FAILED or LOGIN_QR_SUCCESS`() =
+        testBlocking {
+            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.WpComMagicLinkUrl(WP_COM_URL))
+
+            viewModel.onScanResult(successScan())
+
+            // The wp.com handoff is the happy path, not a failure, and not a completed sign-in.
+            verify(analyticsTracker, never()).track(eq(AnalyticsEvent.LOGIN_QR_SCAN_FAILED), any(), any(), any(), any())
+            verify(analyticsTracker, never()).track(AnalyticsEvent.LOGIN_QR_SUCCESS)
+        }
+
     private fun successScan(raw: String = RAW_SCAN) =
         CodeScannerStatus.Success(code = raw, format = BarcodeFormat.FormatQRCode)
 


### PR DESCRIPTION
### Description

Fixes WOOMOB-2932

Adds support for scanning the WordPress.com magic-login QR code (`https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=<envelope>`) from the in-app scanner. Today this QR works only via 3rd-party scanners (Google Lens, etc.) — those open Chrome, wp.com 3xx-redirects to `woocommerce://magic-login`, and the existing intent-filter on `MagicLinkInterceptActivity` signs the user in. This PR makes the in-app scanner take the **same** path: it recognises the URL, hands it to the browser via `ChromeCustomTabUtils.launchUrl`, and reuses the existing magic-link flow without re-implementing it.

The wp.com `token` query value is opaque to the client (the server resolves it during the redirect), so we deliberately don't try to synthesise the deeplink locally. The `scheme=woocommerce` query param is required — a QR with `scheme=wordpress` is intended for the WordPress app and is rejected as `Invalid`.

A new analytics event `LOGIN_QR_HANDED_OFF_WP_COM_MAGIC_LINK` fires when we initiate the handoff. The downstream `SIGNED_IN` event continues to fire automatically via the existing `MagicLinkInterceptActivity` → FluxC → `LoginAnalyticsListener.trackAnalyticsSignIn` pipeline once the browser redirect completes.

Stacked on top of #15742 — must merge after Step 10. Carries `status: do not merge` until that lands.

### Test Steps

1. Be signed out of the app. With the QR login feature gate enabled (step-10 wires this up), navigate to the QR login prologue and tap **Scan**.
2. Scan WordPress.com Magic Link QR Code.
3. Notice the app signs in.

### Images/gif

N/A — no UI changes; same scanner surface from step-10. Only the recognised payload set has expanded.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

Release notes for the QR login feature will accumulate on the final step in the stack once the gate is flipped.