### PR TITLE
[WOOMOB-2907] Implement show_cards structured card contract

### DIFF
--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -16,6 +16,8 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolut
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsStructured
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -85,15 +87,7 @@ class ShowCardsToolHandler internal constructor(
 
         val validation = referenceValidator.validate(arguments.references)
         val validRefs = validation.validRefs
-        val resolutions = runCatching { resolver.resolve(validRefs) }
-            .getOrElse {
-                validRefs.map { ref ->
-                    ShowCardsResolution.Missing(
-                        ref = ref,
-                        reason = ShowCardsRejectionReason.FetchFailed,
-                    )
-                }
-            }
+        val resolutions = resolveRefs(validRefs)
         val resolvedCards = resolutions.filterIsInstance<ShowCardsResolution.Resolved>()
         val structured = ShowCardsStructured(
             requested = validation.requested,
@@ -112,6 +106,21 @@ class ShowCardsToolHandler internal constructor(
             ),
         )
     }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private suspend fun resolveRefs(validRefs: List<ValidatedRef>) =
+        try {
+            resolver.resolve(validRefs)
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            validRefs.map { ref ->
+                ShowCardsResolution.Missing(
+                    ref = ref,
+                    reason = ShowCardsRejectionReason.FetchFailed,
+                )
+            }
+        }
 
     private fun ShowCardsResolution.Resolved.toResolvedRef(): ResolvedRef =
         ResolvedRef(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -21,6 +21,7 @@ import javax.inject.Inject
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -129,7 +130,7 @@ class ShowCardsToolHandler internal constructor(
         ResolvedRef(
             family = ref.family.serializedName,
             id = ref.id,
-            summary = summary,
+            summary = summary.filterAllowedKeysFor(ref.family),
         )
 
     private fun ShowCardsResolution.Missing.toMissingRef(): MissingRef =
@@ -139,7 +140,18 @@ class ShowCardsToolHandler internal constructor(
             reason = reason,
         )
 
+    private fun JsonObject.filterAllowedKeysFor(family: ShowCardFamily): JsonObject {
+        val allowedKeys = when (family) {
+            ShowCardFamily.Order -> ORDER_SUMMARY_KEYS
+            ShowCardFamily.Product -> PRODUCT_SUMMARY_KEYS
+        }
+        return JsonObject(filterKeys { it in allowedKeys })
+    }
+
     private companion object {
+        val ORDER_SUMMARY_KEYS = setOf("id", "number", "status", "total", "currency", "date_created")
+        val PRODUCT_SUMMARY_KEYS = setOf("id", "name", "sku", "price", "stock_status")
+
         val json = Json {
             explicitNulls = false
         }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -6,18 +6,16 @@ import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import com.woocommerce.android.aiassistant.tools.handlers.cards.DefaultShowCardsResolver
-import com.woocommerce.android.aiassistant.tools.handlers.cards.MAX_SHOW_CARDS_REFS
 import com.woocommerce.android.aiassistant.tools.handlers.cards.MissingRef
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ResolvedRef
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsArguments
-import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsRejectionReason
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsReferenceValidator
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsRejectionReason
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolution
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsStructured
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
-import javax.inject.Inject
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -28,6 +26,7 @@ import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
+import javax.inject.Inject
 
 class ShowCardsToolHandler internal constructor(
     private val resolver: ShowCardsResolver,
@@ -45,7 +44,7 @@ class ShowCardsToolHandler internal constructor(
             putJsonObject("properties") {
                 putJsonObject("references") {
                     put("type", "array")
-                    put("maxItems", MAX_SHOW_CARDS_REFS)
+                    put("maxItems", 10)
                     putJsonObject("items") {
                         put("type", "object")
                         put("additionalProperties", false)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -2,15 +2,50 @@ package com.woocommerce.android.aiassistant.tools.handlers
 
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
-import com.woocommerce.android.aiassistant.core.chat.inputSchema
+import com.woocommerce.android.aiassistant.tools.handlers.cards.MAX_SHOW_CARDS_REFS
 import javax.inject.Inject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
 
 class ShowCardsToolHandler @Inject constructor() : StubToolHandler() {
     override val descriptor = ToolDescriptor(
         name = "show_cards",
         description = "Show entity cards in the UI for orders or products selected by the assistant.",
-        inputSchema = inputSchema {
-            string("family")
+        inputSchema = buildJsonObject {
+            put("type", "object")
+            put("additionalProperties", false)
+            putJsonObject("properties") {
+                putJsonObject("references") {
+                    put("type", "array")
+                    put("maxItems", MAX_SHOW_CARDS_REFS)
+                    putJsonObject("items") {
+                        put("type", "object")
+                        put("additionalProperties", false)
+                        putJsonObject("properties") {
+                            putJsonObject("family") {
+                                put("type", "string")
+                                putJsonArray("enum") {
+                                    add("order")
+                                    add("product")
+                                }
+                            }
+                            putJsonObject("id") {
+                                put("type", "string")
+                            }
+                        }
+                        putJsonArray("required") {
+                            add("family")
+                            add("id")
+                        }
+                    }
+                }
+            }
+            putJsonArray("required") {
+                add("references")
+            }
         },
         safetyLevel = ToolSafetyLevel.SAFE,
     )

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -12,22 +12,19 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ResolvedRef
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsArguments
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsRejectionReason
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsReferenceValidator
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolution
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsStructured
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
-import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
 import javax.inject.Inject
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
@@ -35,6 +32,7 @@ import kotlinx.serialization.json.putJsonObject
 class ShowCardsToolHandler internal constructor(
     private val resolver: ShowCardsResolver,
 ) : AssistantToolHandler {
+    private val referenceValidator = ShowCardsReferenceValidator()
 
     @Inject constructor() : this(DefaultShowCardsResolver())
 
@@ -86,7 +84,8 @@ class ShowCardsToolHandler internal constructor(
             return ToolResult.ValidationError(call.id, "Invalid arguments: ${exception.message}")
         }
 
-        val validRefs = parseValidRefs(arguments.references)
+        val validation = referenceValidator.validate(arguments.references)
+        val validRefs = validation.validRefs
         val resolutions = runCatching { resolver.resolve(validRefs) }
             .getOrElse {
                 validRefs.map { ref ->
@@ -98,12 +97,12 @@ class ShowCardsToolHandler internal constructor(
             }
         val resolvedCards = resolutions.filterIsInstance<ShowCardsResolution.Resolved>()
         val structured = ShowCardsStructured(
-            requested = arguments.references.size,
+            requested = validation.requested,
             validated = validRefs.size,
             rendered = resolvedCards.size,
             resolvedRefs = resolvedCards.map { it.toResolvedRef() },
             missingRefs = resolutions.filterIsInstance<ShowCardsResolution.Missing>().map { it.toMissingRef() },
-            rejectedRefs = emptyList(),
+            rejectedRefs = validation.rejectedRefs,
         )
 
         return ToolResult.Success(
@@ -114,17 +113,6 @@ class ShowCardsToolHandler internal constructor(
             ),
         )
     }
-
-    private fun parseValidRefs(references: List<JsonElement>): List<ValidatedRef> =
-        references.mapIndexedNotNull { index, reference ->
-            val ref = reference.jsonObject
-            val family = ref["family"]?.jsonPrimitive?.content?.let(ShowCardFamily::from)
-                ?: return@mapIndexedNotNull null
-            val id = ref["id"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
-                ?: return@mapIndexedNotNull null
-
-            ValidatedRef(index = index, family = family, id = id)
-        }
 
     private fun ShowCardsResolution.Resolved.toResolvedRef(): ResolvedRef =
         ResolvedRef(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import com.woocommerce.android.aiassistant.tools.handlers.cards.DefaultShowCardsResolver
+import com.woocommerce.android.aiassistant.tools.handlers.cards.MAX_SHOW_CARDS_REFS
 import com.woocommerce.android.aiassistant.tools.handlers.cards.MissingRef
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ResolvedRef
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
@@ -46,7 +47,7 @@ class ShowCardsToolHandler internal constructor(
             putJsonObject("properties") {
                 putJsonObject("references") {
                     put("type", "array")
-                    put("maxItems", 10)
+                    put("maxItems", MAX_SHOW_CARDS_REFS)
                     putJsonObject("items") {
                         put("type", "object")
                         put("additionalProperties", false)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -1,16 +1,42 @@
 package com.woocommerce.android.aiassistant.tools.handlers
 
+import com.woocommerce.android.aiassistant.core.chat.AssistantToolHandler
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.tools.handlers.cards.DefaultShowCardsResolver
 import com.woocommerce.android.aiassistant.tools.handlers.cards.MAX_SHOW_CARDS_REFS
+import com.woocommerce.android.aiassistant.tools.handlers.cards.MissingRef
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ResolvedRef
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsArguments
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsRejectionReason
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolution
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsStructured
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
 import javax.inject.Inject
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 
-class ShowCardsToolHandler @Inject constructor() : StubToolHandler() {
+class ShowCardsToolHandler internal constructor(
+    private val resolver: ShowCardsResolver,
+) : AssistantToolHandler {
+
+    @Inject constructor() : this(DefaultShowCardsResolver())
+
     override val descriptor = ToolDescriptor(
         name = "show_cards",
         description = "Show entity cards in the UI for orders or products selected by the assistant.",
@@ -49,4 +75,73 @@ class ShowCardsToolHandler @Inject constructor() : StubToolHandler() {
         },
         safetyLevel = ToolSafetyLevel.SAFE,
     )
+
+    override suspend fun execute(call: ToolCall): ToolResult {
+        val arguments = try {
+            json.decodeFromJsonElement<ShowCardsArguments>(call.arguments)
+        } catch (exception: SerializationException) {
+            return ToolResult.ValidationError(call.id, "Invalid arguments: ${exception.message}")
+        } catch (exception: IllegalArgumentException) {
+            return ToolResult.ValidationError(call.id, "Invalid arguments: ${exception.message}")
+        }
+
+        val validRefs = parseValidRefs(arguments.references)
+        val resolutions = runCatching { resolver.resolve(validRefs) }
+            .getOrElse {
+                validRefs.map { ref ->
+                    ShowCardsResolution.Missing(
+                        ref = ref,
+                        reason = ShowCardsRejectionReason.FetchFailed,
+                    )
+                }
+            }
+        val resolvedCards = resolutions.filterIsInstance<ShowCardsResolution.Resolved>()
+        val structured = ShowCardsStructured(
+            requested = arguments.references.size,
+            validated = validRefs.size,
+            rendered = resolvedCards.size,
+            resolvedRefs = resolvedCards.map { it.toResolvedRef() },
+            missingRefs = resolutions.filterIsInstance<ShowCardsResolution.Missing>().map { it.toMissingRef() },
+            rejectedRefs = emptyList(),
+        )
+
+        return ToolResult.Success(
+            toolCallId = call.id,
+            structured = json.encodeToJsonElement(structured),
+            uiStructured = json.encodeToJsonElement(
+                ShowCardsUiStructured(cards = resolvedCards.map { it.card })
+            ),
+        )
+    }
+
+    private fun parseValidRefs(references: List<JsonElement>): List<ValidatedRef> =
+        references.mapIndexedNotNull { index, reference ->
+            val ref = reference.jsonObject
+            val family = ref["family"]?.jsonPrimitive?.content?.let(ShowCardFamily::from)
+                ?: return@mapIndexedNotNull null
+            val id = ref["id"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+                ?: return@mapIndexedNotNull null
+
+            ValidatedRef(index = index, family = family, id = id)
+        }
+
+    private fun ShowCardsResolution.Resolved.toResolvedRef(): ResolvedRef =
+        ResolvedRef(
+            family = ref.family.serializedName,
+            id = ref.id,
+            summary = summary,
+        )
+
+    private fun ShowCardsResolution.Missing.toMissingRef(): MissingRef =
+        MissingRef(
+            family = ref.family.serializedName,
+            id = ref.id,
+            reason = reason,
+        )
+
+    private companion object {
+        val json = Json {
+            explicitNulls = false
+        }
+    }
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
@@ -46,6 +46,25 @@ internal data class ResolvedRef(
 )
 
 @Serializable
+internal data class OrderSummary(
+    val id: String,
+    val number: String? = null,
+    val status: String? = null,
+    val total: String? = null,
+    val currency: String? = null,
+    @SerialName("date_created") val dateCreated: String? = null,
+)
+
+@Serializable
+internal data class ProductSummary(
+    val id: String,
+    val name: String? = null,
+    val sku: String? = null,
+    val price: String? = null,
+    @SerialName("stock_status") val stockStatus: String? = null,
+)
+
+@Serializable
 internal data class MissingRef(
     val family: String,
     val id: String,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.aiassistant.tools.handlers.cards
+
+import kotlinx.serialization.json.JsonElement
+
+internal const val MAX_SHOW_CARDS_REFS = 10
+
+internal data class ShowCardsArguments(
+    val references: List<JsonElement> = emptyList()
+)
+
+internal enum class ShowCardFamily(val serializedName: String) {
+    Order("order"),
+    Product("product");
+
+    companion object {
+        fun from(value: String): ShowCardFamily? =
+            entries.firstOrNull { it.serializedName == value }
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
@@ -1,9 +1,13 @@
 package com.woocommerce.android.aiassistant.tools.handlers.cards
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 
 internal const val MAX_SHOW_CARDS_REFS = 10
 
+@Serializable
 internal data class ShowCardsArguments(
     val references: List<JsonElement> = emptyList()
 )
@@ -17,3 +21,69 @@ internal enum class ShowCardFamily(val serializedName: String) {
             entries.firstOrNull { it.serializedName == value }
     }
 }
+
+internal data class ValidatedRef(
+    val index: Int,
+    val family: ShowCardFamily,
+    val id: String,
+)
+
+@Serializable
+internal data class ShowCardsStructured(
+    val requested: Int,
+    val validated: Int,
+    val rendered: Int,
+    @SerialName("resolved_refs") val resolvedRefs: List<ResolvedRef>,
+    @SerialName("missing_refs") val missingRefs: List<MissingRef>,
+    @SerialName("rejected_refs") val rejectedRefs: List<RejectedRef>,
+)
+
+@Serializable
+internal data class ResolvedRef(
+    val family: String,
+    val id: String,
+    val summary: JsonObject,
+)
+
+@Serializable
+internal data class MissingRef(
+    val family: String,
+    val id: String,
+    val reason: ShowCardsRejectionReason,
+)
+
+@Serializable
+internal data class RejectedRef(
+    val index: Int,
+    val family: String? = null,
+    val id: String? = null,
+    val reason: ShowCardsRejectionReason,
+)
+
+@Serializable
+internal enum class ShowCardsRejectionReason {
+    @SerialName("malformed_ref") MalformedRef,
+    @SerialName("missing_family") MissingFamily,
+    @SerialName("unsupported_family") UnsupportedFamily,
+    @SerialName("missing_id") MissingId,
+    @SerialName("invalid_id") InvalidId,
+    @SerialName("duplicate_ref") DuplicateRef,
+    @SerialName("over_limit") OverLimit,
+    @SerialName("fetch_failed") FetchFailed,
+    @SerialName("not_found") NotFound
+}
+
+@Serializable
+internal data class ShowCardsUiStructured(
+    val cards: List<ShowCardPayload>,
+)
+
+@Serializable
+internal data class ShowCardPayload(
+    val family: String,
+    val id: String,
+    val title: String,
+    val subtitle: String? = null,
+    val badges: List<String> = emptyList(),
+    val attributes: Map<String, String> = emptyMap(),
+)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
@@ -81,15 +81,32 @@ internal data class RejectedRef(
 
 @Serializable
 internal enum class ShowCardsRejectionReason {
-    @SerialName("malformed_ref") MalformedRef,
-    @SerialName("missing_family") MissingFamily,
-    @SerialName("unsupported_family") UnsupportedFamily,
-    @SerialName("missing_id") MissingId,
-    @SerialName("invalid_id") InvalidId,
-    @SerialName("duplicate_ref") DuplicateRef,
-    @SerialName("over_limit") OverLimit,
-    @SerialName("fetch_failed") FetchFailed,
-    @SerialName("not_found") NotFound
+    @SerialName("malformed_ref")
+    MalformedRef,
+
+    @SerialName("missing_family")
+    MissingFamily,
+
+    @SerialName("unsupported_family")
+    UnsupportedFamily,
+
+    @SerialName("missing_id")
+    MissingId,
+
+    @SerialName("invalid_id")
+    InvalidId,
+
+    @SerialName("duplicate_ref")
+    DuplicateRef,
+
+    @SerialName("over_limit")
+    OverLimit,
+
+    @SerialName("fetch_failed")
+    FetchFailed,
+
+    @SerialName("not_found")
+    NotFound
 }
 
 @Serializable

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
@@ -62,7 +62,7 @@ internal class ShowCardsReferenceValidator {
         (get(key) as? JsonPrimitive)?.contentOrNull
 
     private fun JsonPrimitive.stringContentOrNull(): String? =
-        contentOrNull?.takeIf { toString().startsWith("\"") }
+        contentOrNull?.takeIf { isString }
 
     private fun String.isValidShowCardsId(): Boolean = isNotBlank()
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
@@ -20,6 +20,7 @@ internal class ShowCardsReferenceValidator {
         )
     }
 
+    @Suppress("ReturnCount")
     private fun validateReference(index: Int, reference: JsonElement, state: ValidationState) {
         val ref = reference as? JsonObject
             ?: return state.reject(index = index, reason = ShowCardsRejectionReason.MalformedRef)
@@ -39,12 +40,15 @@ internal class ShowCardsReferenceValidator {
                 reason = ShowCardsRejectionReason.UnsupportedFamily,
             )
 
-        val id = ref.stringOrNull("id")
+        val idElement = ref["id"]
             ?: return state.reject(
                 index = index,
                 family = family.serializedName,
                 reason = ShowCardsRejectionReason.MissingId,
             )
+        val id = (idElement as? JsonPrimitive)
+            ?.stringContentOrNull()
+            ?: return state.rejectInvalidId(index, family)
 
         when {
             !id.isValidShowCardsId() -> state.rejectInvalidId(index, family, id)
@@ -57,7 +61,13 @@ internal class ShowCardsReferenceValidator {
     private fun JsonObject.stringOrNull(key: String): String? =
         (get(key) as? JsonPrimitive)?.contentOrNull
 
+    private fun JsonPrimitive.stringContentOrNull(): String? =
+        contentOrNull?.takeIf { toString().startsWith("\"") }
+
     private fun String.isValidShowCardsId(): Boolean = isNotBlank()
+
+    private fun ValidationState.rejectInvalidId(index: Int, family: ShowCardFamily) =
+        reject(index, family.serializedName, reason = ShowCardsRejectionReason.InvalidId)
 
     private fun ValidationState.rejectInvalidId(index: Int, family: ShowCardFamily, id: String) =
         reject(index, family.serializedName, id, ShowCardsRejectionReason.InvalidId)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
@@ -9,6 +9,7 @@ internal class ShowCardsReferenceValidator {
     fun validate(references: List<JsonElement>): ShowCardsValidationResult {
         val validRefs = mutableListOf<ValidatedRef>()
         val rejectedRefs = mutableListOf<RejectedRef>()
+        val seen = linkedSetOf<Pair<ShowCardFamily, String>>()
 
         references.forEachIndexed { index, reference ->
             val ref = reference as? JsonObject
@@ -50,6 +51,16 @@ internal class ShowCardsReferenceValidator {
                     family = family.serializedName,
                     id = id,
                     reason = ShowCardsRejectionReason.InvalidId,
+                )
+                return@forEachIndexed
+            }
+
+            if (!seen.add(family to id)) {
+                rejectedRefs += RejectedRef(
+                    index = index,
+                    family = family.serializedName,
+                    id = id,
+                    reason = ShowCardsRejectionReason.DuplicateRef,
                 )
                 return@forEachIndexed
             }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
@@ -7,88 +7,86 @@ import kotlinx.serialization.json.contentOrNull
 
 internal class ShowCardsReferenceValidator {
     fun validate(references: List<JsonElement>): ShowCardsValidationResult {
-        val validRefs = mutableListOf<ValidatedRef>()
-        val rejectedRefs = mutableListOf<RejectedRef>()
-        val seen = linkedSetOf<Pair<ShowCardFamily, String>>()
+        val state = ValidationState()
 
         references.forEachIndexed { index, reference ->
-            val ref = reference as? JsonObject
-            if (ref == null) {
-                rejectedRefs += RejectedRef(index = index, reason = ShowCardsRejectionReason.MalformedRef)
-                return@forEachIndexed
-            }
-
-            val rawFamily = ref.stringOrNull("family")
-            if (rawFamily == null) {
-                rejectedRefs += RejectedRef(index = index, id = ref.stringOrNull("id"), reason = ShowCardsRejectionReason.MissingFamily)
-                return@forEachIndexed
-            }
-
-            val family = ShowCardFamily.from(rawFamily)
-            if (family == null) {
-                rejectedRefs += RejectedRef(
-                    index = index,
-                    family = rawFamily,
-                    id = ref.stringOrNull("id"),
-                    reason = ShowCardsRejectionReason.UnsupportedFamily,
-                )
-                return@forEachIndexed
-            }
-
-            val id = ref.stringOrNull("id")
-            if (id == null) {
-                rejectedRefs += RejectedRef(
-                    index = index,
-                    family = family.serializedName,
-                    reason = ShowCardsRejectionReason.MissingId,
-                )
-                return@forEachIndexed
-            }
-
-            if (!id.isValidShowCardsId()) {
-                rejectedRefs += RejectedRef(
-                    index = index,
-                    family = family.serializedName,
-                    id = id,
-                    reason = ShowCardsRejectionReason.InvalidId,
-                )
-                return@forEachIndexed
-            }
-
-            if (!seen.add(family to id)) {
-                rejectedRefs += RejectedRef(
-                    index = index,
-                    family = family.serializedName,
-                    id = id,
-                    reason = ShowCardsRejectionReason.DuplicateRef,
-                )
-                return@forEachIndexed
-            }
-
-            if (validRefs.size >= MAX_SHOW_CARDS_REFS) {
-                rejectedRefs += RejectedRef(
-                    index = index,
-                    family = family.serializedName,
-                    id = id,
-                    reason = ShowCardsRejectionReason.OverLimit,
-                )
-                return@forEachIndexed
-            }
-
-            validRefs += ValidatedRef(index = index, family = family, id = id)
+            validateReference(index, reference, state)
         }
 
         return ShowCardsValidationResult(
             requested = references.size,
-            validRefs = validRefs,
-            rejectedRefs = rejectedRefs,
+            validRefs = state.validRefs,
+            rejectedRefs = state.rejectedRefs,
         )
+    }
+
+    private fun validateReference(index: Int, reference: JsonElement, state: ValidationState) {
+        val ref = reference as? JsonObject
+            ?: return state.reject(index = index, reason = ShowCardsRejectionReason.MalformedRef)
+
+        val rawFamily = ref.stringOrNull("family")
+            ?: return state.reject(
+                index = index,
+                id = ref.stringOrNull("id"),
+                reason = ShowCardsRejectionReason.MissingFamily,
+            )
+
+        val family = ShowCardFamily.from(rawFamily)
+            ?: return state.reject(
+                index = index,
+                family = rawFamily,
+                id = ref.stringOrNull("id"),
+                reason = ShowCardsRejectionReason.UnsupportedFamily,
+            )
+
+        val id = ref.stringOrNull("id")
+            ?: return state.reject(
+                index = index,
+                family = family.serializedName,
+                reason = ShowCardsRejectionReason.MissingId,
+            )
+
+        when {
+            !id.isValidShowCardsId() -> state.rejectInvalidId(index, family, id)
+            !state.seen.add(family to id) -> state.rejectDuplicate(index, family, id)
+            state.validRefs.size >= MAX_SHOW_CARDS_REFS -> state.rejectOverLimit(index, family, id)
+            else -> state.validRefs += ValidatedRef(index = index, family = family, id = id)
+        }
     }
 
     private fun JsonObject.stringOrNull(key: String): String? =
         (get(key) as? JsonPrimitive)?.contentOrNull
 
     private fun String.isValidShowCardsId(): Boolean = isNotBlank()
+
+    private fun ValidationState.rejectInvalidId(index: Int, family: ShowCardFamily, id: String) =
+        reject(index, family.serializedName, id, ShowCardsRejectionReason.InvalidId)
+
+    private fun ValidationState.rejectDuplicate(index: Int, family: ShowCardFamily, id: String) =
+        reject(index, family.serializedName, id, ShowCardsRejectionReason.DuplicateRef)
+
+    private fun ValidationState.rejectOverLimit(index: Int, family: ShowCardFamily, id: String) =
+        reject(index, family.serializedName, id, ShowCardsRejectionReason.OverLimit)
+
+    private class ValidationState {
+        val validRefs = mutableListOf<ValidatedRef>()
+        val rejectedRefs = mutableListOf<RejectedRef>()
+        val seen = linkedSetOf<Pair<ShowCardFamily, String>>()
+
+        fun reject(
+            index: Int,
+            family: String? = null,
+            id: String? = null,
+            reason: ShowCardsRejectionReason,
+        ) {
+            rejectedRefs += RejectedRef(
+                index = index,
+                family = family,
+                id = id,
+                reason = reason,
+            )
+        }
+    }
 }
 
 internal data class ShowCardsValidationResult(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
@@ -1,0 +1,77 @@
+package com.woocommerce.android.aiassistant.tools.handlers.cards
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+internal class ShowCardsReferenceValidator {
+    fun validate(references: List<JsonElement>): ShowCardsValidationResult {
+        val validRefs = mutableListOf<ValidatedRef>()
+        val rejectedRefs = mutableListOf<RejectedRef>()
+
+        references.forEachIndexed { index, reference ->
+            val ref = reference as? JsonObject
+            if (ref == null) {
+                rejectedRefs += RejectedRef(index = index, reason = ShowCardsRejectionReason.MalformedRef)
+                return@forEachIndexed
+            }
+
+            val rawFamily = ref.stringOrNull("family")
+            if (rawFamily == null) {
+                rejectedRefs += RejectedRef(index = index, id = ref.stringOrNull("id"), reason = ShowCardsRejectionReason.MissingFamily)
+                return@forEachIndexed
+            }
+
+            val family = ShowCardFamily.from(rawFamily)
+            if (family == null) {
+                rejectedRefs += RejectedRef(
+                    index = index,
+                    family = rawFamily,
+                    id = ref.stringOrNull("id"),
+                    reason = ShowCardsRejectionReason.UnsupportedFamily,
+                )
+                return@forEachIndexed
+            }
+
+            val id = ref.stringOrNull("id")
+            if (id == null) {
+                rejectedRefs += RejectedRef(
+                    index = index,
+                    family = family.serializedName,
+                    reason = ShowCardsRejectionReason.MissingId,
+                )
+                return@forEachIndexed
+            }
+
+            if (!id.isValidShowCardsId()) {
+                rejectedRefs += RejectedRef(
+                    index = index,
+                    family = family.serializedName,
+                    id = id,
+                    reason = ShowCardsRejectionReason.InvalidId,
+                )
+                return@forEachIndexed
+            }
+
+            validRefs += ValidatedRef(index = index, family = family, id = id)
+        }
+
+        return ShowCardsValidationResult(
+            requested = references.size,
+            validRefs = validRefs,
+            rejectedRefs = rejectedRefs,
+        )
+    }
+
+    private fun JsonObject.stringOrNull(key: String): String? =
+        (get(key) as? JsonPrimitive)?.contentOrNull
+
+    private fun String.isValidShowCardsId(): Boolean = isNotBlank()
+}
+
+internal data class ShowCardsValidationResult(
+    val requested: Int,
+    val validRefs: List<ValidatedRef>,
+    val rejectedRefs: List<RejectedRef>,
+)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
@@ -65,6 +65,16 @@ internal class ShowCardsReferenceValidator {
                 return@forEachIndexed
             }
 
+            if (validRefs.size >= MAX_SHOW_CARDS_REFS) {
+                rejectedRefs += RejectedRef(
+                    index = index,
+                    family = family.serializedName,
+                    id = id,
+                    reason = ShowCardsRejectionReason.OverLimit,
+                )
+                return@forEachIndexed
+            }
+
             validRefs += ValidatedRef(index = index, family = family, id = id)
         }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
@@ -1,0 +1,32 @@
+package com.woocommerce.android.aiassistant.tools.handlers.cards
+
+import kotlinx.serialization.json.JsonObject
+
+internal interface ShowCardsResolver {
+    suspend fun resolve(refs: List<ValidatedRef>): List<ShowCardsResolution>
+}
+
+internal sealed interface ShowCardsResolution {
+    val ref: ValidatedRef
+
+    data class Resolved(
+        override val ref: ValidatedRef,
+        val summary: JsonObject,
+        val card: ShowCardPayload,
+    ) : ShowCardsResolution
+
+    data class Missing(
+        override val ref: ValidatedRef,
+        val reason: ShowCardsRejectionReason,
+    ) : ShowCardsResolution
+}
+
+internal class DefaultShowCardsResolver : ShowCardsResolver {
+    override suspend fun resolve(refs: List<ValidatedRef>): List<ShowCardsResolution> =
+        refs.map { ref ->
+            ShowCardsResolution.Missing(
+                ref = ref,
+                reason = ShowCardsRejectionReason.NotFound,
+            )
+        }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.aiassistant.tools.handlers
 
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.tools.handlers.cards.OrderSummary
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ProductSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolution
@@ -9,11 +11,11 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolve
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -57,6 +59,27 @@ class ShowCardsToolHandlerTest {
         assertThat(structured["rendered"]?.jsonPrimitive?.int).isEqualTo(1)
     }
 
+    @Test
+    fun `resolved order summary contains only allowlisted fields`() = runTest {
+        val result = callShowCards(FakeResolver.resolving(orderCard(id = "123")))
+
+        val summary = firstResolvedSummary(result)
+
+        assertThat(summary.keys).containsExactly("id", "number", "status", "total", "currency", "date_created")
+    }
+
+    @Test
+    fun `resolved product summary contains only allowlisted fields`() = runTest {
+        val result = callShowCards(
+            resolver = FakeResolver.resolving(productCard(id = "456")),
+            referencesJson = """[{ "family": "product", "id": "456" }]"""
+        )
+
+        val summary = firstResolvedSummary(result)
+
+        assertThat(summary.keys).containsExactly("id", "name", "sku", "price", "stock_status")
+    }
+
     private fun handlerWith(resolver: ShowCardsResolver) =
         ShowCardsToolHandler(resolver)
 
@@ -71,23 +94,66 @@ class ShowCardsToolHandlerTest {
         )
     )
 
+    private suspend fun callShowCards(
+        resolver: FakeResolver,
+        referencesJson: String = """[{ "family": "order", "id": "123" }]""",
+    ): ToolResult = executeShowCards(
+        handler = handlerWith(resolver),
+        argumentsJson = """{ "references": $referencesJson }""",
+    )
+
     private fun assertSuccess(result: ToolResult): ToolResult.Success {
         assertThat(result).isInstanceOf(ToolResult.Success::class.java)
         return result as ToolResult.Success
     }
+
+    private fun firstResolvedSummary(result: ToolResult) =
+        assertSuccess(result).structured.jsonObject
+            .getValue("resolved_refs").jsonArray
+            .first().jsonObject
+            .getValue("summary").jsonObject
 
     private fun orderCard(id: String): ShowCardsResolution.Resolved {
         val ref = ValidatedRef(index = 0, family = ShowCardFamily.Order, id = id)
 
         return ShowCardsResolution.Resolved(
             ref = ref,
-            summary = buildJsonObject {
-                put("id", id)
-            },
+            summary = json.encodeToJsonElement(
+                OrderSummary(
+                    id = id,
+                    number = "#$id",
+                    status = "processing",
+                    total = "12.34",
+                    currency = "USD",
+                    dateCreated = "2026-05-01T10:00:00Z",
+                )
+            ).jsonObject,
             card = ShowCardPayload(
                 family = "order",
                 id = id,
                 title = "#$id",
+            )
+        )
+    }
+
+    private fun productCard(id: String): ShowCardsResolution.Resolved {
+        val ref = ValidatedRef(index = 0, family = ShowCardFamily.Product, id = id)
+
+        return ShowCardsResolution.Resolved(
+            ref = ref,
+            summary = json.encodeToJsonElement(
+                ProductSummary(
+                    id = id,
+                    name = "Socks",
+                    sku = "woo-socks",
+                    price = "9.99",
+                    stockStatus = "instock",
+                )
+            ).jsonObject,
+            card = ShowCardPayload(
+                family = "product",
+                id = id,
+                title = "Socks",
             )
         )
     }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -11,11 +11,16 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolve
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -78,6 +83,22 @@ class ShowCardsToolHandlerTest {
         val summary = firstResolvedSummary(result)
 
         assertThat(summary.keys).containsExactly("id", "name", "sku", "price", "stock_status")
+    }
+
+    @Test
+    fun `structured excludes render payload descriptions html images metadata and raw json`() = runTest {
+        val result = callShowCards(
+            resolver = FakeResolver.resolving(leakyProductCard(id = "456")),
+            referencesJson = """[{ "family": "product", "id": "456" }]"""
+        )
+
+        val structuredText = assertSuccess(result).structured.toString()
+
+        assertThat(structuredText).doesNotContain("Long description")
+        assertThat(structuredText).doesNotContain("<p>Private</p>")
+        assertThat(structuredText).doesNotContain("image.png")
+        assertThat(structuredText).doesNotContain("metadata")
+        assertThat(structuredText).doesNotContain("raw")
     }
 
     private fun handlerWith(resolver: ShowCardsResolver) =
@@ -154,6 +175,42 @@ class ShowCardsToolHandlerTest {
                 family = "product",
                 id = id,
                 title = "Socks",
+            )
+        )
+    }
+
+    private fun leakyProductCard(id: String): ShowCardsResolution.Resolved {
+        val ref = ValidatedRef(index = 0, family = ShowCardFamily.Product, id = id)
+
+        return ShowCardsResolution.Resolved(
+            ref = ref,
+            summary = buildJsonObject {
+                put("id", id)
+                put("name", "Socks")
+                put("sku", "woo-socks")
+                put("price", "9.99")
+                put("stock_status", "instock")
+                put("description", "Long description")
+                put("html", "<p>Private</p>")
+                put("images", buildJsonArray { add("https://example.com/image.png") })
+                putJsonObject("metadata") {
+                    put("private", "value")
+                }
+                putJsonObject("raw") {
+                    put("entity", "json")
+                }
+            },
+            card = ShowCardPayload(
+                family = "product",
+                id = id,
+                title = "Socks",
+                attributes = mapOf(
+                    "description" to "Long description",
+                    "html" to "<p>Private</p>",
+                    "image" to "https://example.com/image.png",
+                    "metadata" to "private",
+                    "raw" to "entity",
+                ),
             )
         )
     }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -141,6 +141,24 @@ class ShowCardsToolHandlerTest {
         )
     }
 
+    @Test
+    fun `duplicate refs are rejected after the first seen family id pair`() = runTest {
+        val result = callShowCards(
+            resolver = FakeResolver.resolving(orderCard(id = "123"), productCard(id = "123")),
+            referencesJson = """
+                [
+                  { "family": "order", "id": "123" },
+                  { "family": "order", "id": "123" },
+                  { "family": "product", "id": "123" }
+                ]
+            """.trimIndent()
+        )
+
+        assertThat(validated(result)).isEqualTo(2)
+        assertThat(rejectedReasons(result)).containsExactly("duplicate_ref")
+        assertThat(resolvedFamilies(result)).containsExactly("order", "product")
+    }
+
     private fun handlerWith(resolver: ShowCardsResolver) =
         ShowCardsToolHandler(resolver)
 
@@ -178,6 +196,14 @@ class ShowCardsToolHandlerTest {
         assertSuccess(result).structured.jsonObject
             .getValue("rejected_refs").jsonArray
             .map { ref -> ref.jsonObject.getValue("reason").jsonPrimitive.content }
+
+    private fun validated(result: ToolResult): Int =
+        assertSuccess(result).structured.jsonObject.getValue("validated").jsonPrimitive.int
+
+    private fun resolvedFamilies(result: ToolResult): List<String> =
+        assertSuccess(result).structured.jsonObject
+            .getValue("resolved_refs").jsonArray
+            .map { ref -> ref.jsonObject.getValue("family").jsonPrimitive.content }
 
     private fun orderCard(id: String): ShowCardsResolution.Resolved {
         val ref = ValidatedRef(index = 0, family = ShowCardFamily.Order, id = id)

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -30,7 +30,7 @@ class ShowCardsToolHandlerTest {
     private val handler = ShowCardsToolHandler()
 
     @Test
-    fun `show cards descriptor accepts references with Android v1 order and product families`() {
+    fun `when descriptor is inspected, then show cards accepts Android v1 order and product references`() {
         val descriptor = handler.descriptor
 
         assertThat(descriptor.name).isEqualTo("show_cards")
@@ -44,12 +44,12 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `show_cards is classified safe`() {
+    fun `when descriptor is inspected, then show_cards is safe`() {
         assertThat(handler.descriptor.safetyLevel).isEqualTo(ToolSafetyLevel.SAFE)
     }
 
     @Test
-    fun `success structured contains compact result counts and ref lists`() = runTest {
+    fun `given resolved ref, when executed, then structured contains compact result counts and ref lists`() = runTest {
         val result = executeShowCards(
             handler = handlerWith(FakeResolver.resolving(orderCard(id = "123"))),
             argumentsJson = """{"references":[{"family":"order","id":"123"}]}"""
@@ -71,7 +71,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `resolved order summary contains only allowlisted fields`() = runTest {
+    fun `given resolved order, when executed, then summary contains only allowlisted fields`() = runTest {
         val result = callShowCards(FakeResolver.resolving(orderCard(id = "123")))
 
         val summary = firstResolvedSummary(result)
@@ -80,7 +80,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `resolved product summary contains only allowlisted fields`() = runTest {
+    fun `given resolved product, when executed, then summary contains only allowlisted fields`() = runTest {
         val result = callShowCards(
             resolver = FakeResolver.resolving(productCard(id = "456")),
             referencesJson = """[{ "family": "product", "id": "456" }]"""
@@ -92,7 +92,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `structured excludes render payload descriptions html images metadata and raw json`() = runTest {
+    fun `given resolver returns render payload extras, when executed, then structured excludes private fields`() = runTest {
         val result = callShowCards(
             resolver = FakeResolver.resolving(leakyProductCard(id = "456")),
             referencesJson = """[{ "family": "product", "id": "456" }]"""
@@ -108,7 +108,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `success uiStructured contains cards for resolved refs`() = runTest {
+    fun `given resolved ref, when executed, then uiStructured contains cards`() = runTest {
         val result = callShowCards(FakeResolver.resolving(orderCard(id = "123")))
 
         val uiStructured = assertSuccess(result).uiStructured!!.jsonObject
@@ -120,7 +120,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `invalid refs are rejected with lower snake case reasons`() = runTest {
+    fun `given invalid refs, when executed, then rejected refs use lower snake case reasons`() = runTest {
         val result = executeShowCards(
             handler = handler,
             argumentsJson = """
@@ -148,7 +148,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `duplicate refs are rejected after the first seen family id pair`() = runTest {
+    fun `given duplicate refs, when executed, then duplicates after first family id pair are rejected`() = runTest {
         val result = callShowCards(
             resolver = FakeResolver.resolving(orderCard(id = "123"), productCard(id = "123")),
             referencesJson = """
@@ -166,7 +166,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `refs after max ten are rejected as over limit and not rendered`() = runTest {
+    fun `given more than ten refs, when executed, then refs after max ten are rejected and not rendered`() = runTest {
         val refs = (1..11).joinToString(separator = ",") { index ->
             """{ "family": "order", "id": "$index" }"""
         }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -148,6 +148,24 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
+    fun `given non string present ids, when executed, then ids are invalid`() = runTest {
+        val result = executeShowCards(
+            handler = handler,
+            argumentsJson = """
+            {
+              "references": [
+                { "family": "order", "id": 123 },
+                { "family": "product", "id": true },
+                { "family": "order", "id": null }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertThat(rejectedReasons(result)).containsExactly("invalid_id", "invalid_id", "invalid_id")
+    }
+
+    @Test
     fun `given duplicate refs, when executed, then duplicates after first family id pair are rejected`() = runTest {
         val result = callShowCards(
             resolver = FakeResolver.resolving(orderCard(id = "123"), productCard(id = "123")),
@@ -180,6 +198,30 @@ class ShowCardsToolHandlerTest {
         assertThat(rendered(result)).isEqualTo(10)
         assertThat(rejectedReasons(result).last()).isEqualTo("over_limit")
         assertThat(resolvedIds(result)).containsExactly("1", "2", "3", "4", "5", "6", "7", "8", "9", "10")
+    }
+
+    @Test
+    fun `given resolver throws, when executed, then valid refs are missing with fetch failed`() = runTest {
+        val result = executeShowCards(
+            handler = handlerWith(ThrowingResolver),
+            argumentsJson = """{"references":[{"family":"order","id":"123"}]}"""
+        )
+
+        assertThat(missingReasons(result)).containsExactly("fetch_failed")
+        assertThat(rendered(result)).isEqualTo(0)
+        assertThat(uiCards(result)).isEmpty()
+    }
+
+    @Test
+    fun `given default resolver, when executed, then valid refs are missing with not found and no cards`() = runTest {
+        val result = executeShowCards(
+            handler = ShowCardsToolHandler(),
+            argumentsJson = """{"references":[{"family":"order","id":"123"}]}"""
+        )
+
+        assertThat(missingReasons(result)).containsExactly("not_found")
+        assertThat(rendered(result)).isEqualTo(0)
+        assertThat(uiCards(result)).isEmpty()
     }
 
     private fun handlerWith(resolver: ShowCardsResolver) =
@@ -220,6 +262,11 @@ class ShowCardsToolHandlerTest {
             .getValue("rejected_refs").jsonArray
             .map { ref -> ref.jsonObject.getValue("reason").jsonPrimitive.content }
 
+    private fun missingReasons(result: ToolResult): List<String> =
+        assertSuccess(result).structured.jsonObject
+            .getValue("missing_refs").jsonArray
+            .map { ref -> ref.jsonObject.getValue("reason").jsonPrimitive.content }
+
     private fun validated(result: ToolResult): Int =
         assertSuccess(result).structured.jsonObject.getValue("validated").jsonPrimitive.int
 
@@ -235,6 +282,9 @@ class ShowCardsToolHandlerTest {
         assertSuccess(result).structured.jsonObject
             .getValue("resolved_refs").jsonArray
             .map { ref -> ref.jsonObject.getValue("id").jsonPrimitive.content }
+
+    private fun uiCards(result: ToolResult) =
+        assertSuccess(result).uiStructured!!.jsonObject.getValue("cards").jsonArray
 
     private fun orderCard(id: String): ShowCardsResolution.Resolved {
         val ref = ValidatedRef(index = 0, family = ShowCardFamily.Order, id = id)
@@ -327,5 +377,10 @@ class ShowCardsToolHandlerTest {
             fun resolving(vararg resolutions: ShowCardsResolution): FakeResolver =
                 FakeResolver(resolutions.toList())
         }
+    }
+
+    private object ThrowingResolver : ShowCardsResolver {
+        override suspend fun resolve(refs: List<ValidatedRef>): List<ShowCardsResolution> =
+            error("Resolver failed")
     }
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -113,6 +113,34 @@ class ShowCardsToolHandlerTest {
         assertThat(cards.first().jsonObject["id"]?.jsonPrimitive?.content).isEqualTo("123")
     }
 
+    @Test
+    fun `invalid refs are rejected with lower snake case reasons`() = runTest {
+        val result = executeShowCards(
+            handler = handler,
+            argumentsJson = """
+            {
+              "references": [
+                null,
+                { "id": "1" },
+                { "family": "customer", "id": "1" },
+                { "family": "order" },
+                { "family": "product", "id": "" }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val reasons = rejectedReasons(result)
+
+        assertThat(reasons).containsExactly(
+            "malformed_ref",
+            "missing_family",
+            "unsupported_family",
+            "missing_id",
+            "invalid_id"
+        )
+    }
+
     private fun handlerWith(resolver: ShowCardsResolver) =
         ShowCardsToolHandler(resolver)
 
@@ -145,6 +173,11 @@ class ShowCardsToolHandlerTest {
             .getValue("resolved_refs").jsonArray
             .first().jsonObject
             .getValue("summary").jsonObject
+
+    private fun rejectedReasons(result: ToolResult): List<String> =
+        assertSuccess(result).structured.jsonObject
+            .getValue("rejected_refs").jsonArray
+            .map { ref -> ref.jsonObject.getValue("reason").jsonPrimitive.content }
 
     private fun orderCard(id: String): ShowCardsResolution.Resolved {
         val ref = ValidatedRef(index = 0, family = ShowCardFamily.Order, id = id)

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -1,9 +1,24 @@
 package com.woocommerce.android.aiassistant.tools.handlers
 
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolution
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ShowCardsToolHandlerTest {
+    private val json = Json
     private val handler = ShowCardsToolHandler()
 
     @Test
@@ -18,5 +33,74 @@ class ShowCardsToolHandlerTest {
         assertThat(descriptor.inputSchema.toString()).contains("id")
         assertThat(descriptor.inputSchema.toString()).contains("order")
         assertThat(descriptor.inputSchema.toString()).contains("product")
+    }
+
+    @Test
+    fun `success structured contains compact result counts and ref lists`() = runTest {
+        val result = executeShowCards(
+            handler = handlerWith(FakeResolver.resolving(orderCard(id = "123"))),
+            argumentsJson = """{"references":[{"family":"order","id":"123"}]}"""
+        )
+
+        val structured = assertSuccess(result).structured.jsonObject
+
+        assertThat(structured.keys).containsExactly(
+            "requested",
+            "validated",
+            "rendered",
+            "resolved_refs",
+            "missing_refs",
+            "rejected_refs"
+        )
+        assertThat(structured["requested"]?.jsonPrimitive?.int).isEqualTo(1)
+        assertThat(structured["validated"]?.jsonPrimitive?.int).isEqualTo(1)
+        assertThat(structured["rendered"]?.jsonPrimitive?.int).isEqualTo(1)
+    }
+
+    private fun handlerWith(resolver: ShowCardsResolver) =
+        ShowCardsToolHandler(resolver)
+
+    private suspend fun executeShowCards(
+        handler: ShowCardsToolHandler,
+        argumentsJson: String,
+    ): ToolResult = handler.execute(
+        ToolCall(
+            id = "call_1",
+            name = "show_cards",
+            arguments = json.parseToJsonElement(argumentsJson).jsonObject,
+        )
+    )
+
+    private fun assertSuccess(result: ToolResult): ToolResult.Success {
+        assertThat(result).isInstanceOf(ToolResult.Success::class.java)
+        return result as ToolResult.Success
+    }
+
+    private fun orderCard(id: String): ShowCardsResolution.Resolved {
+        val ref = ValidatedRef(index = 0, family = ShowCardFamily.Order, id = id)
+
+        return ShowCardsResolution.Resolved(
+            ref = ref,
+            summary = buildJsonObject {
+                put("id", id)
+            },
+            card = ShowCardPayload(
+                family = "order",
+                id = id,
+                title = "#$id",
+            )
+        )
+    }
+
+    private class FakeResolver(
+        private val resolutions: List<ShowCardsResolution>,
+    ) : ShowCardsResolver {
+        override suspend fun resolve(refs: List<ValidatedRef>): List<ShowCardsResolution> =
+            refs.map { ref -> resolutions.first { it.ref.family == ref.family && it.ref.id == ref.id } }
+
+        companion object {
+            fun resolving(vararg resolutions: ShowCardsResolution): FakeResolver =
+                FakeResolver(resolutions.toList())
+        }
     }
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -101,6 +101,18 @@ class ShowCardsToolHandlerTest {
         assertThat(structuredText).doesNotContain("raw")
     }
 
+    @Test
+    fun `success uiStructured contains cards for resolved refs`() = runTest {
+        val result = callShowCards(FakeResolver.resolving(orderCard(id = "123")))
+
+        val uiStructured = assertSuccess(result).uiStructured!!.jsonObject
+        val cards = uiStructured.getValue("cards").jsonArray
+
+        assertThat(cards).hasSize(1)
+        assertThat(cards.first().jsonObject["family"]?.jsonPrimitive?.content).isEqualTo("order")
+        assertThat(cards.first().jsonObject["id"]?.jsonPrimitive?.content).isEqualTo("123")
+    }
+
     private fun handlerWith(resolver: ShowCardsResolver) =
         ShowCardsToolHandler(resolver)
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -159,6 +159,23 @@ class ShowCardsToolHandlerTest {
         assertThat(resolvedFamilies(result)).containsExactly("order", "product")
     }
 
+    @Test
+    fun `refs after max ten are rejected as over limit and not rendered`() = runTest {
+        val refs = (1..11).joinToString(separator = ",") { index ->
+            """{ "family": "order", "id": "$index" }"""
+        }
+
+        val result = callShowCards(
+            resolver = FakeResolver.resolving(*(1..10).map { orderCard(id = it.toString()) }.toTypedArray()),
+            referencesJson = "[$refs]"
+        )
+
+        assertThat(validated(result)).isEqualTo(10)
+        assertThat(rendered(result)).isEqualTo(10)
+        assertThat(rejectedReasons(result).last()).isEqualTo("over_limit")
+        assertThat(resolvedIds(result)).containsExactly("1", "2", "3", "4", "5", "6", "7", "8", "9", "10")
+    }
+
     private fun handlerWith(resolver: ShowCardsResolver) =
         ShowCardsToolHandler(resolver)
 
@@ -200,10 +217,18 @@ class ShowCardsToolHandlerTest {
     private fun validated(result: ToolResult): Int =
         assertSuccess(result).structured.jsonObject.getValue("validated").jsonPrimitive.int
 
+    private fun rendered(result: ToolResult): Int =
+        assertSuccess(result).structured.jsonObject.getValue("rendered").jsonPrimitive.int
+
     private fun resolvedFamilies(result: ToolResult): List<String> =
         assertSuccess(result).structured.jsonObject
             .getValue("resolved_refs").jsonArray
             .map { ref -> ref.jsonObject.getValue("family").jsonPrimitive.content }
+
+    private fun resolvedIds(result: ToolResult): List<String> =
+        assertSuccess(result).structured.jsonObject
+            .getValue("resolved_refs").jsonArray
+            .map { ref -> ref.jsonObject.getValue("id").jsonPrimitive.content }
 
     private fun orderCard(id: String): ShowCardsResolution.Resolved {
         val ref = ValidatedRef(index = 0, family = ShowCardFamily.Order, id = id)

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -111,7 +111,7 @@ class ShowCardsToolHandlerTest {
     fun `given resolved ref, when executed, then uiStructured contains cards`() = runTest {
         val result = callShowCards(FakeResolver.resolving(orderCard(id = "123")))
 
-        val uiStructured = assertSuccess(result).uiStructured!!.jsonObject
+        val uiStructured = requireNotNull(assertSuccess(result).uiStructured).jsonObject
         val cards = uiStructured.getValue("cards").jsonArray
 
         assertThat(cards).hasSize(1)
@@ -284,7 +284,7 @@ class ShowCardsToolHandlerTest {
             .map { ref -> ref.jsonObject.getValue("id").jsonPrimitive.content }
 
     private fun uiCards(result: ToolResult) =
-        assertSuccess(result).uiStructured!!.jsonObject.getValue("cards").jsonArray
+        requireNotNull(assertSuccess(result).uiStructured).jsonObject.getValue("cards").jsonArray
 
     private fun orderCard(id: String): ShowCardsResolution.Resolved {
         val ref = ValidatedRef(index = 0, family = ShowCardFamily.Order, id = id)

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.aiassistant.tools.handlers
 
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import com.woocommerce.android.aiassistant.tools.handlers.cards.OrderSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ProductSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
@@ -40,6 +41,11 @@ class ShowCardsToolHandlerTest {
         assertThat(descriptor.inputSchema.toString()).contains("id")
         assertThat(descriptor.inputSchema.toString()).contains("order")
         assertThat(descriptor.inputSchema.toString()).contains("product")
+    }
+
+    @Test
+    fun `show_cards is classified safe`() {
+        assertThat(handler.descriptor.safetyLevel).isEqualTo(ToolSafetyLevel.SAFE)
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -1,0 +1,22 @@
+package com.woocommerce.android.aiassistant.tools.handlers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ShowCardsToolHandlerTest {
+    private val handler = ShowCardsToolHandler()
+
+    @Test
+    fun `show cards descriptor accepts references with Android v1 order and product families`() {
+        val descriptor = handler.descriptor
+
+        assertThat(descriptor.name).isEqualTo("show_cards")
+        assertThat(descriptor.description).contains("order")
+        assertThat(descriptor.description).contains("product")
+        assertThat(descriptor.inputSchema.toString()).contains("references")
+        assertThat(descriptor.inputSchema.toString()).contains("family")
+        assertThat(descriptor.inputSchema.toString()).contains("id")
+        assertThat(descriptor.inputSchema.toString()).contains("order")
+        assertThat(descriptor.inputSchema.toString()).contains("product")
+    }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-2907

Implements the Android v1 `show_cards` tool contract for AI Assistant order and product references. The tool now accepts `references: [{ family, id }]`, validates each reference deterministically, dedupes first-seen refs by `(family, id)`, enforces the max reference count, and reports rejected or missing refs with stable lower-snake-case reasons.

The result is split into the two intended surfaces:
- `structured`: compact model-visible data only, including counts, resolved refs, missing refs, and rejected refs.
- `uiStructured.cards`: app-owned card payloads for local UI rendering, kept out of model history.

This also adds a resolver seam for future real order/product resolution. The default resolver reports `not_found`, so this PR does not introduce a new direct FluxC/store/auth path and leaves production data lookup to the follow-up resolver ticket.

### Android/iOS Alignment
| Aspect | Status | Notes |
|---|---|---|
| Contract shape | Mostly aligned: both use `show_cards(references)` and the same six `structured` keys. | This PR keeps the shared contract shape. |
| Supported families | Android currently supports `order` and `product`. iOS also supports `customer` and `product_variation`, with `parent_id` for variation refs. | This is an expected Android v1 gap. Extra families can be added separately when Android expands card coverage. |
| Model/UI split | Aligned: both keep render payloads out of model history and use `uiStructured` for UI-only card data. | This is the main boundary this PR protects. |
| Resolver/runtime parity | Not aligned yet: Android has only the contract seam and default `not_found`; iOS resolves real entities and has card-render bridging. | This is expected for this slice; resolver and UI/card follow-up tickets cover the runtime behavior. |
| Summary fields | Android has compact order/product summaries; iOS exposes a little more, such as `customer_name`. | Summary fields are intentionally compact here. Since Android plans to reuse existing app cards, any summary gaps should be revisited during UI/card integration rather than expanding model-visible `structured` now. |
| Validation/rejections | Functionally aligned, but reason strings differ: Android uses ticket-required lower-snake-case values; iOS uses its own enum raw values. | Shared tooling should not assume identical reason strings across platforms. |
| Tests | Android covers the contract/seam; iOS also covers resolver/data behavior. | Resolver/data coverage belongs with the Android real-resolution follow-up. |

### Test Steps
1. N/A - this is an internal AI Assistant tool contract with no manual UI surface in this ticket.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.