### PR TITLE
[RSM] Convert POS Issue Refund from dialog to full-screen flow | Part 3 | Polish POS refund screen

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -237,11 +237,6 @@ private fun RefundScreenHeader(
                 imageVector = ImageVector.vectorResource(R.drawable.ic_close_24dp),
                 contentDescription = closeContentDescription,
                 modifier = Modifier.size(WooPosIconSize.Large.value),
-                tint = if (closeButtonEnabled) {
-                    MaterialTheme.colorScheme.onSurface
-                } else {
-                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
-                }
             )
         }
 
@@ -273,27 +268,15 @@ private fun RefundScreenButtons(
         verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value)
     ) {
         when (state) {
-            is WooPosRefundState.Loading -> {
-                WooPosButton(
-                    text = stringResource(R.string.continue_button),
-                    onClick = {},
-                    state = WooPosButtonState.DISABLED,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
+            is WooPosRefundState.Loading -> ContinueToReviewButton(
+                enabled = false,
+                onClick = {},
+            )
             is WooPosRefundState.Content -> when (state.step) {
-                WooPosRefundState.Content.RefundStep.SelectItems -> {
-                    WooPosButton(
-                        text = stringResource(R.string.continue_button),
-                        onClick = { onEvent(WooPosRefundUIEvent.ContinueToReviewClicked) },
-                        state = if (state.selectedItemIds.isNotEmpty()) {
-                            WooPosButtonState.ENABLED
-                        } else {
-                            WooPosButtonState.DISABLED
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
+                WooPosRefundState.Content.RefundStep.SelectItems -> ContinueToReviewButton(
+                    enabled = state.selectedItemIds.isNotEmpty(),
+                    onClick = { onEvent(WooPosRefundUIEvent.ContinueToReviewClicked) },
+                )
                 WooPosRefundState.Content.RefundStep.ReviewRefund -> {
                     WooPosButton(
                         text = stringResource(R.string.continue_button),
@@ -393,6 +376,19 @@ private fun RefundScreenButtons(
             }
         }
     }
+}
+
+@Composable
+private fun ContinueToReviewButton(
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    WooPosButton(
+        text = stringResource(R.string.continue_button),
+        onClick = onClick,
+        state = if (enabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED,
+        modifier = Modifier.fillMaxWidth()
+    )
 }
 
 @Composable


### PR DESCRIPTION
## Polish POS refund screen: design-system disabled tint, share Loading/SelectItems button

⚠️ "Don not merge" label - don't merge until the parent branch is `trunk`.

### Description

Second follow-up to the POS Issue Refund fullscreen-flow PR: https://github.com/woocommerce/woocommerce-android/pull/15727. Two small cleanup items in `WooPosIssueRefundScreen.kt` — no behavior change.

**1. Drop the manual disabled-alpha on the close icon.** The header was hard-coding the Material disabled-content opacity (`onSurface.copy(alpha = 0.38f)`). `IconButton` already manages enabled vs. disabled tinting via `LocalContentColor` (with the same 0.38 alpha for disabled), so removing the explicit `tint` argument produces the same visual without a magic number in component code.

**2. Fold the Loading-state Continue button into a shared helper.** Both the `Loading` state and the `Content + SelectItems + empty selection` state were rendering the same DISABLED Continue button via two near-identical button blocks. Extracted a `ContinueToReviewButton(enabled, onClick)` helper so the two branches share one definition. Loading is conceptually \"SelectItems before items have arrived\", and the button rendering now reflects that.

The third item I had originally flagged (extracting the header-height constant) turned out not to apply — an upstream refactor moved the header from a `Box` overlay to a sibling of the content `Column`, eliminating the duplicated height.

This PR is stacked on top of `issue/pos-refund-rename-dialog-to-screen`. The base will roll forward as that one merges.

### Test Steps

Pure cleanup, no behavior change. Quick smoke test:
1. Open POS, go to Orders, pick a refundable order, tap \"Issue refund\".
2. Confirm the close button looks the same as before, both while items are loading and after they arrive.
3. Tap a couple of items, then tap Continue — confirm the button enables/disables as before.
4. Proceed through the full refund flow (Review → Confirm → Processing) to confirm those buttons still render correctly.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the \"[Internal]\" label for non-user-facing changes.