### PR TITLE
[WOOMOB-2896] Add assistant confirmation safety handoff

### DIFF
--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -90,19 +90,7 @@ class AgenticLoopImpl(
 
             val toolExecution = executeTools(assembledResults, validCalls, toolDescriptors)
             if (toolExecution is ToolExecutionOutcome.Cancelled) {
-                val completedCalls = toolExecution.completed.map { it.historyToolCall }
-                val cancelledAssistantMessage = AssistantMessage.Assistant(
-                    content = stream.assistantText.takeIf { it.isNotEmpty() },
-                    toolCalls = completedCalls,
-                )
-                if (cancelledAssistantMessage.content != null || completedCalls.isNotEmpty()) {
-                    newTurnMessages.add(cancelledAssistantMessage)
-                }
-                toolExecution.completed.forEach { completed ->
-                    newTurnMessages.add(completed.toToolMessage())
-                }
-                emit(LoopEvent.Failed(AssistantError.Cancelled))
-                emit(LoopEvent.Finished(LoopOutcome.STOPPED, history + newTurnMessages, retryAvailable = false))
+                emitCancelledToolExecution(toolExecution, stream.assistantText, history, newTurnMessages)
                 return@flow
             }
 
@@ -193,21 +181,10 @@ class AgenticLoopImpl(
         }
         for (call in validCalls) {
             val descriptor = toolDescriptors.find { it.name == call.name }
-            val result = when {
-                descriptor == null ->
-                    ToolResult.ValidationError(call.id, "Unknown tool: ${call.name}")
-                else -> when (val decision = safetyOrchestrator.evaluate(call, descriptor)) {
-                    SafetyDecision.Execute -> executeApprovedTool(call)
-                    is SafetyDecision.RequireConfirmation -> {
-                        emit(LoopEvent.ConfirmationRequested(decision.request))
-                        val confirmationResult = safetyOrchestrator.awaitResult(decision.request.id)
-                        emit(LoopEvent.ConfirmationResolved(confirmationResult))
-                        when (confirmationResult.decision) {
-                            ConfirmationDecision.CONFIRMED -> executeApprovedTool(call)
-                            ConfirmationDecision.CANCELLED -> return ToolExecutionOutcome.Cancelled(completedTools)
-                        }
-                    }
-                }
+            val result = if (descriptor == null) {
+                ToolResult.ValidationError(call.id, "Unknown tool: ${call.name}")
+            } else {
+                executeConfirmedTool(call, descriptor) ?: return ToolExecutionOutcome.Cancelled(completedTools)
             }
             completedTools += CompletedToolCall(call, result)
             emit(LoopEvent.ToolCallFinished(result))
@@ -215,9 +192,46 @@ class AgenticLoopImpl(
         return ToolExecutionOutcome.Completed(completedTools)
     }
 
+    private suspend fun FlowCollector<LoopEvent>.executeConfirmedTool(
+        call: ToolCall,
+        descriptor: ToolDescriptor,
+    ): ToolResult? = when (val decision = safetyOrchestrator.evaluate(call, descriptor)) {
+        SafetyDecision.Execute -> executeApprovedTool(call)
+        is SafetyDecision.RequireConfirmation -> {
+            emit(LoopEvent.ConfirmationRequested(decision.request))
+            val confirmationResult = safetyOrchestrator.awaitResult(decision.request.id)
+            emit(LoopEvent.ConfirmationResolved(confirmationResult))
+            when (confirmationResult.decision) {
+                ConfirmationDecision.CONFIRMED -> executeApprovedTool(call)
+                ConfirmationDecision.CANCELLED -> null
+            }
+        }
+    }
+
     private suspend fun FlowCollector<LoopEvent>.executeApprovedTool(call: ToolCall): ToolResult {
         emit(LoopEvent.ToolCallStarted(call))
         return toolRegistry.execute(call)
+    }
+
+    private suspend fun FlowCollector<LoopEvent>.emitCancelledToolExecution(
+        outcome: ToolExecutionOutcome.Cancelled,
+        assistantText: String,
+        history: List<AssistantMessage>,
+        newTurnMessages: MutableList<AssistantMessage>,
+    ) {
+        val completedCalls = outcome.completed.map { it.historyToolCall }
+        val cancelledAssistantMessage = AssistantMessage.Assistant(
+            content = assistantText.takeIf { it.isNotEmpty() },
+            toolCalls = completedCalls,
+        )
+        if (cancelledAssistantMessage.content != null || completedCalls.isNotEmpty()) {
+            newTurnMessages.add(cancelledAssistantMessage)
+        }
+        outcome.completed.forEach { completed ->
+            newTurnMessages.add(completed.toToolMessage())
+        }
+        emit(LoopEvent.Failed(AssistantError.Cancelled))
+        emit(LoopEvent.Finished(LoopOutcome.STOPPED, history + newTurnMessages, retryAvailable = false))
     }
 
     private data class StreamResult(

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -198,12 +198,17 @@ class AgenticLoopImpl(
     ): ToolResult? = when (val decision = safetyOrchestrator.evaluate(call, descriptor)) {
         SafetyDecision.Execute -> executeApprovedTool(call)
         is SafetyDecision.RequireConfirmation -> {
-            emit(LoopEvent.ConfirmationRequested(decision.request))
-            val confirmationResult = safetyOrchestrator.awaitResult(decision.request.id)
-            emit(LoopEvent.ConfirmationResolved(confirmationResult))
-            when (confirmationResult.decision) {
-                ConfirmationDecision.CONFIRMED -> executeApprovedTool(call)
-                ConfirmationDecision.CANCELLED -> null
+            val requestId = decision.request.id
+            try {
+                emit(LoopEvent.ConfirmationRequested(decision.request))
+                val confirmationResult = safetyOrchestrator.awaitResult(requestId)
+                emit(LoopEvent.ConfirmationResolved(confirmationResult))
+                when (confirmationResult.decision) {
+                    ConfirmationDecision.CONFIRMED -> executeApprovedTool(call)
+                    ConfirmationDecision.CANCELLED -> null
+                }
+            } finally {
+                safetyOrchestrator.cancelPending(requestId)
             }
         }
     }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -11,8 +11,11 @@ import com.woocommerce.android.aiassistant.core.chat.ToolDefinition
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
 import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
-import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import com.woocommerce.android.aiassistant.core.chat.toAssistantError
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationDecision
+import com.woocommerce.android.aiassistant.core.safety.SafetyDecision
+import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
+import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestratorImpl
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
@@ -26,6 +29,7 @@ class AgenticLoopImpl(
     private val toolRegistry: ToolRegistry,
     private val retryPolicy: RetryPolicy,
     private val historyBudgeter: HistoryBudgeter,
+    private val safetyOrchestrator: SafetyOrchestrator = SafetyOrchestratorImpl(),
     private val json: Json,
 ) : AgenticLoop {
 
@@ -68,10 +72,9 @@ class AgenticLoopImpl(
                 content = stream.assistantText.takeIf { it.isNotEmpty() },
                 toolCalls = callsForHistory,
             )
-            modelMessages = modelMessages + newAssistantMsg
-            newTurnMessages.add(newAssistantMsg)
 
             if (stream.finishReason == null) {
+                newTurnMessages.add(newAssistantMsg)
                 emit(failedFinish(history + newTurnMessages, retryAvailable = false, AssistantError.UpstreamFailure))
                 return@flow
             }
@@ -79,16 +82,35 @@ class AgenticLoopImpl(
             val isTerminal = stream.finishReason == FinishReason.STOP ||
                 (stream.finishReason != FinishReason.TOOL_CALLS && stream.toolCallDeltas.isEmpty())
             if (isTerminal) {
+                modelMessages = modelMessages + newAssistantMsg
+                newTurnMessages.add(newAssistantMsg)
                 emit(LoopEvent.Finished(LoopOutcome.COMPLETED, history + newTurnMessages))
                 return@flow
             }
 
-            val toolResults = executeTools(assembledResults, validCalls, toolDescriptors)
-            for (result in toolResults) {
-                val newToolMsg = AssistantMessage.Tool(
-                    toolCallId = result.toolCallId,
-                    content = result.toModelContent(),
+            val toolExecution = executeTools(assembledResults, validCalls, toolDescriptors)
+            if (toolExecution is ToolExecutionOutcome.Cancelled) {
+                val completedCalls = toolExecution.completed.map { it.historyToolCall }
+                val cancelledAssistantMessage = AssistantMessage.Assistant(
+                    content = stream.assistantText.takeIf { it.isNotEmpty() },
+                    toolCalls = completedCalls,
                 )
+                if (cancelledAssistantMessage.content != null || completedCalls.isNotEmpty()) {
+                    newTurnMessages.add(cancelledAssistantMessage)
+                }
+                toolExecution.completed.forEach { completed ->
+                    newTurnMessages.add(completed.toToolMessage())
+                }
+                emit(LoopEvent.Failed(AssistantError.Cancelled))
+                emit(LoopEvent.Finished(LoopOutcome.STOPPED, history + newTurnMessages, retryAvailable = false))
+                return@flow
+            }
+
+            val completedTools = (toolExecution as ToolExecutionOutcome.Completed).completed
+            modelMessages = modelMessages + newAssistantMsg
+            newTurnMessages.add(newAssistantMsg)
+            for (completed in completedTools) {
+                val newToolMsg = completed.toToolMessage()
                 modelMessages = modelMessages + newToolMsg
                 newTurnMessages.add(newToolMsg)
             }
@@ -160,33 +182,42 @@ class AgenticLoopImpl(
         assembledResults: List<ToolCallAssembler.AssemblyResult>,
         validCalls: List<ToolCall>,
         toolDescriptors: List<ToolDescriptor>,
-    ): List<ToolResult> {
-        val toolResults = mutableListOf<ToolResult>()
+    ): ToolExecutionOutcome {
+        val completedTools = mutableListOf<CompletedToolCall>()
         for (r in assembledResults) {
             if (r is ToolCallAssembler.AssemblyResult.MalformedArguments) {
                 val result = ToolResult.ValidationError(r.callId, "Malformed arguments for ${r.toolName}")
-                toolResults += result
+                completedTools += CompletedToolCall(r.toHistoryToolCall(), result)
                 emit(LoopEvent.ToolCallFinished(result))
             }
         }
         for (call in validCalls) {
-            emit(LoopEvent.ToolCallStarted(call))
             val descriptor = toolDescriptors.find { it.name == call.name }
             val result = when {
                 descriptor == null ->
                     ToolResult.ValidationError(call.id, "Unknown tool: ${call.name}")
-                descriptor.safetyLevel == ToolSafetyLevel.UNSAFE -> {
-                    emit(LoopEvent.BlockedBySafety(call))
-                    ToolResult.RejectedBySafety(call.id)
+                else -> when (val decision = safetyOrchestrator.evaluate(call, descriptor)) {
+                    SafetyDecision.Execute -> executeApprovedTool(call)
+                    is SafetyDecision.RequireConfirmation -> {
+                        emit(LoopEvent.ConfirmationRequested(decision.request))
+                        val confirmationResult = safetyOrchestrator.awaitResult(decision.request.id)
+                        emit(LoopEvent.ConfirmationResolved(confirmationResult))
+                        when (confirmationResult.decision) {
+                            ConfirmationDecision.CONFIRMED -> executeApprovedTool(call)
+                            ConfirmationDecision.CANCELLED -> return ToolExecutionOutcome.Cancelled(completedTools)
+                        }
+                    }
                 }
-                else -> toolRegistry.execute(call)
             }
-            toolResults += result
-            if (result !is ToolResult.RejectedBySafety) {
-                emit(LoopEvent.ToolCallFinished(result))
-            }
+            completedTools += CompletedToolCall(call, result)
+            emit(LoopEvent.ToolCallFinished(result))
         }
-        return toolResults
+        return ToolExecutionOutcome.Completed(completedTools)
+    }
+
+    private suspend fun FlowCollector<LoopEvent>.executeApprovedTool(call: ToolCall): ToolResult {
+        emit(LoopEvent.ToolCallStarted(call))
+        return toolRegistry.execute(call)
     }
 
     private data class StreamResult(
@@ -194,6 +225,16 @@ class AgenticLoopImpl(
         val assistantText: String,
         val finishReason: FinishReason?,
         val visibleOutputStarted: Boolean,
+    )
+
+    private sealed interface ToolExecutionOutcome {
+        data class Completed(val completed: List<CompletedToolCall>) : ToolExecutionOutcome
+        data class Cancelled(val completed: List<CompletedToolCall>) : ToolExecutionOutcome
+    }
+
+    private data class CompletedToolCall(
+        val historyToolCall: ToolCall,
+        val result: ToolResult,
     )
 
     private fun messagesWithPartialText(
@@ -211,6 +252,11 @@ class AgenticLoopImpl(
         is ToolResult.RejectedBySafety -> errorJson("Action was not approved")
         is ToolResult.TransportError -> errorJson("Tool execution failed")
     }
+
+    private fun CompletedToolCall.toToolMessage() = AssistantMessage.Tool(
+        toolCallId = result.toolCallId,
+        content = result.toModelContent(),
+    )
 
     private fun ToolCallAssembler.AssemblyResult.toHistoryToolCall(): ToolCall = when (this) {
         is ToolCallAssembler.AssemblyResult.Success -> call

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/LoopEvent.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/LoopEvent.kt
@@ -4,12 +4,17 @@ import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 
 sealed interface LoopEvent {
     data class AssistantTextDelta(val text: String) : LoopEvent
     data class ToolCallStarted(val call: ToolCall) : LoopEvent
     data class ToolCallFinished(val result: ToolResult) : LoopEvent
     data class BlockedBySafety(val call: ToolCall) : LoopEvent
+    data class ConfirmationRequested(val request: ConfirmationRequest) : LoopEvent
+    data class ConfirmationResolved(val result: ConfirmationResult) : LoopEvent
+    data class Failed(val error: AssistantError) : LoopEvent
     data class Finished(
         val outcome: LoopOutcome,
         val updatedHistory: List<AssistantMessage>,

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/LoopEvent.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/LoopEvent.kt
@@ -11,7 +11,6 @@ sealed interface LoopEvent {
     data class AssistantTextDelta(val text: String) : LoopEvent
     data class ToolCallStarted(val call: ToolCall) : LoopEvent
     data class ToolCallFinished(val result: ToolResult) : LoopEvent
-    data class BlockedBySafety(val call: ToolCall) : LoopEvent
     data class ConfirmationRequested(val request: ConfirmationRequest) : LoopEvent
     data class ConfirmationResolved(val result: ConfirmationResult) : LoopEvent
     data class Failed(val error: AssistantError) : LoopEvent

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/ConfirmationRequest.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/ConfirmationRequest.kt
@@ -1,0 +1,22 @@
+package com.woocommerce.android.aiassistant.core.safety
+
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.serialization.json.JsonObject
+
+data class ConfirmationRequest(
+    val id: String,
+    val toolCallId: String,
+    val toolName: String,
+    val arguments: JsonObject,
+    val safetyLevel: ToolSafetyLevel,
+)
+
+data class ConfirmationResult(
+    val requestId: String,
+    val decision: ConfirmationDecision,
+)
+
+enum class ConfirmationDecision {
+    CONFIRMED,
+    CANCELLED,
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestrator.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestrator.kt
@@ -1,0 +1,26 @@
+package com.woocommerce.android.aiassistant.core.safety
+
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+
+interface SafetyOrchestrator {
+    suspend fun evaluate(
+        call: ToolCall,
+        descriptor: ToolDescriptor,
+    ): SafetyDecision
+
+    suspend fun awaitResult(requestId: String): ConfirmationResult
+
+    fun resolve(result: ConfirmationResult): Boolean
+
+    fun confirm(requestId: String): Boolean =
+        resolve(ConfirmationResult(requestId, ConfirmationDecision.CONFIRMED))
+
+    fun cancel(requestId: String): Boolean =
+        resolve(ConfirmationResult(requestId, ConfirmationDecision.CANCELLED))
+}
+
+sealed interface SafetyDecision {
+    data object Execute : SafetyDecision
+    data class RequireConfirmation(val request: ConfirmationRequest) : SafetyDecision
+}

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestrator.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestrator.kt
@@ -13,6 +13,8 @@ interface SafetyOrchestrator {
 
     fun resolve(result: ConfirmationResult): Boolean
 
+    fun cancelPending(requestId: String): Boolean
+
     fun confirm(requestId: String): Boolean =
         resolve(ConfirmationResult(requestId, ConfirmationDecision.CONFIRMED))
 

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImpl.kt
@@ -46,4 +46,9 @@ class SafetyOrchestratorImpl(
         val deferred = pending[result.requestId] ?: return false
         return deferred.complete(result)
     }
+
+    override fun cancelPending(requestId: String): Boolean {
+        val deferred = pending.remove(requestId) ?: return false
+        return deferred.complete(ConfirmationResult(requestId, ConfirmationDecision.CANCELLED))
+    }
 }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImpl.kt
@@ -3,15 +3,14 @@ package com.woocommerce.android.aiassistant.core.safety
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.coroutines.CompletableDeferred
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import kotlinx.coroutines.CompletableDeferred
 
 class SafetyOrchestratorImpl(
     private val requestIdFactory: () -> String = { UUID.randomUUID().toString() },
 ) : SafetyOrchestrator {
     private val pending = ConcurrentHashMap<String, CompletableDeferred<ConfirmationResult>>()
-    private val resolvedBeforeAwait = ConcurrentHashMap<String, ConfirmationResult>()
 
     override suspend fun evaluate(
         call: ToolCall,
@@ -33,21 +32,18 @@ class SafetyOrchestratorImpl(
     }
 
     override suspend fun awaitResult(requestId: String): ConfirmationResult {
-        resolvedBeforeAwait.remove(requestId)?.let { return it }
         val deferred = pending[requestId]
             ?: return ConfirmationResult(requestId, ConfirmationDecision.CANCELLED)
 
         return try {
             deferred.await()
         } finally {
-            pending.remove(requestId)
-            resolvedBeforeAwait.remove(requestId)
+            pending.remove(requestId, deferred)
         }
     }
 
     override fun resolve(result: ConfirmationResult): Boolean {
-        val deferred = pending.remove(result.requestId) ?: return false
-        resolvedBeforeAwait[result.requestId] = result
+        val deferred = pending[result.requestId] ?: return false
         return deferred.complete(result)
     }
 }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImpl.kt
@@ -1,0 +1,53 @@
+package com.woocommerce.android.aiassistant.core.safety
+
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CompletableDeferred
+
+class SafetyOrchestratorImpl(
+    private val requestIdFactory: () -> String = { UUID.randomUUID().toString() },
+) : SafetyOrchestrator {
+    private val pending = ConcurrentHashMap<String, CompletableDeferred<ConfirmationResult>>()
+    private val resolvedBeforeAwait = ConcurrentHashMap<String, ConfirmationResult>()
+
+    override suspend fun evaluate(
+        call: ToolCall,
+        descriptor: ToolDescriptor,
+    ): SafetyDecision {
+        if (descriptor.safetyLevel == ToolSafetyLevel.SAFE) {
+            return SafetyDecision.Execute
+        }
+
+        val request = ConfirmationRequest(
+            id = requestIdFactory(),
+            toolCallId = call.id,
+            toolName = call.name,
+            arguments = call.arguments,
+            safetyLevel = descriptor.safetyLevel,
+        )
+        pending[request.id] = CompletableDeferred()
+        return SafetyDecision.RequireConfirmation(request)
+    }
+
+    override suspend fun awaitResult(requestId: String): ConfirmationResult {
+        resolvedBeforeAwait.remove(requestId)?.let { return it }
+        val deferred = pending[requestId]
+            ?: return ConfirmationResult(requestId, ConfirmationDecision.CANCELLED)
+
+        return try {
+            deferred.await()
+        } finally {
+            pending.remove(requestId)
+            resolvedBeforeAwait.remove(requestId)
+        }
+    }
+
+    override fun resolve(result: ConfirmationResult): Boolean {
+        val deferred = pending.remove(result.requestId) ?: return false
+        resolvedBeforeAwait[result.requestId] = result
+        return deferred.complete(result)
+    }
+}

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -13,8 +13,8 @@ import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationDecision
-import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestratorImpl
 import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
+import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestratorImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -586,7 +586,7 @@ class AgenticLoopImplTest {
     }
 
     @Test
-    fun `given safe tool succeeds before unsafe tool is cancelled, then completed tool history is preserved`() = runTest {
+    fun `given safe tool succeeds before unsafe tool, when unsafe is cancelled, then history is preserved`() = runTest {
         val unsafeDescriptor = ToolDescriptor(
             name = "orders_update",
             description = "Updates an order",

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -12,10 +12,17 @@ import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
 import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationDecision
+import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestratorImpl
+import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
@@ -24,6 +31,7 @@ import kotlinx.serialization.json.put
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AgenticLoopImplTest {
     private val json = assistantJsonForTests()
     private val context = SessionContext(siteId = 1L, catalogSnapshot = CatalogSnapshot(ToolScope.GLOBAL, emptyList()))
@@ -37,13 +45,14 @@ class AgenticLoopImplTest {
         vararg turnResponses: Flow<AssistantEvent>,
         registry: ToolRegistry = NoOpToolRegistry(),
         budgeter: HistoryBudgeter = passThroughBudgeter(),
+        safetyOrchestrator: SafetyOrchestrator = SafetyOrchestratorImpl(),
     ): AgenticLoopImpl {
         var callCount = 0
         val service = object : ChatService {
             override fun streamTurn(request: ChatRequest) =
                 turnResponses[minOf(callCount++, turnResponses.size - 1)]
         }
-        return AgenticLoopImpl(service, registry, ConservativeRetryPolicy, budgeter, json)
+        return AgenticLoopImpl(service, registry, ConservativeRetryPolicy, budgeter, safetyOrchestrator, json)
     }
 
     private fun stubRegistry(
@@ -174,7 +183,14 @@ class AgenticLoopImplTest {
             override suspend fun execute(call: ToolCall) =
                 ToolResult.Success(call.id, structured = structuredPayload, uiStructured = uiOnlyPayload)
         }
-        val loop = AgenticLoopImpl(service, registry, ConservativeRetryPolicy, passThroughBudgeter(), json)
+        val loop = AgenticLoopImpl(
+            service,
+            registry,
+            ConservativeRetryPolicy,
+            passThroughBudgeter(),
+            SafetyOrchestratorImpl(),
+            json,
+        )
 
         loop.runTurn("conv", "go", history, contextWithTools(safeEchoDescriptor())).toList()
 
@@ -246,7 +262,14 @@ class AgenticLoopImplTest {
                 }
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
+        val loop = AgenticLoopImpl(
+            service,
+            NoOpToolRegistry(),
+            ConservativeRetryPolicy,
+            passThroughBudgeter(),
+            SafetyOrchestratorImpl(),
+            json,
+        )
 
         loop.runTurn("conv", "go", history, context).toList()
 
@@ -267,7 +290,14 @@ class AgenticLoopImplTest {
                 }
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
+        val loop = AgenticLoopImpl(
+            service,
+            NoOpToolRegistry(),
+            ConservativeRetryPolicy,
+            passThroughBudgeter(),
+            SafetyOrchestratorImpl(),
+            json,
+        )
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -285,7 +315,14 @@ class AgenticLoopImplTest {
                 return flowOf(AssistantEvent.Failed(ChatStreamError.AUTH))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
+        val loop = AgenticLoopImpl(
+            service,
+            NoOpToolRegistry(),
+            ConservativeRetryPolicy,
+            passThroughBudgeter(),
+            SafetyOrchestratorImpl(),
+            json,
+        )
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -304,7 +341,14 @@ class AgenticLoopImplTest {
                 return flowOf(AssistantEvent.Failed(ChatStreamError.NETWORK))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
+        val loop = AgenticLoopImpl(
+            service,
+            NoOpToolRegistry(),
+            ConservativeRetryPolicy,
+            passThroughBudgeter(),
+            SafetyOrchestratorImpl(),
+            json,
+        )
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -322,7 +366,14 @@ class AgenticLoopImplTest {
                 emit(AssistantEvent.Failed(ChatStreamError.NETWORK))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
+        val loop = AgenticLoopImpl(
+            service,
+            NoOpToolRegistry(),
+            ConservativeRetryPolicy,
+            passThroughBudgeter(),
+            SafetyOrchestratorImpl(),
+            json,
+        )
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -339,7 +390,14 @@ class AgenticLoopImplTest {
                 emit(AssistantEvent.Failed(ChatStreamError.NETWORK))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
+        val loop = AgenticLoopImpl(
+            service,
+            NoOpToolRegistry(),
+            ConservativeRetryPolicy,
+            passThroughBudgeter(),
+            SafetyOrchestratorImpl(),
+            json,
+        )
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -379,6 +437,7 @@ class AgenticLoopImplTest {
             .containsExactly("I'll echo that.", "Done.")
         assertThat(events.filterIsInstance<LoopEvent.ToolCallStarted>()).hasSize(1)
         assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>()).hasSize(1)
+        assertThat(events.filterIsInstance<LoopEvent.ConfirmationRequested>()).isEmpty()
         val finished = events.filterIsInstance<LoopEvent.Finished>().last()
         assertThat(finished.outcome).isEqualTo(LoopOutcome.COMPLETED)
         val toolMessages = finished.updatedHistory.filterIsInstance<AssistantMessage.Tool>()
@@ -387,28 +446,232 @@ class AgenticLoopImplTest {
     }
 
     @Test
-    fun `given UNSAFE tool, when loop runs tool call, then BlockedBySafety is emitted and ToolCallFinished is not`() = runTest {
+    fun `given UNSAFE tool, when loop runs tool call, then confirmation request is emitted before execution`() = runTest {
         val unsafeDescriptor = ToolDescriptor(
-            name = "dangerous",
-            description = "A dangerous tool",
+            name = "orders_update",
+            description = "Updates an order",
             inputSchema = buildJsonObject { },
             safetyLevel = ToolSafetyLevel.UNSAFE,
         )
-        val registry = stubRegistry()
+        var registryExecuted = false
+        val registry = object : ToolRegistry {
+            override fun descriptors() = listOf(unsafeDescriptor)
+            override suspend fun execute(call: ToolCall): ToolResult {
+                registryExecuted = true
+                return ToolResult.Success(call.id, buildJsonObject { put("ok", true) })
+            }
+        }
+        val safetyOrchestrator = SafetyOrchestratorImpl()
         val loop = loopWith(
             flow {
-                emit(AssistantEvent.ToolCallDelta(index = 0, id = "call_1", name = "dangerous", argumentsDelta = "{}"))
+                emit(
+                    AssistantEvent.ToolCallDelta(
+                        index = 0,
+                        id = "call_1",
+                        name = "orders_update",
+                        argumentsDelta = """{"id":42,"status":"processing"}""",
+                    )
+                )
                 emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
             },
             flowOf(AssistantEvent.Finish(FinishReason.STOP)),
             registry = registry,
+            safetyOrchestrator = safetyOrchestrator,
         )
         val context = contextWithTools(unsafeDescriptor)
+        val events = mutableListOf<LoopEvent>()
 
-        val events = loop.runTurn("conv", "go", history, context).toList()
+        val job = launch {
+            loop.runTurn("conv", "go", history, context).toList(events)
+        }
 
-        assertThat(events.filterIsInstance<LoopEvent.BlockedBySafety>()).hasSize(1)
+        runCurrent()
+        val request = events.filterIsInstance<LoopEvent.ConfirmationRequested>().single().request
+        assertThat(request.id).isNotBlank
+        assertThat(request.toolCallId).isEqualTo("call_1")
+        assertThat(request.toolName).isEqualTo("orders_update")
+        assertThat(request.arguments["status"]?.jsonPrimitive?.content).isEqualTo("processing")
+        assertThat(request.safetyLevel).isEqualTo(ToolSafetyLevel.UNSAFE)
+        assertThat(events.filterIsInstance<LoopEvent.ToolCallStarted>()).isEmpty()
+        assertThat(registryExecuted).isFalse
+
+        safetyOrchestrator.confirm(request.id)
+        advanceUntilIdle()
+
+        assertThat(events.filterIsInstance<LoopEvent.ConfirmationResolved>().single().result.decision)
+            .isEqualTo(ConfirmationDecision.CONFIRMED)
+        assertThat(events.filterIsInstance<LoopEvent.ToolCallStarted>()).hasSize(1)
+        assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>()).hasSize(1)
+        assertThat(registryExecuted).isTrue
+        val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+        assertThat(finished.outcome).isEqualTo(LoopOutcome.COMPLETED)
+        job.cancel()
+    }
+
+    @Test
+    fun `given UNSAFE tool is cancelled, when loop awaits confirmation, then cancelled error is emitted and history is clean`() = runTest {
+        val unsafeDescriptor = ToolDescriptor(
+            name = "orders_update",
+            description = "Updates an order",
+            inputSchema = buildJsonObject { },
+            safetyLevel = ToolSafetyLevel.UNSAFE,
+        )
+        var registryExecuted = false
+        var secondModelTurnRequested = false
+        val service = object : ChatService {
+            private var count = 0
+
+            override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> {
+                count++
+                return if (count == 1) {
+                    flow {
+                        emit(
+                            AssistantEvent.ToolCallDelta(
+                                index = 0,
+                                id = "call_1",
+                                name = "orders_update",
+                                argumentsDelta = """{"id":42,"status":"processing"}""",
+                            )
+                        )
+                        emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
+                    }
+                } else {
+                    secondModelTurnRequested = true
+                    flowOf(AssistantEvent.Finish(FinishReason.STOP))
+                }
+            }
+        }
+        val registry = object : ToolRegistry {
+            override fun descriptors() = listOf(unsafeDescriptor)
+            override suspend fun execute(call: ToolCall): ToolResult {
+                registryExecuted = true
+                return ToolResult.Success(call.id, buildJsonObject { put("ok", true) })
+            }
+        }
+        val safetyOrchestrator = SafetyOrchestratorImpl()
+        val loop = AgenticLoopImpl(
+            service,
+            registry,
+            ConservativeRetryPolicy,
+            passThroughBudgeter(),
+            safetyOrchestrator,
+            json,
+        )
+        val events = mutableListOf<LoopEvent>()
+
+        val job = launch {
+            loop.runTurn("conv", "go", history, contextWithTools(unsafeDescriptor)).toList(events)
+        }
+
+        runCurrent()
+        val request = events.filterIsInstance<LoopEvent.ConfirmationRequested>().single().request
+        safetyOrchestrator.cancel(request.id)
+        advanceUntilIdle()
+
+        assertThat(events.filterIsInstance<LoopEvent.ConfirmationResolved>().single().result.decision)
+            .isEqualTo(ConfirmationDecision.CANCELLED)
+        assertThat(events.filterIsInstance<LoopEvent.Failed>().single().error)
+            .isEqualTo(AssistantError.Cancelled)
+        assertThat(events.filterIsInstance<LoopEvent.ToolCallStarted>()).isEmpty()
         assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>()).isEmpty()
+        assertThat(registryExecuted).isFalse
+        assertThat(secondModelTurnRequested).isFalse
+        val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+        assertThat(finished.outcome).isEqualTo(LoopOutcome.STOPPED)
+        assertThat(finished.retryAvailable).isFalse
+        assertThat(finished.updatedHistory.filterIsInstance<AssistantMessage.Tool>()).isEmpty()
+        val assistantMessages = finished.updatedHistory.filterIsInstance<AssistantMessage.Assistant>()
+        assertThat(assistantMessages.flatMap { it.toolCalls }).isEmpty()
+        job.cancel()
+    }
+
+    @Test
+    fun `given safe tool succeeds before unsafe tool is cancelled, then completed tool history is preserved`() = runTest {
+        val unsafeDescriptor = ToolDescriptor(
+            name = "orders_update",
+            description = "Updates an order",
+            inputSchema = buildJsonObject { },
+            safetyLevel = ToolSafetyLevel.UNSAFE,
+        )
+        var secondModelTurnRequested = false
+        val service = object : ChatService {
+            private var count = 0
+
+            override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> {
+                count++
+                return if (count == 1) {
+                    flow {
+                        emit(AssistantEvent.TextDelta("I'll do both."))
+                        emit(
+                            AssistantEvent.ToolCallDelta(
+                                index = 0,
+                                id = "safe_1",
+                                name = "echo",
+                                argumentsDelta = """{"msg":"hello"}""",
+                            )
+                        )
+                        emit(
+                            AssistantEvent.ToolCallDelta(
+                                index = 1,
+                                id = "unsafe_1",
+                                name = "orders_update",
+                                argumentsDelta = """{"id":42,"status":"processing"}""",
+                            )
+                        )
+                        emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
+                    }
+                } else {
+                    secondModelTurnRequested = true
+                    flowOf(AssistantEvent.Finish(FinishReason.STOP))
+                }
+            }
+        }
+        val registry = object : ToolRegistry {
+            override fun descriptors() = listOf(safeEchoDescriptor(), unsafeDescriptor)
+            override suspend fun execute(call: ToolCall): ToolResult =
+                ToolResult.Success(call.id, buildJsonObject { put("echoed", "hello") })
+        }
+        val safetyOrchestrator = SafetyOrchestratorImpl()
+        val loop = AgenticLoopImpl(
+            service,
+            registry,
+            ConservativeRetryPolicy,
+            passThroughBudgeter(),
+            safetyOrchestrator,
+            json,
+        )
+        val events = mutableListOf<LoopEvent>()
+
+        val job = launch {
+            loop.runTurn("conv", "go", history, contextWithTools(safeEchoDescriptor(), unsafeDescriptor)).toList(events)
+        }
+
+        runCurrent()
+        val request = events.filterIsInstance<LoopEvent.ConfirmationRequested>().single().request
+        safetyOrchestrator.cancel(request.id)
+        advanceUntilIdle()
+
+        assertThat(events.filterIsInstance<LoopEvent.ToolCallStarted>().map { it.call.id })
+            .containsExactly("safe_1")
+        assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>().map { it.result.toolCallId })
+            .containsExactly("safe_1")
+        assertThat(events.filterIsInstance<LoopEvent.Failed>().single().error)
+            .isEqualTo(AssistantError.Cancelled)
+        val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+        assertThat(finished.outcome).isEqualTo(LoopOutcome.STOPPED)
+        assertThat(finished.retryAvailable).isFalse
+        assertThat(secondModelTurnRequested).isFalse
+
+        val assistantToolCalls = finished.updatedHistory.filterIsInstance<AssistantMessage.Assistant>()
+            .flatMap { it.toolCalls }
+        assertThat(assistantToolCalls.map { it.id }).containsExactly("safe_1")
+        assertThat(assistantToolCalls.map { it.id }).doesNotContain("unsafe_1")
+
+        val toolMessages = finished.updatedHistory.filterIsInstance<AssistantMessage.Tool>()
+        assertThat(toolMessages.map { it.toolCallId }).containsExactly("safe_1")
+        assertThat(toolMessages.map { it.toolCallId }).doesNotContain("unsafe_1")
+        assertThat(toolMessages.single().content).contains("echoed")
+        job.cancel()
     }
 
     @Test
@@ -430,7 +693,14 @@ class AgenticLoopImplTest {
                 return flowOf(AssistantEvent.TextDelta("Hi"), AssistantEvent.Finish(FinishReason.STOP))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, twoMessageBudgeter, json)
+        val loop = AgenticLoopImpl(
+            service,
+            NoOpToolRegistry(),
+            ConservativeRetryPolicy,
+            twoMessageBudgeter,
+            SafetyOrchestratorImpl(),
+            json,
+        )
 
         loop.runTurn("conv", "hi", bigHistory, context).toList()
 
@@ -453,7 +723,14 @@ class AgenticLoopImplTest {
             override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> =
                 flowOf(AssistantEvent.TextDelta("ok"), AssistantEvent.Finish(FinishReason.STOP))
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, droppingBudgeter, json)
+        val loop = AgenticLoopImpl(
+            service,
+            NoOpToolRegistry(),
+            ConservativeRetryPolicy,
+            droppingBudgeter,
+            SafetyOrchestratorImpl(),
+            json,
+        )
 
         val events = loop.runTurn("conv", "hi", bigHistory, context).toList()
 
@@ -487,7 +764,14 @@ class AgenticLoopImplTest {
             override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> =
                 flowOf(AssistantEvent.Failed(ChatStreamError.AUTH))
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
+        val loop = AgenticLoopImpl(
+            service,
+            NoOpToolRegistry(),
+            ConservativeRetryPolicy,
+            passThroughBudgeter(),
+            SafetyOrchestratorImpl(),
+            json,
+        )
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 
@@ -504,7 +788,14 @@ class AgenticLoopImplTest {
                 emit(AssistantEvent.Failed(ChatStreamError.INVALID_STREAM))
             }
         }
-        val loop = AgenticLoopImpl(service, NoOpToolRegistry(), ConservativeRetryPolicy, passThroughBudgeter(), json)
+        val loop = AgenticLoopImpl(
+            service,
+            NoOpToolRegistry(),
+            ConservativeRetryPolicy,
+            passThroughBudgeter(),
+            SafetyOrchestratorImpl(),
+            json,
+        )
 
         val events = loop.runTurn("conv", "hi", history, context).toList()
 

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -16,7 +16,9 @@ import com.woocommerce.android.aiassistant.core.safety.ConfirmationDecision
 import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
 import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestratorImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -506,6 +508,57 @@ class AgenticLoopImplTest {
         val finished = events.filterIsInstance<LoopEvent.Finished>().last()
         assertThat(finished.outcome).isEqualTo(LoopOutcome.COMPLETED)
         job.cancel()
+    }
+
+    @Test
+    fun `given flow is cancelled after confirmation request, when await is skipped, then pending request is removed`() = runTest {
+        val unsafeDescriptor = ToolDescriptor(
+            name = "orders_update",
+            description = "Updates an order",
+            inputSchema = buildJsonObject { },
+            safetyLevel = ToolSafetyLevel.UNSAFE,
+        )
+        var registryExecuted = false
+        val registry = object : ToolRegistry {
+            override fun descriptors() = listOf(unsafeDescriptor)
+            override suspend fun execute(call: ToolCall): ToolResult {
+                registryExecuted = true
+                return ToolResult.Success(call.id, buildJsonObject { put("ok", true) })
+            }
+        }
+        val safetyOrchestrator = SafetyOrchestratorImpl()
+        val loop = loopWith(
+            flow {
+                emit(
+                    AssistantEvent.ToolCallDelta(
+                        index = 0,
+                        id = "call_1",
+                        name = "orders_update",
+                        argumentsDelta = """{"id":42,"status":"processing"}""",
+                    )
+                )
+                emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
+            },
+            registry = registry,
+            safetyOrchestrator = safetyOrchestrator,
+        )
+        val events = mutableListOf<LoopEvent>()
+
+        val job = launch {
+            loop.runTurn("conv", "go", history, contextWithTools(unsafeDescriptor)).collect { event ->
+                events += event
+                if (event is LoopEvent.ConfirmationRequested) {
+                    cancel()
+                }
+            }
+        }
+
+        advanceUntilIdle()
+
+        val request = events.filterIsInstance<LoopEvent.ConfirmationRequested>().single().request
+        assertThat(job.isCancelled).isTrue
+        assertThat(registryExecuted).isFalse
+        assertThat(safetyOrchestrator.confirm(request.id)).isFalse
     }
 
     @Test

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImplTest.kt
@@ -1,0 +1,121 @@
+package com.woocommerce.android.aiassistant.core.safety
+
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SafetyOrchestratorImplTest {
+    @Test
+    fun `given safe descriptor, when evaluated, then tool executes without pending confirmation`() = runTest {
+        val orchestrator = orchestrator()
+        val call = toolCall(name = "orders_list")
+
+        val decision = orchestrator.evaluate(call, descriptor("orders_list", ToolSafetyLevel.SAFE))
+
+        assertThat(decision).isEqualTo(SafetyDecision.Execute)
+        assertThat(orchestrator.confirm("missing")).isFalse
+    }
+
+    @Test
+    fun `given unsafe descriptor, when evaluated, then request preserves ids name safety and args`() = runTest {
+        val orchestrator = orchestrator()
+        val arguments = buildJsonObject {
+            put("id", 42)
+            put("status", "processing")
+        }
+        val call = toolCall(name = "orders_update", arguments = arguments)
+
+        val decision = orchestrator.evaluate(call, descriptor("orders_update", ToolSafetyLevel.UNSAFE))
+
+        val request = (decision as SafetyDecision.RequireConfirmation).request
+        assertThat(request.id).isNotBlank
+        assertThat(request.toolCallId).isEqualTo("call_1")
+        assertThat(request.toolName).isEqualTo("orders_update")
+        assertThat(request.arguments).isSameAs(arguments)
+        assertThat(request.safetyLevel).isEqualTo(ToolSafetyLevel.UNSAFE)
+    }
+
+    @Test
+    fun `given pending request, when confirmed by id, then await returns confirmed and pending is removed`() = runTest {
+        val orchestrator = orchestrator()
+        val decision = orchestrator.evaluate(
+            toolCall(name = "orders_update"),
+            descriptor("orders_update", ToolSafetyLevel.UNSAFE),
+        ) as SafetyDecision.RequireConfirmation
+
+        val awaited = async { orchestrator.awaitResult(decision.request.id) }
+        runCurrent()
+        val resolved = orchestrator.confirm(decision.request.id)
+
+        assertThat(resolved).isTrue
+        assertThat(awaited.await()).isEqualTo(
+            ConfirmationResult(decision.request.id, ConfirmationDecision.CONFIRMED),
+        )
+        assertThat(orchestrator.confirm(decision.request.id)).isFalse
+    }
+
+    @Test
+    fun `given pending request, when cancelled by id, then await returns cancelled and pending is removed`() = runTest {
+        val orchestrator = orchestrator()
+        val decision = orchestrator.evaluate(
+            toolCall(name = "orders_update"),
+            descriptor("orders_update", ToolSafetyLevel.UNSAFE),
+        ) as SafetyDecision.RequireConfirmation
+
+        val awaited = async { orchestrator.awaitResult(decision.request.id) }
+        runCurrent()
+        val resolved = orchestrator.cancel(decision.request.id)
+
+        assertThat(resolved).isTrue
+        assertThat(awaited.await()).isEqualTo(
+            ConfirmationResult(decision.request.id, ConfirmationDecision.CANCELLED),
+        )
+        assertThat(orchestrator.cancel(decision.request.id)).isFalse
+    }
+
+    @Test
+    fun `given unknown request id, when resolved, then no pending request resumes`() = runTest {
+        val orchestrator = orchestrator()
+
+        val resolved = orchestrator.resolve(
+            ConfirmationResult("missing", ConfirmationDecision.CONFIRMED),
+        )
+
+        assertThat(resolved).isFalse
+    }
+
+    @Test
+    fun `when safety levels are inspected, then only safe and unsafe levels exist`() {
+        assertThat(ToolSafetyLevel.entries).containsExactly(
+            ToolSafetyLevel.SAFE,
+            ToolSafetyLevel.UNSAFE,
+        )
+    }
+
+    private fun toolCall(
+        name: String,
+        arguments: kotlinx.serialization.json.JsonObject = buildJsonObject { },
+    ) = ToolCall(
+        id = "call_1",
+        name = name,
+        arguments = arguments,
+    )
+
+    private fun descriptor(name: String, safetyLevel: ToolSafetyLevel) = ToolDescriptor(
+        name = name,
+        description = "test",
+        inputSchema = buildJsonObject { },
+        safetyLevel = safetyLevel,
+    )
+
+    private fun orchestrator() = SafetyOrchestratorImpl()
+}

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImplTest.kt
@@ -83,6 +83,24 @@ class SafetyOrchestratorImplTest {
     }
 
     @Test
+    fun `given request is confirmed before await starts, when awaited, then confirmed result is returned`() = runTest {
+        val orchestrator = orchestrator()
+        val decision = orchestrator.evaluate(
+            toolCall(name = "orders_update"),
+            descriptor("orders_update", ToolSafetyLevel.UNSAFE),
+        ) as SafetyDecision.RequireConfirmation
+
+        val resolved = orchestrator.confirm(decision.request.id)
+        val result = orchestrator.awaitResult(decision.request.id)
+
+        assertThat(resolved).isTrue
+        assertThat(result).isEqualTo(
+            ConfirmationResult(decision.request.id, ConfirmationDecision.CONFIRMED),
+        )
+        assertThat(orchestrator.confirm(decision.request.id)).isFalse
+    }
+
+    @Test
     fun `given unknown request id, when resolved, then no pending request resumes`() = runTest {
         val orchestrator = orchestrator()
 

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/safety/SafetyOrchestratorImplTest.kt
@@ -101,6 +101,24 @@ class SafetyOrchestratorImplTest {
     }
 
     @Test
+    fun `given pending request without awaiter, when pending is cancelled, then request is removed`() = runTest {
+        val orchestrator = orchestrator()
+        val decision = orchestrator.evaluate(
+            toolCall(name = "orders_update"),
+            descriptor("orders_update", ToolSafetyLevel.UNSAFE),
+        ) as SafetyDecision.RequireConfirmation
+
+        val cancelled = orchestrator.cancelPending(decision.request.id)
+        val result = orchestrator.awaitResult(decision.request.id)
+
+        assertThat(cancelled).isTrue
+        assertThat(result).isEqualTo(
+            ConfirmationResult(decision.request.id, ConfirmationDecision.CANCELLED),
+        )
+        assertThat(orchestrator.confirm(decision.request.id)).isFalse
+    }
+
+    @Test
     fun `given unknown request id, when resolved, then no pending request resumes`() = runTest {
         val orchestrator = orchestrator()
 

--- a/libs/ai-assistant/feature/build.gradle
+++ b/libs/ai-assistant/feature/build.gradle
@@ -26,6 +26,10 @@ android {
         // This can be re-enabled once the compose lint library supports newer metadata versions
         disable "FlowOperatorInvokedInComposition"
     }
+
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
 }
 
 dependencies {
@@ -45,7 +49,9 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.assertj.core)
+    testImplementation(libs.androidx.test.main.core)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
     testImplementation(libs.squareup.okhttp3.mockwebserver)
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
@@ -33,6 +33,7 @@ internal object AiAssistantModule {
 
     @Provides
     @Singleton
+    @Suppress("LongParameterList")
     fun provideAgenticLoop(
         chatService: ChatService,
         toolRegistry: ToolRegistry,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
@@ -9,6 +9,8 @@ import com.woocommerce.android.aiassistant.core.loop.HistoryBudgeter
 import com.woocommerce.android.aiassistant.core.loop.RetryPolicy
 import com.woocommerce.android.aiassistant.core.loop.SlidingWindowHistoryBudgeter
 import com.woocommerce.android.aiassistant.core.loop.ToolCatalogSelector
+import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
+import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestratorImpl
 import com.woocommerce.android.aiassistant.tools.DefaultToolCatalogSelector
 import dagger.Module
 import dagger.Provides
@@ -36,8 +38,16 @@ internal object AiAssistantModule {
         toolRegistry: ToolRegistry,
         retryPolicy: RetryPolicy,
         historyBudgeter: HistoryBudgeter,
+        safetyOrchestrator: SafetyOrchestrator,
         @AiAssistantJson json: Json,
-    ): AgenticLoop = AgenticLoopImpl(chatService, toolRegistry, retryPolicy, historyBudgeter, json)
+    ): AgenticLoop = AgenticLoopImpl(
+        chatService,
+        toolRegistry,
+        retryPolicy,
+        historyBudgeter,
+        safetyOrchestrator,
+        json,
+    )
 
     @Provides
     @Singleton
@@ -50,4 +60,8 @@ internal object AiAssistantModule {
     @Provides
     @Singleton
     fun provideHistoryBudgeter(): HistoryBudgeter = SlidingWindowHistoryBudgeter(windowSize = 10)
+
+    @Provides
+    @Singleton
+    fun provideSafetyOrchestrator(): SafetyOrchestrator = SafetyOrchestratorImpl()
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreview.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreview.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.aiassistant.safety
+
+import androidx.annotation.StringRes
+
+internal data class ConfirmationPreview(
+    val message: ConfirmationPreviewText,
+    val fields: List<ConfirmationPreviewField> = emptyList(),
+)
+
+internal data class ConfirmationPreviewField(
+    val name: String,
+    val label: ConfirmationPreviewText,
+    val value: ConfirmationPreviewText,
+)
+
+internal sealed interface ConfirmationPreviewText {
+    data class Raw(
+        val value: String,
+    ) : ConfirmationPreviewText
+
+    data class Resource(
+        @StringRes val id: Int,
+        val args: List<ConfirmationPreviewText> = emptyList(),
+    ) : ConfirmationPreviewText
+
+    data class Quantity(
+        val quantity: Int,
+        @StringRes val singular: Int,
+        @StringRes val multiple: Int,
+        val args: List<ConfirmationPreviewText> = emptyList(),
+    ) : ConfirmationPreviewText
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
@@ -1,0 +1,43 @@
+package com.woocommerce.android.aiassistant.safety
+
+import android.content.Context
+
+internal class ConfirmationPreviewRenderer(
+    private val context: Context,
+) {
+    fun render(preview: ConfirmationPreview): RenderedConfirmationPreview =
+        RenderedConfirmationPreview(
+            message = render(preview.message),
+            fields = preview.fields.map {
+                RenderedConfirmationPreviewField(
+                    name = it.name,
+                    label = render(it.label),
+                    value = render(it.value),
+                )
+            },
+        )
+
+    private fun render(text: ConfirmationPreviewText): String = when (text) {
+        is ConfirmationPreviewText.Raw -> text.value
+        is ConfirmationPreviewText.Resource -> {
+            val args = text.args.map(::render).toTypedArray()
+            context.getString(text.id, *args)
+        }
+        is ConfirmationPreviewText.Quantity -> {
+            val id = if (text.quantity == 1) text.singular else text.multiple
+            val args = listOf<Any>(text.quantity) + text.args.map(::render)
+            context.getString(id, *args.toTypedArray())
+        }
+    }
+}
+
+internal data class RenderedConfirmationPreview(
+    val message: String,
+    val fields: List<RenderedConfirmationPreviewField>,
+)
+
+internal data class RenderedConfirmationPreviewField(
+    val name: String,
+    val label: String,
+    val value: String,
+)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
@@ -17,6 +17,7 @@ internal class ConfirmationPreviewRenderer(
             },
         )
 
+    @Suppress("SpreadOperator")
     private fun render(text: ConfirmationPreviewText): String = when (text) {
         is ConfirmationPreviewText.Raw -> text.value
         is ConfirmationPreviewText.Resource -> {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
@@ -1,0 +1,334 @@
+package com.woocommerce.android.aiassistant.safety
+
+import androidx.annotation.StringRes
+import com.woocommerce.android.aiassistant.R
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
+import javax.inject.Inject
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+
+internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
+    fun build(request: ConfirmationRequest): ConfirmationPreview = build(request.toolName, request.arguments)
+
+    fun build(call: ToolCall): ConfirmationPreview = build(call.name, call.arguments)
+
+    fun build(
+        toolName: String,
+        arguments: JsonObject,
+    ): ConfirmationPreview = when (toolName) {
+        ORDERS_UPDATE -> ordersUpdate(arguments)
+        ORDERS_BULK_UPDATE -> ordersBulkUpdate(arguments)
+        PRODUCTS_UPDATE -> productsUpdate(arguments)
+        PRODUCTS_BULK_UPDATE -> productsBulkUpdate(arguments)
+        PRODUCT_VARIATIONS_UPDATE -> productVariationsUpdate(arguments)
+        else -> genericPreview(toolName)
+    }
+
+    fun supportsDedicatedPreview(toolName: String): Boolean = toolName in DEDICATED_TOOL_NAMES
+
+    private fun ordersUpdate(arguments: JsonObject): ConfirmationPreview {
+        val id = arguments.longValue("id")
+            ?: return ConfirmationPreview(string(R.string.ai_assistant_confirmation_order_update_generic))
+        val status = arguments.stringValue("status")
+        val fields = buildList {
+            status?.let { add(textField("status", it, R.string.ai_assistant_confirmation_field_status)) }
+        }
+
+        if (status != null) {
+            val message = if (status in CUSTOMER_NOTIFYING_STATUSES) {
+                string(
+                    R.string.ai_assistant_confirmation_order_set_status_emails_customer,
+                    raw(id.toString()),
+                    raw(status),
+                )
+            } else {
+                string(R.string.ai_assistant_confirmation_order_set_status, raw(id.toString()), raw(status))
+            }
+            return ConfirmationPreview(message = message, fields = fields)
+        }
+
+        return ConfirmationPreview(
+            message = string(
+                R.string.ai_assistant_confirmation_order_update_summary,
+                raw(id.toString()),
+                fields.toChangeSummary(),
+            ),
+            fields = fields,
+        )
+    }
+
+    private fun ordersBulkUpdate(arguments: JsonObject): ConfirmationPreview {
+        val ids = arguments.longArrayValue("ids")
+            ?: return ConfirmationPreview(string(R.string.ai_assistant_confirmation_orders_bulk_update_generic))
+        val patch = arguments.objectValue("patch")
+            ?: return ConfirmationPreview(string(R.string.ai_assistant_confirmation_orders_bulk_update_generic))
+        val fields = buildList {
+            patch.stringValue("status")?.let {
+                add(textField("status", it, R.string.ai_assistant_confirmation_field_status))
+            }
+            if (patch.containsKey("customer_note")) {
+                add(
+                    messageField(
+                        name = "customer_note",
+                        value = string(R.string.ai_assistant_confirmation_field_value_updated),
+                        label = R.string.ai_assistant_confirmation_field_customer_note,
+                    )
+                )
+            }
+            patch.stringValue("billing_email")?.let {
+                add(textField("billing_email", it, R.string.ai_assistant_confirmation_field_billing_email))
+            }
+        }
+        val summary = fields.toChangeSummary(
+            statusEmailImpact = patch.stringValue("status")
+                ?.takeIf { it in CUSTOMER_NOTIFYING_STATUSES }
+                ?.let { R.string.ai_assistant_confirmation_change_summary_status_emails_customers },
+        )
+        return ConfirmationPreview(
+            message = quantity(
+                quantity = ids.size,
+                singular = R.string.ai_assistant_confirmation_orders_bulk_update_summary_single,
+                multiple = R.string.ai_assistant_confirmation_orders_bulk_update_summary_multiple,
+                summary,
+            ),
+            fields = fields,
+        )
+    }
+
+    private fun productsUpdate(arguments: JsonObject): ConfirmationPreview {
+        val id = arguments.longValue("id")
+            ?: return ConfirmationPreview(string(R.string.ai_assistant_confirmation_product_update_generic))
+        val fields = productFields(arguments)
+        return ConfirmationPreview(
+            message = string(
+                R.string.ai_assistant_confirmation_product_update_summary,
+                raw(id.toString()),
+                fields.toChangeSummary(),
+            ),
+            fields = fields,
+        )
+    }
+
+    private fun productsBulkUpdate(arguments: JsonObject): ConfirmationPreview {
+        val ids = arguments.longArrayValue("ids")
+            ?: return ConfirmationPreview(string(R.string.ai_assistant_confirmation_products_bulk_update_generic))
+        val patch = arguments.objectValue("patch")
+            ?: return ConfirmationPreview(string(R.string.ai_assistant_confirmation_products_bulk_update_generic))
+        val fields = productFields(patch)
+        return ConfirmationPreview(
+            message = quantity(
+                quantity = ids.size,
+                singular = R.string.ai_assistant_confirmation_products_bulk_update_summary_single,
+                multiple = R.string.ai_assistant_confirmation_products_bulk_update_summary_multiple,
+                fields.toChangeSummary(),
+            ),
+            fields = fields,
+        )
+    }
+
+    private fun productVariationsUpdate(arguments: JsonObject): ConfirmationPreview {
+        val productId = arguments.longValue("product_id")
+            ?: return ConfirmationPreview(
+                string(R.string.ai_assistant_confirmation_product_variation_update_generic)
+            )
+        val variationId = arguments.longValue("id")
+            ?: return ConfirmationPreview(
+                string(R.string.ai_assistant_confirmation_product_variation_update_generic)
+            )
+        val fields = variationFields(arguments)
+        return ConfirmationPreview(
+            message = string(
+                R.string.ai_assistant_confirmation_product_variation_update_summary,
+                raw(variationId.toString()),
+                raw(productId.toString()),
+                fields.toChangeSummary(),
+            ),
+            fields = fields,
+        )
+    }
+
+    private fun productFields(arguments: JsonObject): List<ConfirmationPreviewField> =
+        productOrVariationFields(arguments, includeName = true, includeStockStatus = false, includeSku = false)
+
+    private fun variationFields(arguments: JsonObject): List<ConfirmationPreviewField> =
+        productOrVariationFields(arguments, includeName = false, includeStockStatus = true, includeSku = true)
+
+    private fun productOrVariationFields(
+        arguments: JsonObject,
+        includeName: Boolean,
+        includeStockStatus: Boolean,
+        includeSku: Boolean,
+    ): List<ConfirmationPreviewField> = buildList {
+        arguments.stringValue("name")
+            ?.takeIf { includeName }
+            ?.let { add(textField("name", it, R.string.ai_assistant_confirmation_field_name)) }
+        arguments.stringValue("regular_price")
+            ?.let { add(textField("regular_price", it, R.string.ai_assistant_confirmation_field_regular_price)) }
+        arguments.stringValue("sale_price")
+            ?.let {
+                val value = it.takeIf { price -> price.isNotEmpty() }?.let(::raw)
+                    ?: string(R.string.ai_assistant_confirmation_field_value_off)
+                add(messageField("sale_price", value, R.string.ai_assistant_confirmation_field_sale_price))
+            }
+        arguments.intValue("stock_quantity")
+            ?.let {
+                add(
+                    textField(
+                        name = "stock_quantity",
+                        value = it.toString(),
+                        label = R.string.ai_assistant_confirmation_field_stock_quantity,
+                    )
+                )
+            }
+        arguments.stringValue("stock_status")
+            ?.takeIf { includeStockStatus }
+            ?.let { add(textField("stock_status", it, R.string.ai_assistant_confirmation_field_stock_status)) }
+        arguments.stringValue("status")
+            ?.let { add(textField("status", it, R.string.ai_assistant_confirmation_field_status)) }
+        arguments.stringValue("sku")
+            ?.takeIf { includeSku }
+            ?.let { add(textField("sku", it, R.string.ai_assistant_confirmation_field_sku)) }
+    }
+
+    private fun genericPreview(toolName: String): ConfirmationPreview =
+        ConfirmationPreview(
+            string(R.string.ai_assistant_confirmation_generic_tool_call, raw(toolName))
+        )
+
+    private fun List<ConfirmationPreviewField>.toChangeSummary(
+        @StringRes statusEmailImpact: Int? = null,
+    ): ConfirmationPreviewText {
+        if (isEmpty()) {
+            return string(R.string.ai_assistant_confirmation_change_summary_empty)
+        }
+
+        return map { field ->
+            when (field.name) {
+                "regular_price" -> string(
+                    R.string.ai_assistant_confirmation_change_summary_regular_price,
+                    field.value,
+                )
+                "sale_price" -> string(R.string.ai_assistant_confirmation_change_summary_sale_price, field.value)
+                "stock_quantity" -> string(
+                    R.string.ai_assistant_confirmation_change_summary_stock_quantity,
+                    field.value,
+                )
+                "stock_status" -> string(
+                    R.string.ai_assistant_confirmation_change_summary_stock_status,
+                    field.value,
+                )
+                "sku" -> string(R.string.ai_assistant_confirmation_change_summary_sku, field.value)
+                "customer_note" -> string(R.string.ai_assistant_confirmation_change_summary_customer_note)
+                "billing_email" -> string(
+                    R.string.ai_assistant_confirmation_change_summary_billing_email,
+                    field.value,
+                )
+                "status" -> string(
+                    statusEmailImpact ?: R.string.ai_assistant_confirmation_change_summary_status,
+                    field.value,
+                )
+                else -> string(R.string.ai_assistant_confirmation_change_summary_field, raw(field.name), field.value)
+            }
+        }.toLocalizedList()
+    }
+
+    private fun textField(
+        name: String,
+        value: String,
+        @StringRes label: Int,
+    ): ConfirmationPreviewField = messageField(
+        name = name,
+        value = raw(value),
+        label = label,
+    )
+
+    private fun messageField(
+        name: String,
+        value: ConfirmationPreviewText,
+        @StringRes label: Int,
+    ): ConfirmationPreviewField = ConfirmationPreviewField(
+        name = name,
+        value = value,
+        label = string(label),
+    )
+
+    private fun List<ConfirmationPreviewText>.toLocalizedList(): ConfirmationPreviewText =
+        reduceOrNull { left, right ->
+            string(R.string.ai_assistant_confirmation_message_list_separator, left, right)
+        } ?: string(R.string.ai_assistant_confirmation_change_summary_empty)
+
+    private fun raw(value: String) = ConfirmationPreviewText.Raw(value)
+
+    private fun string(
+        @StringRes id: Int,
+        vararg args: ConfirmationPreviewText,
+    ) = ConfirmationPreviewText.Resource(id, args.toList())
+
+    private fun quantity(
+        quantity: Int,
+        @StringRes singular: Int,
+        @StringRes multiple: Int,
+        vararg args: ConfirmationPreviewText,
+    ) = ConfirmationPreviewText.Quantity(quantity, singular, multiple, args.toList())
+
+    private fun JsonObject.stringValue(name: String): String? =
+        this[name]?.asJsonPrimitiveOrNull()?.contentOrNull
+
+    private fun JsonObject.intValue(name: String): Int? =
+        this[name]?.asJsonPrimitiveOrNull()?.intOrNull
+
+    private fun JsonObject.longValue(name: String): Long? =
+        this[name]?.asJsonPrimitiveOrNull()?.longOrNull
+
+    private fun JsonObject.arrayValue(name: String): JsonArray? =
+        this[name]?.asJsonArrayOrNull()
+
+    private fun JsonObject.longArrayValue(name: String): List<Long>? {
+        val array = arrayValue(name) ?: return null
+        return array.map {
+            it.asJsonPrimitiveOrNull()?.longOrNull ?: return null
+        }
+    }
+
+    private fun JsonObject.objectValue(name: String): JsonObject? =
+        this[name]?.asJsonObjectOrNull()
+
+    private fun JsonElement.asJsonArrayOrNull(): JsonArray? = runCatching { jsonArray }.getOrNull()
+
+    private fun JsonElement.asJsonObjectOrNull(): JsonObject? = runCatching { jsonObject }.getOrNull()
+
+    private fun JsonElement.asJsonPrimitiveOrNull(): JsonPrimitive? = runCatching { jsonPrimitive }.getOrNull()
+
+    private companion object {
+        const val ORDERS_UPDATE = "orders_update"
+        const val ORDERS_BULK_UPDATE = "orders_bulk_update"
+        const val PRODUCTS_UPDATE = "products_update"
+        const val PRODUCTS_BULK_UPDATE = "products_bulk_update"
+        const val PRODUCT_VARIATIONS_UPDATE = "product_variations_update"
+
+        val DEDICATED_TOOL_NAMES = setOf(
+            ORDERS_UPDATE,
+            ORDERS_BULK_UPDATE,
+            PRODUCTS_UPDATE,
+            PRODUCTS_BULK_UPDATE,
+            PRODUCT_VARIATIONS_UPDATE,
+        )
+
+        val CUSTOMER_NOTIFYING_STATUSES = setOf(
+            "processing",
+            "completed",
+            "cancelled",
+            "refunded",
+            "on-hold",
+        )
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
@@ -4,7 +4,6 @@ import androidx.annotation.StringRes
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
-import javax.inject.Inject
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -15,6 +14,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
+import javax.inject.Inject
 
 internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
     fun build(request: ConfirmationRequest): ConfirmationPreview = build(request.toolName, request.arguments)
@@ -91,7 +91,13 @@ internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
         val summary = fields.toChangeSummary(
             statusEmailImpact = patch.stringValue("status")
                 ?.takeIf { it in CUSTOMER_NOTIFYING_STATUSES }
-                ?.let { R.string.ai_assistant_confirmation_change_summary_status_emails_customers },
+                ?.let {
+                    if (ids.size == 1) {
+                        R.string.ai_assistant_confirmation_change_summary_status_emails_customer
+                    } else {
+                        R.string.ai_assistant_confirmation_change_summary_status_emails_customers
+                    }
+                },
         )
         return ConfirmationPreview(
             message = quantity(

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="ai_assistant_confirmation_order_update_generic">Update an order</string>
+    <string name="ai_assistant_confirmation_order_set_status">Set order #%1$s to %2$s</string>
+    <string name="ai_assistant_confirmation_order_set_status_emails_customer">Set order #%1$s to %2$s (emails the customer)</string>
+    <string name="ai_assistant_confirmation_order_update_summary">Update order #%1$s: %2$s</string>
+    <string name="ai_assistant_confirmation_orders_bulk_update_generic">Update many orders</string>
+    <string name="ai_assistant_confirmation_orders_bulk_update_summary_single">Update %1$d order: %2$s</string>
+    <string name="ai_assistant_confirmation_orders_bulk_update_summary_multiple">Update %1$d orders: %2$s</string>
+    <string name="ai_assistant_confirmation_product_update_generic">Update a product</string>
+    <string name="ai_assistant_confirmation_product_update_summary">Update product #%1$s: %2$s</string>
+    <string name="ai_assistant_confirmation_products_bulk_update_generic">Update many products</string>
+    <string name="ai_assistant_confirmation_products_bulk_update_summary_single">Update %1$d product: %2$s</string>
+    <string name="ai_assistant_confirmation_products_bulk_update_summary_multiple">Update %1$d products: %2$s</string>
+    <string name="ai_assistant_confirmation_product_variation_update_generic">Update a product variation</string>
+    <string name="ai_assistant_confirmation_product_variation_update_summary">Update variation #%1$s for product #%2$s: %3$s</string>
+    <string name="ai_assistant_confirmation_generic_tool_call">Review %1$s</string>
+    <string name="ai_assistant_confirmation_change_summary_empty">edit fields</string>
+    <string name="ai_assistant_confirmation_change_summary_status">status -&gt; %1$s</string>
+    <string name="ai_assistant_confirmation_change_summary_status_emails_customers">status -&gt; %1$s (emails customers)</string>
+    <string name="ai_assistant_confirmation_change_summary_regular_price">price -&gt; %1$s</string>
+    <string name="ai_assistant_confirmation_change_summary_sale_price">sale -&gt; %1$s</string>
+    <string name="ai_assistant_confirmation_change_summary_stock_quantity">stock -&gt; %1$s</string>
+    <string name="ai_assistant_confirmation_change_summary_stock_status">stock status -&gt; %1$s</string>
+    <string name="ai_assistant_confirmation_change_summary_sku">SKU -&gt; %1$s</string>
+    <string name="ai_assistant_confirmation_change_summary_customer_note">customer note updated</string>
+    <string name="ai_assistant_confirmation_change_summary_billing_email">billing email -&gt; %1$s</string>
+    <string name="ai_assistant_confirmation_change_summary_field">%1$s -&gt; %2$s</string>
+    <string name="ai_assistant_confirmation_field_status">Status</string>
+    <string name="ai_assistant_confirmation_field_customer_note">Customer note</string>
+    <string name="ai_assistant_confirmation_field_billing_email">Billing email</string>
+    <string name="ai_assistant_confirmation_field_name">Name</string>
+    <string name="ai_assistant_confirmation_field_regular_price">Price</string>
+    <string name="ai_assistant_confirmation_field_sale_price">Sale</string>
+    <string name="ai_assistant_confirmation_field_stock_quantity">Stock</string>
+    <string name="ai_assistant_confirmation_field_stock_status">Stock status</string>
+    <string name="ai_assistant_confirmation_field_sku">SKU</string>
+    <string name="ai_assistant_confirmation_field_value_updated">Updated</string>
+    <string name="ai_assistant_confirmation_field_value_off">Off</string>
+    <string name="ai_assistant_confirmation_message_list_separator">%1$s, %2$s</string>
+</resources>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="ai_assistant_confirmation_generic_tool_call">Review %1$s</string>
     <string name="ai_assistant_confirmation_change_summary_empty">edit fields</string>
     <string name="ai_assistant_confirmation_change_summary_status">status -&gt; %1$s</string>
+    <string name="ai_assistant_confirmation_change_summary_status_emails_customer">status -&gt; %1$s (emails the customer)</string>
     <string name="ai_assistant_confirmation_change_summary_status_emails_customers">status -&gt; %1$s (emails customers)</string>
     <string name="ai_assistant_confirmation_change_summary_regular_price">price -&gt; %1$s</string>
     <string name="ai_assistant_confirmation_change_summary_sale_price">sale -&gt; %1$s</string>

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilderTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilderTest.kt
@@ -1,0 +1,528 @@
+package com.woocommerce.android.aiassistant.safety
+
+import com.woocommerce.android.aiassistant.R
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class WooCommerceConfirmationPreviewBuilderTest {
+    private val builder = WooCommerceConfirmationPreviewBuilder()
+
+    @Test
+    fun `given order status update emails customer, when preview is built, then resource message is included`() {
+        val call = toolCall(
+            name = "orders_update",
+            arguments = buildJsonObject {
+                put("id", 42)
+                put("status", "processing")
+            },
+        )
+
+        val preview = builder.build(call)
+
+        assertThat(preview.message).isEqualTo(
+            string(
+                R.string.ai_assistant_confirmation_order_set_status_emails_customer,
+                raw("42"),
+                raw("processing"),
+            )
+        )
+        assertThat(preview.fields).containsExactly(
+            ConfirmationPreviewField(
+                name = "status",
+                value = raw("processing"),
+                label = label(R.string.ai_assistant_confirmation_field_status),
+            ),
+        )
+    }
+
+    @Test
+    fun `given order update with large id, when preview is built, then id is preserved`() {
+        val call = toolCall(
+            name = "orders_update",
+            arguments = buildJsonObject {
+                put("id", 3_000_000_000L)
+                put("status", "pending")
+            },
+        )
+
+        val preview = builder.build(call)
+
+        assertThat(preview.message).isEqualTo(
+            string(R.string.ai_assistant_confirmation_order_set_status, raw("3000000000"), raw("pending"))
+        )
+    }
+
+    @Test
+    fun `given single order update has unsupported fields, when preview is built, then they are ignored`() {
+        val call = toolCall(
+            name = "orders_update",
+            arguments = buildJsonObject {
+                put("id", 42)
+                put("status", "pending")
+                put("customer_note", "Thanks")
+                put("billing_email", "buyer@example.com")
+            },
+        )
+
+        val preview = builder.build(call)
+
+        assertThat(preview.message).isEqualTo(
+            string(R.string.ai_assistant_confirmation_order_set_status, raw("42"), raw("pending"))
+        )
+        assertThat(preview.fields).containsExactly(
+            ConfirmationPreviewField(
+                name = "status",
+                value = raw("pending"),
+                label = label(R.string.ai_assistant_confirmation_field_status),
+            ),
+        )
+    }
+
+    @Test
+    fun `given bulk order status update emails customers, when preview is built, then nested summary is included`() {
+        val call = toolCall(
+            name = "orders_bulk_update",
+            arguments = buildJsonObject {
+                put("ids", JsonArray((1..5).map { JsonPrimitive(it) }))
+                put("patch", buildJsonObject { put("status", "completed") })
+            },
+        )
+
+        val preview = builder.build(call)
+
+        val summary = string(
+            R.string.ai_assistant_confirmation_change_summary_status_emails_customers,
+            raw("completed"),
+        )
+        assertThat(preview.message).isEqualTo(
+            quantity(
+                quantity = 5,
+                singular = R.string.ai_assistant_confirmation_orders_bulk_update_summary_single,
+                multiple = R.string.ai_assistant_confirmation_orders_bulk_update_summary_multiple,
+                summary,
+            )
+        )
+        assertThat(preview.fields).containsExactly(
+            ConfirmationPreviewField(
+                name = "status",
+                value = raw("completed"),
+                label = label(R.string.ai_assistant_confirmation_field_status),
+            ),
+        )
+    }
+
+    @Test
+    fun `given product price and stock update, when preview is built, then exact changes are included`() {
+        val call = toolCall(
+            name = "products_update",
+            arguments = buildJsonObject {
+                put("id", 7)
+                put("regular_price", "24.99")
+                put("stock_quantity", 100)
+            },
+        )
+
+        val preview = builder.build(call)
+
+        val summary = string(
+            R.string.ai_assistant_confirmation_message_list_separator,
+            string(R.string.ai_assistant_confirmation_change_summary_regular_price, raw("24.99")),
+            string(R.string.ai_assistant_confirmation_change_summary_stock_quantity, raw("100")),
+        )
+        assertThat(preview.message).isEqualTo(
+            string(R.string.ai_assistant_confirmation_product_update_summary, raw("7"), summary)
+        )
+        assertThat(preview.fields).containsExactly(
+            ConfirmationPreviewField(
+                name = "regular_price",
+                value = raw("24.99"),
+                label = label(R.string.ai_assistant_confirmation_field_regular_price),
+            ),
+            ConfirmationPreviewField(
+                name = "stock_quantity",
+                value = raw("100"),
+                label = label(R.string.ai_assistant_confirmation_field_stock_quantity),
+            ),
+        )
+    }
+
+    @Test
+    fun `given product update has unsupported stock status, when preview is built, then it is ignored`() {
+        val call = toolCall(
+            name = "products_update",
+            arguments = buildJsonObject {
+                put("id", 7)
+                put("regular_price", "24.99")
+                put("stock_status", "instock")
+            },
+        )
+
+        val preview = builder.build(call)
+
+        assertThat(preview.message).isEqualTo(
+            string(
+                R.string.ai_assistant_confirmation_product_update_summary,
+                raw("7"),
+                string(R.string.ai_assistant_confirmation_change_summary_regular_price, raw("24.99")),
+            )
+        )
+        assertThat(preview.fields).containsExactly(
+            ConfirmationPreviewField(
+                name = "regular_price",
+                value = raw("24.99"),
+                label = label(R.string.ai_assistant_confirmation_field_regular_price),
+            ),
+        )
+    }
+
+    @Test
+    fun `given bulk product update, when preview is built, then count and fields are included`() {
+        val call = toolCall(
+            name = "products_bulk_update",
+            arguments = buildJsonObject {
+                put("ids", JsonArray(listOf(JsonPrimitive(7), JsonPrimitive(8))))
+                put(
+                    "patch",
+                    buildJsonObject {
+                        put("regular_price", "19.99")
+                        put("status", "draft")
+                    },
+                )
+            },
+        )
+
+        val preview = builder.build(call)
+
+        val summary = string(
+            R.string.ai_assistant_confirmation_message_list_separator,
+            string(R.string.ai_assistant_confirmation_change_summary_regular_price, raw("19.99")),
+            string(R.string.ai_assistant_confirmation_change_summary_status, raw("draft")),
+        )
+        assertThat(preview.message).isEqualTo(
+            quantity(
+                quantity = 2,
+                singular = R.string.ai_assistant_confirmation_products_bulk_update_summary_single,
+                multiple = R.string.ai_assistant_confirmation_products_bulk_update_summary_multiple,
+                summary,
+            )
+        )
+        assertThat(preview.fields).containsExactly(
+            ConfirmationPreviewField(
+                name = "regular_price",
+                value = raw("19.99"),
+                label = label(R.string.ai_assistant_confirmation_field_regular_price),
+            ),
+            ConfirmationPreviewField(
+                name = "status",
+                value = raw("draft"),
+                label = label(R.string.ai_assistant_confirmation_field_status),
+            ),
+        )
+    }
+
+    @Test
+    fun `given product variation update, when preview is built, then product and variation ids are included`() {
+        val call = toolCall(
+            name = "product_variations_update",
+            arguments = buildJsonObject {
+                put("product_id", 7)
+                put("id", 8)
+                put("regular_price", "19.99")
+                put("sale_price", "")
+                put("stock_quantity", 3)
+                put("stock_status", "instock")
+                put("sku", "VAR-8")
+                put("status", "publish")
+            },
+        )
+
+        val preview = builder.build(call)
+
+        val summary = listOf(
+            string(R.string.ai_assistant_confirmation_change_summary_regular_price, raw("19.99")),
+            string(
+                R.string.ai_assistant_confirmation_change_summary_sale_price,
+                string(R.string.ai_assistant_confirmation_field_value_off),
+            ),
+            string(R.string.ai_assistant_confirmation_change_summary_stock_quantity, raw("3")),
+            string(R.string.ai_assistant_confirmation_change_summary_stock_status, raw("instock")),
+            string(R.string.ai_assistant_confirmation_change_summary_status, raw("publish")),
+            string(R.string.ai_assistant_confirmation_change_summary_sku, raw("VAR-8")),
+        ).toLocalizedList()
+        assertThat(preview.message).isEqualTo(
+            string(
+                R.string.ai_assistant_confirmation_product_variation_update_summary,
+                raw("8"),
+                raw("7"),
+                summary,
+            )
+        )
+        assertThat(preview.fields).containsExactly(
+            ConfirmationPreviewField(
+                name = "regular_price",
+                value = raw("19.99"),
+                label = label(R.string.ai_assistant_confirmation_field_regular_price),
+            ),
+            ConfirmationPreviewField(
+                name = "sale_price",
+                value = string(R.string.ai_assistant_confirmation_field_value_off),
+                label = label(R.string.ai_assistant_confirmation_field_sale_price),
+            ),
+            ConfirmationPreviewField(
+                name = "stock_quantity",
+                value = raw("3"),
+                label = label(R.string.ai_assistant_confirmation_field_stock_quantity),
+            ),
+            ConfirmationPreviewField(
+                name = "stock_status",
+                value = raw("instock"),
+                label = label(R.string.ai_assistant_confirmation_field_stock_status),
+            ),
+            ConfirmationPreviewField(
+                name = "status",
+                value = raw("publish"),
+                label = label(R.string.ai_assistant_confirmation_field_status),
+            ),
+            ConfirmationPreviewField(
+                name = "sku",
+                value = raw("VAR-8"),
+                label = label(R.string.ai_assistant_confirmation_field_sku),
+            ),
+        )
+    }
+
+    @Test
+    fun `given unknown tool, when preview is built, then raw arguments are omitted`() {
+        val call = toolCall(
+            name = "custom_tool",
+            arguments = buildJsonObject { put("id", 1) },
+        )
+
+        val preview = builder.build(call)
+
+        assertThat(preview.message).isEqualTo(
+            string(R.string.ai_assistant_confirmation_generic_tool_call, raw("custom_tool"))
+        )
+        assertThat(preview.fields).isEmpty()
+    }
+
+    @Test
+    fun `given order update has wrong-shaped primitive fields, when preview is built, then fields are omitted`() {
+        val call = toolCall(
+            name = "orders_update",
+            arguments = buildJsonObject {
+                put("id", 42)
+                put("status", buildJsonObject { put("value", "processing") })
+                put("billing_email", JsonArray(listOf(JsonPrimitive("buyer@example.com"))))
+            },
+        )
+
+        val preview = builder.build(call)
+
+        assertThat(preview.message).isEqualTo(
+            string(
+                R.string.ai_assistant_confirmation_order_update_summary,
+                raw("42"),
+                string(R.string.ai_assistant_confirmation_change_summary_empty),
+            )
+        )
+        assertThat(preview.fields).isEmpty()
+    }
+
+    @Test
+    fun `given order update has wrong-shaped id, when preview is built, then fallback is used`() {
+        val call = toolCall(
+            name = "orders_update",
+            arguments = buildJsonObject {
+                put("id", buildJsonObject { put("value", 42) })
+                put("status", "processing")
+            },
+        )
+
+        val preview = builder.build(call)
+
+        assertThat(preview.message).isEqualTo(string(R.string.ai_assistant_confirmation_order_update_generic))
+        assertThat(preview.fields).isEmpty()
+    }
+
+    @Test
+    fun `given product update has wrong-shaped primitive fields, when preview is built, then fields are omitted`() {
+        val call = toolCall(
+            name = "products_update",
+            arguments = buildJsonObject {
+                put("id", 7)
+                put("regular_price", buildJsonObject { put("value", "24.99") })
+                put("stock_quantity", JsonArray(listOf(JsonPrimitive(100))))
+                put("status", "draft")
+            },
+        )
+
+        val preview = builder.build(call)
+
+        assertThat(preview.message).isEqualTo(
+            string(
+                R.string.ai_assistant_confirmation_product_update_summary,
+                raw("7"),
+                string(R.string.ai_assistant_confirmation_change_summary_status, raw("draft")),
+            )
+        )
+        assertThat(preview.fields).containsExactly(
+            ConfirmationPreviewField(
+                name = "status",
+                value = raw("draft"),
+                label = label(R.string.ai_assistant_confirmation_field_status),
+            ),
+        )
+    }
+
+    @Test
+    fun `given bulk update has wrong-shaped ids, when preview is built, then fallback is used`() {
+        val orderPreview = builder.build(
+            toolCall(
+                name = "orders_bulk_update",
+                arguments = buildJsonObject {
+                    put("ids", buildJsonObject { put("value", 42) })
+                    put("patch", buildJsonObject { put("status", "completed") })
+                },
+            )
+        )
+        val productPreview = builder.build(
+            toolCall(
+                name = "products_bulk_update",
+                arguments = buildJsonObject {
+                    put("ids", buildJsonObject { put("value", 7) })
+                    put("patch", buildJsonObject { put("regular_price", "19.99") })
+                },
+            )
+        )
+
+        assertThat(orderPreview.message).isEqualTo(
+            string(R.string.ai_assistant_confirmation_orders_bulk_update_generic)
+        )
+        assertThat(orderPreview.fields).isEmpty()
+        assertThat(productPreview.message).isEqualTo(
+            string(R.string.ai_assistant_confirmation_products_bulk_update_generic)
+        )
+        assertThat(productPreview.fields).isEmpty()
+    }
+
+    @Test
+    fun `given bulk update has non-numeric ids, when preview is built, then fallback is used`() {
+        val orderPreview = builder.build(
+            toolCall(
+                name = "orders_bulk_update",
+                arguments = buildJsonObject {
+                    put("ids", JsonArray(listOf(JsonPrimitive(1), JsonPrimitive("bad"))))
+                    put("patch", buildJsonObject { put("status", "completed") })
+                },
+            )
+        )
+        val productPreview = builder.build(
+            toolCall(
+                name = "products_bulk_update",
+                arguments = buildJsonObject {
+                    put("ids", JsonArray(listOf(JsonPrimitive(7), JsonPrimitive("bad"))))
+                    put("patch", buildJsonObject { put("regular_price", "19.99") })
+                },
+            )
+        )
+
+        assertThat(orderPreview.message).isEqualTo(
+            string(R.string.ai_assistant_confirmation_orders_bulk_update_generic)
+        )
+        assertThat(orderPreview.fields).isEmpty()
+        assertThat(productPreview.message).isEqualTo(
+            string(R.string.ai_assistant_confirmation_products_bulk_update_generic)
+        )
+        assertThat(productPreview.fields).isEmpty()
+    }
+
+    @Test
+    fun `given bulk update has wrong-shaped patch fields, when preview is built, then fields are omitted`() {
+        val orderPreview = builder.build(
+            toolCall(
+                name = "orders_bulk_update",
+                arguments = buildJsonObject {
+                    put("ids", JsonArray(listOf(JsonPrimitive(1), JsonPrimitive(2))))
+                    put(
+                        "patch",
+                        buildJsonObject {
+                            put("status", JsonArray(listOf(JsonPrimitive("completed"))))
+                            put("billing_email", buildJsonObject { put("value", "buyer@example.com") })
+                        },
+                    )
+                },
+            )
+        )
+        val productPreview = builder.build(
+            toolCall(
+                name = "products_bulk_update",
+                arguments = buildJsonObject {
+                    put("ids", JsonArray(listOf(JsonPrimitive(7), JsonPrimitive(8))))
+                    put(
+                        "patch",
+                        buildJsonObject {
+                            put("regular_price", JsonArray(listOf(JsonPrimitive("19.99"))))
+                            put("stock_quantity", buildJsonObject { put("value", 100) })
+                        },
+                    )
+                },
+            )
+        )
+
+        assertThat(orderPreview.message).isEqualTo(
+            quantity(
+                quantity = 2,
+                singular = R.string.ai_assistant_confirmation_orders_bulk_update_summary_single,
+                multiple = R.string.ai_assistant_confirmation_orders_bulk_update_summary_multiple,
+                string(R.string.ai_assistant_confirmation_change_summary_empty),
+            )
+        )
+        assertThat(orderPreview.fields).isEmpty()
+        assertThat(productPreview.message).isEqualTo(
+            quantity(
+                quantity = 2,
+                singular = R.string.ai_assistant_confirmation_products_bulk_update_summary_single,
+                multiple = R.string.ai_assistant_confirmation_products_bulk_update_summary_multiple,
+                string(R.string.ai_assistant_confirmation_change_summary_empty),
+            )
+        )
+        assertThat(productPreview.fields).isEmpty()
+    }
+
+    private fun toolCall(
+        name: String,
+        arguments: JsonObject,
+    ) = ToolCall(
+        id = "call_1",
+        name = name,
+        arguments = arguments,
+    )
+
+    private fun label(id: Int) = string(id)
+
+    private fun raw(value: String) = ConfirmationPreviewText.Raw(value)
+
+    private fun string(
+        id: Int,
+        vararg args: ConfirmationPreviewText,
+    ) = ConfirmationPreviewText.Resource(id, args.toList())
+
+    private fun quantity(
+        quantity: Int,
+        singular: Int,
+        multiple: Int,
+        vararg args: ConfirmationPreviewText,
+    ) = ConfirmationPreviewText.Quantity(quantity, singular, multiple, args.toList())
+
+    private fun List<ConfirmationPreviewText>.toLocalizedList(): ConfirmationPreviewText =
+        reduce { left, right ->
+            string(R.string.ai_assistant_confirmation_message_list_separator, left, right)
+        }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilderTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilderTest.kt
@@ -118,6 +118,32 @@ class WooCommerceConfirmationPreviewBuilderTest {
     }
 
     @Test
+    fun `given one order bulk status update emails customer, when preview is built, then singular impact is used`() {
+        val call = toolCall(
+            name = "orders_bulk_update",
+            arguments = buildJsonObject {
+                put("ids", JsonArray(listOf(JsonPrimitive(42))))
+                put("patch", buildJsonObject { put("status", "completed") })
+            },
+        )
+
+        val preview = builder.build(call)
+
+        val summary = string(
+            R.string.ai_assistant_confirmation_change_summary_status_emails_customer,
+            raw("completed"),
+        )
+        assertThat(preview.message).isEqualTo(
+            quantity(
+                quantity = 1,
+                singular = R.string.ai_assistant_confirmation_orders_bulk_update_summary_single,
+                multiple = R.string.ai_assistant_confirmation_orders_bulk_update_summary_multiple,
+                summary,
+            )
+        )
+    }
+
+    @Test
     fun `given product price and stock update, when preview is built, then exact changes are included`() {
         val call = toolCall(
             name = "products_update",
@@ -227,6 +253,7 @@ class WooCommerceConfirmationPreviewBuilderTest {
     }
 
     @Test
+    @Suppress("LongMethod")
     fun `given product variation update, when preview is built, then product and variation ids are included`() {
         val call = toolCall(
             name = "product_variations_update",

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
@@ -64,7 +64,7 @@ class WooCommerceConfirmationPreviewRendererTest {
 
         val rendered = renderer.render(preview)
 
-        assertThat(rendered.message).isEqualTo("Update 1 order: status -> completed (emails customers)")
+        assertThat(rendered.message).isEqualTo("Update 1 order: status -> completed (emails the customer)")
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
@@ -1,0 +1,150 @@
+package com.woocommerce.android.aiassistant.safety
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.woocommerce.android.aiassistant.R
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WooCommerceConfirmationPreviewRendererTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val builder = WooCommerceConfirmationPreviewBuilder()
+    private val renderer = ConfirmationPreviewRenderer(context)
+
+    @Test
+    fun `given order status update, when preview is rendered, then message uses string resource`() {
+        val preview = builder.build(
+            toolCall(
+                name = "orders_update",
+                arguments = buildJsonObject {
+                    put("id", 42)
+                    put("status", "processing")
+                },
+            )
+        )
+
+        val rendered = renderer.render(preview)
+
+        assertThat(rendered.message).isEqualTo(
+            context.getString(
+                R.string.ai_assistant_confirmation_order_set_status_emails_customer,
+                "42",
+                "processing",
+            )
+        )
+        assertThat(rendered.fields).containsExactly(
+            RenderedConfirmationPreviewField(
+                name = "status",
+                label = context.getString(R.string.ai_assistant_confirmation_field_status),
+                value = "processing",
+            )
+        )
+    }
+
+    @Test
+    fun `given one order in bulk update, when preview is rendered, then singular string is used`() {
+        val preview = builder.build(
+            toolCall(
+                name = "orders_bulk_update",
+                arguments = buildJsonObject {
+                    put("ids", JsonArray(listOf(JsonPrimitive(42))))
+                    put("patch", buildJsonObject { put("status", "completed") })
+                },
+            )
+        )
+
+        val rendered = renderer.render(preview)
+
+        assertThat(rendered.message).isEqualTo("Update 1 order: status -> completed (emails customers)")
+    }
+
+    @Test
+    fun `given many products in bulk update, when preview is rendered, then multiple string is used`() {
+        val preview = builder.build(
+            toolCall(
+                name = "products_bulk_update",
+                arguments = buildJsonObject {
+                    put("ids", JsonArray(listOf(JsonPrimitive(7), JsonPrimitive(8))))
+                    put(
+                        "patch",
+                        buildJsonObject {
+                            put("regular_price", "19.99")
+                            put("status", "draft")
+                        },
+                    )
+                },
+            )
+        )
+
+        val rendered = renderer.render(preview)
+
+        assertThat(rendered.message).isEqualTo("Update 2 products: price -> 19.99, status -> draft")
+    }
+
+    @Test
+    fun `given variation update, when preview is rendered, then nested messages are localized`() {
+        val preview = builder.build(
+            toolCall(
+                name = "product_variations_update",
+                arguments = buildJsonObject {
+                    put("product_id", 7)
+                    put("id", 8)
+                    put("regular_price", "19.99")
+                    put("sale_price", "")
+                    put("stock_quantity", 3)
+                    put("stock_status", "instock")
+                    put("sku", "VAR-8")
+                    put("status", "publish")
+                },
+            )
+        )
+
+        val rendered = renderer.render(preview)
+
+        assertThat(rendered.message).isEqualTo(
+            "Update variation #8 for product #7: " +
+                "price -> 19.99, sale -> Off, stock -> 3, stock status -> instock, status -> publish, SKU -> VAR-8"
+        )
+        assertThat(rendered.fields).contains(
+            RenderedConfirmationPreviewField(
+                name = "sale_price",
+                label = context.getString(R.string.ai_assistant_confirmation_field_sale_price),
+                value = context.getString(R.string.ai_assistant_confirmation_field_value_off),
+            )
+        )
+    }
+
+    @Test
+    fun `given unknown tool, when preview is rendered, then generic resource omits raw arguments`() {
+        val preview = builder.build(
+            toolCall(
+                name = "custom_tool",
+                arguments = buildJsonObject { put("id", 1) },
+            )
+        )
+
+        val rendered = renderer.render(preview)
+
+        assertThat(rendered.message).isEqualTo("Review custom_tool")
+        assertThat(rendered.message).doesNotContain("id")
+        assertThat(rendered.fields).isEmpty()
+    }
+
+    private fun toolCall(
+        name: String,
+        arguments: JsonObject,
+    ) = ToolCall(
+        id = "call_1",
+        name = name,
+        arguments = arguments,
+    )
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolCatalogTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolCatalogTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.aiassistant.tools
 
 import com.woocommerce.android.aiassistant.core.chat.AssistantToolHandler
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationPreviewBuilder
 import com.woocommerce.android.aiassistant.tools.analytics.AnalyticsOrdersToolHandler
 import com.woocommerce.android.aiassistant.tools.analytics.AnalyticsRevenueToolHandler
 import com.woocommerce.android.aiassistant.tools.customers.CustomersListToolHandler
@@ -71,10 +72,17 @@ class WooCommerceToolCatalogTest {
             "products_bulk_update",
             "product_variations_update",
         )
+        val bulkWriteToolNames = setOf("orders_bulk_update", "products_bulk_update")
 
         writeToolNames.forEach { name ->
             assertThat(byName.getValue(name).descriptor.safetyLevel)
                 .`as`("$name should be UNSAFE")
+                .isEqualTo(ToolSafetyLevel.UNSAFE)
+        }
+
+        bulkWriteToolNames.forEach { name ->
+            assertThat(byName.getValue(name).descriptor.safetyLevel)
+                .`as`("$name bulk writes should be UNSAFE")
                 .isEqualTo(ToolSafetyLevel.UNSAFE)
         }
 
@@ -84,5 +92,49 @@ class WooCommerceToolCatalogTest {
                 .`as`("$name should be SAFE")
                 .isEqualTo(ToolSafetyLevel.SAFE)
         }
+    }
+
+    @Test
+    fun `when descriptors are inspected, then no deletion tools are present`() {
+        val forbiddenNameParts = listOf("delete", "remove", "destructive")
+        val names = allHandlers.map { it.descriptor.name }
+
+        forbiddenNameParts.forEach { forbidden ->
+            assertThat(names.filter { it.contains(forbidden) })
+                .`as`("catalog should not contain $forbidden tools")
+                .isEmpty()
+        }
+    }
+
+    @Test
+    fun `when descriptors are retrieved, then write-tool descriptions include allowlisted fields and constraints`() {
+        val byName = allHandlers.associateBy { it.descriptor.name }
+
+        val ordersUpdate = byName.getValue("orders_update").descriptor.description
+        assertThat(ordersUpdate).contains("status")
+        assertThat(ordersUpdate).contains("customer emails")
+
+        val ordersBulkUpdate = byName.getValue("orders_bulk_update").descriptor.description
+        assertThat(ordersBulkUpdate).contains("status")
+        assertThat(ordersBulkUpdate).contains("Bulk writes require confirmation")
+
+        val productsUpdate = byName.getValue("products_update").descriptor.description
+        assertThat(productsUpdate).contains("regular_price")
+        assertThat(productsUpdate).contains("stock_quantity")
+
+        val productsBulkUpdate = byName.getValue("products_bulk_update").descriptor.description
+        assertThat(productsBulkUpdate).contains("regular_price")
+        assertThat(productsBulkUpdate).contains("Bulk writes require confirmation")
+    }
+
+    @Test
+    fun `when descriptors are inspected, then every UNSAFE tool has a dedicated confirmation preview`() {
+        val confirmationPreviewBuilder = WooCommerceConfirmationPreviewBuilder()
+        val unsafeToolNames = allHandlers
+            .map { it.descriptor }
+            .filter { it.safetyLevel == ToolSafetyLevel.UNSAFE }
+            .map { it.name }
+
+        assertThat(unsafeToolNames).allMatch(confirmationPreviewBuilder::supportsDedicatedPreview)
     }
 }


### PR DESCRIPTION
### Description

Fixes WOOMOB-2896

**Adds the in-code safety handoff for unsafe AI assistant tool calls and the localized confirmation-preview contract that future UI will render.** Internal-only — the feature is gated behind the `AI_ASSISTANT` local flag and has no merchant-visible surface in this PR.

#### Core safety runtime (`:libs:ai-assistant:core`)

Safety decisions are now enforced in code instead of relying on prompt text:

- safe tools execute immediately
- unsafe tools pause the agentic loop and emit `LoopEvent.ConfirmationRequested`
- the loop awaits `SafetyOrchestrator.confirm(requestId)` / `cancel(requestId)`
- confirmed requests resume normal tool execution
- cancelled requests stop the loop with `AssistantError.Cancelled` / `LoopOutcome.STOPPED`

The core confirmation request stays preview-free and Android-free. It carries only the metadata needed to identify the pending call: confirmation request ID, tool call ID, tool name, raw `JsonObject` arguments, and `ToolSafetyLevel`. This keeps `:core` a pure-Kotlin module — no `Context`, no `R`, no `UiString`, no WooCommerce copy.

The loop also preserves model-history consistency: when a model emits multiple tool calls and a later unsafe call is cancelled, earlier completed calls keep matched assistant tool-call/tool-result pairs, while the cancelled call is not persisted as an unmatched call or a synthetic rejected result.

**Decline behavior diverges from iOS by design.** iOS replays a declined proposal as a `user_cancelled` tool result so the model can produce one more turn. Android ends the turn: the confirmation card is the answer, the unsafe tool is never dispatched, no cancelled call is written to history, and the loop finishes with `LoopOutcome.STOPPED`. This prevents declined writes from being retried or paraphrased. We can revisit if cross-platform parity becomes required.

#### Safety catalog constraints

The catalog stays deliberately narrow this iteration, and tests guard each rule so new unsafe tools cannot be added silently:

- only `SAFE` and `UNSAFE` levels are used (no destructive/deletion tier)
- write and bulk-write tools remain `UNSAFE`
- deletion/destructive tool names are asserted absent
- every unsafe tool must have a dedicated confirmation-preview path

#### Feature-owned localized previews (`:libs:ai-assistant:feature`)

All preview surface lives in `:feature`, where WooCommerce-specific copy belongs:

- `ConfirmationPreview`, `ConfirmationPreviewField`, `ConfirmationPreviewText`
- `ConfirmationPreviewRenderer` — non-Compose, not injectable, callers provide the `Context`. Keeps it testable and avoids baking app-level context into a future UI path. Compose UI can later resolve the same nodes via `LocalContext`.
- `WooCommerceConfirmationPreviewBuilder`
- feature-local `R.string` resources for confirmation messages, field labels, summaries, and values

These types are `internal` so they don't leak to the host before there's a real UI integration point. The preview text model uses Android resources directly and supports raw merchant/API values, string resources with nested preview args, and explicit singular/multiple resource pairs (no `<plurals>` — unsupported by the project's GlotPress flow).

The WooCommerce builder mirrors the existing handler argument contracts:

- single order updates preview supported fields such as `status`
- bulk order updates preview `status`, `customer_note`, `billing_email`
- product updates preview supported fields and ignore unsupported extras (e.g. `stock_status`)
- bulk product updates summarize one or many product IDs
- product variation updates preview `product_id`, variation `id`, and supported variation fields
- numeric IDs are parsed as `Long`, matching handlers; malformed IDs fall back instead of producing misleading copy
- unknown tools use a redacted generic fallback and never expose raw JSON arguments

#### Out of scope

No bottom sheet, no Compose UI, no `:WooCommerce` host integration. Future UI work will consume `LoopEvent.ConfirmationRequested`, build a feature-owned preview from the request, render it, and resolve the request through the same `SafetyOrchestrator`.

### How to verify

Internal infrastructure — no merchant-visible flow yet. Reviewers can validate via:

1. `./gradlew :libs:ai-assistant:core:testDebugUnitTest :libs:ai-assistant:feature:testDebugUnitTest` passes.
2. `:core` has no `android.*`, `dagger.*`, or WooCommerce imports (module remains pure Kotlin).
3. Skim the catalog tests to confirm the safety/preview-coverage invariants.
4. Skim the loop tests for safe-execute, unsafe-pause/resume, cancel-stop, and mixed-history paths.
5. Confirm the diff adds no UI, bottom-sheet, POS, or `:WooCommerce` host code.

### Images/gif

N/A — no UI changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.