### PR TITLE
[WOOMOB-2914] Add assistant error states and retry UX

### DIFF
--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -92,11 +92,7 @@ class AgenticLoopImpl(
             val completedTools = (toolExecution as ToolExecutionOutcome.Completed).completed
             modelMessages = modelMessages + newAssistantMsg
             newTurnMessages.add(newAssistantMsg)
-            for (completed in completedTools) {
-                val newToolMsg = completed.toToolMessage()
-                modelMessages = modelMessages + newToolMsg
-                newTurnMessages.add(newToolMsg)
-            }
+            modelMessages = appendCompletedToolMessages(modelMessages, newTurnMessages, completedTools)
             completedTools.firstOutcomeUnknownError()?.let { error ->
                 emit(LoopEvent.Failed(error))
                 emit(failedFinish(history + newTurnMessages, retryAvailable = false, error))
@@ -277,6 +273,20 @@ class AgenticLoopImpl(
         }
         emit(LoopEvent.Failed(AssistantError.Cancelled))
         emit(LoopEvent.Finished(LoopOutcome.STOPPED, history + newTurnMessages, retryAvailable = false))
+    }
+
+    private fun appendCompletedToolMessages(
+        modelMessages: List<AssistantMessage>,
+        newTurnMessages: MutableList<AssistantMessage>,
+        completedTools: List<CompletedToolCall>,
+    ): List<AssistantMessage> {
+        var updatedModelMessages = modelMessages
+        completedTools.forEach { completed ->
+            val newToolMsg = completed.toToolMessage()
+            updatedModelMessages = updatedModelMessages + newToolMsg
+            newTurnMessages.add(newToolMsg)
+        }
+        return updatedModelMessages
     }
 
     private data class StreamResult(

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -11,6 +11,7 @@ import com.woocommerce.android.aiassistant.core.chat.ToolDefinition
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
 import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import com.woocommerce.android.aiassistant.core.chat.toAssistantError
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationDecision
 import com.woocommerce.android.aiassistant.core.safety.SafetyDecision
@@ -95,6 +96,11 @@ class AgenticLoopImpl(
                 val newToolMsg = completed.toToolMessage()
                 modelMessages = modelMessages + newToolMsg
                 newTurnMessages.add(newToolMsg)
+            }
+            completedTools.firstOutcomeUnknownError()?.let { error ->
+                emit(LoopEvent.Failed(error))
+                emit(failedFinish(history + newTurnMessages, retryAvailable = false, error))
+                return@flow
             }
             iteration++
         }
@@ -201,7 +207,7 @@ class AgenticLoopImpl(
         for (r in assembledResults) {
             if (r is ToolCallAssembler.AssemblyResult.MalformedArguments) {
                 val result = ToolResult.ValidationError(r.callId, "Malformed arguments for ${r.toolName}")
-                completedTools += CompletedToolCall(r.toHistoryToolCall(), result)
+                completedTools += CompletedToolCall(r.toHistoryToolCall(), result, ToolSafetyLevel.SAFE)
                 emit(LoopEvent.ToolCallFinished(result))
             }
         }
@@ -209,7 +215,7 @@ class AgenticLoopImpl(
             val descriptor = toolDescriptors.find { it.name == call.name }
             val result = executeToolIfAllowed(call, descriptor)
                 ?: return ToolExecutionOutcome.Cancelled(completedTools)
-            completedTools += CompletedToolCall(call, result)
+            completedTools += CompletedToolCall(call, result, descriptor?.safetyLevel ?: ToolSafetyLevel.SAFE)
             emit(LoopEvent.ToolCallFinished(result))
         }
         return ToolExecutionOutcome.Completed(completedTools)
@@ -293,7 +299,19 @@ class AgenticLoopImpl(
     private data class CompletedToolCall(
         val historyToolCall: ToolCall,
         val result: ToolResult,
+        val safetyLevel: ToolSafetyLevel,
     )
+
+    private fun List<CompletedToolCall>.firstOutcomeUnknownError(): AssistantError.OutcomeUnknown? =
+        firstNotNullOfOrNull { completed ->
+            val isUnknownWriteOutcome = completed.safetyLevel == ToolSafetyLevel.UNSAFE &&
+                completed.result is ToolResult.TransportError
+            if (isUnknownWriteOutcome) {
+                AssistantError.OutcomeUnknown(toolName = completed.historyToolCall.name)
+            } else {
+                null
+            }
+        }
 
     private fun messagesWithPartialText(
         messages: List<AssistantMessage>,

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/RetryPolicy.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/RetryPolicy.kt
@@ -23,8 +23,8 @@ object ConservativeRetryPolicy : RetryPolicy {
     private const val BACKOFF_MS = 500L
 
     override fun decide(failure: LoopFailureContext): RetryDecision = when {
-        failure.visibleOutputStarted -> RetryDecision.ShowManualRetry
         !isRetryable(failure.error) -> RetryDecision.DoNotRetry
+        failure.visibleOutputStarted -> RetryDecision.ShowManualRetry
         failure.retryCount >= MAX_AUTO_RETRIES -> RetryDecision.ShowManualRetry
         else -> RetryDecision.RetryNow(BACKOFF_MS)
     }

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -610,6 +610,59 @@ class AgenticLoopImplTest {
     }
 
     @Test
+    fun `given confirmed unsafe tool returns transport error, when running turn, then outcome unknown fails without retry`() =
+        runTest {
+            val unsafeDescriptor = ToolDescriptor(
+                name = "orders_update",
+                description = "Updates an order",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.UNSAFE,
+            )
+            val registry = object : ToolRegistry {
+                override fun descriptors() = listOf(unsafeDescriptor)
+
+                override suspend fun execute(call: ToolCall): ToolResult =
+                    ToolResult.TransportError(toolCallId = call.id, retryable = true)
+            }
+            val safetyOrchestrator = SafetyOrchestratorImpl()
+            val loop = loopWith(
+                flow {
+                    emit(
+                        AssistantEvent.ToolCallDelta(
+                            index = 0,
+                            id = "call_1",
+                            name = "orders_update",
+                            argumentsDelta = """{"id":42,"status":"processing"}""",
+                        )
+                    )
+                    emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
+                },
+                registry = registry,
+                safetyOrchestrator = safetyOrchestrator,
+            )
+            val events = mutableListOf<LoopEvent>()
+
+            val job = launch {
+                loop.runTurn("conv", "update order", history, contextWithTools(unsafeDescriptor)).toList(events)
+            }
+
+            runCurrent()
+            val request = events.filterIsInstance<LoopEvent.ConfirmationRequested>().single().request
+            safetyOrchestrator.confirm(request.id)
+            advanceUntilIdle()
+
+            val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+            assertThat(finished.outcome).isEqualTo(LoopOutcome.FAILED)
+            assertThat(finished.retryAvailable).isFalse()
+            assertThat(finished.error).isEqualTo(AssistantError.OutcomeUnknown(toolName = "orders_update"))
+            assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>().single().result)
+                .isEqualTo(ToolResult.TransportError(toolCallId = "call_1", retryable = true))
+            assertThat(finished.updatedHistory.filterIsInstance<AssistantMessage.Tool>().single().toolCallId)
+                .isEqualTo("call_1")
+            job.cancel()
+        }
+
+    @Test
     fun `given UNSAFE tool is cancelled, when loop awaits confirmation, then cancelled error is emitted and history is clean`() = runTest {
         val unsafeDescriptor = ToolDescriptor(
             name = "orders_update",

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -955,7 +955,7 @@ class AgenticLoopImplTest {
 
         val finished = events.filterIsInstance<LoopEvent.Finished>().last()
         assertThat(finished.outcome).isEqualTo(LoopOutcome.FAILED)
-        assertThat(finished.retryAvailable).isTrue
+        assertThat(finished.retryAvailable).isFalse()
         assertThat(finished.error).isEqualTo(AssistantError.UpstreamFailure)
     }
 

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/RetryPolicyTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/RetryPolicyTest.kt
@@ -64,6 +64,28 @@ class RetryPolicyTest {
     }
 
     @Test
+    fun `given upstream failure after visible output, when deciding, then DoNotRetry is returned`() {
+        val decision = policy.decide(
+            LoopFailureContext(AssistantError.UpstreamFailure, visibleOutputStarted = true, retryCount = 0)
+        )
+
+        assertThat(decision).isEqualTo(RetryDecision.DoNotRetry)
+    }
+
+    @Test
+    fun `given outcome unknown after visible output, when deciding, then DoNotRetry is returned`() {
+        val decision = policy.decide(
+            LoopFailureContext(
+                AssistantError.OutcomeUnknown(toolName = "orders_update"),
+                visibleOutputStarted = true,
+                retryCount = 0,
+            )
+        )
+
+        assertThat(decision).isEqualTo(RetryDecision.DoNotRetry)
+    }
+
+    @Test
     fun `given network error and retry count at max, when deciding, then ShowManualRetry is returned`() {
         val decision = policy.decide(
             LoopFailureContext(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatColors.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatColors.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.aiassistant.ui
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.graphics.Color
+
+internal fun ColorScheme.assistantInlineErrorTextColor(): Color = error

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -359,9 +359,31 @@ private fun AssistantStatusPanel(
                 onCancelWrite = onCancelWrite,
             )
         }
+        AssistantUiStatus.ERROR -> {
+            if (state.shouldShowFallbackError) {
+                AssistantFallbackErrorPanel(error = state.error)
+            }
+        }
         AssistantUiStatus.IDLE,
-        AssistantUiStatus.STREAMING,
-        AssistantUiStatus.ERROR -> Unit
+        AssistantUiStatus.STREAMING -> Unit
+    }
+}
+
+@Composable
+private fun AssistantFallbackErrorPanel(error: AssistantUiError?) {
+    if (error == null) return
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.errorContainer)
+            .padding(16.dp),
+    ) {
+        Text(
+            text = stringResource(error.toMessageRes()),
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            style = MaterialTheme.typography.bodyMedium,
+        )
     }
 }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.aiassistant.R
+import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.runtime.AssistantPendingConfirmation
 import kotlinx.serialization.json.buildJsonObject
@@ -136,11 +137,11 @@ fun AssistantChatScreen(
         ) {
             AssistantMessageThread(
                 messages = state.messages,
+                onRetry = onRetry,
                 modifier = Modifier.weight(1f),
             )
             AssistantStatusPanel(
                 state = state,
-                onRetry = onRetry,
                 onConfirmWrite = onConfirmWrite,
                 onCancelWrite = onCancelWrite,
             )
@@ -217,6 +218,7 @@ private fun AssistantStatusLabel(status: AssistantUiStatus) {
 @Composable
 private fun AssistantMessageThread(
     messages: List<AssistantUiMessage>,
+    onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
@@ -236,13 +238,19 @@ private fun AssistantMessageThread(
             items = messages,
             key = { it.id },
         ) { message ->
-            AssistantMessageBubble(message = message)
+            AssistantMessageBubble(
+                message = message,
+                onRetry = onRetry,
+            )
         }
     }
 }
 
 @Composable
-private fun AssistantMessageBubble(message: AssistantUiMessage) {
+private fun AssistantMessageBubble(
+    message: AssistantUiMessage,
+    onRetry: () -> Unit,
+) {
     val isUser = message.role == AssistantUiMessage.Role.USER
     val messageText = message.text.ifEmpty { " " }
     val messageContentDescription = if (isUser) {
@@ -288,12 +296,52 @@ private fun AssistantMessageBubble(message: AssistantUiMessage) {
                 .padding(horizontal = 14.dp, vertical = 10.dp),
             contentAlignment = Alignment.CenterStart,
         ) {
-            Text(
-                text = messageText,
-                color = textColor,
-                style = MaterialTheme.typography.bodyMedium,
-                textAlign = if (isUser) TextAlign.End else TextAlign.Start,
-            )
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                if (message.text.isNotEmpty()) {
+                    Text(
+                        text = message.text,
+                        color = textColor,
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = if (isUser) TextAlign.End else TextAlign.Start,
+                    )
+                }
+                message.error?.let { error ->
+                    AssistantInlineError(
+                        error = error,
+                        onRetry = onRetry,
+                    )
+                }
+                if (message.text.isEmpty() && message.error == null) {
+                    Text(
+                        text = " ",
+                        color = textColor,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AssistantInlineError(
+    error: AssistantMessageError,
+    onRetry: () -> Unit,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = error.error.toDisplayText(),
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        if (error.canRetry) {
+            TextButton(onClick = onRetry) {
+                Text(stringResource(R.string.assistant_chat_retry))
+            }
         }
     }
 }
@@ -301,12 +349,10 @@ private fun AssistantMessageBubble(message: AssistantUiMessage) {
 @Composable
 private fun AssistantStatusPanel(
     state: AssistantUiState,
-    onRetry: () -> Unit,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
 ) {
     when (state.status) {
-        AssistantUiStatus.ERROR -> AssistantErrorPanel(state.error, state.canRetry, onRetry)
         AssistantUiStatus.AWAITING_CONFIRMATION -> state.pendingConfirmation?.let {
             AssistantConfirmationPanel(
                 confirmation = it,
@@ -315,35 +361,8 @@ private fun AssistantStatusPanel(
             )
         }
         AssistantUiStatus.IDLE,
-        AssistantUiStatus.STREAMING -> Unit
-    }
-}
-
-@Composable
-private fun AssistantErrorPanel(
-    error: AssistantUiError?,
-    canRetry: Boolean,
-    onRetry: () -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.errorContainer)
-            .padding(horizontal = 16.dp, vertical = 10.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = error.toDisplayText(),
-            color = MaterialTheme.colorScheme.onErrorContainer,
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.weight(1f),
-        )
-        if (canRetry) {
-            TextButton(onClick = onRetry) {
-                Text(stringResource(R.string.assistant_chat_retry))
-            }
-        }
+        AssistantUiStatus.STREAMING,
+        AssistantUiStatus.ERROR -> Unit
     }
 }
 
@@ -470,6 +489,9 @@ private fun AssistantUiError?.toDisplayText(): String = when (this) {
     AssistantUiError.UNKNOWN,
     null -> stringResource(R.string.assistant_chat_error_unknown)
 }
+
+@Composable
+private fun AssistantError.toDisplayText(): String = toAssistantUiError().toDisplayText()
 
 @Preview(showBackground = true, widthDp = 390, heightDp = 720)
 @Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 720, uiMode = UI_MODE_NIGHT_YES)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -54,7 +54,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.aiassistant.R
-import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.runtime.AssistantPendingConfirmation
 import kotlinx.serialization.json.buildJsonObject
@@ -334,7 +333,7 @@ private fun AssistantInlineError(
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Text(
-            text = error.error.toDisplayText(),
+            text = stringResource(error.error.toMessageRes()),
             color = MaterialTheme.colorScheme.onErrorContainer,
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -472,26 +471,6 @@ private fun AssistantUiStatus.toHeaderText(): String = when (this) {
     )
     AssistantUiStatus.ERROR -> stringResource(R.string.assistant_chat_status_error)
 }
-
-@Composable
-private fun AssistantUiError?.toDisplayText(): String = when (this) {
-    AssistantUiError.NETWORK -> stringResource(R.string.assistant_chat_error_network)
-    AssistantUiError.AUTH -> stringResource(R.string.assistant_chat_error_auth)
-    AssistantUiError.RATE_LIMIT -> stringResource(R.string.assistant_chat_error_rate_limit)
-    AssistantUiError.TIMEOUT -> stringResource(R.string.assistant_chat_error_timeout)
-    AssistantUiError.UPSTREAM_FAILURE -> stringResource(R.string.assistant_chat_error_upstream_failure)
-    AssistantUiError.TOOL_FAILED -> stringResource(R.string.assistant_chat_error_tool_failed)
-    AssistantUiError.INVALID_TOOL_CALL -> stringResource(R.string.assistant_chat_error_invalid_tool_call)
-    AssistantUiError.OUTCOME_UNKNOWN -> stringResource(R.string.assistant_chat_error_outcome_unknown)
-    AssistantUiError.CANCELLED -> stringResource(R.string.assistant_chat_error_cancelled)
-    AssistantUiError.CONFIRMATION_DEFERRED -> stringResource(R.string.assistant_chat_error_confirmation_deferred)
-    AssistantUiError.MAX_ITERATIONS -> stringResource(R.string.assistant_chat_error_max_iterations)
-    AssistantUiError.UNKNOWN,
-    null -> stringResource(R.string.assistant_chat_error_unknown)
-}
-
-@Composable
-private fun AssistantError.toDisplayText(): String = toAssistantUiError().toDisplayText()
 
 @Preview(showBackground = true, widthDp = 390, heightDp = 720)
 @Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 720, uiMode = UI_MODE_NIGHT_YES)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -334,7 +334,7 @@ private fun AssistantInlineError(
     ) {
         Text(
             text = stringResource(error.error.toMessageRes()),
-            color = MaterialTheme.colorScheme.onErrorContainer,
+            color = MaterialTheme.colorScheme.assistantInlineErrorTextColor(),
             style = MaterialTheme.typography.bodyMedium,
         )
         if (error.canRetry) {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -30,12 +30,18 @@ data class AssistantUiMessage(
     val id: String,
     val role: Role,
     val text: String,
+    val error: AssistantMessageError? = null,
 ) {
     enum class Role {
         USER,
         ASSISTANT,
     }
 }
+
+data class AssistantMessageError(
+    val error: AssistantError,
+    val canRetry: Boolean,
+)
 
 enum class AssistantUiError {
     NETWORK,
@@ -65,4 +71,11 @@ fun AssistantError.toAssistantUiError(): AssistantUiError = when (this) {
     is AssistantError.OutcomeUnknown -> AssistantUiError.OUTCOME_UNKNOWN
     AssistantError.Cancelled -> AssistantUiError.CANCELLED
     is AssistantError.Unknown -> AssistantUiError.UNKNOWN
+}
+
+internal fun AssistantError.supportsRetryAction(): Boolean = when (this) {
+    AssistantError.Network,
+    AssistantError.Timeout,
+    AssistantError.RateLimit -> true
+    else -> false
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -19,6 +19,11 @@ data class AssistantUiState(
     val isTurnActive: Boolean
         get() = status == AssistantUiStatus.STREAMING ||
             status == AssistantUiStatus.AWAITING_CONFIRMATION
+
+    val shouldShowFallbackError: Boolean
+        get() = status == AssistantUiStatus.ERROR &&
+            error != null &&
+            messages.lastOrNull()?.error == null
 }
 
 enum class AssistantUiStatus {
@@ -94,4 +99,20 @@ internal fun AssistantError.toMessageRes(): Int = when (this) {
     is AssistantError.OutcomeUnknown -> R.string.assistant_chat_error_outcome_unknown
     AssistantError.Cancelled -> R.string.assistant_chat_error_cancelled
     is AssistantError.Unknown -> R.string.assistant_chat_error_unknown
+}
+
+@StringRes
+internal fun AssistantUiError.toMessageRes(): Int = when (this) {
+    AssistantUiError.NETWORK -> R.string.assistant_chat_error_network
+    AssistantUiError.AUTH -> R.string.assistant_chat_error_auth
+    AssistantUiError.RATE_LIMIT -> R.string.assistant_chat_error_rate_limit
+    AssistantUiError.TIMEOUT -> R.string.assistant_chat_error_timeout
+    AssistantUiError.UPSTREAM_FAILURE -> R.string.assistant_chat_error_upstream_failure
+    AssistantUiError.TOOL_FAILED -> R.string.assistant_chat_error_tool_failed
+    AssistantUiError.INVALID_TOOL_CALL -> R.string.assistant_chat_error_invalid_tool_call
+    AssistantUiError.OUTCOME_UNKNOWN -> R.string.assistant_chat_error_outcome_unknown
+    AssistantUiError.CANCELLED -> R.string.assistant_chat_error_cancelled
+    AssistantUiError.CONFIRMATION_DEFERRED -> R.string.assistant_chat_error_confirmation_deferred
+    AssistantUiError.MAX_ITERATIONS -> R.string.assistant_chat_error_max_iterations
+    AssistantUiError.UNKNOWN -> R.string.assistant_chat_error_unknown
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -1,5 +1,7 @@
 package com.woocommerce.android.aiassistant.ui
 
+import androidx.annotation.StringRes
+import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.runtime.AssistantPendingConfirmation
 
@@ -78,4 +80,18 @@ internal fun AssistantError.supportsRetryAction(): Boolean = when (this) {
     AssistantError.Timeout,
     AssistantError.RateLimit -> true
     else -> false
+}
+
+@StringRes
+internal fun AssistantError.toMessageRes(): Int = when (this) {
+    AssistantError.Network -> R.string.assistant_chat_error_network
+    AssistantError.Auth -> R.string.assistant_chat_error_auth
+    AssistantError.RateLimit -> R.string.assistant_chat_error_rate_limit
+    AssistantError.Timeout -> R.string.assistant_chat_error_timeout
+    AssistantError.UpstreamFailure -> R.string.assistant_chat_error_upstream_failure
+    is AssistantError.ToolFailed -> R.string.assistant_chat_error_tool_failed
+    is AssistantError.InvalidToolCall -> R.string.assistant_chat_error_invalid_tool_call
+    is AssistantError.OutcomeUnknown -> R.string.assistant_chat_error_outcome_unknown
+    AssistantError.Cancelled -> R.string.assistant_chat_error_cancelled
+    is AssistantError.Unknown -> R.string.assistant_chat_error_unknown
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -177,13 +177,22 @@ class AssistantViewModel @AssistedInject constructor(
                 }
             }
             is AssistantRuntimeEvent.Finished -> {
+                val activeMessageId = activeAssistantMessageId
+                val normalizedError = event.normalizedAssistantError()
+                val canRetry = event.canRetry()
                 activeAssistantMessageId = null
                 history = event.updatedHistory
                 _uiState.update {
                     it.copy(
+                        messages = it.messages.withAssistantError(
+                            activeMessageId = activeMessageId,
+                            error = normalizedError,
+                            canRetry = canRetry,
+                            nextId = idGenerator::nextId,
+                        ),
                         status = event.toAssistantUiStatus(),
                         error = event.toAssistantUiError(),
-                        canRetry = event.canRetry(),
+                        canRetry = canRetry,
                         pendingConfirmation = null,
                     )
                 }
@@ -242,10 +251,41 @@ class AssistantViewModel @AssistedInject constructor(
             LoopOutcome.MAX_ITERATIONS -> AssistantUiError.MAX_ITERATIONS
         }
 
+    private fun AssistantRuntimeEvent.Finished.normalizedAssistantError(): AssistantError? =
+        error ?: if (outcome == LoopOutcome.FAILED) AssistantError.Unknown() else null
+
     private fun AssistantRuntimeEvent.Finished.canRetry(): Boolean =
         error != AssistantError.Cancelled &&
             outcome == LoopOutcome.FAILED &&
             retryAvailable
+
+    private fun List<AssistantUiMessage>.withAssistantError(
+        activeMessageId: String?,
+        error: AssistantError?,
+        canRetry: Boolean,
+        nextId: () -> String,
+    ): List<AssistantUiMessage> {
+        if (error == null) return this
+
+        val messageError = AssistantMessageError(error = error, canRetry = canRetry)
+        val targetId = activeMessageId
+        if (targetId == null) {
+            return this + AssistantUiMessage(
+                id = nextId(),
+                role = AssistantUiMessage.Role.ASSISTANT,
+                text = "",
+                error = messageError,
+            )
+        }
+
+        return map { message ->
+            if (message.id == targetId) {
+                message.copy(error = messageError)
+            } else {
+                message
+            }
+        }
+    }
 
     @AssistedFactory
     interface Factory {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -49,7 +49,7 @@ class AssistantViewModel @AssistedInject constructor(
     }
 
     fun onRetry() {
-        if (_uiState.value.isTurnActive) return
+        if (_uiState.value.isTurnActive || !_uiState.value.canRetry) return
 
         val message = lastUserMessage ?: return
         startTurn(message, isRetry = true)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -255,9 +255,9 @@ class AssistantViewModel @AssistedInject constructor(
         error ?: if (outcome == LoopOutcome.FAILED) AssistantError.Unknown() else null
 
     private fun AssistantRuntimeEvent.Finished.canRetry(): Boolean =
-        error != AssistantError.Cancelled &&
-            outcome == LoopOutcome.FAILED &&
-            retryAvailable
+        outcome == LoopOutcome.FAILED &&
+            retryAvailable &&
+            error?.supportsRetryAction() == true
 
     private fun List<AssistantUiMessage>.withAssistantError(
         activeMessageId: String?,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -142,7 +142,7 @@ class AssistantViewModel @AssistedInject constructor(
                 )
             }
             state.copy(
-                messages = state.messages + turnMessages,
+                messages = state.messages.withoutRetryActions() + turnMessages,
                 status = AssistantUiStatus.STREAMING,
                 error = null,
                 canRetry = false,
@@ -258,6 +258,16 @@ class AssistantViewModel @AssistedInject constructor(
         outcome == LoopOutcome.FAILED &&
             retryAvailable &&
             error?.supportsRetryAction() == true
+
+    private fun List<AssistantUiMessage>.withoutRetryActions(): List<AssistantUiMessage> =
+        map { message ->
+            val error = message.error
+            if (error?.canRetry == true) {
+                message.copy(error = error.copy(canRetry = false))
+            } else {
+                message
+            }
+        }
 
     private fun List<AssistantUiMessage>.withAssistantError(
         activeMessageId: String?,

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -62,7 +62,7 @@
     <string name="assistant_chat_error_upstream_failure">Assistant service error</string>
     <string name="assistant_chat_error_tool_failed">Tool failed</string>
     <string name="assistant_chat_error_invalid_tool_call">Invalid tool call</string>
-    <string name="assistant_chat_error_outcome_unknown">Outcome unknown</string>
+    <string name="assistant_chat_error_outcome_unknown">I\'m not sure whether that change was applied. Please verify in your store before trying anything else.</string>
     <string name="assistant_chat_error_cancelled">Request cancelled</string>
     <string name="assistant_chat_error_confirmation_deferred">Confirmation is not available yet</string>
     <string name="assistant_chat_error_max_iterations">Assistant reached its turn limit</string>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -55,16 +55,16 @@
     <string name="assistant_chat_confirm_tool">Confirm %1$s?</string>
     <string name="assistant_chat_confirm">Confirm</string>
     <string name="assistant_chat_cancel">Cancel</string>
-    <string name="assistant_chat_error_network">Network error</string>
-    <string name="assistant_chat_error_auth">Authentication error</string>
-    <string name="assistant_chat_error_rate_limit">Rate limit reached</string>
-    <string name="assistant_chat_error_timeout">Request timed out</string>
-    <string name="assistant_chat_error_upstream_failure">Assistant service error</string>
-    <string name="assistant_chat_error_tool_failed">Tool failed</string>
-    <string name="assistant_chat_error_invalid_tool_call">Invalid tool call</string>
+    <string name="assistant_chat_error_network">Couldn\'t connect. Check your connection and try again.</string>
+    <string name="assistant_chat_error_auth">The assistant couldn\'t access your store. Please sign in again, then reopen the assistant.</string>
+    <string name="assistant_chat_error_rate_limit">The assistant is busy right now. Try again in a moment.</string>
+    <string name="assistant_chat_error_timeout">The request timed out. Try again.</string>
+    <string name="assistant_chat_error_upstream_failure">The assistant service couldn\'t finish this response. Please try again later.</string>
+    <string name="assistant_chat_error_tool_failed">The assistant couldn\'t complete that store action.</string>
+    <string name="assistant_chat_error_invalid_tool_call">The assistant couldn\'t complete that request.</string>
     <string name="assistant_chat_error_outcome_unknown">I\'m not sure whether that change was applied. Please verify in your store before trying anything else.</string>
-    <string name="assistant_chat_error_cancelled">Request cancelled</string>
-    <string name="assistant_chat_error_confirmation_deferred">Confirmation is not available yet</string>
-    <string name="assistant_chat_error_max_iterations">Assistant reached its turn limit</string>
-    <string name="assistant_chat_error_unknown">Something went wrong</string>
+    <string name="assistant_chat_error_cancelled">Request stopped.</string>
+    <string name="assistant_chat_error_confirmation_deferred">Confirmation isn\'t available yet. Please try again from the chat.</string>
+    <string name="assistant_chat_error_max_iterations">The assistant couldn\'t finish after several steps.</string>
+    <string name="assistant_chat_error_unknown">Something went wrong while the assistant was working.</string>
 </resources>

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -1,9 +1,23 @@
 package com.woocommerce.android.aiassistant.ui
 
+import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class AssistantUiStateTest {
+    @Test
+    fun `given transient assistant errors, when checking retry action support, then retry is supported`() {
+        val retryableErrors = listOf(
+            AssistantError.Network,
+            AssistantError.Timeout,
+            AssistantError.RateLimit,
+        )
+
+        retryableErrors.forEach { error ->
+            assertThat(error.supportsRetryAction()).isTrue()
+        }
+    }
+
     @Test
     fun `when status is streaming, then turn is active`() {
         val state = AssistantUiState(status = AssistantUiStatus.STREAMING)

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -48,6 +48,61 @@ class AssistantUiStateTest {
     }
 
     @Test
+    fun `given error state with no inline message error, when checking fallback, then fallback is visible`() {
+        val state = AssistantUiState(
+            status = AssistantUiStatus.ERROR,
+            error = AssistantUiError.MAX_ITERATIONS,
+            messages = listOf(
+                AssistantUiMessage(
+                    id = "message-1",
+                    role = AssistantUiMessage.Role.USER,
+                    text = "Hello",
+                ),
+                AssistantUiMessage(
+                    id = "message-2",
+                    role = AssistantUiMessage.Role.ASSISTANT,
+                    text = "",
+                ),
+            ),
+        )
+
+        assertThat(state.shouldShowFallbackError).isTrue()
+        assertThat(requireNotNull(state.error).toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_max_iterations)
+    }
+
+    @Test
+    fun `given error state with inline message error, when checking fallback, then fallback is hidden`() {
+        val state = AssistantUiState(
+            status = AssistantUiStatus.ERROR,
+            error = AssistantUiError.NETWORK,
+            messages = listOf(
+                AssistantUiMessage(
+                    id = "message-1",
+                    role = AssistantUiMessage.Role.ASSISTANT,
+                    text = "",
+                    error = AssistantMessageError(
+                        error = AssistantError.Network,
+                        canRetry = true,
+                    ),
+                ),
+            ),
+        )
+
+        assertThat(state.shouldShowFallbackError).isFalse()
+    }
+
+    @Test
+    fun `given ui errors, when mapping to message resources, then fallback copy resources are returned`() {
+        assertThat(AssistantUiError.CONFIRMATION_DEFERRED.toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_confirmation_deferred)
+        assertThat(AssistantUiError.MAX_ITERATIONS.toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_max_iterations)
+        assertThat(AssistantUiError.CANCELLED.toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_cancelled)
+    }
+
+    @Test
     fun `when status is streaming, then turn is active`() {
         val state = AssistantUiState(status = AssistantUiStatus.STREAMING)
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -1,11 +1,25 @@
 package com.woocommerce.android.aiassistant.ui
 
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class AssistantUiStateTest {
+    @Test
+    fun `given inline error is on assistant bubble, when resolving text color, then use error color`() {
+        val colorScheme = lightColorScheme(
+            error = Color.Red,
+            onErrorContainer = Color.White,
+            surface = Color.White,
+        )
+
+        assertThat(colorScheme.assistantInlineErrorTextColor()).isEqualTo(Color.Red)
+        assertThat(colorScheme.assistantInlineErrorTextColor()).isNotEqualTo(colorScheme.onErrorContainer)
+    }
+
     @Test
     fun `given transient assistant errors, when checking retry action support, then retry is supported`() {
         val retryableErrors = listOf(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.aiassistant.ui
 
+import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -16,6 +17,34 @@ class AssistantUiStateTest {
         retryableErrors.forEach { error ->
             assertThat(error.supportsRetryAction()).isTrue()
         }
+    }
+
+    @Test
+    fun `given assistant errors, when mapping to message resources, then product copy resources are returned`() {
+        assertThat(AssistantError.Network.toMessageRes()).isEqualTo(R.string.assistant_chat_error_network)
+        assertThat(AssistantError.Timeout.toMessageRes()).isEqualTo(R.string.assistant_chat_error_timeout)
+        assertThat(AssistantError.RateLimit.toMessageRes()).isEqualTo(R.string.assistant_chat_error_rate_limit)
+        assertThat(AssistantError.Auth.toMessageRes()).isEqualTo(R.string.assistant_chat_error_auth)
+        assertThat(AssistantError.UpstreamFailure.toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_upstream_failure)
+        assertThat(AssistantError.ToolFailed(toolName = "orders_update").toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_tool_failed)
+        assertThat(AssistantError.InvalidToolCall(toolName = "orders_update").toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_invalid_tool_call)
+        assertThat(AssistantError.OutcomeUnknown(toolName = "orders_update").toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_outcome_unknown)
+        assertThat(AssistantError.Cancelled.toMessageRes()).isEqualTo(R.string.assistant_chat_error_cancelled)
+        assertThat(AssistantError.Unknown().toMessageRes()).isEqualTo(R.string.assistant_chat_error_unknown)
+    }
+
+    @Test
+    fun `given raw throwable messages, when mapping errors, then raw messages are not used`() {
+        val rawCause = IllegalStateException("raw upstream token abc123")
+
+        assertThat(AssistantError.Unknown(cause = rawCause).toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_unknown)
+        assertThat(AssistantError.ToolFailed(toolName = "orders_update", cause = rawCause).toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_tool_failed)
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -325,6 +325,10 @@ class AssistantViewModelTest {
 
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.ERROR)
         assertThat(viewModel.uiState.value.error).isEqualTo(AssistantUiError.MAX_ITERATIONS)
+        assertThat(viewModel.uiState.value.shouldShowFallbackError).isTrue()
+        assertThat(requireNotNull(viewModel.uiState.value.error).toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_max_iterations)
+        assertThat(viewModel.uiState.value.messages.last().error).isNull()
         assertThat(viewModel.uiState.value.canRetry).isFalse()
         assertThat(viewModel.uiState.value.isTurnActive).isFalse()
     }
@@ -419,6 +423,71 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given retryable failed turn, when a new turn starts, then previous retry action is disabled`() = runTest {
+        viewModel.onSendMessage("First")
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.FAILED,
+                updatedHistory = listOf(AssistantMessage.User("First")),
+                retryAvailable = true,
+                error = AssistantError.Network,
+            )
+        )
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.messages.last().error?.canRetry).isTrue()
+
+        viewModel.onSendMessage("Second")
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.messages.first { it.text.isEmpty() }.error?.canRetry).isFalse()
+        assertThat(viewModel.uiState.value.canRetry).isFalse()
+        assertThat(runtime.retryRequests).isEmpty()
+    }
+
+    @Test
+    fun `given two retryable failed turns, when retry is requested, then latest failed turn is retried`() = runTest {
+        viewModel.onSendMessage("First")
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.FAILED,
+                updatedHistory = listOf(AssistantMessage.User("First")),
+                retryAvailable = true,
+                error = AssistantError.Network,
+            )
+        )
+        advanceUntilIdle()
+
+        viewModel.onSendMessage("Second")
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.FAILED,
+                updatedHistory = listOf(
+                    AssistantMessage.User("First"),
+                    AssistantMessage.User("Second"),
+                ),
+                retryAvailable = true,
+                error = AssistantError.Timeout,
+            )
+        )
+        advanceUntilIdle()
+
+        val messageErrors = viewModel.uiState.value.messages.mapNotNull { it.error }
+        assertThat(messageErrors.map { it.canRetry }).containsExactly(false, true)
+
+        viewModel.onRetry()
+
+        assertThat(runtime.retryRequests).containsExactly(
+            AssistantTurnRequest(
+                conversationId = CONVERSATION_ID,
+                siteId = SITE_ID,
+                toolScope = ToolScope.GLOBAL,
+                userMessage = "Second",
+                history = listOf(AssistantMessage.User("First")),
+            )
+        )
+    }
+
+    @Test
     fun `when runtime awaits confirmation, then state exposes pending confirmation`() = runTest {
         viewModel.onSendMessage("Cancel order 123")
         val confirmation = AssistantPendingConfirmation(
@@ -447,6 +516,10 @@ class AssistantViewModelTest {
         assertThat(runtime.cancelledConversationIds).containsExactly(CONVERSATION_ID)
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.ERROR)
         assertThat(viewModel.uiState.value.error).isEqualTo(AssistantUiError.CANCELLED)
+        assertThat(viewModel.uiState.value.shouldShowFallbackError).isTrue()
+        assertThat(requireNotNull(viewModel.uiState.value.error).toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_cancelled)
+        assertThat(viewModel.uiState.value.messages.last().error).isNull()
         assertThat(viewModel.uiState.value.canRetry).isFalse()
         assertThat(viewModel.uiState.value.pendingConfirmation).isNull()
         assertThat(viewModel.uiState.value.isTurnActive).isFalse()
@@ -643,6 +716,10 @@ class AssistantViewModelTest {
         assertThat(runtime.confirmedConfirmationIds).containsExactly("confirmation-1")
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.ERROR)
         assertThat(viewModel.uiState.value.error).isEqualTo(AssistantUiError.CONFIRMATION_DEFERRED)
+        assertThat(viewModel.uiState.value.shouldShowFallbackError).isTrue()
+        assertThat(requireNotNull(viewModel.uiState.value.error).toMessageRes())
+            .isEqualTo(R.string.assistant_chat_error_confirmation_deferred)
+        assertThat(viewModel.uiState.value.messages.last().error).isNull()
         assertThat(viewModel.uiState.value.pendingConfirmation).isNull()
     }
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -204,6 +204,45 @@ class AssistantViewModelTest {
         }
 
     @Test
+    fun `given outcome unknown failure, when turn fails, then verify message has no retry action`() =
+        runTest {
+            viewModel.onSendMessage("Update order 42")
+            val activeAssistantId = viewModel.uiState.value.messages.last().id
+
+            runtime.emit(
+                AssistantRuntimeEvent.Finished(
+                    outcome = LoopOutcome.FAILED,
+                    updatedHistory = listOf(
+                        AssistantMessage.User("Update order 42"),
+                        AssistantMessage.Assistant("I'll update that order."),
+                    ),
+                    retryAvailable = false,
+                    error = AssistantError.OutcomeUnknown(toolName = "orders_update"),
+                )
+            )
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state.status).isEqualTo(AssistantUiStatus.ERROR)
+            assertThat(state.canRetry).isFalse()
+            assertThat(state.messages.last()).isEqualTo(
+                AssistantUiMessage(
+                    id = activeAssistantId,
+                    role = AssistantUiMessage.Role.ASSISTANT,
+                    text = "",
+                    error = AssistantMessageError(
+                        error = AssistantError.OutcomeUnknown(toolName = "orders_update"),
+                        canRetry = false,
+                    ),
+                )
+            )
+
+            viewModel.onRetry()
+
+            assertThat(runtime.retryRequests).isEmpty()
+        }
+
+    @Test
     fun `when turn reaches max iterations, then state exposes an error`() = runTest {
         viewModel.onSendMessage("Hello")
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -160,6 +160,50 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given network failure with retry available, when turn fails, then active assistant message exposes retry`() =
+        runTest {
+            viewModel.onSendMessage("Hello")
+            val activeAssistantId = viewModel.uiState.value.messages.last().id
+
+            runtime.emit(
+                AssistantRuntimeEvent.Finished(
+                    outcome = LoopOutcome.FAILED,
+                    updatedHistory = listOf(AssistantMessage.User("Hello")),
+                    retryAvailable = true,
+                    error = AssistantError.Network,
+                )
+            )
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state.status).isEqualTo(AssistantUiStatus.ERROR)
+            assertThat(state.canRetry).isTrue()
+            assertThat(state.messages.last()).isEqualTo(
+                AssistantUiMessage(
+                    id = activeAssistantId,
+                    role = AssistantUiMessage.Role.ASSISTANT,
+                    text = "",
+                    error = AssistantMessageError(
+                        error = AssistantError.Network,
+                        canRetry = true,
+                    ),
+                )
+            )
+
+            viewModel.onRetry()
+
+            assertThat(runtime.retryRequests).containsExactly(
+                AssistantTurnRequest(
+                    conversationId = CONVERSATION_ID,
+                    siteId = SITE_ID,
+                    toolScope = ToolScope.GLOBAL,
+                    userMessage = "Hello",
+                    history = emptyList(),
+                )
+            )
+        }
+
+    @Test
     fun `when turn reaches max iterations, then state exposes an error`() = runTest {
         viewModel.onSendMessage("Hello")
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.aiassistant.ui
 
+import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
@@ -276,6 +277,38 @@ class AssistantViewModelTest {
             viewModel.onRetry()
 
             assertThat(runtime.retryRequests).isEmpty()
+        }
+
+    @Test
+    fun `given unknown error with raw cause, when turn fails, then normalized error metadata drives the transcript`() =
+        runTest {
+            val rawCause = IllegalStateException("raw upstream token abc123")
+            val normalizedError = AssistantError.Unknown(cause = rawCause)
+            viewModel.onSendMessage("Hello")
+            val activeAssistantId = viewModel.uiState.value.messages.last().id
+
+            runtime.emit(
+                AssistantRuntimeEvent.Finished(
+                    outcome = LoopOutcome.FAILED,
+                    updatedHistory = listOf(AssistantMessage.User("Hello")),
+                    retryAvailable = false,
+                    error = normalizedError,
+                )
+            )
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.messages.last()).isEqualTo(
+                AssistantUiMessage(
+                    id = activeAssistantId,
+                    role = AssistantUiMessage.Role.ASSISTANT,
+                    text = "",
+                    error = AssistantMessageError(
+                        error = normalizedError,
+                        canRetry = false,
+                    ),
+                )
+            )
+            assertThat(normalizedError.toMessageRes()).isEqualTo(R.string.assistant_chat_error_unknown)
         }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -243,6 +243,42 @@ class AssistantViewModelTest {
         }
 
     @Test
+    fun `given upstream failure marked retryable by runtime, when turn fails, then retry is not exposed`() =
+        runTest {
+            viewModel.onSendMessage("Hello")
+            val activeAssistantId = viewModel.uiState.value.messages.last().id
+
+            runtime.emit(
+                AssistantRuntimeEvent.Finished(
+                    outcome = LoopOutcome.FAILED,
+                    updatedHistory = listOf(AssistantMessage.User("Hello")),
+                    retryAvailable = true,
+                    error = AssistantError.UpstreamFailure,
+                )
+            )
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state.status).isEqualTo(AssistantUiStatus.ERROR)
+            assertThat(state.canRetry).isFalse()
+            assertThat(state.messages.last()).isEqualTo(
+                AssistantUiMessage(
+                    id = activeAssistantId,
+                    role = AssistantUiMessage.Role.ASSISTANT,
+                    text = "",
+                    error = AssistantMessageError(
+                        error = AssistantError.UpstreamFailure,
+                        canRetry = false,
+                    ),
+                )
+            )
+
+            viewModel.onRetry()
+
+            assertThat(runtime.retryRequests).isEmpty()
+        }
+
+    @Test
     fun `when turn reaches max iterations, then state exposes an error`() = runTest {
         viewModel.onSendMessage("Hello")
 


### PR DESCRIPTION
### Description
Fixes WOOMOB-2914

This PR implements AI Assistant chat error states and retry UX on top of the Send/Stop turn cancellation work from WOOMOB-2913. The chat now shows normalized, product-owned error copy in the transcript instead of leaving failures ambiguous or exposing low-level exception details.

#### What changes for users

Transient assistant failures, such as network errors, timeouts, and rate limits, now appear as inline assistant error messages with a **Retry** action. Retrying reuses the failed turn context and clears stale retry actions from older failed turns so only the latest retryable failure can be retried.

Non-retryable failures now show final copy without a retry action. This includes upstream assistant service failures, max-iteration stops, deferred confirmations, and user cancellation states. Confirmed write operations with an unknown transport outcome are handled conservatively with verify-in-store copy and no retry action.

The inline error text uses an error color that remains readable inside the normal assistant bubble. This fixes the contrast issue found during on-device verification where error copy could render white on a light bubble.

#### Implementation details

The core loop and retry policy now preserve normalized `AssistantError` values for UI decisions. The feature layer maps those normalized errors to string resources and transcript metadata, keeping UI copy controlled by product strings rather than raw exception messages.

The chat UI renders assistant errors inline with the related assistant bubble, only exposes Retry for `Network`, `Timeout`, and `RateLimit`, and shows fallback error panels for UI-local states that do not have an inline message. The ViewModel clears old retry affordances whenever a new turn or retry starts.

#### Tests added or updated

This PR adds focused unit coverage for:

- retry availability for transient errors only
- non-retryable upstream failures and unknown write outcomes
- fallback visibility for max-iteration, deferred confirmation, and cancellation states
- stale retry action clearing when a new turn or retry starts
- readable inline error color selection for assistant bubbles
- core loop behavior for retryable and non-retryable errors

### Test Steps
1. Build and install the app from this branch.
2. Open the app, go to the **More Menu** screen, and open the AI Assistant entry point.
3. Configure ApiFaker for the assistant JWT endpoint and make `/wpcom/v2/jetpack-ai-query` return HTTP 429.
4. Send a prompt and confirm the assistant shows readable error copy in the assistant bubble with a **Retry** action.
5. Tap **Retry** and confirm the retry starts a new assistant turn from the failed prompt.
6. Change the mocked assistant response to HTTP 503.
7. Send another prompt and confirm the assistant shows readable final failure copy with no **Retry** action.
8. If exercising confirmed write flows, force a transport failure after confirmation and confirm the UI asks the merchant to verify the result in store without offering **Retry**.

### Images/gif

https://github.com/user-attachments/assets/76278795-dd88-42cc-b8b0-db13838385f4



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.