### PR TITLE
[WOOMOB-2931] Step 12: QR login — prefill site address from site-URL-only QRs

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -124,6 +124,7 @@ enum class AnalyticsEvent(override val siteless: Boolean = false) : IAnalyticsEv
     LOGIN_QR_SCAN_FAILED(siteless = true),
     LOGIN_QR_SUCCESS(siteless = true),
     LOGIN_QR_HANDED_OFF_WP_COM_MAGIC_LINK(siteless = true),
+    LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL(siteless = true),
 
     // -- Site Picker
     SITE_PICKER_STORES_SHOWN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -308,6 +308,11 @@ class LoginActivity :
         loggedInViaUsernamePassword(arrayListOf(localSiteId))
     }
 
+    override fun onQrLoginSiteUrlPrefill(siteUrl: String) {
+        disableDynamicEdgeToEdge()
+        loginViaSiteAddress(prefilledSiteUrl = siteUrl)
+    }
+
     private fun hasJetpackConnectedIntent(): Boolean {
         val action = intent.action
         val uri = intent.data
@@ -508,9 +513,12 @@ class LoginActivity :
         changeFragment(loginMagicLinkRequestFragment, true, LoginMagicLinkRequestFragment.TAG, false)
     }
 
-    override fun loginViaSiteAddress() {
+    override fun loginViaSiteAddress() = loginViaSiteAddress(prefilledSiteUrl = null)
+
+    private fun loginViaSiteAddress(prefilledSiteUrl: String?) {
         unifiedLoginTracker.setFlowAndStep(LOGIN_SITE_ADDRESS, ENTER_SITE_ADDRESS)
-        val loginSiteAddressFragment = getLoginViaSiteAddressFragment() ?: WooLoginSiteAddressFragment()
+        val loginSiteAddressFragment = getLoginViaSiteAddressFragment()
+            ?: WooLoginSiteAddressFragment.newInstance(prefilledSiteUrl)
         changeFragment(loginSiteAddressFragment, true, LoginSiteAddressFragment.TAG)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginSiteAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginSiteAddressFragment.kt
@@ -1,15 +1,43 @@
 package com.woocommerce.android.ui.login.overrides
 
+import android.os.Bundle
+import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.isNotNullOrEmpty
 import org.wordpress.android.login.LoginSiteAddressFragment
+import org.wordpress.android.login.widgets.WPLoginInputRow
 
 class WooLoginSiteAddressFragment : LoginSiteAddressFragment() {
+    companion object {
+        private const val ARG_PREFILLED_SITE_URL = "prefilled_site_url"
+
+        fun newInstance(prefilledSiteUrl: String? = null): WooLoginSiteAddressFragment =
+            WooLoginSiteAddressFragment().apply {
+                arguments = Bundle().apply { putString(ARG_PREFILLED_SITE_URL, prefilledSiteUrl) }
+            }
+    }
+
     @LayoutRes
     override fun getContentLayout() = R.layout.fragment_login_site_address
 
     override fun setupContent(rootView: ViewGroup) {
         super.setupContent(rootView)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val prefilledSiteUrl = arguments?.getString(ARG_PREFILLED_SITE_URL)
+        if (prefilledSiteUrl.isNotNullOrEmpty()) {
+            view.findViewById<WPLoginInputRow>(R.id.login_site_address_row)
+                ?.editText
+                ?.setText(prefilledSiteUrl)
+            // Auto-submit so the merchant goes from "scan QR" to the next login step with no taps,
+            // mirroring WooLoginEmailFragment which calls next(prefilledEmail) on the email screen.
+            discover()
+            // Single-shot: prevent replay on rotation / process recovery.
+            arguments?.remove(ARG_PREFILLED_SITE_URL)
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
@@ -35,5 +35,13 @@ sealed interface QrLoginPayload {
      */
     data class WpComMagicLinkUrl(val url: String) : QrLoginPayload
 
+    /**
+     * The merchant scanned a `woocommerce://qr-login?siteUrl=…` deeplink with no `token` (or a
+     * blank one). The scanner routes them to the existing site-address login screen with the URL
+     * prefilled and validation auto-started — bridging "scan QR" to "enter password / accept site"
+     * with no manual typing.
+     */
+    data class SiteUrl(val siteUrl: String) : QrLoginPayload
+
     data object Invalid : QrLoginPayload
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
@@ -13,6 +13,10 @@ import javax.inject.Inject
  * woocommerce://qr-login?token=<64-byte hex>&siteUrl=<URL-encoded site URL>
  * ```
  *
+ * The same deeplink shape is also used as a "site-URL only" QR — when `token` is missing or
+ * blank, the payload becomes [QrLoginPayload.SiteUrl] and the scanner routes the merchant to
+ * the site-address login screen with the URL prefilled instead of attempting an exchange.
+ *
  * Anything malformed, missing parameters, with the wrong scheme/host, or with a non-https
  * `siteUrl` returns [QrLoginPayload.Invalid]. The parser does not validate the token format
  * beyond non-blank — that's the server's job during exchange. `siteUrl` is parsed via OkHttp's
@@ -28,7 +32,7 @@ class QrLoginPayloadParser @Inject constructor() {
     fun parse(raw: String?): QrLoginPayload {
         parseWpComMagicLinkUrl(raw)?.let { return it }
         if (looksLikeInstallQr(raw)) return QrLoginPayload.InstallQrCode
-        return parseTicket(raw) ?: QrLoginPayload.Invalid
+        return parseQrLoginDeeplink(raw) ?: QrLoginPayload.Invalid
     }
 
     /**
@@ -48,11 +52,21 @@ class QrLoginPayloadParser @Inject constructor() {
         return if (matches) QrLoginPayload.WpComMagicLinkUrl(url = trimmed) else null
     }
 
-    private fun parseTicket(raw: String?): QrLoginPayload.Ticket? {
+    /**
+     * Parses the `woocommerce://qr-login?...` deeplink. Returns [QrLoginPayload.Ticket] when both
+     * `token` and `siteUrl` are present and valid, [QrLoginPayload.SiteUrl] when `siteUrl` is
+     * valid but `token` is missing or blank, and `null` (caller maps to `Invalid`) otherwise.
+     * `siteUrl` validation is identical in both branches.
+     */
+    private fun parseQrLoginDeeplink(raw: String?): QrLoginPayload? {
         val uri = parseDeepLink(raw) ?: return null
-        val token = uri.queryParam(PARAM_TOKEN)?.takeIf { it.isNotBlank() } ?: return null
         val siteUrl = uri.queryParam(PARAM_SITE_URL)?.let(::normalizeSiteUrl) ?: return null
-        return QrLoginPayload.Ticket(token = token, siteUrl = siteUrl)
+        val token = uri.queryParam(PARAM_TOKEN)?.takeIf { it.isNotBlank() }
+        return if (token != null) {
+            QrLoginPayload.Ticket(token = token, siteUrl = siteUrl)
+        } else {
+            QrLoginPayload.SiteUrl(siteUrl = siteUrl)
+        }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -47,6 +47,7 @@ class QrLoginScannerFragment : Fragment() {
     interface Listener {
         fun onQrLoginCompleted(localSiteId: Int)
         fun onQrLoginFallbackClicked()
+        fun onQrLoginSiteUrlPrefill(siteUrl: String)
     }
 
     private val scannerViewModel: BarcodeScanningViewModel by viewModels()
@@ -161,6 +162,8 @@ class QrLoginScannerFragment : Fragment() {
                 is QrLoginScannerViewModel.Dispatch.LoggedIn -> handleLoggedIn(event.localSiteId)
                 is QrLoginScannerViewModel.Dispatch.OpenWpComMagicLinkUrl ->
                     openWpComMagicLinkUrl(event.url)
+                is QrLoginScannerViewModel.Dispatch.RouteToSiteAddressEntry ->
+                    routeToSiteAddressEntry(event.siteUrl)
             }
         }
     }
@@ -206,5 +209,16 @@ class QrLoginScannerFragment : Fragment() {
     private fun openWpComMagicLinkUrl(url: String) {
         scannerViewModel.stopCodesRecognition()
         ChromeCustomTabUtils.launchUrl(requireContext(), url)
+    }
+
+    /**
+     * Hand the site URL off to the host activity, which navigates to the existing site-address
+     * login screen with the URL prefilled and validation auto-started.
+     */
+    private fun routeToSiteAddressEntry(siteUrl: String) {
+        scannerViewModel.stopCodesRecognition()
+        requireNotNull(listener) {
+            "${requireActivity().javaClass.simpleName} must implement QrLoginScannerFragment.Listener"
+        }.onQrLoginSiteUrlPrefill(siteUrl)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -92,6 +92,14 @@ class QrLoginScannerViewModel @Inject constructor(
                 analyticsTracker.track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_WP_COM_MAGIC_LINK)
                 triggerEvent(Dispatch.OpenWpComMagicLinkUrl(url = payload.url))
             }
+            is QrLoginPayload.SiteUrl -> {
+                // Site-URL-only QR — no token to exchange, just route the merchant to the
+                // existing site-address login screen with the URL prefilled and validation
+                // auto-started. Same lock + happy-path tracking as the wp.com branch.
+                loggedIn = true
+                analyticsTracker.track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL)
+                triggerEvent(Dispatch.RouteToSiteAddressEntry(siteUrl = payload.siteUrl))
+            }
             QrLoginPayload.InstallQrCode -> {
                 trackScanFailure(
                     step = Step.PAYLOAD,
@@ -242,6 +250,13 @@ class QrLoginScannerViewModel @Inject constructor(
          * 3rd-party scanner (Google Lens, etc.) takes today.
          */
         data class OpenWpComMagicLinkUrl(val url: String) : Dispatch()
+
+        /**
+         * The merchant scanned a `woocommerce://qr-login?siteUrl=…` deeplink without a token.
+         * The fragment routes the merchant to the existing site-address login screen with
+         * [siteUrl] prefilled and validation auto-started.
+         */
+        data class RouteToSiteAddressEntry(val siteUrl: String) : Dispatch()
     }
 
     sealed interface UiState {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
@@ -71,10 +71,17 @@ class QrLoginPayloadParserTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given missing token, when parsed, then returns Invalid`() {
+    fun `given missing token but valid siteUrl, when parsed, then returns SiteUrl`() {
         val raw = "woocommerce://qr-login?siteUrl=https%3A%2F%2Fstore.example"
 
-        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.SiteUrl(siteUrl = "https://store.example"))
+    }
+
+    @Test
+    fun `given blank token but valid siteUrl, when parsed, then returns SiteUrl`() {
+        val raw = "woocommerce://qr-login?token=&siteUrl=https%3A%2F%2Fstore.example"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.SiteUrl(siteUrl = "https://store.example"))
     }
 
     @Test
@@ -85,10 +92,27 @@ class QrLoginPayloadParserTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given blank token, when parsed, then returns Invalid`() {
-        val raw = "woocommerce://qr-login?token=&siteUrl=https%3A%2F%2Fstore.example"
+    fun `given missing token and non-https siteUrl, when parsed, then returns Invalid`() {
+        // siteUrl validation is identical for Ticket and SiteUrl branches
+        val raw = "woocommerce://qr-login?siteUrl=http%3A%2F%2Fstore.example"
 
         assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given missing token and siteUrl with userinfo, when parsed, then returns Invalid`() {
+        val raw = "woocommerce://qr-login?siteUrl=https%3A%2F%2Fuser%3Apass%40store.example"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given missing token and siteUrl with non-default port, when parsed, then preserves port`() {
+        val raw = "woocommerce://qr-login?siteUrl=https%3A%2F%2Fstore.example%3A8443"
+
+        assertThat(parser.parse(raw)).isEqualTo(
+            QrLoginPayload.SiteUrl(siteUrl = "https://store.example:8443")
+        )
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -560,6 +560,72 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             verify(analyticsTracker, never()).track(AnalyticsEvent.LOGIN_QR_SUCCESS)
         }
 
+    @Test
+    fun `given site url payload, when scan succeeds, then emits RouteToSiteAddressEntry`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.SiteUrl(SITE_URL))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onScanResult(successScan())
+
+        assertThat(events.last()).isEqualTo(
+            QrLoginScannerViewModel.Dispatch.RouteToSiteAddressEntry(siteUrl = SITE_URL)
+        )
+    }
+
+    @Test
+    fun `given site url payload, when scan succeeds, then ui state stays idle`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.SiteUrl(SITE_URL))
+
+        viewModel.onScanResult(successScan())
+
+        assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
+        verify(authenticator, never()).authenticate(any())
+    }
+
+    @Test
+    fun `given site url via deep link, when received, then emits RouteToSiteAddressEntry`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.SiteUrl(SITE_URL))
+        val events = viewModel.event.captureValues()
+
+        viewModel.onDeepLinkPayload(RAW_SCAN)
+
+        assertThat(events.last()).isEqualTo(
+            QrLoginScannerViewModel.Dispatch.RouteToSiteAddressEntry(siteUrl = SITE_URL)
+        )
+    }
+
+    @Test
+    fun `given site url handed off, when another scan arrives, then it is ignored`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.SiteUrl(SITE_URL))
+
+        viewModel.onScanResult(successScan(RAW_SCAN))
+        viewModel.onScanResult(successScan("second-raw"))
+
+        verify(parser, never()).parse("second-raw")
+    }
+
+    @Test
+    fun `given site url payload, when scan succeeds, then tracks LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL`() =
+        testBlocking {
+            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.SiteUrl(SITE_URL))
+
+            viewModel.onScanResult(successScan())
+
+            verify(analyticsTracker).track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL)
+        }
+
+    @Test
+    fun `given site url payload, when scan succeeds, then does not track LOGIN_QR_SCAN_FAILED or LOGIN_QR_SUCCESS`() =
+        testBlocking {
+            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.SiteUrl(SITE_URL))
+
+            viewModel.onScanResult(successScan())
+
+            // Site-URL handoff is the happy path; the user hasn't completed a sign-in yet.
+            verify(analyticsTracker, never()).track(eq(AnalyticsEvent.LOGIN_QR_SCAN_FAILED), any(), any(), any(), any())
+            verify(analyticsTracker, never()).track(AnalyticsEvent.LOGIN_QR_SUCCESS)
+        }
+
     private fun successScan(raw: String = RAW_SCAN) =
         CodeScannerStatus.Success(code = raw, format = BarcodeFormat.FormatQRCode)
 
@@ -571,5 +637,6 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         const val DEFAULT_SITE_ID = 42
         const val WP_COM_URL =
             "https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=abc"
+        const val SITE_URL = "https://store.example.com"
     }
 }


### PR DESCRIPTION
### Description

Fixes WOOMOB-2931

Adds support for `woocommerce://qr-login?siteUrl=…` QR codes that contain a site URL but no token. The parser now branches on token presence: with token → existing `Ticket` (Application Password exchange); without token → new `SiteUrl(siteUrl)`. The latter routes the merchant to the existing site-address login screen with the URL prefilled and validation auto-started, mirroring `WooLoginEmailFragment.next(prefilledEmail)`.

`siteUrl` validation is identical for both branches (HTTPS-only, no userinfo/query/fragment, port preserved). The behavioural change for existing payloads is narrow: a deeplink with a valid `siteUrl` but missing/blank `token` previously returned `Invalid` and now produces a useful prefill flow. New analytics event `LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL` fires on handoff (this is the happy path, not a failure — `LOGIN_QR_SCAN_FAILED` and `LOGIN_QR_SUCCESS` are pinned to NOT fire here).

Stacked on top of #15763 (step-11). Carries `status: do not merge` until that lands.

### Test Steps

1. Be signed out of the app, with the QR login feature gate enabled. Navigate to the QR login prologue and tap **Scan**.
2. Generate a QR encoding `woocommerce://qr-login?siteUrl=https%3A%2F%2Fyour-test-store.example.com` and scan it with the in-app scanner.
3. **Expected:** the site-address login screen opens with `https://your-test-store.example.com` prefilled and the validation indicator already running. Continue the normal site-address login flow from there.

### Images/gif

N/A — no UI changes; the recognised payload set has expanded and an existing screen now accepts a prefill argument.

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

Release notes for the QR login feature will accumulate on the final step in the stack once the gate is flipped.