### PR TITLE
[RSM-1635] Add smarter notifications feature flag

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -33,4 +33,5 @@ enum class FeatureFlag(
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1("woo_self_driven_push_notifications_m1", localValue = false),
     LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
     AI_ASSISTANT("ai_assistant", localValue = PackageUtils.isDebugBuild()),
+    SMARTER_NOTIFICATIONS("smarter_notifications", localValue = PackageUtils.isDebugBuild()),
 }


### PR DESCRIPTION
### Description
Fixes RSM-1635

Adds the `SMARTER_NOTIFICATIONS` feature flag with the remote key `smarter_notifications`.

### Test Steps
1. Build a debug variant.
2. Open Developer options > Feature flags.
3. Confirm `SMARTER_NOTIFICATIONS` is listed and can be overridden.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.