### PR TITLE
Step 15: QR login — add number-matching approval step

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -168,11 +168,10 @@ class QrLoginRestClient @Inject constructor(
         return Request.Builder()
             .url(statusUrl)
             .get()
-            // Force-bust any intermediary HTTP cache (OkHttp's shared cache, edge proxy,
-            // CDN). Polling responses are state-bearing — pinning the first response and
-            // serving it forever means the app sees `scanned` indefinitely even after the
-            // merchant approves on wc-admin.
-            .cacheControl(CacheControl.FORCE_NETWORK)
+            // Force-bust any intermediary HTTP cache (OkHttp's shared cache, edge proxy, CDN).
+            // Polling responses are state-bearing, so pinning the first response means the app
+            // sees `scanned` indefinitely even after the merchant approves on wc-admin.
+            .cacheControl(POLL_CACHE_CONTROL)
             .build()
     }
 
@@ -359,6 +358,10 @@ class QrLoginRestClient @Inject constructor(
         const val HTTP_BAD_REQUEST = 400
         const val HTTP_CONFLICT = 409
         const val HTTP_UPGRADE_REQUIRED = 426
+        val POLL_CACHE_CONTROL = CacheControl.Builder()
+            .noCache()
+            .noStore()
+            .build()
         val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
+import okhttp3.CacheControl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -167,6 +168,11 @@ class QrLoginRestClient @Inject constructor(
         return Request.Builder()
             .url(statusUrl)
             .get()
+            // Force-bust any intermediary HTTP cache (OkHttp's shared cache, edge proxy,
+            // CDN). Polling responses are state-bearing — pinning the first response and
+            // serving it forever means the app sees `scanned` indefinitely even after the
+            // merchant approves on wc-admin.
+            .cacheControl(CacheControl.FORCE_NETWORK)
             .build()
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -318,7 +318,13 @@ class QrLoginRestClient @Inject constructor(
             exchangeGrant
                 ?.takeIf { it.isNotBlank() }
                 ?.let { QrLoginSessionStatus.Approved(it) }
-                ?: QrLoginSessionStatus.Expired
+                ?: run {
+                    WooLog.w(
+                        WooLog.T.LOGIN,
+                        "$QR_LOGIN_APPROVED_NO_GRANT_LOG_ID: approved session-status missing exchange_grant"
+                    )
+                    QrLoginSessionStatus.Expired
+                }
     }
 
     private data class ExchangeRequest(
@@ -358,6 +364,7 @@ class QrLoginRestClient @Inject constructor(
         const val HTTP_BAD_REQUEST = 400
         const val HTTP_CONFLICT = 409
         const val HTTP_UPGRADE_REQUIRED = 426
+        const val QR_LOGIN_APPROVED_NO_GRANT_LOG_ID = "QR_LOGIN_APPROVED_NO_GRANT"
         val POLL_CACHE_CONTROL = CacheControl.Builder()
             .noCache()
             .noStore()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -279,6 +279,8 @@ class QrLoginRestClient @Inject constructor(
     private data class ScanRequest(
         val token: String,
         val device: QrLoginDeviceInfo,
+        // Capability flag for the Core number-matching cutover. Servers that require
+        // number matching reject legacy clients missing this value before mutating token state.
         @SerializedName("supports_number_matching") val supportsNumberMatching: Boolean,
     )
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -307,9 +307,16 @@ class QrLoginRestClient @Inject constructor(
             "scanned" -> QrLoginSessionStatus.Scanned
             "approved" -> approvedOrFailClosed()
             "rejected" -> QrLoginSessionStatus.Rejected
+            "expired" -> QrLoginSessionStatus.Expired
             // Treat unknown states defensively as Expired so the UI shows a terminal screen
             // rather than spinning indefinitely on a state the app doesn't understand.
-            else -> QrLoginSessionStatus.Expired
+            else -> {
+                WooLog.w(
+                    WooLog.T.LOGIN,
+                    "$QR_LOGIN_UNKNOWN_SESSION_STATE_LOG_ID: ${state ?: "(missing)"}"
+                )
+                QrLoginSessionStatus.Expired
+            }
         }
 
         // Approved without a grant shouldn't be possible against a Task-7 server, but if
@@ -365,6 +372,7 @@ class QrLoginRestClient @Inject constructor(
         const val HTTP_CONFLICT = 409
         const val HTTP_UPGRADE_REQUIRED = 426
         const val QR_LOGIN_APPROVED_NO_GRANT_LOG_ID = "QR_LOGIN_APPROVED_NO_GRANT"
+        const val QR_LOGIN_UNKNOWN_SESSION_STATE_LOG_ID = "QR_LOGIN_UNKNOWN_SESSION_STATE"
         val POLL_CACHE_CONTROL = CacheControl.Builder()
             .noCache()
             .noStore()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -15,15 +15,23 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
 import java.net.HttpURLConnection.HTTP_FORBIDDEN
 import java.net.HttpURLConnection.HTTP_NOT_FOUND
+import java.net.HttpURLConnection.HTTP_PRECON_FAILED
 import java.net.HttpURLConnection.HTTP_UNAUTHORIZED
 import javax.inject.Inject
 import javax.inject.Named
 
 /**
- * Calls the QR login token-exchange endpoint on the merchant's WordPress site.
+ * Calls the QR login endpoints on the merchant's WordPress site.
  *
- * The endpoint is unauthenticated — possession of a valid, unexpired, single-use token is the
- * authorization.
+ * Three endpoints are exposed:
+ *   - [scan] reports the merchant scanned the QR. Server picks the real number for the
+ *     coincidence-verification step and returns a session id the app polls for status.
+ *   - [checkSessionStatus] polls for the merchant's tap on wc-admin. Returns the
+ *     `exchange_grant` nonce once approved, which gates the final exchange call.
+ *   - [exchange] swaps the QR token + exchange grant for an Application Password.
+ *
+ * All three are unauthenticated — possession of the single-use token (and the matching
+ * grant nonce on exchange) is the authorization.
  */
 class QrLoginRestClient @Inject constructor(
     @Named("custom-ssl") private val okHttpClient: OkHttpClient,
@@ -32,37 +40,169 @@ class QrLoginRestClient @Inject constructor(
     private val deviceInfoProvider: QrLoginDeviceInfoProvider,
 ) {
 
-    suspend fun exchange(siteUrl: String, token: String): Result<QrLoginCredentials> =
+    suspend fun scan(siteUrl: String, token: String): Result<QrLoginScanResult> =
         withContext(dispatchers.io) {
             try {
-                Result.success(performExchange(siteUrl, token))
+                Result.success(performScan(siteUrl, token))
             } catch (ce: CancellationException) {
                 throw ce
             } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
-                Result.failure(mapException(t))
+                Result.failure(mapScanException(t))
             }
         }
 
-    private fun performExchange(siteUrl: String, token: String): QrLoginCredentials {
-        val request = buildExchangeRequest(siteUrl, token)
+    suspend fun checkSessionStatus(siteUrl: String, sessionId: String): Result<QrLoginSessionStatus> =
+        withContext(dispatchers.io) {
+            try {
+                Result.success(performSessionStatus(siteUrl, sessionId))
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+                Result.failure(mapSessionStatusException(t))
+            }
+        }
+
+    suspend fun exchange(
+        siteUrl: String,
+        token: String,
+        exchangeGrant: String,
+    ): Result<QrLoginCredentials> =
+        withContext(dispatchers.io) {
+            try {
+                Result.success(performExchange(siteUrl, token, exchangeGrant))
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+                Result.failure(mapExchangeException(t))
+            }
+        }
+
+    // region scan
+
+    private fun performScan(siteUrl: String, token: String): QrLoginScanResult {
+        val request = buildScanRequest(siteUrl, token)
         okHttpClient.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) throw mapHttpStatus(response.code)
+            if (!response.isSuccessful) throw mapScanHttpStatus(response.code, response.body.string())
+            return parseScanBody(response.body.string())
+                ?: throw QrLoginScanException.MalformedResponse
+        }
+    }
+
+    private fun buildScanRequest(siteUrl: String, token: String): Request {
+        val baseUrl = siteUrl.toHttpUrlOrNull()
+            ?: throw IllegalArgumentException("siteUrl could not be parsed by HttpUrl")
+        val scanUrl = baseUrl.newBuilder()
+            .addPathSegments(SCAN_PATH_SEGMENTS)
+            .build()
+        val payload = gson.toJson(
+            ScanRequest(
+                token = token,
+                device = deviceInfoProvider.get(),
+                supportsNumberMatching = true,
+            )
+        )
+        return Request.Builder()
+            .url(scanUrl)
+            .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+    }
+
+    private fun parseScanBody(body: String): QrLoginScanResult? {
+        val response = gson.fromJson(body, ScanResponse::class.java)
+        return response?.toResult()
+    }
+
+    private fun mapScanHttpStatus(code: Int, body: String): QrLoginScanException = when (code) {
+        HTTP_UNAUTHORIZED, HTTP_FORBIDDEN -> QrLoginScanException.TokenRejected
+        HTTP_NOT_FOUND -> QrLoginScanException.EndpointMissing
+        HTTP_TOO_MANY_REQUESTS -> QrLoginScanException.RateLimited
+        HTTP_CONFLICT -> QrLoginScanException.AlreadyScanned
+        HTTP_BAD_REQUEST -> QrLoginScanException.MalformedRequest
+        HTTP_UPGRADE_REQUIRED -> QrLoginScanException.UpgradeRequired
+        else -> {
+            WooLog.w(WooLog.T.LOGIN, "QR login scan unexpected HTTP $code: $body")
+            QrLoginScanException.HttpError(code)
+        }
+    }
+
+    private fun mapScanException(throwable: Throwable): Throwable = when (throwable) {
+        is QrLoginScanException -> throwable
+        is IOException -> {
+            WooLog.w(WooLog.T.LOGIN, "QR login scan network failure")
+            QrLoginScanException.Network
+        }
+        is JsonSyntaxException -> {
+            WooLog.w(WooLog.T.LOGIN, "QR login scan response was not valid JSON")
+            QrLoginScanException.MalformedResponse
+        }
+        else -> {
+            WooLog.e(
+                WooLog.T.LOGIN,
+                "QR login scan unexpected failure: ${throwable.javaClass.simpleName}"
+            )
+            QrLoginScanException.Unknown(throwable)
+        }
+    }
+
+    // endregion
+
+    // region session status
+
+    private fun performSessionStatus(siteUrl: String, sessionId: String): QrLoginSessionStatus {
+        val request = buildSessionStatusRequest(siteUrl, sessionId)
+        okHttpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw mapSessionStatusHttpStatus(response.code)
+            val parsed = gson.fromJson(response.body.string(), SessionStatusResponse::class.java)
+            return parsed.toStatus()
+        }
+    }
+
+    private fun buildSessionStatusRequest(siteUrl: String, sessionId: String): Request {
+        val baseUrl = siteUrl.toHttpUrlOrNull()
+            ?: throw IllegalArgumentException("siteUrl could not be parsed by HttpUrl")
+        val statusUrl = baseUrl.newBuilder()
+            .addPathSegments(SESSION_STATUS_PATH_SEGMENTS)
+            .addQueryParameter("session_id", sessionId)
+            .build()
+        return Request.Builder()
+            .url(statusUrl)
+            .get()
+            .build()
+    }
+
+    private fun mapSessionStatusHttpStatus(code: Int): QrLoginSessionStatusException = when (code) {
+        HTTP_NOT_FOUND -> QrLoginSessionStatusException.EndpointMissing
+        HTTP_TOO_MANY_REQUESTS -> QrLoginSessionStatusException.RateLimited
+        else -> QrLoginSessionStatusException.HttpError(code)
+    }
+
+    private fun mapSessionStatusException(throwable: Throwable): Throwable = when (throwable) {
+        is QrLoginSessionStatusException -> throwable
+        is IOException -> QrLoginSessionStatusException.Network
+        is JsonSyntaxException -> QrLoginSessionStatusException.MalformedResponse
+        else -> QrLoginSessionStatusException.Unknown(throwable)
+    }
+
+    // endregion
+
+    // region exchange
+
+    private fun performExchange(siteUrl: String, token: String, exchangeGrant: String): QrLoginCredentials {
+        val request = buildExchangeRequest(siteUrl, token, exchangeGrant)
+        okHttpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw mapExchangeHttpStatus(response.code, response.body.string())
             return parseExchangeBody(response.body.string())
                 ?: throw QrLoginExchangeException.MalformedResponse
         }
     }
 
-    private fun buildExchangeRequest(siteUrl: String, token: String): Request {
-        // The parser only hands us URLs that survived HttpUrl validation, so this should never
-        // be null in practice — fall through to the generic catch if it ever is.
+    private fun buildExchangeRequest(siteUrl: String, token: String, exchangeGrant: String): Request {
         val baseUrl = siteUrl.toHttpUrlOrNull()
             ?: throw IllegalArgumentException("siteUrl could not be parsed by HttpUrl")
         val exchangeUrl = baseUrl.newBuilder()
             .addPathSegments(EXCHANGE_PATH_SEGMENTS)
             .build()
-        val payload = gson.toJson(
-            ExchangeRequest(token = token, device = deviceInfoProvider.get())
-        )
+        val payload = gson.toJson(ExchangeRequest(token = token, exchangeGrant = exchangeGrant))
         return Request.Builder()
             .url(exchangeUrl)
             .post(payload.toRequestBody(JSON_MEDIA_TYPE))
@@ -82,14 +222,33 @@ class QrLoginRestClient @Inject constructor(
         return credentials
     }
 
-    private fun mapHttpStatus(code: Int): QrLoginExchangeException = when (code) {
+    private fun mapExchangeHttpStatus(code: Int, body: String): QrLoginExchangeException = when (code) {
         HTTP_UNAUTHORIZED, HTTP_FORBIDDEN -> QrLoginExchangeException.TokenRejected
         HTTP_NOT_FOUND -> QrLoginExchangeException.EndpointMissing
         HTTP_TOO_MANY_REQUESTS -> QrLoginExchangeException.RateLimited
+        HTTP_PRECON_FAILED -> mapPreconditionFailed(body)
         else -> QrLoginExchangeException.HttpError(code)
     }
 
-    private fun mapException(throwable: Throwable): Throwable = when (throwable) {
+    /**
+     * 412 from /qr-login-exchange splits two ways: `qr_login_not_approved` (the merchant
+     * never tapped a number, or tapped the wrong one) vs `invalid_exchange_grant` (the
+     * grant nonce we sent doesn't match what the server minted at approve time — race
+     * condition the user can act on by starting over).
+     */
+    private fun mapPreconditionFailed(body: String): QrLoginExchangeException = try {
+        val parsed = gson.fromJson(body, ErrorBody::class.java)
+        when (parsed?.code) {
+            "invalid_exchange_grant" -> QrLoginExchangeException.InvalidExchangeGrant
+            "qr_login_not_approved" -> QrLoginExchangeException.NotApproved
+            else -> QrLoginExchangeException.HttpError(HTTP_PRECON_FAILED)
+        }
+    } catch (e: JsonSyntaxException) {
+        WooLog.w(WooLog.T.LOGIN, "QR login exchange 412 body was not JSON: ${e.message}")
+        QrLoginExchangeException.HttpError(HTTP_PRECON_FAILED)
+    }
+
+    private fun mapExchangeException(throwable: Throwable): Throwable = when (throwable) {
         is QrLoginExchangeException -> throwable
         is IOException -> {
             WooLog.w(WooLog.T.LOGIN, "QR login exchange network failure")
@@ -108,9 +267,58 @@ class QrLoginRestClient @Inject constructor(
         }
     }
 
-    private data class ExchangeRequest(
+    // endregion
+
+    // region request / response shapes
+
+    private data class ScanRequest(
         val token: String,
         val device: QrLoginDeviceInfo,
+        @SerializedName("supports_number_matching") val supportsNumberMatching: Boolean,
+    )
+
+    private data class ScanResponse(
+        @SerializedName("session_id") val sessionId: String?,
+        @SerializedName("real_number") val realNumber: String?,
+        @SerializedName("expires_in") val expiresIn: Int?,
+    ) {
+        fun toResult(): QrLoginScanResult? {
+            val session = sessionId?.takeIf { it.isNotBlank() } ?: return null
+            val number = realNumber?.takeIf { it.isNotBlank() } ?: return null
+            val ttl = expiresIn ?: return null
+            return QrLoginScanResult(
+                sessionId = session,
+                realNumber = number,
+                expiresInSeconds = ttl,
+            )
+        }
+    }
+
+    private data class SessionStatusResponse(
+        val state: String?,
+        @SerializedName("exchange_grant") val exchangeGrant: String?,
+    ) {
+        fun toStatus(): QrLoginSessionStatus = when (state) {
+            "scanned" -> QrLoginSessionStatus.Scanned
+            "approved" -> approvedOrFailClosed()
+            "rejected" -> QrLoginSessionStatus.Rejected
+            // Treat unknown states defensively as Expired so the UI shows a terminal screen
+            // rather than spinning indefinitely on a state the app doesn't understand.
+            else -> QrLoginSessionStatus.Expired
+        }
+
+        // Approved without a grant shouldn't be possible against a Task-7 server, but if
+        // it ever happens we fail closed rather than continuing to poll forever.
+        private fun approvedOrFailClosed(): QrLoginSessionStatus =
+            exchangeGrant
+                ?.takeIf { it.isNotBlank() }
+                ?.let { QrLoginSessionStatus.Approved(it) }
+                ?: QrLoginSessionStatus.Expired
+    }
+
+    private data class ExchangeRequest(
+        val token: String,
+        @SerializedName("exchange_grant") val exchangeGrant: String,
     )
 
     private data class ExchangeResponse(
@@ -132,9 +340,19 @@ class QrLoginRestClient @Inject constructor(
         }.joinToString(",").ifEmpty { "(none)" }
     }
 
+    /** Used to disambiguate 412s from the exchange endpoint by their `code` field. */
+    private data class ErrorBody(val code: String?)
+
+    // endregion
+
     private companion object {
+        const val SCAN_PATH_SEGMENTS = "wp-json/wc-admin/mobile-app/qr-login-scan"
+        const val SESSION_STATUS_PATH_SEGMENTS = "wp-json/wc-admin/mobile-app/qr-login-session-status"
         const val EXCHANGE_PATH_SEGMENTS = "wp-json/wc-admin/mobile-app/qr-login-exchange"
         const val HTTP_TOO_MANY_REQUESTS = 429
+        const val HTTP_BAD_REQUEST = 400
+        const val HTTP_CONFLICT = 409
+        const val HTTP_UPGRADE_REQUIRED = 426
         val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
     }
 }
@@ -147,12 +365,65 @@ data class QrLoginCredentials(
         "QrLoginCredentials(userLogin=$userLogin, applicationPassword=***)"
 }
 
+/**
+ * Successful response from `/qr-login-scan`. The [realNumber] is what the merchant must tap
+ * on wc-admin to advance the flow; [sessionId] is the handle the app polls with.
+ */
+data class QrLoginScanResult(
+    val sessionId: String,
+    val realNumber: String,
+    val expiresInSeconds: Int,
+)
+
+/** Result of a single `/qr-login-session-status` poll. */
+sealed interface QrLoginSessionStatus {
+    /** Waiting on the merchant to tap a number on wc-admin. Keep polling. */
+    data object Scanned : QrLoginSessionStatus
+
+    /** Merchant tapped the right number. [grant] is the nonce required by `/qr-login-exchange`. */
+    data class Approved(val grant: String) : QrLoginSessionStatus
+
+    /** Merchant tapped a wrong number or cancelled. Terminal. */
+    data object Rejected : QrLoginSessionStatus
+
+    /** 90-second window elapsed without an approval. Terminal. */
+    data object Expired : QrLoginSessionStatus
+}
+
+sealed class QrLoginScanException(message: String) : Exception(message) {
+    data object TokenRejected : QrLoginScanException("Token was rejected by the site")
+    data object AlreadyScanned : QrLoginScanException("Token has already been scanned")
+    data object EndpointMissing : QrLoginScanException("Scan endpoint not available on the site")
+    data object RateLimited : QrLoginScanException("Rate limit hit on the scan endpoint")
+    data object Network : QrLoginScanException("Network failure during scan")
+    data object MalformedRequest : QrLoginScanException("Scan request body was rejected by the site")
+    data object MalformedResponse : QrLoginScanException("Scan response was malformed")
+    data object UpgradeRequired : QrLoginScanException("Merchant site requires a newer protocol")
+    data class HttpError(val code: Int) : QrLoginScanException("HTTP $code from scan endpoint")
+    data class Unknown(val original: Throwable) :
+        QrLoginScanException("Unknown scan failure: ${original.javaClass.simpleName}")
+}
+
+sealed class QrLoginSessionStatusException(message: String) : Exception(message) {
+    data object EndpointMissing : QrLoginSessionStatusException("Session-status endpoint not available")
+    data object RateLimited : QrLoginSessionStatusException("Rate limit hit on session-status")
+    data object Network : QrLoginSessionStatusException("Network failure during session-status poll")
+    data object MalformedResponse : QrLoginSessionStatusException("Session-status response was malformed")
+    data class HttpError(val code: Int) : QrLoginSessionStatusException("HTTP $code from session-status")
+    data class Unknown(val original: Throwable) :
+        QrLoginSessionStatusException("Unknown session-status failure: ${original.javaClass.simpleName}")
+}
+
 sealed class QrLoginExchangeException(message: String) : Exception(message) {
     data object TokenRejected : QrLoginExchangeException("Token was rejected by the site")
     data object EndpointMissing : QrLoginExchangeException("Exchange endpoint not available on the site")
     data object RateLimited : QrLoginExchangeException("Rate limit hit on the exchange endpoint")
     data object Network : QrLoginExchangeException("Network failure during exchange")
     data object MalformedResponse : QrLoginExchangeException("Exchange response was malformed")
+    data object NotApproved :
+        QrLoginExchangeException("Exchange called before merchant approved the number match")
+    data object InvalidExchangeGrant :
+        QrLoginExchangeException("Exchange grant nonce did not match the server-side value")
     data class HttpError(val code: Int) : QrLoginExchangeException("HTTP $code from exchange endpoint")
     data class Unknown(val original: Throwable) :
         QrLoginExchangeException("Unknown exchange failure: ${original.javaClass.simpleName}")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -47,8 +47,8 @@ class QrLoginRestClient @Inject constructor(
                 Result.success(performScan(siteUrl, token))
             } catch (ce: CancellationException) {
                 throw ce
-            } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
-                Result.failure(mapScanException(t))
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Result.failure(mapScanException(e))
             }
         }
 
@@ -58,8 +58,8 @@ class QrLoginRestClient @Inject constructor(
                 Result.success(performSessionStatus(siteUrl, sessionId))
             } catch (ce: CancellationException) {
                 throw ce
-            } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
-                Result.failure(mapSessionStatusException(t))
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Result.failure(mapSessionStatusException(e))
             }
         }
 
@@ -73,8 +73,8 @@ class QrLoginRestClient @Inject constructor(
                 Result.success(performExchange(siteUrl, token, exchangeGrant))
             } catch (ce: CancellationException) {
                 throw ce
-            } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
-                Result.failure(mapExchangeException(t))
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Result.failure(mapExchangeException(e))
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -449,7 +449,7 @@ sealed class QrLoginExchangeException(message: String) : Exception(message) {
     data object NotApproved :
         QrLoginExchangeException("Exchange called before merchant approved the number match")
     data object InvalidExchangeGrant :
-        QrLoginExchangeException("Exchange grant nonce did not match the server-side value")
+        QrLoginExchangeException("QR login exchange could not be completed")
     data class HttpError(val code: Int) : QrLoginExchangeException("HTTP $code from exchange endpoint")
     data class Unknown(val original: Throwable) :
         QrLoginExchangeException("Unknown exchange failure: ${original.javaClass.simpleName}")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticator.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.login.qrlogin
 
 import com.woocommerce.android.network.qrlogin.QrLoginCredentials
-import com.woocommerce.android.network.qrlogin.QrLoginRestClient
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository
@@ -12,37 +11,38 @@ import org.wordpress.android.fluxc.store.SiteStore
 import javax.inject.Inject
 
 /**
- * Glue layer that turns a scanned QR ticket into a logged-in [SelectedSite].
+ * Glue layer that completes a QR-driven sign-in once the ViewModel has finished the
+ * scan / approve / exchange protocol and obtained valid [QrLoginCredentials].
  *
  * Steps:
- *   1. Exchange the QR ticket for an Application Password (unauthenticated POST to the merchant site).
- *   2. Discover and persist the [SiteModel] using the AP credentials.
- *   3. Save the AP into encrypted shared preferences so subsequent REST calls authenticate.
- *   4. Verify the user is eligible to use the app, then promote the site to the selected site.
+ *   1. Discover and persist the [SiteModel] using the AP credentials.
+ *   2. Save the AP into encrypted shared preferences so subsequent REST calls authenticate.
+ *   3. Verify the user is eligible to use the app, then promote the site to the selected site.
  *
  * Returns the local site id so the caller can drive `loggedInViaUsernamePassword(localSiteId)`.
+ *
+ * The exchange call itself lives in the ViewModel because it's tightly coupled to the
+ * number-matching state machine (must come after `/qr-login-approve` returns a grant), so
+ * the authenticator stays focused on the post-credentials WP login + site setup.
  */
 class QrLoginAuthenticator @Inject constructor(
-    private val exchangeClient: QrLoginRestClient,
     private val wpApiSiteRepository: WPApiSiteRepository,
     private val siteStore: SiteStore,
     private val selectedSite: SelectedSite,
     private val accountRepository: AccountRepository
 ) {
-    suspend fun authenticate(ticket: QrLoginPayload.Ticket): Result<Int> {
-        val credentials = exchangeClient.exchange(ticket.siteUrl, ticket.token)
-            .getOrElse { return Result.failure(it) }
-
-        return try {
-            Result.success(authenticateWithCredentials(ticket.siteUrl, credentials))
-        } catch (ce: CancellationException) {
-            throw ce
-        } catch (e: QrLoginAuthenticationException) {
-            Result.failure(e)
-        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
-            WooLog.e(WooLog.T.LOGIN, "QR login authentication failed", t)
-            Result.failure(t)
-        }
+    suspend fun completeLogin(
+        ticket: QrLoginPayload.Ticket,
+        credentials: QrLoginCredentials,
+    ): Result<Int> = try {
+        Result.success(authenticateWithCredentials(ticket.siteUrl, credentials))
+    } catch (ce: CancellationException) {
+        throw ce
+    } catch (e: QrLoginAuthenticationException) {
+        Result.failure(e)
+    } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+        WooLog.e(WooLog.T.LOGIN, "QR login authentication failed", t)
+        Result.failure(t)
     }
 
     private suspend fun authenticateWithCredentials(siteUrl: String, credentials: QrLoginCredentials): Int {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorMapper.kt
@@ -1,0 +1,86 @@
+package com.woocommerce.android.ui.login.qrlogin
+
+import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
+import com.woocommerce.android.network.qrlogin.QrLoginScanException
+import com.woocommerce.android.network.qrlogin.QrLoginSessionStatusException
+import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.ErrorReason
+import com.woocommerce.android.util.WooLog
+import kotlinx.coroutines.CancellationException
+import org.wordpress.android.fluxc.store.SiteStore.SiteError
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
+import java.io.IOException
+import javax.inject.Inject
+
+class QrLoginErrorMapper @Inject constructor() {
+    fun isRetryEligible(reason: ErrorReason): Boolean = when (reason) {
+        ErrorReason.Network,
+        ErrorReason.ServerError,
+        ErrorReason.RateLimited -> true
+        else -> false
+    }
+
+    fun toScanReason(throwable: Throwable): ErrorReason = when (throwable) {
+        QrLoginScanException.TokenRejected -> ErrorReason.TokenRejected
+        QrLoginScanException.AlreadyScanned -> ErrorReason.MatchAlreadyScanned
+        QrLoginScanException.EndpointMissing -> ErrorReason.EndpointMissing
+        QrLoginScanException.RateLimited -> ErrorReason.RateLimited
+        QrLoginScanException.UpgradeRequired -> ErrorReason.EndpointMissing
+        QrLoginScanException.Network -> ErrorReason.Network
+        QrLoginScanException.MalformedRequest,
+        QrLoginScanException.MalformedResponse -> ErrorReason.ServerError
+        is QrLoginScanException.HttpError -> ErrorReason.ServerError
+        is QrLoginScanException.Unknown -> ErrorReason.Unknown
+        is IOException -> ErrorReason.Network
+        else -> ErrorReason.Unknown
+    }
+
+    fun toPollReason(throwable: Throwable): ErrorReason = when (throwable) {
+        QrLoginSessionStatusException.EndpointMissing -> ErrorReason.EndpointMissing
+        QrLoginSessionStatusException.RateLimited -> ErrorReason.RateLimited
+        QrLoginSessionStatusException.Network -> ErrorReason.Network
+        QrLoginSessionStatusException.MalformedResponse -> ErrorReason.ServerError
+        is QrLoginSessionStatusException.HttpError -> ErrorReason.ServerError
+        is QrLoginSessionStatusException.Unknown -> ErrorReason.Unknown
+        else -> {
+            WooLog.w(WooLog.T.LOGIN, "QR login poll: unmapped failure type ${throwable.javaClass.simpleName}")
+            ErrorReason.Unknown
+        }
+    }
+
+    fun toExchangeReason(throwable: Throwable): ErrorReason = when (throwable) {
+        QrLoginExchangeException.TokenRejected -> ErrorReason.TokenRejected
+        QrLoginExchangeException.EndpointMissing -> ErrorReason.EndpointMissing
+        QrLoginExchangeException.RateLimited -> ErrorReason.RateLimited
+        QrLoginExchangeException.Network -> ErrorReason.Network
+        QrLoginExchangeException.MalformedResponse -> ErrorReason.ServerError
+        QrLoginExchangeException.NotApproved -> ErrorReason.MatchTimedOut
+        QrLoginExchangeException.InvalidExchangeGrant -> ErrorReason.MatchInvalidGrant
+        is QrLoginExchangeException.HttpError -> ErrorReason.ServerError
+        is QrLoginExchangeException.Unknown -> ErrorReason.Unknown
+        else -> ErrorReason.Unknown
+    }
+
+    fun toAuthReason(throwable: Throwable): ErrorReason = when (throwable) {
+        QrLoginAuthenticationException.NotAWooSite -> ErrorReason.NotAWooSite
+        is QrLoginAuthenticationException.UserNotEligible -> ErrorReason.UserNotEligible
+        is CookieNonceAuthenticationException -> ErrorReason.SiteAuthFailure
+        is OnChangedException -> (throwable.error as? SiteError)?.type.toErrorReason()
+        // Catches DNS, socket, SSL handshake, and read failures during the post-exchange site
+        // discovery + AP save chain, which throw raw IOException without QrLoginExchangeException.
+        is IOException -> ErrorReason.Network
+        is CancellationException -> throw throwable
+        else -> {
+            WooLog.w(WooLog.T.LOGIN, "QR login: unmapped failure type ${throwable.javaClass.simpleName}")
+            ErrorReason.Unknown
+        }
+    }
+
+    private fun SiteErrorType?.toErrorReason(): ErrorReason = when (this) {
+        SiteErrorType.UNAUTHORIZED,
+        SiteErrorType.NOT_AUTHENTICATED -> ErrorReason.SiteAuthFailure
+        SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR -> ErrorReason.Network
+        else -> ErrorReason.Unknown
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCColoredButton
-import com.woocommerce.android.ui.compose.component.WCTextButton
+import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 
@@ -43,7 +43,13 @@ fun QrLoginErrorScreen(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             .systemBarsPadding()
-            .padding(horizontal = dimensionResource(id = R.dimen.major_150)),
+            .padding(
+                horizontal = dimensionResource(id = R.dimen.major_150),
+                // Generous bottom padding so any trailing copy ("Any troubles signing in?
+                // Check out the FAQ." or similar fallback link) doesn't visually crowd
+                // the primary CTA above it.
+                vertical = dimensionResource(id = R.dimen.major_200),
+            ),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
@@ -67,17 +73,20 @@ fun QrLoginErrorScreen(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center
         )
-        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_200)))
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_250)))
         WCColoredButton(
             onClick = onPrimaryClicked,
             text = stringResource(id = content.primaryAction),
             modifier = Modifier.fillMaxWidth()
         )
-        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
-        WCTextButton(
+        // 24dp (was 12dp) so the outlined secondary button doesn't visually touch the
+        // primary "Try again" button above it, and so any trailing FAQ / fallback copy
+        // (rendered by parent surfaces below this column) sits comfortably away from
+        // the CTA stack.
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_150)))
+        WCOutlinedButton(
             onClick = onSecondaryClicked,
             text = stringResource(id = content.secondaryAction),
-            allCaps = false,
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
@@ -45,9 +45,6 @@ fun QrLoginErrorScreen(
             .systemBarsPadding()
             .padding(
                 horizontal = dimensionResource(id = R.dimen.major_150),
-                // Generous bottom padding so any trailing copy ("Any troubles signing in?
-                // Check out the FAQ." or similar fallback link) doesn't visually crowd
-                // the primary CTA above it.
                 vertical = dimensionResource(id = R.dimen.major_200),
             ),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -79,10 +76,6 @@ fun QrLoginErrorScreen(
             text = stringResource(id = content.primaryAction),
             modifier = Modifier.fillMaxWidth()
         )
-        // 24dp (was 12dp) so the outlined secondary button doesn't visually touch the
-        // primary "Try again" button above it, and so any trailing FAQ / fallback copy
-        // (rendered by parent surfaces below this column) sits comfortably away from
-        // the CTA stack.
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_150)))
         WCOutlinedButton(
             onClick = onSecondaryClicked,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginNumberDisplayScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginNumberDisplayScreen.kt
@@ -9,35 +9,48 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCTextButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import kotlinx.coroutines.delay
 
+/**
+ * Number-matching approval step. Shows the 3-digit number the merchant must tap on the
+ * matching wc-admin screen for the sign-in to complete. The number is rendered prominently
+ * (large, monospaced) with the host as context and a 90-second countdown.
+ *
+ * Cancel returns to the scanner. The server keeps the session in `scanned` until its
+ * 90-second window elapses, so wc-admin's polling auto-transitions to the "denied" terminal
+ * screen — no explicit cancel call is needed.
+ */
 @Composable
-fun QrLoginConfirmSiteScreen(
+fun QrLoginNumberDisplayScreen(
     host: String,
-    onConfirm: () -> Unit,
+    realNumber: String,
+    expiresAtEpochMs: Long,
     onCancel: () -> Unit,
 ) {
     Column(
@@ -48,8 +61,6 @@ fun QrLoginConfirmSiteScreen(
             .padding(horizontal = dimensionResource(id = R.dimen.major_150)),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        // Hero scrolls so the Connect / Cancel buttons stay visible in landscape on phones
-        // where the static layout would otherwise push them off the bottom edge.
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -58,23 +69,21 @@ fun QrLoginConfirmSiteScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
-            Hero(host = host)
+            Hero(host = host, realNumber = realNumber, expiresAtEpochMs = expiresAtEpochMs)
         }
-        Buttons(onConfirm = onConfirm, onCancel = onCancel)
+        CancelButton(onCancel = onCancel)
     }
 }
 
 @Composable
-private fun Hero(host: String) {
+private fun Hero(host: String, realNumber: String, expiresAtEpochMs: Long) {
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        IconBadge()
-        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_200)))
         Text(
-            text = stringResource(id = R.string.login_qr_confirm_title),
+            text = stringResource(id = R.string.login_qr_match_title),
             style = MaterialTheme.typography.headlineMedium,
             color = MaterialTheme.colorScheme.onBackground,
             fontWeight = FontWeight.SemiBold,
@@ -82,16 +91,18 @@ private fun Hero(host: String) {
         )
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
         Text(
-            text = stringResource(id = R.string.login_qr_confirm_subtitle),
+            text = stringResource(id = R.string.login_qr_match_subtitle, host),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center
         )
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_200)))
-        HostBadge(host = host)
+        NumberTile(realNumber = realNumber)
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_125)))
+        Countdown(expiresAtEpochMs = expiresAtEpochMs)
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_100)))
         Text(
-            text = stringResource(id = R.string.login_qr_confirm_security_note),
+            text = stringResource(id = R.string.login_qr_match_security_note),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center
@@ -100,37 +111,20 @@ private fun Hero(host: String) {
 }
 
 @Composable
-private fun IconBadge() {
-    Box(
-        modifier = Modifier
-            .size(dimensionResource(id = R.dimen.image_major_72))
-            .clip(CircleShape)
-            .background(colorResource(id = R.color.color_primary).copy(alpha = 0.15f)),
-        contentAlignment = Alignment.Center
-    ) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_baseline_qr_code_scanner),
-            contentDescription = null,
-            tint = colorResource(id = R.color.color_primary),
-            modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_100))
-        )
-    }
-}
-
-@Composable
-private fun HostBadge(host: String) {
+private fun NumberTile(realNumber: String) {
     Box(
         modifier = Modifier
             .clip(RoundedCornerShape(dimensionResource(id = R.dimen.major_100)))
-            .background(colorResource(id = R.color.color_primary).copy(alpha = 0.12f))
+            .background(colorResource(id = R.color.color_primary).copy(alpha = TILE_BG_ALPHA))
             .padding(
-                horizontal = dimensionResource(id = R.dimen.major_150),
-                vertical = dimensionResource(id = R.dimen.major_100)
+                horizontal = dimensionResource(id = R.dimen.major_300),
+                vertical = dimensionResource(id = R.dimen.major_200)
             )
     ) {
         Text(
-            text = host,
-            style = MaterialTheme.typography.titleMedium,
+            text = realNumber,
+            style = MaterialTheme.typography.displayLarge.copy(fontFamily = FontFamily.Monospace),
+            fontSize = NUMBER_FONT_SIZE_SP.sp,
             color = colorResource(id = R.color.color_primary),
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center
@@ -139,38 +133,54 @@ private fun HostBadge(host: String) {
 }
 
 @Composable
-private fun Buttons(
-    onConfirm: () -> Unit,
-    onCancel: () -> Unit,
-) {
+private fun Countdown(expiresAtEpochMs: Long) {
+    var secondsRemaining by remember(expiresAtEpochMs) {
+        mutableLongStateOf(((expiresAtEpochMs - System.currentTimeMillis()) / MILLIS_PER_SECOND).coerceAtLeast(0L))
+    }
+    LaunchedEffect(expiresAtEpochMs) {
+        while (secondsRemaining > 0L) {
+            delay(MILLIS_PER_SECOND)
+            secondsRemaining =
+                ((expiresAtEpochMs - System.currentTimeMillis()) / MILLIS_PER_SECOND).coerceAtLeast(0L)
+        }
+    }
+    Text(
+        text = stringResource(id = R.string.login_qr_match_countdown, secondsRemaining),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+    )
+}
+
+@Composable
+private fun CancelButton(onCancel: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(bottom = dimensionResource(id = R.dimen.major_100)),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        WCColoredButton(
-            onClick = onConfirm,
-            text = stringResource(id = R.string.login_qr_confirm_connect),
-            modifier = Modifier.fillMaxWidth()
-        )
-        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
         WCTextButton(
             onClick = onCancel,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text(text = stringResource(id = R.string.login_qr_confirm_cancel))
+            Text(text = stringResource(id = R.string.login_qr_match_cancel))
         }
     }
 }
 
+private const val TILE_BG_ALPHA = 0.12f
+private const val NUMBER_FONT_SIZE_SP = 64
+private const val MILLIS_PER_SECOND = 1_000L
+
 @LightDarkThemePreviews
 @Composable
-private fun QrLoginConfirmSiteScreenPreview() {
+private fun QrLoginNumberDisplayScreenPreview() {
     WooThemeWithBackground {
-        QrLoginConfirmSiteScreen(
+        QrLoginNumberDisplayScreen(
             host = "store.example",
-            onConfirm = {},
+            realNumber = "042",
+            expiresAtEpochMs = System.currentTimeMillis() + 90_000L,
             onCancel = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginNumberDisplayScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginNumberDisplayScreen.kt
@@ -91,12 +91,26 @@ private fun Hero(host: String, realNumber: String, expiresAtEpochMs: Long) {
         )
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
         Text(
-            text = stringResource(id = R.string.login_qr_match_subtitle, host),
+            text = stringResource(id = R.string.login_qr_match_host_label),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_75)))
+        // Prominent host display so the merchant can spot a phishing-style mismatch
+        // (e.g. a homograph attack: `my-stōre.example` vs the punycode form
+        // `xn--my-stre-1za.example` that OkHttp's HttpUrl normalisation surfaces).
+        // The ViewModel's `toDisplayHost` already converts IDN names to ASCII, so any
+        // visual sleight-of-hand in the QR's URL surfaces here for the user to read.
+        HostBadge(host = host)
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_150)))
+        Text(
+            text = stringResource(id = R.string.login_qr_match_subtitle),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center
         )
-        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_200)))
+        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_150)))
         NumberTile(realNumber = realNumber)
         Spacer(Modifier.height(dimensionResource(id = R.dimen.major_125)))
         Countdown(expiresAtEpochMs = expiresAtEpochMs)
@@ -105,6 +119,27 @@ private fun Hero(host: String, realNumber: String, expiresAtEpochMs: Long) {
             text = stringResource(id = R.string.login_qr_match_security_note),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun HostBadge(host: String) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(dimensionResource(id = R.dimen.major_100)))
+            .background(colorResource(id = R.color.color_primary).copy(alpha = TILE_BG_ALPHA))
+            .padding(
+                horizontal = dimensionResource(id = R.dimen.major_150),
+                vertical = dimensionResource(id = R.dimen.major_100)
+            )
+    ) {
+        Text(
+            text = host,
+            style = MaterialTheme.typography.titleMedium,
+            color = colorResource(id = R.color.color_primary),
+            fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -191,8 +191,8 @@ class QrLoginScannerFragment : Fragment() {
     }
 
     /**
-     * Error/endpoint-missing screens in deep-link mode
-     * have nothing to fall back to once dismissed, so we exit. In camera mode the scanner
+     * Same reasoning as [handleCancelNumberMatch]: error/endpoint-missing screens in deep-link
+     * mode have nothing to fall back to once dismissed, so we exit. In camera mode the scanner
      * resumes underneath as soon as the overlay is cleared.
      */
     private fun handleStartOver() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -96,8 +96,7 @@ class QrLoginScannerFragment : Fragment() {
                     shouldShowRequestPermissionRationale(KEY_CAMERA_PERMISSION)
                 )
             },
-            onConfirmSite = qrLoginViewModel::onConfirmSite,
-            onCancelSite = ::handleCancelSite,
+            onCancelNumberMatch = ::handleCancelNumberMatch,
             onConfirmSessionReplace = qrLoginViewModel::onConfirmSessionReplace,
             onCancelSessionReplace = ::handleCancelSessionReplace,
             onStartOver = ::handleStartOver,
@@ -171,19 +170,19 @@ class QrLoginScannerFragment : Fragment() {
     }
 
     /**
-     * Cancel always exits to the previous destination (the prologue in camera mode, the launcher
-     * caller in deep-link mode). Resuming the camera underneath would re-scan the same QR if it
-     * is still framed, which loops the user back into the same confirm screen.
+     * In camera mode, cancelling the number-match step clears the overlay and the camera
+     * resumes underneath. In deep-link mode there is no camera, so the same dismissal would
+     * leave the user on a blank surface — exit the fragment instead.
      */
-    private fun handleCancelSite() {
-        qrLoginViewModel.onCancelSite()
-        requireActivity().onBackPressedDispatcher.onBackPressed()
+    private fun handleCancelNumberMatch() {
+        qrLoginViewModel.onCancelNumberMatch()
+        if (isDeepLinkEntry) requireActivity().onBackPressedDispatcher.onBackPressed()
     }
 
     /**
      * In practice the warning is only reachable via deep link (the in-app scanner is gated
      * behind a logged-out [LoginActivity]), so cancelling closes [LoginActivity] and returns
-     * the merchant to whatever they were doing before tapping the QR link. Existing session
+     * the merchant to whatever they were doing before tapping the QR link. The existing session
      * is left intact.
      */
     private fun handleCancelSessionReplace() {
@@ -192,7 +191,7 @@ class QrLoginScannerFragment : Fragment() {
     }
 
     /**
-     * Same reasoning as [handleCancelSite]: error/endpoint-missing screens in deep-link mode
+     * Error/endpoint-missing screens in deep-link mode
      * have nothing to fall back to once dismissed, so we exit. In camera mode the scanner
      * resumes underneath as soon as the overlay is cleared.
      */

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -31,6 +31,7 @@ class QrLoginScannerFragment : Fragment() {
         const val TAG = "qr-login-scanner-fragment"
         const val KEY_CAMERA_PERMISSION = Manifest.permission.CAMERA
         private const val ARG_DEEP_LINK_PAYLOAD = "arg-deep-link-payload"
+        private const val KEY_IS_DEEP_LINK_ENTRY = "key-is-deep-link-entry"
 
         /**
          * Creates an instance that skips the camera preview and feeds [rawPayload] (a
@@ -53,9 +54,10 @@ class QrLoginScannerFragment : Fragment() {
     private val scannerViewModel: BarcodeScanningViewModel by viewModels()
     private val qrLoginViewModel: QrLoginScannerViewModel by viewModels()
 
-    // Captured once at fragment creation. Kept in memory only — never persisted to
-    // saved-instance-state — and consumed in onViewCreated. On process-death recovery this
-    // stays null so the user falls back to the scanner instead of replaying a stale token.
+    // The payload is captured once at fragment creation, kept in memory only, and consumed in
+    // onViewCreated. The entry mode itself is safe to restore across rotation, but only while the
+    // retained ViewModel still holds a non-idle overlay state. After process death the ViewModel
+    // is idle again, so we fall back to the scanner instead of replaying a stale token.
     private var pendingDeepLinkPayload: String? = null
     private var isDeepLinkEntry: Boolean = false
 
@@ -69,10 +71,17 @@ class QrLoginScannerFragment : Fragment() {
         val payload = arguments?.getString(ARG_DEEP_LINK_PAYLOAD)
         // Strip the payload from arguments before any save-state cycle can persist it.
         arguments = null
+        isDeepLinkEntry = savedInstanceState?.getBoolean(KEY_IS_DEEP_LINK_ENTRY) == true &&
+            qrLoginViewModel.uiState.value !is QrLoginScannerViewModel.UiState.Idle
         if (savedInstanceState == null && payload != null) {
             pendingDeepLinkPayload = payload
             isDeepLinkEntry = true
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(KEY_IS_DEEP_LINK_ENTRY, isDeepLinkEntry)
     }
 
     override fun onCreateView(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerScreen.kt
@@ -16,8 +16,9 @@ import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.ErrorRea
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState
 
 /**
- * Renders the QR-first login screen. Routes between the camera scanner, fullscreen confirm,
- * fullscreen error (which subsumes the endpoint-missing fallback), and the fullscreen
+ * Renders the QR-first login screen. Routes between the camera scanner, the
+ * number-matching approval step (post-scan, awaiting the merchant's tap on wc-admin),
+ * the fullscreen error (which subsumes the endpoint-missing fallback), and the fullscreen
  * signing-in state. The fragment plumbs camera permissions and the post-login handoff; this
  * composable is purely UI routing.
  */
@@ -29,8 +30,7 @@ fun QrLoginScannerScreen(
     onNewFrame: (ImageProxy) -> Unit,
     onBindingException: (Exception) -> Unit,
     onPermissionResult: (Boolean) -> Unit,
-    onConfirmSite: () -> Unit,
-    onCancelSite: () -> Unit,
+    onCancelNumberMatch: () -> Unit,
     onConfirmSessionReplace: () -> Unit,
     onCancelSessionReplace: () -> Unit,
     onStartOver: () -> Unit,
@@ -54,10 +54,11 @@ fun QrLoginScannerScreen(
         }
 
         when (uiState) {
-            is UiState.Confirming -> QrLoginConfirmSiteScreen(
+            is UiState.WaitingForApproval -> QrLoginNumberDisplayScreen(
                 host = uiState.host,
-                onConfirm = onConfirmSite,
-                onCancel = onCancelSite,
+                realNumber = uiState.realNumber,
+                expiresAtEpochMs = uiState.expiresAtEpochMs,
+                onCancel = onCancelNumberMatch,
             )
             is UiState.WarningSessionReplace -> QrLoginSessionReplaceWarningScreen(
                 onConfirm = onConfirmSessionReplace,
@@ -68,7 +69,7 @@ fun QrLoginScannerScreen(
                 onPrimaryClicked = if (uiState.retryTicket != null) onRetryExchange else onStartOver,
                 onSecondaryClicked = onFallbackClicked,
             )
-            UiState.Authenticating -> QrLoginAuthenticatingScreen()
+            is UiState.Authenticating -> QrLoginAuthenticatingScreen()
             UiState.Idle -> Unit
         }
     }
@@ -82,60 +83,94 @@ data class QrLoginErrorContent(
     val bodyHighlightedArgs: List<Int> = emptyList(),
 )
 
-private fun ErrorReason.toErrorContent(): QrLoginErrorContent = when (this) {
-    ErrorReason.InvalidPayload -> QrLoginErrorContent(
-        title = R.string.login_qr_scanner_error_payload_title,
-        body = R.string.login_qr_scanner_error_payload_body,
-        primaryAction = R.string.login_qr_error_primary_scan,
-    )
-    ErrorReason.InstallQrCode -> installQrErrorContent()
-    ErrorReason.TokenRejected -> QrLoginErrorContent(
-        title = R.string.login_qr_scanner_error_token_title,
-        body = R.string.login_qr_scanner_error_token_body,
-        primaryAction = R.string.login_qr_error_primary_scan,
-    )
-    ErrorReason.EndpointMissing -> QrLoginErrorContent(
-        title = R.string.login_qr_endpoint_missing_title,
-        body = R.string.login_qr_endpoint_missing_body,
-        primaryAction = R.string.login_qr_endpoint_missing_retry,
-    )
-    ErrorReason.RateLimited -> QrLoginErrorContent(
-        title = R.string.login_qr_scanner_error_rate_limited_title,
-        body = R.string.login_qr_scanner_error_rate_limited_body,
-        primaryAction = R.string.login_qr_error_primary_retry,
-    )
-    ErrorReason.Network -> QrLoginErrorContent(
-        title = R.string.login_qr_scanner_error_network_title,
-        body = R.string.login_qr_scanner_error_network_body,
-        primaryAction = R.string.login_qr_error_primary_retry,
-    )
-    ErrorReason.ServerError -> QrLoginErrorContent(
-        title = R.string.login_qr_scanner_error_server_title,
-        body = R.string.login_qr_scanner_error_server_body,
-        primaryAction = R.string.login_qr_error_primary_retry,
-    )
-    ErrorReason.SiteAuthFailure -> QrLoginErrorContent(
-        title = R.string.login_qr_scanner_error_site_auth_title,
-        body = R.string.login_qr_scanner_error_site_auth_body,
-        primaryAction = R.string.login_qr_error_primary_retry,
-    )
-    ErrorReason.NotAWooSite -> QrLoginErrorContent(
-        title = R.string.login_qr_scanner_error_not_woo_title,
-        body = R.string.login_qr_scanner_error_not_woo_body,
-        primaryAction = R.string.login_qr_error_primary_scan,
-    )
-    ErrorReason.UserNotEligible -> QrLoginErrorContent(
-        title = R.string.login_qr_scanner_error_user_role_title,
-        body = R.string.login_qr_scanner_error_user_role_body,
-        primaryAction = R.string.login_qr_error_primary_retry,
-    )
-    ErrorReason.Scanner,
-    ErrorReason.Unknown -> QrLoginErrorContent(
-        title = R.string.login_qr_scanner_error_generic_title,
-        body = R.string.login_qr_scanner_error_generic_body,
-        primaryAction = R.string.login_qr_error_primary_retry,
-    )
-}
+private fun ErrorReason.toErrorContent(): QrLoginErrorContent =
+    // InstallQrCode is the only reason that needs the bodyHighlightedArgs field, so it has a
+    // dedicated builder. Everything else is a simple title/body/primaryAction triple, so
+    // the lookup table keeps this function flat and lets us add new reasons without
+    // expanding the cyclomatic complexity of a giant `when` expression.
+    if (this == ErrorReason.InstallQrCode) installQrErrorContent() else simpleErrorContents.getValue(this)
+
+private val simpleErrorContents: Map<ErrorReason, QrLoginErrorContent> = mapOf(
+    ErrorReason.InvalidPayload to errorContent(
+        R.string.login_qr_scanner_error_payload_title,
+        R.string.login_qr_scanner_error_payload_body,
+        R.string.login_qr_error_primary_scan,
+    ),
+    ErrorReason.TokenRejected to errorContent(
+        R.string.login_qr_scanner_error_token_title,
+        R.string.login_qr_scanner_error_token_body,
+        R.string.login_qr_error_primary_scan,
+    ),
+    ErrorReason.EndpointMissing to errorContent(
+        R.string.login_qr_endpoint_missing_title,
+        R.string.login_qr_endpoint_missing_body,
+        R.string.login_qr_endpoint_missing_retry,
+    ),
+    ErrorReason.RateLimited to errorContent(
+        R.string.login_qr_scanner_error_rate_limited_title,
+        R.string.login_qr_scanner_error_rate_limited_body,
+        R.string.login_qr_error_primary_retry,
+    ),
+    ErrorReason.Network to errorContent(
+        R.string.login_qr_scanner_error_network_title,
+        R.string.login_qr_scanner_error_network_body,
+        R.string.login_qr_error_primary_retry,
+    ),
+    ErrorReason.ServerError to errorContent(
+        R.string.login_qr_scanner_error_server_title,
+        R.string.login_qr_scanner_error_server_body,
+        R.string.login_qr_error_primary_retry,
+    ),
+    ErrorReason.SiteAuthFailure to errorContent(
+        R.string.login_qr_scanner_error_site_auth_title,
+        R.string.login_qr_scanner_error_site_auth_body,
+        R.string.login_qr_error_primary_retry,
+    ),
+    ErrorReason.NotAWooSite to errorContent(
+        R.string.login_qr_scanner_error_not_woo_title,
+        R.string.login_qr_scanner_error_not_woo_body,
+        R.string.login_qr_error_primary_scan,
+    ),
+    ErrorReason.UserNotEligible to errorContent(
+        R.string.login_qr_scanner_error_user_role_title,
+        R.string.login_qr_scanner_error_user_role_body,
+        R.string.login_qr_error_primary_retry,
+    ),
+    ErrorReason.MatchRejected to errorContent(
+        R.string.login_qr_scanner_error_match_rejected_title,
+        R.string.login_qr_scanner_error_match_rejected_body,
+        R.string.login_qr_error_primary_scan,
+    ),
+    ErrorReason.MatchTimedOut to errorContent(
+        R.string.login_qr_scanner_error_match_timed_out_title,
+        R.string.login_qr_scanner_error_match_timed_out_body,
+        R.string.login_qr_error_primary_scan,
+    ),
+    ErrorReason.MatchAlreadyScanned to errorContent(
+        R.string.login_qr_scanner_error_match_already_scanned_title,
+        R.string.login_qr_scanner_error_match_already_scanned_body,
+        R.string.login_qr_error_primary_scan,
+    ),
+    ErrorReason.MatchInvalidGrant to errorContent(
+        R.string.login_qr_scanner_error_match_invalid_grant_title,
+        R.string.login_qr_scanner_error_match_invalid_grant_body,
+        R.string.login_qr_error_primary_scan,
+    ),
+    ErrorReason.Scanner to genericErrorContent(),
+    ErrorReason.Unknown to genericErrorContent(),
+)
+
+private fun errorContent(
+    @StringRes title: Int,
+    @StringRes body: Int,
+    @StringRes primaryAction: Int,
+): QrLoginErrorContent = QrLoginErrorContent(title = title, body = body, primaryAction = primaryAction)
+
+private fun genericErrorContent() = errorContent(
+    title = R.string.login_qr_scanner_error_generic_title,
+    body = R.string.login_qr_scanner_error_generic_body,
+    primaryAction = R.string.login_qr_error_primary_retry,
+)
 
 private fun installQrErrorContent() = QrLoginErrorContent(
     title = R.string.login_qr_scanner_error_install_qr_title,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -226,6 +226,7 @@ class QrLoginScannerViewModel @Inject constructor(
                     },
                     onFailure = { failure ->
                         consecutiveErrors++
+                        val reason = failure.toPollReason()
                         WooLog.w(
                             WooLog.T.LOGIN,
                             "QR login poll: failed (consecutive=$consecutiveErrors): $failure"
@@ -237,11 +238,11 @@ class QrLoginScannerViewModel @Inject constructor(
                             trackScanFailure(
                                 step = Step.POLL,
                                 errorContext = failure.javaClass.simpleName,
-                                errorType = ErrorReason.Network.name,
+                                errorType = reason.name,
                             )
                             _uiState.value = Error(
-                                reason = failure.toPollReason(),
-                                retryTicket = ticket
+                                reason = reason,
+                                retryTicket = ticket.takeIf { reason.isRetryEligible() }
                             )
                             return@launch
                         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -298,7 +298,8 @@ class QrLoginScannerViewModel @Inject constructor(
                     )
                     _uiState.value = Error(
                         reason = reason,
-                        retryTicket = ticket.takeIf { reason.isRetryEligible() }
+                        retryTicket = ticket.takeIf { reason.isRetryEligible() },
+                        retryExchangeGrant = exchangeGrant.takeIf { reason.isRetryEligible() }
                     )
                 }
             )
@@ -354,8 +355,11 @@ class QrLoginScannerViewModel @Inject constructor(
      * transient failures (network, rate-limit) where the token is most likely still valid.
      */
     fun onRetryExchange() {
-        val ticket = (_uiState.value as? Error)?.retryTicket ?: return
-        startScan(ticket)
+        val error = _uiState.value as? Error ?: return
+        val ticket = error.retryTicket ?: return
+        error.retryExchangeGrant
+            ?.let { exchangeGrant -> startExchange(ticket, exchangeGrant) }
+            ?: startScan(ticket)
     }
 
     override fun onCleared() {
@@ -515,7 +519,11 @@ class QrLoginScannerViewModel @Inject constructor(
             val sessionId: String,
             val expiresAtEpochMs: Long,
         ) : UiState
-        data class Error(val reason: ErrorReason, val retryTicket: QrLoginPayload.Ticket?) : UiState
+        data class Error(
+            val reason: ErrorReason,
+            val retryTicket: QrLoginPayload.Ticket?,
+            val retryExchangeGrant: String? = null,
+        ) : UiState
         data class WarningSessionReplace(val pending: PendingHandoff) : UiState
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -1,19 +1,16 @@
 package com.woocommerce.android.ui.login.qrlogin
 
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.network.qrlogin.QrLoginCredentials
 import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
 import com.woocommerce.android.network.qrlogin.QrLoginRestClient
-import com.woocommerce.android.network.qrlogin.QrLoginScanException
 import com.woocommerce.android.network.qrlogin.QrLoginScanResult
 import com.woocommerce.android.network.qrlogin.QrLoginSessionStatus
 import com.woocommerce.android.network.qrlogin.QrLoginSessionStatusException
 import com.woocommerce.android.ui.login.AccountRepository
-import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Authenticating
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Error
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Idle
@@ -24,8 +21,6 @@ import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.io.IOException
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,8 +28,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
-import org.wordpress.android.fluxc.store.SiteStore.SiteError
-import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
 import javax.inject.Inject
 
 /**
@@ -59,6 +52,7 @@ class QrLoginScannerViewModel @Inject constructor(
     private val restClient: QrLoginRestClient,
     private val authenticator: QrLoginAuthenticator,
     private val accountRepository: AccountRepository,
+    private val errorMapper: QrLoginErrorMapper,
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedState) {
 
@@ -170,14 +164,15 @@ class QrLoginScannerViewModel @Inject constructor(
             restClient.scan(ticket.siteUrl, ticket.token).fold(
                 onSuccess = { scan -> beginWaitingForApproval(ticket, scan) },
                 onFailure = { failure ->
+                    val reason = errorMapper.toScanReason(failure)
                     trackScanFailure(
                         step = Step.SCAN,
                         errorContext = failure.javaClass.simpleName,
-                        errorType = failure.toScanReason().name,
+                        errorType = reason.name,
                     )
                     _uiState.value = Error(
-                        reason = failure.toScanReason(),
-                        retryTicket = ticket.takeIf { failure.toScanReason().isRetryEligible() }
+                        reason = reason,
+                        retryTicket = ticket.takeIf { errorMapper.isRetryEligible(reason) }
                     )
                 }
             )
@@ -226,7 +221,7 @@ class QrLoginScannerViewModel @Inject constructor(
                     },
                     onFailure = { failure ->
                         consecutiveErrors++
-                        val reason = failure.toPollReason()
+                        val reason = errorMapper.toPollReason(failure)
                         WooLog.w(
                             WooLog.T.LOGIN,
                             "QR login poll: failed (consecutive=$consecutiveErrors): $failure"
@@ -242,7 +237,7 @@ class QrLoginScannerViewModel @Inject constructor(
                             )
                             _uiState.value = Error(
                                 reason = reason,
-                                retryTicket = ticket.takeIf { reason.isRetryEligible() }
+                                retryTicket = ticket.takeIf { errorMapper.isRetryEligible(reason) }
                             )
                             return@launch
                         }
@@ -288,7 +283,7 @@ class QrLoginScannerViewModel @Inject constructor(
             credentialsResult.fold(
                 onSuccess = { credentials -> completeLogin(ticket, credentials) },
                 onFailure = { failure ->
-                    val reason = failure.toExchangeReason()
+                    val reason = errorMapper.toExchangeReason(failure)
                     val httpCode = (failure as? QrLoginExchangeException.HttpError)?.code
                     trackScanFailure(
                         step = Step.EXCHANGE,
@@ -298,8 +293,8 @@ class QrLoginScannerViewModel @Inject constructor(
                     )
                     _uiState.value = Error(
                         reason = reason,
-                        retryTicket = ticket.takeIf { reason.isRetryEligible() },
-                        retryExchangeGrant = exchangeGrant.takeIf { reason.isRetryEligible() }
+                        retryTicket = ticket.takeIf { errorMapper.isRetryEligible(reason) },
+                        retryExchangeGrant = exchangeGrant.takeIf { errorMapper.isRetryEligible(reason) }
                     )
                 }
             )
@@ -315,7 +310,7 @@ class QrLoginScannerViewModel @Inject constructor(
                 triggerEvent(Dispatch.LoggedIn(localSiteId))
             },
             onFailure = { failure ->
-                val reason = failure.toAuthReason()
+                val reason = errorMapper.toAuthReason(failure)
                 trackScanFailure(
                     step = Step.AUTH,
                     errorContext = failure.javaClass.simpleName,
@@ -420,77 +415,6 @@ class QrLoginScannerViewModel @Inject constructor(
             errorType = errorType,
             errorDescription = null
         )
-    }
-
-    private fun ErrorReason.isRetryEligible(): Boolean = when (this) {
-        ErrorReason.Network,
-        ErrorReason.ServerError,
-        ErrorReason.RateLimited -> true
-        else -> false
-    }
-
-    private fun Throwable.toScanReason(): ErrorReason = when (this) {
-        QrLoginScanException.TokenRejected -> ErrorReason.TokenRejected
-        QrLoginScanException.AlreadyScanned -> ErrorReason.MatchAlreadyScanned
-        QrLoginScanException.EndpointMissing -> ErrorReason.EndpointMissing
-        QrLoginScanException.RateLimited -> ErrorReason.RateLimited
-        QrLoginScanException.UpgradeRequired -> ErrorReason.EndpointMissing
-        QrLoginScanException.Network -> ErrorReason.Network
-        QrLoginScanException.MalformedRequest,
-        QrLoginScanException.MalformedResponse -> ErrorReason.ServerError
-        is QrLoginScanException.HttpError -> ErrorReason.ServerError
-        is QrLoginScanException.Unknown -> ErrorReason.Unknown
-        is IOException -> ErrorReason.Network
-        else -> ErrorReason.Unknown
-    }
-
-    private fun Throwable.toPollReason(): ErrorReason = when (this) {
-        QrLoginSessionStatusException.EndpointMissing -> ErrorReason.EndpointMissing
-        QrLoginSessionStatusException.RateLimited -> ErrorReason.RateLimited
-        QrLoginSessionStatusException.Network -> ErrorReason.Network
-        QrLoginSessionStatusException.MalformedResponse -> ErrorReason.ServerError
-        is QrLoginSessionStatusException.HttpError -> ErrorReason.ServerError
-        is QrLoginSessionStatusException.Unknown -> ErrorReason.Unknown
-        else -> {
-            WooLog.w(WooLog.T.LOGIN, "QR login poll: unmapped failure type ${this.javaClass.simpleName}")
-            ErrorReason.Unknown
-        }
-    }
-
-    private fun Throwable.toExchangeReason(): ErrorReason = when (this) {
-        QrLoginExchangeException.TokenRejected -> ErrorReason.TokenRejected
-        QrLoginExchangeException.EndpointMissing -> ErrorReason.EndpointMissing
-        QrLoginExchangeException.RateLimited -> ErrorReason.RateLimited
-        QrLoginExchangeException.Network -> ErrorReason.Network
-        QrLoginExchangeException.MalformedResponse -> ErrorReason.ServerError
-        QrLoginExchangeException.NotApproved -> ErrorReason.MatchTimedOut
-        QrLoginExchangeException.InvalidExchangeGrant -> ErrorReason.MatchInvalidGrant
-        is QrLoginExchangeException.HttpError -> ErrorReason.ServerError
-        is QrLoginExchangeException.Unknown -> ErrorReason.Unknown
-        else -> ErrorReason.Unknown
-    }
-
-    private fun Throwable.toAuthReason(): ErrorReason = when (this) {
-        QrLoginAuthenticationException.NotAWooSite -> ErrorReason.NotAWooSite
-        is QrLoginAuthenticationException.UserNotEligible -> ErrorReason.UserNotEligible
-        is CookieNonceAuthenticationException -> ErrorReason.SiteAuthFailure
-        is OnChangedException -> (error as? SiteError)?.type.toErrorReason()
-        // Catches DNS, socket, SSL handshake, and read failures during the post-exchange site
-        // discovery + AP save chain — those layers throw raw IOException without going through
-        // QrLoginExchangeException.
-        is IOException -> ErrorReason.Network
-        is CancellationException -> throw this
-        else -> {
-            WooLog.w(WooLog.T.LOGIN, "QR login: unmapped failure type ${this.javaClass.simpleName}")
-            ErrorReason.Unknown
-        }
-    }
-
-    private fun SiteErrorType?.toErrorReason(): ErrorReason = when (this) {
-        SiteErrorType.UNAUTHORIZED,
-        SiteErrorType.NOT_AUTHENTICATED -> ErrorReason.SiteAuthFailure
-        SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR -> ErrorReason.Network
-        else -> ErrorReason.Unknown
     }
 
     sealed class Dispatch : Event() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -198,12 +198,21 @@ class QrLoginScannerViewModel @Inject constructor(
 
     private fun startPolling(ticket: QrLoginPayload.Ticket, sessionId: String) {
         pollJob?.cancel()
+        WooLog.d(WooLog.T.LOGIN, "QR login poll: starting")
         pollJob = launch {
             var consecutiveErrors = 0
+            // Fire one poll immediately on entry — no point waiting two seconds for the first
+            // tick when the server-side state may already have advanced by the time we arrive.
+            var firstTick = true
             while (_uiState.value is WaitingForApproval) {
-                delay(POLL_INTERVAL_MS)
+                if (firstTick) {
+                    firstTick = false
+                } else {
+                    delay(POLL_INTERVAL_MS)
+                }
                 if (_uiState.value !is WaitingForApproval) return@launch
 
+                WooLog.d(WooLog.T.LOGIN, "QR login poll: tick")
                 val callResult = restClient.checkSessionStatus(ticket.siteUrl, sessionId)
                 // Guard after the await: cancel/start-over may have flipped state away from
                 // WaitingForApproval while the call was in flight. If so, drop the response
@@ -213,10 +222,15 @@ class QrLoginScannerViewModel @Inject constructor(
                 callResult.fold(
                     onSuccess = { status ->
                         consecutiveErrors = 0
+                        WooLog.d(WooLog.T.LOGIN, "QR login poll: response=$status")
                         if (handleStatus(ticket, status)) return@launch
                     },
                     onFailure = { failure ->
                         consecutiveErrors++
+                        WooLog.w(
+                            WooLog.T.LOGIN,
+                            "QR login poll: failed (consecutive=$consecutiveErrors): $failure"
+                        )
                         if (failure is QrLoginSessionStatusException.RateLimited ||
                             failure is QrLoginSessionStatusException.EndpointMissing ||
                             consecutiveErrors >= MAX_CONSECUTIVE_POLL_ERRORS
@@ -232,11 +246,10 @@ class QrLoginScannerViewModel @Inject constructor(
                             )
                             return@launch
                         }
-                        // Transient — log and let the next tick try again.
-                        WooLog.w(WooLog.T.LOGIN, "QR login session-status poll failed (transient): $failure")
                     }
                 )
             }
+            WooLog.d(WooLog.T.LOGIN, "QR login poll: loop exited (state=${_uiState.value::class.simpleName})")
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -212,7 +212,6 @@ class QrLoginScannerViewModel @Inject constructor(
                 }
                 if (_uiState.value !is WaitingForApproval) return@launch
 
-                WooLog.d(WooLog.T.LOGIN, "QR login poll: tick")
                 val callResult = restClient.checkSessionStatus(ticket.siteUrl, sessionId)
                 // Guard after the await: cancel/start-over may have flipped state away from
                 // WaitingForApproval while the call was in flight. If so, drop the response

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -5,20 +5,29 @@ import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.network.qrlogin.QrLoginCredentials
 import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
+import com.woocommerce.android.network.qrlogin.QrLoginRestClient
+import com.woocommerce.android.network.qrlogin.QrLoginScanException
+import com.woocommerce.android.network.qrlogin.QrLoginScanResult
+import com.woocommerce.android.network.qrlogin.QrLoginSessionStatus
+import com.woocommerce.android.network.qrlogin.QrLoginSessionStatusException
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository.CookieNonceAuthenticationException
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Authenticating
-import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Confirming
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Error
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.Idle
 import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.WarningSessionReplace
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState.WaitingForApproval
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -32,17 +41,22 @@ import javax.inject.Inject
  * Drives the QR login flow once the camera has produced a scan result:
  *
  *   1. Parse the deep link.
- *   2. Exchange the ticket for an Application Password.
- *   3. Persist credentials and resolve the selected site.
- *   4. Tell the activity to land in the main app via [Dispatch.LoggedIn].
+ *   2. Call /qr-login-scan to start the number-matching challenge.
+ *   3. Show the real number on screen and poll /qr-login-session-status until the merchant
+ *      taps the matching tile in wc-admin.
+ *   4. On approval, exchange the resulting grant for an Application Password.
+ *   5. Persist credentials, resolve the selected site, and tell the activity to land in the
+ *      main app via [Dispatch.LoggedIn].
  *
- * Recoverable failures (camera misread, invalid payload, network) keep the scanner running and
- * are tracked via [AnalyticsEvent.LOGIN_QR_SCAN_FAILED] with a [AnalyticsTracker.KEY_STEP] property.
+ * Recoverable failures (camera misread, invalid payload, transient network) keep the
+ * scanner running and are tracked via [AnalyticsEvent.LOGIN_QR_SCAN_FAILED] with a
+ * [AnalyticsTracker.KEY_STEP] property.
  */
 @HiltViewModel
 class QrLoginScannerViewModel @Inject constructor(
     savedState: SavedStateHandle,
     private val parser: QrLoginPayloadParser,
+    private val restClient: QrLoginRestClient,
     private val authenticator: QrLoginAuthenticator,
     private val accountRepository: AccountRepository,
     private val analyticsTracker: AnalyticsTrackerWrapper
@@ -52,6 +66,7 @@ class QrLoginScannerViewModel @Inject constructor(
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
     private var loggedIn = false
+    private var pollJob: Job? = null
 
     fun onScanResult(status: CodeScannerStatus) {
         if (!isIdle()) return
@@ -71,7 +86,8 @@ class QrLoginScannerViewModel @Inject constructor(
 
     /**
      * Entry point when the user opens a `woocommerce://qr-login?...` deep link from a browser.
-     * Reuses the same parse → confirm → exchange pipeline as a scanned QR, minus the camera.
+     * Reuses the same parse → scan → approve → exchange pipeline as a scanned QR, minus the
+     * camera.
      */
     fun onDeepLinkPayload(raw: String) {
         if (!isIdle()) return
@@ -127,10 +143,7 @@ class QrLoginScannerViewModel @Inject constructor(
 
     private fun resumePending(pending: PendingHandoff) {
         when (pending) {
-            is PendingHandoff.Ticket -> _uiState.value = Confirming(
-                ticket = pending.ticket,
-                host = pending.host
-            )
+            is PendingHandoff.Ticket -> startScan(pending.ticket)
             is PendingHandoff.WpComMagicLink -> {
                 // Hand the URL off to the browser; wp.com then 3xx-redirects to
                 // woocommerce://magic-login → MagicLinkInterceptActivity. Lock the state machine
@@ -151,17 +164,118 @@ class QrLoginScannerViewModel @Inject constructor(
         }
     }
 
-    private fun startExchange(ticket: QrLoginPayload.Ticket) {
-        _uiState.value = Authenticating
+    private fun startScan(ticket: QrLoginPayload.Ticket) {
+        _uiState.value = Authenticating(AuthPhase.ScanInFlight)
         launch {
-            authenticator.authenticate(ticket).fold(
-                onSuccess = { localSiteId ->
-                    loggedIn = true
-                    analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SUCCESS)
-                    triggerEvent(Dispatch.LoggedIn(localSiteId))
-                },
+            restClient.scan(ticket.siteUrl, ticket.token).fold(
+                onSuccess = { scan -> beginWaitingForApproval(ticket, scan) },
                 onFailure = { failure ->
-                    val reason = failure.toReason()
+                    trackScanFailure(
+                        step = Step.SCAN,
+                        errorContext = failure.javaClass.simpleName,
+                        errorType = failure.toScanReason().name,
+                    )
+                    _uiState.value = Error(
+                        reason = failure.toScanReason(),
+                        retryTicket = ticket.takeIf { failure.toScanReason().isRetryEligible() }
+                    )
+                }
+            )
+        }
+    }
+
+    private fun beginWaitingForApproval(ticket: QrLoginPayload.Ticket, scan: QrLoginScanResult) {
+        val expiresAt = System.currentTimeMillis() + scan.expiresInSeconds * MILLIS_PER_SECOND
+        _uiState.value = WaitingForApproval(
+            ticket = ticket,
+            host = ticket.siteUrl.toDisplayHost(),
+            realNumber = scan.realNumber,
+            sessionId = scan.sessionId,
+            expiresAtEpochMs = expiresAt,
+        )
+        startPolling(ticket = ticket, sessionId = scan.sessionId)
+    }
+
+    private fun startPolling(ticket: QrLoginPayload.Ticket, sessionId: String) {
+        pollJob?.cancel()
+        pollJob = launch {
+            var consecutiveErrors = 0
+            while (_uiState.value is WaitingForApproval) {
+                delay(POLL_INTERVAL_MS)
+                if (_uiState.value !is WaitingForApproval) return@launch
+
+                val callResult = restClient.checkSessionStatus(ticket.siteUrl, sessionId)
+                // Guard after the await: cancel/start-over may have flipped state away from
+                // WaitingForApproval while the call was in flight. If so, drop the response
+                // on the floor so the user doesn't get bounced into a "Signing in…" spinner
+                // they already cancelled out of.
+                if (_uiState.value !is WaitingForApproval) return@launch
+                callResult.fold(
+                    onSuccess = { status ->
+                        consecutiveErrors = 0
+                        if (handleStatus(ticket, status)) return@launch
+                    },
+                    onFailure = { failure ->
+                        consecutiveErrors++
+                        if (failure is QrLoginSessionStatusException.RateLimited ||
+                            failure is QrLoginSessionStatusException.EndpointMissing ||
+                            consecutiveErrors >= MAX_CONSECUTIVE_POLL_ERRORS
+                        ) {
+                            trackScanFailure(
+                                step = Step.POLL,
+                                errorContext = failure.javaClass.simpleName,
+                                errorType = ErrorReason.Network.name,
+                            )
+                            _uiState.value = Error(
+                                reason = failure.toPollReason(),
+                                retryTicket = ticket
+                            )
+                            return@launch
+                        }
+                        // Transient — log and let the next tick try again.
+                        WooLog.w(WooLog.T.LOGIN, "QR login session-status poll failed (transient): $failure")
+                    }
+                )
+            }
+        }
+    }
+
+    /** @return true if the polling loop should stop. */
+    private fun handleStatus(ticket: QrLoginPayload.Ticket, status: QrLoginSessionStatus): Boolean = when (status) {
+        QrLoginSessionStatus.Scanned -> false
+        is QrLoginSessionStatus.Approved -> {
+            startExchange(ticket = ticket, exchangeGrant = status.grant)
+            true
+        }
+        QrLoginSessionStatus.Rejected -> {
+            trackScanFailure(
+                step = Step.APPROVE,
+                errorContext = null,
+                errorType = ErrorReason.MatchRejected.name,
+            )
+            _uiState.value = Error(reason = ErrorReason.MatchRejected, retryTicket = null)
+            true
+        }
+        QrLoginSessionStatus.Expired -> {
+            trackScanFailure(
+                step = Step.APPROVE,
+                errorContext = null,
+                errorType = ErrorReason.MatchTimedOut.name,
+            )
+            _uiState.value = Error(reason = ErrorReason.MatchTimedOut, retryTicket = null)
+            true
+        }
+    }
+
+    private fun startExchange(ticket: QrLoginPayload.Ticket, exchangeGrant: String) {
+        pollJob?.cancel()
+        _uiState.value = Authenticating(AuthPhase.ExchangeInFlight)
+        launch {
+            val credentialsResult = restClient.exchange(ticket.siteUrl, ticket.token, exchangeGrant)
+            credentialsResult.fold(
+                onSuccess = { credentials -> completeLogin(ticket, credentials) },
+                onFailure = { failure ->
+                    val reason = failure.toExchangeReason()
                     val httpCode = (failure as? QrLoginExchangeException.HttpError)?.code
                     trackScanFailure(
                         step = Step.EXCHANGE,
@@ -178,34 +292,63 @@ class QrLoginScannerViewModel @Inject constructor(
         }
     }
 
+    private suspend fun completeLogin(ticket: QrLoginPayload.Ticket, credentials: QrLoginCredentials) {
+        _uiState.value = Authenticating(AuthPhase.SiteFetchInFlight)
+        authenticator.completeLogin(ticket, credentials).fold(
+            onSuccess = { localSiteId ->
+                loggedIn = true
+                analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SUCCESS)
+                triggerEvent(Dispatch.LoggedIn(localSiteId))
+            },
+            onFailure = { failure ->
+                val reason = failure.toAuthReason()
+                trackScanFailure(
+                    step = Step.AUTH,
+                    errorContext = failure.javaClass.simpleName,
+                    errorType = reason.name,
+                )
+                _uiState.value = Error(reason = reason, retryTicket = null)
+            }
+        )
+    }
+
+    /**
+     * Cancel the in-flight number-match step. The server keeps the session in `scanned`
+     * until its 90-second window elapses; wc-admin's polling then auto-transitions to the
+     * "denied" terminal screen. We don't call any cancel endpoint — the natural expiry
+     * is the contract.
+     */
+    fun onCancelNumberMatch() {
+        if (_uiState.value !is WaitingForApproval) return
+        pollJob?.cancel()
+        pollJob = null
+        _uiState.value = Idle
+    }
+
     /**
      * Reset the blocking state so the user can scan a fresh QR. Tokens are single-use, so we
      * never retry the same payload — the scanner reappears and the merchant generates a new code.
      */
     fun onStartOver() {
         if (loggedIn) return
+        pollJob?.cancel()
+        pollJob = null
         _uiState.value = Idle
     }
 
     /**
-     * Re-runs the exchange with the same ticket from the last attempt. Wired up to error
-     * screens for transient failures (network, server, rate-limited) where the token is most
-     * likely still valid. If the server actually consumed the token before the failure, the
-     * retry surfaces [ErrorReason.TokenRejected] which then routes the user to the scanner
-     * via the standard "Scan a new code" action.
+     * Re-runs the most recent step using the retained ticket. Used by error screens for
+     * transient failures (network, rate-limit) where the token is most likely still valid.
      */
     fun onRetryExchange() {
         val ticket = (_uiState.value as? Error)?.retryTicket ?: return
-        startExchange(ticket)
+        startScan(ticket)
     }
 
-    fun onConfirmSite() {
-        val pending = _uiState.value as? Confirming ?: return
-        startExchange(pending.ticket)
-    }
-
-    fun onCancelSite() {
-        if (_uiState.value is Confirming) _uiState.value = Idle
+    override fun onCleared() {
+        pollJob?.cancel()
+        pollJob = null
+        super.onCleared()
     }
 
     /**
@@ -214,14 +357,14 @@ class QrLoginScannerViewModel @Inject constructor(
      * sessions, plus prefs / analytics / Zendesk / DataStore cleanup) and then resume the
      * original payload action exactly as if the user had been signed out from the start.
      *
-     * We flip into [Authenticating] for the duration of the logout so the UI gives feedback
-     * while [AccountRepository.logout] talks to the server — for the Ticket path this is then
-     * overwritten by [Confirming] so the merchant still sees the host-confirmation step.
+     * We flip into [Authenticating] for the duration of the logout so the UI gives feedback while
+     * [AccountRepository.logout] talks to the server. For the Ticket path this is then overwritten
+     * by the scan / number-match flow.
      */
     fun onConfirmSessionReplace() {
         val pending = (_uiState.value as? WarningSessionReplace)?.pending ?: return
         analyticsTracker.track(AnalyticsEvent.LOGIN_QR_SESSION_REPLACE_CONFIRMED)
-        _uiState.value = Authenticating
+        _uiState.value = Authenticating(AuthPhase.SessionReplaceInFlight)
         launch {
             accountRepository.logout()
             resumePending(pending)
@@ -269,14 +412,45 @@ class QrLoginScannerViewModel @Inject constructor(
         else -> false
     }
 
-    private fun Throwable.toReason(): ErrorReason = when (this) {
+    private fun Throwable.toScanReason(): ErrorReason = when (this) {
+        QrLoginScanException.TokenRejected -> ErrorReason.TokenRejected
+        QrLoginScanException.AlreadyScanned -> ErrorReason.MatchAlreadyScanned
+        QrLoginScanException.EndpointMissing -> ErrorReason.EndpointMissing
+        QrLoginScanException.RateLimited -> ErrorReason.RateLimited
+        QrLoginScanException.UpgradeRequired -> ErrorReason.EndpointMissing
+        QrLoginScanException.Network -> ErrorReason.Network
+        QrLoginScanException.MalformedRequest,
+        QrLoginScanException.MalformedResponse -> ErrorReason.ServerError
+        is QrLoginScanException.HttpError -> ErrorReason.ServerError
+        is QrLoginScanException.Unknown -> ErrorReason.Unknown
+        is IOException -> ErrorReason.Network
+        else -> ErrorReason.Unknown
+    }
+
+    private fun Throwable.toPollReason(): ErrorReason = when (this) {
+        QrLoginSessionStatusException.EndpointMissing -> ErrorReason.EndpointMissing
+        QrLoginSessionStatusException.RateLimited -> ErrorReason.RateLimited
+        QrLoginSessionStatusException.Network -> ErrorReason.Network
+        QrLoginSessionStatusException.MalformedResponse -> ErrorReason.ServerError
+        is QrLoginSessionStatusException.HttpError -> ErrorReason.ServerError
+        is QrLoginSessionStatusException.Unknown -> ErrorReason.Unknown
+        else -> ErrorReason.Network
+    }
+
+    private fun Throwable.toExchangeReason(): ErrorReason = when (this) {
         QrLoginExchangeException.TokenRejected -> ErrorReason.TokenRejected
         QrLoginExchangeException.EndpointMissing -> ErrorReason.EndpointMissing
         QrLoginExchangeException.RateLimited -> ErrorReason.RateLimited
         QrLoginExchangeException.Network -> ErrorReason.Network
         QrLoginExchangeException.MalformedResponse -> ErrorReason.ServerError
+        QrLoginExchangeException.NotApproved -> ErrorReason.MatchTimedOut
+        QrLoginExchangeException.InvalidExchangeGrant -> ErrorReason.MatchInvalidGrant
         is QrLoginExchangeException.HttpError -> ErrorReason.ServerError
         is QrLoginExchangeException.Unknown -> ErrorReason.Unknown
+        else -> ErrorReason.Unknown
+    }
+
+    private fun Throwable.toAuthReason(): ErrorReason = when (this) {
         QrLoginAuthenticationException.NotAWooSite -> ErrorReason.NotAWooSite
         is QrLoginAuthenticationException.UserNotEligible -> ErrorReason.UserNotEligible
         is CookieNonceAuthenticationException -> ErrorReason.SiteAuthFailure
@@ -285,6 +459,7 @@ class QrLoginScannerViewModel @Inject constructor(
         // discovery + AP save chain — those layers throw raw IOException without going through
         // QrLoginExchangeException.
         is IOException -> ErrorReason.Network
+        is CancellationException -> throw this
         else -> {
             WooLog.w(WooLog.T.LOGIN, "QR login: unmapped failure type ${this.javaClass.simpleName}")
             ErrorReason.Unknown
@@ -319,8 +494,14 @@ class QrLoginScannerViewModel @Inject constructor(
 
     sealed interface UiState {
         data object Idle : UiState
-        data class Confirming(val ticket: QrLoginPayload.Ticket, val host: String) : UiState
-        data object Authenticating : UiState
+        data class Authenticating(val phase: AuthPhase) : UiState
+        data class WaitingForApproval(
+            val ticket: QrLoginPayload.Ticket,
+            val host: String,
+            val realNumber: String,
+            val sessionId: String,
+            val expiresAtEpochMs: Long,
+        ) : UiState
         data class Error(val reason: ErrorReason, val retryTicket: QrLoginPayload.Ticket?) : UiState
         data class WarningSessionReplace(val pending: PendingHandoff) : UiState
     }
@@ -336,6 +517,13 @@ class QrLoginScannerViewModel @Inject constructor(
         data class SiteUrlPrefill(val siteUrl: String) : PendingHandoff
     }
 
+    enum class AuthPhase {
+        SessionReplaceInFlight,
+        ScanInFlight,
+        ExchangeInFlight,
+        SiteFetchInFlight,
+    }
+
     enum class ErrorReason {
         InvalidPayload,
         InstallQrCode,
@@ -348,15 +536,22 @@ class QrLoginScannerViewModel @Inject constructor(
         SiteAuthFailure,
         NotAWooSite,
         UserNotEligible,
+        MatchRejected,
+        MatchTimedOut,
+        MatchAlreadyScanned,
+        MatchInvalidGrant,
         Unknown
     }
 
     enum class Step {
-        SCANNER, PAYLOAD, EXCHANGE
+        SCANNER, PAYLOAD, SCAN, POLL, APPROVE, EXCHANGE, AUTH
     }
 
     private companion object {
         const val HTTPS_DEFAULT_PORT = 443
         const val HTTP_DEFAULT_PORT = 80
+        const val POLL_INTERVAL_MS = 2_000L
+        const val MILLIS_PER_SECOND = 1_000L
+        const val MAX_CONSECUTIVE_POLL_ERRORS = 4
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -451,7 +451,10 @@ class QrLoginScannerViewModel @Inject constructor(
         QrLoginSessionStatusException.MalformedResponse -> ErrorReason.ServerError
         is QrLoginSessionStatusException.HttpError -> ErrorReason.ServerError
         is QrLoginSessionStatusException.Unknown -> ErrorReason.Unknown
-        else -> ErrorReason.Network
+        else -> {
+            WooLog.w(WooLog.T.LOGIN, "QR login poll: unmapped failure type ${this.javaClass.simpleName}")
+            ErrorReason.Unknown
+        }
     }
 
     private fun Throwable.toExchangeReason(): ErrorReason = when (this) {

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -228,11 +228,12 @@
     <string name="login_qr_endpoint_missing_body">Your WooCommerce plugin doesn\'t support QR login. Please update WooCommerce on your store and try again, or sign in by entering your site URL.</string>
     <string name="login_qr_endpoint_missing_enter_url">Enter site URL instead</string>
     <string name="login_qr_endpoint_missing_retry">Try scanning again</string>
-    <string name="login_qr_confirm_title">Sign in to this store?</string>
-    <string name="login_qr_confirm_subtitle">Only continue if this is your store.</string>
-    <string name="login_qr_confirm_security_note">You\'re signing in with a one-time code from this store.</string>
-    <string name="login_qr_confirm_connect">Continue</string>
-    <string name="login_qr_confirm_cancel">Cancel</string>
+    <!-- Number-matching approval step -->
+    <string name="login_qr_match_title">Confirm sign-in</string>
+    <string name="login_qr_match_subtitle">Tap this number on your computer to finish signing in to %s.</string>
+    <string name="login_qr_match_countdown" comment="%1$d is seconds remaining before the challenge expires.">Expires in %1$ds</string>
+    <string name="login_qr_match_cancel">Cancel</string>
+    <string name="login_qr_match_security_note">Both screens must show the same number for sign-in to complete.</string>
 
     <!-- Fullscreen error titles + bodies (split from snackbar copy) -->
     <string name="login_qr_scanner_error_generic_title">Couldn\'t read that code</string>
@@ -256,6 +257,14 @@
     <string name="login_qr_scanner_error_not_woo_body">This site doesn\'t have WooCommerce installed.</string>
     <string name="login_qr_scanner_error_user_role_title">Permission needed</string>
     <string name="login_qr_scanner_error_user_role_body">Your account doesn\'t have permission to use the app for this store.</string>
+    <string name="login_qr_scanner_error_match_rejected_title">Sign-in denied</string>
+    <string name="login_qr_scanner_error_match_rejected_body">For your security, this sign-in attempt was cancelled. Generate a new code in your store to try again.</string>
+    <string name="login_qr_scanner_error_match_timed_out_title">Sign-in timed out</string>
+    <string name="login_qr_scanner_error_match_timed_out_body">You didn\'t confirm in time. Generate a new code in your store and try again.</string>
+    <string name="login_qr_scanner_error_match_already_scanned_title">Code already used</string>
+    <string name="login_qr_scanner_error_match_already_scanned_body">That code has already been scanned. Generate a new one in your store.</string>
+    <string name="login_qr_scanner_error_match_invalid_grant_title">Sign-in interrupted</string>
+    <string name="login_qr_scanner_error_match_invalid_grant_body">Your sign-in was interrupted. Generate a new code in your store and try again.</string>
     <string name="login_qr_error_primary_retry">Try again</string>
     <string name="login_qr_error_primary_scan">Scan a new code</string>
     <string name="login_qr_session_replace_title">You\'re already signed in</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -230,7 +230,8 @@
     <string name="login_qr_endpoint_missing_retry">Try scanning again</string>
     <!-- Number-matching approval step -->
     <string name="login_qr_match_title">Confirm sign-in</string>
-    <string name="login_qr_match_subtitle">Tap this number on your computer to finish signing in to %s.</string>
+    <string name="login_qr_match_host_label">You\'re signing in to</string>
+    <string name="login_qr_match_subtitle">Tap this number on your computer to finish.</string>
     <string name="login_qr_match_countdown" comment="%1$d is seconds remaining before the challenge expires.">Expires in %1$ds</string>
     <string name="login_qr_match_cancel">Cancel</string>
     <string name="login_qr_match_security_note">Both screens must show the same number for sign-in to complete.</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -232,7 +232,8 @@
     <string name="login_qr_match_title">Confirm sign-in</string>
     <string name="login_qr_match_host_label">You\'re signing in to</string>
     <string name="login_qr_match_subtitle">Tap this number on your computer to finish.</string>
-    <string name="login_qr_match_countdown" comment="%1$d is seconds remaining before the challenge expires.">Expires in %1$ds</string>
+    <!-- translators: %1$d is seconds remaining before the challenge expires. -->
+    <string name="login_qr_match_countdown">Expires in %1$ds</string>
     <string name="login_qr_match_cancel">Cancel</string>
     <string name="login_qr_match_security_note">Both screens must show the same number for sign-in to complete.</string>
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -232,7 +232,6 @@
     <string name="login_qr_match_title">Confirm sign-in</string>
     <string name="login_qr_match_host_label">You\'re signing in to</string>
     <string name="login_qr_match_subtitle">Tap this number on your computer to finish.</string>
-    <!-- translators: %1$d is seconds remaining before the challenge expires. -->
     <string name="login_qr_match_countdown">Expires in %1$ds</string>
     <string name="login_qr_match_cancel">Cancel</string>
     <string name="login_qr_match_security_note">Both screens must show the same number for sign-in to complete.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
@@ -339,6 +339,9 @@ class QrLoginRestClientTest : BaseUnitTest() {
         assertThat(request.method).isEqualTo("GET")
         assertThat(request.url.toString())
             .isEqualTo("https://store.example/wp-json/wc-admin/mobile-app/qr-login-session-status?session_id=sess-99")
+        assertThat(request.header("Cache-Control"))
+            .contains("no-cache")
+            .contains("no-store")
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.network.qrlogin
 
 import com.google.gson.Gson
+import com.google.gson.JsonObject
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,7 +22,7 @@ import java.io.IOException
 class QrLoginRestClientTest : BaseUnitTest() {
 
     private var lastRequest: Request? = null
-    private var responder: (Request) -> Response = { ok(it, DEFAULT_SUCCESS_BODY) }
+    private var responder: (Request) -> Response = { ok(it, DEFAULT_EXCHANGE_BODY) }
 
     private val okHttpClient = OkHttpClient.Builder()
         .addInterceptor(
@@ -54,9 +55,11 @@ class QrLoginRestClientTest : BaseUnitTest() {
         )
     }
 
+    // region exchange
+
     @Test
     fun `given 200 with valid body, when exchange, then returns credentials`() = testBlocking {
-        val result = client.exchange("https://store.example", "tok")
+        val result = client.exchange("https://store.example", "tok", "grant-1")
 
         assertThat(result.getOrNull()).isEqualTo(
             QrLoginCredentials(userLogin = "admin", applicationPassword = "ap-secret")
@@ -65,58 +68,39 @@ class QrLoginRestClientTest : BaseUnitTest() {
 
     @Test
     fun `given valid credentials, when toString is called, then password is redacted`() = testBlocking {
-        val credentials = requireNotNull(client.exchange("https://store.example", "tok").getOrNull())
+        val credentials = requireNotNull(client.exchange("https://store.example", "tok", "g").getOrNull())
 
         assertThat(credentials.toString()).doesNotContain("ap-secret")
     }
 
     @Test
     fun `given siteUrl with trailing slash, when exchange, then request path is normalized`() = testBlocking {
-        client.exchange("https://store.example/", "tok")
+        client.exchange("https://store.example/", "tok", "g")
 
         assertThat(lastRequest?.url.toString())
             .isEqualTo("https://store.example/wp-json/wc-admin/mobile-app/qr-login-exchange")
     }
 
     @Test
-    fun `given exchange call, when executed, then request is POST with JSON body containing the token`() = testBlocking {
-        client.exchange("https://store.example", "tok-42")
-
-        val request = requireNotNull(lastRequest)
-        assertThat(request.method).isEqualTo("POST")
-        assertThat(request.body?.contentType()?.toString()).startsWith("application/json")
-        val buffer = Buffer().also { requireNotNull(request.body).writeTo(it) }
-        val body = buffer.readUtf8()
-        // The body now also carries a `device` object alongside the token; assert
-        // on the token field shape rather than the full string so future device
-        // payload tweaks don't break this test.
-        assertThat(body).contains(""""token":"tok-42"""")
-    }
-
-    @Test
-    fun `given exchange call, when executed, then JSON body includes device metadata from the provider`() =
+    fun `given exchange call, when executed, then JSON body contains token and exchange_grant and not device`() =
         testBlocking {
-            client.exchange("https://store.example", "tok-42")
+            client.exchange("https://store.example", "tok-42", "grant-xyz")
 
-            val request = requireNotNull(lastRequest)
-            val body = Buffer().also { requireNotNull(request.body).writeTo(it) }.readUtf8()
-            val parsed = Gson().fromJson(body, com.google.gson.JsonObject::class.java)
-            val device = requireNotNull(parsed.getAsJsonObject("device")) {
-                "Exchange request must include a `device` object alongside the token."
-            }
-
-            assertThat(device.get("os").asString).isEqualTo("Android")
-            assertThat(device.get("os_version").asString).isEqualTo("14")
-            assertThat(device.get("model").asString).isEqualTo("Pixel 8 Pro")
-            assertThat(device.get("brand").asString).isEqualTo("google")
-            assertThat(device.get("app_version").asString).isEqualTo("24.7.0")
+            val body = readBody(requireNotNull(lastRequest))
+            val parsed = Gson().fromJson(body, JsonObject::class.java)
+            assertThat(parsed.get("token").asString).isEqualTo("tok-42")
+            assertThat(parsed.get("exchange_grant").asString).isEqualTo("grant-xyz")
+            // The post-Task-7 contract sources `device` from /qr-login-scan, so it must NOT
+            // appear here — sending it would be silently dropped server-side, but we want to
+            // be explicit so a regression is loud.
+            assertThat(parsed.has("device")).isFalse()
         }
 
     @Test
     fun `given 401, when exchange, then TokenRejected`() = testBlocking {
         responder = { respond(it, code = 401) }
 
-        val result = client.exchange("https://store.example", "tok")
+        val result = client.exchange("https://store.example", "tok", "g")
 
         assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.TokenRejected)
     }
@@ -125,7 +109,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given 403, when exchange, then TokenRejected`() = testBlocking {
         responder = { respond(it, code = 403) }
 
-        val result = client.exchange("https://store.example", "tok")
+        val result = client.exchange("https://store.example", "tok", "g")
 
         assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.TokenRejected)
     }
@@ -134,7 +118,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given 404, when exchange, then EndpointMissing`() = testBlocking {
         responder = { respond(it, code = 404) }
 
-        val result = client.exchange("https://store.example", "tok")
+        val result = client.exchange("https://store.example", "tok", "g")
 
         assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.EndpointMissing)
     }
@@ -143,16 +127,43 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given 429, when exchange, then RateLimited`() = testBlocking {
         responder = { respond(it, code = 429) }
 
-        val result = client.exchange("https://store.example", "tok")
+        val result = client.exchange("https://store.example", "tok", "g")
 
         assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.RateLimited)
+    }
+
+    @Test
+    fun `given 412 with qr_login_not_approved code, when exchange, then NotApproved`() = testBlocking {
+        responder = { respond(it, code = 412, body = """{"code":"qr_login_not_approved"}""") }
+
+        val result = client.exchange("https://store.example", "tok", "g")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.NotApproved)
+    }
+
+    @Test
+    fun `given 412 with invalid_exchange_grant code, when exchange, then InvalidExchangeGrant`() = testBlocking {
+        responder = { respond(it, code = 412, body = """{"code":"invalid_exchange_grant"}""") }
+
+        val result = client.exchange("https://store.example", "tok", "g")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.InvalidExchangeGrant)
+    }
+
+    @Test
+    fun `given 412 with unknown code, when exchange, then HttpError 412`() = testBlocking {
+        responder = { respond(it, code = 412, body = """{"code":"something_else"}""") }
+
+        val result = client.exchange("https://store.example", "tok", "g")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.HttpError(412))
     }
 
     @Test
     fun `given 500, when exchange, then HttpError with status code`() = testBlocking {
         responder = { respond(it, code = 500) }
 
-        val result = client.exchange("https://store.example", "tok")
+        val result = client.exchange("https://store.example", "tok", "g")
 
         assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.HttpError(500))
     }
@@ -161,7 +172,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given network IOException, when exchange, then Network`() = testBlocking {
         responder = { throw IOException("connection refused") }
 
-        val result = client.exchange("https://store.example", "tok")
+        val result = client.exchange("https://store.example", "tok", "g")
 
         assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.Network)
     }
@@ -170,7 +181,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given 200 with non-JSON body, when exchange, then MalformedResponse`() = testBlocking {
         responder = { ok(it, body = "not json at all") }
 
-        val result = client.exchange("https://store.example", "tok")
+        val result = client.exchange("https://store.example", "tok", "g")
 
         assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.MalformedResponse)
     }
@@ -179,7 +190,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given 200 missing user_login, when exchange, then MalformedResponse`() = testBlocking {
         responder = { ok(it, body = """{"site_url":"https://x","application_password":"ap"}""") }
 
-        val result = client.exchange("https://store.example", "tok")
+        val result = client.exchange("https://store.example", "tok", "g")
 
         assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.MalformedResponse)
     }
@@ -190,7 +201,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
             ok(it, body = """{"user_login":"admin","site_url":"https://x","application_password":"  "}""")
         }
 
-        val result = client.exchange("https://store.example", "tok")
+        val result = client.exchange("https://store.example", "tok", "g")
 
         assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.MalformedResponse)
     }
@@ -200,7 +211,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
         val boom = RuntimeException("oops")
         responder = { throw boom }
 
-        val result = client.exchange("https://store.example", "tok")
+        val result = client.exchange("https://store.example", "tok", "g")
 
         val failure = result.exceptionOrNull()
         assertThat(failure).isInstanceOf(QrLoginExchangeException.Unknown::class.java)
@@ -208,18 +219,201 @@ class QrLoginRestClientTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given CancellationException during call, when exchange, then it propagates unwrapped`() = testBlocking {
+    fun `given CancellationException during exchange, when called, then it propagates unwrapped`() = testBlocking {
         responder = { throw CancellationException("cancelled") }
 
         var thrown: Throwable? = null
         try {
-            client.exchange("https://store.example", "tok")
+            client.exchange("https://store.example", "tok", "g")
         } catch (t: Throwable) {
             thrown = t
         }
 
         assertThat(thrown).isInstanceOf(CancellationException::class.java)
     }
+
+    // endregion
+
+    // region scan
+
+    @Test
+    fun `given scan call, when executed, then request is POST with token, device, and capability flag`() =
+        testBlocking {
+            responder = { ok(it, DEFAULT_SCAN_BODY) }
+
+            client.scan("https://store.example", "tok-42")
+
+            val request = requireNotNull(lastRequest)
+            assertThat(request.method).isEqualTo("POST")
+            assertThat(request.url.toString())
+                .isEqualTo("https://store.example/wp-json/wc-admin/mobile-app/qr-login-scan")
+            val parsed = Gson().fromJson(readBody(request), JsonObject::class.java)
+            assertThat(parsed.get("token").asString).isEqualTo("tok-42")
+            assertThat(parsed.get("supports_number_matching").asBoolean).isTrue()
+            val device = requireNotNull(parsed.getAsJsonObject("device")) {
+                "Scan request must include a device payload"
+            }
+            assertThat(device.get("os").asString).isEqualTo("Android")
+            assertThat(device.get("os_version").asString).isEqualTo("14")
+            assertThat(device.get("model").asString).isEqualTo("Pixel 8 Pro")
+            assertThat(device.get("brand").asString).isEqualTo("google")
+            assertThat(device.get("app_version").asString).isEqualTo("24.7.0")
+        }
+
+    @Test
+    fun `given 200 valid scan body, when scan, then returns session id and real number`() = testBlocking {
+        responder = { ok(it, DEFAULT_SCAN_BODY) }
+
+        val result = client.scan("https://store.example", "tok")
+
+        assertThat(result.getOrNull()).isEqualTo(
+            QrLoginScanResult(sessionId = "sess-1", realNumber = "042", expiresInSeconds = 90)
+        )
+    }
+
+    @Test
+    fun `given 401, when scan, then TokenRejected`() = testBlocking {
+        responder = { respond(it, code = 401) }
+
+        val result = client.scan("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginScanException.TokenRejected)
+    }
+
+    @Test
+    fun `given 409, when scan, then AlreadyScanned`() = testBlocking {
+        responder = { respond(it, code = 409) }
+
+        val result = client.scan("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginScanException.AlreadyScanned)
+    }
+
+    @Test
+    fun `given 426, when scan, then UpgradeRequired`() = testBlocking {
+        responder = { respond(it, code = 426) }
+
+        val result = client.scan("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginScanException.UpgradeRequired)
+    }
+
+    @Test
+    fun `given 429, when scan, then RateLimited`() = testBlocking {
+        responder = { respond(it, code = 429) }
+
+        val result = client.scan("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginScanException.RateLimited)
+    }
+
+    @Test
+    fun `given network IOException, when scan, then Network`() = testBlocking {
+        responder = { throw IOException("connection refused") }
+
+        val result = client.scan("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginScanException.Network)
+    }
+
+    @Test
+    fun `given 200 missing real_number, when scan, then MalformedResponse`() = testBlocking {
+        responder = { ok(it, body = """{"session_id":"sess-1","expires_in":90}""") }
+
+        val result = client.scan("https://store.example", "tok")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginScanException.MalformedResponse)
+    }
+
+    // endregion
+
+    // region session status
+
+    @Test
+    fun `given session-status call, when executed, then GET request includes session_id`() = testBlocking {
+        responder = { ok(it, """{"state":"scanned"}""") }
+
+        client.checkSessionStatus("https://store.example", "sess-99")
+
+        val request = requireNotNull(lastRequest)
+        assertThat(request.method).isEqualTo("GET")
+        assertThat(request.url.toString())
+            .isEqualTo("https://store.example/wp-json/wc-admin/mobile-app/qr-login-session-status?session_id=sess-99")
+    }
+
+    @Test
+    fun `given state=scanned, when session-status, then Scanned`() = testBlocking {
+        responder = { ok(it, """{"state":"scanned"}""") }
+
+        val result = client.checkSessionStatus("https://store.example", "sess-1")
+
+        assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Scanned)
+    }
+
+    @Test
+    fun `given state=approved with grant, when session-status, then Approved with grant`() = testBlocking {
+        responder = { ok(it, """{"state":"approved","exchange_grant":"grant-99"}""") }
+
+        val result = client.checkSessionStatus("https://store.example", "sess-1")
+
+        assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Approved("grant-99"))
+    }
+
+    @Test
+    fun `given state=approved without grant, when session-status, then fails closed as Expired`() = testBlocking {
+        responder = { ok(it, """{"state":"approved"}""") }
+
+        val result = client.checkSessionStatus("https://store.example", "sess-1")
+
+        assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Expired)
+    }
+
+    @Test
+    fun `given state=rejected, when session-status, then Rejected`() = testBlocking {
+        responder = { ok(it, """{"state":"rejected"}""") }
+
+        val result = client.checkSessionStatus("https://store.example", "sess-1")
+
+        assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Rejected)
+    }
+
+    @Test
+    fun `given state=expired, when session-status, then Expired`() = testBlocking {
+        responder = { ok(it, """{"state":"expired"}""") }
+
+        val result = client.checkSessionStatus("https://store.example", "sess-1")
+
+        assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Expired)
+    }
+
+    @Test
+    fun `given unknown state, when session-status, then fails closed as Expired`() = testBlocking {
+        responder = { ok(it, """{"state":"some_future_state"}""") }
+
+        val result = client.checkSessionStatus("https://store.example", "sess-1")
+
+        assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Expired)
+    }
+
+    @Test
+    fun `given 429, when session-status, then RateLimited`() = testBlocking {
+        responder = { respond(it, code = 429) }
+
+        val result = client.checkSessionStatus("https://store.example", "sess-1")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginSessionStatusException.RateLimited)
+    }
+
+    @Test
+    fun `given network IOException, when session-status, then Network`() = testBlocking {
+        responder = { throw IOException("disconnect") }
+
+        val result = client.checkSessionStatus("https://store.example", "sess-1")
+
+        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginSessionStatusException.Network)
+    }
+
+    // endregion
 
     private fun ok(request: Request, body: String): Response = Response.Builder()
         .request(request)
@@ -237,10 +431,15 @@ class QrLoginRestClientTest : BaseUnitTest() {
         .body(body.toResponseBody(JSON_MEDIA_TYPE))
         .build()
 
+    private fun readBody(request: Request): String =
+        Buffer().also { requireNotNull(request.body).writeTo(it) }.readUtf8()
+
     private companion object {
-        const val DEFAULT_SUCCESS_BODY =
+        const val DEFAULT_EXCHANGE_BODY =
             """{"user_login":"admin","site_url":"https://store.example",""" +
                 """"application_password":"ap-secret"}"""
+        const val DEFAULT_SCAN_BODY =
+            """{"session_id":"sess-1","real_number":"042","expires_in":90}"""
         val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAuthenticatorTest.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.ui.login.qrlogin
 
 import com.woocommerce.android.network.qrlogin.QrLoginCredentials
-import com.woocommerce.android.network.qrlogin.QrLoginRestClient
-import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.login.AccountRepository
 import com.woocommerce.android.ui.login.WPApiSiteRepository
@@ -42,19 +40,15 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
         hasWooCommerce = false
     }
 
-    private val exchangeClient: QrLoginRestClient = mock()
     private val repo: WPApiSiteRepository = mock()
     private val siteStore: SiteStore = mock()
     private val selectedSite: SelectedSite = mock()
     private val accountRepository: AccountRepository = mock()
 
-    private val authenticator =
-        QrLoginAuthenticator(exchangeClient, repo, siteStore, selectedSite, accountRepository)
+    private val authenticator = QrLoginAuthenticator(repo, siteStore, selectedSite, accountRepository)
 
     @Before
     fun setUp() = testBlocking {
-        whenever(exchangeClient.exchange(ticket.siteUrl, ticket.token))
-            .thenReturn(Result.success(credentials))
         whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword))
             .thenReturn(Result.success(site))
         whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.success(true))
@@ -62,8 +56,8 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given happy path, when authenticate, then returns site id and persists credentials`() = testBlocking {
-        val result = authenticator.authenticate(ticket)
+    fun `given happy path, when completeLogin, then returns site id and persists credentials`() = testBlocking {
+        val result = authenticator.completeLogin(ticket, credentials)
 
         assertThat(result).isEqualTo(Result.success(42))
         verify(repo).saveApplicationPassword(
@@ -75,23 +69,11 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given exchange fails, when authenticate, then propagates exchange exception`() = testBlocking {
-        whenever(exchangeClient.exchange(ticket.siteUrl, ticket.token))
-            .thenReturn(Result.failure(QrLoginExchangeException.RateLimited))
-
-        val result = authenticator.authenticate(ticket)
-
-        assertThat(result.exceptionOrNull()).isEqualTo(QrLoginExchangeException.RateLimited)
-        verify(repo, never()).saveApplicationPassword(any(), any(), any())
-        verifyNoInteractions(selectedSite)
-    }
-
-    @Test
-    fun `given site has no WooCommerce, when authenticate, then NotAWooSite and AP not saved`() = testBlocking {
+    fun `given site has no WooCommerce, when completeLogin, then NotAWooSite and AP not saved`() = testBlocking {
         whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword))
             .thenReturn(Result.success(nonWooSite))
 
-        val result = authenticator.authenticate(ticket)
+        val result = authenticator.completeLogin(ticket, credentials)
 
         assertThat(result.exceptionOrNull()).isInstanceOf(QrLoginAuthenticationException.NotAWooSite::class.java)
         verify(repo, never()).saveApplicationPassword(any(), any(), any())
@@ -99,10 +81,10 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given user is not eligible, when authenticate, then UserNotEligible and site not selected`() = testBlocking {
+    fun `given user is not eligible, when completeLogin, then UserNotEligible and site not selected`() = testBlocking {
         whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.success(false))
 
-        val result = authenticator.authenticate(ticket)
+        val result = authenticator.completeLogin(ticket, credentials)
 
         assertThat(result.exceptionOrNull())
             .isInstanceOf(QrLoginAuthenticationException.UserNotEligible::class.java)
@@ -110,38 +92,36 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given user is not eligible, when authenticate, then saved AP is revoked and user logged out`() =
-        testBlocking {
-            whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.success(false))
+    fun `given user is not eligible, when completeLogin, then saved AP is revoked`() = testBlocking {
+        whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.success(false))
 
-            authenticator.authenticate(ticket)
+        authenticator.completeLogin(ticket, credentials)
 
-            verify(repo).saveApplicationPassword(
-                localSiteId = site.id,
-                username = credentials.userLogin,
-                password = credentials.applicationPassword
-            )
-            verify(siteStore).deleteApplicationPassword(site)
-            verify(accountRepository).logout()
-        }
-
-    @Test
-    fun `given eligibility check fails, when authenticate, then saved AP is revoked and user logged out`() =
-        testBlocking {
-            whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.failure(IOException("offline")))
-
-            authenticator.authenticate(ticket)
-
-            verify(siteStore).deleteApplicationPassword(site)
-            verify(accountRepository).logout()
-        }
+        verify(repo).saveApplicationPassword(
+            localSiteId = site.id,
+            username = credentials.userLogin,
+            password = credentials.applicationPassword
+        )
+        verify(siteStore).deleteApplicationPassword(site)
+        verify(accountRepository).logout()
+    }
 
     @Test
-    fun `given fetchSite fails, when authenticate, then failure propagates and AP not saved`() = testBlocking {
+    fun `given eligibility check fails, when completeLogin, then saved AP is revoked`() = testBlocking {
+        whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.failure(IOException("offline")))
+
+        authenticator.completeLogin(ticket, credentials)
+
+        verify(siteStore).deleteApplicationPassword(site)
+        verify(accountRepository).logout()
+    }
+
+    @Test
+    fun `given fetchSite fails, when completeLogin, then failure propagates and AP not saved`() = testBlocking {
         whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword))
             .thenReturn(Result.failure(IllegalStateException("nope")))
 
-        val result = authenticator.authenticate(ticket)
+        val result = authenticator.completeLogin(ticket, credentials)
 
         assertThat(result.isFailure).isTrue()
         verify(repo, never()).saveApplicationPassword(any(), any(), any())
@@ -149,14 +129,14 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given fetchSite throws CancellationException, when authenticate, then it propagates unwrapped`() =
+    fun `given fetchSite throws CancellationException, when completeLogin, then it propagates unwrapped`() =
         testBlocking {
             whenever(repo.fetchSite(ticket.siteUrl, credentials.userLogin, credentials.applicationPassword))
                 .thenAnswer { throw CancellationException("cancelled") }
 
             var thrown: Throwable? = null
             try {
-                authenticator.authenticate(ticket)
+                authenticator.completeLogin(ticket, credentials)
             } catch (t: Throwable) {
                 thrown = t
             }
@@ -165,12 +145,12 @@ class QrLoginAuthenticatorTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given eligibility check fails with IO error, when authenticate, then UserNotEligible carries the cause`() =
+    fun `given eligibility check fails with IO error, when completeLogin, then UserNotEligible carries the cause`() =
         testBlocking {
             val cause = IOException("offline")
             whenever(repo.checkIfUserIsEligible(site)).thenReturn(Result.failure(cause))
 
-            val result = authenticator.authenticate(ticket)
+            val result = authenticator.completeLogin(ticket, credentials)
 
             val failure = result.exceptionOrNull()
             assertThat(failure).isInstanceOf(QrLoginAuthenticationException.UserNotEligible::class.java)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.login.qrlogin
 
 import androidx.lifecycle.SavedStateHandle
-import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
@@ -810,10 +809,6 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     private fun successScan(raw: String = RAW_SCAN) =
         CodeScannerStatus.Success(code = raw, format = BarcodeFormat.FormatQRCode)
 
-    @Suppress("unused")
-    private fun siteError(type: org.wordpress.android.fluxc.store.SiteStore.SiteErrorType): OnChangedException =
-        OnChangedException(org.wordpress.android.fluxc.store.SiteStore.SiteError(type, "boom"))
-
     private companion object {
         const val RAW_SCAN = "raw"
         const val DEFAULT_SITE_ID = 42
@@ -821,6 +816,5 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             "https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=abc"
         const val SITE_URL = "https://store.example.com"
         const val POLL_TICK_MS = 2_000L
-        const val MAX_CONSECUTIVE_POLL_ERRORS = 4
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -62,6 +62,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             restClient = restClient,
             authenticator = authenticator,
             accountRepository = accountRepository,
+            errorMapper = QrLoginErrorMapper(),
             analyticsTracker = analyticsTracker
         )
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -251,6 +251,20 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
         val state = viewModel.uiState.value as UiState.Error
         assertThat(state.reason).isEqualTo(ErrorReason.RateLimited)
+        assertThat(state.retryTicket).isEqualTo(ticket)
+    }
+
+    @Test
+    fun `given endpoint-missing poll, when first error fires, then transitions without retry`() = testBlocking {
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.failure(QrLoginSessionStatusException.EndpointMissing))
+
+        viewModel.onScanResult(successScan())
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.EndpointMissing)
+        assertThat(state.retryTicket).isNull()
     }
 
     // endregion

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -80,13 +80,19 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     }
 
     /**
-     * Tests that don't override [restClient]'s session-status mock still need it to terminate
-     * (returning Expired) so `runTest`'s post-body `advanceUntilIdle` doesn't chase the polling
-     * loop forever. Strict Mockito complains about a global setUp stub that some tests don't
-     * use, so each test opting into the default calls this helper instead.
+     * Tests that don't override [restClient]'s session-status mock still need polling to
+     * terminate so `runTest`'s post-body drain doesn't chase the loop forever, but the
+     * immediate-first-tick optimization means a single `Expired` mock would race past
+     * `WaitingForApproval` before the test can assert on it. Returning `Scanned` for the
+     * first call (loop keeps state in WaitingForApproval, then suspends on the 2-s delay)
+     * and `Expired` for subsequent calls (loop exits cleanly when `runTest` drains time)
+     * gives both the assertion window and the clean shutdown. Strict Mockito complains
+     * about a global setUp stub that some tests don't use, so each test opting into the
+     * default calls this helper instead.
      */
     private suspend fun stubPollingTerminates() {
         whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.success(QrLoginSessionStatus.Scanned))
             .thenReturn(Result.success(QrLoginSessionStatus.Expired))
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -368,6 +368,28 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             val state = viewModel.uiState.value as UiState.Error
             assertThat(state.reason).isEqualTo(ErrorReason.Network)
             assertThat(state.retryTicket).isEqualTo(ticket)
+            assertThat(state.retryExchangeGrant).isEqualTo("grant-1")
+        }
+
+    @Test
+    fun `given exchange network error, when retried, then exchange is re-run with same grant`() =
+        testBlocking {
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+                .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
+            whenever(restClient.exchange(ticket.siteUrl, ticket.token, "grant-1"))
+                .thenReturn(Result.failure(QrLoginExchangeException.Network))
+                .thenReturn(Result.success(credentials))
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+            advanceUntilIdle()
+            viewModel.onRetryExchange()
+            advanceUntilIdle()
+
+            verify(restClient, times(1)).scan(ticket.siteUrl, ticket.token)
+            verify(restClient, times(2)).exchange(ticket.siteUrl, ticket.token, "grant-1")
+            assertThat(events.last())
+                .isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = DEFAULT_SITE_ID))
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -5,34 +5,53 @@ import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.analytics.AnalyticsEvent
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.network.qrlogin.QrLoginCredentials
 import com.woocommerce.android.network.qrlogin.QrLoginExchangeException
+import com.woocommerce.android.network.qrlogin.QrLoginRestClient
+import com.woocommerce.android.network.qrlogin.QrLoginScanException
+import com.woocommerce.android.network.qrlogin.QrLoginScanResult
+import com.woocommerce.android.network.qrlogin.QrLoginSessionStatus
+import com.woocommerce.android.network.qrlogin.QrLoginSessionStatusException
 import com.woocommerce.android.ui.login.AccountRepository
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.ErrorReason
+import com.woocommerce.android.ui.login.qrlogin.QrLoginScannerViewModel.UiState
 import com.woocommerce.android.ui.orders.creation.CodeScannerStatus
 import com.woocommerce.android.ui.orders.creation.CodeScanningErrorType
 import com.woocommerce.android.ui.orders.creation.GoogleBarcodeFormatMapper.BarcodeFormat
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.store.SiteStore.SiteError
-import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType
-import java.net.UnknownHostException
+import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     private val ticket = QrLoginPayload.Ticket(token = "tok", siteUrl = "https://store.example")
+    private val scanResult = QrLoginScanResult(
+        sessionId = "sess-1",
+        realNumber = "042",
+        expiresInSeconds = 90,
+    )
+    private val credentials = QrLoginCredentials(
+        userLogin = "admin",
+        applicationPassword = "ap-secret",
+    )
 
     private val parser: QrLoginPayloadParser = mock()
+    private val restClient: QrLoginRestClient = mock()
     private val authenticator: QrLoginAuthenticator = mock()
     private val accountRepository: AccountRepository = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
@@ -41,6 +60,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         QrLoginScannerViewModel(
             savedState = SavedStateHandle(),
             parser = parser,
+            restClient = restClient,
             authenticator = authenticator,
             accountRepository = accountRepository,
             analyticsTracker = analyticsTracker
@@ -50,456 +70,417 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     @Before
     fun setUp() = testBlocking {
         whenever(parser.parse(RAW_SCAN)).thenReturn(ticket)
-        whenever(authenticator.authenticate(ticket)).thenReturn(Result.success(DEFAULT_SITE_ID))
         // Default to "no active session" so existing flows behave as before; individual tests
         // that exercise the session-replace warning override this.
         whenever(accountRepository.isUserLoggedIn()).thenReturn(false)
         whenever(accountRepository.logout()).thenReturn(true)
+        whenever(restClient.scan(ticket.siteUrl, ticket.token)).thenReturn(Result.success(scanResult))
+        whenever(restClient.exchange(ticket.siteUrl, ticket.token, "grant-1"))
+            .thenReturn(Result.success(credentials))
+        whenever(authenticator.completeLogin(ticket, credentials)).thenReturn(Result.success(DEFAULT_SITE_ID))
     }
 
-    @Test
-    fun `given valid ticket and successful auth, when scan confirmed, then emits LoggedIn`() = testBlocking {
-        val events = viewModel.event.captureValues()
-
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-
-        assertThat(events.last())
-            .isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = DEFAULT_SITE_ID))
+    /**
+     * Tests that don't override [restClient]'s session-status mock still need it to terminate
+     * (returning Expired) so `runTest`'s post-body `advanceUntilIdle` doesn't chase the polling
+     * loop forever. Strict Mockito complains about a global setUp stub that some tests don't
+     * use, so each test opting into the default calls this helper instead.
+     */
+    private suspend fun stubPollingTerminates() {
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.success(QrLoginSessionStatus.Expired))
     }
 
-    @Test
-    fun `given valid ticket, when scan succeeds, then ui state exposes confirming with host`() = testBlocking {
-        viewModel.onScanResult(successScan())
-
-        assertThat(viewModel.uiState.value).isEqualTo(
-            QrLoginScannerViewModel.UiState.Confirming(ticket = ticket, host = "store.example")
-        )
-        verify(authenticator, never()).authenticate(any())
-    }
+    // region scan → waiting for approval
 
     @Test
-    fun `given pending confirmation, when cancel, then ui state returns to idle`() = testBlocking {
-        viewModel.onScanResult(successScan())
-        viewModel.onCancelSite()
+    fun `given valid ticket, when scan succeeds, then state transitions to WaitingForApproval`() = testBlocking {
+        stubPollingTerminates()
 
-        assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
-        verify(authenticator, never()).authenticate(any())
-    }
-
-    @Test
-    fun `given pending confirmation, when another scan arrives, then it is ignored`() = testBlocking {
-        viewModel.onScanResult(successScan(RAW_SCAN))
-        viewModel.onScanResult(successScan("second-raw"))
-
-        assertThat(viewModel.uiState.value)
-            .isInstanceOf(QrLoginScannerViewModel.UiState.Confirming::class.java)
-        verify(parser, never()).parse("second-raw")
-    }
-
-    @Test
-    fun `given canceled confirmation, when next valid scan, then a fresh confirmation is shown`() = testBlocking {
-        viewModel.onScanResult(successScan())
-        viewModel.onCancelSite()
         viewModel.onScanResult(successScan())
 
-        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Confirming
+        val state = viewModel.uiState.value as UiState.WaitingForApproval
+        assertThat(state.realNumber).isEqualTo("042")
+        assertThat(state.sessionId).isEqualTo("sess-1")
+        assertThat(state.host).isEqualTo("store.example")
         assertThat(state.ticket).isEqualTo(ticket)
+        assertThat(state.expiresAtEpochMs).isGreaterThan(System.currentTimeMillis())
     }
 
     @Test
-    fun `given Invalid payload, when scan succeeds, then emits InvalidPayload error`() = testBlocking {
-        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
+    fun `given scan endpoint returns 409, when scan, then emits MatchAlreadyScanned without retry`() = testBlocking {
+        whenever(restClient.scan(ticket.siteUrl, ticket.token))
+            .thenReturn(Result.failure(QrLoginScanException.AlreadyScanned))
 
         viewModel.onScanResult(successScan())
 
-        assertThat(viewModel.uiState.value).isEqualTo(
-            QrLoginScannerViewModel.UiState.Error(
-                reason = QrLoginScannerViewModel.ErrorReason.InvalidPayload,
-                retryTicket = null,
-            )
-        )
-    }
-
-    @Test
-    fun `given Invalid payload, when scan succeeds, then authenticator is not called`() = testBlocking {
-        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
-
-        viewModel.onScanResult(successScan())
-
-        verify(authenticator, never()).authenticate(any())
-    }
-
-    @Test
-    fun `given scanner Failure, when scan result received, then emits Scanner error`() = testBlocking {
-        viewModel.onScanResult(
-            CodeScannerStatus.Failure(error = "boom", type = CodeScanningErrorType.Unknown)
-        )
-
-        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.Scanner)
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.MatchAlreadyScanned)
         assertThat(state.retryTicket).isNull()
     }
 
     @Test
-    fun `given NotFound status, when scan result received, then no events emitted`() = testBlocking {
-        val events = viewModel.event.captureValues()
-
-        viewModel.onScanResult(CodeScannerStatus.NotFound)
-
-        assertThat(events).isEmpty()
-        assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
-    }
-
-    @Test
-    fun `given token rejected by server, when scan confirmed, then emits TokenRejected error without retry`() =
-        testBlocking {
-            whenever(authenticator.authenticate(ticket))
-                .thenReturn(Result.failure(QrLoginExchangeException.TokenRejected))
-
-            viewModel.onScanResult(successScan())
-            viewModel.onConfirmSite()
-
-            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.TokenRejected)
-            assertThat(state.retryTicket).isNull()
-        }
-
-    @Test
-    fun `given malformed exchange response, when scan confirmed, then emits ServerError`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginExchangeException.MalformedResponse))
+    fun `given scan endpoint returns network error, when scan, then emits Network with retry ticket`() = testBlocking {
+        whenever(restClient.scan(ticket.siteUrl, ticket.token))
+            .thenReturn(Result.failure(QrLoginScanException.Network))
 
         viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
 
-        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.ServerError)
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.Network)
         assertThat(state.retryTicket).isEqualTo(ticket)
     }
 
     @Test
-    fun `given server HttpError, when scan confirmed, then emits ServerError with retry ticket`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginExchangeException.HttpError(500)))
+    fun `given scan endpoint returns 426 upgrade required, when scan, then maps to EndpointMissing`() = testBlocking {
+        whenever(restClient.scan(ticket.siteUrl, ticket.token))
+            .thenReturn(Result.failure(QrLoginScanException.UpgradeRequired))
 
         viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
 
-        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.ServerError)
-        assertThat(state.retryTicket).isEqualTo(ticket)
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.EndpointMissing)
     }
 
+    // endregion
+
+    // region polling → approval
+
     @Test
-    fun `given OnChangedException with UNAUTHORIZED site error, when scan confirmed, then emits SiteAuthFailure`() =
+    fun `given approved with grant on first poll, when polling fires, then exchange runs and emits LoggedIn`() =
         testBlocking {
-            whenever(authenticator.authenticate(ticket))
-                .thenReturn(Result.failure(siteError(SiteErrorType.UNAUTHORIZED)))
-
-            viewModel.onScanResult(successScan())
-            viewModel.onConfirmSite()
-
-            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.SiteAuthFailure)
-        }
-
-    @Test
-    fun `given OnChangedException with WPCOM connectivity error, when scan confirmed, then emits Network`() =
-        testBlocking {
-            whenever(authenticator.authenticate(ticket))
-                .thenReturn(Result.failure(siteError(SiteErrorType.WORDPRESS_COM_CONNECTIVITY_ERROR)))
-
-            viewModel.onScanResult(successScan())
-            viewModel.onConfirmSite()
-
-            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.Network)
-        }
-
-    @Test
-    fun `given OnChangedException with generic site error, when scan confirmed, then emits Unknown`() =
-        testBlocking {
-            whenever(authenticator.authenticate(ticket))
-                .thenReturn(Result.failure(siteError(SiteErrorType.GENERIC_ERROR)))
-
-            viewModel.onScanResult(successScan())
-            viewModel.onConfirmSite()
-
-            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.Unknown)
-        }
-
-    @Test
-    fun `given network error, when scan confirmed, then emits Network error with retry ticket`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginExchangeException.Network))
-
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-
-        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.Network)
-        assertThat(state.retryTicket).isEqualTo(ticket)
-    }
-
-    @Test
-    fun `given rate limited error, when scan confirmed, then emits RateLimited error with retry ticket`() =
-        testBlocking {
-            whenever(authenticator.authenticate(ticket))
-                .thenReturn(Result.failure(QrLoginExchangeException.RateLimited))
-
-            viewModel.onScanResult(successScan())
-            viewModel.onConfirmSite()
-
-            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.RateLimited)
-            assertThat(state.retryTicket).isEqualTo(ticket)
-        }
-
-    @Test
-    fun `given endpoint missing, when scan confirmed, then emits EndpointMissing error without retry`() =
-        testBlocking {
-            whenever(authenticator.authenticate(ticket))
-                .thenReturn(Result.failure(QrLoginExchangeException.EndpointMissing))
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+                .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
             val events = viewModel.event.captureValues()
 
             viewModel.onScanResult(successScan())
-            viewModel.onConfirmSite()
+            advanceUntilIdle()
 
-            assertThat(events).isEmpty()
-            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.EndpointMissing)
-            assertThat(state.retryTicket).isNull()
-        }
-
-    @Test
-    fun `given endpoint missing error, when start over called, then state returns to idle`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginExchangeException.EndpointMissing))
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-
-        viewModel.onStartOver()
-
-        assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
-    }
-
-    @Test
-    fun `given endpoint missing error, when another scan arrives, then it is ignored`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginExchangeException.EndpointMissing))
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-
-        viewModel.onScanResult(successScan())
-
-        verify(authenticator, times(1)).authenticate(eq(ticket))
-    }
-
-    @Test
-    fun `given site is not Woo, when auth fails with NotAWooSite, then emits NotAWooSite error`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginAuthenticationException.NotAWooSite))
-
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-
-        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.NotAWooSite)
-    }
-
-    @Test
-    fun `given user is ineligible, when auth fails, then emits UserNotEligible error`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginAuthenticationException.UserNotEligible(original = null)))
-
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-
-        val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-        assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.UserNotEligible)
-    }
-
-    @Test
-    fun `given login succeeded, when another scan arrives, then ignored to avoid double-submit`() = testBlocking {
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-        viewModel.onScanResult(successScan())
-
-        verify(authenticator, times(1)).authenticate(eq(ticket))
-    }
-
-    @Test
-    fun `given exchange failure, when user starts over and rescans, then it is processed`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginExchangeException.Network))
-            .thenReturn(Result.success(99))
-        val events = viewModel.event.captureValues()
-
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-        viewModel.onStartOver()
-        viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-
-        assertThat(events.last()).isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = 99))
-    }
-
-    @Test
-    fun `given Invalid payload, when user starts over and rescans valid, then it is processed`() = testBlocking {
-        whenever(parser.parse("invalid")).thenReturn(QrLoginPayload.Invalid)
-        whenever(parser.parse("valid")).thenReturn(ticket)
-        whenever(authenticator.authenticate(ticket)).thenReturn(Result.success(11))
-        val events = viewModel.event.captureValues()
-
-        viewModel.onScanResult(successScan("invalid"))
-        viewModel.onStartOver()
-        viewModel.onScanResult(successScan("valid"))
-        viewModel.onConfirmSite()
-
-        assertThat(events.last()).isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = 11))
-    }
-
-    @Test
-    fun `given error state, when another scan arrives, then it is ignored`() = testBlocking {
-        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
-        viewModel.onScanResult(successScan())
-
-        viewModel.onScanResult(successScan("second-raw"))
-
-        verify(parser, never()).parse("second-raw")
-    }
-
-    @Test
-    fun `given an error, when onStartOver, then state returns to idle`() = testBlocking {
-        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
-        viewModel.onScanResult(successScan())
-
-        viewModel.onStartOver()
-
-        assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
-    }
-
-    @Test
-    fun `given UnknownHostException from site discovery, when scan confirmed, then emits Network error`() =
-        testBlocking {
-            whenever(authenticator.authenticate(ticket))
-                .thenReturn(Result.failure(UnknownHostException("mystore.example.com")))
-
-            viewModel.onScanResult(successScan())
-            viewModel.onConfirmSite()
-
-            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Error
-            assertThat(state.reason).isEqualTo(QrLoginScannerViewModel.ErrorReason.Network)
-            assertThat(state.retryTicket).isEqualTo(ticket)
-        }
-
-    @Test
-    fun `given retry-eligible error, when onRetryExchange, then exchange is retried with the same ticket`() =
-        testBlocking {
-            whenever(authenticator.authenticate(ticket))
-                .thenReturn(Result.failure(QrLoginExchangeException.Network))
-                .thenReturn(Result.success(DEFAULT_SITE_ID))
-            val events = viewModel.event.captureValues()
-
-            viewModel.onScanResult(successScan())
-            viewModel.onConfirmSite()
-            viewModel.onRetryExchange()
-
-            verify(authenticator, times(2)).authenticate(eq(ticket))
+            verify(restClient).exchange(ticket.siteUrl, ticket.token, "grant-1")
+            verify(authenticator).completeLogin(ticket, credentials)
             assertThat(events.last())
                 .isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = DEFAULT_SITE_ID))
         }
 
     @Test
-    fun `given non-retry-eligible error, when onRetryExchange, then nothing happens`() = testBlocking {
-        whenever(authenticator.authenticate(ticket))
-            .thenReturn(Result.failure(QrLoginExchangeException.TokenRejected))
+    fun `given rejected on poll, when polling fires, then state is MatchRejected with no retry`() = testBlocking {
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.success(QrLoginSessionStatus.Rejected))
 
         viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
-        viewModel.onRetryExchange()
+        advanceUntilIdle()
 
-        verify(authenticator, times(1)).authenticate(eq(ticket))
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.MatchRejected)
+        assertThat(state.retryTicket).isNull()
+        verify(restClient, never()).exchange(any(), any(), any())
     }
 
     @Test
-    fun `given successful login, when authenticator returns site id, then tracks LOGIN_QR_SUCCESS`() = testBlocking {
+    fun `given expired on poll, when polling fires, then state is MatchTimedOut`() = testBlocking {
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.success(QrLoginSessionStatus.Expired))
+
         viewModel.onScanResult(successScan())
-        viewModel.onConfirmSite()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.MatchTimedOut)
+        verify(restClient, never()).exchange(any(), any(), any())
+    }
+
+    @Test
+    fun `given scanned on poll, when polling fires, then state stays WaitingForApproval`() = testBlocking {
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.success(QrLoginSessionStatus.Scanned))
+
+        viewModel.onScanResult(successScan())
+        // Loops indefinitely while still scanned — advance a couple of ticks (with the +1 nudge
+        // so the delay-at-exactly-N edge case fires) and then assert the loop is still alive.
+        advanceTimeBy(POLL_TICK_MS * 2 + 1)
+
+        assertThat(viewModel.uiState.value).isInstanceOf(UiState.WaitingForApproval::class.java)
+        verify(restClient, atLeastOnce()).checkSessionStatus(ticket.siteUrl, scanResult.sessionId)
+        // Stop the loop so runTest's post-body advanceUntilIdle doesn't chase it forever.
+        viewModel.onCancelNumberMatch()
+    }
+
+    @Test
+    fun `given transient poll errors, when fewer than threshold occur, then polling continues`() = testBlocking {
+        // Three transient failures, then a Scanned response: polling must still be active.
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
+            .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
+            .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
+            .thenReturn(Result.success(QrLoginSessionStatus.Scanned))
+
+        viewModel.onScanResult(successScan())
+        advanceTimeBy(POLL_TICK_MS * 4 + 1)
+
+        assertThat(viewModel.uiState.value).isInstanceOf(UiState.WaitingForApproval::class.java)
+        // Stop the loop so runTest's post-body advanceUntilIdle doesn't chase the Scanned mock.
+        viewModel.onCancelNumberMatch()
+    }
+
+    @Test
+    fun `given transient poll errors, when threshold reached, then state transitions to Network error with retry`() =
+        testBlocking {
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+                .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
+
+            viewModel.onScanResult(successScan())
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value as UiState.Error
+            assertThat(state.reason).isEqualTo(ErrorReason.Network)
+            assertThat(state.retryTicket).isEqualTo(ticket)
+        }
+
+    @Test
+    fun `given rate-limited poll, when first error fires, then transitions immediately`() = testBlocking {
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.failure(QrLoginSessionStatusException.RateLimited))
+
+        viewModel.onScanResult(successScan())
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.RateLimited)
+    }
+
+    // endregion
+
+    // region cancel + start over
+
+    @Test
+    fun `given WaitingForApproval, when onCancelNumberMatch, then state returns to Idle and polling stops`() =
+        testBlocking {
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+                .thenReturn(Result.success(QrLoginSessionStatus.Scanned))
+
+            viewModel.onScanResult(successScan())
+            advanceTimeBy(POLL_TICK_MS + 1)
+            viewModel.onCancelNumberMatch()
+            advanceTimeBy(POLL_TICK_MS * 3)
+
+            assertThat(viewModel.uiState.value).isEqualTo(UiState.Idle)
+            // Once cancel fires, no further polls should happen.
+            verify(restClient, atLeastOnce()).checkSessionStatus(any(), any())
+        }
+
+    @Test
+    fun `given waiting for approval, when another scan arrives, then it is ignored`() = testBlocking {
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.success(QrLoginSessionStatus.Scanned))
+
+        viewModel.onScanResult(successScan(RAW_SCAN))
+        // Fire one poll tick so the Scanned mock is actually consumed (otherwise strict-mode
+        // Mockito flags it as an unused stubbing). The +1 nudges the dispatcher past the
+        // delay-at-exactly-N edge case in kotlinx.coroutines.test.
+        advanceTimeBy(POLL_TICK_MS + 1)
+        viewModel.onScanResult(successScan("second-raw"))
+
+        verify(parser, never()).parse("second-raw")
+        // Stop the loop so runTest's post-body advanceUntilIdle doesn't chase it forever.
+        viewModel.onCancelNumberMatch()
+    }
+
+    @Test
+    fun `given Error state, when onStartOver, then state returns to Idle`() = testBlocking {
+        whenever(restClient.scan(ticket.siteUrl, ticket.token))
+            .thenReturn(Result.failure(QrLoginScanException.TokenRejected))
+
+        viewModel.onScanResult(successScan())
+        viewModel.onStartOver()
+
+        assertThat(viewModel.uiState.value).isEqualTo(UiState.Idle)
+    }
+
+    @Test
+    fun `given Network error, when onRetryExchange, then scan is re-run`() = testBlocking {
+        whenever(restClient.scan(ticket.siteUrl, ticket.token))
+            .thenReturn(Result.failure(QrLoginScanException.Network))
+            .thenReturn(Result.success(scanResult))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.success(QrLoginSessionStatus.Scanned))
+
+        viewModel.onScanResult(successScan())
+        viewModel.onRetryExchange()
+        // Let the second scan's poll fire once so the Scanned mock is consumed and the
+        // strict-mode Mockito doesn't flag it as unused.
+        advanceTimeBy(POLL_TICK_MS + 1)
+
+        verify(restClient, times(2)).scan(ticket.siteUrl, ticket.token)
+        // Stop the polling loop the second scan started so the test runner can wind down.
+        viewModel.onCancelNumberMatch()
+    }
+
+    // endregion
+
+    // region exchange failures
+
+    @Test
+    fun `given exchange returns InvalidExchangeGrant, when polling triggers exchange, then MatchInvalidGrant`() =
+        testBlocking {
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+                .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
+            whenever(restClient.exchange(ticket.siteUrl, ticket.token, "grant-1"))
+                .thenReturn(Result.failure(QrLoginExchangeException.InvalidExchangeGrant))
+
+            viewModel.onScanResult(successScan())
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value as UiState.Error
+            assertThat(state.reason).isEqualTo(ErrorReason.MatchInvalidGrant)
+            assertThat(state.retryTicket).isNull()
+        }
+
+    @Test
+    fun `given exchange returns Network, when polling triggers exchange, then Network with retry ticket`() =
+        testBlocking {
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+                .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
+            whenever(restClient.exchange(ticket.siteUrl, ticket.token, "grant-1"))
+                .thenReturn(Result.failure(QrLoginExchangeException.Network))
+
+            viewModel.onScanResult(successScan())
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value as UiState.Error
+            assertThat(state.reason).isEqualTo(ErrorReason.Network)
+            assertThat(state.retryTicket).isEqualTo(ticket)
+        }
+
+    @Test
+    fun `given authenticator returns NotAWooSite, when login completes, then NotAWooSite error`() = testBlocking {
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
+        whenever(authenticator.completeLogin(ticket, credentials))
+            .thenReturn(Result.failure(QrLoginAuthenticationException.NotAWooSite))
+
+        viewModel.onScanResult(successScan())
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.NotAWooSite)
+    }
+
+    @Test
+    fun `given authenticator returns IOException, when login completes, then Network error`() = testBlocking {
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
+        whenever(authenticator.completeLogin(ticket, credentials))
+            .thenReturn(Result.failure(IOException("offline")))
+
+        viewModel.onScanResult(successScan())
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.Network)
+    }
+
+    // endregion
+
+    // region scanner / payload errors (unchanged behavior)
+
+    @Test
+    fun `given Invalid payload, when scan succeeds, then InvalidPayload error and no scan call`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
+
+        viewModel.onScanResult(successScan())
+
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.InvalidPayload)
+        verify(restClient, never()).scan(any(), any())
+    }
+
+    @Test
+    fun `given InstallQrCode payload, when scan succeeds, then InstallQrCode error`() = testBlocking {
+        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.InstallQrCode)
+
+        viewModel.onScanResult(successScan())
+
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.InstallQrCode)
+    }
+
+    @Test
+    fun `given scanner Failure, when scan result received, then Scanner error`() = testBlocking {
+        viewModel.onScanResult(
+            CodeScannerStatus.Failure(error = "boom", type = CodeScanningErrorType.Unknown)
+        )
+
+        val state = viewModel.uiState.value as UiState.Error
+        assertThat(state.reason).isEqualTo(ErrorReason.Scanner)
+    }
+
+    @Test
+    fun `given NotFound status, when scan result received, then state stays Idle`() = testBlocking {
+        viewModel.onScanResult(CodeScannerStatus.NotFound)
+
+        assertThat(viewModel.uiState.value).isEqualTo(UiState.Idle)
+    }
+
+    // endregion
+
+    // region analytics + lifecycle
+
+    @Test
+    fun `given successful login, when LoggedIn dispatched, then tracks LOGIN_QR_SUCCESS`() = testBlocking {
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
+
+        viewModel.onScanResult(successScan())
+        advanceUntilIdle()
 
         verify(analyticsTracker).track(AnalyticsEvent.LOGIN_QR_SUCCESS)
     }
 
     @Test
-    fun `given scanner binding failure, when delivered as Failure, then tracks scan failed with scanner step`() =
-        testBlocking {
-            viewModel.onScanResult(
-                CodeScannerStatus.Failure(error = "boom", type = CodeScanningErrorType.Unknown)
-            )
-
-            verify(analyticsTracker).track(
-                stat = AnalyticsEvent.LOGIN_QR_SCAN_FAILED,
-                properties = mapOf(AnalyticsTracker.KEY_STEP to "scanner"),
-                errorContext = "Unknown",
-                errorType = "Scanner",
-                errorDescription = null,
-            )
-        }
-
-    @Test
-    fun `given exchange network error, when scan confirmed, then tracks scan failed with exchange step`() =
-        testBlocking {
-            whenever(authenticator.authenticate(ticket))
-                .thenReturn(Result.failure(QrLoginExchangeException.Network))
-
-            viewModel.onScanResult(successScan())
-            viewModel.onConfirmSite()
-
-            verify(analyticsTracker).track(
-                stat = AnalyticsEvent.LOGIN_QR_SCAN_FAILED,
-                properties = mapOf(AnalyticsTracker.KEY_STEP to "exchange"),
-                errorContext = "Network",
-                errorType = "Network",
-                errorDescription = null,
-            )
-        }
-
-    @Test
-    fun `given invalid payload, when scan succeeds, then tracks scan failed with payload step`() = testBlocking {
-        whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.Invalid)
-
-        viewModel.onScanResult(successScan())
+    fun `given scanner binding failure, when delivered, then tracks scan failed with scanner step`() = testBlocking {
+        viewModel.onScanResult(
+            CodeScannerStatus.Failure(error = "boom", type = CodeScanningErrorType.Unknown)
+        )
 
         verify(analyticsTracker).track(
             stat = AnalyticsEvent.LOGIN_QR_SCAN_FAILED,
-            properties = mapOf(AnalyticsTracker.KEY_STEP to "payload"),
-            errorContext = null,
-            errorType = "InvalidPayload",
+            properties = mapOf(AnalyticsTracker.KEY_STEP to "scanner"),
+            errorContext = "Unknown",
+            errorType = "Scanner",
             errorDescription = null,
         )
     }
 
     @Test
-    fun `given deep link payload, when onDeepLinkPayload invoked, then exposes pending confirmation`() =
-        testBlocking {
-            viewModel.onDeepLinkPayload(RAW_SCAN)
+    fun `given rejected match, when polling fires, then tracks scan failed with approve step`() = testBlocking {
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            .thenReturn(Result.success(QrLoginSessionStatus.Rejected))
 
-            val state = viewModel.uiState.value as QrLoginScannerViewModel.UiState.Confirming
-            assertThat(state.ticket).isEqualTo(ticket)
-        }
+        viewModel.onScanResult(successScan())
+        advanceUntilIdle()
+
+        verify(analyticsTracker).track(
+            stat = AnalyticsEvent.LOGIN_QR_SCAN_FAILED,
+            properties = mapOf(AnalyticsTracker.KEY_STEP to "approve"),
+            errorContext = null,
+            errorType = "MatchRejected",
+            errorDescription = null,
+        )
+    }
 
     @Test
-    fun `given deep link payload confirmed, when auth succeeds, then emits LoggedIn`() = testBlocking {
-        val events = viewModel.event.captureValues()
+    fun `given deep link payload, when onDeepLinkPayload invoked, then state advances to WaitingForApproval`() =
+        testBlocking {
+            stubPollingTerminates()
 
-        viewModel.onDeepLinkPayload(RAW_SCAN)
-        viewModel.onConfirmSite()
+            viewModel.onDeepLinkPayload(RAW_SCAN)
 
-        assertThat(events.last())
-            .isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = DEFAULT_SITE_ID))
-    }
+            val state = viewModel.uiState.value as UiState.WaitingForApproval
+            assertThat(state.ticket).isEqualTo(ticket)
+            assertThat(state.realNumber).isEqualTo("042")
+        }
+
+    // endregion
 
     @Test
     fun `given wp dot com url payload, when scan succeeds, then emits OpenWpComMagicLinkUrl`() = testBlocking {
@@ -520,7 +501,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         viewModel.onScanResult(successScan())
 
         assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
-        verify(authenticator, never()).authenticate(any())
+        verify(restClient, never()).scan(any(), any())
     }
 
     @Test
@@ -586,7 +567,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         viewModel.onScanResult(successScan())
 
         assertThat(viewModel.uiState.value).isEqualTo(QrLoginScannerViewModel.UiState.Idle)
-        verify(authenticator, never()).authenticate(any())
+        verify(restClient, never()).scan(any(), any())
     }
 
     @Test
@@ -647,7 +628,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
                     QrLoginScannerViewModel.PendingHandoff.Ticket(ticket = ticket, host = "store.example")
                 )
             )
-            verify(authenticator, never()).authenticate(any())
+            verify(restClient, never()).scan(any(), any())
         }
 
     @Test
@@ -716,17 +697,16 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given warning for ticket, when confirmed, then logs out and advances to Confirming`() = testBlocking {
+    fun `given warning for ticket, when confirmed, then logs out and advances to number match`() = testBlocking {
         whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+        stubPollingTerminates()
         viewModel.onScanResult(successScan())
 
         viewModel.onConfirmSessionReplace()
 
         verify(accountRepository).logout()
-        assertThat(viewModel.uiState.value).isEqualTo(
-            QrLoginScannerViewModel.UiState.Confirming(ticket = ticket, host = "store.example")
-        )
-        verify(authenticator, never()).authenticate(any())
+        assertThat(viewModel.uiState.value).isInstanceOf(UiState.WaitingForApproval::class.java)
+        verify(authenticator, never()).completeLogin(any(), any())
     }
 
     @Test
@@ -787,7 +767,8 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given not in warning state, when onConfirmSessionReplace, then nothing happens`() = testBlocking {
-        // user is not logged in, so payload goes straight to Confirming
+        // user is not logged in, so payload goes straight to number matching
+        stubPollingTerminates()
         viewModel.onScanResult(successScan())
 
         viewModel.onConfirmSessionReplace()
@@ -800,11 +781,14 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     fun `given logged in and ticket, when warning confirmed and site confirmed, then emits LoggedIn`() =
         testBlocking {
             whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+                .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
             val events = viewModel.event.captureValues()
 
             viewModel.onScanResult(successScan())
             viewModel.onConfirmSessionReplace()
-            viewModel.onConfirmSite()
+            advanceTimeBy(POLL_TICK_MS)
+            advanceUntilIdle()
 
             assertThat(events.last())
                 .isEqualTo(QrLoginScannerViewModel.Dispatch.LoggedIn(localSiteId = DEFAULT_SITE_ID))
@@ -813,10 +797,11 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     @Test
     fun `given logged out, when ticket payload arrives, then warning is not shown`() = testBlocking {
         // Default mock returns isUserLoggedIn=false; verify legacy path is preserved.
+        stubPollingTerminates()
         viewModel.onScanResult(successScan())
 
         assertThat(viewModel.uiState.value)
-            .isInstanceOf(QrLoginScannerViewModel.UiState.Confirming::class.java)
+            .isInstanceOf(UiState.WaitingForApproval::class.java)
         verify(analyticsTracker, never()).track(AnalyticsEvent.LOGIN_QR_SESSION_REPLACE_WARNING_SHOWN)
     }
 
@@ -825,8 +810,9 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     private fun successScan(raw: String = RAW_SCAN) =
         CodeScannerStatus.Success(code = raw, format = BarcodeFormat.FormatQRCode)
 
-    private fun siteError(type: SiteErrorType): OnChangedException =
-        OnChangedException(SiteError(type, "boom"))
+    @Suppress("unused")
+    private fun siteError(type: org.wordpress.android.fluxc.store.SiteStore.SiteErrorType): OnChangedException =
+        OnChangedException(org.wordpress.android.fluxc.store.SiteStore.SiteError(type, "boom"))
 
     private companion object {
         const val RAW_SCAN = "raw"
@@ -834,5 +820,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         const val WP_COM_URL =
             "https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=abc"
         const val SITE_URL = "https://store.example.com"
+        const val POLL_TICK_MS = 2_000L
+        const val MAX_CONSECUTIVE_POLL_ERRORS = 4
     }
 }


### PR DESCRIPTION
**Do not merge - Parent needs to be merged first.**

### Description

Fixes WOOMOB-2947.

Adds a number-matching approval step to QR login. After the app scans a QR code, it shows a 3-digit number and waits for the merchant to tap the matching number in wp-admin. The app only exchanges the QR token for credentials after the server reports that the correct number was approved.

This PR also:

- Adds `/qr-login-scan` and `/qr-login-session-status` calls.
- Sends `supports_number_matching` in `/qr-login-scan` so WooCommerce Core can identify number-matching-capable clients during rollout.
- Polls session status immediately, then every 2 seconds while waiting for approval.
- Sends `Cache-Control: no-cache, no-store` on status polling requests.
- Logs fail-closed protocol anomalies for approved statuses without grants and unknown session states.
- Keeps unknown poll failures out of the network-error bucket.
- Moves the final credential exchange orchestration into `QrLoginScannerViewModel`.
- Extracts QR login error mapping into `QrLoginErrorMapper`.
- Shows terminal UI for rejected, expired, invalid-grant, and retryable error states.

This is a protocol change and needs the matching WooCommerce Core implementation before end-to-end testing.

### Expected Behavior

- The phone shows the store host, a 3-digit number, and a countdown after scanning.
- wp-admin shows multiple number options for the same QR session.
- Tapping the matching number signs the merchant in.
- Tapping the wrong number or waiting for expiry shows a terminal error in the app.
- Cancelling on the phone returns to the scanner without completing the login.
- Cached `scanned` responses should not keep the app stuck after approval.

### Test Steps

1. Build and install the app: `./gradlew :WooCommerce:installWasabiDebug`.
2. Use a merchant site running the WooCommerce Core number-matching counterpart.
3. Open the QR login screen in wp-admin and render a QR code.
4. In the Android app, open QR login and scan the QR code.
5. Confirm the phone shows a 3-digit number and countdown.
6. In wp-admin, tap the matching number.
7. Confirm the app advances to signing in and lands in the store.
8. Repeat the flow and tap a wrong number in wp-admin. Confirm the app shows the rejected/denied state.
9. Repeat the flow and let the session expire. Confirm the app shows the timeout state.
10. Repeat the flow and tap Cancel on the phone. Confirm the app returns to the scanner.
11. Optional: inspect network traffic and confirm session-status requests include `Cache-Control: no-cache, no-store`.

### Stack

Builds on #15766. This is step 15 in the QR login stack.

Release coordination: Android with this PR must ship before the matching WooCommerce Core protocol change reaches merchant sites.

### Images/gif

To be added before moving out of draft.

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
