### PR TITLE
Revert "Add 2.7% percentage and split Canada/Interac flat application fees"

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -81,19 +81,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WooCommerceStore
-import java.math.BigDecimal
-import java.math.RoundingMode
-import java.util.Currency
 import kotlin.reflect.KMutableProperty0
 
 private const val ARTIFICIAL_RETRY_DELAY = 500L
-
-// The base Canada fee and percentage are overwritten by Transact Server at the capture
-// step for non-Interac payments. Interac payments have no capture step, so the full
-// combined fee (base + Interac + percentage) is what Stripe charges.
-private const val CANADA_FEE_FLAT_IN_CENTS = 5L
-private const val INTERAC_FEE_FLAT_IN_CENTS = 15L
-private val CANADA_FEE_PERCENTAGE = BigDecimal("0.027")
+private const val CANADA_FEE_FLAT_IN_CENTS = 15L
 
 @Suppress("LongParameterList", "LargeClass")
 class CardReaderPaymentController(
@@ -300,7 +291,7 @@ class CardReaderPaymentController(
                 storeName = selectedSite.get().name.ifEmpty { null },
                 siteUrl = selectedSite.get().url.ifEmpty { null },
                 countryCode = countryCode,
-                feeAmount = calculateFeeInCents(countryCode, order.total, order.currency),
+                feeAmount = calculateFeeInCents(countryCode),
                 channel = determinePaymentChannel(paymentOrRefund)
             )
         ).collect { paymentStatus ->
@@ -861,15 +852,9 @@ class CardReaderPaymentController(
         }
     }
 
-    private fun calculateFeeInCents(countryCode: String, orderTotal: BigDecimal, currencyCode: String): Long? =
+    private fun calculateFeeInCents(countryCode: String) =
         if (countryCode == "CA") {
-            val fractionDigits = Currency.getInstance(currencyCode).defaultFractionDigits
-            val percentageInCents = orderTotal
-                .multiply(CANADA_FEE_PERCENTAGE)
-                .movePointRight(fractionDigits)
-                .setScale(0, RoundingMode.HALF_UP)
-                .toLong()
-            percentageInCents + CANADA_FEE_FLAT_IN_CENTS + INTERAC_FEE_FLAT_IN_CENTS
+            CANADA_FEE_FLAT_IN_CENTS
         } else {
             null
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -2666,7 +2666,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given canada and total 0,58, when flow started, then fee set to 22`() =
+    fun `given canada and total 0,58, when flow started, then fee set to 15`() =
         testBlocking {
             // Given
             whenever(wooStore.getStoreCountryCode(any())).thenReturn("CA")
@@ -2678,13 +2678,12 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             controller.start()
 
             // Then
-            // 0.58 * 0.027 * 100 = 1.566 -> 2 cents, + 5 (Canada base) + 15 (Interac) = 22
             verify(cardReaderManager).collectPayment(captor.capture())
-            assertThat(captor.firstValue.feeAmount).isEqualTo(22)
+            assertThat(captor.firstValue.feeAmount).isEqualTo(15)
         }
 
     @Test
-    fun `given canada and total 145,6, when flow started, then fee set to 413`() =
+    fun `given canada and total 135,6, when flow started, then fee set to 15`() =
         testBlocking {
             // Given
             whenever(wooStore.getStoreCountryCode(any())).thenReturn("CA")
@@ -2696,9 +2695,8 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             controller.start()
 
             // Then
-            // 145.6 * 0.027 * 100 = 393.12 -> 393 cents, + 5 (Canada base) + 15 (Interac) = 413
             verify(cardReaderManager).collectPayment(captor.capture())
-            assertThat(captor.firstValue.feeAmount).isEqualTo(413)
+            assertThat(captor.firstValue.feeAmount).isEqualTo(15)
         }
 
     @Test


### PR DESCRIPTION
Reverts woocommerce/woocommerce-android#15728

As per discussion on TRAPLAT-3863, we've actually been correct in charging C$0.15 flat rate all along. 😌 

Reverting this before release is cut prevents any overcharging.