### PR TITLE
Step 14: QR login — send device metadata on exchange

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginDeviceInfoProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginDeviceInfoProvider.kt
@@ -1,0 +1,50 @@
+package com.woocommerce.android.network.qrlogin
+
+import android.os.Build
+import com.google.gson.annotations.SerializedName
+import com.woocommerce.android.BuildConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Wraps the Android `Build` and `BuildConfig` lookups behind an injectable seam so the
+ * QR exchange request can include device metadata without making `QrLoginRestClient`
+ * untestable.
+ *
+ * Production reads `Build.MODEL` / `Build.BRAND` / `Build.VERSION.RELEASE` / `BuildConfig.VERSION_NAME`;
+ * tests pass a fake instance with deterministic values.
+ *
+ * The fields here are mirrored on the server side under the `device` whitelist in
+ * `MobileAppQRLogin::DEVICE_PAYLOAD_KEYS` (WooCommerce Core). Each field is length-capped
+ * server-side, so we don't need to truncate locally.
+ */
+@Singleton
+open class QrLoginDeviceInfoProvider @Inject constructor() {
+    open fun get(): QrLoginDeviceInfo = QrLoginDeviceInfo(
+        os = OS_NAME,
+        osVersion = Build.VERSION.RELEASE.orEmpty(),
+        model = Build.MODEL.orEmpty(),
+        brand = Build.BRAND.orEmpty(),
+        appVersion = BuildConfig.VERSION_NAME.orEmpty(),
+    )
+
+    private companion object {
+        const val OS_NAME = "Android"
+    }
+}
+
+/**
+ * JSON-serializable device metadata sent on the QR login exchange request.
+ *
+ * Field names map to the server whitelist defined in
+ * `MobileAppQRLogin::DEVICE_PAYLOAD_KEYS` (WooCommerce Core). Anything outside that
+ * whitelist is silently dropped server-side, so adding new fields here without a
+ * matching server change is safe but pointless.
+ */
+data class QrLoginDeviceInfo(
+    @SerializedName("os") val os: String,
+    @SerializedName("os_version") val osVersion: String,
+    @SerializedName("model") val model: String,
+    @SerializedName("brand") val brand: String,
+    @SerializedName("app_version") val appVersion: String,
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginDeviceInfoProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginDeviceInfoProvider.kt
@@ -4,7 +4,6 @@ import android.os.Build
 import com.google.gson.annotations.SerializedName
 import com.woocommerce.android.BuildConfig
 import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * Wraps the Android `Build` and `BuildConfig` lookups behind an injectable seam so the
@@ -18,7 +17,6 @@ import javax.inject.Singleton
  * `MobileAppQRLogin::DEVICE_PAYLOAD_KEYS` (WooCommerce Core). Each field is length-capped
  * server-side, so we don't need to truncate locally.
  */
-@Singleton
 class QrLoginDeviceInfoProvider @Inject constructor() {
     fun get(): QrLoginDeviceInfo = QrLoginDeviceInfo(
         os = OS_NAME,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginDeviceInfoProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginDeviceInfoProvider.kt
@@ -19,8 +19,8 @@ import javax.inject.Singleton
  * server-side, so we don't need to truncate locally.
  */
 @Singleton
-open class QrLoginDeviceInfoProvider @Inject constructor() {
-    open fun get(): QrLoginDeviceInfo = QrLoginDeviceInfo(
+class QrLoginDeviceInfoProvider @Inject constructor() {
+    fun get(): QrLoginDeviceInfo = QrLoginDeviceInfo(
         os = OS_NAME,
         osVersion = Build.VERSION.RELEASE.orEmpty(),
         model = Build.MODEL.orEmpty(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -28,7 +28,8 @@ import javax.inject.Named
 class QrLoginRestClient @Inject constructor(
     @Named("custom-ssl") private val okHttpClient: OkHttpClient,
     private val gson: Gson,
-    private val dispatchers: CoroutineDispatchers
+    private val dispatchers: CoroutineDispatchers,
+    private val deviceInfoProvider: QrLoginDeviceInfoProvider,
 ) {
 
     suspend fun exchange(siteUrl: String, token: String): Result<QrLoginCredentials> =
@@ -59,7 +60,9 @@ class QrLoginRestClient @Inject constructor(
         val exchangeUrl = baseUrl.newBuilder()
             .addPathSegments(EXCHANGE_PATH_SEGMENTS)
             .build()
-        val payload = gson.toJson(ExchangeRequest(token))
+        val payload = gson.toJson(
+            ExchangeRequest(token = token, device = deviceInfoProvider.get())
+        )
         return Request.Builder()
             .url(exchangeUrl)
             .post(payload.toRequestBody(JSON_MEDIA_TYPE))
@@ -105,7 +108,10 @@ class QrLoginRestClient @Inject constructor(
         }
     }
 
-    private data class ExchangeRequest(val token: String)
+    private data class ExchangeRequest(
+        val token: String,
+        val device: QrLoginDeviceInfo,
+    )
 
     private data class ExchangeResponse(
         @SerializedName("user_login") val userLogin: String?,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
@@ -15,6 +15,8 @@ import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -34,8 +36,8 @@ class QrLoginRestClientTest : BaseUnitTest() {
 
     private lateinit var client: QrLoginRestClient
 
-    private val fakeDeviceInfoProvider = object : QrLoginDeviceInfoProvider() {
-        override fun get(): QrLoginDeviceInfo = QrLoginDeviceInfo(
+    private val fakeDeviceInfoProvider = mock<QrLoginDeviceInfoProvider> {
+        on { get() } doReturn QrLoginDeviceInfo(
             os = "Android",
             osVersion = "14",
             model = "Pixel 8 Pro",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
@@ -34,12 +34,23 @@ class QrLoginRestClientTest : BaseUnitTest() {
 
     private lateinit var client: QrLoginRestClient
 
+    private val fakeDeviceInfoProvider = object : QrLoginDeviceInfoProvider() {
+        override fun get(): QrLoginDeviceInfo = QrLoginDeviceInfo(
+            os = "Android",
+            osVersion = "14",
+            model = "Pixel 8 Pro",
+            brand = "google",
+            appVersion = "24.7.0",
+        )
+    }
+
     @Before
     fun setUp() {
         client = QrLoginRestClient(
             okHttpClient = okHttpClient,
             gson = Gson(),
-            dispatchers = coroutinesTestRule.testDispatchers
+            dispatchers = coroutinesTestRule.testDispatchers,
+            deviceInfoProvider = fakeDeviceInfoProvider,
         )
     }
 
@@ -68,15 +79,38 @@ class QrLoginRestClientTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given exchange call, when executed, then request is POST with JSON token body`() = testBlocking {
+    fun `given exchange call, when executed, then request is POST with JSON body containing the token`() = testBlocking {
         client.exchange("https://store.example", "tok-42")
 
         val request = requireNotNull(lastRequest)
         assertThat(request.method).isEqualTo("POST")
         assertThat(request.body?.contentType()?.toString()).startsWith("application/json")
         val buffer = Buffer().also { requireNotNull(request.body).writeTo(it) }
-        assertThat(buffer.readUtf8()).isEqualTo("""{"token":"tok-42"}""")
+        val body = buffer.readUtf8()
+        // The body now also carries a `device` object alongside the token; assert
+        // on the token field shape rather than the full string so future device
+        // payload tweaks don't break this test.
+        assertThat(body).contains(""""token":"tok-42"""")
     }
+
+    @Test
+    fun `given exchange call, when executed, then JSON body includes device metadata from the provider`() =
+        testBlocking {
+            client.exchange("https://store.example", "tok-42")
+
+            val request = requireNotNull(lastRequest)
+            val body = Buffer().also { requireNotNull(request.body).writeTo(it) }.readUtf8()
+            val parsed = Gson().fromJson(body, com.google.gson.JsonObject::class.java)
+            val device = requireNotNull(parsed.getAsJsonObject("device")) {
+                "Exchange request must include a `device` object alongside the token."
+            }
+
+            assertThat(device.get("os").asString).isEqualTo("Android")
+            assertThat(device.get("os_version").asString).isEqualTo("14")
+            assertThat(device.get("model").asString).isEqualTo("Pixel 8 Pro")
+            assertThat(device.get("brand").asString).isEqualTo("google")
+            assertThat(device.get("app_version").asString).isEqualTo("24.7.0")
+        }
 
     @Test
     fun `given 401, when exchange, then TokenRejected`() = testBlocking {


### PR DESCRIPTION
**Do not merge - Parent needs to be merged first.**

### Description

Adds device metadata to the QR login exchange request.

The app now sends a `device` object with the QR login token so WooCommerce Core can show a clearer device name for the Application Password and related sign-in UI. The payload includes:

- `os`
- `os_version`
- `model`
- `brand`
- `app_version`

The values come from `QrLoginDeviceInfoProvider`, which keeps the Android `Build` and `BuildConfig` lookups injectable and testable.

Server-side counterpart: [woocommerce/woocommerce#64456](https://github.com/woocommerce/woocommerce/pull/64456). 

### Expected Behavior

- QR login still works as before.
- On supported WooCommerce Core builds, the issued Application Password and related wp-admin UI can identify the signing-in device.
- On older WooCommerce Core builds, the extra metadata is ignored and the login still succeeds.

### Test Steps

1. Build and install the app: `./gradlew :WooCommerce:installWasabiDebug`.
2. Use a merchant site running the WooCommerce Core counterpart.
3. Generate a QR login code in wp-admin.
4. Scan the QR code with the Android app and complete sign-in.
5. In wp-admin, open `Users > Profile > Application Passwords`.
6. Confirm the new Application Password uses the device-aware name/details when supported by the server.
7. Optional: inspect the QR login request and confirm the JSON body contains `device` alongside the token.
8. Regression check: repeat on an older WooCommerce Core build and confirm QR login still succeeds.

### Stack

Builds on #15772. This is step 14 in the QR login stack.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
