### PR TITLE
[RSM-1624] Add smarter notification settings UI

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsContract.kt
@@ -13,6 +13,7 @@ interface MainSettingsContract {
         fun setupAnnouncementOption()
         fun setupEnablePushNotificationsOption()
         fun setupJetpackInstallOption()
+        fun setupNotificationsOption()
         fun onNotificationsClicked()
 
         val isCloseAccountOptionVisible: Boolean
@@ -23,9 +24,10 @@ interface MainSettingsContract {
 
     interface View : BaseView<Presenter> {
         fun showDeviceAppNotificationSettings()
-        fun showNotificationsSettingsScreen()
+        fun showNotificationsSettingsScreen(showSmarterNotifications: Boolean)
         fun showLatestAnnouncementOption(announcement: FeatureAnnouncement)
         fun setEnablePushNotificationsOptionVisible(isVisible: Boolean)
         fun handleJetpackInstallOption(supportsJetpackInstallation: Boolean)
+        fun handleNotificationsOption(showSmarterNotifications: Boolean)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsFragment.kt
@@ -122,16 +122,6 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
             startActivity(HelpActivity.createIntent(requireActivity(), HelpOrigin.SETTINGS, null))
         }
 
-        binding.optionNotifications.optionTitle = if (presenter.isChaChingSoundEnabled) {
-            getString(R.string.settings_notifs_device)
-        } else {
-            getString(R.string.settings_notifs)
-        }
-        binding.optionNotifications.optionValue = if (presenter.isChaChingSoundEnabled) {
-            getString(R.string.settings_notifs_device_detail)
-        } else {
-            null
-        }
         binding.optionNotifications.setOnClickListener {
             presenter.onNotificationsClicked()
         }
@@ -190,6 +180,7 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         presenter.setupAnnouncementOption()
         presenter.setupEnablePushNotificationsOption()
         presenter.setupJetpackInstallOption()
+        presenter.setupNotificationsOption()
 
         binding.optionEnablePushNotifications.setOnClickListener {
             AnalyticsTracker.track(AnalyticsEvent.SETTINGS_PUSH_NOTIFICATIONS_BUTTON_TAP)
@@ -257,9 +248,11 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
         activity?.startActivity(intent)
     }
 
-    override fun showNotificationsSettingsScreen() {
+    override fun showNotificationsSettingsScreen(showSmarterNotifications: Boolean) {
         findNavController().navigateSafely(
-            MainSettingsFragmentDirections.actionMainSettingsFragmentToNotificationSettingsFragment()
+            MainSettingsFragmentDirections.actionMainSettingsFragmentToNotificationSettingsFragment(
+                showSmarterNotifications = showSmarterNotifications
+            )
         )
     }
 
@@ -311,6 +304,19 @@ class MainSettingsFragment : Fragment(R.layout.fragment_settings_main), MainSett
     override fun setEnablePushNotificationsOptionVisible(isVisible: Boolean) {
         binding.optionEnablePushNotifications.isVisible = isVisible
         updateStoreSettingsContainerVisibility()
+    }
+
+    override fun handleNotificationsOption(showSmarterNotifications: Boolean) {
+        binding.optionNotifications.optionTitle = if (!showSmarterNotifications && presenter.isChaChingSoundEnabled) {
+            getString(R.string.settings_notifs_device)
+        } else {
+            getString(R.string.settings_notifs)
+        }
+        binding.optionNotifications.optionValue = if (!showSmarterNotifications && presenter.isChaChingSoundEnabled) {
+            getString(R.string.settings_notifs_device_detail)
+        } else {
+            null
+        }
     }
 
     private fun updateStoreSettingsContainerVisibility() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenter.kt
@@ -7,12 +7,15 @@ import com.woocommerce.android.ciab.CIABAffectedFeature
 import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
+import com.woocommerce.android.notifications.push.PushNotificationRepository
 import com.woocommerce.android.notifications.push.ShouldShowEnablePushNotificationsUi
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.util.StringUtils
 import kotlinx.coroutines.CoroutineScope
@@ -36,10 +39,13 @@ class MainSettingsPresenter @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val getWooVersion: GetWooCorePluginCachedVersion,
     private val appPrefs: AppPrefsWrapper,
-    private val ciabSiteGateKeeper: CIABSiteGateKeeper
+    private val ciabSiteGateKeeper: CIABSiteGateKeeper,
+    private val featureFlagRepository: FeatureFlagRepository,
+    private val pushNotificationRepository: PushNotificationRepository
 ) : MainSettingsContract.Presenter {
     override val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var appSettingsFragmentView: MainSettingsContract.View? = null
+    private var selectedSitePushNotificationsSelfDriven = false
 
     override val isChaChingSoundEnabled: Boolean
         get() = notificationChannelsHandler.checkNewOrderNotificationSound() == NewOrderNotificationSoundStatus.DEFAULT
@@ -83,13 +89,37 @@ class MainSettingsPresenter @Inject constructor(
         appSettingsFragmentView?.handleJetpackInstallOption(supportsJetpackInstallation = supportsJetpackInstallation)
     }
 
+    override fun setupNotificationsOption() {
+        if (!featureFlagRepository.isEnabled(FeatureFlag.SMARTER_NOTIFICATIONS)) {
+            appSettingsFragmentView?.handleNotificationsOption(showSmarterNotifications = false)
+            return
+        }
+
+        coroutineScope.launch {
+            selectedSitePushNotificationsSelfDriven = isSelectedSitePushNotificationsSelfDriven()
+            appSettingsFragmentView?.handleNotificationsOption(
+                showSmarterNotifications = selectedSitePushNotificationsSelfDriven
+            )
+        }
+    }
+
     override fun onNotificationsClicked() {
-        if (isChaChingSoundEnabled) {
+        if (featureFlagRepository.isEnabled(FeatureFlag.SMARTER_NOTIFICATIONS) &&
+            selectedSitePushNotificationsSelfDriven
+        ) {
+            appSettingsFragmentView?.showNotificationsSettingsScreen(showSmarterNotifications = true)
+        } else if (isChaChingSoundEnabled) {
             analyticsTracker.track(AnalyticsEvent.SETTINGS_NOTIFICATIONS_OPEN_CHANNEL_SETTINGS_BUTTON_TAPPED)
             appSettingsFragmentView?.showDeviceAppNotificationSettings()
         } else {
-            appSettingsFragmentView?.showNotificationsSettingsScreen()
+            appSettingsFragmentView?.showNotificationsSettingsScreen(showSmarterNotifications = false)
         }
+    }
+
+    private suspend fun isSelectedSitePushNotificationsSelfDriven(): Boolean {
+        return selectedSite.getIfExists()?.siteId?.let {
+            pushNotificationRepository.isWooPushTokenRegisteredForSite(it)
+        } == true
     }
 
     override val isCloseAccountOptionVisible: Boolean

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
@@ -24,7 +24,7 @@ class NotificationSettingsFragment : BaseFragment() {
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
 
-    override fun getFragmentTitle() = getString(R.string.settings_notifs)
+    override fun getFragmentTitle() = getString(R.string.settings_push_notifications)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.ui.base.BaseFragment
@@ -18,6 +19,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class NotificationSettingsFragment : BaseFragment() {
     private val viewModel: NotificationSettingsViewModel by viewModels()
+    private val navArgs: NotificationSettingsFragmentArgs by navArgs()
 
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
@@ -26,7 +28,10 @@ class NotificationSettingsFragment : BaseFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
-            NotificationSettingsScreen(viewModel)
+            NotificationSettingsScreen(
+                viewModel = viewModel,
+                showSmarterNotifications = navArgs.showSmarterNotifications
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsScreen.kt
@@ -21,7 +21,10 @@ import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrde
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
 @Composable
-fun NotificationSettingsScreen(viewModel: NotificationSettingsViewModel) {
+fun NotificationSettingsScreen(
+    viewModel: NotificationSettingsViewModel,
+    showSmarterNotifications: Boolean
+) {
     viewModel.newOrderNotificationSoundStatus.observeAsState().value?.let {
         NotificationSettingsScreen(
             orderNotificationSoundStatus = it,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsScreen.kt
@@ -71,16 +71,6 @@ private fun SmarterNotificationSettingsScreen(
                 .padding(paddingValues)
                 .verticalScroll(rememberScrollState())
         ) {
-            Text(
-                text = stringResource(R.string.settings_notifs_notification_types),
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(
-                    start = 16.dp,
-                    top = 16.dp,
-                    end = 16.dp
-                )
-            )
             items.forEach { item ->
                 NotificationTypeRow(
                     item = item,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsScreen.kt
@@ -5,32 +5,90 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
+import com.woocommerce.android.ui.compose.component.WCSwitch
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsViewModel.NotificationType
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsViewModel.NotificationTypeItem
 
 @Composable
 fun NotificationSettingsScreen(
     viewModel: NotificationSettingsViewModel,
     showSmarterNotifications: Boolean
 ) {
-    viewModel.newOrderNotificationSoundStatus.observeAsState().value?.let {
-        NotificationSettingsScreen(
-            orderNotificationSoundStatus = it,
-            onManageNotificationsClicked = viewModel::onManageNotificationsClicked,
-            onEnableChaChingSoundClicked = viewModel::onEnableChaChingSoundClicked
-        )
+    if (showSmarterNotifications) {
+        viewModel.notificationTypeItems.observeAsState().value?.let {
+            SmarterNotificationSettingsScreen(
+                items = it,
+                onNotificationTypeEnabledChanged = viewModel::onNotificationTypeEnabledChanged
+            )
+        }
+    } else {
+        viewModel.newOrderNotificationSoundStatus.observeAsState().value?.let {
+            NotificationSettingsScreen(
+                orderNotificationSoundStatus = it,
+                onManageNotificationsClicked = viewModel::onManageNotificationsClicked,
+                onEnableChaChingSoundClicked = viewModel::onEnableChaChingSoundClicked
+            )
+        }
+    }
+}
+
+@Composable
+private fun SmarterNotificationSettingsScreen(
+    items: List<NotificationTypeItem>,
+    onNotificationTypeEnabledChanged: (NotificationType, Boolean) -> Unit
+) {
+    Scaffold(containerColor = MaterialTheme.colorScheme.surface) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = stringResource(R.string.settings_notifs_notification_types),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(
+                    start = 16.dp,
+                    top = 16.dp,
+                    end = 16.dp
+                )
+            )
+            items.forEach { item ->
+                NotificationTypeRow(
+                    item = item,
+                    onEnabledChanged = onNotificationTypeEnabledChanged,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
     }
 }
 
@@ -71,6 +129,52 @@ private fun NotificationSettingsScreen(
 }
 
 @Composable
+private fun NotificationTypeRow(
+    item: NotificationTypeItem,
+    onEnabledChanged: (NotificationType, Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .height(IntrinsicSize.Min)
+            .padding(top = 8.dp)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            Text(
+                text = stringResource(id = item.title),
+                style = MaterialTheme.typography.titleMedium,
+                color = colorResource(id = R.color.color_on_surface_high)
+            )
+            Text(
+                text = stringResource(id = item.subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = colorResource(id = R.color.color_on_surface_medium),
+                modifier = Modifier.padding(top = 2.dp)
+            )
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        WCSwitch(
+            checked = item.isEnabled,
+            onCheckedChange = { onEnabledChanged(item.type, it) }
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Icon(
+            painter = painterResource(id = R.drawable.ic_chevron_right_24dp),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(24.dp)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+    }
+}
+
+@Composable
 private fun NotificationSettingsItem(
     title: String,
     subtitle: String,
@@ -95,6 +199,37 @@ private fun NotificationSettingsItem(
 
 private val NewOrderNotificationSoundStatus.requiresAttention: Boolean
     get() = this != NewOrderNotificationSoundStatus.DEFAULT
+
+@Composable
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+private fun SmarterNotificationSettingsScreenPreview() {
+    WooThemeWithBackground {
+        SmarterNotificationSettingsScreen(
+            items = listOf(
+                NotificationTypeItem(
+                    type = NotificationType.NEW_ORDERS,
+                    title = R.string.settings_notifs_new_orders,
+                    subtitle = R.string.settings_notifs_new_orders_subtitle,
+                    isEnabled = true
+                ),
+                NotificationTypeItem(
+                    type = NotificationType.NEW_REVIEWS,
+                    title = R.string.settings_notifs_new_reviews,
+                    subtitle = R.string.settings_notifs_new_reviews_subtitle,
+                    isEnabled = true
+                ),
+                NotificationTypeItem(
+                    type = NotificationType.STOCK,
+                    title = R.string.settings_notifs_stock,
+                    subtitle = R.string.settings_notifs_stock_subtitle,
+                    isEnabled = true
+                )
+            ),
+            onNotificationTypeEnabledChanged = { _, _ -> }
+        )
+    }
+}
 
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsViewModel.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.prefs.notifications
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
@@ -14,6 +15,7 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
@@ -30,6 +32,38 @@ class NotificationSettingsViewModel @Inject constructor(
         notificationChannelsHandler.checkNewOrderNotificationSound()
     )
     val newOrderNotificationSoundStatus = _newOrderNotificationSoundStatus.asLiveData()
+
+    private val _notificationTypeItems = MutableStateFlow(
+        listOf(
+            NotificationTypeItem(
+                type = NotificationType.NEW_ORDERS,
+                title = R.string.settings_notifs_new_orders,
+                subtitle = R.string.settings_notifs_new_orders_subtitle,
+                isEnabled = true
+            ),
+            NotificationTypeItem(
+                type = NotificationType.NEW_REVIEWS,
+                title = R.string.settings_notifs_new_reviews,
+                subtitle = R.string.settings_notifs_new_reviews_subtitle,
+                isEnabled = true
+            ),
+            NotificationTypeItem(
+                type = NotificationType.STOCK,
+                title = R.string.settings_notifs_stock,
+                subtitle = R.string.settings_notifs_stock_subtitle,
+                isEnabled = true
+            )
+        )
+    )
+    val notificationTypeItems = _notificationTypeItems.asLiveData()
+
+    fun onNotificationTypeEnabledChanged(type: NotificationType, isEnabled: Boolean) {
+        _notificationTypeItems.update { items ->
+            items.map {
+                if (it.type == type) it.copy(isEnabled = isEnabled) else it
+            }
+        }
+    }
 
     fun onManageNotificationsClicked() {
         triggerEvent(OpenDeviceNotificationSettings)
@@ -63,4 +97,17 @@ class NotificationSettingsViewModel @Inject constructor(
     }
 
     object OpenDeviceNotificationSettings : MultiLiveEvent.Event()
+
+    data class NotificationTypeItem(
+        val type: NotificationType,
+        @StringRes val title: Int,
+        @StringRes val subtitle: Int,
+        val isEnabled: Boolean
+    )
+
+    enum class NotificationType {
+        NEW_ORDERS,
+        STOCK,
+        NEW_REVIEWS
+    }
 }

--- a/WooCommerce/src/main/res/layout/fragment_settings_main.xml
+++ b/WooCommerce/src/main/res/layout/fragment_settings_main.xml
@@ -172,8 +172,7 @@
                 android:id="@+id/option_notifications"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:optionTitle="@string/settings_notifs_device"
-                app:optionValue="@string/settings_notifs_device_detail" />
+                app:optionTitle="@string/settings_notifs_device" />
 
         </LinearLayout>
 

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -206,7 +206,12 @@
     <fragment
         android:id="@+id/notificationSettingsFragment"
         android:name="com.woocommerce.android.ui.prefs.notifications.NotificationSettingsFragment"
-        android:label="NotificationSettingsFragment" />
+        android:label="NotificationSettingsFragment">
+        <argument
+            android:name="showSmarterNotifications"
+            android:defaultValue="false"
+            app:argType="boolean" />
+    </fragment>
     <fragment
         android:id="@+id/pluginsFragment"
         android:name="com.woocommerce.android.ui.prefs.plugins.PluginsFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2254,6 +2254,7 @@
     <string name="settings_card_reader_manuals">Card Reader Manuals</string>
     <string name="settings_install_jetpack">Install Jetpack</string>
     <string name="settings_notifs">Notifications</string>
+    <string name="settings_push_notifications">Push notifications</string>
     <string name="settings_store_name">Store name</string>
     <string name="settings_enable_push_notifications">Enable Push Notifications</string>
     <string name="settings_notifs_device">Manage notifications</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2258,7 +2258,6 @@
     <string name="settings_enable_push_notifications">Enable Push Notifications</string>
     <string name="settings_notifs_device">Manage notifications</string>
     <string name="settings_notifs_device_detail">Sounds, urgency, and notification dot</string>
-    <string name="settings_notifs_notification_types">Notification types</string>
     <string name="settings_notifs_enable_chaching_sound">Enable Cha-Ching sound</string>
     <string name="settings_notifs_enable_chaching_sound_description">Orders notifications sound has been disabled, turn it back on to hear the \'cha-ching\' with every new sale.</string>
     <string name="settings_notifs_restore_chaching_sound_description">Orders notifications sound has been modified, use this button to restore the \'cha-ching\' sound.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2258,9 +2258,16 @@
     <string name="settings_enable_push_notifications">Enable Push Notifications</string>
     <string name="settings_notifs_device">Manage notifications</string>
     <string name="settings_notifs_device_detail">Sounds, urgency, and notification dot</string>
+    <string name="settings_notifs_notification_types">Notification types</string>
     <string name="settings_notifs_enable_chaching_sound">Enable Cha-Ching sound</string>
     <string name="settings_notifs_enable_chaching_sound_description">Orders notifications sound has been disabled, turn it back on to hear the \'cha-ching\' with every new sale.</string>
     <string name="settings_notifs_restore_chaching_sound_description">Orders notifications sound has been modified, use this button to restore the \'cha-ching\' sound.</string>
+    <string name="settings_notifs_new_orders">New orders</string>
+    <string name="settings_notifs_new_orders_subtitle">All orders</string>
+    <string name="settings_notifs_stock">Stock</string>
+    <string name="settings_notifs_stock_subtitle">All stock alerts</string>
+    <string name="settings_notifs_new_reviews">New reviews</string>
+    <string name="settings_notifs_new_reviews_subtitle">All reviews</string>
     <string name="settings_image_optimization_title">Image optimization</string>
     <string name="settings_image_optimization_message">Resize and compress images for faster uploading</string>
     <string name="settings_about">About the app</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/MainSettingsPresenterTest.kt
@@ -7,12 +7,15 @@ import com.woocommerce.android.ciab.CIABAffectedFeature
 import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
+import com.woocommerce.android.notifications.push.PushNotificationRepository
 import com.woocommerce.android.notifications.push.ShouldShowEnablePushNotificationsUi
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.whatsnew.FeatureAnnouncementRepository
 import com.woocommerce.android.util.BuildConfigWrapper
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.GetWooCorePluginCachedVersion
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,10 +24,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import kotlin.test.assertEquals
@@ -45,6 +50,8 @@ class MainSettingsPresenterTest : BaseUnitTest() {
     private val appPrefs: AppPrefsWrapper = mock()
     private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock()
     private val shouldShowEnablePushNotificationsUi: ShouldShowEnablePushNotificationsUi = mock()
+    private val featureFlagRepository: FeatureFlagRepository = mock()
+    private val pushNotificationRepository: PushNotificationRepository = mock()
 
     private val view: MainSettingsContract.View = mock()
     private lateinit var presenter: MainSettingsPresenter
@@ -63,7 +70,9 @@ class MainSettingsPresenterTest : BaseUnitTest() {
             analyticsTracker = analyticsTracker,
             getWooVersion = getWooVersion,
             appPrefs = appPrefs,
-            ciabSiteGateKeeper = ciabSiteGateKeeper
+            ciabSiteGateKeeper = ciabSiteGateKeeper,
+            featureFlagRepository = featureFlagRepository,
+            pushNotificationRepository = pushNotificationRepository
         )
         presenter.takeView(view)
     }
@@ -92,7 +101,7 @@ class MainSettingsPresenterTest : BaseUnitTest() {
 
             presenter.onNotificationsClicked()
 
-            verify(view).showNotificationsSettingsScreen()
+            verify(view).showNotificationsSettingsScreen(showSmarterNotifications = false)
         }
 
     @Test
@@ -105,7 +114,95 @@ class MainSettingsPresenterTest : BaseUnitTest() {
 
             presenter.onNotificationsClicked()
 
-            verify(view).showNotificationsSettingsScreen()
+            verify(view).showNotificationsSettingsScreen(showSmarterNotifications = false)
+        }
+
+    @Test
+    fun `given smarter notifications enabled for Woo-driven site, when notifications button clicked, then open smarter settings`() =
+        testBlocking {
+            setup {
+                val site = mock<SiteModel> { on { siteId } doReturn SITE_ID }
+                whenever(featureFlagRepository.isEnabled(FeatureFlag.SMARTER_NOTIFICATIONS)).thenReturn(true)
+                whenever(selectedSite.getIfExists()).thenReturn(site)
+                whenever(pushNotificationRepository.isWooPushTokenRegisteredForSite(SITE_ID)).thenReturn(true)
+            }
+
+            presenter.setupNotificationsOption()
+            advanceUntilIdle()
+            presenter.onNotificationsClicked()
+
+            verify(view).showNotificationsSettingsScreen(showSmarterNotifications = true)
+        }
+
+    @Test
+    fun `given smarter notifications enabled for non-Woo-driven site, when notifications button clicked, then open device notification settings`() =
+        testBlocking {
+            setup {
+                val site = mock<SiteModel> { on { siteId } doReturn SITE_ID }
+                whenever(featureFlagRepository.isEnabled(FeatureFlag.SMARTER_NOTIFICATIONS)).thenReturn(true)
+                whenever(selectedSite.getIfExists()).thenReturn(site)
+                whenever(pushNotificationRepository.isWooPushTokenRegisteredForSite(SITE_ID)).thenReturn(false)
+                whenever(notificationChannelsHandler.checkNewOrderNotificationSound())
+                    .thenReturn(NewOrderNotificationSoundStatus.DEFAULT)
+            }
+
+            presenter.setupNotificationsOption()
+            advanceUntilIdle()
+            presenter.onNotificationsClicked()
+
+            verify(view).showDeviceAppNotificationSettings()
+            verify(analyticsTracker).track(AnalyticsEvent.SETTINGS_NOTIFICATIONS_OPEN_CHANNEL_SETTINGS_BUTTON_TAPPED)
+        }
+
+    @Test
+    fun `given smarter notifications enabled for non-Woo-driven site with modified sound, when notifications button clicked, then open notifications settings`() =
+        testBlocking {
+            setup {
+                val site = mock<SiteModel> { on { siteId } doReturn SITE_ID }
+                whenever(featureFlagRepository.isEnabled(FeatureFlag.SMARTER_NOTIFICATIONS)).thenReturn(true)
+                whenever(selectedSite.getIfExists()).thenReturn(site)
+                whenever(pushNotificationRepository.isWooPushTokenRegisteredForSite(SITE_ID)).thenReturn(false)
+                whenever(notificationChannelsHandler.checkNewOrderNotificationSound())
+                    .thenReturn(NewOrderNotificationSoundStatus.SOUND_MODIFIED)
+            }
+
+            presenter.setupNotificationsOption()
+            advanceUntilIdle()
+            presenter.onNotificationsClicked()
+
+            verify(view).showNotificationsSettingsScreen(showSmarterNotifications = false)
+        }
+
+    @Test
+    fun `given smarter notifications enabled for Woo-driven site, when settings shown, then show smarter option`() =
+        testBlocking {
+            setup {
+                val site = mock<SiteModel> { on { siteId } doReturn SITE_ID }
+                whenever(featureFlagRepository.isEnabled(FeatureFlag.SMARTER_NOTIFICATIONS)).thenReturn(true)
+                whenever(selectedSite.getIfExists()).thenReturn(site)
+                whenever(pushNotificationRepository.isWooPushTokenRegisteredForSite(SITE_ID)).thenReturn(true)
+            }
+
+            presenter.setupNotificationsOption()
+            advanceUntilIdle()
+
+            verify(view).handleNotificationsOption(showSmarterNotifications = true)
+        }
+
+    @Test
+    fun `given smarter notifications enabled for non-Woo-driven site, when settings shown, then show default option`() =
+        testBlocking {
+            setup {
+                val site = mock<SiteModel> { on { siteId } doReturn SITE_ID }
+                whenever(featureFlagRepository.isEnabled(FeatureFlag.SMARTER_NOTIFICATIONS)).thenReturn(true)
+                whenever(selectedSite.getIfExists()).thenReturn(site)
+                whenever(pushNotificationRepository.isWooPushTokenRegisteredForSite(SITE_ID)).thenReturn(false)
+            }
+
+            presenter.setupNotificationsOption()
+            advanceUntilIdle()
+
+            verify(view).handleNotificationsOption(showSmarterNotifications = false)
         }
 
     @Test
@@ -200,5 +297,9 @@ class MainSettingsPresenterTest : BaseUnitTest() {
         presenter.dropView()
         advanceUntilIdle()
         assertThat(shouldShowPushNotificationOption.subscriptionCount.value).isEqualTo(0)
+    }
+
+    companion object {
+        private const val SITE_ID = 123L
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsViewModelTest.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.ShowTestNotification
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsViewModel.NotificationType
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -128,5 +129,40 @@ class NotificationSettingsViewModelTest : BaseUnitTest() {
             channelType = NotificationChannelType.NEW_ORDER,
             dismissDelay = 10.seconds
         )
+    }
+
+    @Test
+    fun `when view is loaded, then expose notification type rows`() = testBlocking {
+        setup()
+
+        val notificationTypeItems = viewModel.notificationTypeItems.captureValues().last()
+
+        assertThat(notificationTypeItems.map { it.type }).containsExactly(
+            NotificationType.NEW_ORDERS,
+            NotificationType.NEW_REVIEWS,
+            NotificationType.STOCK
+        )
+    }
+
+    @Test
+    fun `when view is loaded, then all notification type switches are enabled`() = testBlocking {
+        setup()
+
+        val notificationTypeItems = viewModel.notificationTypeItems.captureValues().last()
+
+        assertThat(notificationTypeItems.map { it.isEnabled }).containsOnly(true)
+    }
+
+    @Test
+    fun `when notification type switch is changed, then update row state`() = testBlocking {
+        setup()
+
+        viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, false)
+
+        val notificationTypeItems = viewModel.notificationTypeItems.captureValues().last()
+
+        assertThat(
+            notificationTypeItems.first { it.type == NotificationType.STOCK }.isEnabled
+        ).isFalse()
     }
 }


### PR DESCRIPTION
### Description
Fixes RSM-1624

Adds the smarter notifications entry point to the Settings notifications row behind the `smarter_notifications` feature flag.

For Woo-driven sites, tapping `Notifications` now opens the new Notifications screen. Non-Woo-driven sites keep the existing notification settings behavior.

This also adds the initial `Notification types` list with `New orders`, `New reviews`, and `Stock` rows. The row subtitles use temporary static values for now; they will reflect the selected settings once detail screens and persistence are added.

### Test Steps
1. Enable the `smarter_notifications` feature flag.
2. Open a Woo-driven site and go to Settings.
3. Tap `Notifications`.
4. Confirm the Notifications screen shows the `Notification types` section with `New orders`, `New reviews`, and `Stock`.
5. Open a non-Woo-driven site, then tap the Settings notifications row.
6. Confirm the existing notification settings behavior is unchanged.

### Images/gif
<img width="350" src="https://github.com/user-attachments/assets/a725b47f-540f-48c6-8a99-e55225bef290" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.