### PR TITLE
[WOOMOB-2913] Implement assistant Send/Stop turn cancellation

### DIFF
--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -150,6 +150,10 @@ class AgenticLoopImpl(
             )
 
             val widenedError = failure.kind.toAssistantError(failure.cause)
+            if (widenedError == AssistantError.Cancelled) {
+                emitStoppedCancellation(fullHistory, assistantText.toString())
+                return null
+            }
             when (
                 val decision = retryPolicy.decide(
                     LoopFailureContext(widenedError, visibleOutputStarted, retryCount)
@@ -171,6 +175,21 @@ class AgenticLoopImpl(
                 }
             }
         }
+    }
+
+    private suspend fun FlowCollector<LoopEvent>.emitStoppedCancellation(
+        fullHistory: List<AssistantMessage>,
+        assistantText: String,
+    ) {
+        emit(LoopEvent.Failed(AssistantError.Cancelled))
+        emit(
+            LoopEvent.Finished(
+                outcome = LoopOutcome.STOPPED,
+                updatedHistory = messagesWithPartialText(fullHistory, assistantText),
+                retryAvailable = false,
+                error = AssistantError.Cancelled,
+            )
+        )
     }
 
     private suspend fun FlowCollector<LoopEvent>.executeTools(

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -408,6 +408,54 @@ class AgenticLoopImplTest {
     }
 
     @Test
+    fun `given stream cancellation before visible output, when running turn, then stopped cancelled finish is emitted without retry`() =
+        runTest {
+            val loop = loopWith(
+                flowOf(AssistantEvent.Failed(ChatStreamError.CANCELLED))
+            )
+
+            val events = loop.runTurn("conv", "hi", history, context).toList()
+
+            assertThat(events.filterIsInstance<LoopEvent.Failed>().single().error)
+                .isEqualTo(AssistantError.Cancelled)
+            val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+            assertThat(finished.outcome).isEqualTo(LoopOutcome.STOPPED)
+            assertThat(finished.retryAvailable).isFalse()
+            assertThat(finished.error).isEqualTo(AssistantError.Cancelled)
+            assertThat(finished.updatedHistory).containsExactly(
+                AssistantMessage.System("You are a helpful assistant."),
+                AssistantMessage.User("hi"),
+            )
+        }
+
+    @Test
+    fun `given stream emits partial text then cancellation, when running turn, then partial text is preserved and finish is stopped without retry`() =
+        runTest {
+            val loop = loopWith(
+                flow {
+                    emit(AssistantEvent.TextDelta("partial"))
+                    emit(AssistantEvent.Failed(ChatStreamError.CANCELLED))
+                }
+            )
+
+            val events = loop.runTurn("conv", "hi", history, context).toList()
+
+            assertThat(events.filterIsInstance<LoopEvent.AssistantTextDelta>().single().text)
+                .isEqualTo("partial")
+            assertThat(events.filterIsInstance<LoopEvent.Failed>().single().error)
+                .isEqualTo(AssistantError.Cancelled)
+            val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+            assertThat(finished.outcome).isEqualTo(LoopOutcome.STOPPED)
+            assertThat(finished.retryAvailable).isFalse()
+            assertThat(finished.error).isEqualTo(AssistantError.Cancelled)
+            assertThat(finished.updatedHistory).containsExactly(
+                AssistantMessage.System("You are a helpful assistant."),
+                AssistantMessage.User("hi"),
+                AssistantMessage.Assistant(content = "partial", toolCalls = emptyList()),
+            )
+        }
+
+    @Test
     fun `given stub SAFE tool, when loop runs one tool call then STOP, then completes with tool result in history`() = runTest {
         val echoResult = buildJsonObject { put("echoed", "hello") }
         val registry = stubRegistry(result = ToolResult.Success("call_1", echoResult))

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.aiassistant.runtime
 
+import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
 import com.woocommerce.android.aiassistant.core.loop.AgenticLoop
@@ -45,6 +46,7 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
             siteId = request.siteId,
             catalogSnapshot = toolCatalogSelector.select(request.toolScope, toolRegistry.descriptors()),
         )
+        var pendingError: AssistantError? = null
 
         agenticLoop.runTurn(
             conversationId = request.conversationId,
@@ -59,16 +61,19 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
                 is LoopEvent.ConfirmationRequested -> emit(
                     AssistantRuntimeEvent.AwaitingConfirmation(event.request.toPendingConfirmation())
                 )
-                is LoopEvent.Finished -> emit(
-                    AssistantRuntimeEvent.Finished(
-                        outcome = event.outcome,
-                        updatedHistory = event.updatedHistory,
-                        retryAvailable = event.retryAvailable,
-                        error = event.error,
+                is LoopEvent.Finished -> {
+                    emit(
+                        AssistantRuntimeEvent.Finished(
+                            outcome = event.outcome,
+                            updatedHistory = event.updatedHistory,
+                            retryAvailable = event.retryAvailable,
+                            error = event.error ?: pendingError,
+                        )
                     )
-                )
+                    pendingError = null
+                }
+                is LoopEvent.Failed -> pendingError = event.error
                 is LoopEvent.ConfirmationResolved,
-                is LoopEvent.Failed,
                 is LoopEvent.ToolCallFinished,
                 is LoopEvent.ToolCallStarted -> Unit
             }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -417,10 +418,14 @@ private fun AssistantComposer(
                     ),
                 )
                 if (isTurnActive) {
-                    OutlinedButton(
+                    Button(
                         onClick = onCancelTurn,
                         modifier = Modifier.heightIn(min = 56.dp),
                         shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.onError,
+                        ),
                     ) {
                         Text(stringResource(R.string.assistant_chat_stop))
                     }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -144,7 +144,7 @@ fun AssistantChatScreen(
             AssistantComposer(
                 inputText = inputText,
                 onInputTextChange = onInputTextChange,
-                isStreaming = state.isStreaming,
+                isTurnActive = state.isTurnActive,
                 onSendMessage = onSendMessage,
                 onCancelTurn = onCancelTurn,
             )
@@ -380,11 +380,11 @@ private fun AssistantConfirmationPanel(
 private fun AssistantComposer(
     inputText: String,
     onInputTextChange: (String) -> Unit,
-    isStreaming: Boolean,
+    isTurnActive: Boolean,
     onSendMessage: () -> Unit,
     onCancelTurn: () -> Unit,
 ) {
-    val canSend = inputText.isNotBlank() && !isStreaming
+    val canSend = inputText.isNotBlank() && !isTurnActive
     Surface(
         color = MaterialTheme.colorScheme.surface,
         shadowElevation = 4.dp,
@@ -414,7 +414,7 @@ private fun AssistantComposer(
                         }
                     ),
                 )
-                if (isStreaming) {
+                if (isTurnActive) {
                     OutlinedButton(
                         onClick = onCancelTurn,
                         modifier = Modifier.heightIn(min = 56.dp),

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -89,9 +89,11 @@ fun AssistantChatScreen(
         inputText = inputText,
         onInputTextChange = { inputText = it },
         onSendMessage = {
-            val message = inputText
-            inputText = ""
-            viewModel.onSendMessage(message)
+            if (!state.isTurnActive) {
+                val message = inputText
+                inputText = ""
+                viewModel.onSendMessage(message)
+            }
         },
         onCancelTurn = viewModel::onCancelTurn,
         onRetry = viewModel::onRetry,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -13,6 +13,10 @@ data class AssistantUiState(
 ) {
     val isStreaming: Boolean
         get() = status == AssistantUiStatus.STREAMING
+
+    val isTurnActive: Boolean
+        get() = status == AssistantUiStatus.STREAMING ||
+            status == AssistantUiStatus.AWAITING_CONFIRMATION
 }
 
 enum class AssistantUiStatus {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -39,6 +39,8 @@ class AssistantViewModel @AssistedInject constructor(
     private var lastUserMessage: String? = null
 
     fun onSendMessage(message: String) {
+        if (_uiState.value.isTurnActive) return
+
         val trimmedMessage = message.trim()
         if (trimmedMessage.isEmpty()) return
 
@@ -47,6 +49,8 @@ class AssistantViewModel @AssistedInject constructor(
     }
 
     fun onRetry() {
+        if (_uiState.value.isTurnActive) return
+
         val message = lastUserMessage ?: return
         startTurn(message, isRetry = true)
     }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -181,7 +181,7 @@ class AssistantViewModel @AssistedInject constructor(
                 history = event.updatedHistory
                 _uiState.update {
                     it.copy(
-                        status = event.outcome.toAssistantUiStatus(),
+                        status = event.toAssistantUiStatus(),
                         error = event.toAssistantUiError(),
                         canRetry = event.outcome == LoopOutcome.FAILED && event.retryAvailable,
                         pendingConfirmation = null,
@@ -229,12 +229,18 @@ class AssistantViewModel @AssistedInject constructor(
         LoopOutcome.MAX_ITERATIONS -> AssistantUiStatus.ERROR
     }
 
-    private fun AssistantRuntimeEvent.Finished.toAssistantUiError(): AssistantUiError? = when (outcome) {
-        LoopOutcome.COMPLETED,
-        LoopOutcome.STOPPED -> null
-        LoopOutcome.FAILED -> error?.toAssistantUiError() ?: AssistantUiError.UNKNOWN
-        LoopOutcome.MAX_ITERATIONS -> error?.toAssistantUiError() ?: AssistantUiError.MAX_ITERATIONS
+    private fun AssistantRuntimeEvent.Finished.toAssistantUiStatus(): AssistantUiStatus = when {
+        error == AssistantError.Cancelled -> AssistantUiStatus.ERROR
+        else -> outcome.toAssistantUiStatus()
     }
+
+    private fun AssistantRuntimeEvent.Finished.toAssistantUiError(): AssistantUiError? =
+        error?.toAssistantUiError() ?: when (outcome) {
+            LoopOutcome.COMPLETED,
+            LoopOutcome.STOPPED -> null
+            LoopOutcome.FAILED -> AssistantUiError.UNKNOWN
+            LoopOutcome.MAX_ITERATIONS -> AssistantUiError.MAX_ITERATIONS
+        }
 
     @AssistedFactory
     interface Factory {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -183,7 +183,7 @@ class AssistantViewModel @AssistedInject constructor(
                     it.copy(
                         status = event.toAssistantUiStatus(),
                         error = event.toAssistantUiError(),
-                        canRetry = event.outcome == LoopOutcome.FAILED && event.retryAvailable,
+                        canRetry = event.canRetry(),
                         pendingConfirmation = null,
                     )
                 }
@@ -241,6 +241,11 @@ class AssistantViewModel @AssistedInject constructor(
             LoopOutcome.FAILED -> AssistantUiError.UNKNOWN
             LoopOutcome.MAX_ITERATIONS -> AssistantUiError.MAX_ITERATIONS
         }
+
+    private fun AssistantRuntimeEvent.Finished.canRetry(): Boolean =
+        error != AssistantError.Cancelled &&
+            outcome == LoopOutcome.FAILED &&
+            retryAvailable
 
     @AssistedFactory
     interface Factory {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.aiassistant.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
 import com.woocommerce.android.aiassistant.core.loop.ToolScope
@@ -51,6 +52,9 @@ class AssistantViewModel @AssistedInject constructor(
     }
 
     fun onCancelTurn() {
+        if (!_uiState.value.isTurnActive) return
+
+        preserveCancelledTurnInHistory()
         turnJob?.cancel()
         turnJob = null
         activeAssistantMessageId = null
@@ -59,8 +63,8 @@ class AssistantViewModel @AssistedInject constructor(
         }
         _uiState.update {
             it.copy(
-                status = AssistantUiStatus.IDLE,
-                error = null,
+                status = AssistantUiStatus.ERROR,
+                error = AssistantError.Cancelled.toAssistantUiError(),
                 canRetry = false,
                 pendingConfirmation = null,
             )
@@ -181,6 +185,22 @@ class AssistantViewModel @AssistedInject constructor(
                 }
             }
         }
+    }
+
+    private fun preserveCancelledTurnInHistory() {
+        val userMessage = lastUserMessage ?: return
+        val assistantMessageId = activeAssistantMessageId
+        val assistantText = _uiState.value.messages
+            .firstOrNull { it.id == assistantMessageId }
+            ?.text
+            .orEmpty()
+        val cancelledTurnHistory = buildList {
+            add(AssistantMessage.User(userMessage))
+            assistantText.takeIf { it.isNotEmpty() }?.let {
+                add(AssistantMessage.Assistant(content = it))
+            }
+        }
+        history = lastTurnBaseHistory + cancelledTurnHistory
     }
 
     private fun appendAssistantText(delta: String) {

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.aiassistant.runtime
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
@@ -57,6 +58,37 @@ class AgenticLoopAssistantRuntimeTest {
             AssistantRuntimeEvent.Finished(
                 outcome = LoopOutcome.MAX_ITERATIONS,
                 updatedHistory = updatedHistory,
+            )
+        )
+    }
+
+    @Test
+    fun `when loop fails with cancelled before stopped finish, then runtime finish includes cancelled error`() = runTest {
+        val updatedHistory = listOf(
+            AssistantMessage.User("Hello"),
+            AssistantMessage.Assistant("Partial"),
+        )
+        val runtime = runtime(
+            agenticLoop = FakeAgenticLoop(
+                events = listOf(
+                    LoopEvent.Failed(AssistantError.Cancelled),
+                    LoopEvent.Finished(
+                        outcome = LoopOutcome.STOPPED,
+                        updatedHistory = updatedHistory,
+                        retryAvailable = false,
+                    )
+                )
+            ),
+        )
+
+        val events = runtime.startTurn(givenTurnRequest()).toList()
+
+        assertThat(events).containsExactly(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.STOPPED,
+                updatedHistory = updatedHistory,
+                retryAvailable = false,
+                error = AssistantError.Cancelled,
             )
         )
     }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.aiassistant.ui
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AssistantUiStateTest {
+    @Test
+    fun `when status is streaming, then turn is active`() {
+        val state = AssistantUiState(status = AssistantUiStatus.STREAMING)
+
+        assertThat(state.isTurnActive).isTrue()
+    }
+
+    @Test
+    fun `when status is awaiting confirmation, then turn is active`() {
+        val state = AssistantUiState(status = AssistantUiStatus.AWAITING_CONFIRMATION)
+
+        assertThat(state.isTurnActive).isTrue()
+    }
+
+    @Test
+    fun `when status is idle, then turn is not active`() {
+        val state = AssistantUiState(status = AssistantUiStatus.IDLE)
+
+        assertThat(state.isTurnActive).isFalse()
+    }
+
+    @Test
+    fun `when status is error, then turn is not active`() {
+        val state = AssistantUiState(status = AssistantUiStatus.ERROR)
+
+        assertThat(state.isTurnActive).isFalse()
+    }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -123,6 +123,7 @@ class AssistantViewModelTest {
 
         val state = viewModel.uiState.value
         assertThat(state.status).isEqualTo(AssistantUiStatus.IDLE)
+        assertThat(state.isTurnActive).isFalse()
         assertThat(state.canRetry).isFalse()
         assertThat(state.error).isNull()
     }
@@ -143,6 +144,7 @@ class AssistantViewModelTest {
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.ERROR)
         assertThat(viewModel.uiState.value.error).isEqualTo(AssistantUiError.NETWORK)
         assertThat(viewModel.uiState.value.canRetry).isTrue()
+        assertThat(viewModel.uiState.value.isTurnActive).isFalse()
 
         viewModel.onRetry()
 
@@ -172,6 +174,7 @@ class AssistantViewModelTest {
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.ERROR)
         assertThat(viewModel.uiState.value.error).isEqualTo(AssistantUiError.MAX_ITERATIONS)
         assertThat(viewModel.uiState.value.canRetry).isFalse()
+        assertThat(viewModel.uiState.value.isTurnActive).isFalse()
     }
 
     @Test
@@ -283,14 +286,14 @@ class AssistantViewModelTest {
     }
 
     @Test
-    fun `when cancel is requested, then runtime is cancelled and state returns to idle`() = runTest {
+    fun `when cancel is requested, then runtime is cancelled and turn is no longer active`() = runTest {
         viewModel.onSendMessage("Hello")
 
         viewModel.onCancelTurn()
         advanceUntilIdle()
 
         assertThat(runtime.cancelledConversationIds).containsExactly(CONVERSATION_ID)
-        assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.IDLE)
+        assertThat(viewModel.uiState.value.isTurnActive).isFalse()
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -71,6 +71,7 @@ class AssistantViewModelTest {
 
         val state = viewModel.uiState.value
         assertThat(state.status).isEqualTo(AssistantUiStatus.STREAMING)
+        assertThat(state.isTurnActive).isTrue()
         assertThat(state.messages).containsExactly(
             AssistantUiMessage(id = "message-1", role = AssistantUiMessage.Role.USER, text = "Show my recent orders"),
             AssistantUiMessage(id = "message-2", role = AssistantUiMessage.Role.ASSISTANT, text = ""),

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -342,6 +342,58 @@ class AssistantViewModelTest {
         }
 
     @Test
+    fun `given active streaming turn, when another message is sent, then second turn is ignored`() = runTest {
+        viewModel.onSendMessage("First")
+
+        viewModel.onSendMessage("Second")
+        advanceUntilIdle()
+
+        assertThat(runtime.startRequests).containsExactly(
+            AssistantTurnRequest(
+                conversationId = CONVERSATION_ID,
+                siteId = SITE_ID,
+                toolScope = ToolScope.GLOBAL,
+                userMessage = "First",
+                history = emptyList(),
+            )
+        )
+        assertThat(viewModel.uiState.value.messages.map { it.text }).containsExactly("First", "")
+    }
+
+    @Test
+    fun `given awaiting confirmation, when another message is sent, then second turn is ignored`() = runTest {
+        viewModel.onSendMessage("Cancel order 123")
+        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenPendingConfirmation()))
+        advanceUntilIdle()
+
+        viewModel.onSendMessage("Second")
+        advanceUntilIdle()
+
+        assertThat(runtime.startRequests).containsExactly(
+            AssistantTurnRequest(
+                conversationId = CONVERSATION_ID,
+                siteId = SITE_ID,
+                toolScope = ToolScope.GLOBAL,
+                userMessage = "Cancel order 123",
+                history = emptyList(),
+            )
+        )
+        assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.AWAITING_CONFIRMATION)
+        assertThat(viewModel.uiState.value.pendingConfirmation).isEqualTo(givenPendingConfirmation())
+    }
+
+    @Test
+    fun `given active streaming turn, when retry is requested, then retry is ignored`() = runTest {
+        viewModel.onSendMessage("Hello")
+
+        viewModel.onRetry()
+        advanceUntilIdle()
+
+        assertThat(runtime.retryRequests).isEmpty()
+        assertThat(runtime.startRequests).hasSize(1)
+    }
+
+    @Test
     fun `given pending confirmation, when confirm write is requested, then runtime confirm is called`() = runTest {
         viewModel.onSendMessage("Cancel order 123")
         runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenPendingConfirmation()))

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -297,6 +297,51 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given partial assistant text, when cancel is requested, then partial text remains visible`() = runTest {
+        viewModel.onSendMessage("Summarize sales")
+        val activeBubbleId = viewModel.uiState.value.messages.last().id
+        runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("Sales are "))
+        runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("up today"))
+        advanceUntilIdle()
+
+        viewModel.onCancelTurn()
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.messages).contains(
+            AssistantUiMessage(
+                id = activeBubbleId,
+                role = AssistantUiMessage.Role.ASSISTANT,
+                text = "Sales are up today",
+            )
+        )
+    }
+
+    @Test
+    fun `given partial assistant text, when cancelled and new message is sent, then next turn history includes partial text`() =
+        runTest {
+            viewModel.onSendMessage("Summarize sales")
+            runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("Sales are up today"))
+            advanceUntilIdle()
+
+            viewModel.onCancelTurn()
+            advanceUntilIdle()
+            viewModel.onSendMessage("What changed?")
+
+            assertThat(runtime.startRequests.last()).isEqualTo(
+                AssistantTurnRequest(
+                    conversationId = CONVERSATION_ID,
+                    siteId = SITE_ID,
+                    toolScope = ToolScope.GLOBAL,
+                    userMessage = "What changed?",
+                    history = listOf(
+                        AssistantMessage.User("Summarize sales"),
+                        AssistantMessage.Assistant("Sales are up today"),
+                    ),
+                )
+            )
+        }
+
+    @Test
     fun `given pending confirmation, when confirm write is requested, then runtime confirm is called`() = runTest {
         viewModel.onSendMessage("Cancel order 123")
         runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenPendingConfirmation()))

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -293,6 +293,33 @@ class AssistantViewModelTest {
         advanceUntilIdle()
 
         assertThat(runtime.cancelledConversationIds).containsExactly(CONVERSATION_ID)
+        assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.ERROR)
+        assertThat(viewModel.uiState.value.error).isEqualTo(AssistantUiError.CANCELLED)
+        assertThat(viewModel.uiState.value.canRetry).isFalse()
+        assertThat(viewModel.uiState.value.pendingConfirmation).isNull()
+        assertThat(viewModel.uiState.value.isTurnActive).isFalse()
+    }
+
+    @Test
+    fun `when runtime finishes with cancelled error, then state exposes cancelled ui error`() = runTest {
+        viewModel.onSendMessage("Hello")
+
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.STOPPED,
+                updatedHistory = listOf(
+                    AssistantMessage.User("Hello"),
+                    AssistantMessage.Assistant("Partial"),
+                ),
+                retryAvailable = false,
+                error = AssistantError.Cancelled,
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.ERROR)
+        assertThat(viewModel.uiState.value.error).isEqualTo(AssistantUiError.CANCELLED)
+        assertThat(viewModel.uiState.value.canRetry).isFalse()
         assertThat(viewModel.uiState.value.isTurnActive).isFalse()
     }
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -324,6 +324,29 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `when runtime finishes cancelled failed retryable, then retry is not exposed`() = runTest {
+        viewModel.onSendMessage("Hello")
+
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.FAILED,
+                updatedHistory = listOf(
+                    AssistantMessage.User("Hello"),
+                    AssistantMessage.Assistant("Partial"),
+                ),
+                retryAvailable = true,
+                error = AssistantError.Cancelled,
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.ERROR)
+        assertThat(viewModel.uiState.value.error).isEqualTo(AssistantUiError.CANCELLED)
+        assertThat(viewModel.uiState.value.canRetry).isFalse()
+        assertThat(viewModel.uiState.value.isTurnActive).isFalse()
+    }
+
+    @Test
     fun `given partial assistant text, when cancel is requested, then partial text remains visible`() = runTest {
         viewModel.onSendMessage("Summarize sales")
         val activeBubbleId = viewModel.uiState.value.messages.last().id


### PR DESCRIPTION
### Description
Fixes WOOMOB-2913

This PR implements the AI assistant Send → Stop turn-control behavior on top of the WOOMOB-2917 entry-point branch. Reviewers can open the assistant from the More Menu screen, then verify that the composer control behaves like a clear active cancellation control instead of a disabled-looking submit-only button.

#### What changes for users

While an assistant turn is active, the composer action now switches from **Send** to a filled error-colored **Stop** button in the same button location. A turn is considered active while the assistant is streaming or waiting for confirmation, so the user has one consistent place to stop the current turn.

Tapping **Stop** cancels the active turn, preserves any assistant text that has already streamed into the transcript, marks the turn as cancelled, and returns the composer to the normal Send state. The composer text field remains editable while the assistant is responding, but stale Send/IME actions cannot start a second turn until the active turn finishes or is stopped.

#### ViewModel and UI behavior

The assistant UI state now exposes `isTurnActive`, which covers both `STREAMING` and `AWAITING_CONFIRMATION`. The Compose chat screen uses this derived state to decide whether to show Send or Stop, and it keeps the text field enabled while gating duplicate submits.

`AssistantViewModel` now guards direct send and retry calls while a turn is active, so the protection does not rely only on Compose button state. On user cancellation, it keeps the current assistant bubble intact, stores the cancelled partial turn in local history for the next assistant request, clears pending confirmation state, and surfaces `AssistantUiError.CANCELLED` without exposing retry.

#### Runtime and core cancellation behavior

The feature runtime adapter now preserves `LoopEvent.Failed(AssistantError.Cancelled)` and attaches that error to the following `Finished` event when core emits a stopped finish without an explicit error. This keeps cancellation visible to the UI layer.

The core agentic loop now treats stream-level `ChatStreamError.CANCELLED` as a stopped cancellation before retry policy runs. That means stream cancellation emits a cancelled failure followed by `LoopOutcome.STOPPED`, sets `retryAvailable = false`, preserves partial assistant text when present, and avoids showing retry for a cancelled turn.

#### Tests added or updated

This PR adds focused coverage for:

- active-turn state across streaming, awaiting confirmation, idle, and error states
- Send → Stop transition when a turn starts
- Stop → Send reversion after completed, cancelled, failed, and max-iteration finishes
- preserving visible partial assistant text after cancellation
- carrying cancelled partial assistant text into the next request history
- blocking duplicate send/retry while the composer remains editable
- preserving cancelled errors through the runtime adapter
- treating core stream cancellation as stopped and non-retryable before and after partial text

### Test Steps
1. Build and install the app from this branch.
2. Open the app, go to the **More Menu** screen, and open the AI assistant entry point from there.
3. Enter a prompt and tap **Send**.
4. Confirm the composer action changes from **Send** to a filled, active-looking **Stop** button immediately while the assistant turn is active.
5. While the assistant is responding, type in the composer and confirm the text field remains editable.
6. Tap **Stop** after partial assistant text appears.
7. Confirm the partial assistant text remains visible, the turn is shown as cancelled, and the action returns to **Send**.
8. Send another prompt and confirm the previous cancelled partial response remains in the transcript.
9. If a confirmation prompt appears during an active turn, confirm the composer still shows **Stop** and does not allow submitting a second prompt until the turn is stopped or resolved.

### Images/gif

https://github.com/user-attachments/assets/c38e9675-f2f0-4511-972e-dd6d23181195



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.