### PR TITLE
[WOOMOB-2961] Add product variation update assistant tool

### DIFF
--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantToolsModule.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantToolsModule.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.aiassistant.tools.orders.OrdersGetToolHandler
 import com.woocommerce.android.aiassistant.tools.orders.OrdersListToolHandler
 import com.woocommerce.android.aiassistant.tools.orders.OrdersUpdateToolHandler
 import com.woocommerce.android.aiassistant.tools.products.ProductVariationsToolHandler
+import com.woocommerce.android.aiassistant.tools.products.ProductVariationsUpdateToolHandler
 import com.woocommerce.android.aiassistant.tools.products.ProductsBulkUpdateToolHandler
 import com.woocommerce.android.aiassistant.tools.products.ProductsGetToolHandler
 import com.woocommerce.android.aiassistant.tools.products.ProductsListToolHandler
@@ -65,6 +66,10 @@ internal abstract class AiAssistantToolsModule {
     @Binds
     @IntoSet
     abstract fun bindProductVariationsListHandler(impl: ProductVariationsToolHandler): AssistantToolHandler
+
+    @Binds
+    @IntoSet
+    abstract fun bindProductVariationsUpdateHandler(impl: ProductVariationsUpdateToolHandler): AssistantToolHandler
 
     @Binds
     @IntoSet

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelector.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelector.kt
@@ -40,6 +40,7 @@ class DefaultToolCatalogSelector : ToolCatalogSelector {
             "products_update",
             "products_bulk_update",
             "product_variations_list",
+            "product_variations_update",
             "analytics_revenue",
             "show_cards",
         )

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductVariationsDataSource.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductVariationsDataSource.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.aiassistant.tools.products
 
 import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.tools.SelectedSite
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.store.WCProductStore
 import javax.inject.Inject
@@ -10,6 +11,14 @@ internal class AIProductVariationsDataSource @Inject constructor(
     private val selectedSite: SelectedSite,
     private val productStore: WCProductStore,
 ) {
+    data class VariationUpdate(
+        val regularPrice: String? = null,
+        val salePrice: String? = null,
+        val stockQuantity: Int? = null,
+        val stockStatus: String? = null,
+        val sku: String? = null,
+        val status: String? = null,
+    )
 
     suspend fun fetchVariations(
         productId: Long,
@@ -36,6 +45,41 @@ internal class AIProductVariationsDataSource @Inject constructor(
 
     suspend fun getVariation(productId: Long, variationId: Long): Result<WCProductVariationModel> {
         val site = selectedSite.get()
+        return getVariation(site, productId, variationId)
+    }
+
+    suspend fun updateVariation(
+        productId: Long,
+        variationId: Long,
+        update: VariationUpdate,
+    ): Result<WCProductVariationModel> {
+        val site = selectedSite.get()
+        val existingVariation = getVariation(site, productId, variationId).getOrElse {
+            return Result.failure(it)
+        }
+
+        val updatedVariation = existingVariation.copy(
+            regularPrice = update.regularPrice ?: existingVariation.regularPrice,
+            salePrice = update.salePrice ?: existingVariation.salePrice,
+            stockQuantity = update.stockQuantity?.toDouble() ?: existingVariation.stockQuantity,
+            manageStock = if (update.stockQuantity != null) true else existingVariation.manageStock,
+            stockStatus = update.stockStatus ?: existingVariation.stockStatus,
+            sku = update.sku ?: existingVariation.sku,
+            status = update.status ?: existingVariation.status,
+        )
+        val event = productStore.updateVariation(WCProductStore.UpdateVariationPayload(site, updatedVariation))
+        return if (event.isError) {
+            Result.failure(OnChangedException(requireNotNull(event.error)))
+        } else {
+            Result.success(productStore.getVariationByRemoteId(site, productId, variationId) ?: updatedVariation)
+        }
+    }
+
+    private suspend fun getVariation(
+        site: SiteModel,
+        productId: Long,
+        variationId: Long,
+    ): Result<WCProductVariationModel> {
         val cached = productStore.getVariationByRemoteId(site, productId, variationId)
         if (cached != null) return Result.success(cached)
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationDetailResponse.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationDetailResponse.kt
@@ -1,0 +1,33 @@
+package com.woocommerce.android.aiassistant.tools.products
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.wordpress.android.fluxc.model.WCProductVariationModel
+
+@Serializable
+internal data class ProductVariationDetailResponse(
+    val id: Long,
+    @SerialName("product_id") val productId: Long,
+    val status: String,
+    val sku: String,
+    @SerialName("regular_price") val regularPrice: String,
+    @SerialName("sale_price") val salePrice: String,
+    @SerialName("on_sale") val onSale: Boolean,
+    @SerialName("manage_stock") val manageStock: Boolean,
+    @SerialName("stock_quantity") val stockQuantity: Double,
+    @SerialName("stock_status") val stockStatus: String,
+)
+
+internal fun WCProductVariationModel.toProductVariationDetailResponse() =
+    ProductVariationDetailResponse(
+        id = remoteVariationId.value,
+        productId = remoteProductId.value,
+        status = status,
+        sku = sku,
+        regularPrice = regularPrice,
+        salePrice = salePrice,
+        onSale = onSale,
+        manageStock = manageStock,
+        stockQuantity = stockQuantity,
+        stockStatus = stockStatus,
+    )

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsToolHandler.kt
@@ -65,20 +65,6 @@ internal class ProductVariationsToolHandler @Inject constructor(
     )
 
     @Serializable
-    private data class VariationDetail(
-        val id: Long,
-        @SerialName("product_id") val productId: Long,
-        val status: String,
-        val sku: String,
-        @SerialName("regular_price") val regularPrice: String,
-        @SerialName("sale_price") val salePrice: String,
-        @SerialName("on_sale") val onSale: Boolean,
-        @SerialName("manage_stock") val manageStock: Boolean,
-        @SerialName("stock_quantity") val stockQuantity: Double,
-        @SerialName("stock_status") val stockStatus: String,
-    )
-
-    @Serializable
     private data class PriceRange(
         val min: String,
         val max: String,
@@ -94,20 +80,7 @@ internal class ProductVariationsToolHandler @Inject constructor(
     )
 
     private fun WCProductVariationModel.toDetailJson(): JsonObject =
-        json.encodeToJsonElement(
-            VariationDetail(
-                id = remoteVariationId.value,
-                productId = remoteProductId.value,
-                status = status,
-                sku = sku,
-                regularPrice = regularPrice,
-                salePrice = salePrice,
-                onSale = onSale,
-                manageStock = manageStock,
-                stockQuantity = stockQuantity,
-                stockStatus = stockStatus,
-            )
-        ) as JsonObject
+        json.encodeToJsonElement(toProductVariationDetailResponse()) as JsonObject
 
     private fun List<WCProductVariationModel>.toListJson(productId: Long): JsonObject {
         val response = VariationList(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsUpdateToolHandler.kt
@@ -1,0 +1,111 @@
+package com.woocommerce.android.aiassistant.tools.products
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantToolHandler
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.core.chat.inputSchema
+import com.woocommerce.android.aiassistant.core.chat.parseArgs
+import com.woocommerce.android.aiassistant.di.AiAssistantJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import javax.inject.Inject
+
+internal class ProductVariationsUpdateToolHandler @Inject constructor(
+    private val dataSource: AIProductVariationsDataSource,
+    @AiAssistantJson private val json: Json,
+) : AssistantToolHandler {
+
+    override val descriptor = ToolDescriptor(
+        name = "product_variations_update",
+        description = "Update one product variation. Requires parent product_id and variation id. " +
+            "Accepts only regular_price, sale_price, stock_quantity, stock_status, sku, and status. " +
+            "Setting stock_quantity also enables stock management. At most one write is executed per turn.",
+        inputSchema = inputSchema {
+            integer("product_id", description = "The parent product ID. Required.", required = true)
+            integer("id", description = "The variation ID. Required.", required = true)
+            string("regular_price", description = "New regular price as a string.")
+            string("sale_price", description = "New sale price as a string.")
+            integer("stock_quantity", description = "New stock quantity. Also enables manage_stock.")
+            enum(
+                "stock_status",
+                values = listOf("instock", "outofstock", "onbackorder"),
+                description = "New stock status.",
+            )
+            string("sku", description = "New variation SKU.")
+            enum(
+                "status",
+                values = listOf("draft", "pending", "private", "publish"),
+                description = "New variation status.",
+            )
+        },
+        safetyLevel = ToolSafetyLevel.UNSAFE,
+    )
+
+    override suspend fun execute(call: ToolCall): ToolResult {
+        val args = call.parseArgs<Args>(json).getOrElse {
+            return ToolResult.ValidationError(call.id, "Invalid arguments: ${it.message}")
+        }
+        if (!args.hasUpdates()) {
+            return ToolResult.ValidationError(call.id, "At least one variation field must be provided.")
+        }
+        if (args.stockStatus != null && args.stockStatus !in ALLOWED_STOCK_STATUSES) {
+            return ToolResult.ValidationError(call.id, "'${args.stockStatus}' is not an allowed stock_status.")
+        }
+        if (args.status != null && args.status !in ALLOWED_STATUSES) {
+            return ToolResult.ValidationError(call.id, "'${args.status}' is not an allowed status.")
+        }
+
+        return dataSource.updateVariation(
+            productId = args.productId,
+            variationId = args.id,
+            update = AIProductVariationsDataSource.VariationUpdate(
+                regularPrice = args.regularPrice,
+                salePrice = args.salePrice,
+                stockQuantity = args.stockQuantity,
+                stockStatus = args.stockStatus,
+                sku = args.sku,
+                status = args.status,
+            ),
+        ).fold(
+            onSuccess = { variation ->
+                ToolResult.Success(
+                    toolCallId = call.id,
+                    structured = json.encodeToJsonElement(
+                        variation.toProductVariationDetailResponse()
+                    ) as JsonObject,
+                )
+            },
+            onFailure = { ToolResult.TransportError(toolCallId = call.id, retryable = true) },
+        )
+    }
+
+    @Serializable
+    private data class Args(
+        @SerialName("product_id") val productId: Long,
+        val id: Long,
+        @SerialName("regular_price") val regularPrice: String? = null,
+        @SerialName("sale_price") val salePrice: String? = null,
+        @SerialName("stock_quantity") val stockQuantity: Int? = null,
+        @SerialName("stock_status") val stockStatus: String? = null,
+        val sku: String? = null,
+        val status: String? = null,
+    ) {
+        fun hasUpdates(): Boolean =
+            regularPrice != null ||
+                salePrice != null ||
+                stockQuantity != null ||
+                stockStatus != null ||
+                sku != null ||
+                status != null
+    }
+
+    private companion object {
+        val ALLOWED_STOCK_STATUSES = setOf("instock", "outofstock", "onbackorder")
+        val ALLOWED_STATUSES = setOf("draft", "pending", "private", "publish")
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsUpdateToolHandler.kt
@@ -50,14 +50,8 @@ internal class ProductVariationsUpdateToolHandler @Inject constructor(
         val args = call.parseArgs<Args>(json).getOrElse {
             return ToolResult.ValidationError(call.id, "Invalid arguments: ${it.message}")
         }
-        if (!args.hasUpdates()) {
-            return ToolResult.ValidationError(call.id, "At least one variation field must be provided.")
-        }
-        if (args.stockStatus != null && args.stockStatus !in ALLOWED_STOCK_STATUSES) {
-            return ToolResult.ValidationError(call.id, "'${args.stockStatus}' is not an allowed stock_status.")
-        }
-        if (args.status != null && args.status !in ALLOWED_STATUSES) {
-            return ToolResult.ValidationError(call.id, "'${args.status}' is not an allowed status.")
+        args.validationError()?.let {
+            return ToolResult.ValidationError(call.id, it)
         }
 
         return dataSource.updateVariation(
@@ -102,6 +96,15 @@ internal class ProductVariationsUpdateToolHandler @Inject constructor(
                 stockStatus != null ||
                 sku != null ||
                 status != null
+
+        fun validationError(): String? =
+            when {
+                !hasUpdates() -> "At least one variation field must be provided."
+                stockStatus != null && stockStatus !in ALLOWED_STOCK_STATUSES ->
+                    "'$stockStatus' is not an allowed stock_status."
+                status != null && status !in ALLOWED_STATUSES -> "'$status' is not an allowed status."
+                else -> null
+            }
     }
 
     private companion object {

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelectorTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/DefaultToolCatalogSelectorTest.kt
@@ -13,7 +13,7 @@ class DefaultToolCatalogSelectorTest {
     private val catalog = listOf(
         "orders_list", "orders_get", "orders_update", "orders_bulk_update",
         "products_list", "products_get", "products_update", "products_bulk_update",
-        "product_variations_list", "analytics_revenue", "analytics_orders",
+        "product_variations_list", "product_variations_update", "analytics_revenue", "analytics_orders",
         "show_cards", "customers_list",
     ).map { name ->
         ToolDescriptor(
@@ -25,7 +25,7 @@ class DefaultToolCatalogSelectorTest {
     }
 
     @Test
-    fun `when GLOBAL scope is selected, then all 13 tools are returned in catalog order`() {
+    fun `when GLOBAL scope is selected, then all 14 tools are returned in catalog order`() {
         val snapshot = selector.select(ToolScope.GLOBAL, catalog)
 
         assertThat(snapshot.scope).isEqualTo(ToolScope.GLOBAL)
@@ -39,6 +39,7 @@ class DefaultToolCatalogSelectorTest {
             "products_update",
             "products_bulk_update",
             "product_variations_list",
+            "product_variations_update",
             "analytics_revenue",
             "analytics_orders",
             "show_cards",
@@ -65,6 +66,7 @@ class DefaultToolCatalogSelectorTest {
             "products_update",
             "products_bulk_update",
             "product_variations_list",
+            "product_variations_update",
             "analytics_revenue",
             "customers_list",
         )
@@ -81,6 +83,7 @@ class DefaultToolCatalogSelectorTest {
             "products_update",
             "products_bulk_update",
             "product_variations_list",
+            "product_variations_update",
             "analytics_revenue",
             "show_cards",
         )

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolCatalogTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolCatalogTest.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.aiassistant.tools.orders.OrdersGetToolHandler
 import com.woocommerce.android.aiassistant.tools.orders.OrdersListToolHandler
 import com.woocommerce.android.aiassistant.tools.orders.OrdersUpdateToolHandler
 import com.woocommerce.android.aiassistant.tools.products.ProductVariationsToolHandler
+import com.woocommerce.android.aiassistant.tools.products.ProductVariationsUpdateToolHandler
 import com.woocommerce.android.aiassistant.tools.products.ProductsBulkUpdateToolHandler
 import com.woocommerce.android.aiassistant.tools.products.ProductsGetToolHandler
 import com.woocommerce.android.aiassistant.tools.products.ProductsListToolHandler
@@ -31,6 +32,7 @@ class WooCommerceToolCatalogTest {
         ProductsUpdateToolHandler(mock(), mock()),
         ProductsBulkUpdateToolHandler(mock(), mock()),
         ProductVariationsToolHandler(mock(), mock()),
+        ProductVariationsUpdateToolHandler(mock(), mock()),
         AnalyticsRevenueToolHandler(mock(), mock()),
         AnalyticsOrdersToolHandler(mock(), mock()),
         ShowCardsToolHandler(),
@@ -38,7 +40,7 @@ class WooCommerceToolCatalogTest {
     )
 
     @Test
-    fun `when all stub handlers are aggregated, then 13 expected tool names are present`() {
+    fun `when all stub handlers are aggregated, then 14 expected tool names are present`() {
         val names = allHandlers.map { it.descriptor.name }
 
         assertThat(names).containsExactlyInAnyOrder(
@@ -51,6 +53,7 @@ class WooCommerceToolCatalogTest {
             "products_update",
             "products_bulk_update",
             "product_variations_list",
+            "product_variations_update",
             "analytics_revenue",
             "analytics_orders",
             "show_cards",
@@ -61,7 +64,13 @@ class WooCommerceToolCatalogTest {
     @Test
     fun `when descriptors are inspected, then write tools are UNSAFE and read tools are SAFE`() {
         val byName = allHandlers.associateBy { it.descriptor.name }
-        val writeToolNames = setOf("orders_update", "orders_bulk_update", "products_update", "products_bulk_update")
+        val writeToolNames = setOf(
+            "orders_update",
+            "orders_bulk_update",
+            "products_update",
+            "products_bulk_update",
+            "product_variations_update",
+        )
 
         writeToolNames.forEach { name ->
             assertThat(byName.getValue(name).descriptor.safetyLevel)

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductVariationsDataSourceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductVariationsDataSourceTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -122,6 +123,138 @@ class AIProductVariationsDataSourceTest {
             val result = dataSource.getVariation(productId = 100L, variationId = 10L)
 
             assertThat(result.exceptionOrNull()).isInstanceOf(OnChangedException::class.java)
+        }
+
+    @Test
+    fun `given cached variation, when updateVariation is called, then allowed fields are copied and store is updated`() =
+        runTest {
+            val existingVariation = makeVariation(productId = 100L, variationId = 10L).copy(
+                regularPrice = "19.99",
+                salePrice = "",
+                sku = "OLD-SKU",
+                status = "publish",
+                manageStock = false,
+                stockQuantity = 0.0,
+                stockStatus = "instock",
+            )
+            whenever(productStore.getVariationByRemoteId(site, 100L, 10L)).thenReturn(existingVariation).thenReturn(null)
+            whenever(productStore.updateVariation(any()))
+                .thenReturn(WCProductStore.OnVariationUpdated(remoteProductId = 100L, remoteVariationId = 10L))
+
+            val result = dataSource.updateVariation(
+                productId = 100L,
+                variationId = 10L,
+                update = AIProductVariationsDataSource.VariationUpdate(
+                    regularPrice = "29.99",
+                    salePrice = "24.99",
+                    stockQuantity = 7,
+                    stockStatus = "onbackorder",
+                    sku = "NEW-SKU",
+                    status = "private",
+                ),
+            )
+
+            assertThat(result.getOrThrow()).isEqualTo(existingVariation.copy(
+                regularPrice = "29.99",
+                salePrice = "24.99",
+                stockQuantity = 7.0,
+                manageStock = true,
+                stockStatus = "onbackorder",
+                sku = "NEW-SKU",
+                status = "private",
+            ))
+            argumentCaptor<WCProductStore.UpdateVariationPayload>().apply {
+                verify(productStore).updateVariation(capture())
+                assertThat(firstValue.site).isEqualTo(site)
+                assertThat(firstValue.variation).isEqualTo(existingVariation.copy(
+                    regularPrice = "29.99",
+                    salePrice = "24.99",
+                    stockQuantity = 7.0,
+                    manageStock = true,
+                    stockStatus = "onbackorder",
+                    sku = "NEW-SKU",
+                    status = "private",
+                ))
+            }
+        }
+
+    @Test
+    fun `given variation is not cached, when updateVariation is called, then it fetches before updating`() = runTest {
+        val fetchedVariation = makeVariation(productId = 100L, variationId = 10L).copy(sku = "OLD-SKU")
+        whenever(productStore.getVariationByRemoteId(site, 100L, 10L))
+            .thenReturn(null)
+            .thenReturn(fetchedVariation)
+            .thenReturn(null)
+        whenever(productStore.fetchSingleVariation(site, 100L, 10L))
+            .thenReturn(WCProductStore.OnVariationChanged(remoteProductId = 100L, remoteVariationId = 10L))
+        whenever(productStore.updateVariation(any()))
+            .thenReturn(WCProductStore.OnVariationUpdated(remoteProductId = 100L, remoteVariationId = 10L))
+
+        val result = dataSource.updateVariation(
+            productId = 100L,
+            variationId = 10L,
+            update = AIProductVariationsDataSource.VariationUpdate(sku = "NEW-SKU"),
+        )
+
+        assertThat(result.getOrThrow().sku).isEqualTo("NEW-SKU")
+        verify(productStore).fetchSingleVariation(site, 100L, 10L)
+        verify(productStore).updateVariation(any())
+    }
+
+    @Test
+    fun `given variation load fails, when updateVariation is called, then store update is not called`() = runTest {
+        val errorEvent = WCProductStore.OnVariationChanged(remoteProductId = 100L, remoteVariationId = 10L).also {
+            it.error = WCProductStore.ProductError(message = "missing")
+        }
+        whenever(productStore.getVariationByRemoteId(site, 100L, 10L)).thenReturn(null)
+        whenever(productStore.fetchSingleVariation(site, 100L, 10L)).thenReturn(errorEvent)
+
+        val result = dataSource.updateVariation(
+            productId = 100L,
+            variationId = 10L,
+            update = AIProductVariationsDataSource.VariationUpdate(sku = "NEW-SKU"),
+        )
+
+        assertThat(result.exceptionOrNull()).isInstanceOf(OnChangedException::class.java)
+        verify(productStore, never()).updateVariation(any())
+    }
+
+    @Test
+    fun `given store update fails, when updateVariation is called, then failure wraps OnChangedException`() = runTest {
+        val existingVariation = makeVariation(productId = 100L, variationId = 10L)
+        val errorEvent = WCProductStore.OnVariationUpdated(remoteProductId = 100L, remoteVariationId = 10L).also {
+            it.error = WCProductStore.ProductError(message = "update failed")
+        }
+        whenever(productStore.getVariationByRemoteId(site, 100L, 10L)).thenReturn(existingVariation)
+        whenever(productStore.updateVariation(any())).thenReturn(errorEvent)
+
+        val result = dataSource.updateVariation(
+            productId = 100L,
+            variationId = 10L,
+            update = AIProductVariationsDataSource.VariationUpdate(sku = "NEW-SKU"),
+        )
+
+        assertThat(result.exceptionOrNull()).isInstanceOf(OnChangedException::class.java)
+    }
+
+    @Test
+    fun `given refreshed cache exists after update, when updateVariation succeeds, then refreshed variation is returned`() =
+        runTest {
+            val existingVariation = makeVariation(productId = 100L, variationId = 10L).copy(sku = "OLD-SKU")
+            val refreshedVariation = existingVariation.copy(sku = "REFRESHED-SKU")
+            whenever(productStore.getVariationByRemoteId(site, 100L, 10L))
+                .thenReturn(existingVariation)
+                .thenReturn(refreshedVariation)
+            whenever(productStore.updateVariation(any()))
+                .thenReturn(WCProductStore.OnVariationUpdated(remoteProductId = 100L, remoteVariationId = 10L))
+
+            val result = dataSource.updateVariation(
+                productId = 100L,
+                variationId = 10L,
+                update = AIProductVariationsDataSource.VariationUpdate(sku = "NEW-SKU"),
+            )
+
+            assertThat(result.getOrThrow()).isEqualTo(refreshedVariation)
         }
 
     private fun argThatPayload(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductVariationsDataSourceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductVariationsDataSourceTest.kt
@@ -156,19 +156,8 @@ class AIProductVariationsDataSourceTest {
                 ),
             )
 
-            assertThat(result.getOrThrow()).isEqualTo(existingVariation.copy(
-                regularPrice = "29.99",
-                salePrice = "24.99",
-                stockQuantity = 7.0,
-                manageStock = true,
-                stockStatus = "onbackorder",
-                sku = "NEW-SKU",
-                status = "private",
-            ))
-            argumentCaptor<WCProductStore.UpdateVariationPayload>().apply {
-                verify(productStore).updateVariation(capture())
-                assertThat(firstValue.site).isEqualTo(site)
-                assertThat(firstValue.variation).isEqualTo(existingVariation.copy(
+            assertThat(result.getOrThrow()).isEqualTo(
+                existingVariation.copy(
                     regularPrice = "29.99",
                     salePrice = "24.99",
                     stockQuantity = 7.0,
@@ -176,7 +165,22 @@ class AIProductVariationsDataSourceTest {
                     stockStatus = "onbackorder",
                     sku = "NEW-SKU",
                     status = "private",
-                ))
+                )
+            )
+            argumentCaptor<WCProductStore.UpdateVariationPayload>().apply {
+                verify(productStore).updateVariation(capture())
+                assertThat(firstValue.site).isEqualTo(site)
+                assertThat(firstValue.variation).isEqualTo(
+                    existingVariation.copy(
+                        regularPrice = "29.99",
+                        salePrice = "24.99",
+                        stockQuantity = 7.0,
+                        manageStock = true,
+                        stockStatus = "onbackorder",
+                        sku = "NEW-SKU",
+                        status = "private",
+                    )
+                )
             }
         }
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductVariationsDataSourceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductVariationsDataSourceTest.kt
@@ -137,7 +137,9 @@ class AIProductVariationsDataSourceTest {
                 stockQuantity = 0.0,
                 stockStatus = "instock",
             )
-            whenever(productStore.getVariationByRemoteId(site, 100L, 10L)).thenReturn(existingVariation).thenReturn(null)
+            whenever(productStore.getVariationByRemoteId(site, 100L, 10L))
+                .thenReturn(existingVariation)
+                .thenReturn(null)
             whenever(productStore.updateVariation(any()))
                 .thenReturn(WCProductStore.OnVariationUpdated(remoteProductId = 100L, remoteVariationId = 10L))
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsUpdateToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsUpdateToolHandlerTest.kt
@@ -1,0 +1,258 @@
+package com.woocommerce.android.aiassistant.tools.products
+
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.WCProductVariationModel
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProductVariationsUpdateToolHandlerTest {
+
+    private val dataSource: AIProductVariationsDataSource = mock()
+    private val handler = ProductVariationsUpdateToolHandler(
+        dataSource = dataSource,
+        json = Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = false
+            explicitNulls = false
+        },
+    )
+
+    private fun variation(
+        productId: Long = 100L,
+        variationId: Long = 10L,
+    ) = WCProductVariationModel(
+        localSiteId = LocalId(1),
+        remoteProductId = RemoteId(productId),
+        remoteVariationId = RemoteId(variationId),
+        status = "private",
+        sku = "SKU-10",
+        regularPrice = "29.99",
+        salePrice = "24.99",
+        onSale = true,
+        manageStock = true,
+        stockQuantity = 7.0,
+        stockStatus = "onbackorder",
+        price = "24.99",
+    )
+
+    private fun toolCall(arguments: JsonObject): ToolCall =
+        ToolCall(id = "call-1", name = "product_variations_update", arguments = arguments)
+
+    @Test
+    fun `given descriptor, when inspected, then schema contains only supported variation update fields`() {
+        val schema = handler.descriptor.inputSchema
+        val properties = requireNotNull(schema["properties"]).jsonObject
+        val required = requireNotNull(schema["required"]).jsonArray.map { it.jsonPrimitive.content }
+        val stockStatusEnum = requireNotNull(properties["stock_status"]).jsonObject.getValue("enum").jsonArray
+            .map { it.jsonPrimitive.content }
+        val statusEnum = requireNotNull(properties["status"]).jsonObject.getValue("enum").jsonArray
+            .map { it.jsonPrimitive.content }
+
+        assertThat(handler.descriptor.name).isEqualTo("product_variations_update")
+        assertThat(handler.descriptor.safetyLevel).isEqualTo(ToolSafetyLevel.UNSAFE)
+        assertThat(handler.descriptor.description).contains("product_id")
+        assertThat(handler.descriptor.description).contains("stock_quantity")
+        assertThat(requireNotNull(schema["additionalProperties"]).jsonPrimitive.boolean).isFalse
+        assertThat(properties.keys).containsExactlyInAnyOrder(
+            "product_id",
+            "id",
+            "regular_price",
+            "sale_price",
+            "stock_quantity",
+            "stock_status",
+            "sku",
+            "status",
+        )
+        assertThat(required).containsExactly("product_id", "id")
+        assertThat(stockStatusEnum).containsExactly("instock", "outofstock", "onbackorder")
+        assertThat(statusEnum).containsExactly("draft", "pending", "private", "publish")
+    }
+
+    @Test
+    fun `given valid fields, when execute is called, then updateVariation is called and detail JSON is returned`() =
+        runTest {
+            whenever(
+                dataSource.updateVariation(
+                    productId = 100L,
+                    variationId = 10L,
+                    update = AIProductVariationsDataSource.VariationUpdate(
+                        regularPrice = "29.99",
+                        salePrice = "24.99",
+                        stockQuantity = 7,
+                        stockStatus = "onbackorder",
+                        sku = "SKU-10",
+                        status = "private",
+                    ),
+                )
+            ).thenReturn(Result.success(variation()))
+
+            val result = handler.execute(
+                toolCall(
+                    buildJsonObject {
+                        put("product_id", 100)
+                        put("id", 10)
+                        put("regular_price", "29.99")
+                        put("sale_price", "24.99")
+                        put("stock_quantity", 7)
+                        put("stock_status", "onbackorder")
+                        put("sku", "SKU-10")
+                        put("status", "private")
+                    }
+                )
+            )
+
+            assertThat(result).isInstanceOf(ToolResult.Success::class.java)
+            val json = (result as ToolResult.Success).structured.jsonObject
+            assertThat(requireNotNull(json["id"]).jsonPrimitive.long).isEqualTo(10L)
+            assertThat(requireNotNull(json["product_id"]).jsonPrimitive.long).isEqualTo(100L)
+            assertThat(requireNotNull(json["status"]).jsonPrimitive.content).isEqualTo("private")
+            assertThat(requireNotNull(json["sku"]).jsonPrimitive.content).isEqualTo("SKU-10")
+            assertThat(requireNotNull(json["regular_price"]).jsonPrimitive.content).isEqualTo("29.99")
+            assertThat(requireNotNull(json["sale_price"]).jsonPrimitive.content).isEqualTo("24.99")
+            assertThat(requireNotNull(json["on_sale"]).jsonPrimitive.boolean).isTrue
+            assertThat(requireNotNull(json["manage_stock"]).jsonPrimitive.boolean).isTrue
+            assertThat(requireNotNull(json["stock_quantity"]).jsonPrimitive.content).isEqualTo("7.0")
+            assertThat(requireNotNull(json["stock_status"]).jsonPrimitive.content).isEqualTo("onbackorder")
+            verify(dataSource).updateVariation(
+                productId = 100L,
+                variationId = 10L,
+                update = AIProductVariationsDataSource.VariationUpdate(
+                    regularPrice = "29.99",
+                    salePrice = "24.99",
+                    stockQuantity = 7,
+                    stockStatus = "onbackorder",
+                    sku = "SKU-10",
+                    status = "private",
+                ),
+            )
+        }
+
+    @Test
+    fun `given missing product id, when execute is called, then ValidationError is returned before datasource access`() =
+        runTest {
+            val result = handler.execute(toolCall(buildJsonObject { put("id", 10) }))
+
+            assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
+            verify(dataSource, never()).updateVariation(productId = any(), variationId = any(), update = any())
+        }
+
+    @Test
+    fun `given missing id, when execute is called, then ValidationError is returned before datasource access`() =
+        runTest {
+            val result = handler.execute(toolCall(buildJsonObject { put("product_id", 100) }))
+
+            assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
+            verify(dataSource, never()).updateVariation(productId = any(), variationId = any(), update = any())
+        }
+
+    @Test
+    fun `given no editable fields, when execute is called, then ValidationError is returned before datasource access`() =
+        runTest {
+            val result = handler.execute(
+                toolCall(
+                    buildJsonObject {
+                        put("product_id", 100)
+                        put("id", 10)
+                    }
+                )
+            )
+
+            assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
+            verify(dataSource, never()).updateVariation(productId = any(), variationId = any(), update = any())
+        }
+
+    @Test
+    fun `given unknown only editable field, when execute is called, then ValidationError is returned`() = runTest {
+        val result = handler.execute(
+            toolCall(
+                buildJsonObject {
+                    put("product_id", 100)
+                    put("id", 10)
+                    put("unsupported_field", "ignored")
+                }
+            )
+        )
+
+        assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
+        verify(dataSource, never()).updateVariation(productId = any(), variationId = any(), update = any())
+    }
+
+    @Test
+    fun `given unsupported stock status, when execute is called, then ValidationError is returned before datasource access`() =
+        runTest {
+            val result = handler.execute(
+                toolCall(
+                    buildJsonObject {
+                        put("product_id", 100)
+                        put("id", 10)
+                        put("stock_status", "invalid")
+                    }
+                )
+            )
+
+            assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
+            verify(dataSource, never()).updateVariation(productId = any(), variationId = any(), update = any())
+        }
+
+    @Test
+    fun `given unsupported status, when execute is called, then ValidationError is returned before datasource access`() =
+        runTest {
+            val result = handler.execute(
+                toolCall(
+                    buildJsonObject {
+                        put("product_id", 100)
+                        put("id", 10)
+                        put("status", "trash")
+                    }
+                )
+            )
+
+            assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
+            verify(dataSource, never()).updateVariation(productId = any(), variationId = any(), update = any())
+        }
+
+    @Test
+    fun `given datasource failure, when execute is called, then retryable TransportError is returned`() = runTest {
+        whenever(
+            dataSource.updateVariation(
+                productId = 100L,
+                variationId = 10L,
+                update = AIProductVariationsDataSource.VariationUpdate(sku = "SKU-10"),
+            )
+        ).thenReturn(Result.failure(RuntimeException("network error")))
+
+        val result = handler.execute(
+            toolCall(
+                buildJsonObject {
+                    put("product_id", 100)
+                    put("id", 10)
+                    put("sku", "SKU-10")
+                }
+            )
+        )
+
+        assertThat(result).isInstanceOf(ToolResult.TransportError::class.java)
+        assertThat((result as ToolResult.TransportError).retryable).isTrue
+    }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-2961

Adds the Android AI Assistant `product_variations_update` tool so the assistant can update a single product variation using the parent `product_id` and variation `id`.

The new handler is registered in the assistant tool registry, included in the Products catalog, and marked as an unsafe write tool. It supports the editable fields aligned with the existing iOS tool behavior: `regular_price`, `sale_price`, `stock_quantity`, `stock_status`, `sku`, and `status`. The datasource uses the existing single-variation `WCProductStore.updateVariation` path, fetches the current variation before applying changes, and enables stock management when `stock_quantity` is provided.

This also extracts a shared variation detail response so `product_variations_list` detail mode and `product_variations_update` return the same structured shape.

### Test Steps
Green CI is enough.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.