### PR TITLE
Restore tablet horizontal padding on POS Cart and Totals bottom buttons

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -186,6 +186,7 @@ fun WooPosCartScreen(
                         WooPosButton(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .padding(horizontal = WooPosSpacing.Medium.value)
                                 .navigationBarsPadding()
                                 .testTag(WooPosTestTags.CHECKOUT_BUTTON),
                             text = stringResource(R.string.woopos_checkout_button),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -247,7 +247,13 @@ private fun TotalsLoaded(
             onClick = { onUIEvent(WooPosTotalsUIEvent.OnCashPaymentClicked) },
             modifier = Modifier
                 .fillMaxWidth()
-                .then(if (isPhone) Modifier.padding(WooPosSpacing.Large.value) else Modifier)
+                .then(
+                    if (isPhone) {
+                        Modifier.padding(WooPosSpacing.Large.value)
+                    } else {
+                        Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
+                    }
+                )
                 .navigationBarsPadding()
                 .testTag(WooPosTestTags.CASH_PAYMENT_BUTTON)
         )


### PR DESCRIPTION
### Description

Recent commit [`23c1692bc98`](https://github.com/woocommerce/woocommerce-android/commit/23c1692bc98) (*WOOMOB-2660 align bottom button paddings on phones and tablets*) stripped the **horizontal padding** from the tablet POS *Check out* (Cart pane) and *Cash payment* (Totals) bottom buttons, so both buttons started extending edge-to-edge of their pane and looked off.

This restores the padding on tablet only:

- **Cart Check out** — `padding(horizontal = WooPosSpacing.Medium.value)` on the inline button. Phone POS uses the `External` slot via the persistent overlay, so phone behavior is untouched.
- **Cash payment** — extended the existing `if (isPhone) … else …` so the tablet branch gets `padding(horizontal = WooPosSpacing.XLarge.value)`. Phone branch unchanged.

### Test Steps

1. Open the app on a **tablet** in landscape and go to **Point of Sale**.
2. Add a few products to the cart.
3. Verify the *Check out* button at the bottom of the Cart pane has horizontal margin (does not touch the pane edges).
4. Tap *Check out* and verify the *Cash payment* button on the Totals pane has horizontal margin too.
5. Repeat on a **phone** — confirm nothing changed (persistent bottom button still works on Products / Cart, *Cash payment* on Totals still has its phone padding).

### Images/gif

**Tablet — after**

| Cart (Check out) | Totals (Cash payment) |
| --- | --- |
| <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/pos-tablet-cart.png" width="400" /> | <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/pos-tablet-totals.png" width="400" /> |

**Phone — unchanged (sanity check)**

| Products | Cart | Totals |
| --- | --- | --- |
| <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/pos-phone-products-scaled.png" width="260" /> | <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/pos-phone-cart-scaled.png" width="260" /> | <img src="https://pressable-kidinov.mystagingwebsite.com/wp-content/uploads/2026/04/pos-phone-totals-scaled.png" width="260" /> |

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
