### PR TITLE
Fix remote-phone discovery state mismatch and ambiguous auto-reconnect

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -172,8 +172,11 @@ object AppPrefs {
         // last connected card reader's id
         LAST_CONNECTED_CARD_READER_ID,
 
-        // last connected phone reader's display name (for Woo POS remote tap-to-pay)
-        LAST_CONNECTED_PHONE_NAME,
+        // last connected phone reader's stable device id (for Woo POS remote tap-to-pay)
+        LAST_CONNECTED_PHONE_DEVICE_ID,
+
+        // this phone's stable device id when it advertises itself as a Woo POS remote tap-to-pay reader
+        WOO_POS_REMOTE_READER_DEVICE_UUID,
 
         // show card reader tutorial after a reader is connected
         SHOW_CARD_READER_CONNECTED_TUTORIAL,
@@ -582,12 +585,17 @@ object AppPrefs {
 
     fun removeLastConnectedCardReaderId() = remove(UndeletablePrefKey.LAST_CONNECTED_CARD_READER_ID)
 
-    fun setLastConnectedPhoneName(name: String) =
-        setString(UndeletablePrefKey.LAST_CONNECTED_PHONE_NAME, name)
+    fun setLastConnectedPhoneDeviceId(deviceId: String) =
+        setString(UndeletablePrefKey.LAST_CONNECTED_PHONE_DEVICE_ID, deviceId)
 
-    fun getLastConnectedPhoneName() = getString(UndeletablePrefKey.LAST_CONNECTED_PHONE_NAME).orNullIfEmpty()
+    fun getLastConnectedPhoneDeviceId() =
+        getString(UndeletablePrefKey.LAST_CONNECTED_PHONE_DEVICE_ID).orNullIfEmpty()
 
-    fun removeLastConnectedPhoneName() = remove(UndeletablePrefKey.LAST_CONNECTED_PHONE_NAME)
+    fun removeLastConnectedPhoneDeviceId() = remove(UndeletablePrefKey.LAST_CONNECTED_PHONE_DEVICE_ID)
+
+    var wooPosRemoteReaderDeviceUUID: String
+        get() = getString(UndeletablePrefKey.WOO_POS_REMOTE_READER_DEVICE_UUID, "")
+        set(value) = setString(UndeletablePrefKey.WOO_POS_REMOTE_READER_DEVICE_UUID, value)
 
     fun getShowCardReaderConnectedTutorial() = getBoolean(UndeletablePrefKey.SHOW_CARD_READER_CONNECTED_TUTORIAL, true)
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -156,11 +156,13 @@ open class AppPrefsWrapper @Inject constructor() {
 
     fun removeLastConnectedCardReaderId() = AppPrefs.removeLastConnectedCardReaderId()
 
-    fun setLastConnectedPhoneName(name: String) = AppPrefs.setLastConnectedPhoneName(name)
+    fun setLastConnectedPhoneDeviceId(deviceId: String) = AppPrefs.setLastConnectedPhoneDeviceId(deviceId)
 
-    fun getLastConnectedPhoneName() = AppPrefs.getLastConnectedPhoneName()
+    fun getLastConnectedPhoneDeviceId() = AppPrefs.getLastConnectedPhoneDeviceId()
 
-    fun removeLastConnectedPhoneName() = AppPrefs.removeLastConnectedPhoneName()
+    fun removeLastConnectedPhoneDeviceId() = AppPrefs.removeLastConnectedPhoneDeviceId()
+
+    var wooPosRemoteReaderDeviceUUID by AppPrefs::wooPosRemoteReaderDeviceUUID
 
     fun getJetpackBenefitsDismissalDate(): Long {
         return AppPrefs.getJetpackBenefitsDismissalDate()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.payments.cardreader.readermode
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.BuildConfig
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -27,6 +28,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.util.UrlUtils
+import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,6 +38,7 @@ class CardReaderModeViewModel @Inject constructor(
     private val developerOptionsRepository: DeveloperOptionsRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val selectedSite: SelectedSite,
+    private val appPrefsWrapper: AppPrefsWrapper,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow<ViewState?>(null)
@@ -89,9 +92,15 @@ class CardReaderModeViewModel @Inject constructor(
         session.start(
             parentScope = viewModelScope,
             siteHash = siteHash,
+            deviceId = getOrCreateDeviceId(),
             isSimulated = isSimulated,
         )
     }
+
+    private fun getOrCreateDeviceId(): String =
+        appPrefsWrapper.wooPosRemoteReaderDeviceUUID.ifEmpty {
+            UUID.randomUUID().toString().also { appPrefsWrapper.wooPosRemoteReaderDeviceUUID = it }
+        }
 
     private fun trackSessionState(state: CardReaderRemoteSessionState) {
         when (state) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -300,7 +300,7 @@ class WooPosCardReaderConnectionController(
         withContext(dispatchers.io) {
             logger.d("disconnect(): clearing prefs")
             appPrefsWrapper.removeLastConnectedCardReaderId()
-            appPrefsWrapper.removeLastConnectedPhoneName()
+            appPrefsWrapper.removeLastConnectedPhoneDeviceId()
             cardReaderTrackingInfoKeeper.setTransport(null)
 
             logger.d("disconnect(): stopping remote session")
@@ -454,21 +454,8 @@ class WooPosCardReaderConnectionController(
     }
 
     private fun findLastKnownPhone(phones: List<WooPosDiscoveredReader.Phone>): WooPosDiscoveredReader.Phone? {
-        val lastConnectedName = appPrefsWrapper.getLastConnectedPhoneName() ?: return null
-        // The persisted identifier is Build.MODEL, which is not unique across same-model devices.
-        // If multiple discovered phones match, refuse to auto-connect and let the user pick — silently
-        // pairing to the wrong physical device is worse UX than asking once.
-        val matches = phones.filter { it.name == lastConnectedName }
-        return when (matches.size) {
-            0 -> null
-            1 -> matches.first()
-            else -> {
-                logger.d(
-                    "Multiple discovered phones match last-connected name '$lastConnectedName'; skipping auto-connect"
-                )
-                null
-            }
-        }
+        val lastDeviceId = appPrefsWrapper.getLastConnectedPhoneDeviceId() ?: return null
+        return phones.find { it.deviceId == lastDeviceId }
     }
 
     private fun continueSearching() {
@@ -510,13 +497,13 @@ class WooPosCardReaderConnectionController(
             is WooPosRemoteReaderSession.State.Connected -> {
                 logger.d("Remote reader connected: ${phone.name}")
                 tracker.trackConnectionSucceeded()
-                appPrefsWrapper.setLastConnectedPhoneName(phone.name)
+                appPrefsWrapper.setLastConnectedPhoneDeviceId(phone.deviceId)
                 _state.value = Connected(readerName = phone.name)
             }
             is WooPosRemoteReaderSession.State.Failed -> {
                 logger.e("Remote reader connection failed: ${result.message}")
                 tracker.trackConnectionFailed()
-                appPrefsWrapper.removeLastConnectedPhoneName()
+                appPrefsWrapper.removeLastConnectedPhoneDeviceId()
                 _state.value = WooPosCardReaderConnectionState.ConnectingFailed(
                     errorMessage = result.message,
                     onRetryClicked = { onPhoneConnectClicked(phone) },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -50,7 +50,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LargeClass")
 class WooPosCardReaderConnectionController(
     private val cardReaderManager: CardReaderManager,
     private val locationRepository: CardReaderLocationRepository,
@@ -455,7 +455,20 @@ class WooPosCardReaderConnectionController(
 
     private fun findLastKnownPhone(phones: List<WooPosDiscoveredReader.Phone>): WooPosDiscoveredReader.Phone? {
         val lastConnectedName = appPrefsWrapper.getLastConnectedPhoneName() ?: return null
-        return phones.find { it.name == lastConnectedName }
+        // The persisted identifier is Build.MODEL, which is not unique across same-model devices.
+        // If multiple discovered phones match, refuse to auto-connect and let the user pick — silently
+        // pairing to the wrong physical device is worse UX than asking once.
+        val matches = phones.filter { it.name == lastConnectedName }
+        return when (matches.size) {
+            0 -> null
+            1 -> matches.first()
+            else -> {
+                logger.d(
+                    "Multiple discovered phones match last-connected name '$lastConnectedName'; skipping auto-connect"
+                )
+                null
+            }
+        }
     }
 
     private fun continueSearching() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
@@ -32,6 +32,7 @@ class WooPosRemoteReaderDiscovery @Inject constructor(
                 is RemoteReaderDiscoveryEvent.Added -> WooPosPhoneDiscoveryEvent.Added(
                     WooPosDiscoveredReader.Phone(
                         serviceName = event.reader.name,
+                        deviceId = event.reader.deviceId,
                         name = event.reader.deviceName?.takeIf { it.isNotBlank() } ?: event.reader.name,
                         host = event.reader.host,
                         port = event.reader.port,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderDiscovery.kt
@@ -31,6 +31,7 @@ class WooPosRemoteReaderDiscovery @Inject constructor(
             when (event) {
                 is RemoteReaderDiscoveryEvent.Added -> WooPosPhoneDiscoveryEvent.Added(
                     WooPosDiscoveredReader.Phone(
+                        serviceName = event.reader.name,
                         name = event.reader.deviceName?.takeIf { it.isNotBlank() } ?: event.reader.name,
                         host = event.reader.host,
                         port = event.reader.port,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSession.kt
@@ -103,6 +103,7 @@ class WooPosRemoteReaderSession @Inject constructor(
             fingerprintBase64 = reader.fingerprintBase64,
             deviceName = reader.name,
             siteHash = reader.siteHash,
+            deviceId = reader.deviceId,
         )
         return when (val outcome = newClient.connect(discovered, token, locationId)) {
             is ConnectOutcome.Success -> State.Connected(reader, outcome.readerSerial)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
@@ -18,6 +18,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor(
             WooPosPhoneDiscoveryEvent.Added(
                 WooPosDiscoveredReader.Phone(
                     serviceName = "woopos-remote-sim1",
+                    deviceId = "sim-device-id-1",
                     name = "Simulated Pixel 7",
                     host = InetAddress.getByName("127.0.0.1"),
                     port = 9000,
@@ -32,6 +33,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor(
             WooPosPhoneDiscoveryEvent.Added(
                 WooPosDiscoveredReader.Phone(
                     serviceName = "woopos-remote-sim2",
+                    deviceId = "sim-device-id-2",
                     name = "Simulated Galaxy S24",
                     host = InetAddress.getByName("127.0.0.2"),
                     port = 9001,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosSimulatedRemoteReaderDiscovery.kt
@@ -17,6 +17,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor(
         emit(
             WooPosPhoneDiscoveryEvent.Added(
                 WooPosDiscoveredReader.Phone(
+                    serviceName = "woopos-remote-sim1",
                     name = "Simulated Pixel 7",
                     host = InetAddress.getByName("127.0.0.1"),
                     port = 9000,
@@ -30,6 +31,7 @@ class WooPosSimulatedRemoteReaderDiscovery @Inject constructor(
         emit(
             WooPosPhoneDiscoveryEvent.Added(
                 WooPosDiscoveredReader.Phone(
+                    serviceName = "woopos-remote-sim2",
                     name = "Simulated Galaxy S24",
                     host = InetAddress.getByName("127.0.0.2"),
                     port = 9001,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
@@ -27,6 +27,7 @@ sealed class WooPosDiscoveredReader {
     }
 
     data class Phone(
+        val serviceName: String,
         val name: String,
         val host: InetAddress,
         val port: Int,
@@ -126,18 +127,18 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
             // receiving the Lost event for the previous one (Android NSD goodbye is
             // unreliable). Drop any earlier entries from the same host so we don't show
             // the same device twice.
-            val staleNames = state.phonesByFingerprint.values
+            val staleServiceNames = state.phonesByFingerprint.values
                 .filter { it.host == phone.host && it.fingerprintBase64 != fingerprint }
-                .map { it.name }
-            staleNames.forEach { name ->
-                val staleFp = state.fingerprintByName.remove(name)
+                .map { it.serviceName }
+            staleServiceNames.forEach { serviceName ->
+                val staleFp = state.fingerprintByServiceName.remove(serviceName)
                 if (staleFp != null) state.phonesByFingerprint.remove(staleFp)
             }
 
             val isUpdate = state.phonesByFingerprint.containsKey(fingerprint)
             if (isUpdate || state.phonesByFingerprint.size < MAX_DISCOVERED_PHONES) {
                 state.phonesByFingerprint[fingerprint] = phone
-                state.fingerprintByName[phone.name] = fingerprint
+                state.fingerprintByServiceName[phone.serviceName] = fingerprint
                 send(WooPosUnifiedDiscoveryEvent.ReadersFound(state.snapshot()))
             }
         }
@@ -149,7 +150,7 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
         serviceName: String,
     ) {
         mutex.withLock {
-            val fingerprint = state.fingerprintByName.remove(serviceName) ?: return@withLock
+            val fingerprint = state.fingerprintByServiceName.remove(serviceName) ?: return@withLock
             state.phonesByFingerprint.remove(fingerprint)
             send(WooPosUnifiedDiscoveryEvent.ReadersFound(state.snapshot()))
         }
@@ -158,7 +159,7 @@ class WooPosUnifiedDiscoveryStream @Inject constructor(
     private class DiscoveryState {
         var bluetoothReaders: List<CardReader> = emptyList()
         val phonesByFingerprint: LinkedHashMap<String, WooPosDiscoveredReader.Phone> = linkedMapOf()
-        val fingerprintByName: MutableMap<String, String> = mutableMapOf()
+        val fingerprintByServiceName: MutableMap<String, String> = mutableMapOf()
 
         fun snapshot(): List<WooPosDiscoveredReader> =
             bluetoothReaders.map(WooPosDiscoveredReader::Bluetooth) + phonesByFingerprint.values

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStream.kt
@@ -28,6 +28,7 @@ sealed class WooPosDiscoveredReader {
 
     data class Phone(
         val serviceName: String,
+        val deviceId: String,
         val name: String,
         val host: InetAddress,
         val port: Int,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.payments.cardreader.readermode
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.cardreader.CardReaderManager
@@ -51,6 +52,9 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
             }
         )
     }
+    private val appPrefsWrapper: AppPrefsWrapper = mock {
+        on { wooPosRemoteReaderDeviceUUID }.thenReturn("test-device-id")
+    }
 
     private lateinit var store: ViewModelStore
     private lateinit var viewModel: CardReaderModeViewModel
@@ -67,6 +71,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
                     developerOptionsRepository,
                     analyticsTrackerWrapper,
                     selectedSite,
+                    appPrefsWrapper,
                 ) as T
         }
         viewModel = ViewModelProvider(store, factory)[CardReaderModeViewModel::class.java]
@@ -75,7 +80,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
     @Test
     fun `when view model initialized, then session is not started yet`() {
         // THEN
-        verify(session, never()).start(any(), any(), any())
+        verify(session, never()).start(any(), any(), any(), any())
     }
 
     @Test
@@ -84,7 +89,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
         // THEN
-        verify(session).start(any(), any(), any())
+        verify(session).start(any(), any(), any(), any())
     }
 
     @Test
@@ -94,7 +99,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
         viewModel.onLocationPermissionResult(granted = true, shouldShowRationale = false)
 
         // THEN
-        verify(session, times(1)).start(any(), any(), any())
+        verify(session, times(1)).start(any(), any(), any(), any())
     }
 
     @Test
@@ -105,7 +110,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat(viewModel.viewState.value).isInstanceOf(RemoteTapToPayLocationPermissionExplainer::class.java)
-        verify(session, never()).start(any(), any(), any())
+        verify(session, never()).start(any(), any(), any(), any())
     }
 
     @Test
@@ -116,7 +121,7 @@ class CardReaderModeViewModelTest : BaseUnitTest() {
 
         // THEN
         assertThat(viewModel.viewState.value).isInstanceOf(RemoteTapToPayLocationPermissionDenied::class.java)
-        verify(session, never()).start(any(), any(), any())
+        verify(session, never()).start(any(), any(), any(), any())
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -728,6 +728,7 @@ class WooPosCardPaymentViewModelTest {
 
     private fun simulatedRemoteReader() =
         WooPosDiscoveredReader.Phone(
+            serviceName = "woopos-remote-test",
             name = "phone",
             host = InetAddress.getByName("127.0.0.1"),
             port = 1234,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosCardPaymentViewModelTest.kt
@@ -729,6 +729,7 @@ class WooPosCardPaymentViewModelTest {
     private fun simulatedRemoteReader() =
         WooPosDiscoveredReader.Phone(
             serviceName = "woopos-remote-test",
+            deviceId = "test-device-id",
             name = "phone",
             host = InetAddress.getByName("127.0.0.1"),
             port = 1234,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
@@ -171,6 +171,7 @@ class WooPosRemoteReaderSessionTest {
 
     private fun phone(isSimulated: Boolean) = WooPosDiscoveredReader.Phone(
         serviceName = "woopos-remote-test",
+        deviceId = "test-device-id",
         name = "Pixel",
         host = InetAddress.getLoopbackAddress(),
         port = 9000,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderSessionTest.kt
@@ -170,6 +170,7 @@ class WooPosRemoteReaderSessionTest {
     )
 
     private fun phone(isSimulated: Boolean) = WooPosDiscoveredReader.Phone(
+        serviceName = "woopos-remote-test",
         name = "Pixel",
         host = InetAddress.getLoopbackAddress(),
         port = 9000,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
@@ -235,8 +235,10 @@ class WooPosUnifiedDiscoveryStreamTest {
         siteHash: String = siteIdHash(TABLET_SITE_ID),
         serviceName: String = "woopos-remote-${name.hashCode().toString(16)}",
         fingerprintBase64: String = "AB4F",
+        deviceId: String = "device-${name.hashCode().toString(16)}",
     ) = WooPosDiscoveredReader.Phone(
         serviceName = serviceName,
+        deviceId = deviceId,
         name = name,
         host = InetAddress.getLoopbackAddress(),
         port = 9000,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosUnifiedDiscoveryStreamTest.kt
@@ -115,7 +115,7 @@ class WooPosUnifiedDiscoveryStreamTest {
         whenever(remoteDiscovery.discover()).thenReturn(
             flowOf(
                 WooPosPhoneDiscoveryEvent.Added(phone),
-                WooPosPhoneDiscoveryEvent.Removed(phone.name),
+                WooPosPhoneDiscoveryEvent.Removed(phone.serviceName),
             )
         )
         whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(true)
@@ -138,6 +138,41 @@ class WooPosUnifiedDiscoveryStreamTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    @Test
+    fun `given phone whose display name differs from service name, when removed by service name, then phone is dropped`() =
+        runTest {
+            // GIVEN
+            whenever(cardReaderManager.discoverReaders(false, types)).thenReturn(
+                flowOf(CardReaderDiscoveryEvents.Started)
+            )
+            val phone = phone(name = "Pixel 8", serviceName = "woopos-remote-a3f4")
+            whenever(remoteDiscovery.discover()).thenReturn(
+                flowOf(
+                    WooPosPhoneDiscoveryEvent.Added(phone),
+                    WooPosPhoneDiscoveryEvent.Removed("woopos-remote-a3f4"),
+                )
+            )
+            whenever(featureFlagRepository.isEnabled(FeatureFlag.REMOTE_TAP_TO_PAY)).thenReturn(true)
+            val sut = WooPosUnifiedDiscoveryStream(
+                cardReaderManager,
+                remoteDiscovery,
+                simulatedRemoteDiscovery,
+                featureFlagRepository,
+                selectedSite,
+                logger,
+            )
+
+            // WHEN / THEN
+            sut.discover(isSimulated = false, cardReaderTypesToDiscover = types).test {
+                assertThat(awaitItem()).isEqualTo(WooPosUnifiedDiscoveryEvent.Started)
+                val withPhone = awaitItem() as WooPosUnifiedDiscoveryEvent.ReadersFound
+                assertThat(withPhone.readers).containsExactly(phone)
+                val withoutPhone = awaitItem() as WooPosUnifiedDiscoveryEvent.ReadersFound
+                assertThat(withoutPhone.readers).isEmpty()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
     @Test
     fun `given phone advertises different site hash, when discovered, then phone is not surfaced`() = runTest {
@@ -195,11 +230,17 @@ class WooPosUnifiedDiscoveryStreamTest {
         }
     }
 
-    private fun phone(name: String, siteHash: String = siteIdHash(TABLET_SITE_ID)) = WooPosDiscoveredReader.Phone(
+    private fun phone(
+        name: String,
+        siteHash: String = siteIdHash(TABLET_SITE_ID),
+        serviceName: String = "woopos-remote-${name.hashCode().toString(16)}",
+        fingerprintBase64: String = "AB4F",
+    ) = WooPosDiscoveredReader.Phone(
+        serviceName = serviceName,
         name = name,
         host = InetAddress.getLoopbackAddress(),
         port = 9000,
-        fingerprintBase64 = "AB4F",
+        fingerprintBase64 = fingerprintBase64,
         siteHash = siteHash,
     )
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -388,6 +388,7 @@ class WooPosHomeFloatingToolbarViewModelTest {
         // GIVEN
         val phone = WooPosDiscoveredReader.Phone(
             serviceName = "woopos-remote-test",
+            deviceId = "test-device-id",
             name = "Andrey's phone",
             host = InetAddress.getByName("127.0.0.1"),
             port = 0,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/toolbar/WooPosHomeFloatingToolbarViewModelTest.kt
@@ -387,6 +387,7 @@ class WooPosHomeFloatingToolbarViewModelTest {
     fun `given remote session is Connected, when initialized, then state should be Connected`() = runTest {
         // GIVEN
         val phone = WooPosDiscoveredReader.Phone(
+            serviceName = "woopos-remote-test",
             name = "Andrey's phone",
             host = InetAddress.getByName("127.0.0.1"),
             port = 0,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1982,6 +1982,7 @@ class WooPosTotalsViewModelTest {
 
     private fun simulatedRemoteReader() =
         com.woocommerce.android.ui.woopos.cardreader.remote.WooPosDiscoveredReader.Phone(
+            serviceName = "woopos-remote-test",
             name = "phone",
             host = java.net.InetAddress.getByName("127.0.0.1"),
             port = 1234,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1983,6 +1983,7 @@ class WooPosTotalsViewModelTest {
     private fun simulatedRemoteReader() =
         com.woocommerce.android.ui.woopos.cardreader.remote.WooPosDiscoveredReader.Phone(
             serviceName = "woopos-remote-test",
+            deviceId = "test-device-id",
             name = "phone",
             host = java.net.InetAddress.getByName("127.0.0.1"),
             port = 1234,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteDiscovery.kt
@@ -27,6 +27,7 @@ data class DiscoveredRemoteReader(
     val fingerprintBase64: String,
     val deviceName: String?,
     val siteHash: String,
+    val deviceId: String,
 )
 
 internal class DefaultCardReaderRemoteDiscovery(
@@ -66,4 +67,5 @@ private fun CardReaderRemoteResolvedHost.toPublic() =
         fingerprintBase64 = fingerprintBase64,
         deviceName = deviceName,
         siteHash = siteHash,
+        deviceId = deviceId,
     )

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
@@ -34,6 +34,7 @@ internal class CardReaderRemoteNsd(
         fingerprint: String,
         deviceName: String,
         siteHash: String,
+        deviceId: String,
     ): CardReaderRemoteNsdRegistration =
         withContext(ioDispatcher) {
             val serviceInfo = NsdServiceInfo().apply {
@@ -44,6 +45,7 @@ internal class CardReaderRemoteNsd(
                 setAttribute(TXT_KEY_VERSION, PROTOCOL_VERSION)
                 setAttribute(TXT_KEY_DEVICE_NAME, deviceName)
                 setAttribute(TXT_KEY_SITE_HASH, siteHash)
+                setAttribute(TXT_KEY_DEVICE_ID, deviceId)
             }
 
             val listener = object : NsdManager.RegistrationListener {
@@ -178,16 +180,19 @@ internal class CardReaderRemoteNsd(
         val fingerprint = attributes[TXT_KEY_FINGERPRINT]?.toString(Charsets.UTF_8)
         val host = firstHost()
         val siteHash = attributes[TXT_KEY_SITE_HASH]?.toString(Charsets.UTF_8)
+        val deviceId = attributes[TXT_KEY_DEVICE_ID]?.toString(Charsets.UTF_8)
         val isValid = version == PROTOCOL_VERSION &&
             !fingerprint.isNullOrEmpty() &&
             host != null &&
-            !siteHash.isNullOrEmpty()
+            !siteHash.isNullOrEmpty() &&
+            !deviceId.isNullOrEmpty()
         if (!isValid) {
             Log.w(
                 TAG,
                 "Dropping NSD service $serviceName " +
                     "(version=$version, fingerprintLen=${fingerprint?.length ?: 0}, " +
-                    "host=$host, siteHashLen=${siteHash?.length ?: 0})"
+                    "host=$host, siteHashLen=${siteHash?.length ?: 0}, " +
+                    "deviceIdLen=${deviceId?.length ?: 0})"
             )
             return null
         }
@@ -200,6 +205,7 @@ internal class CardReaderRemoteNsd(
             version = version,
             deviceName = deviceName,
             siteHash = siteHash,
+            deviceId = deviceId,
         )
     }
 
@@ -225,6 +231,7 @@ internal class CardReaderRemoteNsd(
         const val TXT_KEY_VERSION = "ver"
         const val TXT_KEY_DEVICE_NAME = "name"
         const val TXT_KEY_SITE_HASH = "siteHash"
+        const val TXT_KEY_DEVICE_ID = "did"
         const val PROTOCOL_VERSION = "1"
         private const val SERVICE_NAME_PREFIX = "woopos-remote"
         private const val SUFFIX_RANGE_EXCLUSIVE = 0x10000
@@ -250,6 +257,7 @@ internal data class CardReaderRemoteResolvedHost(
     val version: String,
     val deviceName: String?,
     val siteHash: String,
+    val deviceId: String,
 )
 
 internal sealed class CardReaderRemoteNsdEvent {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -70,10 +70,12 @@ class CardReaderRemoteSession internal constructor(
     private var readerWasConnected: Boolean = false
     private var useSimulatedReader: Boolean = false
     private var siteHash: String = ""
+    private var deviceId: String = ""
 
-    fun start(parentScope: CoroutineScope, siteHash: String, isSimulated: Boolean = false) {
+    fun start(parentScope: CoroutineScope, siteHash: String, deviceId: String, isSimulated: Boolean = false) {
         useSimulatedReader = isSimulated
         this.siteHash = siteHash
+        this.deviceId = deviceId
         startInternal(parentScope)
     }
 
@@ -136,7 +138,7 @@ class CardReaderRemoteSession internal constructor(
         server.start()
 
         val registration = nsdFactory.create(context)
-            .advertise(server.port, server.fingerprint, deviceName(), siteHash)
+            .advertise(server.port, server.fingerprint, deviceName(), siteHash, deviceId)
         nsdRegistration = registration
 
         logWrapper.d(

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/DefaultCardReaderRemoteTabletClientTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/DefaultCardReaderRemoteTabletClientTest.kt
@@ -98,6 +98,7 @@ class DefaultCardReaderRemoteTabletClientTest : CardReaderBaseUnitTest() {
         fingerprintBase64 = "AB4F",
         deviceName = "Pixel",
         siteHash = "site-hash",
+        deviceId = "test-device-id",
     )
 
     private fun aPaymentInfo() = PaymentInfo(


### PR DESCRIPTION
### Description

Two related bugs found while reviewing the remote tap-to-pay branch. Both have to do with how the tablet identifies a discovered phone reader.

**1. Discovery add/remove key mismatch.** `Added` events keyed phones in the in-memory map by display name (`Build.MODEL`, e.g. `"Pixel 8"`), but `Removed` events emit the NSD service name (`"woopos-remote-a3f4"`). The names never matched, so phones that went offline stayed in the discovered list forever. Fixed by adding a `serviceName` field to `WooPosDiscoveredReader.Phone` and keying the discovery state by it.

**2. Auto-reconnect could pair to the wrong same-model phone.** `setLastConnectedPhoneName(phone.name)` persists `Build.MODEL`, which is not unique across same-model devices. With two same-model phones on the LAN, auto-reconnect would silently pair to whichever NSD resolved first. Auto-reconnect is preserved — but `findLastKnownPhone` now returns null when more than one discovered phone matches the persisted name, so the user picks manually in that case. A proper fix (per-install device UUID broadcast in NSD TXT) is left as a follow-up.

Each fix is in its own commit.

### Steps to reproduce (before this PR)

**Bug 1 — stale phone never removed**
1. On the tablet, open Woo POS → start a card-reader connection.
2. On a paired phone, open **Card Reader Mode** so it appears in the tablet's list.
3. Close **Card Reader Mode** on the phone (or kill the app).
4. **Expected:** the phone disappears from the tablet's list within a few seconds.
   **Before:** the phone stays in the list until the tablet's discovery is restarted.

**Bug 2 — auto-pair to wrong phone of the same model**
Probably not possible to test that without code changes

The persisted "last connected phone" name only survives a successful connect — an explicit disconnect from the tablet clears it. So the bug is reachable when the tablet did NOT explicitly disconnect (phone went offline, tablet app was killed, network dropped):

1. Two phones of the same model on the same Wi-Fi (e.g. two Pixel 8s — call them **A** and **B**).
2. On the tablet: open Woo POS → connection screen → pair to **A** → take a payment so the connection succeeds (this persists `LastConnectedPhoneName = "Pixel 8"`).
3. Do **not** disconnect from the tablet UI. Instead, close **Card Reader Mode** on **A** (or kill the app on A so its NSD broadcast stops).
4. Start **Card Reader Mode** on **B**. **A** stays off.
5. On the tablet: leave the connection screen and come back (or kill and re-open the POS app).
6. **Expected:** the tablet should not silently auto-connect to a different physical device than the one previously paired.
   **Before:** the tablet auto-connects to **B** because the persisted `\"Pixel 8\"` matches its display name.
   **After:** if both **A** and **B** are visible, the tablet skips auto-connect and shows them in the list for the user to pick. If only **B** is visible, auto-connect still fires (single match) — accepting that this corner case still mispairs; the proper fix needs a stable per-device ID, tracked separately.

### Test Steps

1. Repeat Bug 1 reproduction — the phone now disappears from the list shortly after Card Reader Mode is closed.
2. Bug 2 — collision case: with two same-model phones both running Card Reader Mode, after pairing to one and putting it offline (without disconnecting), open the connection screen with both phones visible — the tablet does not auto-connect; both phones appear in the list for the user to pick.
3. Bug 2 — happy path: with a single phone, pair → take a payment → close Card Reader Mode without disconnecting → re-open it → tablet still auto-connects to it.
4. Smoke: a normal connect → pay → disconnect cycle with one phone still works.
5. Smoke: Bluetooth reader auto-reconnect (different code path) still works.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.