### PR TITLE
RSM-638 Enable IPP and POS in expansion countries

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProvider.kt
@@ -1,11 +1,34 @@
 package com.woocommerce.android.ui.payments.cardreader
 
+import com.woocommerce.android.cardreader.config.CardReaderConfig
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
+import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import javax.inject.Inject
 
 class CardReaderCountryConfigProvider @Inject constructor(
     private val cardReaderConfigFactory: CardReaderConfigFactory,
+    private val featureFlagRepository: FeatureFlagRepository,
 ) {
-    fun provideCountryConfigFor(countryCode: String?) =
-        cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
+    fun provideCountryConfigFor(countryCode: String?): CardReaderConfig {
+        val raw = cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
+        if (raw is CardReaderConfigForUnsupportedCountry) return raw
+
+        val normalised = countryCode?.uppercase()
+        return when (normalised) {
+            in PRIMARY_EXPANSION_COUNTRIES ->
+                if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)) raw
+                else CardReaderConfigForUnsupportedCountry
+            in EU_EXTENDED_COUNTRIES ->
+                if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)) raw
+                else CardReaderConfigForUnsupportedCountry
+            else -> raw
+        }
+    }
+
+    private companion object {
+        val PRIMARY_EXPANSION_COUNTRIES = setOf("FR", "DE", "IE", "NL", "SG", "NZ")
+        val EU_EXTENDED_COUNTRIES = setOf("AT", "BE", "FI", "IT", "LU", "PT", "ES")
+    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProvider.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
+import java.util.Locale
 import javax.inject.Inject
 
 class CardReaderCountryConfigProvider @Inject constructor(
@@ -15,7 +16,7 @@ class CardReaderCountryConfigProvider @Inject constructor(
         val raw = cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
         if (raw is CardReaderConfigForUnsupportedCountry) return raw
 
-        val normalised = countryCode?.uppercase()
+        val normalised = countryCode?.uppercase(Locale.ROOT)
         return when (normalised) {
             in PRIMARY_EXPANSION_COUNTRIES ->
                 if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProvider.kt
@@ -18,11 +18,17 @@ class CardReaderCountryConfigProvider @Inject constructor(
         val normalised = countryCode?.uppercase()
         return when (normalised) {
             in PRIMARY_EXPANSION_COUNTRIES ->
-                if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)) raw
-                else CardReaderConfigForUnsupportedCountry
+                if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)) {
+                    raw
+                } else {
+                    CardReaderConfigForUnsupportedCountry
+                }
             in EU_EXTENDED_COUNTRIES ->
-                if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)) raw
-                else CardReaderConfigForUnsupportedCountry
+                if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)) {
+                    raw
+                } else {
+                    CardReaderConfigForUnsupportedCountry
+                }
             else -> raw
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProvider.kt
@@ -16,26 +16,31 @@ class CardReaderCountryConfigProvider @Inject constructor(
         val raw = cardReaderConfigFactory.getCardReaderConfigFor(countryCode)
         if (raw is CardReaderConfigForUnsupportedCountry) return raw
 
-        val normalised = countryCode?.uppercase(Locale.ROOT)
-        return when (normalised) {
-            in PRIMARY_EXPANSION_COUNTRIES ->
-                if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)) {
-                    raw
-                } else {
-                    CardReaderConfigForUnsupportedCountry
-                }
-            in EU_EXTENDED_COUNTRIES ->
-                if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)) {
-                    raw
-                } else {
-                    CardReaderConfigForUnsupportedCountry
-                }
-            else -> raw
+        val gatingFlag = countryCode?.uppercase(Locale.ROOT)?.let(EXPANSION_COUNTRY_FEATURE_FLAGS::get)
+            ?: return raw
+
+        return if (featureFlagRepository.isEnabled(gatingFlag)) {
+            raw
+        } else {
+            CardReaderConfigForUnsupportedCountry
         }
     }
 
     private companion object {
-        val PRIMARY_EXPANSION_COUNTRIES = setOf("FR", "DE", "IE", "NL", "SG", "NZ")
-        val EU_EXTENDED_COUNTRIES = setOf("AT", "BE", "FI", "IT", "LU", "PT", "ES")
+        val EXPANSION_COUNTRY_FEATURE_FLAGS = mapOf(
+            "FR" to FeatureFlag.IPP_COUNTRY_EXPANSION,
+            "DE" to FeatureFlag.IPP_COUNTRY_EXPANSION,
+            "IE" to FeatureFlag.IPP_COUNTRY_EXPANSION,
+            "NL" to FeatureFlag.IPP_COUNTRY_EXPANSION,
+            "SG" to FeatureFlag.IPP_COUNTRY_EXPANSION,
+            "NZ" to FeatureFlag.IPP_COUNTRY_EXPANSION,
+            "AT" to FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED,
+            "BE" to FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED,
+            "FI" to FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED,
+            "IT" to FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED,
+            "LU" to FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED,
+            "PT" to FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED,
+            "ES" to FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED,
+        )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModel.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
+import com.woocommerce.android.ui.woopos.tab.WooPosSupportedCountries
 import com.woocommerce.android.ui.woopos.util.WooPosGetStoreCountryCode
 import com.woocommerce.android.ui.woopos.util.WooPosGetStoreCountryName
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
@@ -53,6 +54,7 @@ class WooPosEligibilityViewModel @Inject constructor(
     private val ciabSiteGateKeeper: CIABSiteGateKeeper,
     private val getCountryName: WooPosGetStoreCountryName,
     private val getCountryCode: WooPosGetStoreCountryCode,
+    private val supportedCountries: WooPosSupportedCountries,
 ) : ViewModel() {
 
     private val _retryState = MutableStateFlow<WooPosEligibilityRetryState?>(null)
@@ -158,7 +160,7 @@ class WooPosEligibilityViewModel @Inject constructor(
                 resourceProvider.getString(R.string.woopos_eligibility_reason_feature_switch_disabled)
             WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency -> {
                 val countryCode = getCountryCode()
-                val supportedCurrency = WooPosCanBeLaunchedInTab.SUPPORTED_COUNTRY_CURRENCY_PAIRS
+                val supportedCurrency = supportedCountries.supportedCountryCurrencyPairs()
                     .find { (country, _) -> country.equals(countryCode, ignoreCase = true) }
                     ?.second?.uppercase()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTab.kt
@@ -29,6 +29,7 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
     private val fetchWooCoreVersion: FetchActiveWCPluginVersion,
     private val wooCommerceStore: WooCommerceStore,
     private val isRemotelyEnabled: WooPOSIsRemotelyEnabled,
+    private val supportedCountries: WooPosSupportedCountries,
     private val wooPosLog: WooPosLogWrapper,
 ) {
 
@@ -157,10 +158,13 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
             wooCommerceStore.getSiteSettings(site) ?: wooCommerceStore.fetchSiteGeneralSettings(site).model
         }
 
-    private fun isCountryAndCurrencySupported(countryCode: String, currency: String) =
-        SUPPORTED_COUNTRY_CURRENCY_PAIRS.any {
-            it.first.equals(countryCode, true) && it.second.equals(currency, true)
+    private suspend fun isCountryAndCurrencySupported(countryCode: String, currency: String): Boolean {
+        val pairs = supportedCountries.supportedCountryCurrencyPairs()
+        return pairs.any {
+            it.first.equals(countryCode, ignoreCase = true) &&
+                it.second.equals(currency, ignoreCase = true)
         }
+    }
 
     private fun isWooCoreSupportsOrderAutoDraftsAndExtraPaymentsProps(wooCoreVersion: String): Boolean {
         return wooCoreVersion.semverCompareTo(WC_VERSION_SUPPORTS_POS_PRODUCT_FILTERING) >= 0
@@ -180,7 +184,6 @@ class WooPosCanBeLaunchedInTab @Inject constructor(
 
     companion object {
         const val MINIMUM_SUPPORTED_WC_VERSION = "9.6.0"
-        val SUPPORTED_COUNTRY_CURRENCY_PAIRS = listOf("us" to "usd", "gb" to "gbp")
 
         private const val WC_VERSION_SUPPORTS_POS_PRODUCT_FILTERING = MINIMUM_SUPPORTED_WC_VERSION
         private const val WC_VERSION_SUPPORTS_POS_FEATURE_SWITCH = "10.0.0"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountries.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountries.kt
@@ -1,0 +1,38 @@
+package com.woocommerce.android.ui.woopos.tab
+
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WooPosSupportedCountries @Inject constructor(
+    private val featureFlagRepository: FeatureFlagRepository,
+) {
+    suspend fun supportedCountryCurrencyPairs(): List<Pair<String, String>> {
+        featureFlagRepository.awaitRemoteFlagsLoaded()
+        return buildList {
+            addAll(BASE_PAIRS)
+            if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)) {
+                addAll(PRIMARY_EXPANSION_PAIRS)
+            }
+            if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)) {
+                addAll(EU_EXTENDED_PAIRS)
+            }
+        }
+    }
+
+    suspend fun supportedCountries(): List<String> = supportedCountryCurrencyPairs().map { it.first }
+
+    private companion object {
+        val BASE_PAIRS = listOf("us" to "usd", "gb" to "gbp")
+        val PRIMARY_EXPANSION_PAIRS = listOf(
+            "fr" to "eur", "de" to "eur", "ie" to "eur", "nl" to "eur",
+            "sg" to "sgd", "nz" to "nzd",
+        )
+        val EU_EXTENDED_PAIRS = listOf(
+            "at" to "eur", "be" to "eur", "fi" to "eur", "it" to "eur",
+            "lu" to "eur", "pt" to "eur", "es" to "eur",
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountries.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountries.kt
@@ -27,12 +27,21 @@ class WooPosSupportedCountries @Inject constructor(
     private companion object {
         val BASE_PAIRS = listOf("us" to "usd", "gb" to "gbp")
         val PRIMARY_EXPANSION_PAIRS = listOf(
-            "fr" to "eur", "de" to "eur", "ie" to "eur", "nl" to "eur",
-            "sg" to "sgd", "nz" to "nzd",
+            "fr" to "eur",
+            "de" to "eur",
+            "ie" to "eur",
+            "nl" to "eur",
+            "sg" to "sgd",
+            "nz" to "nzd",
         )
         val EU_EXTENDED_PAIRS = listOf(
-            "at" to "eur", "be" to "eur", "fi" to "eur", "it" to "eur",
-            "lu" to "eur", "pt" to "eur", "es" to "eur",
+            "at" to "eur",
+            "be" to "eur",
+            "fi" to "eur",
+            "it" to "eur",
+            "lu" to "eur",
+            "pt" to "eur",
+            "es" to "eur",
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountries.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountries.kt
@@ -25,7 +25,7 @@ class WooPosSupportedCountries @Inject constructor(
     suspend fun supportedCountries(): List<String> = supportedCountryCurrencyPairs().map { it.first }
 
     private companion object {
-        val BASE_PAIRS = listOf("us" to "usd", "gb" to "gbp")
+        val BASE_PAIRS = listOf("us" to "usd", "pr" to "usd", "gb" to "gbp")
         val PRIMARY_EXPANSION_PAIRS = listOf(
             "fr" to "eur",
             "de" to "eur",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
@@ -21,6 +21,7 @@ class WooPosTabShouldBeVisible @Inject constructor(
     private val wooCommerceStore: WooCommerceStore,
     private val featureFlagRepository: FeatureFlagRepository,
     private val ciabSiteGateKeeper: CIABSiteGateKeeper,
+    private val supportedCountries: WooPosSupportedCountries,
     private val wooPosLog: WooPosLogWrapper,
 ) {
     suspend operator fun invoke(forceRefresh: Boolean = false): Result<Boolean> = withContext(Dispatchers.IO) {
@@ -74,9 +75,6 @@ class WooPosTabShouldBeVisible @Inject constructor(
         return@withContext Result.success(isSupported)
     }
 
-    private fun isCountrySupported(countryCode: String) = SUPPORTED_COUNTRIES.contains(countryCode.lowercase())
-
-    private companion object {
-        private val SUPPORTED_COUNTRIES = listOf("us", "gb")
-    }
+    private suspend fun isCountrySupported(countryCode: String): Boolean =
+        supportedCountries.supportedCountries().contains(countryCode.lowercase())
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisible.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.util.FeatureFlagRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.util.Locale
 import javax.inject.Inject
 
 class WooPosTabShouldBeVisible @Inject constructor(
@@ -76,5 +77,5 @@ class WooPosTabShouldBeVisible @Inject constructor(
     }
 
     private suspend fun isCountrySupported(countryCode: String): Boolean =
-        supportedCountries.supportedCountries().contains(countryCode.lowercase())
+        supportedCountries.supportedCountries().contains(countryCode.lowercase(Locale.ROOT))
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -34,4 +34,9 @@ enum class FeatureFlag(
     LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
     AI_ASSISTANT("ai_assistant", localValue = PackageUtils.isDebugBuild()),
     SMARTER_NOTIFICATIONS("smarter_notifications", localValue = PackageUtils.isDebugBuild()),
+    IPP_COUNTRY_EXPANSION("woo_ipp_country_expansion", localValue = PackageUtils.isDebugBuild()),
+    IPP_COUNTRY_EXPANSION_EU_EXTENDED(
+        "woo_ipp_country_expansion_eu_extended",
+        localValue = PackageUtils.isDebugBuild(),
+    ),
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -34,9 +34,6 @@ enum class FeatureFlag(
     LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
     AI_ASSISTANT("ai_assistant", localValue = PackageUtils.isDebugBuild()),
     SMARTER_NOTIFICATIONS("smarter_notifications", localValue = PackageUtils.isDebugBuild()),
-    IPP_COUNTRY_EXPANSION("woo_ipp_country_expansion", localValue = PackageUtils.isDebugBuild()),
-    IPP_COUNTRY_EXPANSION_EU_EXTENDED(
-        "woo_ipp_country_expansion_eu_extended",
-        localValue = PackageUtils.isDebugBuild(),
-    ),
+    IPP_COUNTRY_EXPANSION("woo_ipp_country_expansion"),
+    IPP_COUNTRY_EXPANSION_EU_EXTENDED("woo_ipp_country_expansion_eu_extended"),
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProviderTest.kt
@@ -1,65 +1,145 @@
 package com.woocommerce.android.ui.payments.cardreader
 
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
+import com.woocommerce.android.cardreader.config.CardReaderConfigForAT
+import com.woocommerce.android.cardreader.config.CardReaderConfigForBE
 import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
+import com.woocommerce.android.cardreader.config.CardReaderConfigForDE
+import com.woocommerce.android.cardreader.config.CardReaderConfigForES
+import com.woocommerce.android.cardreader.config.CardReaderConfigForFI
+import com.woocommerce.android.cardreader.config.CardReaderConfigForFR
 import com.woocommerce.android.cardreader.config.CardReaderConfigForGB
+import com.woocommerce.android.cardreader.config.CardReaderConfigForIE
+import com.woocommerce.android.cardreader.config.CardReaderConfigForIT
+import com.woocommerce.android.cardreader.config.CardReaderConfigForLU
+import com.woocommerce.android.cardreader.config.CardReaderConfigForNL
+import com.woocommerce.android.cardreader.config.CardReaderConfigForNZ
+import com.woocommerce.android.cardreader.config.CardReaderConfigForPT
+import com.woocommerce.android.cardreader.config.CardReaderConfigForSG
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUSA
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 class CardReaderCountryConfigProviderTest {
     private val cardReaderConfigFactory: CardReaderConfigFactory = CardReaderConfigFactory()
+    private val featureFlagRepository: FeatureFlagRepository = mock {
+        on { isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION) }.thenReturn(false)
+        on { isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED) }.thenReturn(false)
+    }
 
-    private val cardReaderCountryConfigProvider = CardReaderCountryConfigProvider(
+    private val sut = CardReaderCountryConfigProvider(
         cardReaderConfigFactory,
+        featureFlagRepository,
     )
+
+    // --- Base countries: unaffected by flags ---
 
     @Test
     fun `given CA country code, when config provide, then Canada returned`() {
-        // GIVEN
-        val countryCode = "CA"
-
-        // WHEN
-        val config = cardReaderCountryConfigProvider.provideCountryConfigFor(countryCode)
-
-        // THEN
-        assertThat(config).isInstanceOf(CardReaderConfigForCanada::class.java)
+        assertThat(sut.provideCountryConfigFor("CA"))
+            .isInstanceOf(CardReaderConfigForCanada::class.java)
     }
 
     @Test
     fun `given US country code, when config provide, then USA returned`() {
-        // GIVEN
-        val countryCode = "US"
-
-        // WHEN
-        val config = cardReaderCountryConfigProvider.provideCountryConfigFor(countryCode)
-
-        // THEN
-        assertThat(config).isInstanceOf(CardReaderConfigForUSA::class.java)
-    }
-
-    @Test
-    fun `given RU country code, when config provide, then unsupported config returned`() {
-        // GIVEN
-        val countryCode = "RU"
-
-        // WHEN
-        val config = cardReaderCountryConfigProvider.provideCountryConfigFor(countryCode)
-
-        // THEN
-        assertThat(config).isInstanceOf(CardReaderConfigForUnsupportedCountry::class.java)
+        assertThat(sut.provideCountryConfigFor("US"))
+            .isInstanceOf(CardReaderConfigForUSA::class.java)
     }
 
     @Test
     fun `given GB country code, when config provide, then GB config returned`() {
-        // GIVEN
-        val countryCode = "GB"
+        assertThat(sut.provideCountryConfigFor("GB"))
+            .isInstanceOf(CardReaderConfigForGB::class.java)
+    }
 
-        // WHEN
-        val config = cardReaderCountryConfigProvider.provideCountryConfigFor(countryCode)
+    @Test
+    fun `given RU country code, when config provide, then unsupported config returned`() {
+        assertThat(sut.provideCountryConfigFor("RU"))
+            .isInstanceOf(CardReaderConfigForUnsupportedCountry::class.java)
+    }
 
-        // THEN
-        assertThat(config).isInstanceOf(CardReaderConfigForGB::class.java)
+    // --- Australia stays unsupported with both flags on ---
+
+    @Test
+    fun `given AU country code with both expansion flags enabled, when config provide, then unsupported returned`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(true)
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(true)
+
+        assertThat(sut.provideCountryConfigFor("AU"))
+            .isInstanceOf(CardReaderConfigForUnsupportedCountry::class.java)
+    }
+
+    // --- Primary expansion group: gated by IPP_COUNTRY_EXPANSION ---
+
+    @Test
+    fun `given primary expansion country and primary flag on, when config provide, then per-country config returned`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(true)
+
+        assertThat(sut.provideCountryConfigFor("FR")).isInstanceOf(CardReaderConfigForFR::class.java)
+        assertThat(sut.provideCountryConfigFor("DE")).isInstanceOf(CardReaderConfigForDE::class.java)
+        assertThat(sut.provideCountryConfigFor("IE")).isInstanceOf(CardReaderConfigForIE::class.java)
+        assertThat(sut.provideCountryConfigFor("NL")).isInstanceOf(CardReaderConfigForNL::class.java)
+        assertThat(sut.provideCountryConfigFor("SG")).isInstanceOf(CardReaderConfigForSG::class.java)
+        assertThat(sut.provideCountryConfigFor("NZ")).isInstanceOf(CardReaderConfigForNZ::class.java)
+    }
+
+    @Test
+    fun `given primary expansion country and primary flag off, when config provide, then unsupported returned`() {
+        listOf("FR", "DE", "IE", "NL", "SG", "NZ").forEach { code ->
+            assertThat(sut.provideCountryConfigFor(code))
+                .`as`("Expected $code to be unsupported when primary flag is off")
+                .isInstanceOf(CardReaderConfigForUnsupportedCountry::class.java)
+        }
+    }
+
+    @Test
+    fun `given primary expansion country with only EU extended flag on, when config provide, then unsupported returned`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(true)
+
+        listOf("FR", "DE", "IE", "NL", "SG", "NZ").forEach { code ->
+            assertThat(sut.provideCountryConfigFor(code))
+                .`as`("Expected $code to be unsupported when only EU extended flag is on")
+                .isInstanceOf(CardReaderConfigForUnsupportedCountry::class.java)
+        }
+    }
+
+    // --- EU extended group: gated by IPP_COUNTRY_EXPANSION_EU_EXTENDED ---
+
+    @Test
+    fun `given EU extended country and EU extended flag on, when config provide, then per-country config returned`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(true)
+
+        assertThat(sut.provideCountryConfigFor("AT")).isInstanceOf(CardReaderConfigForAT::class.java)
+        assertThat(sut.provideCountryConfigFor("BE")).isInstanceOf(CardReaderConfigForBE::class.java)
+        assertThat(sut.provideCountryConfigFor("FI")).isInstanceOf(CardReaderConfigForFI::class.java)
+        assertThat(sut.provideCountryConfigFor("IT")).isInstanceOf(CardReaderConfigForIT::class.java)
+        assertThat(sut.provideCountryConfigFor("LU")).isInstanceOf(CardReaderConfigForLU::class.java)
+        assertThat(sut.provideCountryConfigFor("PT")).isInstanceOf(CardReaderConfigForPT::class.java)
+        assertThat(sut.provideCountryConfigFor("ES")).isInstanceOf(CardReaderConfigForES::class.java)
+    }
+
+    @Test
+    fun `given EU extended country and EU extended flag off, when config provide, then unsupported returned`() {
+        listOf("AT", "BE", "FI", "IT", "LU", "PT", "ES").forEach { code ->
+            assertThat(sut.provideCountryConfigFor(code))
+                .`as`("Expected $code to be unsupported when EU extended flag is off")
+                .isInstanceOf(CardReaderConfigForUnsupportedCountry::class.java)
+        }
+    }
+
+    @Test
+    fun `given EU extended country with only primary flag on, when config provide, then unsupported returned`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(true)
+
+        listOf("AT", "BE", "FI", "IT", "LU", "PT", "ES").forEach { code ->
+            assertThat(sut.provideCountryConfigFor(code))
+                .`as`("Expected $code to be unsupported when only primary flag is on")
+                .isInstanceOf(CardReaderConfigForUnsupportedCountry::class.java)
+        }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModelTest.kt
@@ -26,6 +26,7 @@ import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.reset
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -51,6 +52,8 @@ class WooPosEligibilityViewModelTest {
     init {
         whenever(mockResourceProvider.getString(any())).thenReturn("Test suggestion text")
         whenever(mockResourceProvider.getString(any(), any())).thenReturn("Test suggestion text with params")
+        whenever(mockResourceProvider.getString(any(), any(), any()))
+            .thenReturn("Test suggestion text with country and currency")
         runBlocking {
             whenever(mockStoreCountryProvider()).doReturn("United States")
             whenever(mockStoreCountryCodeProvider()).doReturn("us")
@@ -235,6 +238,48 @@ class WooPosEligibilityViewModelTest {
             assertThat(navigated).hasSize(1)
             job.cancel()
         }
+    }
+
+    @Test
+    fun `given DE store and primary expansion flag on, when ineligible due to unsupported currency, then message uses EUR`() = runTest {
+        // GIVEN
+        whenever(supportedCountries.supportedCountryCurrencyPairs()).thenReturn(
+            listOf("us" to "usd", "gb" to "gbp", "de" to "eur"),
+        )
+        val sut = createSut()
+        whenever(mockStoreCountryProvider()).thenReturn("Germany")
+        whenever(mockStoreCountryCodeProvider()).thenReturn("de")
+
+        // WHEN
+        sut.initialize(WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency)
+        advanceUntilIdle()
+
+        // THEN
+        verify(mockResourceProvider).getString(
+            eq(com.woocommerce.android.R.string.woopos_eligibility_reason_unsupported_currency_country_pair),
+            eq("Germany"),
+            eq("EUR"),
+        )
+    }
+
+    @Test
+    fun `given DE store and primary expansion flag off, when ineligible due to unsupported currency, then generic message used`() = runTest {
+        // GIVEN
+        whenever(supportedCountries.supportedCountryCurrencyPairs()).thenReturn(
+            listOf("us" to "usd", "gb" to "gbp"),
+        )
+        val sut = createSut()
+        whenever(mockStoreCountryProvider()).thenReturn("Germany")
+        whenever(mockStoreCountryCodeProvider()).thenReturn("de")
+
+        // WHEN
+        sut.initialize(WooPosLaunchability.NonLaunchabilityReason.UnsupportedCurrency)
+        advanceUntilIdle()
+
+        // THEN
+        verify(mockResourceProvider).getString(
+            eq(com.woocommerce.android.R.string.woopos_eligibility_reason_unsupported_currency_generic),
+        )
     }
 
     private fun mockUriParse(): MockedStatic<Uri> {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModelTest.kt
@@ -54,7 +54,9 @@ class WooPosEligibilityViewModelTest {
         runBlocking {
             whenever(mockStoreCountryProvider()).doReturn("United States")
             whenever(mockStoreCountryCodeProvider()).doReturn("us")
-            whenever(supportedCountries.supportedCountryCurrencyPairs()).thenReturn(listOf("us" to "usd", "gb" to "gbp"))
+            whenever(
+                supportedCountries.supportedCountryCurrencyPairs()
+            ).thenReturn(listOf("us" to "usd", "gb" to "gbp"))
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/eligibility/WooPosEligibilityViewModelTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.ciab.CIABSiteGateKeeper
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.tab.WooPosCanBeLaunchedInTab
 import com.woocommerce.android.ui.woopos.tab.WooPosLaunchability
+import com.woocommerce.android.ui.woopos.tab.WooPosSupportedCountries
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.WooPosGetStoreCountryCode
 import com.woocommerce.android.ui.woopos.util.WooPosGetStoreCountryName
@@ -41,6 +42,7 @@ class WooPosEligibilityViewModelTest {
     private val mockCiabSiteGateKeeper: CIABSiteGateKeeper = mock()
     private val mockStoreCountryProvider: WooPosGetStoreCountryName = mock()
     private val mockStoreCountryCodeProvider: WooPosGetStoreCountryCode = mock()
+    private val supportedCountries: WooPosSupportedCountries = mock()
 
     @Rule
     @JvmField
@@ -52,6 +54,7 @@ class WooPosEligibilityViewModelTest {
         runBlocking {
             whenever(mockStoreCountryProvider()).doReturn("United States")
             whenever(mockStoreCountryCodeProvider()).doReturn("us")
+            whenever(supportedCountries.supportedCountryCurrencyPairs()).thenReturn(listOf("us" to "usd", "gb" to "gbp"))
         }
     }
 
@@ -122,6 +125,7 @@ class WooPosEligibilityViewModelTest {
             mockCiabSiteGateKeeper,
             mockStoreCountryProvider,
             mockStoreCountryCodeProvider,
+            supportedCountries,
         )
 
         // WHEN
@@ -146,6 +150,7 @@ class WooPosEligibilityViewModelTest {
             mockCiabSiteGateKeeper,
             mockStoreCountryProvider,
             mockStoreCountryCodeProvider,
+            supportedCountries,
         )
 
         sut.initialize(reason)
@@ -175,6 +180,7 @@ class WooPosEligibilityViewModelTest {
             mockCiabSiteGateKeeper,
             mockStoreCountryProvider,
             mockStoreCountryCodeProvider,
+            supportedCountries,
         )
 
         sut.initialize(initialReason)
@@ -247,6 +253,7 @@ class WooPosEligibilityViewModelTest {
             mockCiabSiteGateKeeper,
             mockStoreCountryProvider,
             mockStoreCountryCodeProvider,
+            supportedCountries,
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -34,6 +34,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     private val isRemotelyEnabled: WooPOSIsRemotelyEnabled = mock()
     private val getWooCoreVersion: GetWooCorePluginCachedVersion = mock()
     private val fetchWooCoreVersion: FetchActiveWCPluginVersion = mock()
+    private val supportedCountries: WooPosSupportedCountries = mock()
 
     private lateinit var sut: WooPosCanBeLaunchedInTab
     private lateinit var siteModel: SiteModel
@@ -53,6 +54,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
 
         whenever(isRemotelyEnabled.invoke(any())).thenReturn(Result.success(true))
         whenever(appPrefs.isPOSLaunchableForSite(eq(siteModel.id))).thenReturn(false)
+        whenever(supportedCountries.supportedCountryCurrencyPairs()).thenReturn(listOf("us" to "usd", "gb" to "gbp"))
 
         sut = WooPosCanBeLaunchedInTab(
             appPrefs = appPrefs,
@@ -61,6 +63,7 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
             fetchWooCoreVersion = fetchWooCoreVersion,
             wooCommerceStore = wooCommerceStore,
             isRemotelyEnabled = isRemotelyEnabled,
+            supportedCountries = supportedCountries,
             wooPosLog = mock()
         )
     }
@@ -283,6 +286,48 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
         val result = sut()
 
         assertEquals(Launchable, result)
+    }
+
+    // --- Supported countries dynamic list ---
+
+    @Test
+    fun `given DE country and EUR currency and primary flag on, when invoked, then return Launchable`() = testBlocking {
+        whenever(supportedCountries.supportedCountryCurrencyPairs())
+            .thenReturn(listOf("us" to "usd", "gb" to "gbp", "de" to "eur"))
+        val siteSettings = buildSiteSettings(countryCode = "DE", currencyCode = "EUR")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+
+        assertEquals(Launchable, sut())
+    }
+
+    @Test
+    fun `given DE country and EUR currency and primary flag off, when invoked, then return UnsupportedCurrency`() = testBlocking {
+        whenever(supportedCountries.supportedCountryCurrencyPairs())
+            .thenReturn(listOf("us" to "usd", "gb" to "gbp"))
+        val siteSettings = buildSiteSettings(countryCode = "DE", currencyCode = "EUR")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+
+        val result = sut()
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
+    }
+
+    @Test
+    fun `given AU country and AUD currency and both flags on, when invoked, then return UnsupportedCurrency`() = testBlocking {
+        whenever(supportedCountries.supportedCountryCurrencyPairs())
+            .thenReturn(
+                listOf(
+                    "us" to "usd", "gb" to "gbp",
+                    "fr" to "eur", "de" to "eur", "ie" to "eur", "nl" to "eur",
+                    "sg" to "sgd", "nz" to "nzd",
+                    "at" to "eur", "be" to "eur", "fi" to "eur", "it" to "eur",
+                    "lu" to "eur", "pt" to "eur", "es" to "eur",
+                )
+            )
+        val siteSettings = buildSiteSettings(countryCode = "AU", currencyCode = "AUD")
+        whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
+
+        val result = sut()
+        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
     }
 
     // ---

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountriesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountriesTest.kt
@@ -37,9 +37,14 @@ class WooPosSupportedCountriesTest : BaseUnitTest() {
 
         assertThat(sut.supportedCountryCurrencyPairs())
             .containsExactlyInAnyOrder(
-                "us" to "usd", "gb" to "gbp",
-                "fr" to "eur", "de" to "eur", "ie" to "eur", "nl" to "eur",
-                "sg" to "sgd", "nz" to "nzd",
+                "us" to "usd",
+                "gb" to "gbp",
+                "fr" to "eur",
+                "de" to "eur",
+                "ie" to "eur",
+                "nl" to "eur",
+                "sg" to "sgd",
+                "nz" to "nzd",
             )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountriesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountriesTest.kt
@@ -1,0 +1,80 @@
+package com.woocommerce.android.ui.woopos.tab
+
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosSupportedCountriesTest : BaseUnitTest() {
+
+    private val featureFlagRepository: FeatureFlagRepository = mock()
+
+    private lateinit var sut: WooPosSupportedCountries
+
+    @Before
+    fun setup() = testBlocking {
+        whenever(featureFlagRepository.awaitRemoteFlagsLoaded()).thenReturn(Unit)
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(false)
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(false)
+        sut = WooPosSupportedCountries(featureFlagRepository)
+    }
+
+    @Test
+    fun `given both flags off, when supportedCountryCurrencyPairs called, then base pairs only returned`() = testBlocking {
+        assertThat(sut.supportedCountryCurrencyPairs())
+            .containsExactlyInAnyOrder("us" to "usd", "gb" to "gbp")
+    }
+
+    @Test
+    fun `given primary flag on, when supportedCountryCurrencyPairs called, then base plus primary group returned`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(true)
+
+        assertThat(sut.supportedCountryCurrencyPairs())
+            .containsExactlyInAnyOrder(
+                "us" to "usd", "gb" to "gbp",
+                "fr" to "eur", "de" to "eur", "ie" to "eur", "nl" to "eur",
+                "sg" to "sgd", "nz" to "nzd",
+            )
+    }
+
+    @Test
+    fun `given EU extended flag on, when supportedCountryCurrencyPairs called, then base plus EU extended group returned`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(true)
+
+        assertThat(sut.supportedCountryCurrencyPairs())
+            .containsExactlyInAnyOrder(
+                "us" to "usd", "gb" to "gbp",
+                "at" to "eur", "be" to "eur", "fi" to "eur", "it" to "eur",
+                "lu" to "eur", "pt" to "eur", "es" to "eur",
+            )
+    }
+
+    @Test
+    fun `given both flags on, when supportedCountryCurrencyPairs called, then all 15 pairs returned and AU absent`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(true)
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(true)
+
+        val pairs = sut.supportedCountryCurrencyPairs()
+        assertThat(pairs).hasSize(15)
+        assertThat(pairs.map { it.first }).doesNotContain("au")
+    }
+
+    @Test
+    fun `given both flags on, when supportedCountries called, then all country codes returned`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(true)
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(true)
+
+        assertThat(sut.supportedCountries())
+            .containsExactlyInAnyOrder(
+                "us", "gb",
+                "fr", "de", "ie", "nl", "sg", "nz",
+                "at", "be", "fi", "it", "lu", "pt", "es",
+            )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountriesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountriesTest.kt
@@ -28,7 +28,12 @@ class WooPosSupportedCountriesTest : BaseUnitTest() {
     @Test
     fun `given both flags off, when supportedCountryCurrencyPairs called, then base pairs only returned`() = testBlocking {
         assertThat(sut.supportedCountryCurrencyPairs())
-            .containsExactlyInAnyOrder("us" to "usd", "gb" to "gbp")
+            .containsExactlyInAnyOrder("us" to "usd", "pr" to "usd", "gb" to "gbp")
+    }
+
+    @Test
+    fun `given both flags off, when supportedCountryCurrencyPairs called, then PR is included alongside US`() = testBlocking {
+        assertThat(sut.supportedCountryCurrencyPairs()).contains("pr" to "usd")
     }
 
     @Test
@@ -38,6 +43,7 @@ class WooPosSupportedCountriesTest : BaseUnitTest() {
         assertThat(sut.supportedCountryCurrencyPairs())
             .containsExactlyInAnyOrder(
                 "us" to "usd",
+                "pr" to "usd",
                 "gb" to "gbp",
                 "fr" to "eur",
                 "de" to "eur",
@@ -54,19 +60,19 @@ class WooPosSupportedCountriesTest : BaseUnitTest() {
 
         assertThat(sut.supportedCountryCurrencyPairs())
             .containsExactlyInAnyOrder(
-                "us" to "usd", "gb" to "gbp",
+                "us" to "usd", "pr" to "usd", "gb" to "gbp",
                 "at" to "eur", "be" to "eur", "fi" to "eur", "it" to "eur",
                 "lu" to "eur", "pt" to "eur", "es" to "eur",
             )
     }
 
     @Test
-    fun `given both flags on, when supportedCountryCurrencyPairs called, then all 15 pairs returned and AU absent`() = testBlocking {
+    fun `given both flags on, when supportedCountryCurrencyPairs called, then all 16 pairs returned and AU absent`() = testBlocking {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(true)
         whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(true)
 
         val pairs = sut.supportedCountryCurrencyPairs()
-        assertThat(pairs).hasSize(15)
+        assertThat(pairs).hasSize(16)
         assertThat(pairs.map { it.first }).doesNotContain("au")
     }
 
@@ -77,7 +83,7 @@ class WooPosSupportedCountriesTest : BaseUnitTest() {
 
         assertThat(sut.supportedCountries())
             .containsExactlyInAnyOrder(
-                "us", "gb",
+                "us", "pr", "gb",
                 "fr", "de", "ie", "nl", "sg", "nz",
                 "at", "be", "fi", "it", "lu", "pt", "es",
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
@@ -219,7 +219,9 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
     @Test
     fun `given AU country with both flags on, when invoked, then return success false`() = testBlocking {
         whenever(supportedCountries.supportedCountries())
-            .thenReturn(listOf("us", "gb", "fr", "de", "ie", "nl", "sg", "nz", "at", "be", "fi", "it", "lu", "pt", "es"))
+            .thenReturn(
+                listOf("us", "gb", "fr", "de", "ie", "nl", "sg", "nz", "at", "be", "fi", "it", "lu", "pt", "es")
+            )
         val siteSettings = buildSiteSettings(countryCode = "AU", currencyCode = "AUD")
         whenever(wooCommerceStore.fetchSiteGeneralSettings(siteModel)).thenReturn(WooResult(siteSettings))
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
@@ -37,6 +37,7 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
     private val ciabSiteGateKeeper: CIABSiteGateKeeper = mock {
         on { isFeatureUnsupported(CIABAffectedFeature.POS) } doReturn false
     }
+    private val supportedCountries: WooPosSupportedCountries = mock()
 
     private lateinit var sut: WooPosTabShouldBeVisible
     private lateinit var siteModel: SiteModel
@@ -49,6 +50,7 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS)).thenReturn(true)
         whenever(featureFlagRepository.awaitRemoteFlagsLoaded()).thenReturn(Unit)
         whenever(appPrefs.isPOSTabVisibleForSite(any())).thenReturn(false)
+        whenever(supportedCountries.supportedCountries()).thenReturn(listOf("us", "gb"))
         val siteSettings = buildSiteSettings()
         whenever(wooCommerceStore.fetchSiteGeneralSettings(siteModel)).thenReturn(WooResult(siteSettings))
 
@@ -59,6 +61,7 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
             wooCommerceStore = wooCommerceStore,
             featureFlagRepository = featureFlagRepository,
             ciabSiteGateKeeper = ciabSiteGateKeeper,
+            supportedCountries = supportedCountries,
             wooPosLog = mock()
         )
     }
@@ -191,10 +194,45 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
         verify(appPrefs).clearPOSTabVisibilityForSite(siteModel.id)
     }
 
-    private fun buildSiteSettings(countryCode: String = "us") =
+    @Test
+    fun `given primary expansion country DE and primary flag on, when invoked, then return success true`() = testBlocking {
+        whenever(supportedCountries.supportedCountries()).thenReturn(listOf("us", "gb", "de"))
+        val siteSettings = buildSiteSettings(countryCode = "DE", currencyCode = "EUR")
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(siteModel)).thenReturn(WooResult(siteSettings))
+
+        val r = sut(forceRefresh = true)
+        assertTrue(r.isSuccess)
+        assertTrue(r.getOrThrow())
+    }
+
+    @Test
+    fun `given primary expansion country DE and primary flag off, when invoked, then return success false`() = testBlocking {
+        whenever(supportedCountries.supportedCountries()).thenReturn(listOf("us", "gb"))
+        val siteSettings = buildSiteSettings(countryCode = "DE", currencyCode = "EUR")
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(siteModel)).thenReturn(WooResult(siteSettings))
+
+        val r = sut(forceRefresh = true)
+        assertTrue(r.isSuccess)
+        assertFalse(r.getOrThrow())
+    }
+
+    @Test
+    fun `given AU country with both flags on, when invoked, then return success false`() = testBlocking {
+        whenever(supportedCountries.supportedCountries())
+            .thenReturn(listOf("us", "gb", "fr", "de", "ie", "nl", "sg", "nz", "at", "be", "fi", "it", "lu", "pt", "es"))
+        val siteSettings = buildSiteSettings(countryCode = "AU", currencyCode = "AUD")
+        whenever(wooCommerceStore.fetchSiteGeneralSettings(siteModel)).thenReturn(WooResult(siteSettings))
+
+        val r = sut(forceRefresh = true)
+        assertTrue(r.isSuccess)
+        assertFalse(r.getOrThrow())
+    }
+
+    private fun buildSiteSettings(countryCode: String = "us", currencyCode: String = "USD") =
         WCSettingsTestUtils.generateSettings(
             siteId = LocalOrRemoteId.LocalId(1)
         ).copy(
-            countryCode = countryCode
+            countryCode = countryCode,
+            currencyCode = currencyCode
         )
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigFactory.kt
@@ -7,6 +7,19 @@ class CardReaderConfigFactory {
             "US", "PR" -> CardReaderConfigForUSA
             "CA" -> CardReaderConfigForCanada
             "GB" -> CardReaderConfigForGB
+            "FR" -> CardReaderConfigForFR
+            "DE" -> CardReaderConfigForDE
+            "IE" -> CardReaderConfigForIE
+            "NL" -> CardReaderConfigForNL
+            "SG" -> CardReaderConfigForSG
+            "NZ" -> CardReaderConfigForNZ
+            "AT" -> CardReaderConfigForAT
+            "BE" -> CardReaderConfigForBE
+            "FI" -> CardReaderConfigForFI
+            "IT" -> CardReaderConfigForIT
+            "LU" -> CardReaderConfigForLU
+            "PT" -> CardReaderConfigForPT
+            "ES" -> CardReaderConfigForES
             else -> CardReaderConfigForUnsupportedCountry
         }
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigFactory.kt
@@ -1,26 +1,29 @@
 package com.woocommerce.android.cardreader.config
 
 class CardReaderConfigFactory {
-    fun getCardReaderConfigFor(countryCode: String?): CardReaderConfig {
-        return when (countryCode) {
+    fun getCardReaderConfigFor(countryCode: String?): CardReaderConfig =
+        COUNTRY_CONFIGS[countryCode] ?: CardReaderConfigForUnsupportedCountry
+
+    private companion object {
+        val COUNTRY_CONFIGS: Map<String, CardReaderConfigForSupportedCountry> = mapOf(
             // PR is Puerto Rico and it's a US territory
-            "US", "PR" -> CardReaderConfigForUSA
-            "CA" -> CardReaderConfigForCanada
-            "GB" -> CardReaderConfigForGB
-            "FR" -> CardReaderConfigForFR
-            "DE" -> CardReaderConfigForDE
-            "IE" -> CardReaderConfigForIE
-            "NL" -> CardReaderConfigForNL
-            "SG" -> CardReaderConfigForSG
-            "NZ" -> CardReaderConfigForNZ
-            "AT" -> CardReaderConfigForAT
-            "BE" -> CardReaderConfigForBE
-            "FI" -> CardReaderConfigForFI
-            "IT" -> CardReaderConfigForIT
-            "LU" -> CardReaderConfigForLU
-            "PT" -> CardReaderConfigForPT
-            "ES" -> CardReaderConfigForES
-            else -> CardReaderConfigForUnsupportedCountry
-        }
+            "US" to CardReaderConfigForUSA,
+            "PR" to CardReaderConfigForUSA,
+            "CA" to CardReaderConfigForCanada,
+            "GB" to CardReaderConfigForGB,
+            "FR" to CardReaderConfigForFR,
+            "DE" to CardReaderConfigForDE,
+            "IE" to CardReaderConfigForIE,
+            "NL" to CardReaderConfigForNL,
+            "SG" to CardReaderConfigForSG,
+            "NZ" to CardReaderConfigForNZ,
+            "AT" to CardReaderConfigForAT,
+            "BE" to CardReaderConfigForBE,
+            "FI" to CardReaderConfigForFI,
+            "IT" to CardReaderConfigForIT,
+            "LU" to CardReaderConfigForLU,
+            "PT" to CardReaderConfigForPT,
+            "ES" to CardReaderConfigForES,
+        )
     }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForAT.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForAT.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForAT : CardReaderConfigForSupportedCountry(
+    currency = "EUR",
+    countryCode = "AT",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForBE.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForBE.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForBE : CardReaderConfigForSupportedCountry(
+    currency = "EUR",
+    countryCode = "BE",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForDE.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForDE.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForDE : CardReaderConfigForSupportedCountry(
+    currency = "EUR",
+    countryCode = "DE",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForES.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForES.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForES : CardReaderConfigForSupportedCountry(
+    currency = "EUR",
+    countryCode = "ES",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForFI.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForFI.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForFI : CardReaderConfigForSupportedCountry(
+    currency = "EUR",
+    countryCode = "FI",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForFR.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForFR.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForFR : CardReaderConfigForSupportedCountry(
+    currency = "EUR",
+    countryCode = "FR",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForIE.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForIE.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForIE : CardReaderConfigForSupportedCountry(
+    currency = "EUR",
+    countryCode = "IE",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForIT.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForIT.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForIT : CardReaderConfigForSupportedCountry(
+    currency = "EUR",
+    countryCode = "IT",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForLU.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForLU.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForLU : CardReaderConfigForSupportedCountry(
+    currency = "EUR",
+    countryCode = "LU",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForNL.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForNL.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForNL : CardReaderConfigForSupportedCountry(
+    currency = "EUR",
+    countryCode = "NL",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForNZ.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForNZ.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForNZ : CardReaderConfigForSupportedCountry(
+    currency = "NZD",
+    countryCode = "NZ",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForPT.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForPT.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForPT : CardReaderConfigForSupportedCountry(
+    currency = "EUR",
+    countryCode = "PT",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForSG.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForSG.kt
@@ -1,0 +1,28 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForSG : CardReaderConfigForSupportedCountry(
+    currency = "SGD",
+    countryCode = "SG",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.STRIPE,
+            supportedSince = "6.2.0"
+        ),
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "4.4.0"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
@@ -1,7 +1,21 @@
 package com.woocommerce.android.cardreader.internal.config
 
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
+import com.woocommerce.android.cardreader.config.CardReaderConfigForAT
+import com.woocommerce.android.cardreader.config.CardReaderConfigForBE
 import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
+import com.woocommerce.android.cardreader.config.CardReaderConfigForDE
+import com.woocommerce.android.cardreader.config.CardReaderConfigForES
+import com.woocommerce.android.cardreader.config.CardReaderConfigForFI
+import com.woocommerce.android.cardreader.config.CardReaderConfigForFR
+import com.woocommerce.android.cardreader.config.CardReaderConfigForGB
+import com.woocommerce.android.cardreader.config.CardReaderConfigForIE
+import com.woocommerce.android.cardreader.config.CardReaderConfigForIT
+import com.woocommerce.android.cardreader.config.CardReaderConfigForLU
+import com.woocommerce.android.cardreader.config.CardReaderConfigForNL
+import com.woocommerce.android.cardreader.config.CardReaderConfigForNZ
+import com.woocommerce.android.cardreader.config.CardReaderConfigForPT
+import com.woocommerce.android.cardreader.config.CardReaderConfigForSG
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUSA
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
 import com.woocommerce.android.cardreader.internal.CardReaderBaseUnitTest
@@ -69,5 +83,89 @@ class CardReaderConfigFactoryTest : CardReaderBaseUnitTest() {
 
         // THEN
         assertThat(cardReaderConfig).isInstanceOf(expectedCardReaderConfig::class.java)
+    }
+
+    @Test
+    fun `given country code FR, when getCardReaderConfigFor is called, then France card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("FR"))
+            .isInstanceOf(CardReaderConfigForFR::class.java)
+    }
+
+    @Test
+    fun `given country code DE, when getCardReaderConfigFor is called, then Germany card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("DE"))
+            .isInstanceOf(CardReaderConfigForDE::class.java)
+    }
+
+    @Test
+    fun `given country code IE, when getCardReaderConfigFor is called, then Ireland card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("IE"))
+            .isInstanceOf(CardReaderConfigForIE::class.java)
+    }
+
+    @Test
+    fun `given country code NL, when getCardReaderConfigFor is called, then Netherlands card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("NL"))
+            .isInstanceOf(CardReaderConfigForNL::class.java)
+    }
+
+    @Test
+    fun `given country code SG, when getCardReaderConfigFor is called, then Singapore card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("SG"))
+            .isInstanceOf(CardReaderConfigForSG::class.java)
+    }
+
+    @Test
+    fun `given country code NZ, when getCardReaderConfigFor is called, then New Zealand card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("NZ"))
+            .isInstanceOf(CardReaderConfigForNZ::class.java)
+    }
+
+    @Test
+    fun `given country code AT, when getCardReaderConfigFor is called, then Austria card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("AT"))
+            .isInstanceOf(CardReaderConfigForAT::class.java)
+    }
+
+    @Test
+    fun `given country code BE, when getCardReaderConfigFor is called, then Belgium card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("BE"))
+            .isInstanceOf(CardReaderConfigForBE::class.java)
+    }
+
+    @Test
+    fun `given country code FI, when getCardReaderConfigFor is called, then Finland card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("FI"))
+            .isInstanceOf(CardReaderConfigForFI::class.java)
+    }
+
+    @Test
+    fun `given country code IT, when getCardReaderConfigFor is called, then Italy card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("IT"))
+            .isInstanceOf(CardReaderConfigForIT::class.java)
+    }
+
+    @Test
+    fun `given country code LU, when getCardReaderConfigFor is called, then Luxembourg card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("LU"))
+            .isInstanceOf(CardReaderConfigForLU::class.java)
+    }
+
+    @Test
+    fun `given country code PT, when getCardReaderConfigFor is called, then Portugal card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("PT"))
+            .isInstanceOf(CardReaderConfigForPT::class.java)
+    }
+
+    @Test
+    fun `given country code ES, when getCardReaderConfigFor is called, then Spain card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("ES"))
+            .isInstanceOf(CardReaderConfigForES::class.java)
+    }
+
+    @Test
+    fun `given country code AU, when getCardReaderConfigFor is called, then unsupported config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("AU"))
+            .isInstanceOf(CardReaderConfigForUnsupportedCountry::class.java)
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.cardreader.config.CardReaderConfigForDE
 import com.woocommerce.android.cardreader.config.CardReaderConfigForES
 import com.woocommerce.android.cardreader.config.CardReaderConfigForFI
 import com.woocommerce.android.cardreader.config.CardReaderConfigForFR
-import com.woocommerce.android.cardreader.config.CardReaderConfigForGB
 import com.woocommerce.android.cardreader.config.CardReaderConfigForIE
 import com.woocommerce.android.cardreader.config.CardReaderConfigForIT
 import com.woocommerce.android.cardreader.config.CardReaderConfigForLU

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
@@ -8,6 +8,7 @@ import com.woocommerce.android.cardreader.config.CardReaderConfigForDE
 import com.woocommerce.android.cardreader.config.CardReaderConfigForES
 import com.woocommerce.android.cardreader.config.CardReaderConfigForFI
 import com.woocommerce.android.cardreader.config.CardReaderConfigForFR
+import com.woocommerce.android.cardreader.config.CardReaderConfigForGB
 import com.woocommerce.android.cardreader.config.CardReaderConfigForIE
 import com.woocommerce.android.cardreader.config.CardReaderConfigForIT
 import com.woocommerce.android.cardreader.config.CardReaderConfigForLU
@@ -69,6 +70,12 @@ class CardReaderConfigFactoryTest : CardReaderBaseUnitTest() {
 
         // THEN
         assertThat(cardReaderConfig).isInstanceOf(expectedCardReaderConfig::class.java)
+    }
+
+    @Test
+    fun `given country code GB, when getCardReaderConfigFor is called, then GB card reader config returned`() {
+        assertThat(cardReaderConfigFactory.getCardReaderConfigFor("GB"))
+            .isInstanceOf(CardReaderConfigForGB::class.java)
     }
 
     @Test


### PR DESCRIPTION
Closes [RSM-638](https://linear.app/a8c/issue/RSM-638/enable-terminal-payments-and-pos-in-android).

Android counterpart of [woocommerce-ios RSM-637](https://linear.app/a8c/issue/RSM-637).

### Description

Rolls out In-Person Payments and POS to 13 new countries behind two new remote feature flags. With both flags off the app behaves exactly as before — only US, PR, CA, GB are supported. With either flag on, the relevant countries become eligible for both IPP onboarding and the POS tab.

| Flag | Remote key | Countries |
|---|---|---|
| `IPP_COUNTRY_EXPANSION` | `woo_ipp_country_expansion` | FR, DE, IE, NL, SG, NZ |
| `IPP_COUNTRY_EXPANSION_EU_EXTENDED` | `woo_ipp_country_expansion_eu_extended` | AT, BE, FI, IT, LU, PT, ES |

**Australia is intentionally excluded** pending EFTPOS support per [RSM-642](https://linear.app/a8c/issue/RSM-642) / [RSM-643](https://linear.app/a8c/issue/RSM-643). A unit test asserts AU stays unsupported even when both flags are enabled.

#### Per-country configuration

Each new country gets:
- `supportedReaders = [WisePad3]` (no Tap to Pay)
- `paymentMethodTypes = [CARD_PRESENT]`
- `supportedExtensions`: WCPay >= 4.4.0, Stripe >= 6.2.0
- `minimumAllowedChargeAmount = 0.50` (in local currency — EUR/SGD/NZD)
- `maximumTTPAllowedChargeAmountWithoutPin = null` (TTP not offered)

`minimumAllowedChargeAmount = 0.50` matches the GB-equivalent value the iOS PR settled on. Android's `CardReaderConfigForSupportedCountry` does not model a per-country contactless cap for external readers (only `maximumTTPAllowedChargeAmountWithoutPin`, which is TTP-specific), so there is nothing to tune on a per-country basis here.

#### Architecture

- Two new entries in `FeatureFlag` (`IPP_COUNTRY_EXPANSION`, `IPP_COUNTRY_EXPANSION_EU_EXTENDED`), both with the default `localValue = true`. We will register both remote keys before this release is rolled out, otherwise `remoteValue == null` would default to `true` and the new countries would appear before rollout. It's likely that these will be set to true, immediately, the flags just give us options while we confirm the countries (the first list is more likely than the second.)

iOS uses a per-site `Bool?` cached in `GeneralStoreSettings` plus a refresher because Yosemite's `FeatureFlagAction` dispatch is async. Android's `FeatureFlagRepository.isEnabled()` is synchronous after one fetch, and `SiteObserver` already refetches remote flags on every site switch (same cadence as plugins/store-id), so we don't need the per-site cache or refresher.

### Test Steps

#### Manual smoke test on a debug build

1. Sign in to a US/USD store. IPP and POS behave exactly as on `trunk` regardless of flag state.
2. Sign in to a German EUR store, a Singaporean SGD store, an Italian EUR store (covers both flag groups), or a New Zealand NZD store. Without any flag override, IPP/POS remain hidden / surface "country not supported" exactly as before.
3. In Settings → Developer → **Feature Flags**, enable `woo_ipp_country_expansion`, then relaunch.
4. The DE/NL/FR/IE/SG/NZ test stores now render the IPP onboarding flows; reader pairing offers **WisePad 3 only** (no Tap to Pay, no Chipper).
5. Disable that flag, enable `woo_ipp_country_expansion_eu_extended`, relaunch. The AT/BE/FI/IT/LU/PT/ES test stores now render IPP; the FR/DE/IE/NL/SG/NZ stores fall back to "unsupported".
6. Verify the existing US/PR/CA/GB stores remain unchanged with both overrides on.
7. Toggle both overrides off and confirm the new countries fall back to "unsupported".

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes. — No user-visible change ships until WPCom enables the remote flag, so release notes will be added when the rollout starts.