### PR TITLE
[POS] Preserve POS nav back stack across config changes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] Stop POS background catalog sync once the initial sync completes for users who never open POS [https://github.com/woocommerce/woocommerce-android/pull/15651]
 - [*] Replaced the POS Orders "Learn more" empty-state button with a "Refresh" action and updated the empty-state copy [https://github.com/woocommerce/woocommerce-android/pull/15694]
 - [*] Fixed product images failing to load when the Photon service is unavailable [https://github.com/woocommerce/woocommerce-android/pull/15646]
+- [***] Fixed bug where POS navigation was reset to home on config change [https://github.com/woocommerce/woocommerce-android/pull/15793]
 
 24.6
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/WooPosActivity.kt
@@ -32,13 +32,16 @@ class WooPosActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // POS is session-based: cart, product cache, order cache, and data source selection
-        // all live in in-memory singletons. On process death these are lost, but Compose
-        // Navigation restores the back stack to the home screen, skipping the splash flow
-        // that initializes them — causing IllegalStateException in WooPosProductsDataSource.
-        // Passing null forces a fresh start from the splash screen, which re-initializes
-        // everything. On config changes the process stays alive and singletons survive,
-        // so going through splash again is instant (no loading screen).
-        super.onCreate(null)
+        // all live in in-memory singletons set up by the splash flow. On a config change
+        // (theme, rotation, font scale) the process stays alive and the singletons survive,
+        // so we preserve savedInstanceState and let Compose Navigation restore the back
+        // stack to the screen the user was on. On process death the OS spawns a fresh
+        // process with empty singletons; restoring the back stack to a non-splash route
+        // would skip initialization and crash in WooPosProductsDataSource — so we discard
+        // savedInstanceState to force a fresh splash. hasInitializedSession is process-
+        // scoped: it's reset to false in a new process, true after the first onCreate.
+        super.onCreate(if (hasInitializedSession) savedInstanceState else null)
+        hasInitializedSession = true
         WindowCompat.setDecorFitsSystemWindows(window, false)
         lockWooPosOrientation()
 
@@ -51,6 +54,10 @@ class WooPosActivity : AppCompatActivity() {
                 WooPosRootScreen(modifier = Modifier.gesturesOrButtonsNavigationPadding())
             }
         }
+    }
+
+    companion object {
+        private var hasInitializedSession = false
     }
 }
 


### PR DESCRIPTION
### Description

Fixes a bug where any config change (theme switch, font scale, display size) on POS would reset the navigation back stack to the home screen, kicking the user out of Settings, Cart, Checkout, etc. 

**Root cause.** A previous fix ([a49534b8da7](https://github.com/woocommerce/woocommerce-android/commit/a49534b8da7), \"Fix POS crash on process death restoration\") changed `WooPosActivity.onCreate` to always pass `null` to `super.onCreate(...)`. The intent was to prevent Compose Navigation from restoring the back stack to a non-splash destination after process death, where in-memory `@Singleton`s like `WooPosProductsDataSource.activeSource` are reset and the splash flow is the only thing that re-initializes them. Without that fix, restoring straight to a non-splash route crashes with `IllegalStateException` in `WooPosProductsDataSource`.

The hammer was too big though: every config change also goes through `onCreate` with a non-null `savedInstanceState`, and discarding it indiscriminately wipes the back stack even when the process is alive and the singletons are fine.

**Fix.** Distinguish a config change (process alive, singletons retained — preserve saved state) from a process-death restoration (fresh process, singletons gone — discard saved state and force splash). A process-scoped `companion object` flag does this without coupling the activity to any specific singleton: it's `false` in a freshly-spawned process and flipped to `true` after the first `onCreate` runs. The original crash protection is preserved.

### Test Steps

Reproduce the bug, then verify the fix:

1. Launch POS on a phone
2. Navigate to Settings (Menu → Settings)
3. Pull down the system tray and toggle dark/light theme.
4. Expected: the screen you were on is still showing. (Before this fix, you'd land back on the POS home screen.)
5. Repeat on tablet to confirm no regression.

Process-death sanity check (preserves the original crash fix):

1. Open POS and navigate to Settings.
2. Background the app, then kill it via \`adb shell am kill com.woocommerce.android\` (or Android Studio's \"Terminate Application\").
3. Reopen POS from the launcher. Expected: lands on splash, completes init, no crash. Should not restore to Settings.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the \"[Internal]\" label for non-user-facing changes.