### PR TITLE
[WOOMOB-2917] Wire AI assistant More menu entry point

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -494,6 +494,7 @@ class AnalyticsTracker private constructor(
         const val VALUE_MORE_MENU_PAYMENTS = "payments"
         const val VALUE_MORE_MENU_UPGRADES = "upgrades"
         const val VALUE_MORE_MENU_CUSTOMERS = "customers"
+        const val VALUE_MORE_MENU_AI_ASSISTANT = "ai_assistant"
 
         // We have to call in non consistent way to match the iOS naming
         const val VALUE_MORE_MENU_POS = "pointOfSale"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
@@ -1,0 +1,38 @@
+package com.woocommerce.android.ui.aiassistant
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woocommerce.android.R
+import com.woocommerce.android.aiassistant.ui.chat.AssistantChatScreen
+import com.woocommerce.android.aiassistant.ui.chat.AssistantChatViewModel
+import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.main.AppBarStatus
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class AiAssistantHostFragment : BaseFragment() {
+    private val viewModel: AssistantChatViewModel by viewModels()
+
+    override val activityAppBarStatus: AppBarStatus
+        get() = AppBarStatus.Hidden
+
+    override fun getFragmentTitle() = getString(R.string.more_menu_button_ai_assistant)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return composeView {
+            AssistantChatScreen(
+                viewModel = viewModel,
+                onBack = { findNavController().popBackStack() },
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
@@ -4,15 +4,16 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.woocommerce.android.R
+import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.aiassistant.ui.AssistantRoute
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class AiAssistantHostFragment : BaseFragment() {
-    override fun getFragmentTitle() = getString(R.string.more_menu_button_ai_assistant)
+    override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -20,7 +21,10 @@ class AiAssistantHostFragment : BaseFragment() {
         savedInstanceState: Bundle?
     ): View {
         return composeView {
-            AssistantRoute(conversationId = ASSISTANT_CONVERSATION_ID)
+            AssistantRoute(
+                conversationId = ASSISTANT_CONVERSATION_ID,
+                onBack = { findNavController().navigateUp() },
+            )
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
@@ -4,39 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.viewModels
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import com.woocommerce.android.R
-import com.woocommerce.android.aiassistant.core.loop.ToolScope
-import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
-import com.woocommerce.android.aiassistant.ui.AssistantChatScreen
-import com.woocommerce.android.aiassistant.ui.AssistantViewModel
-import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.aiassistant.ui.AssistantRoute
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class AiAssistantHostFragment : BaseFragment() {
-    @Inject lateinit var assistantRuntime: AssistantRuntime
-    @Inject lateinit var selectedSite: SelectedSite
-
-    private val viewModel: AssistantViewModel by viewModels {
-        object : ViewModelProvider.Factory {
-            @Suppress("UNCHECKED_CAST")
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return AssistantViewModel(
-                    runtime = assistantRuntime,
-                    conversationId = ASSISTANT_CONVERSATION_ID,
-                    siteId = selectedSite.get().siteId,
-                    toolScope = ToolScope.GLOBAL,
-                ) as T
-            }
-        }
-    }
-
     override fun getFragmentTitle() = getString(R.string.more_menu_button_ai_assistant)
 
     override fun onCreateView(
@@ -45,9 +20,7 @@ class AiAssistantHostFragment : BaseFragment() {
         savedInstanceState: Bundle?
     ): View {
         return composeView {
-            AssistantChatScreen(
-                viewModel = viewModel,
-            )
+            AssistantRoute(conversationId = ASSISTANT_CONVERSATION_ID)
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
@@ -5,21 +5,37 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.woocommerce.android.R
-import com.woocommerce.android.aiassistant.ui.chat.AssistantChatScreen
-import com.woocommerce.android.aiassistant.ui.chat.AssistantChatViewModel
+import com.woocommerce.android.aiassistant.core.loop.ToolScope
+import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
+import com.woocommerce.android.aiassistant.ui.AssistantChatScreen
+import com.woocommerce.android.aiassistant.ui.AssistantViewModel
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
-import com.woocommerce.android.ui.main.AppBarStatus
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AiAssistantHostFragment : BaseFragment() {
-    private val viewModel: AssistantChatViewModel by viewModels()
+    @Inject lateinit var assistantRuntime: AssistantRuntime
+    @Inject lateinit var selectedSite: SelectedSite
 
-    override val activityAppBarStatus: AppBarStatus
-        get() = AppBarStatus.Hidden
+    private val viewModel: AssistantViewModel by viewModels {
+        object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return AssistantViewModel(
+                    runtime = assistantRuntime,
+                    conversationId = ASSISTANT_CONVERSATION_ID,
+                    siteId = selectedSite.get().siteId,
+                    toolScope = ToolScope.GLOBAL,
+                ) as T
+            }
+        }
+    }
 
     override fun getFragmentTitle() = getString(R.string.more_menu_button_ai_assistant)
 
@@ -31,8 +47,11 @@ class AiAssistantHostFragment : BaseFragment() {
         return composeView {
             AssistantChatScreen(
                 viewModel = viewModel,
-                onBack = { findNavController().popBackStack() },
             )
         }
+    }
+
+    companion object {
+        private const val ASSISTANT_CONVERSATION_ID = "more-menu-assistant"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuFragment.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.ui.moremenu.MoreMenuEvent.NavigateToSubscriptions
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.OpenBlazeCampaignCreationEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.OpenBlazeCampaignListEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.StartSitePickerEvent
+import com.woocommerce.android.ui.moremenu.MoreMenuEvent.ViewAiAssistantEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.ViewBookingsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.ViewCouponsEvent
 import com.woocommerce.android.ui.moremenu.MoreMenuEvent.ViewCustomersEvent
@@ -112,6 +113,7 @@ class MoreMenuFragment : TopLevelFragment() {
                 is ViewCouponsEvent -> navigateToCoupons()
                 is ViewCustomersEvent -> navigateToCustomers()
                 is ViewPayments -> navigateToPayments()
+                is ViewAiAssistantEvent -> navigateToAiAssistant()
                 is OpenBlazeCampaignCreationEvent -> openBlazeCreationFlow()
                 is OpenBlazeCampaignListEvent -> openBlazeCampaignList()
                 is MultiLiveEvent.Event.LaunchUrlInChromeTab ->
@@ -144,6 +146,12 @@ class MoreMenuFragment : TopLevelFragment() {
     private fun navigateToPayments() {
         findNavController().navigateSafely(
             MoreMenuFragmentDirections.actionMoreMenuToPaymentFlow(CardReaderFlowParam.CardReadersHub())
+        )
+    }
+
+    private fun navigateToAiAssistant() {
+        findNavController().navigateSafely(
+            MoreMenuFragmentDirections.actionMoreMenuToAiAssistantHostFragment()
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuState.kt
@@ -30,6 +30,7 @@ sealed class MoreMenuEvent : MultiLiveEvent.Event() {
     data object ViewCouponsEvent : MoreMenuEvent()
 
     data object ViewCustomersEvent : MoreMenuEvent()
+    data object ViewAiAssistantEvent : MoreMenuEvent()
 }
 
 data class MoreMenuItemSection(
@@ -52,7 +53,7 @@ data class MoreMenuItemButton(
     }
 
     enum class Type {
-        Blaze, GoogleForWoo, Inbox, Settings, Payments, Bookings
+        Blaze, GoogleForWoo, Inbox, Settings, Payments, Bookings, AiAssistant
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.analytics.AnalyticsEvent.BLAZE_ENTRY_POINT_DISPLA
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_OPTION
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_ADMIN_MENU
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_AI_ASSISTANT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_BOOKINGS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_COUPONS
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_MORE_MENU_CUSTOMERS
@@ -38,6 +39,8 @@ import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.taptopay.isAvailable
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -81,6 +84,7 @@ class MoreMenuViewModel @Inject constructor(
     observeBookingsVisibility: ObserveBookingsVisibility,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val ciabSiteGateKeeper: CIABSiteGateKeeper,
+    private val featureFlagRepository: FeatureFlagRepository,
 ) : ScopedViewModel(savedState) {
     private var storeHasGoogleAdsCampaigns = false
     private val shouldShowBookingsInMenu = MutableStateFlow(false)
@@ -143,6 +147,7 @@ class MoreMenuViewModel @Inject constructor(
             inboxState = buttonsStates[MoreMenuItemButton.Type.Inbox]!!,
             paymentsState = buttonsStates[MoreMenuItemButton.Type.Payments]!!,
             bookingsButtonState = buttonsStates[MoreMenuItemButton.Type.Bookings]!!,
+            aiAssistantState = buttonsStates[MoreMenuItemButton.Type.AiAssistant]!!,
         )
     )
 
@@ -167,6 +172,7 @@ class MoreMenuViewModel @Inject constructor(
         inboxState: MoreMenuItemButton.State,
         paymentsState: MoreMenuItemButton.State,
         bookingsButtonState: MoreMenuItemButton.State,
+        aiAssistantState: MoreMenuItemButton.State,
     ) = MoreMenuItemSection(
         title = R.string.more_menu_general_section_title,
         items = listOf(
@@ -177,6 +183,13 @@ class MoreMenuViewModel @Inject constructor(
                 badgeState = buildPaymentsBadgeState(paymentsFeatureWasClicked),
                 onClick = ::onPaymentsButtonClick,
                 state = paymentsState
+            ),
+            MoreMenuItemButton(
+                title = R.string.more_menu_button_ai_assistant,
+                description = R.string.more_menu_button_ai_assistant_description,
+                icon = R.drawable.ic_more_menu_ai_assistant,
+                onClick = ::onAiAssistantButtonClick,
+                state = aiAssistantState,
             ),
             MoreMenuItemButton(
                 title = R.string.bookings_tab_title,
@@ -343,6 +356,11 @@ class MoreMenuViewModel @Inject constructor(
     private fun onBookingsButtonClick() {
         trackMoreMenuOptionSelected(VALUE_MORE_MENU_BOOKINGS)
         triggerEvent(MoreMenuEvent.ViewBookingsEvent)
+    }
+
+    private fun onAiAssistantButtonClick() {
+        trackMoreMenuOptionSelected(VALUE_MORE_MENU_AI_ASSISTANT)
+        triggerEvent(MoreMenuEvent.ViewAiAssistantEvent)
     }
 
     private fun onPromoteProductsWithGoogle() {
@@ -517,7 +535,10 @@ class MoreMenuViewModel @Inject constructor(
             doCheckAvailability(MoreMenuItemButton.Type.Settings) { moreMenuRepository.isUpgradesEnabled() },
             doCheckAvailability(MoreMenuItemButton.Type.Payments) {
                 ciabSiteGateKeeper.isFeatureSupported(CIABAffectedFeature.InPersonPayments)
-            }
+            },
+            doCheckAvailability(MoreMenuItemButton.Type.AiAssistant) {
+                featureFlagRepository.isEnabled(FeatureFlag.AI_ASSISTANT)
+            },
         ).merge()
             .map { update ->
                 initialState[update.first] = update.second

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModel.kt
@@ -519,6 +519,7 @@ class MoreMenuViewModel @Inject constructor(
             MoreMenuItemButton.State.Loading
         }.toMutableMap().apply {
             this[MoreMenuItemButton.Type.Bookings] = MoreMenuItemButton.State.Hidden
+            this[MoreMenuItemButton.Type.AiAssistant] = MoreMenuItemButton.State.Hidden
         }
 
         return listOf(

--- a/WooCommerce/src/main/res/drawable/ic_more_menu_ai_assistant.xml
+++ b/WooCommerce/src/main/res/drawable/ic_more_menu_ai_assistant.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+
+    <path
+        android:fillColor="#7F54B3"
+        android:pathData="M16,3C8.832,3 3,8.832 3,16C3,23.168 8.832,29 16,29C23.168,29 29,23.168 29,16C29,8.832 23.168,3 16,3ZM16,6C21.514,6 26,10.486 26,16C26,21.514 21.514,26 16,26C10.486,26 6,21.514 6,16C6,10.486 10.486,6 16,6Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M15.5,9L17.55,14.45L23,16.5L17.55,18.55L15.5,24L13.45,18.55L8,16.5L13.45,14.45L15.5,9Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M23,7L24,9L26,10L24,11L23,13L22,11L20,10L22,9L23,7Z" />
+</vector>

--- a/WooCommerce/src/main/res/navigation/nav_graph_main.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_main.xml
@@ -329,7 +329,14 @@
                 android:defaultValue="false"
                 app:argType="boolean" />
         </action>
+        <action
+            android:id="@+id/action_moreMenu_to_aiAssistantHostFragment"
+            app:destination="@id/aiAssistantHostFragment" />
     </fragment>
+    <fragment
+        android:id="@+id/aiAssistantHostFragment"
+        android:name="com.woocommerce.android.ui.aiassistant.AiAssistantHostFragment"
+        android:label="fragment_ai_assistant" />
     <fragment
         android:id="@+id/feedbackSurveyFragment"
         android:name="com.woocommerce.android.ui.feedback.FeedbackSurveyFragment"

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3154,6 +3154,9 @@
     <string name="more_menu_button_payments">Payments</string>
     <string name="more_menu_button_payments_description">Take payments on the go</string>
 
+    <string name="more_menu_button_ai_assistant">AI Assistant</string>
+    <string name="more_menu_button_ai_assistant_description">Ask about your store</string>
+
     <string name="more_menu_button_bookings_description">Manage your client appointments</string>
 
     <string name="more_menu_button_google">Google for WooCommerce</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/moremenu/MoreMenuViewModelTests.kt
@@ -15,6 +15,8 @@ import com.woocommerce.android.ui.moremenu.domain.MoreMenuRepository
 import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.plans.domain.SitePlan
 import com.woocommerce.android.ui.plans.repository.SitePlanRepository
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -99,6 +101,10 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         on { isFeatureSupported(any()) } doReturn true
     }
 
+    private val featureFlagRepository: FeatureFlagRepository = mock {
+        on { isEnabled(FeatureFlag.AI_ASSISTANT) } doReturn false
+    }
+
     private lateinit var viewModel: MoreMenuViewModel
     private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
 
@@ -120,7 +126,8 @@ class MoreMenuViewModelTests : BaseUnitTest() {
             hasGoogleAdsCampaigns = hasGoogleAdsCampaigns,
             observeBookingsVisibility = observeBookingsVisibility,
             analyticsTrackerWrapper = analyticsTrackerWrapper,
-            ciabSiteGateKeeper = ciabSiteGateKeeper
+            ciabSiteGateKeeper = ciabSiteGateKeeper,
+            featureFlagRepository = featureFlagRepository,
         )
     }
 
@@ -556,4 +563,58 @@ class MoreMenuViewModelTests : BaseUnitTest() {
         val items = state.menuSections.flatMap { it.items }
         assertThat(items.none { it.title == R.string.more_menu_button_payments }).isTrue()
     }
+
+    @Test
+    fun `given ai assistant flag is enabled, when building state, then ai assistant button is displayed`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(featureFlagRepository.isEnabled(FeatureFlag.AI_ASSISTANT)).thenReturn(true)
+            }
+
+            // WHEN
+            val state = viewModel.moreMenuViewState.captureValues().last()
+
+            // THEN
+            val button = state.menuSections.flatMap { it.items }
+                .first { it.title == R.string.more_menu_button_ai_assistant }
+            assertThat(button.description).isEqualTo(R.string.more_menu_button_ai_assistant_description)
+            assertThat(button.icon).isEqualTo(R.drawable.ic_more_menu_ai_assistant)
+        }
+
+    @Test
+    fun `given ai assistant flag is disabled, when building state, then ai assistant button is hidden`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(featureFlagRepository.isEnabled(FeatureFlag.AI_ASSISTANT)).thenReturn(false)
+            }
+
+            // WHEN
+            val state = viewModel.moreMenuViewState.captureValues().last()
+
+            // THEN
+            val items = state.menuSections.flatMap { it.items }
+            assertThat(items.none { it.title == R.string.more_menu_button_ai_assistant }).isTrue()
+        }
+
+    @Test
+    fun `given ai assistant flag is enabled, when ai assistant button clicked, then navigate to assistant`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(featureFlagRepository.isEnabled(FeatureFlag.AI_ASSISTANT)).thenReturn(true)
+            }
+            val state = viewModel.moreMenuViewState.captureValues().last()
+            val button = state.menuSections.flatMap { it.items }
+                .first { it.title == R.string.more_menu_button_ai_assistant }
+
+            // WHEN
+            val event = viewModel.event.runAndCaptureValues {
+                button.onClick()
+            }.last()
+
+            // THEN
+            assertThat(event).isEqualTo(MoreMenuEvent.ViewAiAssistantEvent)
+        }
 }

--- a/libs/ai-assistant/feature/build.gradle
+++ b/libs/ai-assistant/feature/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.hilt.navigation.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui.main)
     implementation(libs.androidx.compose.ui.tooling.preview)
@@ -68,4 +69,13 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
     testImplementation(libs.squareup.okhttp3.mockwebserver)
+}
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // Required by hiltViewModel() at runtime even when dependency analysis cannot see generated references.
+            exclude(libs.androidx.hilt.navigation.compose.get().module.toString())
+        }
+    }
 }

--- a/libs/ai-assistant/feature/build.gradle
+++ b/libs/ai-assistant/feature/build.gradle
@@ -56,6 +56,13 @@ dependencies {
     implementation(libs.squareup.okhttp3)
     implementation(libs.squareup.okhttp3.sse)
     implementation(libs.google.dagger.hilt.android.main)
+    implementation(libs.androidx.lifecycle.viewmodel.savedstate)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.ui.main)
+    implementation(libs.androidx.compose.material.main)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling.main)
 
     ksp(libs.google.dagger.hilt.compiler)
 

--- a/libs/ai-assistant/feature/build.gradle
+++ b/libs/ai-assistant/feature/build.gradle
@@ -56,13 +56,6 @@ dependencies {
     implementation(libs.squareup.okhttp3)
     implementation(libs.squareup.okhttp3.sse)
     implementation(libs.google.dagger.hilt.android.main)
-    implementation(libs.androidx.lifecycle.viewmodel.savedstate)
-    implementation(libs.androidx.lifecycle.runtime.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui.main)
-    implementation(libs.androidx.compose.material.main)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    debugImplementation(libs.androidx.compose.ui.tooling.main)
 
     ksp(libs.google.dagger.hilt.compiler)
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
@@ -12,6 +12,8 @@ import com.woocommerce.android.aiassistant.core.loop.ToolCatalogSelector
 import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
 import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestratorImpl
 import com.woocommerce.android.aiassistant.tools.DefaultToolCatalogSelector
+import com.woocommerce.android.aiassistant.ui.AssistantMessageIdGenerator
+import com.woocommerce.android.aiassistant.ui.UuidAssistantMessageIdGenerator
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -65,4 +67,7 @@ internal object AiAssistantModule {
     @Provides
     @Singleton
     fun provideSafetyOrchestrator(): SafetyOrchestrator = SafetyOrchestratorImpl()
+
+    @Provides
+    fun provideAssistantMessageIdGenerator(): AssistantMessageIdGenerator = UuidAssistantMessageIdGenerator
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/di/AiAssistantModule.kt
@@ -30,7 +30,7 @@ internal object AiAssistantModule {
     fun provideAiAssistantJson(): Json = Json {
         ignoreUnknownKeys = true
         encodeDefaults = false
-        explicitNulls = true
+        explicitNulls = false
     }
 
     @Provides

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -2,14 +2,16 @@ package com.woocommerce.android.aiassistant.tools.handlers
 
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
-import kotlinx.serialization.json.buildJsonObject
+import com.woocommerce.android.aiassistant.core.chat.inputSchema
 import javax.inject.Inject
 
 class ShowCardsToolHandler @Inject constructor() : StubToolHandler() {
     override val descriptor = ToolDescriptor(
         name = "show_cards",
         description = "Show entity cards in the UI for orders or products selected by the assistant.",
-        inputSchema = buildJsonObject { },
+        inputSchema = inputSchema {
+            string("family")
+        },
         safetyLevel = ToolSafetyLevel.SAFE,
     )
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -22,12 +22,17 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -37,11 +42,13 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -54,6 +61,7 @@ import kotlinx.serialization.json.put
 @Composable
 fun AssistantRoute(
     conversationId: String,
+    onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val viewModel = hiltViewModel<AssistantViewModel, AssistantViewModel.Factory> { factory ->
@@ -62,6 +70,7 @@ fun AssistantRoute(
 
     AssistantChatScreen(
         viewModel = viewModel,
+        onBack = onBack,
         modifier = modifier,
     )
 }
@@ -69,6 +78,7 @@ fun AssistantRoute(
 @Composable
 fun AssistantChatScreen(
     viewModel: AssistantViewModel,
+    onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsState()
@@ -87,6 +97,7 @@ fun AssistantChatScreen(
         onRetry = viewModel::onRetry,
         onConfirmWrite = viewModel::onConfirmWrite,
         onCancelWrite = viewModel::onCancelWrite,
+        onBack = onBack,
         modifier = modifier,
     )
 }
@@ -101,18 +112,25 @@ fun AssistantChatScreen(
     onRetry: () -> Unit,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
+    onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
+    Scaffold(
         modifier = modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            AssistantTopAppBar(
+                status = state.status,
+                onBack = onBack,
+            )
+        },
+    ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .padding(innerPadding)
                 .imePadding(),
         ) {
-            AssistantHeader(status = state.status)
             AssistantMessageThread(
                 messages = state.messages,
                 modifier = Modifier.weight(1f),
@@ -134,46 +152,62 @@ fun AssistantChatScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun AssistantHeader(status: AssistantUiStatus) {
+private fun AssistantTopAppBar(
+    status: AssistantUiStatus,
+    onBack: () -> Unit,
+) {
+    TopAppBar(
+        title = {
+            Text(
+                text = stringResource(R.string.assistant_chat_title),
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_assistant_back),
+                    contentDescription = stringResource(R.string.assistant_chat_back_content_description),
+                )
+            }
+        },
+        actions = {
+            AssistantStatusLabel(status = status)
+        },
+    )
+}
+
+@Composable
+private fun AssistantStatusLabel(status: AssistantUiStatus) {
     val statusLabel = status.toHeaderText()
     val statusContentDescription = stringResource(
         R.string.assistant_chat_status_content_description,
         statusLabel,
     )
     Surface(
-        color = MaterialTheme.colorScheme.surface,
-        shadowElevation = 1.dp,
+        modifier = Modifier
+            .padding(end = 12.dp)
+            .widthIn(max = 156.dp)
+            .semantics {
+                contentDescription = statusContentDescription
+            },
+        shape = RoundedCornerShape(50),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 12.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(R.string.assistant_chat_title),
-                modifier = Modifier.weight(1f),
-                color = MaterialTheme.colorScheme.onSurface,
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Surface(
-                modifier = Modifier.semantics {
-                    contentDescription = statusContentDescription
-                },
-                shape = RoundedCornerShape(50),
-                color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-            ) {
-                Text(
-                    text = statusLabel,
-                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.labelSmall,
-                )
-            }
-        }
+        Text(
+            text = statusLabel,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.labelSmall,
+        )
     }
 }
 
@@ -449,6 +483,7 @@ private fun AssistantChatScreenPreview() {
         onRetry = {},
         onConfirmWrite = {},
         onCancelWrite = {},
+        onBack = {},
     )
 }
 
@@ -478,5 +513,6 @@ private fun AssistantChatScreenConfirmationPreview() {
         onRetry = {},
         onConfirmWrite = {},
         onCancelWrite = {},
+        onBack = {},
     )
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -44,11 +44,27 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.runtime.AssistantPendingConfirmation
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+
+@Composable
+fun AssistantRoute(
+    conversationId: String,
+    modifier: Modifier = Modifier,
+) {
+    val viewModel = hiltViewModel<AssistantViewModel, AssistantViewModel.Factory> { factory ->
+        factory.create(conversationId)
+    }
+
+    AssistantChatScreen(
+        viewModel = viewModel,
+        modifier = modifier,
+    )
+}
 
 @Composable
 fun AssistantChatScreen(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -9,6 +9,11 @@ import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
 import com.woocommerce.android.aiassistant.runtime.AssistantTurnRequest
+import com.woocommerce.android.tools.SelectedSite
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,12 +21,12 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-class AssistantViewModel(
+@HiltViewModel(assistedFactory = AssistantViewModel.Factory::class)
+class AssistantViewModel @AssistedInject constructor(
+    @Assisted private val conversationId: String,
     private val runtime: AssistantRuntime,
-    private val conversationId: String,
-    private val siteId: Long,
-    private val toolScope: ToolScope,
-    private val idGenerator: AssistantMessageIdGenerator = UuidAssistantMessageIdGenerator,
+    private val selectedSite: SelectedSite,
+    private val idGenerator: AssistantMessageIdGenerator,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(AssistantUiState())
     val uiState: StateFlow<AssistantUiState> = _uiState.asStateFlow()
@@ -139,8 +144,8 @@ class AssistantViewModel(
 
         val request = AssistantTurnRequest(
             conversationId = conversationId,
-            siteId = siteId,
-            toolScope = toolScope,
+            siteId = selectedSite.get().siteId,
+            toolScope = ToolScope.GLOBAL,
             userMessage = message,
             history = lastTurnBaseHistory,
         )
@@ -205,5 +210,10 @@ class AssistantViewModel(
         LoopOutcome.STOPPED -> null
         LoopOutcome.FAILED -> error?.toAssistantUiError() ?: AssistantUiError.UNKNOWN
         LoopOutcome.MAX_ITERATIONS -> error?.toAssistantUiError() ?: AssistantUiError.MAX_ITERATIONS
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(conversationId: String): AssistantViewModel
     }
 }

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_back.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_back.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,11H7.83L13.42,5.41L12,4L4,12L12,20L13.41,18.59L7.83,13H20V11Z" />
+</vector>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="assistant_chat_status_streaming">Working</string>
     <string name="assistant_chat_status_awaiting_confirmation">Review required</string>
     <string name="assistant_chat_status_error">Needs attention</string>
+    <string name="assistant_chat_back_content_description">Back</string>
     <string name="assistant_chat_status_content_description">Assistant status: %1$s</string>
     <string name="assistant_chat_message_user_content_description">You: %1$s</string>
     <string name="assistant_chat_message_assistant_content_description">Assistant: %1$s</string>

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -80,7 +79,7 @@ class JetpackAiChatServiceTest {
     }
 
     @Test
-    fun `given assistant tool calls with null content, when sent, then request preserves null assistant content`() = runTest {
+    fun `given assistant tool calls with null content, when sent, then request omits assistant content`() = runTest {
         server.enqueue(sseResponse(SAMPLE_SSE_BODY))
 
         val service = newService()
@@ -107,7 +106,7 @@ class JetpackAiChatServiceTest {
         val body = Json.parseToJsonElement(recorded.body.readUtf8()).jsonObject
         val assistantMessage = body.getValue("messages").jsonArray.single().jsonObject
 
-        assertThat(assistantMessage.getValue("content")).isEqualTo(JsonNull)
+        assertThat(assistantMessage).doesNotContainKey("content")
         assertThat(assistantMessage.getValue("tool_calls").jsonArray).hasSize(1)
     }
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/openai/OpenAiMappingTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/openai/OpenAiMappingTest.kt
@@ -9,7 +9,6 @@ import com.woocommerce.android.aiassistant.core.chat.FinishReason
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolDefinition
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
@@ -71,7 +70,7 @@ class OpenAiMappingTest {
         assertThat(systemMessage.getValue("role").jsonPrimitive.content).isEqualTo("system")
         assertThat(userMessage.getValue("role").jsonPrimitive.content).isEqualTo("user")
         assertThat(assistantMessage.getValue("role").jsonPrimitive.content).isEqualTo("assistant")
-        assertThat(assistantMessage.getValue("content")).isEqualTo(JsonNull)
+        assertThat(assistantMessage).doesNotContainKey("content")
         assertThat(
             assistantMessage.getValue("tool_calls").jsonArray.single().jsonObject
                 .getValue("function").jsonObject

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
 import com.woocommerce.android.aiassistant.runtime.AssistantTurnRequest
+import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -25,22 +26,28 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.SiteModel
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AssistantViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private lateinit var runtime: FakeAssistantRuntime
+    private lateinit var selectedSite: SelectedSite
     private lateinit var viewModel: AssistantViewModel
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         runtime = FakeAssistantRuntime()
+        selectedSite = mock {
+            on { get() } doReturn SiteModel().apply { siteId = SITE_ID }
+        }
         viewModel = AssistantViewModel(
-            runtime = runtime,
             conversationId = CONVERSATION_ID,
-            siteId = SITE_ID,
-            toolScope = ToolScope.GLOBAL,
+            runtime = runtime,
+            selectedSite = selectedSite,
             idGenerator = SequentialAssistantMessageIdGenerator(),
         )
     }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2917

This PR adds the first Android AI Assistant entry-point integration for the store management app. It wires a temporary AI Assistant item into the More menu behind the existing `FeatureFlag.AI_ASSISTANT` flag, and tapping that item opens the assistant chat screen owned by `:libs:ai-assistant:feature`.

The More menu location is intentionally temporary during the assistant development phase. It gives the team and reviewers a stable, low-risk way to launch and exercise the assistant chat while the final product entry points are still being built. Future PRs can replace or supplement this temporary entry with contextual order/product flows without changing the assistant feature ownership boundary introduced here.

This PR is based on `issue/woomob-2911-2912-ai-assistant-tools`, where the assistant UI/runtime work already lives. The implementation keeps responsibilities split by module:
- `:WooCommerce` owns only host integration: the More menu item, feature flag gate, navigation action, app-owned More strings/icon/tracking value, and the thin `AiAssistantHostFragment`.
- `:libs:ai-assistant:feature` owns the assistant route, Hilt ViewModel creation, chat screen UI, assistant resources, and assistant runtime-facing ViewModel behavior.
- `:libs:ai-assistant:core` continues to own assistant core contracts and runtime types.

The host Fragment stays deliberately thin. It uses the existing store app `composeView { ... }` helper so the WooCommerce Compose theme is applied once, hides the Activity app bar, passes only the temporary More-entry `conversationId` and `onBack` callback to `AssistantRoute`, and does not import or construct assistant runtime/ViewModel dependencies.

The assistant screen owns the single visible app bar. The feature route obtains the `AssistantViewModel` internally with Hilt, renders a Material 3 `Scaffold`, and shows the assistant title, back affordance, and compact status label in the screen top bar. This avoids the previous duplicate top-bar state while preserving the Hilt/feature-route boundary.

Included in this PR:
- More menu AI Assistant item behind `FeatureFlag.AI_ASSISTANT`.
- Navigation from More to `AiAssistantHostFragment` and back to More.
- Thin host Fragment integration using `composeView { AssistantRoute(...) }`.
- Feature-owned route-level ViewModel creation with assisted `conversationId`.
- Single assistant-owned top app bar with status label.
- Focused unit coverage for More menu visibility/click behavior and assistant ViewModel request construction.

Intentionally out of scope:
- Final assistant entry-point placement.
- Order card navigation.
- Product card navigation.
- Full `AssistantNavigator` behavior.
- Confirmation-flow UI integration beyond what exists in the base assistant feature.
- Streaming/tool execution changes outside the existing assistant feature/runtime work.

### Test Steps
1. Use a debug build or enable the `AI_ASSISTANT` feature flag.
2. Open the More tab.
3. Confirm the AI Assistant item is visible in the More menu.
4. Tap AI Assistant.
5. Confirm the assistant chat screen opens with one visible top bar.
6. Confirm the top bar shows the AI Assistant title, back affordance, and assistant status label.
7. Tap the composer and confirm text input remains usable with the keyboard open.
8. Press toolbar back or system back.
9. Confirm the app returns to More.
10. Disable the `AI_ASSISTANT` feature flag and confirm the More item is hidden.

### Images/gif

https://github.com/user-attachments/assets/14b05dcf-a00f-43dc-ae9e-7d808807fde0

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.