### PR TITLE
[WOOMOB-2895] Implement sliding-window HistoryBudgeter

### DIFF
--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/CardRef.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/CardRef.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.aiassistant.core.chat
+
+data class CardRef(
+    val entityType: String,
+    val entityId: String,
+)

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/CardRef.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/CardRef.kt
@@ -2,5 +2,5 @@ package com.woocommerce.android.aiassistant.core.chat
 
 data class CardRef(
     val entityType: String,
-    val entityId: String,
+    val entityId: Long,
 )

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -23,6 +23,7 @@ class AgenticLoopImpl(
     private val chatService: ChatService,
     private val toolRegistry: ToolRegistry,
     private val retryPolicy: RetryPolicy,
+    private val historyBudgeter: HistoryBudgeter,
     private val json: Json,
 ) : AgenticLoop {
 
@@ -36,14 +37,21 @@ class AgenticLoopImpl(
         val toolDefs = toolDescriptors.map { it.toToolDefinition() }
         val assembler = ToolCallAssembler(json)
 
-        var messages: List<AssistantMessage> = history + AssistantMessage.User(userMessage)
+        val currentUserTurn = AssistantMessage.User(userMessage)
+        val systemPrompt = history.filterIsInstance<AssistantMessage.System>().firstOrNull()
+            ?: AssistantMessage.System("")
+        val rawTranscript = history.filterNot { it is AssistantMessage.System }
+        val budgeted = historyBudgeter.build(systemPrompt, rawTranscript, currentUserTurn)
+
+        var modelMessages: List<AssistantMessage> = budgeted.messages
+        val newTurnMessages = mutableListOf<AssistantMessage>(currentUserTurn)
         var visibleOutputStarted = false
         var iteration = 0
 
         while (iteration < MAX_ITERATIONS) {
             val stream = streamWithRetry(
-                ChatRequest(messages = messages, tools = toolDefs),
-                messages,
+                ChatRequest(messages = modelMessages, tools = toolDefs),
+                history + newTurnMessages,
                 visibleOutputStarted,
             ) ?: return@flow
             visibleOutputStarted = stream.visibleOutputStarted
@@ -54,39 +62,43 @@ class AgenticLoopImpl(
                 .filterIsInstance<ToolCallAssembler.AssemblyResult.Success>()
                 .map { it.call }
 
-            messages = messages + AssistantMessage.Assistant(
+            val newAssistantMsg = AssistantMessage.Assistant(
                 content = stream.assistantText.takeIf { it.isNotEmpty() },
                 toolCalls = callsForHistory,
             )
+            modelMessages = modelMessages + newAssistantMsg
+            newTurnMessages.add(newAssistantMsg)
 
             if (stream.finishReason == null) {
-                emit(LoopEvent.Finished(LoopOutcome.FAILED, messages, retryAvailable = false))
+                emit(LoopEvent.Finished(LoopOutcome.FAILED, history + newTurnMessages, retryAvailable = false))
                 return@flow
             }
 
             val isTerminal = stream.finishReason == FinishReason.STOP ||
                 (stream.finishReason != FinishReason.TOOL_CALLS && stream.toolCallDeltas.isEmpty())
             if (isTerminal) {
-                emit(LoopEvent.Finished(LoopOutcome.COMPLETED, messages))
+                emit(LoopEvent.Finished(LoopOutcome.COMPLETED, history + newTurnMessages))
                 return@flow
             }
 
             val toolResults = executeTools(assembledResults, validCalls, toolDescriptors)
             for (result in toolResults) {
-                messages = messages + AssistantMessage.Tool(
+                val newToolMsg = AssistantMessage.Tool(
                     toolCallId = result.toolCallId,
                     content = result.toModelContent(),
                 )
+                modelMessages = modelMessages + newToolMsg
+                newTurnMessages.add(newToolMsg)
             }
             iteration++
         }
 
-        emit(LoopEvent.Finished(LoopOutcome.MAX_ITERATIONS, messages))
+        emit(LoopEvent.Finished(LoopOutcome.MAX_ITERATIONS, history + newTurnMessages))
     }
 
     private suspend fun FlowCollector<LoopEvent>.streamWithRetry(
         request: ChatRequest,
-        messages: List<AssistantMessage>,
+        fullHistory: List<AssistantMessage>,
         initialVisibleOutput: Boolean,
     ): StreamResult? {
         var visibleOutputStarted = initialVisibleOutput
@@ -128,12 +140,12 @@ class AgenticLoopImpl(
                     retryCount++
                 }
                 is RetryDecision.ShowManualRetry -> {
-                    val failedHistory = messagesWithPartialText(messages, assistantText.toString())
+                    val failedHistory = messagesWithPartialText(fullHistory, assistantText.toString())
                     emit(LoopEvent.Finished(LoopOutcome.FAILED, failedHistory, retryAvailable = true))
                     return null
                 }
                 is RetryDecision.DoNotRetry -> {
-                    val failedHistory = messagesWithPartialText(messages, assistantText.toString())
+                    val failedHistory = messagesWithPartialText(fullHistory, assistantText.toString())
                     emit(LoopEvent.Finished(LoopOutcome.FAILED, failedHistory, retryAvailable = false))
                     return null
                 }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/BudgetedHistory.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/BudgetedHistory.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.aiassistant.core.loop
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+import com.woocommerce.android.aiassistant.core.chat.CardRef
+
+data class BudgetedHistory(
+    val messages: List<AssistantMessage>,
+    val retainedEntityRefs: List<CardRef> = emptyList(),
+)

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/HistoryBudgeter.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/HistoryBudgeter.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.aiassistant.core.loop
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+
+fun interface HistoryBudgeter {
+    fun build(
+        systemPrompt: AssistantMessage.System,
+        rawTranscript: List<AssistantMessage>,
+        currentUserTurn: AssistantMessage.User,
+    ): BudgetedHistory
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
@@ -3,7 +3,7 @@ package com.woocommerce.android.aiassistant.core.loop
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 
 class SlidingWindowHistoryBudgeter(
-    val windowSize: Int = DEFAULT_WINDOW_SIZE,
+    private val windowSize: Int = DEFAULT_WINDOW_SIZE,
 ) : HistoryBudgeter {
 
     override fun build(

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
@@ -19,6 +19,6 @@ class SlidingWindowHistoryBudgeter(
     }
 
     companion object {
-        const val DEFAULT_WINDOW_SIZE = 20
+        internal const val DEFAULT_WINDOW_SIZE = 20
     }
 }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.aiassistant.core.loop
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+
+class SlidingWindowHistoryBudgeter(
+    val windowSize: Int = DEFAULT_WINDOW_SIZE,
+) : HistoryBudgeter {
+
+    override fun build(
+        systemPrompt: AssistantMessage.System,
+        rawTranscript: List<AssistantMessage>,
+        currentUserTurn: AssistantMessage.User,
+    ): BudgetedHistory {
+        val window = rawTranscript.takeLast(windowSize)
+        return BudgetedHistory(
+            messages = listOf(systemPrompt) + window + currentUserTurn,
+            retainedEntityRefs = emptyList(),
+        )
+    }
+
+    companion object {
+        const val DEFAULT_WINDOW_SIZE = 20
+    }
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeter.kt
@@ -6,12 +6,17 @@ class SlidingWindowHistoryBudgeter(
     private val windowSize: Int = DEFAULT_WINDOW_SIZE,
 ) : HistoryBudgeter {
 
+    init {
+        require(windowSize >= 0) { "windowSize must be non-negative, was $windowSize" }
+    }
+
     override fun build(
         systemPrompt: AssistantMessage.System,
         rawTranscript: List<AssistantMessage>,
         currentUserTurn: AssistantMessage.User,
     ): BudgetedHistory {
         val window = rawTranscript.takeLast(windowSize)
+            .dropWhile { it is AssistantMessage.Tool }
         return BudgetedHistory(
             messages = listOf(systemPrompt) + window + currentUserTurn,
             retainedEntityRefs = emptyList(),

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -28,16 +28,21 @@ class AgenticLoopImplTest {
     private val context = SessionContext(siteId = 1L, catalogSnapshot = CatalogSnapshot(ToolScope.GLOBAL, emptyList()))
     private val history = listOf<AssistantMessage>(AssistantMessage.System("You are a helpful assistant."))
 
+    private fun passThroughBudgeter(): HistoryBudgeter = HistoryBudgeter { system, transcript, user ->
+        BudgetedHistory(messages = listOf(system) + transcript + user)
+    }
+
     private fun loopWith(
         vararg turnResponses: Flow<AssistantEvent>,
         registry: ToolRegistry = NoOpToolRegistry(),
+        budgeter: HistoryBudgeter = passThroughBudgeter(),
     ): AgenticLoopImpl {
         var callCount = 0
         val service = object : ChatService {
             override fun streamTurn(request: ChatRequest) =
                 turnResponses[minOf(callCount++, turnResponses.size - 1)]
         }
-        return AgenticLoopImpl(service, registry, ConservativeRetryPolicy, json)
+        return AgenticLoopImpl(service, registry, ConservativeRetryPolicy, budgeter, json)
     }
 
     private fun stubRegistry(
@@ -168,7 +173,7 @@ class AgenticLoopImplTest {
             override suspend fun execute(call: ToolCall) =
                 ToolResult.Success(call.id, structured = structuredPayload, uiStructured = uiOnlyPayload)
         }
-        val loop = AgenticLoopImpl(service, registry, ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, registry, ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         loop.runTurn("conv", "go", history, contextWithTools(safeEchoDescriptor())).toList()
 
@@ -261,7 +266,7 @@ class AgenticLoopImplTest {
                 }
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -279,7 +284,7 @@ class AgenticLoopImplTest {
                 return flowOf(AssistantEvent.Failed(AssistantErrorKind.AUTH))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -298,7 +303,7 @@ class AgenticLoopImplTest {
                 return flowOf(AssistantEvent.Failed(AssistantErrorKind.NETWORK))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -316,7 +321,7 @@ class AgenticLoopImplTest {
                 emit(AssistantEvent.Failed(AssistantErrorKind.NETWORK))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -333,7 +338,7 @@ class AgenticLoopImplTest {
                 emit(AssistantEvent.Failed(AssistantErrorKind.NETWORK))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, json)
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -403,5 +408,59 @@ class AgenticLoopImplTest {
 
         assertThat(events.filterIsInstance<LoopEvent.BlockedBySafety>()).hasSize(1)
         assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>()).isEmpty()
+    }
+
+    @Test
+    fun `given budgeter trims history, when running turn, then model receives only budgeted messages`() = runTest {
+        val bigHistory = listOf(
+            AssistantMessage.System("sys"),
+            AssistantMessage.User("turn 1"),
+            AssistantMessage.Assistant("response 1"),
+            AssistantMessage.User("turn 2"),
+            AssistantMessage.Assistant("response 2"),
+        )
+        val twoMessageBudgeter = HistoryBudgeter { system, _, user ->
+            BudgetedHistory(messages = listOf(system, user))
+        }
+        var capturedMessages: List<AssistantMessage>? = null
+        val service = object : ChatService {
+            override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> {
+                capturedMessages = request.messages
+                return flowOf(AssistantEvent.TextDelta("Hi"), AssistantEvent.Finish(FinishReason.STOP))
+            }
+        }
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, twoMessageBudgeter, json)
+
+        loop.runTurn("conv", "hi", bigHistory, context).toList()
+
+        assertThat(capturedMessages).hasSize(2)
+        assertThat(capturedMessages?.first()).isEqualTo(AssistantMessage.System("sys"))
+        assertThat(capturedMessages?.last()).isEqualTo(AssistantMessage.User("hi"))
+    }
+
+    @Test
+    fun `given budgeter trims history, when running turn, then updatedHistory contains full prior history plus new turn messages`() = runTest {
+        val bigHistory = listOf(
+            AssistantMessage.System("sys"),
+            AssistantMessage.User("turn 1"),
+            AssistantMessage.Assistant("response 1"),
+        )
+        val droppingBudgeter = HistoryBudgeter { system, _, user ->
+            BudgetedHistory(messages = listOf(system, user))
+        }
+        val service = object : ChatService {
+            override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> =
+                flowOf(AssistantEvent.TextDelta("ok"), AssistantEvent.Finish(FinishReason.STOP))
+        }
+        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, droppingBudgeter, json)
+
+        val events = loop.runTurn("conv", "hi", bigHistory, context).toList()
+
+        val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+        assertThat(finished.updatedHistory).hasSize(bigHistory.size + 2)
+        assertThat(finished.updatedHistory.take(bigHistory.size)).isEqualTo(bigHistory)
+        assertThat(finished.updatedHistory[bigHistory.size]).isEqualTo(AssistantMessage.User("hi"))
+        assertThat(finished.updatedHistory[bigHistory.size + 1])
+            .isEqualTo(AssistantMessage.Assistant(content = "ok", toolCalls = emptyList()))
     }
 }

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -463,4 +463,20 @@ class AgenticLoopImplTest {
         assertThat(finished.updatedHistory[bigHistory.size + 1])
             .isEqualTo(AssistantMessage.Assistant(content = "ok", toolCalls = emptyList()))
     }
+
+    @Test
+    fun `given history with no system message, when running turn, then loop completes with empty system prompt`() = runTest {
+        val historyWithoutSystem = listOf(
+            AssistantMessage.User("prior question"),
+            AssistantMessage.Assistant("prior answer"),
+        )
+        val loop = loopWith(
+            flowOf(AssistantEvent.TextDelta("hi"), AssistantEvent.Finish(FinishReason.STOP))
+        )
+
+        val events = loop.runTurn("conv", "hello", historyWithoutSystem, context).toList()
+
+        val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+        assertThat(finished.outcome).isEqualTo(LoopOutcome.COMPLETED)
+    }
 }

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
@@ -1,0 +1,86 @@
+package com.woocommerce.android.aiassistant.core.loop
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SlidingWindowHistoryBudgeterTest {
+    private val system = AssistantMessage.System("You are a helpful assistant.")
+    private val user = AssistantMessage.User("What can you do?")
+
+    @Test
+    fun `given empty transcript, when building, then messages contain only system and user turn`() {
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 5)
+
+        val result = budgeter.build(system, emptyList(), user)
+
+        assertThat(result.messages).containsExactly(system, user)
+    }
+
+    @Test
+    fun `given transcript shorter than window size, when building, then all transcript messages are included`() {
+        val transcript = listOf(
+            AssistantMessage.User("hi"),
+            AssistantMessage.Assistant("Hello!"),
+        )
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 10)
+
+        val result = budgeter.build(system, transcript, user)
+
+        assertThat(result.messages).containsExactly(system, transcript[0], transcript[1], user)
+    }
+
+    @Test
+    fun `given transcript longer than window size, when building, then only most recent messages are included`() {
+        val old1 = AssistantMessage.User("old turn")
+        val old2 = AssistantMessage.Assistant("old response")
+        val recent1 = AssistantMessage.User("recent turn")
+        val recent2 = AssistantMessage.Assistant("recent response")
+        val transcript = listOf(old1, old2, recent1, recent2)
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 2)
+
+        val result = budgeter.build(system, transcript, user)
+
+        assertThat(result.messages).containsExactly(system, recent1, recent2, user)
+    }
+
+    @Test
+    fun `given transcript longer than window size, when building, then oldest messages are excluded`() {
+        val old = AssistantMessage.User("old message")
+        val recent = AssistantMessage.User("recent message")
+        val transcript = listOf(old, AssistantMessage.Assistant("..."), recent)
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 1)
+
+        val result = budgeter.build(system, transcript, user)
+
+        assertThat(result.messages).doesNotContain(old)
+        assertThat(result.messages).contains(recent)
+    }
+
+    @Test
+    fun `given any transcript, when building, then system prompt is first message`() {
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 5)
+
+        val result = budgeter.build(system, listOf(AssistantMessage.User("hello")), user)
+
+        assertThat(result.messages.first()).isEqualTo(system)
+    }
+
+    @Test
+    fun `given any transcript, when building, then current user turn is last message`() {
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 5)
+
+        val result = budgeter.build(system, listOf(AssistantMessage.User("hello")), user)
+
+        assertThat(result.messages.last()).isEqualTo(user)
+    }
+
+    @Test
+    fun `given any transcript, when building, then retainedEntityRefs is empty`() {
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 5)
+
+        val result = budgeter.build(system, listOf(AssistantMessage.User("hello")), user)
+
+        assertThat(result.retainedEntityRefs).isEmpty()
+    }
+}

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.aiassistant.core.loop
 
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import kotlinx.serialization.json.buildJsonObject
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 
 class SlidingWindowHistoryBudgeterTest {
@@ -69,5 +72,31 @@ class SlidingWindowHistoryBudgeterTest {
         val result = budgeter.build(system, listOf(AssistantMessage.User("hello")), user)
 
         assertThat(result.retainedEntityRefs).isEmpty()
+    }
+
+    @Test
+    fun `given window cuts into tool-call exchange, when building, then no orphaned Tool message starts the window`() {
+        val toolCall = ToolCall(id = "call_1", name = "orders_list", arguments = buildJsonObject { })
+        val assistantWithToolCall = AssistantMessage.Assistant(content = null, toolCalls = listOf(toolCall))
+        val toolResult = AssistantMessage.Tool(toolCallId = "call_1", content = """{"orders":[]}""")
+        val assistantFinal = AssistantMessage.Assistant(content = "Here are your orders.")
+        val transcript = listOf(
+            AssistantMessage.User("show orders"),
+            assistantWithToolCall,
+            toolResult,
+            assistantFinal,
+        )
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 2)
+
+        val result = budgeter.build(system, transcript, user)
+
+        assertThat(result.messages).doesNotContain(toolResult)
+        assertThat(result.messages.filterIsInstance<AssistantMessage.Tool>()).isEmpty()
+    }
+
+    @Test
+    fun `given negative window size, when constructing, then throws IllegalArgumentException`() {
+        assertThatThrownBy { SlidingWindowHistoryBudgeter(windowSize = -1) }
+            .isInstanceOf(IllegalArgumentException::class.java)
     }
 }

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
@@ -95,6 +95,29 @@ class SlidingWindowHistoryBudgeterTest {
     }
 
     @Test
+    fun `given window size 2 on 4-message transcript ending with tool then assistant, when building, then orphaned tool is dropped and only assistant response is kept`() {
+        // Transcript: [User, Assistant(toolCalls=[c1]), Tool(c1), Assistant("Done")]
+        // takeLast(2) alone would give [Tool(c1), Assistant("Done")] — Tool(c1) has no
+        // preceding assistant tool-call message, which is invalid for the OpenAI wire format.
+        // The budgeter must advance the window start past orphaned Tool messages.
+        val toolCall = ToolCall(id = "call_1", name = "orders_list", arguments = buildJsonObject { })
+        val assistantWithToolCall = AssistantMessage.Assistant(content = null, toolCalls = listOf(toolCall))
+        val toolResult = AssistantMessage.Tool(toolCallId = "call_1", content = """{"orders":[]}""")
+        val assistantFinal = AssistantMessage.Assistant(content = "Here are your orders.")
+        val transcript = listOf(
+            AssistantMessage.User("show orders"),
+            assistantWithToolCall,
+            toolResult,
+            assistantFinal,
+        )
+        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 2)
+
+        val result = budgeter.build(system, transcript, user)
+
+        assertThat(result.messages).containsExactly(system, assistantFinal, user)
+    }
+
+    @Test
     fun `given negative window size, when constructing, then throws IllegalArgumentException`() {
         assertThatThrownBy { SlidingWindowHistoryBudgeter(windowSize = -1) }
             .isInstanceOf(IllegalArgumentException::class.java)

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/SlidingWindowHistoryBudgeterTest.kt
@@ -45,19 +45,6 @@ class SlidingWindowHistoryBudgeterTest {
     }
 
     @Test
-    fun `given transcript longer than window size, when building, then oldest messages are excluded`() {
-        val old = AssistantMessage.User("old message")
-        val recent = AssistantMessage.User("recent message")
-        val transcript = listOf(old, AssistantMessage.Assistant("..."), recent)
-        val budgeter = SlidingWindowHistoryBudgeter(windowSize = 1)
-
-        val result = budgeter.build(system, transcript, user)
-
-        assertThat(result.messages).doesNotContain(old)
-        assertThat(result.messages).contains(recent)
-    }
-
-    @Test
     fun `given any transcript, when building, then system prompt is first message`() {
         val budgeter = SlidingWindowHistoryBudgeter(windowSize = 5)
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
@@ -6,7 +6,9 @@ import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
 import com.woocommerce.android.aiassistant.core.loop.AgenticLoop
 import com.woocommerce.android.aiassistant.core.loop.AgenticLoopImpl
 import com.woocommerce.android.aiassistant.core.loop.ConservativeRetryPolicy
+import com.woocommerce.android.aiassistant.core.loop.HistoryBudgeter
 import com.woocommerce.android.aiassistant.core.loop.RetryPolicy
+import com.woocommerce.android.aiassistant.core.loop.SlidingWindowHistoryBudgeter
 import com.woocommerce.android.aiassistant.core.loop.ToolCatalogSelector
 import com.woocommerce.android.aiassistant.tools.DefaultToolCatalogSelector
 import com.woocommerce.android.aiassistant.tools.WooCommerceToolRegistry
@@ -103,12 +105,17 @@ internal abstract class AiAssistantModule {
 
         @Provides
         @Singleton
+        fun provideHistoryBudgeter(): HistoryBudgeter = SlidingWindowHistoryBudgeter()
+
+        @Provides
+        @Singleton
         fun provideAgenticLoop(
             chatService: ChatService,
             toolRegistry: ToolRegistry,
             retryPolicy: RetryPolicy,
+            historyBudgeter: HistoryBudgeter,
             @AiAssistantJson json: Json,
-        ): AgenticLoop = AgenticLoopImpl(chatService, toolRegistry, retryPolicy, json)
+        ): AgenticLoop = AgenticLoopImpl(chatService, toolRegistry, retryPolicy, historyBudgeter, json)
 
         @Provides
         @Singleton


### PR DESCRIPTION
Fixes WOOMOB-2895

### Description

Implements the `HistoryBudgeter` interface and its production implementation, `SlidingWindowHistoryBudgeter`, and wires it into `AgenticLoopImpl` and the Hilt DI graph.

**Why this is needed:**
Without a history budget, `AgenticLoopImpl` resends the entire conversation transcript to the model on every turn. As sessions grow, this inflates token usage and risks hitting context limits. The agreed v1 policy (session-only sliding window) trims the model's view to the most recent N messages while leaving the UI transcript untouched.

**What changed:**

*New types (`:libs:ai-assistant:core`):*
- `CardRef(entityType: String, entityId: Long)` — a lightweight reference to an active-thread entity (order, product, customer) for follow-up context. `retainedEntityRefs` carries these through the budget seam so a future ticket can inject them into the model's prompt for follow-ups like "open the second one".
- `BudgetedHistory` — the budgeter's output: a trimmed message list for the model, plus `retainedEntityRefs`.
- `HistoryBudgeter` — a `fun interface` with a single `build(systemPrompt, rawTranscript, currentUserTurn)` method. Separating the three roles makes the contract unambiguous: the implementer decides which historical messages to include; the caller always provides the full transcript and gets the full transcript back.
- `SlidingWindowHistoryBudgeter` — the production implementation: `rawTranscript.takeLast(windowSize)`, with a configurable window (default 20 messages).

*Modified:*
- `AgenticLoopImpl` — injects `HistoryBudgeter`. On each `runTurn` call it splits the caller's `history` into the system prompt and raw transcript, calls the budgeter, and tracks two separate lists: `modelMessages` (budgeted, sent to `ChatRequest`) and `newTurnMessages` (messages generated this turn). `LoopEvent.Finished.updatedHistory` is always `history + newTurnMessages`, so the caller's full transcript is preserved regardless of how aggressively the budgeter trims.
- `AiAssistantModule` — provides `SlidingWindowHistoryBudgeter` as `HistoryBudgeter` and passes it into `AgenticLoopImpl`.

**Stacks on:** [WOOMOB-2894 PR #15767](https://github.com/woocommerce/woocommerce-android/pull/15767)

### Test Steps

This PR adds no user-visible behaviour — the budgeting is internal to the AI assistant runtime and the assistant UI is not yet connected to the runtime in a releasable build. Verification is through the unit tests added in this PR:

1. Run `:libs:ai-assistant:core:test` — all `SlidingWindowHistoryBudgeterTest` and `AgenticLoopImplTest` cases should pass.
2. In particular, `given budgeter trims history, when running turn, then model receives only budgeted messages` verifies that the model's `ChatRequest` contains only the windowed messages, and `given budgeter trims history, when running turn, then updatedHistory contains full prior history plus new turn messages` verifies that the full transcript is returned to the caller.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.