### PR TITLE
[WOOMOB-2806] Step 13: QR login — warn before replacing an active session

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsEvent.kt
@@ -125,6 +125,9 @@ enum class AnalyticsEvent(override val siteless: Boolean = false) : IAnalyticsEv
     LOGIN_QR_SUCCESS(siteless = true),
     LOGIN_QR_HANDED_OFF_WP_COM_MAGIC_LINK(siteless = true),
     LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL(siteless = true),
+    LOGIN_QR_SESSION_REPLACE_WARNING_SHOWN(siteless = true),
+    LOGIN_QR_SESSION_REPLACE_CONFIRMED(siteless = true),
+    LOGIN_QR_SESSION_REPLACE_DISMISSED(siteless = true),
 
     // -- Site Picker
     SITE_PICKER_STORES_SHOWN,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -98,6 +98,8 @@ class QrLoginScannerFragment : Fragment() {
             },
             onConfirmSite = qrLoginViewModel::onConfirmSite,
             onCancelSite = ::handleCancelSite,
+            onConfirmSessionReplace = qrLoginViewModel::onConfirmSessionReplace,
+            onCancelSessionReplace = ::handleCancelSessionReplace,
             onStartOver = ::handleStartOver,
             onRetryExchange = qrLoginViewModel::onRetryExchange,
             onFallbackClicked = { listener?.onQrLoginFallbackClicked() },
@@ -175,6 +177,17 @@ class QrLoginScannerFragment : Fragment() {
      */
     private fun handleCancelSite() {
         qrLoginViewModel.onCancelSite()
+        requireActivity().onBackPressedDispatcher.onBackPressed()
+    }
+
+    /**
+     * In practice the warning is only reachable via deep link (the in-app scanner is gated
+     * behind a logged-out [LoginActivity]), so cancelling closes [LoginActivity] and returns
+     * the merchant to whatever they were doing before tapping the QR link. Existing session
+     * is left intact.
+     */
+    private fun handleCancelSessionReplace() {
+        qrLoginViewModel.onCancelSessionReplace()
         requireActivity().onBackPressedDispatcher.onBackPressed()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
@@ -31,6 +31,8 @@ fun QrLoginScannerScreen(
     onPermissionResult: (Boolean) -> Unit,
     onConfirmSite: () -> Unit,
     onCancelSite: () -> Unit,
+    onConfirmSessionReplace: () -> Unit,
+    onCancelSessionReplace: () -> Unit,
     onStartOver: () -> Unit,
     onRetryExchange: () -> Unit,
     onFallbackClicked: () -> Unit,
@@ -56,6 +58,10 @@ fun QrLoginScannerScreen(
                 host = uiState.host,
                 onConfirm = onConfirmSite,
                 onCancel = onCancelSite,
+            )
+            is UiState.WarningSessionReplace -> QrLoginSessionReplaceWarningScreen(
+                onConfirm = onConfirmSessionReplace,
+                onCancel = onCancelSessionReplace,
             )
             is UiState.Error -> QrLoginErrorScreen(
                 content = uiState.reason.toErrorContent(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -6,11 +6,13 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Authenticating
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Confirming
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Error
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Idle
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.WarningSessionReplace
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -42,6 +44,7 @@ class QrLoginScannerViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val parser: QrLoginPayloadParser,
     private val authenticator: QrLoginAuthenticator,
+    private val accountRepository: AccountRepository,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedState) {
 
@@ -107,8 +110,19 @@ class QrLoginScannerViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Gate every QR hand-off (ticket / wp.com magic link / site-URL prefill) on the user being
+     * signed out. If a session is already active we surface a confirmation screen first; the
+     * user must opt in to replacing it before we run [AccountRepository.logout] and resume the
+     * original action.
+     */
     private fun handleHandoff(pending: PendingHandoff) {
-        resumePending(pending)
+        if (accountRepository.isUserLoggedIn()) {
+            analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SESSION_REPLACE_WARNING_SHOWN)
+            _uiState.value = WarningSessionReplace(pending)
+        } else {
+            resumePending(pending)
+        }
     }
 
     private fun resumePending(pending: PendingHandoff) {
@@ -192,6 +206,32 @@ class QrLoginScannerViewModel @Inject constructor(
 
     fun onCancelSite() {
         if (_uiState.value is Confirming) _uiState.value = Idle
+    }
+
+    /**
+     * The merchant accepted the session-replace warning. Run the canonical logout via
+     * [AccountRepository.logout] (which handles both wp.com OAuth and per-site app-password
+     * sessions, plus prefs / analytics / Zendesk / DataStore cleanup) and then resume the
+     * original payload action exactly as if the user had been signed out from the start.
+     *
+     * We flip into [Authenticating] for the duration of the logout so the UI gives feedback
+     * while [AccountRepository.logout] talks to the server — for the Ticket path this is then
+     * overwritten by [Confirming] so the merchant still sees the host-confirmation step.
+     */
+    fun onConfirmSessionReplace() {
+        val pending = (_uiState.value as? WarningSessionReplace)?.pending ?: return
+        analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SESSION_REPLACE_CONFIRMED)
+        _uiState.value = Authenticating
+        launch {
+            accountRepository.logout()
+            resumePending(pending)
+        }
+    }
+
+    fun onCancelSessionReplace() {
+        if (_uiState.value !is WarningSessionReplace) return
+        analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SESSION_REPLACE_DISMISSED)
+        _uiState.value = Idle
     }
 
     /**
@@ -282,13 +322,13 @@ class QrLoginScannerViewModel @Inject constructor(
         data class Confirming(val ticket: QrLoginPayload.Ticket, val host: String) : UiState
         data object Authenticating : UiState
         data class Error(val reason: ErrorReason, val retryTicket: QrLoginPayload.Ticket?) : UiState
+        data class WarningSessionReplace(val pending: PendingHandoff) : UiState
     }
 
     /**
-     * Captures a parsed QR payload that has been routed through [handleHandoff]. Splitting the
-     * dispatch into "build the pending action" and "resume the pending action" lets us insert
-     * additional gates (e.g. session checks) between the two halves without duplicating the
-     * per-payload branch logic.
+     * Captures a parsed QR payload that we deferred while showing the session-replace warning.
+     * On confirm we run logout and then dispatch the matching action via [resumePending];
+     * on cancel we simply drop it and return to [UiState.Idle].
      */
     sealed interface PendingHandoff {
         data class Ticket(val ticket: QrLoginPayload.Ticket, val host: String) : PendingHandoff

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -216,14 +216,27 @@ class QrLoginScannerViewModel @Inject constructor(
      * We flip into [Authenticating] for the duration of the logout so the UI gives feedback
      * while [AccountRepository.logout] talks to the server — for the Ticket path this is then
      * overwritten by [Confirming] so the merchant still sees the host-confirmation step.
+     *
+     * If logout fails (only the wp.com path can; it returns false without running cleanup, so
+     * the access token and selected site are still in place), we must NOT resume — installing
+     * fresh credentials on top of a live session is exactly what the warning exists to prevent.
+     * Surface a generic error and let the merchant scan again, which re-shows the warning.
      */
     fun onConfirmSessionReplace() {
         val pending = (_uiState.value as? WarningSessionReplace)?.pending ?: return
         analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SESSION_REPLACE_CONFIRMED)
         _uiState.value = Authenticating
         launch {
-            accountRepository.logout()
-            resumePending(pending)
+            if (accountRepository.logout()) {
+                resumePending(pending)
+            } else {
+                trackScanFailure(
+                    step = Step.EXCHANGE,
+                    errorContext = null,
+                    errorType = SESSION_REPLACE_LOGOUT_FAILED,
+                )
+                _uiState.value = makeErrorState(ErrorReason.Network, ticket = null)
+            }
         }
     }
 
@@ -441,5 +454,6 @@ class QrLoginScannerViewModel @Inject constructor(
     private companion object {
         const val HTTPS_DEFAULT_PORT = 443
         const val HTTP_DEFAULT_PORT = 80
+        const val SESSION_REPLACE_LOGOUT_FAILED = "session_replace_logout_failed"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -79,27 +79,15 @@ class QrLoginScannerViewModel @Inject constructor(
 
     private fun handlePayload(payload: QrLoginPayload) {
         when (payload) {
-            is QrLoginPayload.Ticket -> _uiState.value = Confirming(
-                ticket = payload,
-                host = payload.siteUrl.toDisplayHost()
+            is QrLoginPayload.Ticket -> handleHandoff(
+                PendingHandoff.Ticket(ticket = payload, host = payload.siteUrl.toDisplayHost())
             )
-            is QrLoginPayload.WpComMagicLinkUrl -> {
-                // Hand the URL off to the browser; wp.com then 3xx-redirects to
-                // woocommerce://magic-login → MagicLinkInterceptActivity. Lock the state machine
-                // because the user is leaving the scanner and the outcome is no longer ours to
-                // handle. This is the happy path — we track the handoff, not a scan failure.
-                loggedIn = true
-                analyticsTracker.track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_WP_COM_MAGIC_LINK)
-                triggerEvent(Dispatch.OpenWpComMagicLinkUrl(url = payload.url))
-            }
-            is QrLoginPayload.SiteUrl -> {
-                // Site-URL-only QR — no token to exchange, just route the merchant to the
-                // existing site-address login screen with the URL prefilled and validation
-                // auto-started. Same lock + happy-path tracking as the wp.com branch.
-                loggedIn = true
-                analyticsTracker.track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL)
-                triggerEvent(Dispatch.RouteToSiteAddressEntry(siteUrl = payload.siteUrl))
-            }
+            is QrLoginPayload.WpComMagicLinkUrl -> handleHandoff(
+                PendingHandoff.WpComMagicLink(url = payload.url)
+            )
+            is QrLoginPayload.SiteUrl -> handleHandoff(
+                PendingHandoff.SiteUrlPrefill(siteUrl = payload.siteUrl)
+            )
             QrLoginPayload.InstallQrCode -> {
                 trackScanFailure(
                     step = Step.PAYLOAD,
@@ -115,6 +103,36 @@ class QrLoginScannerViewModel @Inject constructor(
                     errorType = ErrorReason.InvalidPayload.name,
                 )
                 _uiState.value = Error(reason = ErrorReason.InvalidPayload, retryTicket = null)
+            }
+        }
+    }
+
+    private fun handleHandoff(pending: PendingHandoff) {
+        resumePending(pending)
+    }
+
+    private fun resumePending(pending: PendingHandoff) {
+        when (pending) {
+            is PendingHandoff.Ticket -> _uiState.value = Confirming(
+                ticket = pending.ticket,
+                host = pending.host
+            )
+            is PendingHandoff.WpComMagicLink -> {
+                // Hand the URL off to the browser; wp.com then 3xx-redirects to
+                // woocommerce://magic-login → MagicLinkInterceptActivity. Lock the state machine
+                // because the user is leaving the scanner and the outcome is no longer ours to
+                // handle. This is the happy path — we track the handoff, not a scan failure.
+                loggedIn = true
+                analyticsTracker.track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_WP_COM_MAGIC_LINK)
+                triggerEvent(Dispatch.OpenWpComMagicLinkUrl(url = pending.url))
+            }
+            is PendingHandoff.SiteUrlPrefill -> {
+                // Site-URL-only QR — no token to exchange, just route the merchant to the
+                // existing site-address login screen with the URL prefilled and validation
+                // auto-started. Same lock + happy-path tracking as the wp.com branch.
+                loggedIn = true
+                analyticsTracker.track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL)
+                triggerEvent(Dispatch.RouteToSiteAddressEntry(siteUrl = pending.siteUrl))
             }
         }
     }
@@ -264,6 +282,18 @@ class QrLoginScannerViewModel @Inject constructor(
         data class Confirming(val ticket: QrLoginPayload.Ticket, val host: String) : UiState
         data object Authenticating : UiState
         data class Error(val reason: ErrorReason, val retryTicket: QrLoginPayload.Ticket?) : UiState
+    }
+
+    /**
+     * Captures a parsed QR payload that has been routed through [handleHandoff]. Splitting the
+     * dispatch into "build the pending action" and "resume the pending action" lets us insert
+     * additional gates (e.g. session checks) between the two halves without duplicating the
+     * per-payload branch logic.
+     */
+    sealed interface PendingHandoff {
+        data class Ticket(val ticket: QrLoginPayload.Ticket, val host: String) : PendingHandoff
+        data class WpComMagicLink(val url: String) : PendingHandoff
+        data class SiteUrlPrefill(val siteUrl: String) : PendingHandoff
     }
 
     enum class ErrorReason {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginSessionReplaceWarningScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginSessionReplaceWarningScreen.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.login.qrlogin
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -38,6 +39,10 @@ fun QrLoginSessionReplaceWarningScreen(
     onConfirm: () -> Unit,
     onCancel: () -> Unit,
 ) {
+    // Route system back through the same dismiss path as the Cancel button so the analytics
+    // and state reset stay symmetric — without this, system back would bypass
+    // onCancelSessionReplace and we'd lose the dismissed event.
+    BackHandler(onBack = onCancel)
     Column(
         modifier = Modifier
             .fillMaxSize()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginSessionReplaceWarningScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginSessionReplaceWarningScreen.kt
@@ -1,0 +1,143 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCColoredButton
+import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun QrLoginSessionReplaceWarningScreen(
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .systemBarsPadding()
+            .padding(horizontal = dimensionResource(id = R.dimen.major_150)),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Hero scrolls so the Continue / Cancel buttons stay visible in landscape on phones.
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Hero()
+        }
+        Buttons(onConfirm = onConfirm, onCancel = onCancel)
+    }
+}
+
+@Composable
+private fun Hero() {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        WarningIconBadge()
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_200)))
+        Text(
+            text = stringResource(id = R.string.login_qr_session_replace_title),
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_100)))
+        Text(
+            text = stringResource(id = R.string.login_qr_session_replace_body),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun WarningIconBadge() {
+    Box(
+        modifier = Modifier
+            .size(dimensionResource(id = R.dimen.image_major_72))
+            .clip(CircleShape)
+            .background(colorResource(id = R.color.color_alert).copy(alpha = 0.15f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_warning_filled_24dp),
+            contentDescription = null,
+            tint = colorResource(id = R.color.color_alert),
+            modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_100))
+        )
+    }
+}
+
+@Composable
+private fun Buttons(
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = dimensionResource(id = R.dimen.major_100)),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        WCColoredButton(
+            onClick = onConfirm,
+            text = stringResource(id = R.string.login_qr_session_replace_continue),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
+        WCTextButton(
+            onClick = onCancel,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(text = stringResource(id = R.string.login_qr_session_replace_cancel))
+        }
+    }
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun QrLoginSessionReplaceWarningScreenPreview() {
+    WooThemeWithBackground {
+        QrLoginSessionReplaceWarningScreen(
+            onConfirm = {},
+            onCancel = {}
+        )
+    }
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -258,6 +258,10 @@
     <string name="login_qr_scanner_error_user_role_body">Your account doesn\'t have permission to use the app for this store.</string>
     <string name="login_qr_error_primary_retry">Try again</string>
     <string name="login_qr_error_primary_scan">Scan a new code</string>
+    <string name="login_qr_session_replace_title">You\'re already signed in</string>
+    <string name="login_qr_session_replace_body">Continuing will sign you out of your current session and start a new sign-in. Anything you haven\'t saved may be lost.</string>
+    <string name="login_qr_session_replace_continue">Continue and sign out</string>
+    <string name="login_qr_session_replace_cancel">Cancel</string>
 
     <string name="login_pick_store">Select store to connect</string>
     <string name="login_non_woo_stores_label">Other sites</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -259,7 +259,7 @@
     <string name="login_qr_error_primary_retry">Try again</string>
     <string name="login_qr_error_primary_scan">Scan a new code</string>
     <string name="login_qr_session_replace_title">You\'re already signed in</string>
-    <string name="login_qr_session_replace_body">Continuing will sign you out of your current session and start a new sign-in. Anything you haven\'t saved may be lost.</string>
+    <string name="login_qr_session_replace_body">Continuing will sign you out of your current session and start a new sign-in.</string>
     <string name="login_qr_session_replace_continue">Continue and sign out</string>
     <string name="login_qr_session_replace_cancel">Cancel</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
+import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
 import com.woocommerce.android.ui.orders.creation.CodeScanningErrorType
 import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
@@ -33,6 +34,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     private val parser: QrLoginPayloadParser = mock()
     private val authenticator: QrLoginAuthenticator = mock()
+    private val accountRepository: AccountRepository = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
 
     private val viewModel by lazy {
@@ -40,6 +42,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             savedState = SavedStateHandle(),
             parser = parser,
             authenticator = authenticator,
+            accountRepository = accountRepository,
             analyticsTracker = analyticsTracker
         )
     }
@@ -48,6 +51,10 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     fun setUp() = testBlocking {
         whenever(parser.parse(RAW_SCAN)).thenReturn(ticket)
         whenever(authenticator.authenticate(ticket)).thenReturn(Result.success(DEFAULT_SITE_ID))
+        // Default to "no active session" so existing flows behave as before; individual tests
+        // that exercise the session-replace warning override this.
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(false)
+        whenever(accountRepository.logout()).thenReturn(true)
     }
 
     @Test
@@ -625,6 +632,195 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             verify(analyticsTracker, never()).track(eq(AnalyticsEvent.LOGIN_QR_SCAN_FAILED), any(), any(), any(), any())
             verify(analyticsTracker, never()).track(AnalyticsEvent.LOGIN_QR_SUCCESS)
         }
+
+    // region Session-replace warning (logged-in user)
+
+    @Test
+    fun `given logged in and ticket payload, when scan succeeds, then ui state exposes WarningSessionReplace`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+
+            viewModel.onScanResult(successScan())
+
+            assertThat(viewModel.uiState.value).isEqualTo(
+                QrLoginScannerViewModel.UiState.WarningSessionReplace(
+                    QrLoginScannerViewModel.PendingHandoff.Ticket(ticket = ticket, host = "store.example")
+                )
+            )
+            verify(authenticator, never()).authenticate(any())
+        }
+
+    @Test
+    fun `given logged in and wp dot com payload, when scan succeeds, then ui state exposes WarningSessionReplace`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.WpComMagicLinkUrl(WP_COM_URL))
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+
+            assertThat(viewModel.uiState.value).isEqualTo(
+                QrLoginScannerViewModel.UiState.WarningSessionReplace(
+                    QrLoginScannerViewModel.PendingHandoff.WpComMagicLink(url = WP_COM_URL)
+                )
+            )
+            assertThat(events).isEmpty()
+        }
+
+    @Test
+    fun `given logged in and site url payload, when scan succeeds, then ui state exposes WarningSessionReplace`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.SiteUrl(SITE_URL))
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+
+            assertThat(viewModel.uiState.value).isEqualTo(
+                QrLoginScannerViewModel.UiState.WarningSessionReplace(
+                    QrLoginScannerViewModel.PendingHandoff.SiteUrlPrefill(siteUrl = SITE_URL)
+                )
+            )
+            assertThat(events).isEmpty()
+        }
+
+    @Test
+    fun `given logged in and any payload, when scan succeeds, then tracks LOGIN_QR_SESSION_REPLACE_WARNING_SHOWN`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+
+            viewModel.onScanResult(successScan())
+
+            verify(analyticsTracker).track(AnalyticsEvent.LOGIN_QR_SESSION_REPLACE_WARNING_SHOWN)
+        }
+
+    @Test
+    fun `given logged in and ticket via deep link, when received, then ui state exposes WarningSessionReplace`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+
+            viewModel.onDeepLinkPayload(RAW_SCAN)
+
+            assertThat(viewModel.uiState.value)
+                .isInstanceOf(QrLoginScannerViewModel.UiState.WarningSessionReplace::class.java)
+        }
+
+    @Test
+    fun `given warning state, when another scan arrives, then it is ignored`() = testBlocking {
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+        viewModel.onScanResult(successScan(RAW_SCAN))
+
+        viewModel.onScanResult(successScan("second-raw"))
+
+        verify(parser, never()).parse("second-raw")
+    }
+
+    @Test
+    fun `given warning for ticket, when confirmed, then logs out and advances to Confirming`() = testBlocking {
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+        viewModel.onScanResult(successScan())
+
+        viewModel.onConfirmSessionReplace()
+
+        verify(accountRepository).logout()
+        assertThat(viewModel.uiState.value).isEqualTo(
+            QrLoginScannerViewModel.UiState.Confirming(ticket = ticket, host = "store.example")
+        )
+        verify(authenticator, never()).authenticate(any())
+    }
+
+    @Test
+    fun `given warning for wp dot com, when confirmed, then logs out and emits OpenWpComMagicLinkUrl`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.WpComMagicLinkUrl(WP_COM_URL))
+            val events = viewModel.event.captureValues()
+            viewModel.onScanResult(successScan())
+
+            viewModel.onConfirmSessionReplace()
+
+            verify(accountRepository).logout()
+            assertThat(events.last()).isEqualTo(
+                QrLoginScannerViewModel.Dispatch.OpenWpComMagicLinkUrl(url = WP_COM_URL)
+            )
+            verify(analyticsTracker).track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_WP_COM_MAGIC_LINK)
+        }
+
+    @Test
+    fun `given warning for site url, when confirmed, then logs out and emits RouteToSiteAddressEntry`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.SiteUrl(SITE_URL))
+            val events = viewModel.event.captureValues()
+            viewModel.onScanResult(successScan())
+
+            viewModel.onConfirmSessionReplace()
+
+            verify(accountRepository).logout()
+            assertThat(events.last()).isEqualTo(
+                QrLoginScannerViewModel.Dispatch.RouteToSiteAddressEntry(siteUrl = SITE_URL)
+            )
+            verify(analyticsTracker).track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL)
+        }
+
+    @Test
+    fun `given warning, when confirmed, then tracks LOGIN_QR_SESSION_REPLACE_CONFIRMED`() = testBlocking {
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+        viewModel.onScanResult(successScan())
+
+        viewModel.onConfirmSessionReplace()
+
+        verify(analyticsTracker).track(AnalyticsEvent.LOGIN_QR_SESSION_REPLACE_CONFIRMED)
+    }
+
+    @Test
+    fun `given warning, when cancelled, then returns to idle without logging out`() = testBlocking {
+        whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+        viewModel.onScanResult(successScan())
+
+        viewModel.onCancelSessionReplace()
+
+        assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
+        verify(accountRepository, never()).logout()
+        verify(analyticsTracker).track(AnalyticsEvent.LOGIN_QR_SESSION_REPLACE_DISMISSED)
+    }
+
+    @Test
+    fun `given not in warning state, when onConfirmSessionReplace, then nothing happens`() = testBlocking {
+        // user is not logged in, so payload goes straight to Confirming
+        viewModel.onScanResult(successScan())
+
+        viewModel.onConfirmSessionReplace()
+
+        verify(accountRepository, never()).logout()
+        verify(analyticsTracker, never()).track(AnalyticsEvent.LOGIN_QR_SESSION_REPLACE_CONFIRMED)
+    }
+
+    @Test
+    fun `given logged in and ticket, when warning confirmed and site confirmed, then emits LoggedIn`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+            viewModel.onConfirmSessionReplace()
+            viewModel.onConfirmSite()
+
+            assertThat(events.last())
+                .isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = DEFAULT_SITE_ID))
+        }
+
+    @Test
+    fun `given logged out, when ticket payload arrives, then warning is not shown`() = testBlocking {
+        // Default mock returns isUserLoggedIn=false; verify legacy path is preserved.
+        viewModel.onScanResult(successScan())
+
+        assertThat(viewModel.uiState.value)
+            .isInstanceOf(QrLoginScannerViewModel.UiState.Confirming::class.java)
+        verify(analyticsTracker, never()).track(AnalyticsEvent.LOGIN_QR_SESSION_REPLACE_WARNING_SHOWN)
+    }
+
+    // endregion
 
     private fun successScan(raw: String = RAW_SCAN) =
         CodeScannerStatus.Success(code = raw, format = BarcodeFormat.FormatQRCode)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -807,6 +807,39 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given warning, when confirmed and logout fails, then does not resume and surfaces network error`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(accountRepository.logout()).thenReturn(false)
+            val events = viewModel.event.captureValues()
+            viewModel.onScanResult(successScan())
+
+            viewModel.onConfirmSessionReplace()
+
+            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
+            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.Network)
+            assertThat(events).noneMatch { it is QrLoginScannerViewModel.Dispatch }
+        }
+
+    @Test
+    fun `given warning, when confirmed and logout fails, then tracks scan failed with logout error type`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(accountRepository.logout()).thenReturn(false)
+            viewModel.onScanResult(successScan())
+
+            viewModel.onConfirmSessionReplace()
+
+            verify(analyticsTracker).track(
+                stat = AnalyticsEvent.LOGIN_QR_SCAN_FAILED,
+                properties = mapOf(AnalyticsTracker.KEY_STEP to "exchange"),
+                errorContext = null,
+                errorType = "session_replace_logout_failed",
+                errorDescription = null,
+            )
+        }
+
+    @Test
     fun `given logged in and ticket, when warning confirmed and site confirmed, then emits LoggedIn`() =
         testBlocking {
             whenever(accountRepository.isUserLoggedIn()).thenReturn(true)


### PR DESCRIPTION
### Description

Fixes WOOMOB-2806

When a user is already signed in and a QR-login deep link arrives (Ticket / wp.com magic link / site-URL prefill), the scanner now interrupts the hand-off with a fullscreen warning that "you're already signed in, continuing will sign you out." On confirm, `AccountRepository.logout()` runs (covering both wp.com OAuth and per-site app-password sessions, plus prefs / Zendesk / DataStore / selected-site cleanup) and the original payload action resumes from a clean state. On cancel, the existing session is left intact and the activity exits.

The warning copy is intentionally generic — the user-facing wp.com vs. app-password distinction isn't surfaced anywhere else in the QR flow, and the canonical logout handles both shapes uniformly. In practice the warning is only reachable via deep link (the in-app QR scanner sits behind a logged-out `LoginActivity`), but the `AccountRepository.isUserLoggedIn()` gate in the ViewModel means we're correct in either case.

The work is split into 6 atomic commits — refactor → scaffolding (events, strings, screen) → feature wiring → BackHandler polish — each one focused and individually reviewable.

### Test Steps

1. Sign in to a wp.com account.
2. Trigger a Ticket QR deep link via `adb shell am start -a android.intent.action.VIEW -d "woocommerce://qr-login?ticket=…&siteUrl=…"`. Expect the warning → tap **Continue and sign out** → existing session is logged out → **Sign in to this store?** confirmation appears → tap Continue → app authenticates with the new credentials.
3. With a wp.com session still active, trigger a wp.com magic-link QR. Expect warning → Continue → logout → browser opens for magic-link sign-in.
4. Sign in via app-password to site A; trigger a site-URL-only QR for site B. Expect warning → Continue → app-password for site A is cleared (check logcat for `Application password deleted for site Id…`) → land on the prefilled site-address login screen.
5. Reach the warning, tap **Cancel** (or system back). Expect to return to wherever the deep link interrupted, with the existing session intact, and `LOGIN_QR_SESSION_REPLACE_DISMISSED` fired.
6. Sign **out**. Trigger any of the three QR types — the warning should not appear (regression check).

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.