### PR TITLE
[POC] Add Tap to Pay support in POS

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentNavigation.kt
@@ -14,10 +14,12 @@ import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
 const val CARD_PAYMENT_ROUTE_ORDER_ID_KEY = "orderId"
 const val CARD_PAYMENT_ROUTE_SOURCE_KEY = "source"
 const val CARD_PAYMENT_ROUTE_SHOW_CASH_PAYMENT_KEY = "showCashPayment"
+const val CARD_PAYMENT_ROUTE_READER_TYPE_KEY = "readerType"
 const val CARD_PAYMENT_ROUTE =
     "$HOME_ROUTE/card_payment/{$CARD_PAYMENT_ROUTE_ORDER_ID_KEY}" +
         "?$CARD_PAYMENT_ROUTE_SOURCE_KEY={$CARD_PAYMENT_ROUTE_SOURCE_KEY}" +
-        "&$CARD_PAYMENT_ROUTE_SHOW_CASH_PAYMENT_KEY={$CARD_PAYMENT_ROUTE_SHOW_CASH_PAYMENT_KEY}"
+        "&$CARD_PAYMENT_ROUTE_SHOW_CASH_PAYMENT_KEY={$CARD_PAYMENT_ROUTE_SHOW_CASH_PAYMENT_KEY}" +
+        "&$CARD_PAYMENT_ROUTE_READER_TYPE_KEY={$CARD_PAYMENT_ROUTE_READER_TYPE_KEY}"
 
 enum class CardPaymentSource {
     CHECKOUT,
@@ -28,12 +30,14 @@ fun NavController.navigateToCardPaymentScreen(
     orderId: Long,
     source: CardPaymentSource = CardPaymentSource.CHECKOUT,
     showCashPaymentButton: Boolean = false,
+    readerType: String = "EXTERNAL",
 ) {
     navigateOnce(
         CARD_PAYMENT_ROUTE
             .replace("{$CARD_PAYMENT_ROUTE_ORDER_ID_KEY}", orderId.toString())
             .replace("{$CARD_PAYMENT_ROUTE_SOURCE_KEY}", source.name)
             .replace("{$CARD_PAYMENT_ROUTE_SHOW_CASH_PAYMENT_KEY}", showCashPaymentButton.toString())
+            .replace("{$CARD_PAYMENT_ROUTE_READER_TYPE_KEY}", readerType)
     )
 }
 
@@ -51,6 +55,10 @@ fun NavGraphBuilder.cardPaymentScreen(
             navArgument(CARD_PAYMENT_ROUTE_SHOW_CASH_PAYMENT_KEY) {
                 type = NavType.BoolType
                 defaultValue = false
+            },
+            navArgument(CARD_PAYMENT_ROUTE_READER_TYPE_KEY) {
+                type = NavType.StringType
+                defaultValue = "EXTERNAL"
             }
         ),
         enterTransition = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentScreen.kt
@@ -1,6 +1,11 @@
 package com.woocommerce.android.ui.woopos.cardpayment
 
+import android.Manifest
+import android.location.LocationManager
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.fadeIn
@@ -66,9 +71,37 @@ fun WooPosCardPaymentScreen(
 ) {
     val viewModel: WooPosCardPaymentViewModel = hiltViewModel()
     val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            viewModel.onLocationPermissionGranted()
+        } else {
+            viewModel.onLocationPermissionDenied()
+        }
+    }
 
     LaunchedEffect(Unit) {
-        viewModel.navigationEvent.collect { onNavigationEvent(it) }
+        viewModel.navigationEvent.collect { event ->
+            when (event) {
+                is WooPosNavigationEvent.EnsureLocationPermission -> {
+                    locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                }
+                is WooPosNavigationEvent.CheckLocationEnabled -> {
+                    val locationManager = context.getSystemService(LocationManager::class.java)
+                    val isEnabled = locationManager?.isProviderEnabled(LocationManager.GPS_PROVIDER) == true ||
+                        locationManager?.isProviderEnabled(LocationManager.NETWORK_PROVIDER) == true
+                    if (isEnabled) {
+                        viewModel.onLocationEnabled()
+                    } else {
+                        viewModel.onLocationDisabled()
+                    }
+                }
+                else -> onNavigationEvent(event)
+            }
+        }
     }
 
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -110,6 +143,12 @@ private fun WooPosCardPaymentScreenContent(
     Box(modifier = Modifier.fillMaxSize()) {
         StateChangeAnimated(visible = state is WooPosCardPaymentState.Initiating) {
             CardPaymentInitiating()
+        }
+
+        StateChangeAnimated(visible = state is WooPosCardPaymentState.ConnectingTapToPay) {
+            if (state is WooPosCardPaymentState.ConnectingTapToPay) {
+                CardPaymentConnectingTapToPay(state = state, onBackClicked = onBackClicked)
+            }
         }
 
         StateChangeAnimated(visible = state is WooPosCardPaymentState.Collecting.Preparing) {
@@ -183,6 +222,48 @@ private fun CardPaymentInitiating() {
         contentAlignment = Alignment.Center,
     ) {
         WooPosCircularLoadingIndicator(modifier = Modifier.size(WooPosComponentSize.XLarge.value))
+    }
+}
+
+@Composable
+private fun CardPaymentConnectingTapToPay(
+    state: WooPosCardPaymentState.ConnectingTapToPay,
+    onBackClicked: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        WooPosToolbar(
+            titleText = state.title,
+            onBackClicked = onBackClicked,
+        )
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                WooPosCircularLoadingIndicator(modifier = Modifier.size(WooPosComponentSize.XLarge.value))
+                Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
+                WooPosText(
+                    text = state.title,
+                    style = WooPosTypography.BodyLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
+                WooPosText(
+                    text = state.subtitle,
+                    style = WooPosTypography.BodyMedium,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
     }
 }
 
@@ -470,7 +551,10 @@ private fun CardPaymentCenteredLayout(
                     .fillMaxWidth()
                     .verticalScroll(rememberScrollState())
                     .defaultMinSize(minHeight = maxHeight)
-                    .padding(vertical = WooPosSpacing.XXXLarge.value),
+                    .padding(
+                        vertical = WooPosSpacing.XXXLarge.value,
+                        horizontal = WooPosSpacing.XLarge.value,
+                    ),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.SpaceEvenly,
             ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentState.kt
@@ -26,6 +26,11 @@ sealed class WooPosCardPaymentState {
         ) : Collecting()
     }
 
+    data class ConnectingTapToPay(
+        val title: String,
+        val subtitle: String,
+    ) : WooPosCardPaymentState()
+
     data class PaymentInProgress(
         val title: String,
         val subtitle: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModel.kt
@@ -3,16 +3,25 @@ package com.woocommerce.android.ui.woopos.cardpayment
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.CardReaderManager
+import com.woocommerce.android.cardreader.connection.CardReaderDiscoveryEvents
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connecting
 import com.woocommerce.android.cardreader.connection.CardReaderStatus.NotConnected
+import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover.SpecificReaders.BuiltInReaders
+import com.woocommerce.android.cardreader.connection.ReaderType.BuildInReader.TapToPayDevice
+import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderLocationRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
+import com.woocommerce.android.ui.prefs.developer.DeveloperOptionsRepository
 import com.woocommerce.android.ui.woopos.bookings.BOOKING_PAYMENT_FLOW_FINISHED_KEY
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
@@ -22,6 +31,7 @@ import com.woocommerce.android.ui.woopos.paymentsuccess.PaymentSuccessSource
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.util.WooPosNetworkStatus
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.UiStringParser
 import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -32,6 +42,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -47,12 +58,19 @@ class WooPosCardPaymentViewModel @Inject constructor(
     private val analyticsTracker: WooPosCardPaymentAnalyticsTracker,
     private val cardPaymentRepository: WooPosCardPaymentRepository,
     private val priceFormat: WooPosFormatPrice,
+    private val cardReaderManager: CardReaderManager,
+    private val developerOptionsRepository: DeveloperOptionsRepository,
+    private val locationRepository: CardReaderLocationRepository,
+    private val cardReaderOnboardingChecker: CardReaderOnboardingChecker,
+    private val dispatchers: CoroutineDispatchers,
 ) : ViewModel() {
 
     private val orderId: Long = requireNotNull(savedState[CARD_PAYMENT_ROUTE_ORDER_ID_KEY])
     private val source: CardPaymentSource = (savedState[CARD_PAYMENT_ROUTE_SOURCE_KEY] as? String)
         ?.let { runCatching { CardPaymentSource.valueOf(it) }.getOrNull() }
         ?: CardPaymentSource.CHECKOUT
+    private val readerType: String = savedState[CARD_PAYMENT_ROUTE_READER_TYPE_KEY] ?: "EXTERNAL"
+    private val isTapToPayMode: Boolean = readerType == "BUILT_IN"
 
     private val _state = MutableStateFlow<WooPosCardPaymentState>(WooPosCardPaymentState.Initiating)
     val state: StateFlow<WooPosCardPaymentState> = _state.asStateFlow()
@@ -69,6 +87,7 @@ class WooPosCardPaymentViewModel @Inject constructor(
     private var controllerEventJob: Job? = null
     private var isTTPPaymentInProgress: Boolean by TTPPaymentProgressDelegate(savedState)
     private var analyticsTrackerJob: Job? = null
+    private var paymentCompleted = false
 
     init {
         viewModelScope.launch {
@@ -105,11 +124,18 @@ class WooPosCardPaymentViewModel @Inject constructor(
 
     private fun observeCardReaderStatus() {
         viewModelScope.launch {
+            if (isTapToPayMode) {
+                connectTapToPay()
+            }
             cardReaderFacade.readerStatus.collect { status ->
+                if (paymentCompleted) return@collect
                 when (status) {
                     is NotConnected, is Connecting -> {
                         val currentState = _state.value
                         if (currentState is WooPosCardPaymentState.PaymentInProgress) {
+                            return@collect
+                        }
+                        if (isTapToPayMode && currentState is WooPosCardPaymentState.ConnectingTapToPay) {
                             return@collect
                         }
                         _state.value = buildReaderDisconnectedState()
@@ -130,6 +156,117 @@ class WooPosCardPaymentViewModel @Inject constructor(
             }
         }
     }
+
+    private fun connectTapToPay() {
+        _state.value = WooPosCardPaymentState.ConnectingTapToPay(
+            title = resourceProvider.getString(R.string.woopos_tap_to_pay_connecting_title),
+            subtitle = resourceProvider.getString(R.string.woopos_tap_to_pay_connecting_subtitle),
+        )
+        viewModelScope.launch {
+            _navigationEvent.emit(WooPosNavigationEvent.EnsureLocationPermission)
+        }
+    }
+
+    fun onLocationPermissionGranted() {
+        viewModelScope.launch {
+            _navigationEvent.emit(WooPosNavigationEvent.CheckLocationEnabled)
+        }
+    }
+
+    fun onLocationEnabled() {
+        viewModelScope.launch {
+            // Disconnect any existing reader (external or stale TTP) before starting fresh
+            if (cardReaderManager.readerStatus.value is Connected ||
+                cardReaderManager.readerStatus.value is CardReaderStatus.Reconnecting
+            ) {
+                cardReaderManager.cancelReconnection()
+                cardReaderManager.disconnectReader()
+            }
+            initializeCardReaderForTtp()
+            startTtpDiscovery()
+        }
+    }
+
+    fun onLocationDisabled() {
+        _state.value = buildTtpConnectionFailedState(
+            resourceProvider.getString(R.string.woopos_tap_to_pay_enable_location)
+        )
+    }
+
+    fun onLocationPermissionDenied() {
+        _state.value = buildTtpConnectionFailedState(
+            resourceProvider.getString(R.string.woopos_tap_to_pay_location_permission_required)
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun startTtpDiscovery() {
+        if (cardReaderManager.readerStatus.value is CardReaderStatus.Connecting) return
+        viewModelScope.launch {
+            try {
+                cardReaderManager
+                    .discoverReaders(
+                        isSimulated = developerOptionsRepository.isSimulatedCardReaderEnabled(),
+                        cardReaderTypesToDiscover = BuiltInReaders(listOf(TapToPayDevice))
+                    )
+                    .flowOn(dispatchers.io)
+                    .collect { event -> handleTtpDiscoveryEvent(event) }
+            } catch (e: Exception) {
+                _state.value = buildTtpConnectionFailedState(
+                    e.message ?: resourceProvider.getString(
+                        R.string.woopos_success_totals_error_reader_not_connected_subtitle
+                    )
+                )
+            }
+        }
+    }
+
+    private fun initializeCardReaderForTtp() {
+        if (!cardReaderManager.initialized) {
+            cardReaderManager.initialize(
+                updateFrequency = developerOptionsRepository.getUpdateSimulatedReaderOption(),
+                useInterac = developerOptionsRepository.isInteracPaymentEnabled(),
+                isDebug = BuildConfig.DEBUG,
+            )
+        }
+        cardReaderManager.setupTapToPayUx(
+            CardReaderManager.TapToPayUxConfig(
+                primaryColor = R.color.color_primary,
+                successColor = R.color.woo_green_50,
+                errorColor = R.color.color_error,
+                isDarkMode = resourceProvider.isDarkMode(),
+            )
+        )
+    }
+
+    private suspend fun handleTtpDiscoveryEvent(event: CardReaderDiscoveryEvents) {
+        when (event) {
+            is CardReaderDiscoveryEvents.ReadersFound -> {
+                val reader = event.list.firstOrNull() ?: return
+                val pluginType = cardReaderOnboardingChecker.getOnboardingState().preferredPlugin
+                    ?: PluginType.WOOCOMMERCE_PAYMENTS
+                val locationResult = locationRepository.getDefaultLocationId(pluginType)
+                if (locationResult is CardReaderLocationRepository.LocationIdFetchingResult.Success) {
+                    cardReaderManager.startConnectionToReader(reader, locationResult.locationId)
+                } else {
+                    _state.value = buildTtpConnectionFailedState(
+                        resourceProvider.getString(R.string.woopos_success_totals_error_reader_not_connected_subtitle)
+                    )
+                }
+            }
+            is CardReaderDiscoveryEvents.Failed -> {
+                _state.value = buildTtpConnectionFailedState(event.msg)
+            }
+            is CardReaderDiscoveryEvents.Started,
+            is CardReaderDiscoveryEvents.Succeeded -> Unit
+        }
+    }
+
+    private fun buildTtpConnectionFailedState(subtitle: String) = WooPosCardPaymentState.PaymentFailed(
+        title = resourceProvider.getString(R.string.woopos_success_totals_payment_failed_title),
+        subtitle = subtitle,
+        isDismissButtonVisible = true,
+    )
 
     private fun collectPayment() {
         if (!networkStatus.isConnected()) {
@@ -191,14 +328,13 @@ class WooPosCardPaymentViewModel @Inject constructor(
                         handlePaymentSuccessful()
                     }
 
-                    is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment -> {
+                    is CardReaderPaymentState.PaymentFailed -> {
                         _state.value = buildPaymentFailedState(paymentState)
                     }
 
                     CardReaderPaymentState.ReFetchingOrder -> Unit
 
                     is CardReaderPaymentOrRefundState.CardReaderInteracRefundState,
-                    is CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment,
                     is CardReaderPaymentState.PrintingReceipt,
                     CardReaderPaymentState.SharingReceipt -> {
                         throw IllegalArgumentException("Payment state: $paymentState not compatible with POS")
@@ -250,6 +386,8 @@ class WooPosCardPaymentViewModel @Inject constructor(
     }
 
     private suspend fun handlePaymentSuccessful() {
+        paymentCompleted = true
+        cancelPayment()
         val successSource = when (source) {
             CardPaymentSource.CHECKOUT -> PaymentSuccessSource.CARD_CHECKOUT
             CardPaymentSource.BOOKINGS -> PaymentSuccessSource.CARD_BOOKINGS
@@ -263,7 +401,7 @@ class WooPosCardPaymentViewModel @Inject constructor(
     }
 
     private fun buildPaymentFailedState(
-        state: CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment
+        state: CardReaderPaymentState.PaymentFailed
     ): WooPosCardPaymentState.PaymentFailed {
         val isRetryAvailable = state.onRetry != null
         val actionButtonLabel = if (isRetryAvailable) {
@@ -295,12 +433,14 @@ class WooPosCardPaymentViewModel @Inject constructor(
     )
 
     fun onScreenResumed() {
+        if (isTapToPayMode) return
         if (_state.value is WooPosCardPaymentState.Collecting) {
             collectPayment()
         }
     }
 
     fun onScreenPaused() {
+        if (isTapToPayMode) return
         if (_state.value is WooPosCardPaymentState.Collecting) {
             cancelPayment()
         }
@@ -311,7 +451,7 @@ class WooPosCardPaymentViewModel @Inject constructor(
         check(paymentState != null) {
             "Retry clicked but payment controller is null"
         }
-        check(paymentState is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment) {
+        check(paymentState is CardReaderPaymentState.PaymentFailed) {
             "Retry clicked but payment state is not PaymentFailed"
         }
         val onRetry = paymentState.onRetry

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderFacade.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderFacade.kt
@@ -2,8 +2,10 @@ package com.woocommerce.android.ui.woopos.cardreader
 
 import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
+import com.woocommerce.android.cardreader.connection.ReaderType
 import com.woocommerce.android.cardreader.connection.event.CardReaderBatteryStatus
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateAvailability
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
@@ -19,5 +21,14 @@ class WooPosCardReaderFacade @Inject constructor(
 
     fun cancelReconnection() {
         cardReaderManager.cancelReconnection()
+    }
+
+    fun getConnectedReaderType(): CardReaderType {
+        val status = readerStatus.value
+        return if (status is CardReaderStatus.Connected && ReaderType.isBuiltInReaderType(status.cardReader.type)) {
+            CardReaderType.BUILT_IN
+        } else {
+            CardReaderType.EXTERNAL
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderOnboardingActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosCardReaderOnboardingActivity.kt
@@ -92,6 +92,10 @@ class WooPosCardReaderOnboardingActivity : AppCompatActivity(R.layout.activity_w
                 return
             }
 
+        val cardReaderType = intent.getStringExtra(KEY_READER_TYPE)
+            ?.let { runCatching { CardReaderType.valueOf(it) }.getOrNull() }
+            ?: CardReaderType.EXTERNAL
+
         graph.setStartDestination(R.id.cardReaderOnboardingFragment)
         navController.setGraph(
             graph,
@@ -100,7 +104,7 @@ class WooPosCardReaderOnboardingActivity : AppCompatActivity(R.layout.activity_w
                     cardReaderFlowParam = CardReaderFlowParam.WooPosConnection,
                     onboardingState = onboardingState
                 ),
-                cardReaderType = CardReaderType.EXTERNAL
+                cardReaderType = cardReaderType
             ).toBundle()
         )
     }
@@ -108,10 +112,16 @@ class WooPosCardReaderOnboardingActivity : AppCompatActivity(R.layout.activity_w
     companion object {
         const val WOO_POS_CARD_ONBOARDING_REQUEST_KEY = "woo_pos_card_onboarding_request"
         private const val KEY_ONBOARDING_STATE = "key_onboarding_state"
+        private const val KEY_READER_TYPE = "key_reader_type"
 
-        fun buildIntent(context: Context, onboardingState: CardReaderOnboardingState): Intent {
+        fun buildIntent(
+            context: Context,
+            onboardingState: CardReaderOnboardingState,
+            cardReaderType: CardReaderType = CardReaderType.EXTERNAL,
+        ): Intent {
             return Intent(context, WooPosCardReaderOnboardingActivity::class.java).apply {
                 putExtra(KEY_ONBOARDING_STATE, onboardingState)
+                putExtra(KEY_READER_TYPE, cardReaderType.name)
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosIsTapToPayAvailable.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosIsTapToPayAvailable.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.ui.woopos.cardreader
+
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
+import com.woocommerce.android.ui.payments.taptopay.isAvailable
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import javax.inject.Inject
+
+class WooPosIsTapToPayAvailable @Inject constructor(
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
+    private val featureFlagRepository: FeatureFlagRepository,
+) {
+    operator fun invoke(): Boolean =
+        featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_PHONE) &&
+            tapToPayAvailabilityStatus().isAvailable
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
@@ -56,6 +56,7 @@ sealed class ChildToParentEvent {
 
     sealed class NavigationEvent : ChildToParentEvent() {
         data class ToCashPayment(val orderId: Long) : NavigationEvent()
+        data class ToTapToPay(val orderId: Long) : NavigationEvent()
         data class ToEmailReceipt(val orderId: Long) : NavigationEvent()
         data object ReturnHomeFromCashWhenCardPaymentStarted : NavigationEvent()
         data object ExitPos : NavigationEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowParam.PaymentOrRefund.Payment.PaymentType
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
-import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderInteracRefundErrorMapper
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderInteracRefundableChecker
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
@@ -21,6 +20,7 @@ import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptShare
 import com.woocommerce.android.ui.payments.tracking.CardReaderTrackingInfoKeeper
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
 import org.wordpress.android.fluxc.store.WooCommerceStore
@@ -47,6 +47,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
     private val paymentReceiptHelper: PaymentReceiptHelper,
     private val cardReaderOnboardingChecker: CardReaderOnboardingChecker,
     private val paymentReceiptShare: PaymentReceiptShare,
+    private val cardReaderFacade: WooPosCardReaderFacade,
 ) {
     fun create(
         orderId: Long,
@@ -77,7 +78,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
             orderId = orderId,
             paymentType = paymentType
         ),
-        cardReaderType = CardReaderType.EXTERNAL,
+        cardReaderType = cardReaderFacade.getConnectedReaderType(),
         isTTPPaymentInProgress = isTTPPaymentInProgress,
         allowCancelledStatus = allowCancelledStatus,
     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -51,6 +51,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorS
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToolbar
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
@@ -177,12 +178,19 @@ private fun TotalsLoaded(
     state: WooPosTotalsViewState.Checkout,
     onUIEvent: (WooPosTotalsUIEvent) -> Unit,
 ) {
+    val isPhone = currentWooPosBreakpoint() == WooPosBreakpoint.Phone
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        if (isPhone) {
+            WooPosToolbar(
+                titleText = stringResource(R.string.woopos_checkout_button),
+                onBackClicked = { onUIEvent(WooPosTotalsUIEvent.OnBackClicked) },
+            )
+        }
         Column(
             modifier = Modifier
                 .weight(1f)
@@ -198,7 +206,12 @@ private fun TotalsLoaded(
             ) {
                 when (val readerStatus = state.readerStatus) {
                     is WooPosTotalsViewState.ReaderStatus.Disconnected -> {
-                        ReaderDisconnected(status = readerStatus, onUIEvent = onUIEvent)
+                        if (readerStatus.isTapToPayAvailable) {
+                            // Don't show fullscreen disconnected error; payment method
+                            // buttons are rendered below the totals grid instead.
+                        } else {
+                            ReaderDisconnected(status = readerStatus, onUIEvent = onUIEvent)
+                        }
                     }
                     is WooPosTotalsViewState.ReaderStatus.Preparing -> {
                         PreparingReader(
@@ -241,15 +254,98 @@ private fun TotalsLoaded(
             Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
         }
 
-        val isPhone = currentWooPosBreakpoint() == WooPosBreakpoint.Phone
+        val readerStatus = state.readerStatus
+        val isDisconnectedWithTtp = readerStatus is WooPosTotalsViewState.ReaderStatus.Disconnected &&
+            readerStatus.isTapToPayAvailable
+
+        val buttonPadding = if (isPhone) {
+            Modifier.padding(WooPosSpacing.Large.value)
+        } else {
+            Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
+        }
+        if (isDisconnectedWithTtp) {
+            PaymentMethodList(
+                isTapToPayAvailable = true,
+                onUIEvent = onUIEvent,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .then(buttonPadding)
+                    .navigationBarsPadding()
+            )
+        } else {
+            PaymentButtons(
+                isTapToPayAvailable = state.isTapToPayAvailable,
+                onUIEvent = onUIEvent,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .then(buttonPadding)
+                    .navigationBarsPadding()
+            )
+        }
+    }
+}
+
+@Composable
+private fun PaymentMethodList(
+    isTapToPayAvailable: Boolean,
+    onUIEvent: (WooPosTotalsUIEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),
+    ) {
+        WooPosOutlinedButton(
+            text = stringResource(R.string.woopos_payment_card_reader_label),
+            onClick = { onUIEvent(WooPosTotalsUIEvent.ConnectReaderClicked) },
+            modifier = Modifier.fillMaxWidth()
+        )
+        if (isTapToPayAvailable) {
+            WooPosOutlinedButton(
+                text = stringResource(R.string.woopos_payment_tap_to_pay_label),
+                onClick = { onUIEvent(WooPosTotalsUIEvent.OnTapToPayClicked) },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
         WooPosOutlinedButton(
             text = stringResource(R.string.woopos_payment_take_cash_payment_label),
             onClick = { onUIEvent(WooPosTotalsUIEvent.OnCashPaymentClicked) },
             modifier = Modifier
                 .fillMaxWidth()
-                .then(if (isPhone) Modifier.padding(WooPosSpacing.Large.value) else Modifier)
-                .navigationBarsPadding()
                 .testTag(WooPosTestTags.CASH_PAYMENT_BUTTON)
+        )
+    }
+}
+
+@Composable
+private fun PaymentButtons(
+    isTapToPayAvailable: Boolean,
+    onUIEvent: (WooPosTotalsUIEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (isTapToPayAvailable) {
+        Column(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),
+        ) {
+            WooPosOutlinedButton(
+                text = stringResource(R.string.woopos_payment_tap_to_pay_label),
+                onClick = { onUIEvent(WooPosTotalsUIEvent.OnTapToPayClicked) },
+                modifier = Modifier.fillMaxWidth()
+            )
+            WooPosOutlinedButton(
+                text = stringResource(R.string.woopos_payment_take_cash_payment_label),
+                onClick = { onUIEvent(WooPosTotalsUIEvent.OnCashPaymentClicked) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(WooPosTestTags.CASH_PAYMENT_BUTTON)
+            )
+        }
+    } else {
+        WooPosOutlinedButton(
+            text = stringResource(R.string.woopos_payment_take_cash_payment_label),
+            onClick = { onUIEvent(WooPosTotalsUIEvent.OnCashPaymentClicked) },
+            modifier = modifier.testTag(WooPosTestTags.CASH_PAYMENT_BUTTON)
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
@@ -12,5 +12,6 @@ sealed class WooPosTotalsUIEvent {
     data object OnStartReceiptFlowClicked : WooPosTotalsUIEvent()
     data object OnCashPaymentClicked : WooPosTotalsUIEvent()
     data object ConnectReaderClicked : WooPosTotalsUIEvent()
+    data object OnTapToPayClicked : WooPosTotalsUIEvent()
     data object OnBackClicked : WooPosTotalsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -16,11 +16,13 @@ import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardRea
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosIsTapToPayAvailable
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToCashPayment
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToEmailReceipt
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToTapToPay
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.OnNewTransactionStarted
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.OrderSuccessfullyPaidByCard
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.ToastMessageDisplayed
@@ -67,6 +69,7 @@ class WooPosTotalsViewModel @Inject constructor(
     private val totalsAnalyticsTracker: WooPosTotalsAnalyticsTracker,
     private val wooPosLogWrapper: WooPosLogWrapper,
     private val performIncrementalSyncUseCase: WooPosPerformLocalCatalogIncrementalSync,
+    private val isTapToPayAvailable: WooPosIsTapToPayAvailable,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
@@ -181,6 +184,8 @@ class WooPosTotalsViewModel @Inject constructor(
                 }
             }
 
+            WooPosTotalsUIEvent.OnTapToPayClicked -> handleTapToPayClicked()
+
             WooPosTotalsUIEvent.OnBackClicked -> handleBackPress()
 
             WooPosTotalsUIEvent.GoBackToCheckoutAfterFailedCouponValidation -> handleEditOrderClicked()
@@ -200,6 +205,12 @@ class WooPosTotalsViewModel @Inject constructor(
                 ToEmailReceipt(dataState.value.orderId)
             )
         }
+    }
+
+    private fun handleTapToPayClicked() = viewModelScope.launch {
+        childrenToParentEventSender.sendToParent(
+            ToTapToPay(dataState.value.orderId)
+        )
     }
 
     private fun handleCashPaymentClicked() = viewModelScope.launch {
@@ -222,7 +233,7 @@ class WooPosTotalsViewModel @Inject constructor(
             check(paymentState != null) {
                 "Retry failed transaction clicked but payment controller is null"
             }
-            check(paymentState is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment) {
+            check(paymentState is CardReaderPaymentState.PaymentFailed) {
                 "Retry failed transaction clicked but payment state is not PaymentFailed"
             }
             when {
@@ -403,7 +414,7 @@ class WooPosTotalsViewModel @Inject constructor(
                         childrenToParentEventSender.sendToParent(OrderSuccessfullyPaidByCard)
                     }
 
-                    is CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment -> {
+                    is CardReaderPaymentState.PaymentFailed -> {
                         uiState.value = buildPaymentFailedState(paymentState)
                         childrenToParentEventSender.sendToParent(ChildToParentEvent.PaymentFailed)
                     }
@@ -411,7 +422,6 @@ class WooPosTotalsViewModel @Inject constructor(
                     CardReaderPaymentState.ReFetchingOrder -> Unit
 
                     is CardReaderPaymentOrRefundState.CardReaderInteracRefundState,
-                    is CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment,
                     is CardReaderPaymentState.PrintingReceipt,
                     CardReaderPaymentState.SharingReceipt -> {
                         throw IllegalArgumentException("Payment state: $paymentState not compatible with POS")
@@ -473,7 +483,7 @@ class WooPosTotalsViewModel @Inject constructor(
     }
 
     private fun buildPaymentFailedState(
-        state: CardReaderPaymentState.PaymentFailed.ExternalReaderFailedPayment
+        state: CardReaderPaymentState.PaymentFailed
     ): PaymentFailed {
         val isRetryAvailable = state.onRetry != null
         val retryButtonLabel = if (isRetryAvailable) {
@@ -723,6 +733,7 @@ class WooPosTotalsViewModel @Inject constructor(
                 orderTotalText = priceFormat(totalAmount),
             ),
             readerStatus = readerStatus,
+            isTapToPayAvailable = isTapToPayAvailable(),
         )
     }
 
@@ -733,6 +744,7 @@ class WooPosTotalsViewModel @Inject constructor(
             actionButtonLabel = resourceProvider.getString(
                 R.string.woopos_success_totals_error_reader_not_connected_cta_button_label
             ),
+            isTapToPayAvailable = isTapToPayAvailable(),
         )
 
     @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
@@ -10,6 +10,7 @@ sealed class WooPosTotalsViewState : Parcelable {
     data class Checkout(
         val totals: Totals,
         val readerStatus: ReaderStatus,
+        val isTapToPayAvailable: Boolean = false,
     ) : WooPosTotalsViewState()
 
     sealed class Totals : Parcelable {
@@ -51,6 +52,7 @@ sealed class WooPosTotalsViewState : Parcelable {
             val title: String,
             val subtitle: String,
             val actionButtonLabel: String,
+            val isTapToPayAvailable: Boolean = false,
         ) : ReaderStatus()
 
         @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/paymentsuccess/WooPosPaymentSuccessScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/paymentsuccess/WooPosPaymentSuccessScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -72,7 +73,8 @@ private fun PaymentSuccessContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.surfaceBright),
+            .background(MaterialTheme.colorScheme.surfaceBright)
+            .padding(horizontal = WooPosSpacing.XLarge.value),
         contentAlignment = Alignment.Center
     ) {
         val hugeSpacing = WooPosSpacing.Huge.value

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
@@ -18,6 +18,7 @@ sealed class WooPosNavigationEvent {
         val orderId: Long,
         val source: CardPaymentSource = CardPaymentSource.CHECKOUT,
         val showCashPaymentButton: Boolean = false,
+        val readerType: String = "EXTERNAL",
     ) : WooPosNavigationEvent()
     data class OpenEmailReceipt(
         val orderId: Long,
@@ -42,6 +43,8 @@ sealed class WooPosNavigationEvent {
         val orderId: Long,
         val source: PaymentSuccessSource,
     ) : WooPosNavigationEvent()
+    data object EnsureLocationPermission : WooPosNavigationEvent()
+    data object CheckLocationEnabled : WooPosNavigationEvent()
     data class OpenWebView(
         val url: String,
         val title: String = "",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
@@ -34,7 +34,7 @@ fun NavHostController.handleNavigationEvent(
         is WooPosNavigationEvent.OpenCashPayment -> navigateToCashPaymentScreen(event.orderId, event.source)
 
         is WooPosNavigationEvent.OpenCardPayment ->
-            navigateToCardPaymentScreen(event.orderId, event.source, event.showCashPaymentButton)
+            navigateToCardPaymentScreen(event.orderId, event.source, event.showCashPaymentButton, event.readerType)
 
         is WooPosNavigationEvent.GoBackWithResult -> {
             previousBackStackEntry
@@ -94,5 +94,8 @@ fun NavHostController.handleNavigationEvent(
 
         is WooPosNavigationEvent.OpenWebView ->
             navigateToWebViewScreen(event.url, event.title)
+
+        WooPosNavigationEvent.EnsureLocationPermission,
+        WooPosNavigationEvent.CheckLocationEnabled -> Unit
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosRootHost.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosRootHost.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
 import com.woocommerce.android.ui.woopos.home.WooPosHomeViewModel
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.ExitPosClicked
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenBookings
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenCardPayment
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenCashPayment
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenEmailReceipt
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenOrders
@@ -27,6 +28,13 @@ fun WooPosRootHost(
         homeViewModel.navigationEvent.collect {
             when (it) {
                 is NavigationEvent.ToCashPayment -> onNavigationEvent(OpenCashPayment(it.orderId))
+                is NavigationEvent.ToTapToPay -> onNavigationEvent(
+                    OpenCardPayment(
+                        orderId = it.orderId,
+                        showCashPaymentButton = true,
+                        readerType = "BUILT_IN",
+                    )
+                )
                 is NavigationEvent.ToEmailReceipt -> onNavigationEvent(OpenEmailReceipt(it.orderId))
                 NavigationEvent.ExitPos -> onNavigationEvent(ExitPosClicked)
                 NavigationEvent.ReturnHomeFromCashWhenCardPaymentStarted -> onNavigationEvent(ReturnHomeFromCashPayment)

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3773,6 +3773,12 @@
     <string name="woopos_success_totals_error_reader_not_connected_title">Reader not connected</string>
     <string name="woopos_success_totals_error_reader_not_connected_subtitle">To process this payment, please connect your reader.</string>
     <string name="woopos_success_totals_error_reader_not_connected_cta_button_label">Connect to reader</string>
+    <string name="woopos_payment_card_reader_label">Card reader</string>
+    <string name="woopos_payment_tap_to_pay_label">Tap to Pay</string>
+    <string name="woopos_tap_to_pay_connecting_title">Setting up Tap to Pay</string>
+    <string name="woopos_tap_to_pay_connecting_subtitle">Preparing your device for payment</string>
+    <string name="woopos_tap_to_pay_location_permission_required">Location permission is required to use Tap to Pay</string>
+    <string name="woopos_tap_to_pay_enable_location">Please enable location services to use Tap to Pay</string>
     <string name="woopos_totals_reader_getting_ready">Getting ready</string>
     <string name="woopos_totals_reader_checking_order">Checking order</string>
     <string name="woopos_totals_reader_preparing_reader_for_payment">Preparing reader for payment</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -2,13 +2,17 @@ package com.woocommerce.android.ui.woopos.cardpayment
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import com.woocommerce.android.cardreader.CardReaderManager
 import com.woocommerce.android.cardreader.connection.CardReader
 import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.payments.cardreader.connect.CardReaderLocationRepository
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.payment.PaymentFlowError
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
+import com.woocommerce.android.ui.prefs.developer.DeveloperOptionsRepository
 import com.woocommerce.android.ui.woopos.bookings.BOOKING_PAYMENT_FLOW_FINISHED_KEY
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.cashpayment.CashPaymentSource
@@ -71,6 +75,10 @@ class WooPosCardPaymentViewModelTest {
     }
     private val analyticsTracker: WooPosCardPaymentAnalyticsTracker = mock()
     private val cardPaymentRepository: WooPosCardPaymentRepository = mock()
+    private val cardReaderManager: CardReaderManager = mock()
+    private val developerOptionsRepository: DeveloperOptionsRepository = mock()
+    private val locationRepository: CardReaderLocationRepository = mock()
+    private val cardReaderOnboardingChecker: CardReaderOnboardingChecker = mock()
     private val priceFormat: WooPosFormatPrice = mock {
         on { invoke(any<BigDecimal>()) } doReturn "$0.00"
     }
@@ -113,6 +121,11 @@ class WooPosCardPaymentViewModelTest {
             analyticsTracker = analyticsTracker,
             cardPaymentRepository = cardPaymentRepository,
             priceFormat = priceFormat,
+            cardReaderManager = cardReaderManager,
+            developerOptionsRepository = developerOptionsRepository,
+            locationRepository = locationRepository,
+            cardReaderOnboardingChecker = cardReaderOnboardingChecker,
+            dispatchers = coroutineTestRule.testDispatchers,
         )
     }
 
@@ -402,6 +415,11 @@ class WooPosCardPaymentViewModelTest {
             analyticsTracker = analyticsTracker,
             cardPaymentRepository = cardPaymentRepository,
             priceFormat = priceFormat,
+            cardReaderManager = cardReaderManager,
+            developerOptionsRepository = developerOptionsRepository,
+            locationRepository = locationRepository,
+            cardReaderOnboardingChecker = cardReaderOnboardingChecker,
+            dispatchers = coroutineTestRule.testDispatchers,
         )
         advanceUntilIdle()
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -32,6 +32,7 @@ import com.woocommerce.android.ui.payments.receipt.PaymentReceiptShare
 import com.woocommerce.android.ui.payments.tracking.CardReaderTrackingInfoKeeper
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosIsTapToPayAvailable
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.BackFromCheckoutToCartClicked
@@ -73,6 +74,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -124,6 +126,10 @@ class WooPosTotalsViewModelTest {
     private val paymentReceiptShare: PaymentReceiptShare = mock()
     private val uiStringParser: UiStringParser = mock()
     private val wooPosLogWrapper: WooPosLogWrapper = mock()
+    private val cardReaderFacade: WooPosCardReaderFacade = mock()
+    private val isTapToPayAvailable: WooPosIsTapToPayAvailable = mock {
+        on { invoke() } doReturn false
+    }
     private val paymentControllerFactory = WooPosCardReaderPaymentControllerFactory(
         cardReaderManager = cardReaderManager,
         orderRepository = orderRepository,
@@ -144,6 +150,7 @@ class WooPosTotalsViewModelTest {
         paymentReceiptHelper = paymentReceiptHelper,
         cardReaderOnboardingChecker = cardReaderOnboardingChecker,
         paymentReceiptShare = paymentReceiptShare,
+        cardReaderFacade = cardReaderFacade,
     )
 
     private fun createMockSavedStateHandle(): SavedStateHandle {
@@ -155,7 +162,6 @@ class WooPosTotalsViewModelTest {
         )
     }
 
-    private val cardReaderFacade: WooPosCardReaderFacade = mock()
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val performIncrementalSyncUseCase: WooPosPerformLocalCatalogIncrementalSync = mock()
     private val productsDataSource: WooPosProductsDataSource = mock()
@@ -2093,5 +2099,6 @@ class WooPosTotalsViewModelTest {
         ),
         wooPosLogWrapper = wooPosLogWrapper,
         performIncrementalSyncUseCase = performIncrementalSyncUseCase,
+        isTapToPayAvailable = isTapToPayAvailable,
     )
 }

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -3767,6 +3767,12 @@
     <string name="woopos_success_totals_error_reader_not_connected_title">Reader not connected</string>
     <string name="woopos_success_totals_error_reader_not_connected_subtitle">To process this payment, please connect your reader.</string>
     <string name="woopos_success_totals_error_reader_not_connected_cta_button_label">Connect to reader</string>
+    <string name="woopos_payment_card_reader_label">Card reader</string>
+    <string name="woopos_payment_tap_to_pay_label">Tap to Pay</string>
+    <string name="woopos_tap_to_pay_connecting_title">Setting up Tap to Pay</string>
+    <string name="woopos_tap_to_pay_connecting_subtitle">Preparing your device for payment</string>
+    <string name="woopos_tap_to_pay_location_permission_required">Location permission is required to use Tap to Pay</string>
+    <string name="woopos_tap_to_pay_enable_location">Please enable location services to use Tap to Pay</string>
     <string name="woopos_totals_reader_getting_ready">Getting ready</string>
     <string name="woopos_totals_reader_checking_order">Checking order</string>
     <string name="woopos_totals_reader_preparing_reader_for_payment">Preparing reader for payment</string>


### PR DESCRIPTION
### Description

Add Tap to Pay (TTP) as a payment method in the POS checkout flow, gated behind the `WOO_POS_PHONE` feature flag and `TapToPayAvailabilityStatus` (device NFC, country support).

**Checkout screen behavior:**
- **BT reader connected + TTP available:** Shows the existing "tap card" reader status, with Tap to Pay and Cash payment buttons at the bottom.
- **BT reader disconnected + TTP available:** Replaces the fullscreen "reader not connected" error with a payment method list: Card reader, Tap to Pay, Cash payment.
- **TTP not available:** Existing behavior unchanged.

**TTP payment flow:**
Tapping "Tap to Pay" navigates to the card payment screen with `readerType=BUILT_IN`. The VM requests location permission, verifies location services are enabled, initializes the card reader manager, calls `setupTapToPayUx()`, discovers the built-in NFC reader, connects to it, and collects payment via the Stripe Terminal SDK's TTP overlay. The `onScreenPaused`/`onScreenResumed` cancel logic is skipped in TTP mode since the Stripe TTP Activity takes the foreground during payment.

**Other changes:**
- `WooPosCardReaderPaymentControllerFactory` now dynamically determines `CardReaderType` from the connected reader via `WooPosCardReaderFacade.getConnectedReaderType()` instead of hardcoding `EXTERNAL`.
- Both `WooPosCardPaymentViewModel` and `WooPosTotalsViewModel` handle `BuiltInReaderFailedPayment` states (previously threw `IllegalArgumentException`).
- `WooPosCardReaderOnboardingActivity` accepts a dynamic `CardReaderType` via intent extra.
- Phone checkout screen now shows a toolbar with back button.
- Added horizontal padding to the card payment centered layout and payment success screen for phone form factor.

### Test Steps

1. Enable the `WOO_POS_PHONE` feature flag in developer options
2. Open POS on a phone with NFC support (or use simulated reader in dev options)
3. Add items to cart and tap Checkout
4. With no BT reader connected, verify three payment options appear: Card reader, Tap to Pay, Cash payment
5. Tap "Tap to Pay" — grant location permission if prompted — verify TTP connects and the Stripe NFC overlay appears
6. Complete a payment and verify the success screen shows with proper padding
7. Tap Done and verify you return to checkout without errors
8. Connect a BT reader and verify the checkout shows the "tap card" animation with Tap to Pay and Cash buttons at the bottom
9. On a tablet, verify existing BT reader flow is unchanged when the feature flag is off

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.