### PR TITLE
[WOOMOB-2894] Add tool registry and catalog selector wiring

### DIFF
--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantToolHandler.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantToolHandler.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.aiassistant.core.chat
 
-fun interface AssistantToolHandler {
+interface AssistantToolHandler {
+    val descriptor: ToolDescriptor
     suspend fun execute(call: ToolCall): ToolResult
 }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantToolHandler.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/AssistantToolHandler.kt
@@ -1,0 +1,5 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+fun interface AssistantToolHandler {
+    suspend fun execute(call: ToolCall): ToolResult
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/CardRef.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/CardRef.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+data class CardRef(
+    val entityType: String,
+    val entityId: String,
+)

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/CardRef.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/CardRef.kt
@@ -2,5 +2,5 @@ package com.woocommerce.android.aiassistant.core.chat
 
 data class CardRef(
     val entityType: String,
-    val entityId: String,
+    val entityId: Long,
 )

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -167,7 +167,9 @@ class AgenticLoopImpl(
                 else -> toolRegistry.execute(call)
             }
             toolResults += result
-            emit(LoopEvent.ToolCallFinished(result))
+            if (result !is ToolResult.RejectedBySafety) {
+                emit(LoopEvent.ToolCallFinished(result))
+            }
         }
         return toolResults
     }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -32,7 +32,7 @@ class AgenticLoopImpl(
         history: List<AssistantMessage>,
         context: SessionContext,
     ): Flow<LoopEvent> = flow {
-        val toolDescriptors = toolRegistry.descriptors()
+        val toolDescriptors = context.catalogSnapshot.tools
         val toolDefs = toolDescriptors.map { it.toToolDefinition() }
         val assembler = ToolCallAssembler(json)
 

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -23,6 +23,7 @@ class AgenticLoopImpl(
     private val chatService: ChatService,
     private val toolRegistry: ToolRegistry,
     private val retryPolicy: RetryPolicy,
+    private val historyBudgeter: HistoryBudgeter,
     private val json: Json,
 ) : AgenticLoop {
 
@@ -36,14 +37,21 @@ class AgenticLoopImpl(
         val toolDefs = toolDescriptors.map { it.toToolDefinition() }
         val assembler = ToolCallAssembler(json)
 
-        var messages: List<AssistantMessage> = history + AssistantMessage.User(userMessage)
+        val currentUserTurn = AssistantMessage.User(userMessage)
+        val systemPrompt = history.filterIsInstance<AssistantMessage.System>().firstOrNull()
+            ?: AssistantMessage.System("")
+        val rawTranscript = history.filterNot { it is AssistantMessage.System }
+        val budgeted = historyBudgeter.build(systemPrompt, rawTranscript, currentUserTurn)
+
+        var modelMessages: List<AssistantMessage> = budgeted.messages
+        val newTurnMessages = mutableListOf<AssistantMessage>(currentUserTurn)
         var visibleOutputStarted = false
         var iteration = 0
 
         while (iteration < MAX_ITERATIONS) {
             val stream = streamWithRetry(
-                ChatRequest(messages = messages, tools = toolDefs),
-                messages,
+                ChatRequest(messages = modelMessages, tools = toolDefs),
+                history + newTurnMessages,
                 visibleOutputStarted,
             ) ?: return@flow
             visibleOutputStarted = stream.visibleOutputStarted
@@ -54,39 +62,43 @@ class AgenticLoopImpl(
                 .filterIsInstance<ToolCallAssembler.AssemblyResult.Success>()
                 .map { it.call }
 
-            messages = messages + AssistantMessage.Assistant(
+            val newAssistantMsg = AssistantMessage.Assistant(
                 content = stream.assistantText.takeIf { it.isNotEmpty() },
                 toolCalls = callsForHistory,
             )
+            modelMessages = modelMessages + newAssistantMsg
+            newTurnMessages.add(newAssistantMsg)
 
             if (stream.finishReason == null) {
-                emit(LoopEvent.Finished(LoopOutcome.FAILED, messages, retryAvailable = false))
+                emit(LoopEvent.Finished(LoopOutcome.FAILED, history + newTurnMessages, retryAvailable = false))
                 return@flow
             }
 
             val isTerminal = stream.finishReason == FinishReason.STOP ||
                 (stream.finishReason != FinishReason.TOOL_CALLS && stream.toolCallDeltas.isEmpty())
             if (isTerminal) {
-                emit(LoopEvent.Finished(LoopOutcome.COMPLETED, messages))
+                emit(LoopEvent.Finished(LoopOutcome.COMPLETED, history + newTurnMessages))
                 return@flow
             }
 
             val toolResults = executeTools(assembledResults, validCalls, toolDescriptors)
             for (result in toolResults) {
-                messages = messages + AssistantMessage.Tool(
+                val newToolMsg = AssistantMessage.Tool(
                     toolCallId = result.toolCallId,
                     content = result.toModelContent(),
                 )
+                modelMessages = modelMessages + newToolMsg
+                newTurnMessages.add(newToolMsg)
             }
             iteration++
         }
 
-        emit(LoopEvent.Finished(LoopOutcome.MAX_ITERATIONS, messages))
+        emit(LoopEvent.Finished(LoopOutcome.MAX_ITERATIONS, history + newTurnMessages))
     }
 
     private suspend fun FlowCollector<LoopEvent>.streamWithRetry(
         request: ChatRequest,
-        messages: List<AssistantMessage>,
+        fullHistory: List<AssistantMessage>,
         initialVisibleOutput: Boolean,
     ): StreamResult? {
         var visibleOutputStarted = initialVisibleOutput
@@ -128,12 +140,12 @@ class AgenticLoopImpl(
                     retryCount++
                 }
                 is RetryDecision.ShowManualRetry -> {
-                    val failedHistory = messagesWithPartialText(messages, assistantText.toString())
+                    val failedHistory = messagesWithPartialText(fullHistory, assistantText.toString())
                     emit(LoopEvent.Finished(LoopOutcome.FAILED, failedHistory, retryAvailable = true))
                     return null
                 }
                 is RetryDecision.DoNotRetry -> {
-                    val failedHistory = messagesWithPartialText(messages, assistantText.toString())
+                    val failedHistory = messagesWithPartialText(fullHistory, assistantText.toString())
                     emit(LoopEvent.Finished(LoopOutcome.FAILED, failedHistory, retryAvailable = false))
                     return null
                 }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/BudgetedHistory.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/BudgetedHistory.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.aiassistant.core.loop
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+import com.woocommerce.android.aiassistant.core.chat.CardRef
+
+data class BudgetedHistory(
+    val messages: List<AssistantMessage>,
+    val retainedEntityRefs: List<CardRef> = emptyList(),
+)

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/CatalogSnapshot.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/CatalogSnapshot.kt
@@ -1,0 +1,8 @@
+package com.woocommerce.android.aiassistant.core.loop
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+
+data class CatalogSnapshot(
+    val scope: ToolScope,
+    val tools: List<ToolDescriptor>,
+)

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/HistoryBudgeter.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/HistoryBudgeter.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.aiassistant.core.loop
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+
+fun interface HistoryBudgeter {
+    fun build(
+        systemPrompt: AssistantMessage.System,
+        rawTranscript: List<AssistantMessage>,
+        currentUserTurn: AssistantMessage.User,
+    ): BudgetedHistory
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SessionContext.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SessionContext.kt
@@ -1,3 +1,6 @@
 package com.woocommerce.android.aiassistant.core.loop
 
-data class SessionContext(val siteId: Long)
+data class SessionContext(
+    val siteId: Long,
+    val catalogSnapshot: CatalogSnapshot,
+)

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.aiassistant.core.loop
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 
 class SlidingWindowHistoryBudgeter(
-    val windowSize: Int = DEFAULT_WINDOW_SIZE,
+    private val windowSize: Int = DEFAULT_WINDOW_SIZE,
 ) : HistoryBudgeter {
 
     override fun build(

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
@@ -19,6 +19,6 @@ class SlidingWindowHistoryBudgeter(
     }
 
     companion object {
-        const val DEFAULT_WINDOW_SIZE = 20
+        internal const val DEFAULT_WINDOW_SIZE = 20
     }
 }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.aiassistant.core.loop
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+
+class SlidingWindowHistoryBudgeter(
+    val windowSize: Int = DEFAULT_WINDOW_SIZE,
+) : HistoryBudgeter {
+
+    override fun build(
+        systemPrompt: AssistantMessage.System,
+        rawTranscript: List<AssistantMessage>,
+        currentUserTurn: AssistantMessage.User,
+    ): BudgetedHistory {
+        val window = rawTranscript.takeLast(windowSize)
+        return BudgetedHistory(
+            messages = listOf(systemPrompt) + window + currentUserTurn,
+            retainedEntityRefs = emptyList(),
+        )
+    }
+
+    companion object {
+        const val DEFAULT_WINDOW_SIZE = 20
+    }
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
@@ -6,12 +6,17 @@ class SlidingWindowHistoryBudgeter(
     private val windowSize: Int = DEFAULT_WINDOW_SIZE,
 ) : HistoryBudgeter {
 
+    init {
+        require(windowSize >= 0) { "windowSize must be non-negative, was $windowSize" }
+    }
+
     override fun build(
         systemPrompt: AssistantMessage.System,
         rawTranscript: List<AssistantMessage>,
         currentUserTurn: AssistantMessage.User,
     ): BudgetedHistory {
         val window = rawTranscript.takeLast(windowSize)
+            .dropWhile { it is AssistantMessage.Tool }
         return BudgetedHistory(
             messages = listOf(systemPrompt) + window + currentUserTurn,
             retainedEntityRefs = emptyList(),

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/ToolCatalogSelector.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/ToolCatalogSelector.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.aiassistant.core.loop
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+
+fun interface ToolCatalogSelector {
+    fun select(scope: ToolScope, fullRegistry: List<ToolDescriptor>): CatalogSnapshot
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/ToolScope.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/ToolScope.kt
@@ -1,0 +1,3 @@
+package com.woocommerce.android.aiassistant.core.loop
+
+enum class ToolScope { GLOBAL, ORDERS, PRODUCTS, ANALYTICS }

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -41,10 +41,9 @@ class AgenticLoopImplTest {
     }
 
     private fun stubRegistry(
-        vararg tools: ToolDescriptor,
         result: ToolResult = ToolResult.Success("call_1", buildJsonObject { put("ok", true) }),
     ): ToolRegistry = object : ToolRegistry {
-        override fun descriptors() = tools.toList()
+        override fun descriptors() = emptyList<ToolDescriptor>()
         override suspend fun execute(call: ToolCall) = result
     }
 
@@ -76,7 +75,7 @@ class AgenticLoopImplTest {
             emit(AssistantEvent.ToolCallDelta(index = 0, id = "call_x", name = "echo", argumentsDelta = "{}"))
             emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
         }
-        val registry = stubRegistry(safeEchoDescriptor(), result = ToolResult.Success("call_x", buildJsonObject { }))
+        val registry = stubRegistry(result = ToolResult.Success("call_x", buildJsonObject { }))
         val loop = loopWith(
             singleIteration,
             singleIteration,
@@ -347,7 +346,7 @@ class AgenticLoopImplTest {
     @Test
     fun `given stub SAFE tool, when loop runs one tool call then STOP, then completes with tool result in history`() = runTest {
         val echoResult = buildJsonObject { put("echoed", "hello") }
-        val registry = stubRegistry(safeEchoDescriptor(), result = ToolResult.Success("call_1", echoResult))
+        val registry = stubRegistry(result = ToolResult.Success("call_1", echoResult))
         val loop = loopWith(
             flow {
                 emit(AssistantEvent.TextDelta("I'll echo that."))
@@ -379,5 +378,30 @@ class AgenticLoopImplTest {
         val toolMessages = finished.updatedHistory.filterIsInstance<AssistantMessage.Tool>()
         assertThat(toolMessages).hasSize(1)
         assertThat(toolMessages[0].content).contains("echoed")
+    }
+
+    @Test
+    fun `given UNSAFE tool, when loop runs tool call, then BlockedBySafety is emitted and ToolCallFinished is not`() = runTest {
+        val unsafeDescriptor = ToolDescriptor(
+            name = "dangerous",
+            description = "A dangerous tool",
+            inputSchema = buildJsonObject { },
+            safetyLevel = ToolSafetyLevel.UNSAFE,
+        )
+        val registry = stubRegistry()
+        val loop = loopWith(
+            flow {
+                emit(AssistantEvent.ToolCallDelta(index = 0, id = "call_1", name = "dangerous", argumentsDelta = "{}"))
+                emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
+            },
+            flowOf(AssistantEvent.Finish(FinishReason.STOP)),
+            registry = registry,
+        )
+        val context = contextWithTools(unsafeDescriptor)
+
+        val events = loop.runTurn("conv", "go", history, context).toList()
+
+        assertThat(events.filterIsInstance<LoopEvent.BlockedBySafety>()).hasSize(1)
+        assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>()).isEmpty()
     }
 }

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -28,16 +28,21 @@ class AgenticLoopImplTest {
     private val context = SessionContext(siteId = 1L, catalogSnapshot = CatalogSnapshot(ToolScope.GLOBAL, emptyList()))
     private val history = listOf<AssistantMessage>(AssistantMessage.System("You are a helpful assistant."))
 
+    private fun passThroughBudgeter(): HistoryBudgeter = HistoryBudgeter { system, transcript, user ->
+        BudgetedHistory(messages = listOf(system) + transcript + user)
+    }
+
     private fun loopWith(
         vararg turnResponses: Flow<AssistantEvent>,
         registry: ToolRegistry = NoOpToolRegistry(),
+        budgeter: HistoryBudgeter = passThroughBudgeter(),
     ): AgenticLoopImpl {
         var callCount = 0
         val service = object : ChatService {
             override fun streamTurn(request: ChatRequest) =
                 turnResponses[minOf(callCount++, turnResponses.size - 1)]
         }
-        return AgenticLoopImpl(service, registry, ConservativeRetryPolicy, json)
+        return AgenticLoopImpl(service, registry, ConservativeRetryPolicy, budgeter, json)
     }
 
     private fun stubRegistry(
@@ -168,7 +173,7 @@ class AgenticLoopImplTest {
             override suspend fun execute(call: ToolCall) =
                 ToolResult.Success(call.id, structured = structuredPayload, uiStructured = uiOnlyPayload)
         }
-        val loop = AgenticLoopImpl(service, registry, ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, registry, ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         loop.runTurn("conv", "go", history, contextWithTools(safeEchoDescriptor())).toList()
 
@@ -261,7 +266,7 @@ class AgenticLoopImplTest {
                 }
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -279,7 +284,7 @@ class AgenticLoopImplTest {
                 return flowOf(AssistantEvent.Failed(AssistantErrorKind.AUTH))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -298,7 +303,7 @@ class AgenticLoopImplTest {
                 return flowOf(AssistantEvent.Failed(AssistantErrorKind.NETWORK))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -316,7 +321,7 @@ class AgenticLoopImplTest {
                 emit(AssistantEvent.Failed(AssistantErrorKind.NETWORK))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -333,7 +338,7 @@ class AgenticLoopImplTest {
                 emit(AssistantEvent.Failed(AssistantErrorKind.NETWORK))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -403,5 +408,59 @@ class AgenticLoopImplTest {
 
         assertThat(events.filterIsInstance<LoopEvent.BlockedBySafety>()).hasSize(1)
         assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>()).isEmpty()
+    }
+
+    @Test
+    fun `given budgeter trims history, when running turn, then model receives only budgeted messages`() = runTest {
+        val bigHistory = listOf(
+            AssistantMessage.System("sys"),
+            AssistantMessage.User("turn 1"),
+            AssistantMessage.Assistant("response 1"),
+            AssistantMessage.User("turn 2"),
+            AssistantMessage.Assistant("response 2"),
+        )
+        val twoMessageBudgeter = HistoryBudgeter { system, _, user ->
+            BudgetedHistory(messages = listOf(system, user))
+        }
+        var capturedMessages: List<AssistantMessage>? = null
+        val service = object : ChatService {
+            override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> {
+                capturedMessages = request.messages
+                return flowOf(AssistantEvent.TextDelta("Hi"), AssistantEvent.Finish(FinishReason.STOP))
+            }
+        }
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, twoMessageBudgeter, json)
+
+        loop.runTurn("conv", "hi", bigHistory, context).toList()
+
+        assertThat(capturedMessages).hasSize(2)
+        assertThat(capturedMessages?.first()).isEqualTo(AssistantMessage.System("sys"))
+        assertThat(capturedMessages?.last()).isEqualTo(AssistantMessage.User("hi"))
+    }
+
+    @Test
+    fun `given budgeter trims history, when running turn, then updatedHistory contains full prior history plus new turn messages`() = runTest {
+        val bigHistory = listOf(
+            AssistantMessage.System("sys"),
+            AssistantMessage.User("turn 1"),
+            AssistantMessage.Assistant("response 1"),
+        )
+        val droppingBudgeter = HistoryBudgeter { system, _, user ->
+            BudgetedHistory(messages = listOf(system, user))
+        }
+        val service = object : ChatService {
+            override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> =
+                flowOf(AssistantEvent.TextDelta("ok"), AssistantEvent.Finish(FinishReason.STOP))
+        }
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, droppingBudgeter, json)
+
+        val events = loop.runTurn("conv", "hi", bigHistory, context).toList()
+
+        val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+        assertThat(finished.updatedHistory).hasSize(bigHistory.size + 2)
+        assertThat(finished.updatedHistory.take(bigHistory.size)).isEqualTo(bigHistory)
+        assertThat(finished.updatedHistory[bigHistory.size]).isEqualTo(AssistantMessage.User("hi"))
+        assertThat(finished.updatedHistory[bigHistory.size + 1])
+            .isEqualTo(AssistantMessage.Assistant(content = "ok", toolCalls = emptyList()))
     }
 }

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -25,7 +25,7 @@ import org.junit.Test
 
 class AgenticLoopImplTest {
     private val json = assistantJsonForTests()
-    private val context = SessionContext(siteId = 1L)
+    private val context = SessionContext(siteId = 1L, catalogSnapshot = CatalogSnapshot(ToolScope.GLOBAL, emptyList()))
     private val history = listOf<AssistantMessage>(AssistantMessage.System("You are a helpful assistant."))
 
     private fun loopWith(
@@ -55,6 +55,9 @@ class AgenticLoopImplTest {
         safetyLevel = ToolSafetyLevel.SAFE,
     )
 
+    private fun contextWithTools(vararg tools: ToolDescriptor) =
+        SessionContext(siteId = 1L, catalogSnapshot = CatalogSnapshot(ToolScope.GLOBAL, tools.toList()))
+
     @Test
     fun `given model returns STOP finish reason, when running turn, then Finished with COMPLETED is emitted`() = runTest {
         val loop = loopWith(
@@ -83,7 +86,7 @@ class AgenticLoopImplTest {
             registry = registry
         )
 
-        val events = loop.runTurn("conv", "go", history, context).toList()
+        val events = loop.runTurn("conv", "go", history, contextWithTools(safeEchoDescriptor())).toList()
 
         val finished = events.filterIsInstance<LoopEvent.Finished>().last()
         assertThat(finished.outcome).isEqualTo(LoopOutcome.MAX_ITERATIONS)
@@ -168,7 +171,7 @@ class AgenticLoopImplTest {
         }
         val loop = AgenticLoopImpl(service, registry, ConservativeRetryPolicy, json)
 
-        loop.runTurn("conv", "go", history, context).toList()
+        loop.runTurn("conv", "go", history, contextWithTools(safeEchoDescriptor())).toList()
 
         val toolMsg = secondCallMessages?.filterIsInstance<AssistantMessage.Tool>()?.firstOrNull()
         assertThat(toolMsg).isNotNull
@@ -202,7 +205,7 @@ class AgenticLoopImplTest {
             registry = registry
         )
 
-        val events = loop.runTurn("conv", "go", history, context).toList()
+        val events = loop.runTurn("conv", "go", history, contextWithTools(safeEchoDescriptor())).toList()
 
         assertThat(registryExecuted).isFalse
         val validationErrors = events.filterIsInstance<LoopEvent.ToolCallFinished>()
@@ -365,7 +368,7 @@ class AgenticLoopImplTest {
             registry = registry
         )
 
-        val events = loop.runTurn("conv", "echo hello", history, context).toList()
+        val events = loop.runTurn("conv", "echo hello", history, contextWithTools(safeEchoDescriptor())).toList()
 
         assertThat(events.filterIsInstance<LoopEvent.AssistantTextDelta>().map { it.text })
             .containsExactly("I'll echo that.", "Done.")

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -463,4 +463,20 @@ class AgenticLoopImplTest {
         assertThat(finished.updatedHistory[bigHistory.size + 1])
             .isEqualTo(AssistantMessage.Assistant(content = "ok", toolCalls = emptyList()))
     }
+
+    @Test
+    fun `given history with no system message, when running turn, then loop completes with empty system prompt`() = runTest {
+        val historyWithoutSystem = listOf(
+            AssistantMessage.User("prior question"),
+            AssistantMessage.Assistant("prior answer"),
+        )
+        val loop = loopWith(
+            flowOf(AssistantEvent.TextDelta("hi"), AssistantEvent.Finish(FinishReason.STOP))
+        )
+
+        val events = loop.runTurn("conv", "hello", historyWithoutSystem, context).toList()
+
+        val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+        assertThat(finished.outcome).isEqualTo(LoopOutcome.COMPLETED)
+    }
 }

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
@@ -1,0 +1,86 @@
+package com.woocommerce.android.aiassistant.core.loop
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SlidingWindowHistoryBudgeterTest {
+    private val system = AssistantMessage.System("You are a helpful assistant.")
+    private val user = AssistantMessage.User("What can you do?")
+
+    @Test
+    fun `given empty transcript, when building, then messages contain only system and user turn`() {
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 5)
+
+        val result = budgeter.build(system, emptyList(), user)
+
+        assertThat(result.messages).containsExactly(system, user)
+    }
+
+    @Test
+    fun `given transcript shorter than window size, when building, then all transcript messages are included`() {
+        val transcript = listOf(
+            AssistantMessage.User("hi"),
+            AssistantMessage.Assistant("Hello!"),
+        )
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 10)
+
+        val result = budgeter.build(system, transcript, user)
+
+        assertThat(result.messages).containsExactly(system, transcript[0], transcript[1], user)
+    }
+
+    @Test
+    fun `given transcript longer than window size, when building, then only most recent messages are included`() {
+        val old1 = AssistantMessage.User("old turn")
+        val old2 = AssistantMessage.Assistant("old response")
+        val recent1 = AssistantMessage.User("recent turn")
+        val recent2 = AssistantMessage.Assistant("recent response")
+        val transcript = listOf(old1, old2, recent1, recent2)
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 2)
+
+        val result = budgeter.build(system, transcript, user)
+
+        assertThat(result.messages).containsExactly(system, recent1, recent2, user)
+    }
+
+    @Test
+    fun `given transcript longer than window size, when building, then oldest messages are excluded`() {
+        val old = AssistantMessage.User("old message")
+        val recent = AssistantMessage.User("recent message")
+        val transcript = listOf(old, AssistantMessage.Assistant("..."), recent)
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 1)
+
+        val result = budgeter.build(system, transcript, user)
+
+        assertThat(result.messages).doesNotContain(old)
+        assertThat(result.messages).contains(recent)
+    }
+
+    @Test
+    fun `given any transcript, when building, then system prompt is first message`() {
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 5)
+
+        val result = budgeter.build(system, listOf(AssistantMessage.User("hello")), user)
+
+        assertThat(result.messages.first()).isEqualTo(system)
+    }
+
+    @Test
+    fun `given any transcript, when building, then current user turn is last message`() {
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 5)
+
+        val result = budgeter.build(system, listOf(AssistantMessage.User("hello")), user)
+
+        assertThat(result.messages.last()).isEqualTo(user)
+    }
+
+    @Test
+    fun `given any transcript, when building, then retainedEntityRefs is empty`() {
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 5)
+
+        val result = budgeter.build(system, listOf(AssistantMessage.User("hello")), user)
+
+        assertThat(result.retainedEntityRefs).isEmpty()
+    }
+}

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.aiassistant.core.loop
 
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import kotlinx.serialization.json.buildJsonObject
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 
 class SlidingWindowHistoryBudgeterTest {
@@ -69,5 +72,31 @@ class SlidingWindowHistoryBudgeterTest {
         val result = budgeter.build(system, listOf(AssistantMessage.User("hello")), user)
 
         assertThat(result.retainedEntityRefs).isEmpty()
+    }
+
+    @Test
+    fun `given window cuts into tool-call exchange, when building, then no orphaned Tool message starts the window`() {
+        val toolCall = ToolCall(id = "call_1", name = "orders_list", arguments = buildJsonObject { })
+        val assistantWithToolCall = AssistantMessage.Assistant(content = null, toolCalls = listOf(toolCall))
+        val toolResult = AssistantMessage.Tool(toolCallId = "call_1", content = """{"orders":[]}""")
+        val assistantFinal = AssistantMessage.Assistant(content = "Here are your orders.")
+        val transcript = listOf(
+            AssistantMessage.User("show orders"),
+            assistantWithToolCall,
+            toolResult,
+            assistantFinal,
+        )
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 2)
+
+        val result = budgeter.build(system, transcript, user)
+
+        assertThat(result.messages).doesNotContain(toolResult)
+        assertThat(result.messages.filterIsInstance<AssistantMessage.Tool>()).isEmpty()
+    }
+
+    @Test
+    fun `given negative window size, when constructing, then throws IllegalArgumentException`() {
+        assertThatThrownBy { SlidingWindowHistoryBudgeter(windowSize = -1) }
+            .isInstanceOf(IllegalArgumentException::class.java)
     }
 }

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
@@ -95,6 +95,29 @@ class SlidingWindowHistoryBudgeterTest {
     }
 
     @Test
+    fun `given window size 2 on 4-message transcript ending with tool then assistant, when building, then orphaned tool is dropped and only assistant response is kept`() {
+        // Transcript: [User, Assistant(toolCalls=[c1]), Tool(c1), Assistant("Done")]
+        // takeLast(2) alone would give [Tool(c1), Assistant("Done")] — Tool(c1) has no
+        // preceding assistant tool-call message, which is invalid for the OpenAI wire format.
+        // The budgeter must advance the window start past orphaned Tool messages.
+        val toolCall = ToolCall(id = "call_1", name = "orders_list", arguments = buildJsonObject { })
+        val assistantWithToolCall = AssistantMessage.Assistant(content = null, toolCalls = listOf(toolCall))
+        val toolResult = AssistantMessage.Tool(toolCallId = "call_1", content = """{"orders":[]}""")
+        val assistantFinal = AssistantMessage.Assistant(content = "Here are your orders.")
+        val transcript = listOf(
+            AssistantMessage.User("show orders"),
+            assistantWithToolCall,
+            toolResult,
+            assistantFinal,
+        )
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 2)
+
+        val result = budgeter.build(system, transcript, user)
+
+        assertThat(result.messages).containsExactly(system, assistantFinal, user)
+    }
+
+    @Test
     fun `given negative window size, when constructing, then throws IllegalArgumentException`() {
         assertThatThrownBy { SlidingWindowHistoryBudgeter(windowSize = -1) }
             .isInstanceOf(IllegalArgumentException::class.java)

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
@@ -45,19 +45,6 @@ class SlidingWindowHistoryBudgeterTest {
     }
 
     @Test
-    fun `given transcript longer than window size, when building, then oldest messages are excluded`() {
-        val old = AssistantMessage.User("old message")
-        val recent = AssistantMessage.User("recent message")
-        val transcript = listOf(old, AssistantMessage.Assistant("..."), recent)
-        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 1)
-
-        val result = budgeter.build(system, transcript, user)
-
-        assertThat(result.messages).doesNotContain(old)
-        assertThat(result.messages).contains(recent)
-    }
-
-    @Test
     fun `given any transcript, when building, then system prompt is first message`() {
         val budgeter = SlidingWindowHistoryBudgeter(windowSize = 5)
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
@@ -10,48 +10,112 @@ import com.woocommerce.android.aiassistant.core.loop.RetryPolicy
 import com.woocommerce.android.aiassistant.core.loop.ToolCatalogSelector
 import com.woocommerce.android.aiassistant.tools.DefaultToolCatalogSelector
 import com.woocommerce.android.aiassistant.tools.WooCommerceToolRegistry
+import com.woocommerce.android.aiassistant.tools.handlers.AnalyticsOrdersToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.AnalyticsRevenueToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.CustomersListToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.OrdersBulkUpdateToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.OrdersGetToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.OrdersListToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.OrdersUpdateToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ProductVariationsListToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ProductsBulkUpdateToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ProductsGetToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ProductsListToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ProductsUpdateToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ShowCardsToolHandler
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
 import kotlinx.serialization.json.Json
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal object AiAssistantModule {
-    @Provides
+internal abstract class AiAssistantModule {
+
+    @Binds
     @Singleton
-    @AiAssistantJson
-    fun provideAiAssistantJson(): Json = Json {
-        ignoreUnknownKeys = true
-        encodeDefaults = false
+    abstract fun bindToolRegistry(impl: WooCommerceToolRegistry): ToolRegistry
+
+    @Binds
+    @IntoSet
+    abstract fun bindOrdersListHandler(impl: OrdersListToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindOrdersGetHandler(impl: OrdersGetToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindOrdersUpdateHandler(impl: OrdersUpdateToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindOrdersBulkUpdateHandler(impl: OrdersBulkUpdateToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindProductsListHandler(impl: ProductsListToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindProductsGetHandler(impl: ProductsGetToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindProductsUpdateHandler(impl: ProductsUpdateToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindProductsBulkUpdateHandler(impl: ProductsBulkUpdateToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindProductVariationsListHandler(impl: ProductVariationsListToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindAnalyticsRevenueHandler(impl: AnalyticsRevenueToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindAnalyticsOrdersHandler(impl: AnalyticsOrdersToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindShowCardsHandler(impl: ShowCardsToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindCustomersListHandler(impl: CustomersListToolHandler): AssistantToolHandler
+
+    companion object {
+        @Provides
+        @Singleton
+        @AiAssistantJson
+        fun provideAiAssistantJson(): Json = Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = false
+        }
+
+        @Provides
+        @Singleton
+        fun provideAgenticLoop(
+            chatService: ChatService,
+            toolRegistry: ToolRegistry,
+            retryPolicy: RetryPolicy,
+            @AiAssistantJson json: Json,
+        ): AgenticLoop = AgenticLoopImpl(chatService, toolRegistry, retryPolicy, json)
+
+        @Provides
+        @Singleton
+        fun provideToolCatalogSelector(): ToolCatalogSelector = DefaultToolCatalogSelector()
+
+        @Provides
+        @Singleton
+        fun provideRetryPolicy(): RetryPolicy = ConservativeRetryPolicy
     }
-
-    @Provides
-    @Singleton
-    fun provideAgenticLoop(
-        chatService: ChatService,
-        toolRegistry: ToolRegistry,
-        retryPolicy: RetryPolicy,
-        @AiAssistantJson json: Json,
-    ): AgenticLoop = AgenticLoopImpl(chatService, toolRegistry, retryPolicy, json)
-
-    @Provides
-    @Singleton
-    fun provideToolRegistry(
-        handlers: Set<@JvmSuppressWildcards AssistantToolHandler>,
-    ): ToolRegistry = WooCommerceToolRegistry(handlers)
-
-    @Provides
-    @Singleton
-    fun provideToolCatalogSelector(): ToolCatalogSelector = DefaultToolCatalogSelector()
-
-    @Provides
-    @Singleton
-    fun provideToolHandlers(): Set<@JvmSuppressWildcards AssistantToolHandler> = emptySet()
-
-    @Provides
-    @Singleton
-    fun provideRetryPolicy(): RetryPolicy = ConservativeRetryPolicy
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
@@ -40,7 +40,7 @@ internal object AiAssistantModule {
     @Provides
     @Singleton
     fun provideToolRegistry(
-        handlers: Map<String, AssistantToolHandler>,
+        handlers: Set<@JvmSuppressWildcards AssistantToolHandler>,
     ): ToolRegistry = WooCommerceToolRegistry(handlers)
 
     @Provides
@@ -49,7 +49,7 @@ internal object AiAssistantModule {
 
     @Provides
     @Singleton
-    fun provideToolHandlers(): Map<String, AssistantToolHandler> = emptyMap()
+    fun provideToolHandlers(): Set<@JvmSuppressWildcards AssistantToolHandler> = emptySet()
 
     @Provides
     @Singleton

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
@@ -6,7 +6,9 @@ import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
 import com.woocommerce.android.aiassistant.core.loop.AgenticLoop
 import com.woocommerce.android.aiassistant.core.loop.AgenticLoopImpl
 import com.woocommerce.android.aiassistant.core.loop.ConservativeRetryPolicy
+import com.woocommerce.android.aiassistant.core.loop.HistoryBudgeter
 import com.woocommerce.android.aiassistant.core.loop.RetryPolicy
+import com.woocommerce.android.aiassistant.core.loop.SlidingWindowHistoryBudgeter
 import com.woocommerce.android.aiassistant.core.loop.ToolCatalogSelector
 import com.woocommerce.android.aiassistant.tools.DefaultToolCatalogSelector
 import com.woocommerce.android.aiassistant.tools.WooCommerceToolRegistry
@@ -103,12 +105,17 @@ internal abstract class AiAssistantModule {
 
         @Provides
         @Singleton
+        fun provideHistoryBudgeter(): HistoryBudgeter = SlidingWindowHistoryBudgeter()
+
+        @Provides
+        @Singleton
         fun provideAgenticLoop(
             chatService: ChatService,
             toolRegistry: ToolRegistry,
             retryPolicy: RetryPolicy,
+            historyBudgeter: HistoryBudgeter,
             @AiAssistantJson json: Json,
-        ): AgenticLoop = AgenticLoopImpl(chatService, toolRegistry, retryPolicy, json)
+        ): AgenticLoop = AgenticLoopImpl(chatService, toolRegistry, retryPolicy, historyBudgeter, json)
 
         @Provides
         @Singleton

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
@@ -1,12 +1,15 @@
 package com.woocommerce.android.aiassistant.di
 
+import com.woocommerce.android.aiassistant.core.chat.AssistantToolHandler
 import com.woocommerce.android.aiassistant.core.chat.ChatService
 import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
 import com.woocommerce.android.aiassistant.core.loop.AgenticLoop
 import com.woocommerce.android.aiassistant.core.loop.AgenticLoopImpl
 import com.woocommerce.android.aiassistant.core.loop.ConservativeRetryPolicy
-import com.woocommerce.android.aiassistant.core.loop.NoOpToolRegistry
 import com.woocommerce.android.aiassistant.core.loop.RetryPolicy
+import com.woocommerce.android.aiassistant.core.loop.ToolCatalogSelector
+import com.woocommerce.android.aiassistant.tools.DefaultToolCatalogSelector
+import com.woocommerce.android.aiassistant.tools.WooCommerceToolRegistry
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -36,7 +39,17 @@ internal object AiAssistantModule {
 
     @Provides
     @Singleton
-    fun provideToolRegistry(): ToolRegistry = NoOpToolRegistry()
+    fun provideToolRegistry(
+        handlers: Map<String, AssistantToolHandler>,
+    ): ToolRegistry = WooCommerceToolRegistry(handlers)
+
+    @Provides
+    @Singleton
+    fun provideToolCatalogSelector(): ToolCatalogSelector = DefaultToolCatalogSelector()
+
+    @Provides
+    @Singleton
+    fun provideToolHandlers(): Map<String, AssistantToolHandler> = emptyMap()
 
     @Provides
     @Singleton

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelector.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelector.kt
@@ -1,0 +1,55 @@
+package com.woocommerce.android.aiassistant.tools
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.loop.CatalogSnapshot
+import com.woocommerce.android.aiassistant.core.loop.ToolCatalogSelector
+import com.woocommerce.android.aiassistant.core.loop.ToolScope
+
+class DefaultToolCatalogSelector : ToolCatalogSelector {
+
+    override fun select(scope: ToolScope, fullRegistry: List<ToolDescriptor>): CatalogSnapshot {
+        val allowedToolNames = when (scope) {
+            ToolScope.GLOBAL -> null
+            ToolScope.ORDERS -> ORDERS_TOOL_NAMES
+            ToolScope.PRODUCTS -> PRODUCTS_TOOL_NAMES
+            ToolScope.ANALYTICS -> ANALYTICS_TOOL_NAMES
+        }
+
+        val tools = if (allowedToolNames == null) {
+            fullRegistry
+        } else {
+            fullRegistry.filter { it.name in allowedToolNames }
+        }
+
+        return CatalogSnapshot(scope = scope, tools = tools)
+    }
+
+    private companion object {
+        val ORDERS_TOOL_NAMES = setOf(
+            "orders_list",
+            "orders_get",
+            "orders_update",
+            "orders_bulk_update",
+            "analytics_orders",
+            "show_cards",
+        )
+
+        val PRODUCTS_TOOL_NAMES = setOf(
+            "products_list",
+            "products_get",
+            "products_update",
+            "products_bulk_update",
+            "product_variations_list",
+            "analytics_revenue",
+            "show_cards",
+        )
+
+        val ANALYTICS_TOOL_NAMES = setOf(
+            "analytics_revenue",
+            "analytics_orders",
+            "orders_list",
+            "products_list",
+            "show_cards",
+        )
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistry.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistry.kt
@@ -12,7 +12,7 @@ class WooCommerceToolRegistry(
     private val handlers: Map<String, AssistantToolHandler>,
 ) : ToolRegistry {
 
-    override fun descriptors(): List<ToolDescriptor> = CATALOG
+    override fun descriptors(): List<ToolDescriptor> = CATALOG.filter { it.name in handlers }
 
     override suspend fun execute(call: ToolCall): ToolResult {
         val handler = handlers[call.name]

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistry.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistry.kt
@@ -5,116 +5,19 @@ import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
 import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
-import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
-import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
 
-class WooCommerceToolRegistry(
-    private val handlers: Map<String, AssistantToolHandler>,
+class WooCommerceToolRegistry @Inject constructor(
+    handlers: Set<@JvmSuppressWildcards AssistantToolHandler>,
 ) : ToolRegistry {
 
-    override fun descriptors(): List<ToolDescriptor> = CATALOG.filter { it.name in handlers }
+    private val handlersByName: Map<String, AssistantToolHandler> = handlers.associateBy { it.descriptor.name }
+
+    override fun descriptors(): List<ToolDescriptor> = handlersByName.values.map { it.descriptor }
 
     override suspend fun execute(call: ToolCall): ToolResult {
-        val handler = handlers[call.name]
+        val handler = handlersByName[call.name]
             ?: return ToolResult.ValidationError(call.id, "No handler registered for tool: ${call.name}")
         return handler.execute(call)
-    }
-
-    companion object {
-        val CATALOG: List<ToolDescriptor> = listOf(
-            ToolDescriptor(
-                name = "orders_list",
-                description = "List and search orders. Supports filtering by status, date range, and customer.",
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.SAFE,
-            ),
-            ToolDescriptor(
-                name = "orders_get",
-                description = "Get a single order by ID.",
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.SAFE,
-            ),
-            ToolDescriptor(
-                name = "orders_update",
-                description = """
-                    Update a single order. Accepts only the `status` field.
-                    Allowed transitions: on-hold -> processing, processing -> completed.
-                    Cancellation and refund flows are not supported by this tool.
-                    At most one write is executed per turn; additional write calls in the same turn will be rejected by the runtime.
-                """.trimIndent(),
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.UNSAFE,
-            ),
-            ToolDescriptor(
-                name = "orders_bulk_update",
-                description = """
-                    Update multiple orders. Accepts only the `status` field per order.
-                    Allowed transitions: on-hold -> processing, processing -> completed.
-                    Bulk writes require confirmation. At most one write operation (single or bulk) is executed per turn.
-                """.trimIndent(),
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.UNSAFE,
-            ),
-            ToolDescriptor(
-                name = "products_list",
-                description = "List and search products. Supports filtering by status, category, and stock.",
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.SAFE,
-            ),
-            ToolDescriptor(
-                name = "products_get",
-                description = "Get a single product by ID.",
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.SAFE,
-            ),
-            ToolDescriptor(
-                name = "products_update",
-                description = """
-                    Update a single product. Accepts only these fields: regular_price, manage_stock, stock_quantity, stock_status, status.
-                    At most one write is executed per turn; additional write calls in the same turn will be rejected by the runtime.
-                """.trimIndent(),
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.UNSAFE,
-            ),
-            ToolDescriptor(
-                name = "products_bulk_update",
-                description = """
-                    Update multiple products. Accepts only these fields per product: regular_price, manage_stock, stock_quantity, stock_status, status.
-                    Bulk writes require confirmation. At most one write operation (single or bulk) is executed per turn.
-                """.trimIndent(),
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.UNSAFE,
-            ),
-            ToolDescriptor(
-                name = "product_variations_list",
-                description = "List variations for a variable product.",
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.SAFE,
-            ),
-            ToolDescriptor(
-                name = "analytics_revenue",
-                description = "Get revenue analytics for a date range.",
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.SAFE,
-            ),
-            ToolDescriptor(
-                name = "analytics_orders",
-                description = "Get order-count analytics for a date range.",
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.SAFE,
-            ),
-            ToolDescriptor(
-                name = "show_cards",
-                description = "Show entity cards in the UI for orders or products selected by the assistant.",
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.SAFE,
-            ),
-            ToolDescriptor(
-                name = "customers_list",
-                description = "List customers or get a specific customer by ID.",
-                inputSchema = buildJsonObject { },
-                safetyLevel = ToolSafetyLevel.SAFE,
-            ),
-        )
     }
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistry.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistry.kt
@@ -1,0 +1,120 @@
+package com.woocommerce.android.aiassistant.tools
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantToolHandler
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+
+class WooCommerceToolRegistry(
+    private val handlers: Map<String, AssistantToolHandler>,
+) : ToolRegistry {
+
+    override fun descriptors(): List<ToolDescriptor> = CATALOG
+
+    override suspend fun execute(call: ToolCall): ToolResult {
+        val handler = handlers[call.name]
+            ?: return ToolResult.ValidationError(call.id, "No handler registered for tool: ${call.name}")
+        return handler.execute(call)
+    }
+
+    companion object {
+        val CATALOG: List<ToolDescriptor> = listOf(
+            ToolDescriptor(
+                name = "orders_list",
+                description = "List and search orders. Supports filtering by status, date range, and customer.",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.SAFE,
+            ),
+            ToolDescriptor(
+                name = "orders_get",
+                description = "Get a single order by ID.",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.SAFE,
+            ),
+            ToolDescriptor(
+                name = "orders_update",
+                description = """
+                    Update a single order. Accepts only the `status` field.
+                    Allowed transitions: on-hold -> processing, processing -> completed.
+                    Cancellation and refund flows are not supported by this tool.
+                    At most one write is executed per turn; additional write calls in the same turn will be rejected by the runtime.
+                """.trimIndent(),
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.UNSAFE,
+            ),
+            ToolDescriptor(
+                name = "orders_bulk_update",
+                description = """
+                    Update multiple orders. Accepts only the `status` field per order.
+                    Allowed transitions: on-hold -> processing, processing -> completed.
+                    Bulk writes require confirmation. At most one write operation (single or bulk) is executed per turn.
+                """.trimIndent(),
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.UNSAFE,
+            ),
+            ToolDescriptor(
+                name = "products_list",
+                description = "List and search products. Supports filtering by status, category, and stock.",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.SAFE,
+            ),
+            ToolDescriptor(
+                name = "products_get",
+                description = "Get a single product by ID.",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.SAFE,
+            ),
+            ToolDescriptor(
+                name = "products_update",
+                description = """
+                    Update a single product. Accepts only these fields: regular_price, manage_stock, stock_quantity, stock_status, status.
+                    At most one write is executed per turn; additional write calls in the same turn will be rejected by the runtime.
+                """.trimIndent(),
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.UNSAFE,
+            ),
+            ToolDescriptor(
+                name = "products_bulk_update",
+                description = """
+                    Update multiple products. Accepts only these fields per product: regular_price, manage_stock, stock_quantity, stock_status, status.
+                    Bulk writes require confirmation. At most one write operation (single or bulk) is executed per turn.
+                """.trimIndent(),
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.UNSAFE,
+            ),
+            ToolDescriptor(
+                name = "product_variations_list",
+                description = "List variations for a variable product.",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.SAFE,
+            ),
+            ToolDescriptor(
+                name = "analytics_revenue",
+                description = "Get revenue analytics for a date range.",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.SAFE,
+            ),
+            ToolDescriptor(
+                name = "analytics_orders",
+                description = "Get order-count analytics for a date range.",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.SAFE,
+            ),
+            ToolDescriptor(
+                name = "show_cards",
+                description = "Show entity cards in the UI for orders or products selected by the assistant.",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.SAFE,
+            ),
+            ToolDescriptor(
+                name = "customers_list",
+                description = "List customers or get a specific customer by ID.",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.SAFE,
+            ),
+        )
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistry.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistry.kt
@@ -13,6 +13,13 @@ class WooCommerceToolRegistry @Inject constructor(
 
     private val handlersByName: Map<String, AssistantToolHandler> = handlers.associateBy { it.descriptor.name }
 
+    init {
+        val names = handlers.map { it.descriptor.name }
+        require(names.size == names.toSet().size) {
+            "Duplicate tool names: ${names.groupBy { it }.filter { it.value.size > 1 }.keys}"
+        }
+    }
+
     override fun descriptors(): List<ToolDescriptor> = handlersByName.values.map { it.descriptor }
 
     override suspend fun execute(call: ToolCall): ToolResult {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/AnalyticsOrdersToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/AnalyticsOrdersToolHandler.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class AnalyticsOrdersToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "analytics_orders",
+        description = "Get order-count analytics for a date range.",
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.SAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/AnalyticsRevenueToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/AnalyticsRevenueToolHandler.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class AnalyticsRevenueToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "analytics_revenue",
+        description = "Get revenue analytics for a date range.",
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.SAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/CustomersListToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/CustomersListToolHandler.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class CustomersListToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "customers_list",
+        description = "List customers or get a specific customer by ID.",
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.SAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/OrdersBulkUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/OrdersBulkUpdateToolHandler.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class OrdersBulkUpdateToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "orders_bulk_update",
+        description = """
+            Update multiple orders. Accepts only the `status` field per order.
+            Allowed transitions: on-hold -> processing, processing -> completed.
+            Bulk writes require confirmation. At most one write operation (single or bulk) is executed per turn.
+        """.trimIndent(),
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.UNSAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/OrdersGetToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/OrdersGetToolHandler.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class OrdersGetToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "orders_get",
+        description = "Get a single order by ID.",
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.SAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/OrdersListToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/OrdersListToolHandler.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class OrdersListToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "orders_list",
+        description = "List and search orders. Supports filtering by status, date range, and customer.",
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.SAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/OrdersUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/OrdersUpdateToolHandler.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class OrdersUpdateToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "orders_update",
+        description = """
+            Update a single order. Accepts only the `status` field.
+            Allowed transitions: on-hold -> processing, processing -> completed.
+            Cancellation and refund flows are not supported by this tool.
+            At most one write is executed per turn; additional write calls in the same turn will be rejected by the runtime.
+        """.trimIndent(),
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.UNSAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/OrdersUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/OrdersUpdateToolHandler.kt
@@ -12,7 +12,8 @@ class OrdersUpdateToolHandler @Inject constructor() : StubToolHandler() {
             Update a single order. Accepts only the `status` field.
             Allowed transitions: on-hold -> processing, processing -> completed.
             Cancellation and refund flows are not supported by this tool.
-            At most one write is executed per turn; additional write calls in the same turn will be rejected by the runtime.
+            At most one write is executed per turn;
+            additional write calls in the same turn will be rejected by the runtime.
         """.trimIndent(),
         inputSchema = buildJsonObject { },
         safetyLevel = ToolSafetyLevel.UNSAFE,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductVariationsListToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductVariationsListToolHandler.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class ProductVariationsListToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "product_variations_list",
+        description = "List variations for a variable product.",
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.SAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsBulkUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsBulkUpdateToolHandler.kt
@@ -9,7 +9,8 @@ class ProductsBulkUpdateToolHandler @Inject constructor() : StubToolHandler() {
     override val descriptor = ToolDescriptor(
         name = "products_bulk_update",
         description = """
-            Update multiple products. Accepts only these fields per product: regular_price, manage_stock, stock_quantity, stock_status, status.
+            Update multiple products. Accepts only these fields per product:
+            regular_price, manage_stock, stock_quantity, stock_status, status.
             Bulk writes require confirmation. At most one write operation (single or bulk) is executed per turn.
         """.trimIndent(),
         inputSchema = buildJsonObject { },

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsBulkUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsBulkUpdateToolHandler.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class ProductsBulkUpdateToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "products_bulk_update",
+        description = """
+            Update multiple products. Accepts only these fields per product: regular_price, manage_stock, stock_quantity, stock_status, status.
+            Bulk writes require confirmation. At most one write operation (single or bulk) is executed per turn.
+        """.trimIndent(),
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.UNSAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsGetToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsGetToolHandler.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class ProductsGetToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "products_get",
+        description = "Get a single product by ID.",
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.SAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsListToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsListToolHandler.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class ProductsListToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "products_list",
+        description = "List and search products. Supports filtering by status, category, and stock.",
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.SAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsUpdateToolHandler.kt
@@ -1,0 +1,18 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class ProductsUpdateToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "products_update",
+        description = """
+            Update a single product. Accepts only these fields: regular_price, manage_stock, stock_quantity, stock_status, status.
+            At most one write is executed per turn; additional write calls in the same turn will be rejected by the runtime.
+        """.trimIndent(),
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.UNSAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ProductsUpdateToolHandler.kt
@@ -9,8 +9,10 @@ class ProductsUpdateToolHandler @Inject constructor() : StubToolHandler() {
     override val descriptor = ToolDescriptor(
         name = "products_update",
         description = """
-            Update a single product. Accepts only these fields: regular_price, manage_stock, stock_quantity, stock_status, status.
-            At most one write is executed per turn; additional write calls in the same turn will be rejected by the runtime.
+            Update a single product. Accepts only these fields:
+            regular_price, manage_stock, stock_quantity, stock_status, status.
+            At most one write is executed per turn;
+            additional write calls in the same turn will be rejected by the runtime.
         """.trimIndent(),
         inputSchema = buildJsonObject { },
         safetyLevel = ToolSafetyLevel.UNSAFE,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.buildJsonObject
+import javax.inject.Inject
+
+class ShowCardsToolHandler @Inject constructor() : StubToolHandler() {
+    override val descriptor = ToolDescriptor(
+        name = "show_cards",
+        description = "Show entity cards in the UI for orders or products selected by the assistant.",
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.SAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/StubToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/StubToolHandler.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantToolHandler
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
+
+abstract class StubToolHandler : AssistantToolHandler {
+    override suspend fun execute(call: ToolCall): ToolResult =
+        ToolResult.ValidationError(
+            toolCallId = call.id,
+            reason = "Tool ${descriptor.name} is not yet implemented",
+        )
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelectorTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelectorTest.kt
@@ -16,7 +16,12 @@ class DefaultToolCatalogSelectorTest {
         "product_variations_list", "analytics_revenue", "analytics_orders",
         "show_cards", "customers_list",
     ).map { name ->
-        ToolDescriptor(name = name, description = "", inputSchema = buildJsonObject { }, safetyLevel = ToolSafetyLevel.SAFE)
+        ToolDescriptor(
+            name = name,
+            description = "",
+            inputSchema = buildJsonObject { },
+            safetyLevel = ToolSafetyLevel.SAFE,
+        )
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelectorTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelectorTest.kt
@@ -1,13 +1,23 @@
 package com.woocommerce.android.aiassistant.tools
 
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import com.woocommerce.android.aiassistant.core.loop.ToolScope
+import kotlinx.serialization.json.buildJsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class DefaultToolCatalogSelectorTest {
 
     private val selector = DefaultToolCatalogSelector()
-    private val catalog = WooCommerceToolRegistry.CATALOG
+    private val catalog = listOf(
+        "orders_list", "orders_get", "orders_update", "orders_bulk_update",
+        "products_list", "products_get", "products_update", "products_bulk_update",
+        "product_variations_list", "analytics_revenue", "analytics_orders",
+        "show_cards", "customers_list",
+    ).map { name ->
+        ToolDescriptor(name = name, description = "", inputSchema = buildJsonObject { }, safetyLevel = ToolSafetyLevel.SAFE)
+    }
 
     @Test
     fun `when GLOBAL scope is selected, then all 13 tools are returned in catalog order`() {

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelectorTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelectorTest.kt
@@ -1,0 +1,95 @@
+package com.woocommerce.android.aiassistant.tools
+
+import com.woocommerce.android.aiassistant.core.loop.ToolScope
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class DefaultToolCatalogSelectorTest {
+
+    private val selector = DefaultToolCatalogSelector()
+    private val catalog = WooCommerceToolRegistry.CATALOG
+
+    @Test
+    fun `when GLOBAL scope is selected, then all 13 tools are returned in catalog order`() {
+        val snapshot = selector.select(ToolScope.GLOBAL, catalog)
+
+        assertThat(snapshot.scope).isEqualTo(ToolScope.GLOBAL)
+        assertThat(snapshot.tools.map { it.name }).containsExactly(
+            "orders_list",
+            "orders_get",
+            "orders_update",
+            "orders_bulk_update",
+            "products_list",
+            "products_get",
+            "products_update",
+            "products_bulk_update",
+            "product_variations_list",
+            "analytics_revenue",
+            "analytics_orders",
+            "show_cards",
+            "customers_list",
+        )
+    }
+
+    @Test
+    fun `when ORDERS scope is selected, then only order tools are returned and product-only tools are excluded`() {
+        val snapshot = selector.select(ToolScope.ORDERS, catalog)
+
+        assertThat(snapshot.scope).isEqualTo(ToolScope.ORDERS)
+        assertThat(snapshot.tools.map { it.name }).containsExactly(
+            "orders_list",
+            "orders_get",
+            "orders_update",
+            "orders_bulk_update",
+            "analytics_orders",
+            "show_cards",
+        )
+        assertThat(snapshot.tools.map { it.name }).doesNotContain(
+            "products_list",
+            "products_get",
+            "products_update",
+            "products_bulk_update",
+            "product_variations_list",
+            "analytics_revenue",
+            "customers_list",
+        )
+    }
+
+    @Test
+    fun `when PRODUCTS scope is selected, then only product tools are returned`() {
+        val snapshot = selector.select(ToolScope.PRODUCTS, catalog)
+
+        assertThat(snapshot.scope).isEqualTo(ToolScope.PRODUCTS)
+        assertThat(snapshot.tools.map { it.name }).containsExactly(
+            "products_list",
+            "products_get",
+            "products_update",
+            "products_bulk_update",
+            "product_variations_list",
+            "analytics_revenue",
+            "show_cards",
+        )
+    }
+
+    @Test
+    fun `when ANALYTICS scope is selected, then only analytics tools are returned`() {
+        val snapshot = selector.select(ToolScope.ANALYTICS, catalog)
+
+        assertThat(snapshot.scope).isEqualTo(ToolScope.ANALYTICS)
+        assertThat(snapshot.tools.map { it.name }).containsExactly(
+            "orders_list",
+            "products_list",
+            "analytics_revenue",
+            "analytics_orders",
+            "show_cards",
+        )
+    }
+
+    @Test
+    fun `given same scope and catalog, when select is called repeatedly, then equal snapshots are returned`() {
+        val firstSnapshot = selector.select(ToolScope.ORDERS, catalog)
+        val secondSnapshot = selector.select(ToolScope.ORDERS, catalog)
+
+        assertThat(firstSnapshot).isEqualTo(secondSnapshot)
+    }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolCatalogTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolCatalogTest.kt
@@ -1,0 +1,99 @@
+package com.woocommerce.android.aiassistant.tools
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantToolHandler
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.tools.handlers.AnalyticsOrdersToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.AnalyticsRevenueToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.CustomersListToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.OrdersBulkUpdateToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.OrdersGetToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.OrdersListToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.OrdersUpdateToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ProductVariationsListToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ProductsBulkUpdateToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ProductsGetToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ProductsListToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ProductsUpdateToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.ShowCardsToolHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class WooCommerceToolCatalogTest {
+
+    private val allHandlers: Set<AssistantToolHandler> = setOf(
+        OrdersListToolHandler(),
+        OrdersGetToolHandler(),
+        OrdersUpdateToolHandler(),
+        OrdersBulkUpdateToolHandler(),
+        ProductsListToolHandler(),
+        ProductsGetToolHandler(),
+        ProductsUpdateToolHandler(),
+        ProductsBulkUpdateToolHandler(),
+        ProductVariationsListToolHandler(),
+        AnalyticsRevenueToolHandler(),
+        AnalyticsOrdersToolHandler(),
+        ShowCardsToolHandler(),
+        CustomersListToolHandler(),
+    )
+
+    @Test
+    fun `when all stub handlers are aggregated, then 13 expected tool names are present`() {
+        val names = allHandlers.map { it.descriptor.name }
+
+        assertThat(names).containsExactlyInAnyOrder(
+            "orders_list",
+            "orders_get",
+            "orders_update",
+            "orders_bulk_update",
+            "products_list",
+            "products_get",
+            "products_update",
+            "products_bulk_update",
+            "product_variations_list",
+            "analytics_revenue",
+            "analytics_orders",
+            "show_cards",
+            "customers_list",
+        )
+    }
+
+    @Test
+    fun `when descriptors are inspected, then write tools are UNSAFE and read tools are SAFE`() {
+        val byName = allHandlers.associateBy { it.descriptor.name }
+        val writeToolNames = setOf("orders_update", "orders_bulk_update", "products_update", "products_bulk_update")
+
+        writeToolNames.forEach { name ->
+            assertThat(byName.getValue(name).descriptor.safetyLevel)
+                .`as`("$name should be UNSAFE")
+                .isEqualTo(ToolSafetyLevel.UNSAFE)
+        }
+
+        val readToolNames = byName.keys - writeToolNames
+        readToolNames.forEach { name ->
+            assertThat(byName.getValue(name).descriptor.safetyLevel)
+                .`as`("$name should be SAFE")
+                .isEqualTo(ToolSafetyLevel.SAFE)
+        }
+    }
+
+    @Test
+    fun `when descriptors are retrieved, then write-tool descriptions include allowlisted fields and constraints`() {
+        val byName = allHandlers.associateBy { it.descriptor.name }
+
+        val ordersUpdate = byName.getValue("orders_update").descriptor.description
+        assertThat(ordersUpdate).contains("status")
+        assertThat(ordersUpdate).contains("on-hold")
+
+        val ordersBulkUpdate = byName.getValue("orders_bulk_update").descriptor.description
+        assertThat(ordersBulkUpdate).contains("status")
+        assertThat(ordersBulkUpdate).contains("Bulk writes require confirmation")
+
+        val productsUpdate = byName.getValue("products_update").descriptor.description
+        assertThat(productsUpdate).contains("regular_price")
+        assertThat(productsUpdate).contains("stock_quantity")
+
+        val productsBulkUpdate = byName.getValue("products_bulk_update").descriptor.description
+        assertThat(productsBulkUpdate).contains("regular_price")
+        assertThat(productsBulkUpdate).contains("Bulk writes require confirmation")
+    }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
@@ -83,12 +83,17 @@ class WooCommerceToolRegistryTest {
             val result = registry.execute(ToolCall(id = "c1", name = "nonexistent", arguments = buildJsonObject { }))
 
             assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
+            val error = result as ToolResult.ValidationError
+            assertThat(error.reason).contains("nonexistent")
         }
 
     @Test
     fun `given a registered handler, when execute is called with matching tool name, then handler result is returned`() =
         runTest {
-            val expectedResult = ToolResult.ValidationError("call_1", "fixed-response")
+            val expectedResult = ToolResult.Success(
+                toolCallId = "call_1",
+                structured = buildJsonObject { },
+            )
             val handler = AssistantToolHandler { expectedResult }
             val registry = WooCommerceToolRegistry(mapOf("orders_list" to handler))
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
@@ -1,0 +1,99 @@
+package com.woocommerce.android.aiassistant.tools
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantToolHandler
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class WooCommerceToolRegistryTest {
+
+    @Test
+    fun `when descriptors are retrieved, then all 13 expected tool names are present`() {
+        val registry = WooCommerceToolRegistry(emptyMap())
+
+        val names = registry.descriptors().map { it.name }
+
+        assertThat(names).containsExactlyInAnyOrder(
+            "orders_list",
+            "orders_get",
+            "orders_update",
+            "orders_bulk_update",
+            "products_list",
+            "products_get",
+            "products_update",
+            "products_bulk_update",
+            "product_variations_list",
+            "analytics_revenue",
+            "analytics_orders",
+            "show_cards",
+            "customers_list",
+        )
+    }
+
+    @Test
+    fun `when descriptors are retrieved, then write tools are UNSAFE and read tools are SAFE`() {
+        val registry = WooCommerceToolRegistry(emptyMap())
+        val descriptorsByName = registry.descriptors().associateBy { it.name }
+
+        val writeToolNames = setOf("orders_update", "orders_bulk_update", "products_update", "products_bulk_update")
+        writeToolNames.forEach { name ->
+            assertThat(descriptorsByName.getValue(name).safetyLevel)
+                .`as`("$name should be UNSAFE")
+                .isEqualTo(ToolSafetyLevel.UNSAFE)
+        }
+
+        val readToolNames = descriptorsByName.keys - writeToolNames
+        readToolNames.forEach { name ->
+            assertThat(descriptorsByName.getValue(name).safetyLevel)
+                .`as`("$name should be SAFE")
+                .isEqualTo(ToolSafetyLevel.SAFE)
+        }
+    }
+
+    @Test
+    fun `when descriptors are retrieved, then write-tool descriptions include allowlisted fields`() {
+        val registry = WooCommerceToolRegistry(emptyMap())
+        val descriptorsByName = registry.descriptors().associateBy { it.name }
+
+        assertThat(descriptorsByName.getValue("products_update").description).contains("regular_price")
+        assertThat(descriptorsByName.getValue("orders_update").description).contains("on-hold")
+    }
+
+    @Test
+    fun `given empty handlers map, when execute is called with unknown tool name, then ValidationError is returned`() =
+        runTest {
+            val registry = WooCommerceToolRegistry(emptyMap())
+
+            val result = registry.execute(ToolCall(id = "c1", name = "nonexistent", arguments = buildJsonObject { }))
+
+            assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
+        }
+
+    @Test
+    fun `given a registered handler, when execute is called with matching tool name, then handler result is returned`() =
+        runTest {
+            val expectedResult = ToolResult.ValidationError("call_1", "fixed-response")
+            val handler = AssistantToolHandler { expectedResult }
+            val registry = WooCommerceToolRegistry(mapOf("orders_list" to handler))
+
+            val result = registry.execute(
+                ToolCall(id = "call_1", name = "orders_list", arguments = buildJsonObject { })
+            )
+
+            assertThat(result).isEqualTo(expectedResult)
+        }
+
+    @Test
+    fun `given empty handlers map, when execute is called with known catalog tool name, then ValidationError is returned`() =
+        runTest {
+            val registry = WooCommerceToolRegistry(emptyMap())
+
+            val result = registry.execute(ToolCall(id = "c2", name = "orders_list", arguments = buildJsonObject { }))
+
+            assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
+        }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
@@ -55,12 +55,24 @@ class WooCommerceToolRegistryTest {
     }
 
     @Test
-    fun `when descriptors are retrieved, then write-tool descriptions include allowlisted fields`() {
-        val registry = WooCommerceToolRegistry(emptyMap())
-        val descriptorsByName = registry.descriptors().associateBy { it.name }
+    fun `when descriptors are retrieved, then write-tool descriptions include allowlisted fields and constraints`() {
+        val descriptorsByName = WooCommerceToolRegistry.CATALOG.associateBy { it.name }
 
-        assertThat(descriptorsByName.getValue("products_update").description).contains("regular_price")
-        assertThat(descriptorsByName.getValue("orders_update").description).contains("on-hold")
+        val ordersUpdate = requireNotNull(descriptorsByName["orders_update"]).description
+        assertThat(ordersUpdate).contains("status")
+        assertThat(ordersUpdate).contains("on-hold")
+
+        val ordersBulkUpdate = requireNotNull(descriptorsByName["orders_bulk_update"]).description
+        assertThat(ordersBulkUpdate).contains("status")
+        assertThat(ordersBulkUpdate).contains("Bulk writes require confirmation")
+
+        val productsUpdate = requireNotNull(descriptorsByName["products_update"]).description
+        assertThat(productsUpdate).contains("regular_price")
+        assertThat(productsUpdate).contains("stock_quantity")
+
+        val productsBulkUpdate = requireNotNull(descriptorsByName["products_bulk_update"]).description
+        assertThat(productsBulkUpdate).contains("regular_price")
+        assertThat(productsBulkUpdate).contains("Bulk writes require confirmation")
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
@@ -12,10 +12,8 @@ import org.junit.Test
 class WooCommerceToolRegistryTest {
 
     @Test
-    fun `when descriptors are retrieved, then all 13 expected tool names are present`() {
-        val registry = WooCommerceToolRegistry(emptyMap())
-
-        val names = registry.descriptors().map { it.name }
+    fun `when CATALOG is inspected, then all 13 expected tool names are present`() {
+        val names = WooCommerceToolRegistry.CATALOG.map { it.name }
 
         assertThat(names).containsExactlyInAnyOrder(
             "orders_list",
@@ -35,9 +33,25 @@ class WooCommerceToolRegistryTest {
     }
 
     @Test
-    fun `when descriptors are retrieved, then write tools are UNSAFE and read tools are SAFE`() {
+    fun `given no registered handlers, when descriptors are retrieved, then empty list is returned`() {
         val registry = WooCommerceToolRegistry(emptyMap())
-        val descriptorsByName = registry.descriptors().associateBy { it.name }
+
+        assertThat(registry.descriptors()).isEmpty()
+    }
+
+    @Test
+    fun `given handlers registered for a subset of tools, when descriptors are retrieved, then only those tools are returned`() {
+        val handler = AssistantToolHandler { ToolResult.Success(it.id, buildJsonObject { }) }
+        val registry = WooCommerceToolRegistry(mapOf("orders_list" to handler, "products_get" to handler))
+
+        val names = registry.descriptors().map { it.name }
+
+        assertThat(names).containsExactlyInAnyOrder("orders_list", "products_get")
+    }
+
+    @Test
+    fun `when CATALOG is inspected, then write tools are UNSAFE and read tools are SAFE`() {
+        val descriptorsByName = WooCommerceToolRegistry.CATALOG.associateBy { it.name }
 
         val writeToolNames = setOf("orders_update", "orders_bulk_update", "products_update", "products_bulk_update")
         writeToolNames.forEach { name ->

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.aiassistant.tools
 
 import com.woocommerce.android.aiassistant.core.chat.AssistantToolHandler
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import kotlinx.coroutines.test.runTest
@@ -41,8 +42,12 @@ class WooCommerceToolRegistryTest {
 
     @Test
     fun `given handlers registered for a subset of tools, when descriptors are retrieved, then only those tools are returned`() {
-        val handler = AssistantToolHandler { ToolResult.Success(it.id, buildJsonObject { }) }
-        val registry = WooCommerceToolRegistry(mapOf("orders_list" to handler, "products_get" to handler))
+        val registry = WooCommerceToolRegistry(
+            mapOf(
+                "orders_list" to FakeToolHandler(fakeDescriptor("orders_list")) { ToolResult.Success(it.id, buildJsonObject { }) },
+                "products_get" to FakeToolHandler(fakeDescriptor("products_get")) { ToolResult.Success(it.id, buildJsonObject { }) },
+            )
+        )
 
         val names = registry.descriptors().map { it.name }
 
@@ -108,7 +113,7 @@ class WooCommerceToolRegistryTest {
                 toolCallId = "call_1",
                 structured = buildJsonObject { },
             )
-            val handler = AssistantToolHandler { expectedResult }
+            val handler = FakeToolHandler(fakeDescriptor("orders_list")) { expectedResult }
             val registry = WooCommerceToolRegistry(mapOf("orders_list" to handler))
 
             val result = registry.execute(
@@ -127,4 +132,18 @@ class WooCommerceToolRegistryTest {
 
             assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
         }
+
+    private class FakeToolHandler(
+        override val descriptor: ToolDescriptor,
+        private val onExecute: suspend (ToolCall) -> ToolResult,
+    ) : AssistantToolHandler {
+        override suspend fun execute(call: ToolCall): ToolResult = onExecute(call)
+    }
+
+    private fun fakeDescriptor(name: String) = ToolDescriptor(
+        name = name,
+        description = "fake",
+        inputSchema = buildJsonObject { },
+        safetyLevel = ToolSafetyLevel.SAFE,
+    )
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolRegistryTest.kt
@@ -13,41 +13,17 @@ import org.junit.Test
 class WooCommerceToolRegistryTest {
 
     @Test
-    fun `when CATALOG is inspected, then all 13 expected tool names are present`() {
-        val names = WooCommerceToolRegistry.CATALOG.map { it.name }
-
-        assertThat(names).containsExactlyInAnyOrder(
-            "orders_list",
-            "orders_get",
-            "orders_update",
-            "orders_bulk_update",
-            "products_list",
-            "products_get",
-            "products_update",
-            "products_bulk_update",
-            "product_variations_list",
-            "analytics_revenue",
-            "analytics_orders",
-            "show_cards",
-            "customers_list",
-        )
-    }
-
-    @Test
-    fun `given no registered handlers, when descriptors are retrieved, then empty list is returned`() {
-        val registry = WooCommerceToolRegistry(emptyMap())
+    fun `given an empty handler set, when descriptors are retrieved, then empty list is returned`() {
+        val registry = WooCommerceToolRegistry(emptySet())
 
         assertThat(registry.descriptors()).isEmpty()
     }
 
     @Test
-    fun `given handlers registered for a subset of tools, when descriptors are retrieved, then only those tools are returned`() {
-        val registry = WooCommerceToolRegistry(
-            mapOf(
-                "orders_list" to FakeToolHandler(fakeDescriptor("orders_list")) { ToolResult.Success(it.id, buildJsonObject { }) },
-                "products_get" to FakeToolHandler(fakeDescriptor("products_get")) { ToolResult.Success(it.id, buildJsonObject { }) },
-            )
-        )
+    fun `given handlers, when descriptors are retrieved, then descriptors from each handler are exposed`() {
+        val ordersList = FakeToolHandler(fakeDescriptor("orders_list"))
+        val productsGet = FakeToolHandler(fakeDescriptor("products_get"))
+        val registry = WooCommerceToolRegistry(setOf(ordersList, productsGet))
 
         val names = registry.descriptors().map { it.name }
 
@@ -55,49 +31,9 @@ class WooCommerceToolRegistryTest {
     }
 
     @Test
-    fun `when CATALOG is inspected, then write tools are UNSAFE and read tools are SAFE`() {
-        val descriptorsByName = WooCommerceToolRegistry.CATALOG.associateBy { it.name }
-
-        val writeToolNames = setOf("orders_update", "orders_bulk_update", "products_update", "products_bulk_update")
-        writeToolNames.forEach { name ->
-            assertThat(descriptorsByName.getValue(name).safetyLevel)
-                .`as`("$name should be UNSAFE")
-                .isEqualTo(ToolSafetyLevel.UNSAFE)
-        }
-
-        val readToolNames = descriptorsByName.keys - writeToolNames
-        readToolNames.forEach { name ->
-            assertThat(descriptorsByName.getValue(name).safetyLevel)
-                .`as`("$name should be SAFE")
-                .isEqualTo(ToolSafetyLevel.SAFE)
-        }
-    }
-
-    @Test
-    fun `when descriptors are retrieved, then write-tool descriptions include allowlisted fields and constraints`() {
-        val descriptorsByName = WooCommerceToolRegistry.CATALOG.associateBy { it.name }
-
-        val ordersUpdate = requireNotNull(descriptorsByName["orders_update"]).description
-        assertThat(ordersUpdate).contains("status")
-        assertThat(ordersUpdate).contains("on-hold")
-
-        val ordersBulkUpdate = requireNotNull(descriptorsByName["orders_bulk_update"]).description
-        assertThat(ordersBulkUpdate).contains("status")
-        assertThat(ordersBulkUpdate).contains("Bulk writes require confirmation")
-
-        val productsUpdate = requireNotNull(descriptorsByName["products_update"]).description
-        assertThat(productsUpdate).contains("regular_price")
-        assertThat(productsUpdate).contains("stock_quantity")
-
-        val productsBulkUpdate = requireNotNull(descriptorsByName["products_bulk_update"]).description
-        assertThat(productsBulkUpdate).contains("regular_price")
-        assertThat(productsBulkUpdate).contains("Bulk writes require confirmation")
-    }
-
-    @Test
-    fun `given empty handlers map, when execute is called with unknown tool name, then ValidationError is returned`() =
+    fun `given an empty handler set, when execute is called with any tool name, then ValidationError is returned`() =
         runTest {
-            val registry = WooCommerceToolRegistry(emptyMap())
+            val registry = WooCommerceToolRegistry(emptySet())
 
             val result = registry.execute(ToolCall(id = "c1", name = "nonexistent", arguments = buildJsonObject { }))
 
@@ -109,33 +45,33 @@ class WooCommerceToolRegistryTest {
     @Test
     fun `given a registered handler, when execute is called with matching tool name, then handler result is returned`() =
         runTest {
-            val expectedResult = ToolResult.Success(
-                toolCallId = "call_1",
-                structured = buildJsonObject { },
-            )
-            val handler = FakeToolHandler(fakeDescriptor("orders_list")) { expectedResult }
-            val registry = WooCommerceToolRegistry(mapOf("orders_list" to handler))
+            val expected = ToolResult.Success(toolCallId = "call_1", structured = buildJsonObject { })
+            val handler = FakeToolHandler(fakeDescriptor("orders_list")) { expected }
+            val registry = WooCommerceToolRegistry(setOf(handler))
 
             val result = registry.execute(
                 ToolCall(id = "call_1", name = "orders_list", arguments = buildJsonObject { })
             )
 
-            assertThat(result).isEqualTo(expectedResult)
+            assertThat(result).isEqualTo(expected)
         }
 
     @Test
-    fun `given empty handlers map, when execute is called with known catalog tool name, then ValidationError is returned`() =
+    fun `given a registered handler, when execute is called with a different tool name, then ValidationError is returned`() =
         runTest {
-            val registry = WooCommerceToolRegistry(emptyMap())
+            val handler = FakeToolHandler(fakeDescriptor("orders_list"))
+            val registry = WooCommerceToolRegistry(setOf(handler))
 
-            val result = registry.execute(ToolCall(id = "c2", name = "orders_list", arguments = buildJsonObject { }))
+            val result = registry.execute(
+                ToolCall(id = "call_2", name = "products_get", arguments = buildJsonObject { })
+            )
 
             assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
         }
 
     private class FakeToolHandler(
         override val descriptor: ToolDescriptor,
-        private val onExecute: suspend (ToolCall) -> ToolResult,
+        private val onExecute: suspend (ToolCall) -> ToolResult = { ToolResult.Success(it.id, buildJsonObject { }) },
     ) : AssistantToolHandler {
         override suspend fun execute(call: ToolCall): ToolResult = onExecute(call)
     }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/StubToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/StubToolHandlerTest.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class StubToolHandlerTest {
+
+    @Test
+    fun `given a stub handler, when execute is called, then ValidationError mentioning tool name is returned`() = runTest {
+        val handler = object : StubToolHandler() {
+            override val descriptor = ToolDescriptor(
+                name = "sample_tool",
+                description = "d",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.SAFE,
+            )
+        }
+
+        val result = handler.execute(ToolCall(id = "call_1", name = "sample_tool", arguments = buildJsonObject { }))
+
+        assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
+        val error = result as ToolResult.ValidationError
+        assertThat(error.toolCallId).isEqualTo("call_1")
+        assertThat(error.reason).contains("sample_tool")
+        assertThat(error.reason).contains("not yet implemented")
+    }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-2894

This stacks on top of #15764 and wires the assistant tool catalog so conversations can use a pinned per-scope snapshot instead of re-reading the full registry on every turn.

It adds the catalog contracts and feature-side wiring needed for tool scoping:
- introduces `ToolScope`, `CatalogSnapshot`, and `ToolCatalogSelector`
- updates `SessionContext` and `AgenticLoopImpl` to consume the pinned catalog snapshot for tool definitions and lookup
- adds `WooCommerceToolRegistry` (Set-based, driven by handlers) and `DefaultToolCatalogSelector` for GLOBAL, ORDERS, PRODUCTS, and ANALYTICS scopes
- adds `AssistantToolHandler` as an interface with a `descriptor` property, so each handler carries its own `ToolDescriptor` alongside its `execute()` logic
- adds a `StubToolHandler` abstract base class and 13 concrete stub handler classes (one per tool), each declaring its descriptor and returning a "not yet implemented" error until the real data-layer call is wired
- wires all 13 handlers into `AiAssistantModule` via Hilt `@Binds @IntoSet` multibinding

**Tool implementations are not part of this PR.** Each stub handler carries the stable descriptor (name, description, safety level, field constraints) for its tool and returns a `ValidationError` from `execute()`. The actual data-layer implementations (REST calls, FluxC store access) will be added in follow-up tickets — each one replaces the stub's `execute()` body. Because the registry is entirely driven by the injected `Set<AssistantToolHandler>`, adding a real handler requires no registry or DI changes.

The design also makes phantom-tool exposure structurally impossible: `descriptors()` is derived from the injected handler set, so a tool cannot appear in the catalog without a corresponding handler already wired in DI.

### Test Steps
1. Review `AssistantToolHandler` and confirm it is now a regular interface with a `val descriptor: ToolDescriptor` property.
2. Review `WooCommerceToolRegistry` and confirm it takes `Set<AssistantToolHandler>`, derives descriptors from handlers (no hardcoded CATALOG), and guards against duplicate tool names at construction time.
3. Review `DefaultToolCatalogSelector` and confirm each scope returns the expected subset.
4. Review the `handlers/` package and confirm all 13 stub handlers are present with correct tool names, safety levels, and write-constraint descriptions.
5. Review `AiAssistantModule` and confirm the `@Binds @IntoSet` bindings wire all 13 handlers.
6. Confirm `AgenticLoopImpl` reads tool descriptors from `SessionContext.catalogSnapshot.tools`.
7. Run `WooCommerceToolCatalogTest` and confirm all 3 invariant tests pass (13 names, SAFE/UNSAFE classification, write-constraint text).

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.