### PR TITLE
Add assistant headless test harness

### DIFF
--- a/libs/ai-assistant/core/build.gradle
+++ b/libs/ai-assistant/core/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id("org.jetbrains.kotlin.jvm")
+    id("java-test-fixtures")
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.dependency.analysis)
 }
@@ -16,4 +17,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.assertj.core)
     testImplementation(libs.kotlinx.coroutines.test)
+
+    testFixturesApi(libs.kotlinx.coroutines.core)
+    testFixturesApi(libs.kotlinx.serialization.json)
 }

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessBaselineParserTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessBaselineParserTest.kt
@@ -1,0 +1,44 @@
+package com.woocommerce.android.aiassistant.core.headless
+
+import kotlinx.serialization.json.Json
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class HeadlessBaselineParserTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+    }
+
+    @Test
+    fun `given baseline json, when parsing, then scenario contract is decoded`() {
+        val baseline = HeadlessBaselineParser(json).parse(
+            """
+            {
+              "version": 1,
+              "scenarios": [
+                {
+                  "id": "orders-processing",
+                  "turns": [
+                    {
+                      "userMessage": "How many processing orders do I have?",
+                      "hardChecks": [
+                        { "type": "TOOL_CALLED", "value": "orders_list" }
+                      ]
+                    }
+                  ],
+                  "hardChecks": [
+                    { "type": "OUTCOME_EQUALS", "value": "COMPLETED" }
+                  ]
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertThat(baseline.version).isEqualTo(1)
+        assertThat(baseline.scenarios.single().id).isEqualTo("orders-processing")
+        assertThat(baseline.scenarios.single().turns.single().hardChecks.single())
+            .isEqualTo(HeadlessHardCheck(HeadlessHardCheckType.TOOL_CALLED, "orders_list"))
+    }
+}

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessHardCheckEvaluatorTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessHardCheckEvaluatorTest.kt
@@ -1,0 +1,69 @@
+package com.woocommerce.android.aiassistant.core.headless
+
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
+import kotlinx.serialization.json.buildJsonObject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class HeadlessHardCheckEvaluatorTest {
+    @Test
+    fun `given run result, when checks match trace, then evaluator returns passed checks`() {
+        val result = HeadlessRunResult(
+            scenarioId = "orders-processing",
+            turns = listOf(
+                HeadlessTurnResult(
+                    turnIndex = 0,
+                    userMessage = "How many processing orders do I have?",
+                    assistantText = "There are 2 processing orders.",
+                    outcome = LoopOutcome.COMPLETED,
+                    toolCalls = listOf(
+                        HeadlessToolCallTrace(
+                            id = "call_1",
+                            name = "orders_list",
+                            arguments = buildJsonObject { },
+                            safetyLevel = ToolSafetyLevel.SAFE,
+                            resultKind = HeadlessToolResultKind.SUCCESS,
+                        )
+                    ),
+                )
+            ),
+        )
+
+        val checks = HeadlessHardCheckEvaluator.evaluate(
+            result,
+            listOf(
+                HeadlessHardCheck(HeadlessHardCheckType.OUTCOME_EQUALS, "COMPLETED"),
+                HeadlessHardCheck(HeadlessHardCheckType.ASSISTANT_TEXT_CONTAINS, "processing orders"),
+                HeadlessHardCheck(HeadlessHardCheckType.TOOL_CALLED, "orders_list"),
+                HeadlessHardCheck(HeadlessHardCheckType.TOOL_NOT_CALLED, "orders_update"),
+            )
+        )
+
+        assertThat(checks).allMatch { it.passed }
+    }
+
+    @Test
+    fun `given run result, when check does not match trace, then evaluator returns failed check`() {
+        val result = HeadlessRunResult(
+            scenarioId = "orders-processing",
+            turns = listOf(
+                HeadlessTurnResult(
+                    turnIndex = 0,
+                    userMessage = "How many processing orders do I have?",
+                    assistantText = "I cannot answer that.",
+                    outcome = LoopOutcome.COMPLETED,
+                    toolCalls = emptyList(),
+                )
+            ),
+        )
+
+        val checks = HeadlessHardCheckEvaluator.evaluate(
+            result,
+            listOf(HeadlessHardCheck(HeadlessHardCheckType.TOOL_CALLED, "orders_list"))
+        )
+
+        assertThat(checks.single().passed).isFalse
+        assertThat(checks.single().message).contains("orders_list")
+    }
+}

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/headless/WooAssistantHeadlessTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/headless/WooAssistantHeadlessTest.kt
@@ -1,0 +1,232 @@
+package com.woocommerce.android.aiassistant.core.headless
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantEvent
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+import com.woocommerce.android.aiassistant.core.chat.FinishReason
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.core.loop.BudgetedHistory
+import com.woocommerce.android.aiassistant.core.loop.CatalogSnapshot
+import com.woocommerce.android.aiassistant.core.loop.ConservativeRetryPolicy
+import com.woocommerce.android.aiassistant.core.loop.HistoryBudgeter
+import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
+import com.woocommerce.android.aiassistant.core.loop.SessionContext
+import com.woocommerce.android.aiassistant.core.loop.ToolScope
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationDecision
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class WooAssistantHeadlessTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+    }
+
+    @Test
+    fun `given scripted turns and recording registry, when running scenario, then result captures assistant text and tool trace`() =
+        runTest {
+            val toolDescriptor = toolDescriptor("orders_list", ToolSafetyLevel.SAFE)
+            val registry = RecordingHeadlessToolRegistry(
+                descriptors = listOf(toolDescriptor),
+                results = mapOf(
+                    "orders_list" to ToolResult.Success(
+                        toolCallId = "call_1",
+                        structured = buildJsonObject { put("count", 2) },
+                    )
+                ),
+            )
+            val harness = harness(orderListResponses(), registry)
+
+            val result = harness.runScenario(
+                scenario = scenario(
+                    id = "orders-processing",
+                    userMessage = "How many processing orders do I have?",
+                    toolDescriptor = toolDescriptor,
+                )
+            )
+
+            assertThat(result.scenarioId).isEqualTo("orders-processing")
+            assertThat(result.turns).hasSize(1)
+            assertThat(result.turns.single().assistantText)
+                .isEqualTo("Checking orders.There are 2 processing orders.")
+            assertThat(result.turns.single().toolCalls).containsExactly(
+                HeadlessToolCallTrace(
+                    id = "call_1",
+                    name = "orders_list",
+                    arguments = buildJsonObject { put("status", "processing") },
+                    safetyLevel = ToolSafetyLevel.SAFE,
+                    resultKind = HeadlessToolResultKind.SUCCESS,
+                )
+            )
+            assertThat(registry.calls.map(ToolCall::name)).containsExactly("orders_list")
+        }
+
+    @Test
+    fun `given unsafe tool and confirming safety, when running scenario, then result captures confirmation handoff`() =
+        runTest {
+            val toolDescriptor = toolDescriptor("orders_update", ToolSafetyLevel.UNSAFE)
+            val registry = RecordingHeadlessToolRegistry(
+                descriptors = listOf(toolDescriptor),
+                results = mapOf(
+                    "orders_update" to ToolResult.Success(
+                        toolCallId = "call_1",
+                        structured = buildJsonObject { put("ok", true) },
+                    )
+                ),
+            )
+            val harness = harness(
+                responses = orderUpdateResponses(includeFinalAnswer = true),
+                registry = registry,
+                safetyOrchestrator = ScriptedHeadlessSafetyOrchestrator(
+                    defaultDecision = ConfirmationDecision.CONFIRMED,
+                ),
+            )
+
+            val result = harness.runScenario(
+                scenario = scenario(
+                    id = "complete-order",
+                    userMessage = "Complete order 42",
+                    toolDescriptor = toolDescriptor,
+                )
+            )
+
+            val turn = result.turns.single()
+            assertThat(turn.outcome).isEqualTo(LoopOutcome.COMPLETED)
+            assertThat(turn.confirmationRequests).containsExactly(
+                HeadlessConfirmationRequestTrace(
+                    id = "call_1-confirmation",
+                    toolCallId = "call_1",
+                    toolName = "orders_update",
+                    arguments = buildJsonObject {
+                        put("id", 42)
+                        put("status", "completed")
+                    },
+                    safetyLevel = ToolSafetyLevel.UNSAFE,
+                )
+            )
+            assertThat(turn.confirmationResults).containsExactly(
+                HeadlessConfirmationResultTrace(
+                    requestId = "call_1-confirmation",
+                    decision = "CONFIRMED",
+                )
+            )
+            assertThat(turn.toolCalls.map { it.name }).containsExactly("orders_update")
+            assertThat(registry.calls.map(ToolCall::name)).containsExactly("orders_update")
+        }
+
+    @Test
+    fun `given unsafe tool and default headless safety, when running scenario, then tool is cancelled`() =
+        runTest {
+            val toolDescriptor = toolDescriptor("orders_update", ToolSafetyLevel.UNSAFE)
+            val registry = RecordingHeadlessToolRegistry(
+                descriptors = listOf(toolDescriptor),
+                results = mapOf(
+                    "orders_update" to ToolResult.Success(
+                        toolCallId = "call_1",
+                        structured = buildJsonObject { put("ok", true) },
+                    )
+                ),
+            )
+            val harness = harness(orderUpdateResponses(includeFinalAnswer = false), registry)
+
+            val result = harness.runScenario(
+                scenario = scenario(
+                    id = "cancel-order-update",
+                    userMessage = "Complete order 42",
+                    toolDescriptor = toolDescriptor,
+                )
+            )
+
+            val turn = result.turns.single()
+            assertThat(turn.outcome).isEqualTo(LoopOutcome.STOPPED)
+            assertThat(turn.confirmationResults.single().decision).isEqualTo("CANCELLED")
+            assertThat(turn.errors).isEmpty()
+            assertThat(turn.toolCalls).isEmpty()
+            assertThat(registry.calls).isEmpty()
+        }
+
+    private fun toolDescriptor(
+        name: String,
+        safetyLevel: ToolSafetyLevel,
+    ) = ToolDescriptor(
+        name = name,
+        description = "Test tool",
+        inputSchema = buildJsonObject { },
+        safetyLevel = safetyLevel,
+    )
+
+    private fun orderListResponses() = listOf(
+        listOf(
+            AssistantEvent.TextDelta("Checking orders."),
+            AssistantEvent.ToolCallDelta(
+                index = 0,
+                id = "call_1",
+                name = "orders_list",
+                argumentsDelta = """{"status":"processing"}""",
+            ),
+            AssistantEvent.Finish(FinishReason.TOOL_CALLS),
+        ),
+        listOf(
+            AssistantEvent.TextDelta("There are 2 processing orders."),
+            AssistantEvent.Finish(FinishReason.STOP),
+        ),
+    )
+
+    private fun orderUpdateResponses(includeFinalAnswer: Boolean): List<List<AssistantEvent>> {
+        val toolCallResponse = listOf(
+            AssistantEvent.ToolCallDelta(
+                index = 0,
+                id = "call_1",
+                name = "orders_update",
+                argumentsDelta = """{"id":42,"status":"completed"}""",
+            ),
+            AssistantEvent.Finish(FinishReason.TOOL_CALLS),
+        )
+        val finalAnswer = listOf(
+            AssistantEvent.TextDelta("Order updated."),
+            AssistantEvent.Finish(FinishReason.STOP),
+        )
+        return if (includeFinalAnswer) {
+            listOf(toolCallResponse, finalAnswer)
+        } else {
+            listOf(toolCallResponse)
+        }
+    }
+
+    private fun harness(
+        responses: List<List<AssistantEvent>>,
+        registry: RecordingHeadlessToolRegistry,
+        safetyOrchestrator: ScriptedHeadlessSafetyOrchestrator = ScriptedHeadlessSafetyOrchestrator(),
+    ) = WooAssistantHeadless(
+        chatService = ScriptedHeadlessChatService(responses),
+        toolRegistry = registry,
+        retryPolicy = ConservativeRetryPolicy,
+        historyBudgeter = passThroughBudgeter(),
+        json = json,
+        safetyOrchestrator = safetyOrchestrator,
+    )
+
+    private fun scenario(
+        id: String,
+        userMessage: String,
+        toolDescriptor: ToolDescriptor,
+    ) = HeadlessScenario(
+        id = id,
+        turns = listOf(HeadlessTurnSpec(userMessage = userMessage)),
+        initialHistory = listOf(AssistantMessage.System("You are a helpful commerce assistant.")),
+        context = SessionContext(
+            siteId = 1L,
+            catalogSnapshot = CatalogSnapshot(ToolScope.GLOBAL, listOf(toolDescriptor)),
+        ),
+    )
+
+    private fun passThroughBudgeter() = HistoryBudgeter { system, transcript, user ->
+        BudgetedHistory(listOf(system) + transcript + user)
+    }
+}

--- a/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessBaselineParser.kt
+++ b/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessBaselineParser.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.aiassistant.core.headless
+
+import kotlinx.serialization.json.Json
+
+class HeadlessBaselineParser(
+    private val json: Json,
+) {
+    fun parse(source: String): HeadlessBaseline =
+        json.decodeFromString(HeadlessBaseline.serializer(), source)
+}

--- a/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessHardCheckEvaluator.kt
+++ b/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessHardCheckEvaluator.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.aiassistant.core.headless
+
+data class HeadlessHardCheckResult(
+    val check: HeadlessHardCheck,
+    val passed: Boolean,
+    val message: String,
+)
+
+object HeadlessHardCheckEvaluator {
+    fun evaluate(
+        result: HeadlessRunResult,
+        checks: List<HeadlessHardCheck>,
+    ): List<HeadlessHardCheckResult> = checks.map { check ->
+        val passed = when (check.type) {
+            HeadlessHardCheckType.OUTCOME_EQUALS ->
+                result.turns.all { it.outcome.name == check.value }
+            HeadlessHardCheckType.ASSISTANT_TEXT_CONTAINS ->
+                result.turns.any { it.assistantText.contains(check.value) }
+            HeadlessHardCheckType.TOOL_CALLED ->
+                result.turns.any { turn -> turn.toolCalls.any { it.name == check.value } }
+            HeadlessHardCheckType.TOOL_NOT_CALLED ->
+                result.turns.none { turn -> turn.toolCalls.any { it.name == check.value } }
+        }
+        HeadlessHardCheckResult(
+            check = check,
+            passed = passed,
+            message = if (passed) {
+                "Passed ${check.type} for ${check.value}"
+            } else {
+                "Failed ${check.type} for ${check.value}"
+            },
+        )
+    }
+}

--- a/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessRunResult.kt
+++ b/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessRunResult.kt
@@ -1,0 +1,56 @@
+package com.woocommerce.android.aiassistant.core.headless
+
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+data class HeadlessRunResult(
+    val scenarioId: String,
+    val turns: List<HeadlessTurnResult>,
+)
+
+@Serializable
+data class HeadlessTurnResult(
+    val turnIndex: Int,
+    val userMessage: String,
+    val assistantText: String,
+    val outcome: LoopOutcome,
+    val toolCalls: List<HeadlessToolCallTrace>,
+    val confirmationRequests: List<HeadlessConfirmationRequestTrace> = emptyList(),
+    val confirmationResults: List<HeadlessConfirmationResultTrace> = emptyList(),
+    val errors: List<String> = emptyList(),
+)
+
+@Serializable
+data class HeadlessToolCallTrace(
+    val id: String,
+    val name: String,
+    val arguments: JsonObject,
+    val safetyLevel: ToolSafetyLevel,
+    val resultKind: HeadlessToolResultKind,
+)
+
+@Serializable
+data class HeadlessConfirmationRequestTrace(
+    val id: String,
+    val toolCallId: String,
+    val toolName: String,
+    val arguments: JsonObject,
+    val safetyLevel: ToolSafetyLevel,
+)
+
+@Serializable
+data class HeadlessConfirmationResultTrace(
+    val requestId: String,
+    val decision: String,
+)
+
+@Serializable
+enum class HeadlessToolResultKind {
+    SUCCESS,
+    VALIDATION_ERROR,
+    TRANSPORT_ERROR,
+    REJECTED_BY_SAFETY,
+}

--- a/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessScenario.kt
+++ b/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/HeadlessScenario.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.aiassistant.core.headless
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+import com.woocommerce.android.aiassistant.core.loop.SessionContext
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HeadlessBaseline(
+    val version: Int,
+    val scenarios: List<HeadlessScenarioSpec>,
+)
+
+@Serializable
+data class HeadlessScenarioSpec(
+    val id: String,
+    val turns: List<HeadlessTurnSpec>,
+    val hardChecks: List<HeadlessHardCheck> = emptyList(),
+)
+
+data class HeadlessScenario(
+    val id: String,
+    val turns: List<HeadlessTurnSpec>,
+    val initialHistory: List<AssistantMessage>,
+    val context: SessionContext,
+)
+
+@Serializable
+data class HeadlessTurnSpec(
+    val userMessage: String,
+    val hardChecks: List<HeadlessHardCheck> = emptyList(),
+)
+
+@Serializable
+data class HeadlessHardCheck(
+    val type: HeadlessHardCheckType,
+    val value: String,
+)
+
+@Serializable
+enum class HeadlessHardCheckType {
+    OUTCOME_EQUALS,
+    ASSISTANT_TEXT_CONTAINS,
+    TOOL_CALLED,
+    TOOL_NOT_CALLED,
+}

--- a/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/RecordingHeadlessToolRegistry.kt
+++ b/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/RecordingHeadlessToolRegistry.kt
@@ -1,0 +1,21 @@
+package com.woocommerce.android.aiassistant.core.headless
+
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
+
+class RecordingHeadlessToolRegistry(
+    private val descriptors: List<ToolDescriptor>,
+    private val results: Map<String, ToolResult>,
+) : ToolRegistry {
+    val calls = mutableListOf<ToolCall>()
+
+    override fun descriptors(): List<ToolDescriptor> = descriptors
+
+    override suspend fun execute(call: ToolCall): ToolResult {
+        calls += call
+        return results[call.name]
+            ?: ToolResult.ValidationError(call.id, "No scripted result for tool: ${call.name}")
+    }
+}

--- a/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/ScriptedHeadlessChatService.kt
+++ b/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/ScriptedHeadlessChatService.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.aiassistant.core.headless
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantEvent
+import com.woocommerce.android.aiassistant.core.chat.ChatRequest
+import com.woocommerce.android.aiassistant.core.chat.ChatService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class ScriptedHeadlessChatService(
+    private val responses: List<List<AssistantEvent>>,
+) : ChatService {
+    private var calls = 0
+
+    override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> = flow {
+        val response = responses[minOf(calls, responses.lastIndex)]
+        calls++
+        response.forEach { emit(it) }
+    }
+}

--- a/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/ScriptedHeadlessSafetyOrchestrator.kt
+++ b/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/ScriptedHeadlessSafetyOrchestrator.kt
@@ -1,0 +1,56 @@
+package com.woocommerce.android.aiassistant.core.headless
+
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationDecision
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
+import com.woocommerce.android.aiassistant.core.safety.SafetyDecision
+import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
+
+class ScriptedHeadlessSafetyOrchestrator(
+    private val defaultDecision: ConfirmationDecision = ConfirmationDecision.CANCELLED,
+    private val decisionsByToolCallId: Map<String, ConfirmationDecision> = emptyMap(),
+    private val requestIdFactory: (ToolCall) -> String = { call -> "${call.id}-confirmation" },
+) : SafetyOrchestrator {
+    val requests = mutableListOf<ConfirmationRequest>()
+    val results = mutableListOf<ConfirmationResult>()
+
+    override suspend fun evaluate(
+        call: ToolCall,
+        descriptor: ToolDescriptor,
+    ): SafetyDecision {
+        if (descriptor.safetyLevel == ToolSafetyLevel.SAFE) {
+            return SafetyDecision.Execute
+        }
+
+        val request = ConfirmationRequest(
+            id = requestIdFactory(call),
+            toolCallId = call.id,
+            toolName = call.name,
+            arguments = call.arguments,
+            safetyLevel = descriptor.safetyLevel,
+        )
+        requests += request
+        return SafetyDecision.RequireConfirmation(request)
+    }
+
+    override suspend fun awaitResult(requestId: String): ConfirmationResult {
+        val request = requests.firstOrNull { it.id == requestId }
+        val result = ConfirmationResult(
+            requestId = requestId,
+            decision = request?.let { decisionsByToolCallId[it.toolCallId] } ?: defaultDecision,
+        )
+        results += result
+        return result
+    }
+
+    override fun resolve(result: ConfirmationResult): Boolean {
+        results += result
+        return requests.any { it.id == result.requestId }
+    }
+
+    override fun cancelPending(requestId: String): Boolean =
+        resolve(ConfirmationResult(requestId, ConfirmationDecision.CANCELLED))
+}

--- a/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/WooAssistantHeadless.kt
+++ b/libs/ai-assistant/core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless/WooAssistantHeadless.kt
@@ -1,0 +1,132 @@
+package com.woocommerce.android.aiassistant.core.headless
+
+import com.woocommerce.android.aiassistant.core.chat.AssistantError
+import com.woocommerce.android.aiassistant.core.chat.ChatService
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.core.loop.AgenticLoopImpl
+import com.woocommerce.android.aiassistant.core.loop.HistoryBudgeter
+import com.woocommerce.android.aiassistant.core.loop.LoopEvent
+import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
+import com.woocommerce.android.aiassistant.core.loop.RetryPolicy
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
+import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
+import kotlinx.coroutines.flow.toList
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+
+class WooAssistantHeadless(
+    private val chatService: ChatService,
+    private val toolRegistry: ToolRegistry,
+    private val retryPolicy: RetryPolicy,
+    private val historyBudgeter: HistoryBudgeter,
+    private val json: Json,
+    private val safetyOrchestrator: SafetyOrchestrator = ScriptedHeadlessSafetyOrchestrator(),
+) {
+    suspend fun runScenario(scenario: HeadlessScenario): HeadlessRunResult {
+        var history = scenario.initialHistory
+        val turns = scenario.turns.mapIndexed { index, turn ->
+            val loop = AgenticLoopImpl(
+                chatService = chatService,
+                toolRegistry = toolRegistry,
+                retryPolicy = retryPolicy,
+                historyBudgeter = historyBudgeter,
+                safetyOrchestrator = safetyOrchestrator,
+                json = json,
+            )
+            val events = loop.runTurn(
+                conversationId = scenario.id,
+                userMessage = turn.userMessage,
+                history = history,
+                context = scenario.context,
+            ).toList()
+            val finished = events.filterIsInstance<LoopEvent.Finished>().lastOrNull()
+            if (finished != null) {
+                history = finished.updatedHistory
+            }
+            HeadlessTurnResult(
+                turnIndex = index,
+                userMessage = turn.userMessage,
+                assistantText = events.filterIsInstance<LoopEvent.AssistantTextDelta>().joinToString("") { it.text },
+                outcome = finished?.outcome ?: LoopOutcome.FAILED,
+                toolCalls = events.toToolCallTraces(scenario.context.catalogSnapshot.tools),
+                confirmationRequests = events.filterIsInstance<LoopEvent.ConfirmationRequested>().map {
+                    it.request.toTrace()
+                },
+                confirmationResults = events.filterIsInstance<LoopEvent.ConfirmationResolved>().map {
+                    it.result.toTrace()
+                },
+                errors = events.filterIsInstance<LoopEvent.Failed>().map { it.error.toTraceLabel() },
+            )
+        }
+        return HeadlessRunResult(scenarioId = scenario.id, turns = turns)
+    }
+
+    private fun List<LoopEvent>.toToolCallTraces(descriptors: List<ToolDescriptor>): List<HeadlessToolCallTrace> {
+        val startedCalls = mutableMapOf<String, ToolCall>()
+        val traces = mutableListOf<HeadlessToolCallTrace>()
+        forEach { event ->
+            when (event) {
+                is LoopEvent.ToolCallStarted -> startedCalls[event.call.id] = event.call
+                is LoopEvent.ToolCallFinished -> traces += event.result.toTrace(startedCalls, descriptors)
+                is LoopEvent.AssistantTextDelta,
+                is LoopEvent.ConfirmationRequested,
+                is LoopEvent.ConfirmationResolved,
+                is LoopEvent.Failed,
+                is LoopEvent.Finished -> Unit
+            }
+        }
+        return traces
+    }
+
+    private fun ToolResult.toTrace(
+        startedCalls: Map<String, ToolCall>,
+        descriptors: List<ToolDescriptor>,
+    ): HeadlessToolCallTrace {
+        val call = startedCalls[toolCallId]
+        val descriptor = call?.let { c -> descriptors.firstOrNull { it.name == c.name } }
+        return HeadlessToolCallTrace(
+            id = toolCallId,
+            name = call?.name.orEmpty(),
+            arguments = call?.arguments ?: JsonObject(emptyMap()),
+            safetyLevel = requireNotNull(descriptor) { "Missing descriptor for tool result: $toolCallId" }.safetyLevel,
+            resultKind = toResultKind(),
+        )
+    }
+
+    private fun ToolResult.toResultKind(): HeadlessToolResultKind = when (this) {
+        is ToolResult.Success -> HeadlessToolResultKind.SUCCESS
+        is ToolResult.ValidationError -> HeadlessToolResultKind.VALIDATION_ERROR
+        is ToolResult.TransportError -> HeadlessToolResultKind.TRANSPORT_ERROR
+        is ToolResult.RejectedBySafety -> HeadlessToolResultKind.REJECTED_BY_SAFETY
+    }
+
+    private fun ConfirmationRequest.toTrace() = HeadlessConfirmationRequestTrace(
+        id = id,
+        toolCallId = toolCallId,
+        toolName = toolName,
+        arguments = arguments,
+        safetyLevel = safetyLevel,
+    )
+
+    private fun ConfirmationResult.toTrace() = HeadlessConfirmationResultTrace(
+        requestId = requestId,
+        decision = decision.name,
+    )
+
+    private fun AssistantError.toTraceLabel(): String = when (this) {
+        AssistantError.Auth -> "AUTH"
+        AssistantError.Cancelled -> "CANCELLED"
+        AssistantError.Network -> "NETWORK"
+        AssistantError.RateLimit -> "RATE_LIMIT"
+        AssistantError.Timeout -> "TIMEOUT"
+        AssistantError.UpstreamFailure -> "UPSTREAM_FAILURE"
+        is AssistantError.InvalidToolCall -> "INVALID_TOOL_CALL:$toolName"
+        is AssistantError.OutcomeUnknown -> "OUTCOME_UNKNOWN:$toolName"
+        is AssistantError.ToolFailed -> "TOOL_FAILED:$toolName"
+        is AssistantError.Unknown -> "UNKNOWN"
+    }
+}

--- a/libs/ai-assistant/feature/build.gradle
+++ b/libs/ai-assistant/feature/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
     testImplementation(libs.squareup.okhttp3.mockwebserver)
+    testImplementation(testFixtures(project(":libs:ai-assistant:core")))
 }
 
 dependencyAnalysis {

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceHeadlessHarnessTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceHeadlessHarnessTest.kt
@@ -1,0 +1,103 @@
+package com.woocommerce.android.aiassistant.chat
+
+import com.woocommerce.android.aiassistant.core.auth.JwtTokenProvider
+import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
+import com.woocommerce.android.aiassistant.core.headless.HeadlessScenario
+import com.woocommerce.android.aiassistant.core.headless.HeadlessTurnSpec
+import com.woocommerce.android.aiassistant.core.headless.WooAssistantHeadless
+import com.woocommerce.android.aiassistant.core.loop.BudgetedHistory
+import com.woocommerce.android.aiassistant.core.loop.CatalogSnapshot
+import com.woocommerce.android.aiassistant.core.loop.ConservativeRetryPolicy
+import com.woocommerce.android.aiassistant.core.loop.HistoryBudgeter
+import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
+import com.woocommerce.android.aiassistant.core.loop.NoOpToolRegistry
+import com.woocommerce.android.aiassistant.core.loop.SessionContext
+import com.woocommerce.android.aiassistant.core.loop.ToolScope
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class JetpackAiChatServiceHeadlessHarnessTest {
+    private lateinit var server: MockWebServer
+    private val assistantJson = assistantJsonForTests()
+
+    private val httpClient = OkHttpClient.Builder()
+        .readTimeout(0, TimeUnit.MILLISECONDS)
+        .callTimeout(5, TimeUnit.SECONDS)
+        .build()
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `given real chat service with mocked SSE response, when headless harness runs, then it captures assistant text`() =
+        runTest {
+            server.enqueue(sseResponse())
+            val harness = WooAssistantHeadless(
+                chatService = JetpackAiChatService(
+                    httpClient = httpClient,
+                    tokenProvider = StaticTokenProvider,
+                    streamParser = ChatStreamParser(assistantJson),
+                    json = assistantJson,
+                    baseUrl = server.url("/").toString().removeSuffix("/"),
+                ),
+                toolRegistry = NoOpToolRegistry(),
+                retryPolicy = ConservativeRetryPolicy,
+                historyBudgeter = HistoryBudgeter { system, transcript, user ->
+                    BudgetedHistory(listOf(system) + transcript + user)
+                },
+                json = assistantJson,
+            )
+
+            val result = harness.runScenario(
+                HeadlessScenario(
+                    id = "transport-smoke",
+                    turns = listOf(HeadlessTurnSpec("Say hi")),
+                    initialHistory = listOf(AssistantMessage.System("You are helpful.")),
+                    context = SessionContext(
+                        siteId = 1L,
+                        catalogSnapshot = CatalogSnapshot(ToolScope.GLOBAL, emptyList()),
+                    ),
+                )
+            )
+
+            assertThat(result.turns.single().outcome).isEqualTo(LoopOutcome.COMPLETED)
+            assertThat(result.turns.single().assistantText).isEqualTo("Hello world")
+            assertThat(server.takeRequest().getHeader("Authorization")).isEqualTo("Bearer test-token")
+        }
+
+    private fun sseResponse(): MockResponse = MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "text/event-stream")
+        .setBody(
+            """
+            data: {"choices":[{"delta":{"content":"Hello"}}]}
+
+            data: {"choices":[{"delta":{"content":" world"}}]}
+
+            data: {"choices":[{"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """.trimIndent()
+        )
+
+    private object StaticTokenProvider : JwtTokenProvider {
+        override suspend fun provide(): String = "test-token"
+        override suspend fun invalidate() = Unit
+    }
+}


### PR DESCRIPTION
### Description
Part of WOOMOB-2896 follow-up work.

This adds a reusable headless test harness for the AI assistant core test fixtures, modeled after the iOS headless harness approach but adapted to the Android JVM/Robolectric test stack.

The initial implementation intentionally uses scripted model stream events and scripted tool results. That keeps the first version simple and deterministic while still validating the agentic loop end to end: assistant text streaming, tool-call assembly, tool execution, follow-up model turns, safety confirmation handoff events, loop outcomes, and hard-check evaluation.

This does not try to validate real LLM behavior or live WooCommerce API responses yet. Instead, it establishes the reusable fixture surface in `:libs:ai-assistant:core` so a separate PR can build live demo-store headless tests on top of the same harness by swapping in higher-level tool/data wiring.

The harness can run assistant scenarios without launching UI, record assistant text, tool calls, tool result kinds, confirmation requests/results, and loop errors, and evaluate hard checks from JSON baselines. It also adds scripted chat, tool registry, and safety orchestrator fixtures so future live-demo-store smoke tests can reuse the same core harness without depending on production UI wiring.

The safety coverage follows the current trunk behavior: confirmed unsafe tools execute, while cancelled unsafe tools finish the turn with `LoopOutcome.STOPPED` and no tool execution.

### Test Steps
1. Review the new `:libs:ai-assistant:core` test fixtures under `core/src/testFixtures/kotlin/com/woocommerce/android/aiassistant/core/headless`.
2. Verify the headless tests cover safe tool execution, confirmed unsafe tool execution, default-cancelled unsafe tool execution, baseline parsing, and hard-check evaluation.
3. Verify the feature test demonstrates consuming the core headless fixtures from `:libs:ai-assistant:feature`.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.