### PR TITLE
Fix Performance card stat label alignment when Jetpack badge is shown

### DIFF
--- a/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
+++ b/WooCommerce/src/main/res/layout/dashboard_main_stats_row.xml
@@ -19,7 +19,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/major_100"
         android:baselineAligned="false"
-        android:gravity="top"
+        android:gravity="bottom"
         android:orientation="horizontal">
 
         <LinearLayout


### PR DESCRIPTION
### Description

Fixes a regression from [#15750](https://github.com/woocommerce/woocommerce-android/pull/15750): the `Paid orders` / `Visitors` / `Conversion` labels in the Performance card no longer line up when the visitors column shows the Jetpack badge.

That PR flipped the stat row's `gravity` from `bottom` to `top`. Because the visitors column is taller in the badge state (Jetpack icon + skeleton stacked above a bottom-anchored label), top alignment leaves its label sitting ~24 dp below the others. Reverting to `gravity="bottom"` restores a shared baseline. There's a small tradeoff, when selecting `completed orders` the label will be 2 lines and thus may seem miss aligned with the rest. However, when Jetpack is not enable visitors and conversion numbers will never be displayed so it doesn't look that off: 

<img width="398" height="119" alt="Screenshot 2026-04-30 at 17 45 30" src="https://github.com/user-attachments/assets/f1f47fcd-9509-431e-8924-9e9113c737ba" />

### Test Steps

1. Open a site whose visitor stats are unavailable (Jetpack-disconnected or self-hosted/JCP store) so the Performance card shows the Jetpack badge.
2. On the **My Store** tab, confirm `Paid orders`, `Visitors`, and `Conversion` share the same baseline.
3. Switch to a site with visitor stats and confirm labels still align (regression check).

### Images/gif

| Before | After |
| --- | --- |
| <img width="300" alt="Screenshot 2026-04-30 at 17 11 46" src="https://github.com/user-attachments/assets/d209ead8-d5cb-48fe-93db-594469261c0b" /> | <img width="300" alt="Screenshot 2026-04-30 at 17 37 32" src="https://github.com/user-attachments/assets/fc60257e-2885-472d-a8ef-d83b7b36f4ce" /> |

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.