### PR TITLE
[WOOMOB-2966] Implement show_cards reference resolver

### DIFF
--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/CachedLookupResult.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/CachedLookupResult.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.aiassistant.tools
+
+internal data class CachedLookupResult<T>(
+    val items: List<T>,
+    val cacheHitCount: Int,
+    val cacheMissCount: Int,
+    val fetchAttempted: Boolean,
+    val fetchFailed: Boolean,
+)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.di.AiAssistantJson
 import com.woocommerce.android.aiassistant.tools.handlers.cards.DefaultShowCardsResolver
 import com.woocommerce.android.aiassistant.tools.handlers.cards.MAX_SHOW_CARDS_REFS
 import com.woocommerce.android.aiassistant.tools.handlers.cards.MissingRef
@@ -31,12 +32,25 @@ import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 import javax.inject.Inject
 
-class ShowCardsToolHandler internal constructor(
+internal class ShowCardsToolHandler internal constructor(
     private val resolver: ShowCardsResolver,
+    private val json: Json,
 ) : AssistantToolHandler {
     private val referenceValidator = ShowCardsReferenceValidator()
 
-    @Inject constructor() : this(DefaultShowCardsResolver())
+    @Inject constructor(
+        resolver: DefaultShowCardsResolver,
+        @AiAssistantJson json: Json,
+    ) : this(resolver as ShowCardsResolver, json)
+
+    internal constructor(resolver: ShowCardsResolver) : this(
+        resolver = resolver,
+        json = Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = false
+            explicitNulls = false
+        },
+    )
 
     override val descriptor = ToolDescriptor(
         name = "show_cards",
@@ -148,9 +162,5 @@ class ShowCardsToolHandler internal constructor(
     private companion object {
         val ORDER_SUMMARY_KEYS = setOf("id", "number", "status", "total", "currency", "date_created")
         val PRODUCT_SUMMARY_KEYS = setOf("id", "name", "sku", "price", "stock_status")
-
-        val json = Json {
-            explicitNulls = false
-        }
     }
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -128,7 +128,7 @@ internal class ShowCardsToolHandler internal constructor(
             resolver.resolve(validRefs)
         } catch (exception: CancellationException) {
             throw exception
-        } catch (exception: Exception) {
+        } catch (_: Exception) {
             validRefs.map { ref ->
                 ShowCardsResolution.Missing(
                     ref = ref,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
@@ -1,9 +1,7 @@
 package com.woocommerce.android.aiassistant.tools.handlers.cards
 
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
@@ -124,9 +122,7 @@ internal data class ShowCardPayload(
     val details: ShowCardDetails,
 )
 
-@OptIn(ExperimentalSerializationApi::class)
 @Serializable
-@JsonClassDiscriminator("kind")
 internal sealed interface ShowCardDetails {
     @Serializable
     @SerialName("order")

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.aiassistant.tools.handlers.cards
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
@@ -119,7 +121,28 @@ internal data class ShowCardPayload(
     val family: String,
     val id: String,
     val title: String,
-    val subtitle: String? = null,
-    val badges: List<String> = emptyList(),
-    val attributes: Map<String, String> = emptyMap(),
+    val details: ShowCardDetails,
 )
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+@JsonClassDiscriminator("kind")
+internal sealed interface ShowCardDetails {
+    @Serializable
+    @SerialName("order")
+    data class Order(
+        val status: String? = null,
+        val total: String? = null,
+        val currency: String? = null,
+        @SerialName("date_created") val dateCreated: String? = null,
+    ) : ShowCardDetails
+
+    @Serializable
+    @SerialName("product")
+    data class Product(
+        val sku: String? = null,
+        val price: String? = null,
+        @SerialName("stock_status") val stockStatus: String? = null,
+        val status: String? = null,
+    ) : ShowCardDetails
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
@@ -64,7 +64,8 @@ internal class ShowCardsReferenceValidator {
     private fun JsonPrimitive.stringContentOrNull(): String? =
         contentOrNull?.takeIf { isString }
 
-    private fun String.isValidShowCardsId(): Boolean = isNotBlank()
+    private fun String.isValidShowCardsId(): Boolean =
+        toLongOrNull()?.let { it > 0L } == true
 
     private fun ValidationState.rejectInvalidId(index: Int, family: ShowCardFamily) =
         reject(index, family.serializedName, reason = ShowCardsRejectionReason.InvalidId)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
@@ -1,6 +1,15 @@
 package com.woocommerce.android.aiassistant.tools.handlers.cards
 
+import com.woocommerce.android.aiassistant.di.AiAssistantJson
+import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
+import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
+import javax.inject.Inject
 
 internal interface ShowCardsResolver {
     suspend fun resolve(refs: List<ValidatedRef>): List<ShowCardsResolution>
@@ -21,12 +30,122 @@ internal sealed interface ShowCardsResolution {
     ) : ShowCardsResolution
 }
 
-internal class DefaultShowCardsResolver : ShowCardsResolver {
-    override suspend fun resolve(refs: List<ValidatedRef>): List<ShowCardsResolution> =
-        refs.map { ref ->
-            ShowCardsResolution.Missing(
+internal class DefaultShowCardsResolver @Inject constructor(
+    private val ordersDataSource: AIOrdersDataSource,
+    private val productsDataSource: AIProductsDataSource,
+    @AiAssistantJson private val json: Json,
+) : ShowCardsResolver {
+    override suspend fun resolve(refs: List<ValidatedRef>): List<ShowCardsResolution> {
+        val orderResults = resolveOrders(refs.filter { it.family == ShowCardFamily.Order })
+        val productResults = resolveProducts(refs.filter { it.family == ShowCardFamily.Product })
+
+        return refs.map { ref ->
+            orderResults[ref] ?: productResults[ref] ?: ShowCardsResolution.Missing(
                 ref = ref,
                 reason = ShowCardsRejectionReason.NotFound,
             )
         }
+    }
+
+    private suspend fun resolveOrders(refs: List<ValidatedRef>): Map<ValidatedRef, ShowCardsResolution> {
+        if (refs.isEmpty()) return emptyMap()
+
+        val ids = refs.map { it.id.toLong() }
+        return ordersDataSource.getOrders(ids).fold(
+            onSuccess = { orders ->
+                val ordersById = orders.associateBy { it.orderId }
+                refs.associateWith { ref ->
+                    ordersById[ref.id.toLong()]?.toResolved(ref)
+                        ?: ShowCardsResolution.Missing(ref, ShowCardsRejectionReason.NotFound)
+                }
+            },
+            onFailure = {
+                refs.associateWith { ref -> ShowCardsResolution.Missing(ref, ShowCardsRejectionReason.FetchFailed) }
+            },
+        )
+    }
+
+    private suspend fun resolveProducts(refs: List<ValidatedRef>): Map<ValidatedRef, ShowCardsResolution> {
+        if (refs.isEmpty()) return emptyMap()
+
+        val ids = refs.map { it.id.toLong() }
+        return productsDataSource.getProducts(ids).fold(
+            onSuccess = { products ->
+                val productsById = products.associateBy { it.remoteProductId }
+                refs.associateWith { ref ->
+                    productsById[ref.id.toLong()]?.toResolved(ref)
+                        ?: ShowCardsResolution.Missing(ref, ShowCardsRejectionReason.NotFound)
+                }
+            },
+            onFailure = {
+                refs.associateWith { ref -> ShowCardsResolution.Missing(ref, ShowCardsRejectionReason.FetchFailed) }
+            },
+        )
+    }
+
+    private fun OrderEntity.toResolved(ref: ValidatedRef) = ShowCardsResolution.Resolved(
+        ref = ref,
+        summary = jsonObject(
+            OrderSummary(
+                id = ref.id,
+                number = number,
+                status = status,
+                total = total,
+                currency = currency,
+                dateCreated = dateCreated,
+            )
+        ),
+        card = ShowCardPayload(
+            family = ShowCardFamily.Order.serializedName,
+            id = ref.id,
+            title = number.toDisplayOrderNumber(orderId),
+            subtitle = status.takeIf { it.isNotBlank() },
+            badges = listOfNotBlank(status),
+            attributes = mapOfNotBlank(
+                "total" to total,
+                "currency" to currency,
+                "date_created" to dateCreated,
+            ),
+        ),
+    )
+
+    private fun WCProductModel.toResolved(ref: ValidatedRef) = ShowCardsResolution.Resolved(
+        ref = ref,
+        summary = jsonObject(
+            ProductSummary(
+                id = ref.id,
+                name = name,
+                sku = sku,
+                price = price,
+                stockStatus = stockStatus,
+            )
+        ),
+        card = ShowCardPayload(
+            family = ShowCardFamily.Product.serializedName,
+            id = ref.id,
+            title = name.ifBlank { "Product $remoteProductId" },
+            subtitle = sku.takeIf { it.isNotBlank() },
+            badges = listOfNotBlank(stockStatus, status),
+            attributes = mapOfNotBlank(
+                "price" to price,
+                "stock_status" to stockStatus,
+                "status" to status,
+            ),
+        ),
+    )
+
+    private inline fun <reified T> jsonObject(value: T): JsonObject =
+        json.encodeToJsonElement(value).jsonObject
 }
+
+private fun String.toDisplayOrderNumber(orderId: Long): String {
+    val fallback = orderId.toString()
+    val value = takeIf { it.isNotBlank() } ?: fallback
+    return if (value.startsWith("#")) value else "#$value"
+}
+
+private fun listOfNotBlank(vararg values: String): List<String> =
+    values.filter { it.isNotBlank() }
+
+private fun mapOfNotBlank(vararg pairs: Pair<String, String>): Map<String, String> =
+    pairs.filter { (_, value) -> value.isNotBlank() }.toMap()

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
@@ -100,12 +100,11 @@ internal class DefaultShowCardsResolver @Inject constructor(
             family = ShowCardFamily.Order.serializedName,
             id = ref.id,
             title = number.toDisplayOrderNumber(orderId),
-            subtitle = status.takeIf { it.isNotBlank() },
-            badges = listOfNotBlank(status),
-            attributes = mapOfNotBlank(
-                "total" to total,
-                "currency" to currency,
-                "date_created" to dateCreated,
+            details = ShowCardDetails.Order(
+                status = status.takeIf { it.isNotBlank() },
+                total = total.takeIf { it.isNotBlank() },
+                currency = currency.takeIf { it.isNotBlank() },
+                dateCreated = dateCreated.takeIf { it.isNotBlank() },
             ),
         ),
     )
@@ -125,12 +124,11 @@ internal class DefaultShowCardsResolver @Inject constructor(
             family = ShowCardFamily.Product.serializedName,
             id = ref.id,
             title = name.ifBlank { "Product $remoteProductId" },
-            subtitle = sku.takeIf { it.isNotBlank() },
-            badges = listOfNotBlank(stockStatus, status),
-            attributes = mapOfNotBlank(
-                "price" to price,
-                "stock_status" to stockStatus,
-                "status" to status,
+            details = ShowCardDetails.Product(
+                sku = sku.takeIf { it.isNotBlank() },
+                price = price.takeIf { it.isNotBlank() },
+                stockStatus = stockStatus.takeIf { it.isNotBlank() },
+                status = status.takeIf { it.isNotBlank() },
             ),
         ),
     )
@@ -144,12 +142,6 @@ private fun String.toDisplayOrderNumber(orderId: Long): String {
     val value = takeIf { it.isNotBlank() } ?: fallback
     return if (value.startsWith("#")) value else "#$value"
 }
-
-private fun listOfNotBlank(vararg values: String): List<String> =
-    values.filter { it.isNotBlank() }
-
-private fun mapOfNotBlank(vararg pairs: Pair<String, String>): Map<String, String> =
-    pairs.filter { (_, value) -> value.isNotBlank() }.toMap()
 
 private fun CachedLookupResult<*>.missingReason(): ShowCardsRejectionReason =
     if (fetchFailed) ShowCardsRejectionReason.FetchFailed else ShowCardsRejectionReason.NotFound

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.aiassistant.tools.handlers.cards
 
 import com.woocommerce.android.aiassistant.di.AiAssistantJson
+import com.woocommerce.android.aiassistant.tools.CachedLookupResult
 import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
 import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
 import kotlinx.serialization.json.Json
@@ -53,10 +54,10 @@ internal class DefaultShowCardsResolver @Inject constructor(
         val ids = refs.map { it.id.toLong() }
         return ordersDataSource.getOrders(ids).fold(
             onSuccess = { orders ->
-                val ordersById = orders.associateBy { it.orderId }
+                val ordersById = orders.items.associateBy { it.orderId }
                 refs.associateWith { ref ->
                     ordersById[ref.id.toLong()]?.toResolved(ref)
-                        ?: ShowCardsResolution.Missing(ref, ShowCardsRejectionReason.NotFound)
+                        ?: ShowCardsResolution.Missing(ref, orders.missingReason())
                 }
             },
             onFailure = {
@@ -71,10 +72,10 @@ internal class DefaultShowCardsResolver @Inject constructor(
         val ids = refs.map { it.id.toLong() }
         return productsDataSource.getProducts(ids).fold(
             onSuccess = { products ->
-                val productsById = products.associateBy { it.remoteProductId }
+                val productsById = products.items.associateBy { it.remoteProductId }
                 refs.associateWith { ref ->
                     productsById[ref.id.toLong()]?.toResolved(ref)
-                        ?: ShowCardsResolution.Missing(ref, ShowCardsRejectionReason.NotFound)
+                        ?: ShowCardsResolution.Missing(ref, products.missingReason())
                 }
             },
             onFailure = {
@@ -149,3 +150,6 @@ private fun listOfNotBlank(vararg values: String): List<String> =
 
 private fun mapOfNotBlank(vararg pairs: Pair<String, String>): Map<String, String> =
     pairs.filter { (_, value) -> value.isNotBlank() }.toMap()
+
+private fun CachedLookupResult<*>.missingReason(): ShowCardsRejectionReason =
+    if (fetchFailed) ShowCardsRejectionReason.FetchFailed else ShowCardsRejectionReason.NotFound

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSource.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSource.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.aiassistant.tools.orders
 
 import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.aiassistant.tools.CachedLookupResult
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.flow.last
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
@@ -83,14 +84,61 @@ internal class AIOrdersDataSource @Inject constructor(
         }
     }
 
-    suspend fun getOrders(orderIds: List<Long>): Result<List<OrderEntity>> {
+    suspend fun getOrders(orderIds: List<Long>): Result<CachedLookupResult<OrderEntity>> {
         val ids = orderIds.distinct()
-        if (ids.isEmpty()) return Result.success(emptyList())
+        if (ids.isEmpty()) {
+            return Result.success(
+                CachedLookupResult(
+                    items = emptyList(),
+                    cacheHitCount = 0,
+                    cacheMissCount = 0,
+                    fetchAttempted = false,
+                    fetchFailed = false,
+                )
+            )
+        }
 
-        return fetchOrders(
-            include = ids,
-            perPage = ids.size,
-        ).map { page -> page.orders }
+        val site = selectedSite.get()
+        val cachedOrders = orderStore.getOrdersByIdsAndSite(ids, site)
+        val cachedIds = cachedOrders.map { it.orderId }.toSet()
+        val idsToFetch = ids.filterNot { it in cachedIds }
+        if (idsToFetch.isEmpty()) {
+            return Result.success(
+                CachedLookupResult(
+                    items = cachedOrders,
+                    cacheHitCount = cachedIds.size,
+                    cacheMissCount = 0,
+                    fetchAttempted = false,
+                    fetchFailed = false,
+                )
+            )
+        }
+
+        val fetched = fetchOrders(include = idsToFetch, perPage = idsToFetch.size)
+        return fetched.fold(
+            onSuccess = { page ->
+                Result.success(
+                    CachedLookupResult(
+                        items = cachedOrders + page.orders,
+                        cacheHitCount = cachedIds.size,
+                        cacheMissCount = idsToFetch.size,
+                        fetchAttempted = true,
+                        fetchFailed = false,
+                    )
+                )
+            },
+            onFailure = {
+                Result.success(
+                    CachedLookupResult(
+                        items = cachedOrders,
+                        cacheHitCount = cachedIds.size,
+                        cacheMissCount = idsToFetch.size,
+                        fetchAttempted = true,
+                        fetchFailed = true,
+                    )
+                )
+            },
+        )
     }
 
     suspend fun updateOrderStatus(orderId: Long, newStatus: String): Result<Unit> = runCatching {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSource.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSource.kt
@@ -116,10 +116,10 @@ internal class AIOrdersDataSource @Inject constructor(
 
         val fetched = fetchOrders(include = idsToFetch, perPage = idsToFetch.size)
         return fetched.fold(
-            onSuccess = { page ->
+            onSuccess = {
                 Result.success(
                     CachedLookupResult(
-                        items = cachedOrders + page.orders,
+                        items = orderStore.getOrdersByIdsAndSite(ids, site),
                         cacheHitCount = cachedIds.size,
                         cacheMissCount = idsToFetch.size,
                         fetchAttempted = true,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSource.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSource.kt
@@ -83,6 +83,16 @@ internal class AIOrdersDataSource @Inject constructor(
         }
     }
 
+    suspend fun getOrders(orderIds: List<Long>): Result<List<OrderEntity>> {
+        val ids = orderIds.distinct()
+        if (ids.isEmpty()) return Result.success(emptyList())
+
+        return fetchOrders(
+            include = ids,
+            perPage = ids.size,
+        ).map { page -> page.orders }
+    }
+
     suspend fun updateOrderStatus(orderId: Long, newStatus: String): Result<Unit> = runCatching {
         val site = selectedSite.get()
         val statusModel = WCOrderStatusModel(statusKey = newStatus)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSource.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSource.kt
@@ -84,6 +84,25 @@ internal class AIProductsDataSource @Inject constructor(
         return getProduct(site, productId)
     }
 
+    suspend fun getProducts(productIds: List<Long>): Result<List<WCProductModel>> {
+        val ids = productIds.distinct()
+        if (ids.isEmpty()) return Result.success(emptyList())
+
+        val site = selectedSite.get()
+        val result = productStore.fetchProducts(
+            site = site,
+            offset = 0,
+            pageSize = ids.size,
+            includedProductIds = ids,
+            forceRefresh = false,
+        )
+        return if (result.isError) {
+            Result.failure(OnChangedException(requireNotNull(result.error)))
+        } else {
+            Result.success(ids.mapNotNull { id -> productStore.getProductByRemoteId(site, id) })
+        }
+    }
+
     suspend fun updateProduct(productId: Long, update: ProductUpdate): Result<WCProductModel> {
         val site = selectedSite.get()
         val existingProduct = getProduct(site, productId).getOrElse {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSource.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSource.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.aiassistant.tools.products
 
 import com.woocommerce.android.OnChangedException
+import com.woocommerce.android.aiassistant.tools.CachedLookupResult
 import com.woocommerce.android.tools.SelectedSite
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCProductModel
@@ -84,22 +85,63 @@ internal class AIProductsDataSource @Inject constructor(
         return getProduct(site, productId)
     }
 
-    suspend fun getProducts(productIds: List<Long>): Result<List<WCProductModel>> {
+    suspend fun getProducts(productIds: List<Long>): Result<CachedLookupResult<WCProductModel>> {
         val ids = productIds.distinct()
-        if (ids.isEmpty()) return Result.success(emptyList())
+        if (ids.isEmpty()) {
+            return Result.success(
+                CachedLookupResult(
+                    items = emptyList(),
+                    cacheHitCount = 0,
+                    cacheMissCount = 0,
+                    fetchAttempted = false,
+                    fetchFailed = false,
+                )
+            )
+        }
 
         val site = selectedSite.get()
+        val cachedProducts = productStore.getProductsByRemoteIds(site, ids)
+        val cachedIds = cachedProducts.map { it.remoteProductId }.toSet()
+        val idsToFetch = ids.filterNot { it in cachedIds }
+        if (idsToFetch.isEmpty()) {
+            return Result.success(
+                CachedLookupResult(
+                    items = cachedProducts,
+                    cacheHitCount = cachedIds.size,
+                    cacheMissCount = 0,
+                    fetchAttempted = false,
+                    fetchFailed = false,
+                )
+            )
+        }
+
         val result = productStore.fetchProducts(
             site = site,
             offset = 0,
-            pageSize = ids.size,
-            includedProductIds = ids,
+            pageSize = idsToFetch.size,
+            includedProductIds = idsToFetch,
             forceRefresh = false,
         )
         return if (result.isError) {
-            Result.failure(OnChangedException(requireNotNull(result.error)))
+            Result.success(
+                CachedLookupResult(
+                    items = cachedProducts,
+                    cacheHitCount = cachedIds.size,
+                    cacheMissCount = idsToFetch.size,
+                    fetchAttempted = true,
+                    fetchFailed = true,
+                )
+            )
         } else {
-            Result.success(ids.mapNotNull { id -> productStore.getProductByRemoteId(site, id) })
+            Result.success(
+                CachedLookupResult(
+                    items = productStore.getProductsByRemoteIds(site, ids),
+                    cacheHitCount = cachedIds.size,
+                    cacheMissCount = idsToFetch.size,
+                    fetchAttempted = true,
+                    fetchFailed = false,
+                )
+            )
         }
     }
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolCatalogTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolCatalogTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.aiassistant.tools.analytics.AnalyticsOrdersToolHa
 import com.woocommerce.android.aiassistant.tools.analytics.AnalyticsRevenueToolHandler
 import com.woocommerce.android.aiassistant.tools.customers.CustomersListToolHandler
 import com.woocommerce.android.aiassistant.tools.handlers.ShowCardsToolHandler
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
 import com.woocommerce.android.aiassistant.tools.orders.OrdersBulkUpdateToolHandler
 import com.woocommerce.android.aiassistant.tools.orders.OrdersGetToolHandler
 import com.woocommerce.android.aiassistant.tools.orders.OrdersListToolHandler
@@ -36,7 +37,7 @@ class WooCommerceToolCatalogTest {
         ProductVariationsUpdateToolHandler(mock(), mock()),
         AnalyticsRevenueToolHandler(mock(), mock()),
         AnalyticsOrdersToolHandler(mock(), mock()),
-        ShowCardsToolHandler(),
+        ShowCardsToolHandler(mock<ShowCardsResolver>()),
         CustomersListToolHandler(mock()),
     )
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -5,6 +5,7 @@ import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import com.woocommerce.android.aiassistant.tools.handlers.cards.OrderSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ProductSummary
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardDetails
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsRejectionReason
@@ -97,7 +98,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `given resolver returns render payload extras, when executed, then structured excludes private fields`() = runTest {
+    fun `given resolver returns summary extras, when executed, then structured excludes private fields`() = runTest {
         val result = callShowCards(
             resolver = FakeResolver.resolving(leakyProductCard(id = "456")),
             referencesJson = """[{ "family": "product", "id": "456" }]"""
@@ -122,6 +123,51 @@ class ShowCardsToolHandlerTest {
         assertThat(cards).hasSize(1)
         assertThat(cards.first().jsonObject["family"]?.jsonPrimitive?.content).isEqualTo("order")
         assertThat(cards.first().jsonObject["id"]?.jsonPrimitive?.content).isEqualTo("123")
+    }
+
+    @Test
+    fun `given resolved order, when executed, then uiStructured contains typed order details`() = runTest {
+        val result = callShowCards(FakeResolver.resolving(orderCard(id = "123")))
+
+        val card = uiCards(result).single().jsonObject
+        val details = card.getValue("details").jsonObject
+
+        assertThat(card.keys).containsExactly("family", "id", "title", "details")
+        assertThat(card.getValue("family").jsonPrimitive.content).isEqualTo("order")
+        assertThat(card.getValue("id").jsonPrimitive.content).isEqualTo("123")
+        assertThat(card.getValue("title").jsonPrimitive.content).isEqualTo("#123")
+        assertThat(details.keys).containsExactly("kind", "status", "total", "currency", "date_created")
+        assertThat(details.getValue("kind").jsonPrimitive.content).isEqualTo("order")
+        assertThat(details.getValue("status").jsonPrimitive.content).isEqualTo("processing")
+        assertThat(details.getValue("total").jsonPrimitive.content).isEqualTo("12.34")
+        assertThat(details.getValue("currency").jsonPrimitive.content).isEqualTo("USD")
+        assertThat(details.getValue("date_created").jsonPrimitive.content).isEqualTo("2026-05-01T10:00:00Z")
+        assertThat(card.keys).doesNotContain("subtitle", "badges", "attributes")
+        assertThat(assertSuccess(result).structured.toString()).doesNotContain("details")
+    }
+
+    @Test
+    fun `given resolved product, when executed, then uiStructured contains typed product details`() = runTest {
+        val result = callShowCards(
+            resolver = FakeResolver.resolving(productCard(id = "456")),
+            referencesJson = """[{ "family": "product", "id": "456" }]"""
+        )
+
+        val card = uiCards(result).single().jsonObject
+        val details = card.getValue("details").jsonObject
+
+        assertThat(card.keys).containsExactly("family", "id", "title", "details")
+        assertThat(card.getValue("family").jsonPrimitive.content).isEqualTo("product")
+        assertThat(card.getValue("id").jsonPrimitive.content).isEqualTo("456")
+        assertThat(card.getValue("title").jsonPrimitive.content).isEqualTo("Socks")
+        assertThat(details.keys).containsExactly("kind", "sku", "price", "stock_status", "status")
+        assertThat(details.getValue("kind").jsonPrimitive.content).isEqualTo("product")
+        assertThat(details.getValue("sku").jsonPrimitive.content).isEqualTo("woo-socks")
+        assertThat(details.getValue("price").jsonPrimitive.content).isEqualTo("9.99")
+        assertThat(details.getValue("stock_status").jsonPrimitive.content).isEqualTo("instock")
+        assertThat(details.getValue("status").jsonPrimitive.content).isEqualTo("publish")
+        assertThat(card.keys).doesNotContain("subtitle", "badges", "attributes")
+        assertThat(assertSuccess(result).structured.toString()).doesNotContain("details")
     }
 
     @Test
@@ -343,6 +389,12 @@ class ShowCardsToolHandlerTest {
                 family = "order",
                 id = id,
                 title = "#$id",
+                details = ShowCardDetails.Order(
+                    status = "processing",
+                    total = "12.34",
+                    currency = "USD",
+                    dateCreated = "2026-05-01T10:00:00Z",
+                ),
             )
         )
     }
@@ -365,6 +417,12 @@ class ShowCardsToolHandlerTest {
                 family = "product",
                 id = id,
                 title = "Socks",
+                details = ShowCardDetails.Product(
+                    sku = "woo-socks",
+                    price = "9.99",
+                    stockStatus = "instock",
+                    status = "publish",
+                ),
             )
         )
     }
@@ -394,12 +452,11 @@ class ShowCardsToolHandlerTest {
                 family = "product",
                 id = id,
                 title = "Socks",
-                attributes = mapOf(
-                    "description" to "Long description",
-                    "html" to "<p>Private</p>",
-                    "image" to "https://example.com/image.png",
-                    "metadata" to "private",
-                    "raw" to "entity",
+                details = ShowCardDetails.Product(
+                    sku = "woo-socks",
+                    price = "9.99",
+                    stockStatus = "instock",
+                    status = "publish",
                 ),
             )
         )

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -11,12 +11,14 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsRejectionReason
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolution
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
@@ -129,20 +131,17 @@ class ShowCardsToolHandlerTest {
     fun `given resolved order, when executed, then uiStructured contains typed order details`() = runTest {
         val result = callShowCards(FakeResolver.resolving(orderCard(id = "123")))
 
-        val card = uiCards(result).single().jsonObject
-        val details = card.getValue("details").jsonObject
+        val card = typedUiCards(result).single()
+        val details = card.details as ShowCardDetails.Order
 
-        assertThat(card.keys).containsExactly("family", "id", "title", "details")
-        assertThat(card.getValue("family").jsonPrimitive.content).isEqualTo("order")
-        assertThat(card.getValue("id").jsonPrimitive.content).isEqualTo("123")
-        assertThat(card.getValue("title").jsonPrimitive.content).isEqualTo("#123")
-        assertThat(details.keys).containsExactly("kind", "status", "total", "currency", "date_created")
-        assertThat(details.getValue("kind").jsonPrimitive.content).isEqualTo("order")
-        assertThat(details.getValue("status").jsonPrimitive.content).isEqualTo("processing")
-        assertThat(details.getValue("total").jsonPrimitive.content).isEqualTo("12.34")
-        assertThat(details.getValue("currency").jsonPrimitive.content).isEqualTo("USD")
-        assertThat(details.getValue("date_created").jsonPrimitive.content).isEqualTo("2026-05-01T10:00:00Z")
-        assertThat(card.keys).doesNotContain("subtitle", "badges", "attributes")
+        assertThat(card.family).isEqualTo("order")
+        assertThat(card.id).isEqualTo("123")
+        assertThat(card.title).isEqualTo("#123")
+        assertThat(details.status).isEqualTo("processing")
+        assertThat(details.total).isEqualTo("12.34")
+        assertThat(details.currency).isEqualTo("USD")
+        assertThat(details.dateCreated).isEqualTo("2026-05-01T10:00:00Z")
+        assertThat(uiCards(result).single().jsonObject.keys).doesNotContain("subtitle", "badges", "attributes")
         assertThat(assertSuccess(result).structured.toString()).doesNotContain("details")
     }
 
@@ -153,20 +152,17 @@ class ShowCardsToolHandlerTest {
             referencesJson = """[{ "family": "product", "id": "456" }]"""
         )
 
-        val card = uiCards(result).single().jsonObject
-        val details = card.getValue("details").jsonObject
+        val card = typedUiCards(result).single()
+        val details = card.details as ShowCardDetails.Product
 
-        assertThat(card.keys).containsExactly("family", "id", "title", "details")
-        assertThat(card.getValue("family").jsonPrimitive.content).isEqualTo("product")
-        assertThat(card.getValue("id").jsonPrimitive.content).isEqualTo("456")
-        assertThat(card.getValue("title").jsonPrimitive.content).isEqualTo("Socks")
-        assertThat(details.keys).containsExactly("kind", "sku", "price", "stock_status", "status")
-        assertThat(details.getValue("kind").jsonPrimitive.content).isEqualTo("product")
-        assertThat(details.getValue("sku").jsonPrimitive.content).isEqualTo("woo-socks")
-        assertThat(details.getValue("price").jsonPrimitive.content).isEqualTo("9.99")
-        assertThat(details.getValue("stock_status").jsonPrimitive.content).isEqualTo("instock")
-        assertThat(details.getValue("status").jsonPrimitive.content).isEqualTo("publish")
-        assertThat(card.keys).doesNotContain("subtitle", "badges", "attributes")
+        assertThat(card.family).isEqualTo("product")
+        assertThat(card.id).isEqualTo("456")
+        assertThat(card.title).isEqualTo("Socks")
+        assertThat(details.sku).isEqualTo("woo-socks")
+        assertThat(details.price).isEqualTo("9.99")
+        assertThat(details.stockStatus).isEqualTo("instock")
+        assertThat(details.status).isEqualTo("publish")
+        assertThat(uiCards(result).single().jsonObject.keys).doesNotContain("subtitle", "badges", "attributes")
         assertThat(assertSuccess(result).structured.toString()).doesNotContain("details")
     }
 
@@ -369,6 +365,11 @@ class ShowCardsToolHandlerTest {
 
     private fun uiCards(result: ToolResult) =
         requireNotNull(assertSuccess(result).uiStructured).jsonObject.getValue("cards").jsonArray
+
+    private fun typedUiCards(result: ToolResult) =
+        json.decodeFromJsonElement<ShowCardsUiStructured>(
+            requireNotNull(assertSuccess(result).uiStructured)
+        ).cards
 
     private fun orderCard(id: String): ShowCardsResolution.Resolved {
         val ref = ValidatedRef(index = 0, family = ShowCardFamily.Order, id = id)

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.OrderSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ProductSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsRejectionReason
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolution
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
@@ -26,8 +27,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ShowCardsToolHandlerTest {
-    private val json = Json
-    private val handler = ShowCardsToolHandler()
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+        explicitNulls = false
+    }
+    private val handler = handlerWith(FakeResolver.empty())
 
     @Test
     fun `when descriptor is inspected, then show cards accepts Android v1 order and product references`() {
@@ -166,6 +171,25 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
+    fun `given non numeric string ids, when executed, then ids are invalid and not resolved`() = runTest {
+        val result = executeShowCards(
+            handler = handlerWith(FakeResolver.empty()),
+            argumentsJson = """
+            {
+              "references": [
+                { "family": "order", "id": "abc" },
+                { "family": "product", "id": "12x" },
+                { "family": "order", "id": "0" }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertThat(validated(result)).isEqualTo(0)
+        assertThat(rejectedReasons(result)).containsExactly("invalid_id", "invalid_id", "invalid_id")
+    }
+
+    @Test
     fun `given duplicate refs, when executed, then duplicates after first family id pair are rejected`() = runTest {
         val result = callShowCards(
             resolver = FakeResolver.resolving(orderCard(id = "123"), productCard(id = "123")),
@@ -213,16 +237,30 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `given default resolver, when executed, then valid refs are missing with not found and no cards`() = runTest {
-        val result = executeShowCards(
-            handler = ShowCardsToolHandler(),
-            argumentsJson = """{"references":[{"family":"order","id":"123"}]}"""
-        )
+    fun `given one resolved and one missing ref, when executed, then structured and ui cards preserve partial success`() =
+        runTest {
+            val result = callShowCards(
+                resolver = FakeResolver.returning(
+                    listOf(
+                        orderCard(id = "123"),
+                        ShowCardsResolution.Missing(
+                            ref = ValidatedRef(index = 1, family = ShowCardFamily.Product, id = "456"),
+                            reason = ShowCardsRejectionReason.NotFound,
+                        ),
+                    )
+                ),
+                referencesJson = """
+                    [
+                      { "family": "order", "id": "123" },
+                      { "family": "product", "id": "456" }
+                    ]
+                """.trimIndent(),
+            )
 
-        assertThat(missingReasons(result)).containsExactly("not_found")
-        assertThat(rendered(result)).isEqualTo(0)
-        assertThat(uiCards(result)).isEmpty()
-    }
+            assertThat(rendered(result)).isEqualTo(1)
+            assertThat(missingReasons(result)).containsExactly("not_found")
+            assertThat(uiCards(result)).hasSize(1)
+        }
 
     private fun handlerWith(resolver: ShowCardsResolver) =
         ShowCardsToolHandler(resolver)
@@ -374,8 +412,13 @@ class ShowCardsToolHandlerTest {
             refs.map { ref -> resolutions.first { it.ref.family == ref.family && it.ref.id == ref.id } }
 
         companion object {
+            fun empty(): FakeResolver = FakeResolver(emptyList())
+
             fun resolving(vararg resolutions: ShowCardsResolution): FakeResolver =
                 FakeResolver(resolutions.toList())
+
+            fun returning(resolutions: List<ShowCardsResolution>): FakeResolver =
+                FakeResolver(resolutions)
         }
     }
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
@@ -1,0 +1,144 @@
+package com.woocommerce.android.aiassistant.tools.handlers.cards
+
+import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
+import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonPrimitive
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
+
+class ShowCardsResolverTest {
+    private val ordersDataSource: AIOrdersDataSource = mock()
+    private val productsDataSource: AIProductsDataSource = mock()
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+        explicitNulls = false
+    }
+
+    private val resolver = DefaultShowCardsResolver(
+        ordersDataSource = ordersDataSource,
+        productsDataSource = productsDataSource,
+        json = json,
+    )
+
+    @Test
+    fun `given mixed refs, when resolved, then output preserves input order`() = runTest {
+        val orderOne = order(id = 1L, number = "1001")
+        val orderTwo = order(id = 2L, number = "1002")
+        val product = product(id = 3L, name = "Socks")
+        whenever(ordersDataSource.getOrders(listOf(1L, 2L))).thenReturn(Result.success(listOf(orderTwo, orderOne)))
+        whenever(productsDataSource.getProducts(listOf(3L))).thenReturn(Result.success(listOf(product)))
+
+        val result = resolver.resolve(
+            listOf(
+                ref(ShowCardFamily.Order, "1"),
+                ref(ShowCardFamily.Product, "3"),
+                ref(ShowCardFamily.Order, "2"),
+            )
+        )
+
+        verify(ordersDataSource).getOrders(listOf(1L, 2L))
+        verify(productsDataSource).getProducts(listOf(3L))
+        assertThat(result.map { it.ref.family.serializedName to it.ref.id }).containsExactly(
+            "order" to "1",
+            "product" to "3",
+            "order" to "2",
+        )
+        assertThat(result).allSatisfy { resolution ->
+            assertThat(resolution).isInstanceOf(ShowCardsResolution.Resolved::class.java)
+        }
+    }
+
+    @Test
+    fun `given missing order, when resolved, then missing ref is not found`() = runTest {
+        whenever(ordersDataSource.getOrders(listOf(99L))).thenReturn(Result.success(emptyList()))
+
+        val result = resolver.resolve(listOf(ref(ShowCardFamily.Order, "99")))
+
+        val missing = result.single() as ShowCardsResolution.Missing
+        assertThat(missing.reason).isEqualTo(ShowCardsRejectionReason.NotFound)
+    }
+
+    @Test
+    fun `given order fetch fails and product succeeds, when resolved, then product still resolves`() = runTest {
+        whenever(ordersDataSource.getOrders(listOf(1L))).thenReturn(Result.failure(IllegalStateException("boom")))
+        whenever(productsDataSource.getProducts(listOf(2L))).thenReturn(Result.success(listOf(product(id = 2L))))
+
+        val result = resolver.resolve(
+            listOf(
+                ref(ShowCardFamily.Order, "1"),
+                ref(ShowCardFamily.Product, "2"),
+            )
+        )
+
+        val orderResult = result[0] as ShowCardsResolution.Missing
+        val productResult = result[1] as ShowCardsResolution.Resolved
+        assertThat(orderResult.reason).isEqualTo(ShowCardsRejectionReason.FetchFailed)
+        assertThat(productResult.summary.getValue("id").jsonPrimitive.content).isEqualTo("2")
+    }
+
+    @Test
+    fun `given resolved entities, when resolved, then summaries and cards use compact app-owned fields`() = runTest {
+        whenever(ordersDataSource.getOrders(listOf(1L))).thenReturn(Result.success(listOf(order(id = 1L))))
+        whenever(productsDataSource.getProducts(listOf(2L))).thenReturn(Result.success(listOf(product(id = 2L))))
+
+        val result = resolver.resolve(
+            listOf(
+                ref(ShowCardFamily.Order, "1"),
+                ref(ShowCardFamily.Product, "2"),
+            )
+        ).filterIsInstance<ShowCardsResolution.Resolved>()
+
+        assertThat(
+            result[0].summary.keys
+        ).containsExactly(
+            "id",
+            "number",
+            "status",
+            "total",
+            "currency",
+            "date_created",
+        )
+        assertThat(result[0].card.family).isEqualTo("order")
+        assertThat(result[0].card.id).isEqualTo("1")
+        assertThat(result[1].summary.keys).containsExactly("id", "name", "sku", "price", "stock_status")
+        assertThat(result[1].card.family).isEqualTo("product")
+        assertThat(result[1].card.id).isEqualTo("2")
+    }
+
+    private fun ref(family: ShowCardFamily, id: String) = ValidatedRef(index = 0, family = family, id = id)
+
+    private fun order(
+        id: Long,
+        number: String = id.toString(),
+    ) = OrderEntity(
+        localSiteId = LocalId(1),
+        orderId = id,
+        number = number,
+        status = "processing",
+        total = "12.34",
+        currency = "USD",
+        dateCreated = "2026-05-01T10:00:00Z",
+    )
+
+    private fun product(
+        id: Long,
+        name: String = "Socks",
+    ) = WCProductModel(
+        remoteId = RemoteId(id),
+        name = name,
+        sku = "woo-socks",
+        price = "9.99",
+        stockStatus = "instock",
+        status = "publish",
+    )
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
@@ -117,9 +117,21 @@ class ShowCardsResolverTest {
         )
         assertThat(result[0].card.family).isEqualTo("order")
         assertThat(result[0].card.id).isEqualTo("1")
+        assertThat(result[0].card.title).isEqualTo("#1")
+        val orderDetails = result[0].card.details as ShowCardDetails.Order
+        assertThat(orderDetails.status).isEqualTo("processing")
+        assertThat(orderDetails.total).isEqualTo("12.34")
+        assertThat(orderDetails.currency).isEqualTo("USD")
+        assertThat(orderDetails.dateCreated).isEqualTo("2026-05-01T10:00:00Z")
         assertThat(result[1].summary.keys).containsExactly("id", "name", "sku", "price", "stock_status")
         assertThat(result[1].card.family).isEqualTo("product")
         assertThat(result[1].card.id).isEqualTo("2")
+        assertThat(result[1].card.title).isEqualTo("Socks")
+        val productDetails = result[1].card.details as ShowCardDetails.Product
+        assertThat(productDetails.sku).isEqualTo("woo-socks")
+        assertThat(productDetails.price).isEqualTo("9.99")
+        assertThat(productDetails.stockStatus).isEqualTo("instock")
+        assertThat(productDetails.status).isEqualTo("publish")
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.aiassistant.tools.handlers.cards
 
+import com.woocommerce.android.aiassistant.tools.CachedLookupResult
 import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
 import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
 import kotlinx.coroutines.test.runTest
@@ -35,8 +36,10 @@ class ShowCardsResolverTest {
         val orderOne = order(id = 1L, number = "1001")
         val orderTwo = order(id = 2L, number = "1002")
         val product = product(id = 3L, name = "Socks")
-        whenever(ordersDataSource.getOrders(listOf(1L, 2L))).thenReturn(Result.success(listOf(orderTwo, orderOne)))
-        whenever(productsDataSource.getProducts(listOf(3L))).thenReturn(Result.success(listOf(product)))
+        whenever(ordersDataSource.getOrders(listOf(1L, 2L))).thenReturn(
+            Result.success(orderLookup(orderTwo, orderOne))
+        )
+        whenever(productsDataSource.getProducts(listOf(3L))).thenReturn(Result.success(productLookup(product)))
 
         val result = resolver.resolve(
             listOf(
@@ -60,7 +63,7 @@ class ShowCardsResolverTest {
 
     @Test
     fun `given missing order, when resolved, then missing ref is not found`() = runTest {
-        whenever(ordersDataSource.getOrders(listOf(99L))).thenReturn(Result.success(emptyList()))
+        whenever(ordersDataSource.getOrders(listOf(99L))).thenReturn(Result.success(orderLookup()))
 
         val result = resolver.resolve(listOf(ref(ShowCardFamily.Order, "99")))
 
@@ -71,7 +74,9 @@ class ShowCardsResolverTest {
     @Test
     fun `given order fetch fails and product succeeds, when resolved, then product still resolves`() = runTest {
         whenever(ordersDataSource.getOrders(listOf(1L))).thenReturn(Result.failure(IllegalStateException("boom")))
-        whenever(productsDataSource.getProducts(listOf(2L))).thenReturn(Result.success(listOf(product(id = 2L))))
+        whenever(productsDataSource.getProducts(listOf(2L))).thenReturn(
+            Result.success(productLookup(product(id = 2L)))
+        )
 
         val result = resolver.resolve(
             listOf(
@@ -88,8 +93,10 @@ class ShowCardsResolverTest {
 
     @Test
     fun `given resolved entities, when resolved, then summaries and cards use compact app-owned fields`() = runTest {
-        whenever(ordersDataSource.getOrders(listOf(1L))).thenReturn(Result.success(listOf(order(id = 1L))))
-        whenever(productsDataSource.getProducts(listOf(2L))).thenReturn(Result.success(listOf(product(id = 2L))))
+        whenever(ordersDataSource.getOrders(listOf(1L))).thenReturn(Result.success(orderLookup(order(id = 1L))))
+        whenever(productsDataSource.getProducts(listOf(2L))).thenReturn(
+            Result.success(productLookup(product(id = 2L)))
+        )
 
         val result = resolver.resolve(
             listOf(
@@ -115,7 +122,78 @@ class ShowCardsResolverTest {
         assertThat(result[1].card.id).isEqualTo("2")
     }
 
+    @Test
+    fun `given cached order and failed fetch for missing order, when resolved, then cached order is returned`() =
+        runTest {
+            whenever(ordersDataSource.getOrders(listOf(1L, 2L))).thenReturn(
+                Result.success(
+                    CachedLookupResult(
+                        items = listOf(order(id = 1L)),
+                        cacheHitCount = 1,
+                        cacheMissCount = 1,
+                        fetchAttempted = true,
+                        fetchFailed = true,
+                    )
+                )
+            )
+
+            val result = resolver.resolve(
+                listOf(
+                    ref(ShowCardFamily.Order, "1"),
+                    ref(ShowCardFamily.Order, "2"),
+                )
+            )
+
+            assertThat(result[0]).isInstanceOf(ShowCardsResolution.Resolved::class.java)
+            val missing = result[1] as ShowCardsResolution.Missing
+            assertThat(missing.reason).isEqualTo(ShowCardsRejectionReason.FetchFailed)
+        }
+
+    @Test
+    fun `given fetch succeeds but product id is absent, when resolved, then missing product is not found`() = runTest {
+        whenever(productsDataSource.getProducts(listOf(10L, 11L))).thenReturn(
+            Result.success(
+                CachedLookupResult(
+                    items = listOf(product(id = 10L)),
+                    cacheHitCount = 0,
+                    cacheMissCount = 2,
+                    fetchAttempted = true,
+                    fetchFailed = false,
+                )
+            )
+        )
+
+        val result = resolver.resolve(
+            listOf(
+                ref(ShowCardFamily.Product, "10"),
+                ref(ShowCardFamily.Product, "11"),
+            )
+        )
+
+        assertThat(result[0]).isInstanceOf(ShowCardsResolution.Resolved::class.java)
+        val missing = result[1] as ShowCardsResolution.Missing
+        assertThat(missing.reason).isEqualTo(ShowCardsRejectionReason.NotFound)
+    }
+
     private fun ref(family: ShowCardFamily, id: String) = ValidatedRef(index = 0, family = family, id = id)
+
+    private fun orderLookup(vararg orders: OrderEntity): CachedLookupResult<OrderEntity> =
+        CachedLookupResult(
+            items = orders.toList(),
+            cacheHitCount = 0,
+            cacheMissCount = orders.size,
+            fetchAttempted = true,
+            fetchFailed = false,
+        )
+
+    private fun productLookup(vararg products: WCProductModel): CachedLookupResult<WCProductModel> =
+        CachedLookupResult(
+            items = products.toList(),
+            cacheHitCount = 0,
+            cacheMissCount = products.size,
+            fetchAttempted = true,
+            fetchFailed = false,
+        )
 
     private fun order(
         id: Long,

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSourceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSourceTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
@@ -205,12 +206,16 @@ class AIOrdersDataSourceTest {
                 OrderEntity(localSiteId = LocalId(1), orderId = 123L),
                 OrderEntity(localSiteId = LocalId(1), orderId = 456L),
             )
+            whenever(orderStore.getOrdersByIdsAndSite(listOf(123L, 456L), site)).thenReturn(emptyList())
             stubFetchOrders(WooResult(orders))
 
-            val result = dataSource.getOrders(orderIds = listOf(123L, 456L))
+            val result = dataSource.getOrders(orderIds = listOf(123L, 456L)).getOrThrow()
 
-            assertThat(result.isSuccess).isTrue
-            assertThat(result.getOrThrow()).containsExactlyElementsOf(orders)
+            assertThat(result.items).containsExactlyElementsOf(orders)
+            assertThat(result.cacheHitCount).isEqualTo(0)
+            assertThat(result.cacheMissCount).isEqualTo(2)
+            assertThat(result.fetchAttempted).isTrue
+            assertThat(result.fetchFailed).isFalse
             verify(orderStore).fetchOrders(
                 site = any(),
                 count = eq(2),
@@ -221,6 +226,67 @@ class AIOrdersDataSourceTest {
                 searchQuery = anyOrNull(),
                 customer = anyOrNull(),
                 include = eq(listOf(123L, 456L)),
+                after = anyOrNull(),
+                before = anyOrNull(),
+                deleteOldData = eq(false),
+            )
+        }
+
+    @Test
+    fun `given all requested orders are cached, when getOrders is called, then no fetch is made`() = runTest {
+        val orders = listOf(
+            OrderEntity(localSiteId = LocalId(1), orderId = 123L),
+            OrderEntity(localSiteId = LocalId(1), orderId = 456L),
+        )
+        whenever(orderStore.getOrdersByIdsAndSite(listOf(123L, 456L), site)).thenReturn(orders)
+
+        val result = dataSource.getOrders(orderIds = listOf(123L, 456L)).getOrThrow()
+
+        assertThat(result.items).containsExactlyElementsOf(orders)
+        assertThat(result.cacheHitCount).isEqualTo(2)
+        assertThat(result.cacheMissCount).isEqualTo(0)
+        assertThat(result.fetchAttempted).isFalse
+        assertThat(result.fetchFailed).isFalse
+        verify(orderStore, never()).fetchOrders(
+            site = any(),
+            count = any(),
+            page = any(),
+            orderBy = any(),
+            sortOrder = any(),
+            statusFilter = anyOrNull(),
+            searchQuery = anyOrNull(),
+            customer = anyOrNull(),
+            include = anyOrNull(),
+            after = anyOrNull(),
+            before = anyOrNull(),
+            deleteOldData = any(),
+        )
+    }
+
+    @Test
+    fun `given some requested orders are cached and fetch fails, when getOrders is called, then cached orders are returned`() =
+        runTest {
+            val cachedOrder = OrderEntity(localSiteId = LocalId(1), orderId = 123L)
+            whenever(orderStore.getOrdersByIdsAndSite(listOf(123L, 456L), site)).thenReturn(listOf(cachedOrder))
+            stubFetchOrders(WooResult(WooError(WooErrorType.API_ERROR, GenericErrorType.SERVER_ERROR, "boom")))
+
+            val result = dataSource.getOrders(orderIds = listOf(123L, 456L)).getOrThrow()
+
+            assertThat(result.items).containsExactly(cachedOrder)
+            assertThat(result.cacheHitCount).isEqualTo(1)
+            assertThat(result.cacheMissCount).isEqualTo(1)
+            assertThat(result.fetchAttempted).isTrue
+            assertThat(result.fetchFailed).isTrue
+            verify(orderStore).fetchOrders(
+                site = any(),
+                count = eq(1),
+                page = eq(1),
+                orderBy = eq(OrderBy.DATE),
+                sortOrder = eq(SortOrder.DESCENDING),
+                statusFilter = anyOrNull(),
+                searchQuery = anyOrNull(),
+                customer = anyOrNull(),
+                include = eq(listOf(456L)),
                 after = anyOrNull(),
                 before = anyOrNull(),
                 deleteOldData = eq(false),

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSourceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSourceTest.kt
@@ -199,6 +199,35 @@ class AIOrdersDataSourceTest {
         }
 
     @Test
+    fun `given order ids, when getOrders is called, then orders are fetched once with include ids`() =
+        runTest {
+            val orders = listOf(
+                OrderEntity(localSiteId = LocalId(1), orderId = 123L),
+                OrderEntity(localSiteId = LocalId(1), orderId = 456L),
+            )
+            stubFetchOrders(WooResult(orders))
+
+            val result = dataSource.getOrders(orderIds = listOf(123L, 456L))
+
+            assertThat(result.isSuccess).isTrue
+            assertThat(result.getOrThrow()).containsExactlyElementsOf(orders)
+            verify(orderStore).fetchOrders(
+                site = any(),
+                count = eq(2),
+                page = eq(1),
+                orderBy = eq(OrderBy.DATE),
+                sortOrder = eq(SortOrder.DESCENDING),
+                statusFilter = anyOrNull(),
+                searchQuery = anyOrNull(),
+                customer = anyOrNull(),
+                include = eq(listOf(123L, 456L)),
+                after = anyOrNull(),
+                before = anyOrNull(),
+                deleteOldData = eq(false),
+            )
+        }
+
+    @Test
     fun `given remote update succeeds, when updateOrderStatus is called, then success result is returned`() =
         runTest {
             val successFlow = flowOf(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSourceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSourceTest.kt
@@ -200,14 +200,16 @@ class AIOrdersDataSourceTest {
         }
 
     @Test
-    fun `given order ids, when getOrders is called, then orders are fetched once with include ids`() =
+    fun `given order ids, when getOrders is called, then orders are fetched and read from cache`() =
         runTest {
             val orders = listOf(
                 OrderEntity(localSiteId = LocalId(1), orderId = 123L),
                 OrderEntity(localSiteId = LocalId(1), orderId = 456L),
             )
-            whenever(orderStore.getOrdersByIdsAndSite(listOf(123L, 456L), site)).thenReturn(emptyList())
-            stubFetchOrders(WooResult(orders))
+            whenever(orderStore.getOrdersByIdsAndSite(listOf(123L, 456L), site))
+                .thenReturn(emptyList())
+                .thenReturn(orders)
+            stubFetchOrders(WooResult(emptyList()))
 
             val result = dataSource.getOrders(orderIds = listOf(123L, 456L)).getOrThrow()
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSourceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSourceTest.kt
@@ -232,6 +232,9 @@ class AIProductsDataSourceTest {
         runTest {
             val first = makeProduct(id = 10L, name = "First")
             val second = makeProduct(id = 11L, name = "Second")
+            whenever(productStore.getProductsByRemoteIds(site, listOf(10L, 11L)))
+                .thenReturn(emptyList())
+                .thenReturn(listOf(first, second))
             whenever(
                 productStore.fetchProducts(
                     site = any(),
@@ -247,18 +250,48 @@ class AIProductsDataSourceTest {
                     posProductsOnly = any(),
                 )
             ).thenReturn(WooResult(true))
-            whenever(productStore.getProductByRemoteId(site, 10L)).thenReturn(first)
-            whenever(productStore.getProductByRemoteId(site, 11L)).thenReturn(second)
 
-            val result = dataSource.getProducts(productIds = listOf(10L, 11L))
+            val result = dataSource.getProducts(productIds = listOf(10L, 11L)).getOrThrow()
 
-            assertThat(result.isSuccess).isTrue
-            assertThat(result.getOrThrow()).containsExactly(first, second)
+            assertThat(result.items).containsExactly(first, second)
+            assertThat(result.cacheHitCount).isEqualTo(0)
+            assertThat(result.cacheMissCount).isEqualTo(2)
+            assertThat(result.fetchAttempted).isTrue
+            assertThat(result.fetchFailed).isFalse
         }
 
     @Test
-    fun `given included product fetch fails, when getProducts is called, then failure result is returned`() =
+    fun `given all requested products are cached, when getProducts is called, then no fetch is made`() = runTest {
+        val products = listOf(makeProduct(id = 10L), makeProduct(id = 11L))
+        whenever(productStore.getProductsByRemoteIds(site, listOf(10L, 11L))).thenReturn(products)
+
+        val result = dataSource.getProducts(productIds = listOf(10L, 11L)).getOrThrow()
+
+        assertThat(result.items).containsExactlyElementsOf(products)
+        assertThat(result.cacheHitCount).isEqualTo(2)
+        assertThat(result.cacheMissCount).isEqualTo(0)
+        assertThat(result.fetchAttempted).isFalse
+        assertThat(result.fetchFailed).isFalse
+        verify(productStore, never()).fetchProducts(
+            site = any(),
+            offset = any(),
+            pageSize = any(),
+            sortType = any(),
+            includedProductIds = any(),
+            excludedProductIds = any(),
+            filterOptions = any(),
+            includeTypes = any(),
+            forceRefresh = any(),
+            orderCurrency = anyOrNull(),
+            posProductsOnly = any(),
+        )
+    }
+
+    @Test
+    fun `given some requested products are cached and fetch fails, when getProducts is called, then cached products are returned`() =
         runTest {
+            val cachedProduct = makeProduct(id = 10L)
+            whenever(productStore.getProductsByRemoteIds(site, listOf(10L, 11L))).thenReturn(listOf(cachedProduct))
             whenever(
                 productStore.fetchProducts(
                     site = any(),
@@ -275,9 +308,55 @@ class AIProductsDataSourceTest {
                 )
             ).thenReturn(WooResult(WooError(WooErrorType.API_ERROR, GenericErrorType.SERVER_ERROR, "boom")))
 
-            val result = dataSource.getProducts(productIds = listOf(10L))
+            val result = dataSource.getProducts(productIds = listOf(10L, 11L)).getOrThrow()
 
-            assertThat(result.isFailure).isTrue
+            assertThat(result.items).containsExactly(cachedProduct)
+            assertThat(result.cacheHitCount).isEqualTo(1)
+            assertThat(result.cacheMissCount).isEqualTo(1)
+            assertThat(result.fetchAttempted).isTrue
+            assertThat(result.fetchFailed).isTrue
+            verify(productStore).fetchProducts(
+                site = any(),
+                offset = eq(0),
+                pageSize = eq(1),
+                sortType = any(),
+                includedProductIds = eq(listOf(11L)),
+                excludedProductIds = any(),
+                filterOptions = any(),
+                includeTypes = any(),
+                forceRefresh = eq(false),
+                orderCurrency = anyOrNull(),
+                posProductsOnly = any(),
+            )
+        }
+
+    @Test
+    fun `given included product fetch fails, when getProducts is called, then fetch failure result is returned`() =
+        runTest {
+            whenever(productStore.getProductsByRemoteIds(site, listOf(10L))).thenReturn(emptyList())
+            whenever(
+                productStore.fetchProducts(
+                    site = any(),
+                    offset = any(),
+                    pageSize = any(),
+                    sortType = any(),
+                    includedProductIds = any(),
+                    excludedProductIds = any(),
+                    filterOptions = any(),
+                    includeTypes = any(),
+                    forceRefresh = any(),
+                    orderCurrency = anyOrNull(),
+                    posProductsOnly = any(),
+                )
+            ).thenReturn(WooResult(WooError(WooErrorType.API_ERROR, GenericErrorType.SERVER_ERROR, "boom")))
+
+            val result = dataSource.getProducts(productIds = listOf(10L)).getOrThrow()
+
+            assertThat(result.items).isEmpty()
+            assertThat(result.cacheHitCount).isEqualTo(0)
+            assertThat(result.cacheMissCount).isEqualTo(1)
+            assertThat(result.fetchAttempted).isTrue
+            assertThat(result.fetchFailed).isTrue
         }
 
     // --- updateProduct ---

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSourceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSourceTest.kt
@@ -227,6 +227,59 @@ class AIProductsDataSourceTest {
         assertThat(result.isFailure).isTrue
     }
 
+    @Test
+    fun `given product ids, when getProducts is called, then products are fetched once with include ids`() =
+        runTest {
+            val first = makeProduct(id = 10L, name = "First")
+            val second = makeProduct(id = 11L, name = "Second")
+            whenever(
+                productStore.fetchProducts(
+                    site = any(),
+                    offset = eq(0),
+                    pageSize = eq(2),
+                    sortType = any(),
+                    includedProductIds = eq(listOf(10L, 11L)),
+                    excludedProductIds = any(),
+                    filterOptions = any(),
+                    includeTypes = any(),
+                    forceRefresh = eq(false),
+                    orderCurrency = anyOrNull(),
+                    posProductsOnly = any(),
+                )
+            ).thenReturn(WooResult(true))
+            whenever(productStore.getProductByRemoteId(site, 10L)).thenReturn(first)
+            whenever(productStore.getProductByRemoteId(site, 11L)).thenReturn(second)
+
+            val result = dataSource.getProducts(productIds = listOf(10L, 11L))
+
+            assertThat(result.isSuccess).isTrue
+            assertThat(result.getOrThrow()).containsExactly(first, second)
+        }
+
+    @Test
+    fun `given included product fetch fails, when getProducts is called, then failure result is returned`() =
+        runTest {
+            whenever(
+                productStore.fetchProducts(
+                    site = any(),
+                    offset = any(),
+                    pageSize = any(),
+                    sortType = any(),
+                    includedProductIds = any(),
+                    excludedProductIds = any(),
+                    filterOptions = any(),
+                    includeTypes = any(),
+                    forceRefresh = any(),
+                    orderCurrency = anyOrNull(),
+                    posProductsOnly = any(),
+                )
+            ).thenReturn(WooResult(WooError(WooErrorType.API_ERROR, GenericErrorType.SERVER_ERROR, "boom")))
+
+            val result = dataSource.getProducts(productIds = listOf(10L))
+
+            assertThat(result.isFailure).isTrue
+        }
+
     // --- updateProduct ---
 
     @Test


### PR DESCRIPTION
### Description
Fixes WOOMOB-2966

This PR implements the Android AI Assistant `show_cards` reference resolver on top of the structured card contract added in #15801. That earlier PR defined the tool input/output shape and protected the model/UI split, but its default resolver intentionally returned `not_found` for every valid ref. This PR replaces that seam with real order/product resolution while preserving the same `show_cards(references)` contract.

#### What changed

`show_cards` now resolves validated `order` and `product` references into app-owned card payloads:

- refs are still validated and deduped before resolution
- unsupported families remain rejected before any data-source call
- order refs are resolved through `AIOrdersDataSource`
- product refs are resolved through `AIProductsDataSource`
- refs are batched once per supported family
- the final output preserves the input display order after validation/dedupe
- resolved refs include compact model-visible summaries
- unresolved refs are returned in `missing_refs` with stable reasons

The resolver builds two separate result surfaces:

- `structured`: compact model-visible data only — counts, resolved refs, missing refs, rejected refs, and small summaries
- `uiStructured.cards`: app-owned render payloads for local UI rendering, kept out of model history

This keeps raw FluxC/store entities and full render payloads out of model-visible history.

#### Cache-first resolver behavior

The resolver path now prefers locally cached FluxC data before fetching. The new batch helpers first read the local store cache, then fetch only IDs that were not already cached:

- `AIOrdersDataSource.getOrders()` reads `WCOrderStore.getOrdersByIdsAndSite()` first, then fetches uncached misses via the existing include-backed order fetch path.
- `AIProductsDataSource.getProducts()` reads `WCProductStore.getProductsByRemoteIds()` first, then fetches uncached misses with `includedProductIds` and `forceRefresh = false`.

The helper return type, `CachedLookupResult<T>`, carries resolved items plus cache hit/miss and fetch status metadata. This lets cached cards still render if fetching uncached misses fails. In that partial-failure case, only refs that were not cached and still cannot be resolved are marked `fetch_failed`. If the fetch succeeds but an ID is still absent from storage, that ref remains `not_found`.

True in-memory same-turn tool-result caching is intentionally deferred. The current tool registry and agent loop do not expose a turn-scoped entity cache to tool handlers without broader orchestration changes, so this PR implements the safe local-cache-first slice only.

#### Data-source and module boundaries

The resolver stays behind the existing AI data-source boundary. It does not import or call `WCOrderStore`, `WCProductStore`, `SelectedSite`, FluxC error types, auth, or REST/cache APIs directly. Selected-site lookup, FluxC access, fetch behavior, and error mapping remain owned by `AIOrdersDataSource` and `AIProductsDataSource`.

All production changes are contained in `:libs:ai-assistant:feature`. There are no `:WooCommerce` host changes, no new auth path, no customer/product-variation card support, and no UI rendering changes in this PR.

#### Tests added or updated

This PR adds focused coverage for:

- resolver batching and display-order preservation across mixed order/product refs
- order/product summary and card payload mapping from app-owned data
- positive numeric ID validation before resolver lookup
- missing refs after successful lookup returning `not_found`
- per-family fetch failure isolation
- cached order/product hits short-circuiting fetches
- partial cache hits still being returned when fetching misses fails
- unresolved miss refs becoming `fetch_failed` only when the miss fetch failed
- compact `structured` output excluding private render payload fields
- catalog/schema coverage for the `show_cards` tool descriptor

Validation performed locally after rebasing onto current `origin/trunk`:

- `ANDROID_HOME=/Users/hicham/Library/Android/sdk ./gradlew :libs:ai-assistant:feature:testDebugUnitTest --tests "*.ShowCardsToolHandlerTest" --tests "*.ShowCardsResolverTest" --tests "*.AIOrdersDataSourceTest" --tests "*.AIProductsDataSourceTest" --tests "*.WooCommerceToolCatalogTest"`
- `ANDROID_HOME=/Users/hicham/Library/Android/sdk ./gradlew detektAll --auto-correct`
- `git diff --check origin/trunk...HEAD`
- checked changed Kotlin files for `FIXME`, force unwraps, and wildcard imports

### Test Steps
Rich cards are not surfaced yet, so green CI is enough.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.