### PR TITLE
[WOOMOB-2908] Add assistant order card renderer contract

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRowTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRowTest.kt
@@ -1,0 +1,109 @@
+package com.woocommerce.android.ui.orders.compose
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OrderSummaryRowTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun givenWideContainer_whenOrderSummaryRowIsRendered_thenDashboardArrangementIsPreserved() {
+        val posLabel = InstrumentationRegistry.getInstrumentation()
+            .targetContext
+            .getString(R.string.pos_badge)
+
+        composeTestRule.setContent {
+            WooThemeWithBackground {
+                Box(modifier = Modifier.width(380.dp)) {
+                    OrderSummaryRow(
+                        order = orderSummaryRowModel(isPosOrder = true),
+                        onClick = {},
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("#1001").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Jane Doe").assertIsDisplayed()
+        composeTestRule.onNodeWithText("2026-05-01").assertIsDisplayed()
+        composeTestRule.onNodeWithText("processing").assertIsDisplayed()
+        composeTestRule.onNodeWithText(posLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithText("12.34 USD").assertIsDisplayed()
+        assertTextDoesNotExist("Jane Doe  2026-05-01")
+
+        val number = boundsFor("#1001")
+        val date = boundsFor("2026-05-01")
+        val customer = boundsFor("Jane Doe")
+        val status = boundsFor("processing")
+        val pos = boundsFor(posLabel)
+        val total = boundsFor("12.34 USD")
+
+        assertTrue("Expected date to stay on the same left/top row as the order number", date.left > number.right)
+        assertTrue("Expected status tag to stay on the right/top side of the row", status.left > date.right)
+        assertTrue("Expected POS tag to stay to the right of the status tag", pos.left > status.right)
+        assertTrue("Expected customer name below the order number", customer.top > number.bottom)
+        assertTrue("Expected total below the status row", total.top > status.bottom)
+        assertTrue("Expected total to stay right-aligned below the status row", total.right >= pos.right)
+    }
+
+    @Test
+    fun givenNarrowContainer_whenOrderSummaryRowIsRendered_thenMetadataUsesCompactLine() {
+        composeTestRule.setContent {
+            WooThemeWithBackground {
+                Box(modifier = Modifier.width(332.dp)) {
+                    OrderSummaryRow(
+                        order = orderSummaryRowModel(),
+                        onClick = {},
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("#1001").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Jane Doe  2026-05-01").assertIsDisplayed()
+        assertTextDoesNotExist("Jane Doe")
+        assertTextDoesNotExist("2026-05-01")
+    }
+
+    private fun boundsFor(text: String): Rect {
+        val nodes = composeTestRule
+            .onAllNodesWithText(text, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+        assertTrue("Expected to find node with text $text", nodes.isNotEmpty())
+        return nodes.first().boundsInRoot
+    }
+
+    private fun assertTextDoesNotExist(text: String) {
+        val nodes = composeTestRule
+            .onAllNodesWithText(text)
+            .fetchSemanticsNodes()
+        assertTrue("Expected text not to exist: $text", nodes.isEmpty())
+    }
+
+    private fun orderSummaryRowModel(isPosOrder: Boolean = false) = OrderSummaryRowModel(
+        number = "#1001",
+        date = "2026-05-01",
+        customerName = "Jane Doe",
+        status = "processing",
+        statusColor = R.color.tag_bg_processing,
+        totalPrice = "12.34 USD",
+        isPosOrder = isPosOrder,
+    )
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
 import com.woocommerce.android.aiassistant.ui.AssistantRoute
+import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
@@ -24,6 +25,10 @@ class AiAssistantHostFragment : BaseFragment() {
             AssistantRoute(
                 conversationId = ASSISTANT_CONVERSATION_ID,
                 onBack = { findNavController().navigateUp() },
+                assistantCardRenderer = WooAssistantCardRenderer(),
+                onCardAction = { action ->
+                    findNavController().navigateSafely(action.toNavDirections())
+                },
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
@@ -10,10 +10,14 @@ import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.main.AppBarStatus
+import com.woocommerce.android.util.CurrencyFormatter
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AiAssistantHostFragment : BaseFragment() {
+    @Inject lateinit var currencyFormatter: CurrencyFormatter
+
     override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 
     override fun onCreateView(
@@ -25,7 +29,7 @@ class AiAssistantHostFragment : BaseFragment() {
             AssistantRoute(
                 conversationId = ASSISTANT_CONVERSATION_ID,
                 onBack = { findNavController().navigateUp() },
-                assistantCardRenderer = WooAssistantCardRenderer(),
+                assistantCardRenderer = WooAssistantCardRenderer(currencyFormatter),
                 onCardAction = { action ->
                     findNavController().navigateSafely(action.toNavDirections())
                 },

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardActionNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardActionNavigator.kt
@@ -1,0 +1,17 @@
+package com.woocommerce.android.ui.aiassistant
+
+import androidx.navigation.NavDirections
+import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
+import com.woocommerce.android.ui.products.details.ProductDetailFragment
+
+internal fun AssistantCardAction.toNavDirections(): NavDirections =
+    when (this) {
+        is AssistantCardAction.OpenOrder -> NavGraphMainDirections.actionGlobalOrderDetailFragment(
+            orderId = remoteOrderId,
+            ignoreTwoPaneLayoutLogic = true,
+        )
+        is AssistantCardAction.OpenProduct -> NavGraphMainDirections.actionGlobalProductDetailFragment(
+            mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId),
+        )
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
@@ -37,6 +37,7 @@ internal fun AssistantCard.Order.toOrderSummaryRowModel() = OrderSummaryRowModel
     statusColor = status.toOrderStatusColor(),
     totalPrice = total,
     isPosOrder = false,
+    layoutMode = OrderSummaryRowModel.LayoutMode.COMPACT,
 )
 
 @ColorRes

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
@@ -11,8 +11,11 @@ import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.compose.OrderSummaryRow
 import com.woocommerce.android.ui.orders.compose.OrderSummaryRowModel
+import com.woocommerce.android.util.CurrencyFormatter
 
-class WooAssistantCardRenderer : AssistantCardRenderer {
+class WooAssistantCardRenderer(
+    private val currencyFormatter: CurrencyFormatter,
+) : AssistantCardRenderer {
     @Composable
     override fun OrderCard(
         card: AssistantCard.Order,
@@ -20,7 +23,7 @@ class WooAssistantCardRenderer : AssistantCardRenderer {
         modifier: Modifier,
     ) {
         OrderSummaryRow(
-            order = card.toOrderSummaryRowModel(),
+            order = card.toOrderSummaryRowModel(currencyFormatter),
             onClick = { onAction(card.toOpenOrderAction()) },
             modifier = modifier,
         )
@@ -29,15 +32,22 @@ class WooAssistantCardRenderer : AssistantCardRenderer {
 
 internal fun AssistantCard.Order.toOpenOrderAction() = AssistantCardAction.OpenOrder(remoteOrderId)
 
-internal fun AssistantCard.Order.toOrderSummaryRowModel() = OrderSummaryRowModel(
+internal fun AssistantCard.Order.toOrderSummaryRowModel(currencyFormatter: CurrencyFormatter) = OrderSummaryRowModel(
     number = number,
     date = date,
     customerName = customerName,
     status = status,
     statusColor = status.toOrderStatusColor(),
-    totalPrice = total,
+    totalPrice = formatTotalPrice(currencyFormatter),
     isPosOrder = false,
 )
+
+private fun AssistantCard.Order.formatTotalPrice(currencyFormatter: CurrencyFormatter): String =
+    when {
+        total.isBlank() -> ""
+        currency.isBlank() -> total
+        else -> currencyFormatter.formatCurrency(total, currency)
+    }
 
 @ColorRes
 private fun String.toOrderStatusColor(): Int =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
@@ -1,0 +1,55 @@
+package com.woocommerce.android.ui.aiassistant
+
+import androidx.annotation.ColorRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.woocommerce.android.R
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardRenderer
+import com.woocommerce.android.ciab.CIABOrderStatusMapper
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.orders.compose.OrderSummaryRow
+import com.woocommerce.android.ui.orders.compose.OrderSummaryRowModel
+
+class WooAssistantCardRenderer : AssistantCardRenderer {
+    @Composable
+    override fun OrderCard(
+        card: AssistantCard.Order,
+        onAction: (AssistantCardAction) -> Unit,
+        modifier: Modifier,
+    ) {
+        OrderSummaryRow(
+            order = card.toOrderSummaryRowModel(),
+            onClick = { onAction(card.toOpenOrderAction()) },
+            modifier = modifier,
+        )
+    }
+}
+
+internal fun AssistantCard.Order.toOpenOrderAction() = AssistantCardAction.OpenOrder(remoteOrderId)
+
+internal fun AssistantCard.Order.toOrderSummaryRowModel() = OrderSummaryRowModel(
+    number = number,
+    date = date,
+    customerName = customerName,
+    status = status,
+    statusColor = status.toOrderStatusColor(),
+    totalPrice = total,
+    isPosOrder = false,
+)
+
+@ColorRes
+private fun String.toOrderStatusColor(): Int =
+    when (Order.Status.fromValue(this)) {
+        is Order.Status.Processing -> R.color.tag_bg_processing
+        is Order.Status.Completed -> R.color.tag_bg_completed
+        is Order.Status.Failed -> R.color.tag_bg_failed
+        is Order.Status.OnHold -> R.color.tag_bg_on_hold
+        is Order.Status.Custom -> if (this == CIABOrderStatusMapper.OPEN_KEY) {
+            R.color.tag_bg_processing
+        } else {
+            R.color.tag_bg_other
+        }
+        else -> R.color.tag_bg_other
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
@@ -37,7 +37,6 @@ internal fun AssistantCard.Order.toOrderSummaryRowModel() = OrderSummaryRowModel
     statusColor = status.toOrderStatusColor(),
     totalPrice = total,
     isPosOrder = false,
-    layoutMode = OrderSummaryRowModel.LayoutMode.COMPACT,
 )
 
 @ColorRes

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/orders/DashboardOrdersCard.kt
@@ -1,11 +1,8 @@
 package com.woocommerce.android.ui.dashboard.orders
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -19,10 +16,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -37,7 +32,6 @@ import androidx.navigation.navOptions
 import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.compose.animations.SkeletonView
-import com.woocommerce.android.ui.compose.component.WCTag
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.dashboard.DashboardFilterableCardHeader
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
@@ -49,6 +43,8 @@ import com.woocommerce.android.ui.dashboard.orders.DashboardOrdersViewModel.View
 import com.woocommerce.android.ui.dashboard.orders.DashboardOrdersViewModel.ViewState.Error
 import com.woocommerce.android.ui.dashboard.orders.DashboardOrdersViewModel.ViewState.Loading
 import com.woocommerce.android.ui.dashboard.orders.DashboardOrdersViewModel.ViewState.OrderItem
+import com.woocommerce.android.ui.orders.compose.OrderSummaryRow
+import com.woocommerce.android.ui.orders.compose.OrderSummaryRowModel
 import com.woocommerce.android.ui.orders.filters.data.OrderStatusOption
 import com.woocommerce.android.ui.orders.list.OrderListFragmentDirections
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
@@ -172,7 +168,10 @@ fun TopOrders(
             EmptyView()
         } else {
             orders.forEach { order ->
-                OrderListItem(order, onOrderClicked)
+                OrderSummaryRow(
+                    order = order.toOrderSummaryRowModel(),
+                    onClick = { onOrderClicked(order) },
+                )
 
                 Divider(
                     modifier = Modifier
@@ -183,6 +182,16 @@ fun TopOrders(
         }
     }
 }
+
+private fun OrderItem.toOrderSummaryRowModel() = OrderSummaryRowModel(
+    number = number,
+    date = date,
+    customerName = customerName,
+    status = status,
+    statusColor = statusColor,
+    totalPrice = totalPrice,
+    isPosOrder = isPosOrder,
+)
 
 @Composable
 private fun Loading() {
@@ -256,89 +265,6 @@ private fun LoadingItem() {
                 .width(70.dp)
                 .constrainAs(total) {
                     top.linkTo(status.bottom)
-                    end.linkTo(parent.end)
-                }
-        )
-    }
-}
-
-@Suppress("DestructuringDeclarationWithTooManyEntries")
-@Composable
-private fun OrderListItem(order: OrderItem, onOrderClicked: (OrderItem) -> Unit) {
-    ConstraintLayout(
-        modifier = Modifier
-            .fillMaxWidth()
-            .focusable(true)
-            .clickable(onClick = { onOrderClicked(order) })
-            .padding(16.dp)
-    ) {
-        val (number, date, name, statusRow, total) = createRefs()
-
-        Text(
-            text = order.number,
-            style = MaterialTheme.typography.body1,
-            color = colorResource(id = R.color.color_on_surface_medium),
-            modifier = Modifier.constrainAs(number) {
-                top.linkTo(parent.top)
-                start.linkTo(parent.start)
-            }
-        )
-
-        Text(
-            text = order.date,
-            style = MaterialTheme.typography.body1,
-            color = colorResource(id = R.color.color_on_surface_medium),
-            modifier = Modifier
-                .padding(start = 16.dp)
-                .constrainAs(date) {
-                    top.linkTo(parent.top)
-                    start.linkTo(number.end)
-                }
-        )
-
-        Text(
-            text = order.customerName,
-            style = MaterialTheme.typography.body1,
-            modifier = Modifier
-                .padding(top = 8.dp)
-                .constrainAs(name) {
-                    top.linkTo(number.bottom)
-                    start.linkTo(parent.start)
-                }
-        )
-
-        Row(
-            modifier = Modifier
-                .constrainAs(statusRow) {
-                    top.linkTo(parent.top)
-                    end.linkTo(parent.end)
-                },
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            WCTag(
-                text = order.status,
-                textColor = colorResource(id = R.color.color_on_secondary),
-                backgroundColor = colorResource(id = order.statusColor),
-                fontWeight = FontWeight.Normal
-            )
-
-            if (order.isPosOrder) {
-                WCTag(
-                    text = stringResource(id = R.string.pos_badge),
-                    textColor = colorResource(id = R.color.tag_text_pos),
-                    backgroundColor = colorResource(id = R.color.tag_bg_pos),
-                    fontWeight = FontWeight.Normal
-                )
-            }
-        }
-
-        Text(
-            text = order.totalPrice,
-            style = MaterialTheme.typography.body1,
-            modifier = Modifier
-                .padding(top = 8.dp)
-                .constrainAs(total) {
-                    top.linkTo(statusRow.bottom)
                     end.linkTo(parent.end)
                 }
         )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRow.kt
@@ -3,16 +3,20 @@ package com.woocommerce.android.ui.orders.compose
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.woocommerce.android.R
@@ -25,12 +29,32 @@ fun OrderSummaryRow(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val rowModifier = modifier
+        .fillMaxWidth()
+        .focusable(true)
+        .clickable(onClick = onClick)
+        .padding(16.dp)
+
+    when (order.layoutMode) {
+        OrderSummaryRowModel.LayoutMode.DASHBOARD -> DashboardOrderSummaryRow(
+            order = order,
+            modifier = rowModifier,
+        )
+        OrderSummaryRowModel.LayoutMode.COMPACT -> CompactOrderSummaryRow(
+            order = order,
+            modifier = rowModifier,
+        )
+    }
+}
+
+@Suppress("DestructuringDeclarationWithTooManyEntries")
+@Composable
+private fun DashboardOrderSummaryRow(
+    order: OrderSummaryRowModel,
+    modifier: Modifier = Modifier,
+) {
     ConstraintLayout(
         modifier = modifier
-            .fillMaxWidth()
-            .focusable(true)
-            .clickable(onClick = onClick)
-            .padding(16.dp)
     ) {
         val (number, date, name, statusRow, total) = createRefs()
 
@@ -75,21 +99,7 @@ fun OrderSummaryRow(
                 },
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            WCTag(
-                text = order.status,
-                textColor = colorResource(id = R.color.color_on_secondary),
-                backgroundColor = colorResource(id = order.statusColor),
-                fontWeight = FontWeight.Normal
-            )
-
-            if (order.isPosOrder) {
-                WCTag(
-                    text = stringResource(id = R.string.pos_badge),
-                    textColor = colorResource(id = R.color.tag_text_pos),
-                    backgroundColor = colorResource(id = R.color.tag_bg_pos),
-                    fontWeight = FontWeight.Normal
-                )
-            }
+            OrderStatusTags(order = order)
         }
 
         Text(
@@ -101,6 +111,73 @@ fun OrderSummaryRow(
                     top.linkTo(statusRow.bottom)
                     end.linkTo(parent.end)
                 }
+        )
+    }
+}
+
+@Composable
+private fun CompactOrderSummaryRow(
+    order: OrderSummaryRowModel,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = order.number,
+                style = MaterialTheme.typography.body1,
+                color = colorResource(id = R.color.color_on_surface_medium),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OrderStatusTags(order = order)
+            }
+        }
+
+        val metadata = listOf(order.customerName, order.date).filter { it.isNotBlank() }
+        if (metadata.isNotEmpty()) {
+            Text(
+                text = metadata.joinToString("  "),
+                style = MaterialTheme.typography.body1,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        Text(
+            text = order.totalPrice,
+            style = MaterialTheme.typography.body1,
+            textAlign = TextAlign.End,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun OrderStatusTags(order: OrderSummaryRowModel) {
+    WCTag(
+        text = order.status,
+        textColor = colorResource(id = R.color.color_on_secondary),
+        backgroundColor = colorResource(id = order.statusColor),
+        fontWeight = FontWeight.Normal,
+    )
+
+    if (order.isPosOrder) {
+        WCTag(
+            text = stringResource(id = R.string.pos_badge),
+            textColor = colorResource(id = R.color.tag_text_pos),
+            backgroundColor = colorResource(id = R.color.tag_bg_pos),
+            fontWeight = FontWeight.Normal,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRow.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.orders.compose
 
-import androidx.annotation.ColorRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
@@ -18,16 +17,6 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCTag
-
-data class OrderSummaryRowModel(
-    val number: String,
-    val date: String,
-    val customerName: String,
-    val status: String,
-    @ColorRes val statusColor: Int,
-    val totalPrice: String,
-    val isPosOrder: Boolean = false,
-)
 
 @Suppress("DestructuringDeclarationWithTooManyEntries")
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRow.kt
@@ -1,0 +1,117 @@
+package com.woocommerce.android.ui.orders.compose
+
+import androidx.annotation.ColorRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCTag
+
+data class OrderSummaryRowModel(
+    val number: String,
+    val date: String,
+    val customerName: String,
+    val status: String,
+    @ColorRes val statusColor: Int,
+    val totalPrice: String,
+    val isPosOrder: Boolean = false,
+)
+
+@Suppress("DestructuringDeclarationWithTooManyEntries")
+@Composable
+fun OrderSummaryRow(
+    order: OrderSummaryRowModel,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ConstraintLayout(
+        modifier = modifier
+            .fillMaxWidth()
+            .focusable(true)
+            .clickable(onClick = onClick)
+            .padding(16.dp)
+    ) {
+        val (number, date, name, statusRow, total) = createRefs()
+
+        Text(
+            text = order.number,
+            style = MaterialTheme.typography.body1,
+            color = colorResource(id = R.color.color_on_surface_medium),
+            modifier = Modifier.constrainAs(number) {
+                top.linkTo(parent.top)
+                start.linkTo(parent.start)
+            }
+        )
+
+        Text(
+            text = order.date,
+            style = MaterialTheme.typography.body1,
+            color = colorResource(id = R.color.color_on_surface_medium),
+            modifier = Modifier
+                .padding(start = 16.dp)
+                .constrainAs(date) {
+                    top.linkTo(parent.top)
+                    start.linkTo(number.end)
+                }
+        )
+
+        Text(
+            text = order.customerName,
+            style = MaterialTheme.typography.body1,
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .constrainAs(name) {
+                    top.linkTo(number.bottom)
+                    start.linkTo(parent.start)
+                }
+        )
+
+        Row(
+            modifier = Modifier
+                .constrainAs(statusRow) {
+                    top.linkTo(parent.top)
+                    end.linkTo(parent.end)
+                },
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            WCTag(
+                text = order.status,
+                textColor = colorResource(id = R.color.color_on_secondary),
+                backgroundColor = colorResource(id = order.statusColor),
+                fontWeight = FontWeight.Normal
+            )
+
+            if (order.isPosOrder) {
+                WCTag(
+                    text = stringResource(id = R.string.pos_badge),
+                    textColor = colorResource(id = R.color.tag_text_pos),
+                    backgroundColor = colorResource(id = R.color.tag_bg_pos),
+                    fontWeight = FontWeight.Normal
+                )
+            }
+        }
+
+        Text(
+            text = order.totalPrice,
+            style = MaterialTheme.typography.body1,
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .constrainAs(total) {
+                    top.linkTo(statusRow.bottom)
+                    end.linkTo(parent.end)
+                }
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRow.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.orders.compose
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,100 +20,83 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.WCTag
 
-@Suppress("DestructuringDeclarationWithTooManyEntries")
 @Composable
 fun OrderSummaryRow(
     order: OrderSummaryRowModel,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val rowModifier = modifier
-        .fillMaxWidth()
-        .focusable(true)
-        .clickable(onClick = onClick)
-        .padding(16.dp)
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxWidth()
+            .focusable(true)
+            .clickable(onClick = onClick)
+    ) {
+        val contentModifier = Modifier
+            .fillMaxWidth()
+            .padding(ROW_PADDING)
+        val contentWidth = maxWidth - ROW_PADDING * 2
 
-    when (order.layoutMode) {
-        OrderSummaryRowModel.LayoutMode.DASHBOARD -> DashboardOrderSummaryRow(
-            order = order,
-            modifier = rowModifier,
-        )
-        OrderSummaryRowModel.LayoutMode.COMPACT -> CompactOrderSummaryRow(
-            order = order,
-            modifier = rowModifier,
-        )
+        if (contentWidth < COMPACT_CONTENT_WIDTH_THRESHOLD) {
+            CompactOrderSummaryRow(
+                order = order,
+                modifier = contentModifier,
+            )
+        } else {
+            DashboardOrderSummaryRow(
+                order = order,
+                modifier = contentModifier,
+            )
+        }
     }
 }
 
-@Suppress("DestructuringDeclarationWithTooManyEntries")
 @Composable
 private fun DashboardOrderSummaryRow(
     order: OrderSummaryRowModel,
     modifier: Modifier = Modifier,
 ) {
-    ConstraintLayout(
-        modifier = modifier
-    ) {
-        val (number, date, name, statusRow, total) = createRefs()
+    Box(modifier = modifier) {
+        Column(modifier = Modifier.align(Alignment.TopStart)) {
+            Row {
+                Text(
+                    text = order.number,
+                    style = MaterialTheme.typography.body1,
+                    color = colorResource(id = R.color.color_on_surface_medium),
+                )
 
-        Text(
-            text = order.number,
-            style = MaterialTheme.typography.body1,
-            color = colorResource(id = R.color.color_on_surface_medium),
-            modifier = Modifier.constrainAs(number) {
-                top.linkTo(parent.top)
-                start.linkTo(parent.start)
+                Text(
+                    text = order.date,
+                    style = MaterialTheme.typography.body1,
+                    color = colorResource(id = R.color.color_on_surface_medium),
+                    modifier = Modifier.padding(start = 16.dp)
+                )
             }
-        )
 
-        Text(
-            text = order.date,
-            style = MaterialTheme.typography.body1,
-            color = colorResource(id = R.color.color_on_surface_medium),
-            modifier = Modifier
-                .padding(start = 16.dp)
-                .constrainAs(date) {
-                    top.linkTo(parent.top)
-                    start.linkTo(number.end)
-                }
-        )
-
-        Text(
-            text = order.customerName,
-            style = MaterialTheme.typography.body1,
-            modifier = Modifier
-                .padding(top = 8.dp)
-                .constrainAs(name) {
-                    top.linkTo(number.bottom)
-                    start.linkTo(parent.start)
-                }
-        )
-
-        Row(
-            modifier = Modifier
-                .constrainAs(statusRow) {
-                    top.linkTo(parent.top)
-                    end.linkTo(parent.end)
-                },
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            OrderStatusTags(order = order)
+            Text(
+                text = order.customerName,
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier.padding(top = 8.dp)
+            )
         }
 
-        Text(
-            text = order.totalPrice,
-            style = MaterialTheme.typography.body1,
-            modifier = Modifier
-                .padding(top = 8.dp)
-                .constrainAs(total) {
-                    top.linkTo(statusRow.bottom)
-                    end.linkTo(parent.end)
-                }
-        )
+        Column(
+            modifier = Modifier.align(Alignment.TopEnd),
+            horizontalAlignment = Alignment.End,
+        ) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OrderStatusTags(order = order)
+            }
+
+            Text(
+                text = order.totalPrice,
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+        }
     }
 }
 
@@ -181,3 +166,6 @@ private fun OrderStatusTags(order: OrderSummaryRowModel) {
         )
     }
 }
+
+private val ROW_PADDING = 16.dp
+private val COMPACT_CONTENT_WIDTH_THRESHOLD = 320.dp

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRowModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRowModel.kt
@@ -10,10 +10,4 @@ data class OrderSummaryRowModel(
     @ColorRes val statusColor: Int,
     val totalPrice: String,
     val isPosOrder: Boolean = false,
-    val layoutMode: LayoutMode = LayoutMode.DASHBOARD,
-) {
-    enum class LayoutMode {
-        DASHBOARD,
-        COMPACT,
-    }
-}
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRowModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRowModel.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.ui.orders.compose
+
+import androidx.annotation.ColorRes
+
+data class OrderSummaryRowModel(
+    val number: String,
+    val date: String,
+    val customerName: String,
+    val status: String,
+    @ColorRes val statusColor: Int,
+    val totalPrice: String,
+    val isPosOrder: Boolean = false,
+)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRowModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/compose/OrderSummaryRowModel.kt
@@ -10,4 +10,10 @@ data class OrderSummaryRowModel(
     @ColorRes val statusColor: Int,
     val totalPrice: String,
     val isPosOrder: Boolean = false,
-)
+    val layoutMode: LayoutMode = LayoutMode.DASHBOARD,
+) {
+    enum class LayoutMode {
+        DASHBOARD,
+        COMPACT,
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardActionNavigatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardActionNavigatorTest.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.aiassistant
 
-import com.woocommerce.android.R
 import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
 import com.woocommerce.android.ui.products.details.ProductDetailFragment
 import org.assertj.core.api.Assertions.assertThat

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardActionNavigatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardActionNavigatorTest.kt
@@ -1,0 +1,35 @@
+package com.woocommerce.android.ui.aiassistant
+
+import com.woocommerce.android.R
+import com.woocommerce.android.NavGraphMainDirections
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
+import com.woocommerce.android.ui.products.details.ProductDetailFragment
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class WooAssistantCardActionNavigatorTest {
+    @Test
+    fun `given open order action, when mapped, then order details direction is returned`() {
+        val direction = AssistantCardAction.OpenOrder(remoteOrderId = 123L).toNavDirections()
+
+        assertThat(direction.actionId).isEqualTo(R.id.action_global_orderDetailFragment)
+        assertThat(direction).isEqualTo(
+            NavGraphMainDirections.actionGlobalOrderDetailFragment(
+                orderId = 123L,
+                ignoreTwoPaneLayoutLogic = true,
+            )
+        )
+    }
+
+    @Test
+    fun `given open product action, when mapped, then product details direction is returned`() {
+        val direction = AssistantCardAction.OpenProduct(remoteProductId = 456L).toNavDirections()
+
+        assertThat(direction.actionId).isEqualTo(R.id.action_global_productDetailFragment)
+        assertThat(direction).isEqualTo(
+            NavGraphMainDirections.actionGlobalProductDetailFragment(
+                mode = ProductDetailFragment.Mode.ShowProduct(remoteProductId = 456L),
+            )
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
@@ -3,21 +3,37 @@ package com.woocommerce.android.ui.aiassistant
 import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
+import com.woocommerce.android.util.CurrencyFormatter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class WooAssistantCardRendererTest {
+    private val currencyFormatter: CurrencyFormatter = mock()
+
     @Test
-    fun `given assistant order card, when mapped, then host row model uses the same displayed fields`() {
-        val model = orderCard().toOrderSummaryRowModel()
+    fun `given assistant order card, when mapped, then host row model formats total with order currency`() {
+        whenever(currencyFormatter.formatCurrency("12.34", "USD")).thenReturn("$12.34")
+
+        val model = orderCard().toOrderSummaryRowModel(currencyFormatter)
 
         assertThat(model.number).isEqualTo("#1001")
         assertThat(model.date).isEqualTo("2026-05-01T10:00:00Z")
         assertThat(model.customerName).isEqualTo("Jane Doe")
         assertThat(model.status).isEqualTo("processing")
         assertThat(model.statusColor).isEqualTo(R.color.tag_bg_processing)
-        assertThat(model.totalPrice).isEqualTo("12.34 USD")
+        assertThat(model.totalPrice).isEqualTo("$12.34")
         assertThat(model.isPosOrder).isFalse()
+        verify(currencyFormatter).formatCurrency("12.34", "USD")
+    }
+
+    @Test
+    fun `given assistant order card without currency, when mapped, then raw total is used`() {
+        val model = orderCard(currency = "").toOrderSummaryRowModel(currencyFormatter)
+
+        assertThat(model.totalPrice).isEqualTo("12.34")
     }
 
     @Test
@@ -29,16 +45,20 @@ class WooAssistantCardRendererTest {
 
     @Test
     fun `given ciab open status, when mapped, then processing color is used like dashboard orders`() {
-        val model = orderCard(status = "open").toOrderSummaryRowModel()
+        val model = orderCard(status = "open", currency = "").toOrderSummaryRowModel(currencyFormatter)
 
         assertThat(model.statusColor).isEqualTo(R.color.tag_bg_processing)
     }
 
-    private fun orderCard(status: String = "processing") = AssistantCard.Order(
+    private fun orderCard(
+        status: String = "processing",
+        currency: String = "USD",
+    ) = AssistantCard.Order(
         remoteOrderId = 123L,
         number = "#1001",
         status = status,
-        total = "12.34 USD",
+        total = "12.34",
+        currency = currency,
         customerName = "Jane Doe",
         date = "2026-05-01T10:00:00Z",
     )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
@@ -1,0 +1,45 @@
+package com.woocommerce.android.ui.aiassistant
+
+import com.woocommerce.android.R
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class WooAssistantCardRendererTest {
+    @Test
+    fun `given assistant order card, when mapped, then host row model uses the same displayed fields`() {
+        val model = orderCard().toOrderSummaryRowModel()
+
+        assertThat(model.number).isEqualTo("#1001")
+        assertThat(model.date).isEqualTo("2026-05-01T10:00:00Z")
+        assertThat(model.customerName).isEqualTo("Jane Doe")
+        assertThat(model.status).isEqualTo("processing")
+        assertThat(model.statusColor).isEqualTo(R.color.tag_bg_processing)
+        assertThat(model.totalPrice).isEqualTo("12.34 USD")
+        assertThat(model.isPosOrder).isFalse()
+    }
+
+    @Test
+    fun `given assistant order card, when action helper is used, then open order id is used`() {
+        val action = orderCard().toOpenOrderAction()
+
+        assertThat(action).isEqualTo(AssistantCardAction.OpenOrder(remoteOrderId = 123L))
+    }
+
+    @Test
+    fun `given ciab open status, when mapped, then processing color is used like dashboard orders`() {
+        val model = orderCard(status = "open").toOrderSummaryRowModel()
+
+        assertThat(model.statusColor).isEqualTo(R.color.tag_bg_processing)
+    }
+
+    private fun orderCard(status: String = "processing") = AssistantCard.Order(
+        remoteOrderId = 123L,
+        number = "#1001",
+        status = status,
+        total = "12.34 USD",
+        customerName = "Jane Doe",
+        date = "2026-05-01T10:00:00Z",
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.aiassistant
 import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
-import com.woocommerce.android.ui.orders.compose.OrderSummaryRowModel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -19,7 +18,6 @@ class WooAssistantCardRendererTest {
         assertThat(model.statusColor).isEqualTo(R.color.tag_bg_processing)
         assertThat(model.totalPrice).isEqualTo("12.34 USD")
         assertThat(model.isPosOrder).isFalse()
-        assertThat(model.layoutMode).isEqualTo(OrderSummaryRowModel.LayoutMode.COMPACT)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.aiassistant
 import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
+import com.woocommerce.android.ui.orders.compose.OrderSummaryRowModel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -18,6 +19,7 @@ class WooAssistantCardRendererTest {
         assertThat(model.statusColor).isEqualTo(R.color.tag_bg_processing)
         assertThat(model.totalPrice).isEqualTo("12.34 USD")
         assertThat(model.isPosOrder).isFalse()
+        assertThat(model.layoutMode).isEqualTo(OrderSummaryRowModel.LayoutMode.COMPACT)
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -160,7 +160,15 @@ internal class ShowCardsToolHandler internal constructor(
     }
 
     private companion object {
-        val ORDER_SUMMARY_KEYS = setOf("id", "number", "status", "total", "currency", "date_created")
+        val ORDER_SUMMARY_KEYS = setOf(
+            "id",
+            "number",
+            "status",
+            "total",
+            "currency",
+            "date_created",
+            "customer_name",
+        )
         val PRODUCT_SUMMARY_KEYS = setOf("id", "name", "sku", "price", "stock_status")
     }
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
@@ -53,6 +53,7 @@ internal data class OrderSummary(
     val total: String? = null,
     val currency: String? = null,
     @SerialName("date_created") val dateCreated: String? = null,
+    @SerialName("customer_name") val customerName: String? = null,
 )
 
 @Serializable
@@ -131,6 +132,7 @@ internal sealed interface ShowCardDetails {
         val total: String? = null,
         val currency: String? = null,
         @SerialName("date_created") val dateCreated: String? = null,
+        @SerialName("customer_name") val customerName: String? = null,
     ) : ShowCardDetails
 
     @Serializable

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
@@ -94,6 +94,7 @@ internal class DefaultShowCardsResolver @Inject constructor(
                 total = total,
                 currency = currency,
                 dateCreated = dateCreated,
+                customerName = customerName,
             )
         ),
         card = ShowCardPayload(
@@ -105,6 +106,7 @@ internal class DefaultShowCardsResolver @Inject constructor(
                 total = total.takeIf { it.isNotBlank() },
                 currency = currency.takeIf { it.isNotBlank() },
                 dateCreated = dateCreated.takeIf { it.isNotBlank() },
+                customerName = customerName.takeIf { it.isNotBlank() },
             ),
         ),
     )
@@ -142,6 +144,11 @@ private fun String.toDisplayOrderNumber(orderId: Long): String {
     val value = takeIf { it.isNotBlank() } ?: fallback
     return if (value.startsWith("#")) value else "#$value"
 }
+
+private val OrderEntity.customerName: String
+    get() = listOf(billingFirstName, billingLastName)
+        .filter { it.isNotBlank() }
+        .joinToString(" ")
 
 private fun CachedLookupResult<*>.missingReason(): ShowCardsRejectionReason =
     if (fetchFailed) ShowCardsRejectionReason.FetchFailed else ShowCardsRejectionReason.NotFound

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -348,6 +348,7 @@ private fun AssistantMessageSegments(
                 onConfirmWrite = onConfirmWrite,
                 onCancelWrite = onCancelWrite,
             )
+            is AssistantUiSegment.Card -> Unit
             is AssistantUiSegment.Text -> AssistantMessageTextSegment(
                 text = segment.text,
                 textColor = textColor,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -61,6 +61,9 @@ import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreview
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreviewField
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardRenderer
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -69,6 +72,8 @@ fun AssistantRoute(
     conversationId: String,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
+    assistantCardRenderer: AssistantCardRenderer? = null,
+    onCardAction: (AssistantCardAction) -> Unit = {},
 ) {
     val viewModel = hiltViewModel<AssistantViewModel, AssistantViewModel.Factory> { factory ->
         factory.create(conversationId)
@@ -78,6 +83,8 @@ fun AssistantRoute(
         viewModel = viewModel,
         onBack = onBack,
         modifier = modifier,
+        assistantCardRenderer = assistantCardRenderer,
+        onCardAction = onCardAction,
     )
 }
 
@@ -86,6 +93,8 @@ fun AssistantChatScreen(
     viewModel: AssistantViewModel,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
+    assistantCardRenderer: AssistantCardRenderer? = null,
+    onCardAction: (AssistantCardAction) -> Unit = {},
 ) {
     val state by viewModel.uiState.collectAsState()
     var inputText by rememberSaveable { mutableStateOf("") }
@@ -107,6 +116,8 @@ fun AssistantChatScreen(
         onCancelWrite = viewModel::onCancelWrite,
         onBack = onBack,
         modifier = modifier,
+        assistantCardRenderer = assistantCardRenderer,
+        onCardAction = onCardAction,
     )
 }
 
@@ -122,6 +133,8 @@ fun AssistantChatScreen(
     onCancelWrite: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
+    assistantCardRenderer: AssistantCardRenderer? = null,
+    onCardAction: (AssistantCardAction) -> Unit = {},
 ) {
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -144,6 +157,8 @@ fun AssistantChatScreen(
                 onRetry = onRetry,
                 onConfirmWrite = onConfirmWrite,
                 onCancelWrite = onCancelWrite,
+                assistantCardRenderer = assistantCardRenderer,
+                onCardAction = onCardAction,
                 modifier = Modifier.weight(1f),
             )
             AssistantStatusPanel(state = state)
@@ -224,6 +239,8 @@ private fun AssistantMessageThread(
     onRetry: () -> Unit,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
+    assistantCardRenderer: AssistantCardRenderer?,
+    onCardAction: (AssistantCardAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
@@ -248,6 +265,8 @@ private fun AssistantMessageThread(
                 onRetry = onRetry,
                 onConfirmWrite = onConfirmWrite,
                 onCancelWrite = onCancelWrite,
+                assistantCardRenderer = assistantCardRenderer,
+                onCardAction = onCardAction,
             )
         }
     }
@@ -259,6 +278,8 @@ private fun AssistantMessageBubble(
     onRetry: () -> Unit,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
+    assistantCardRenderer: AssistantCardRenderer?,
+    onCardAction: (AssistantCardAction) -> Unit,
 ) {
     val isUser = message.role == AssistantUiMessage.Role.USER
     val messageText = message.text.ifEmpty { " " }
@@ -314,6 +335,8 @@ private fun AssistantMessageBubble(
                     isUser = isUser,
                     onConfirmWrite = onConfirmWrite,
                     onCancelWrite = onCancelWrite,
+                    assistantCardRenderer = assistantCardRenderer,
+                    onCardAction = onCardAction,
                 )
                 message.error?.let { error ->
                     AssistantInlineError(
@@ -340,6 +363,8 @@ private fun AssistantMessageSegments(
     isUser: Boolean,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
+    assistantCardRenderer: AssistantCardRenderer?,
+    onCardAction: (AssistantCardAction) -> Unit,
 ) {
     message.segments.forEach { segment ->
         when (segment) {
@@ -348,13 +373,34 @@ private fun AssistantMessageSegments(
                 onConfirmWrite = onConfirmWrite,
                 onCancelWrite = onCancelWrite,
             )
-            is AssistantUiSegment.Card -> Unit
+            is AssistantUiSegment.Card -> AssistantCardSegment(
+                card = segment.card,
+                assistantCardRenderer = assistantCardRenderer,
+                onCardAction = onCardAction,
+            )
             is AssistantUiSegment.Text -> AssistantMessageTextSegment(
                 text = segment.text,
                 textColor = textColor,
                 isUser = isUser,
             )
         }
+    }
+}
+
+@Composable
+private fun AssistantCardSegment(
+    card: AssistantCard,
+    assistantCardRenderer: AssistantCardRenderer?,
+    onCardAction: (AssistantCardAction) -> Unit,
+) {
+    if (assistantCardRenderer == null) return
+
+    when (card) {
+        is AssistantCard.Order -> assistantCardRenderer.OrderCard(
+            card = card,
+            onAction = onCardAction,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }
 
@@ -721,6 +767,14 @@ private fun AssistantChatScreenPreview() {
             messages = listOf(
                 AssistantUiMessage("preview-1", AssistantUiMessage.Role.USER, "Show today's sales"),
                 AssistantUiMessage("preview-2", AssistantUiMessage.Role.ASSISTANT, "Sales are up 12% today."),
+                AssistantUiMessage(
+                    id = "preview-3",
+                    role = AssistantUiMessage.Role.ASSISTANT,
+                    segments = listOf(
+                        AssistantUiSegment.Text("Here is order #3479."),
+                        AssistantUiSegment.Card(sampleOrderCard()),
+                    ),
+                ),
             )
         ),
         inputText = "",
@@ -731,6 +785,7 @@ private fun AssistantChatScreenPreview() {
         onConfirmWrite = {},
         onCancelWrite = {},
         onBack = {},
+        assistantCardRenderer = PreviewAssistantCardRenderer,
     )
 }
 
@@ -776,6 +831,50 @@ private fun AssistantChatScreenConfirmationPreview() {
         onBack = {},
     )
 }
+
+private object PreviewAssistantCardRenderer : AssistantCardRenderer {
+    @Composable
+    override fun OrderCard(
+        card: AssistantCard.Order,
+        onAction: (AssistantCardAction) -> Unit,
+        modifier: Modifier,
+    ) {
+        Surface(
+            modifier = modifier,
+            shape = RoundedCornerShape(12.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        ) {
+            Column(
+                modifier = Modifier.padding(14.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = card.number,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = listOf(card.customerName, card.status, card.total)
+                        .filter { it.isNotBlank() }
+                        .joinToString(" - "),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
+}
+
+private fun sampleOrderCard() = AssistantCard.Order(
+    remoteOrderId = 3479L,
+    number = "#3479",
+    status = "processing",
+    total = "42.00 USD",
+    customerName = "Jane Doe",
+    date = "2026-05-01T10:00:00Z",
+)
 
 private fun sampleConfirmationPreview() = RenderedConfirmationPreview(
     message = "Update order #3479",

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -856,7 +856,7 @@ private object PreviewAssistantCardRenderer : AssistantCardRenderer {
                     fontWeight = FontWeight.SemiBold,
                 )
                 Text(
-                    text = listOf(card.customerName, card.status, card.total)
+                    text = listOf(card.customerName, card.status, card.unformattedTotal)
                         .filter { it.isNotBlank() }
                         .joinToString(" - "),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -871,10 +871,16 @@ private fun sampleOrderCard() = AssistantCard.Order(
     remoteOrderId = 3479L,
     number = "#3479",
     status = "processing",
-    total = "42.00 USD",
+    total = "42.00",
+    currency = "USD",
     customerName = "Jane Doe",
     date = "2026-05-01T10:00:00Z",
 )
+
+private val AssistantCard.Order.unformattedTotal: String
+    get() = total.takeIf { it.isNotBlank() }
+        ?.let { listOf(it, currency).filter { value -> value.isNotBlank() }.joinToString(" ") }
+        .orEmpty()
 
 private fun sampleConfirmationPreview() = RenderedConfirmationPreview(
     message = "Update order #3479",

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreview
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 
 data class AssistantUiState(
     val messages: List<AssistantUiMessage> = emptyList(),
@@ -69,6 +70,8 @@ sealed interface AssistantUiSegment {
     data class Text(val text: String) : AssistantUiSegment
 
     data class ConfirmationCard(val model: AssistantConfirmationCard) : AssistantUiSegment
+
+    data class Card(val card: AssistantCard) : AssistantUiSegment
 }
 
 data class AssistantConfirmationCard(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCard.kt
@@ -6,6 +6,7 @@ sealed interface AssistantCard {
         val number: String,
         val status: String,
         val total: String,
+        val currency: String,
         val customerName: String,
         val date: String,
     ) : AssistantCard

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCard.kt
@@ -1,0 +1,12 @@
+package com.woocommerce.android.aiassistant.ui.cards
+
+sealed interface AssistantCard {
+    data class Order(
+        val remoteOrderId: Long,
+        val number: String,
+        val status: String,
+        val total: String,
+        val customerName: String,
+        val date: String,
+    ) : AssistantCard
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardAction.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardAction.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.aiassistant.ui.cards
+
+sealed interface AssistantCardAction {
+    data class OpenOrder(val remoteOrderId: Long) : AssistantCardAction
+    data class OpenProduct(val remoteProductId: Long) : AssistantCardAction
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.aiassistant.ui.cards
+
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+
+internal object AssistantCardPayloadParser {
+    fun parse(payload: ShowCardsUiStructured): List<AssistantCard> =
+        payload.cards.mapNotNull(::parseCard)
+
+    private fun parseCard(card: ShowCardPayload): AssistantCard? {
+        if (card.family != ORDER_FAMILY) return null
+
+        val remoteOrderId = card.id.toLongOrNull()?.takeIf { it > 0 } ?: return null
+        val attributes = card.attributes
+        val status = attributes["status"]
+            ?: card.subtitle
+            ?: card.badges.firstOrNull()
+            ?: ""
+
+        return AssistantCard.Order(
+            remoteOrderId = remoteOrderId,
+            number = card.title,
+            status = status,
+            total = listOfNotBlank(attributes["total"], attributes["currency"]).joinToString(" "),
+            customerName = attributes["customer_name"].orEmpty(),
+            date = attributes["date_created"].orEmpty(),
+        )
+    }
+
+    private fun listOfNotBlank(vararg values: String?): List<String> =
+        values.filterNotNull().filter { it.isNotBlank() }
+
+    private const val ORDER_FAMILY = "order"
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
@@ -18,14 +18,12 @@ internal object AssistantCardPayloadParser {
             remoteOrderId = remoteOrderId,
             number = card.title,
             status = details.status.orEmpty(),
-            total = listOfNotBlank(details.total, details.currency).joinToString(" "),
+            total = details.total.orEmpty(),
+            currency = details.currency.orEmpty(),
             customerName = details.customerName.orEmpty(),
             date = details.dateCreated.orEmpty(),
         )
     }
-
-    private fun listOfNotBlank(vararg values: String?): List<String> =
-        values.filterNotNull().filter { it.isNotBlank() }
 
     private const val ORDER_FAMILY = "order"
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.aiassistant.ui.cards
 
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardDetails
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
 
@@ -11,19 +12,15 @@ internal object AssistantCardPayloadParser {
         if (card.family != ORDER_FAMILY) return null
 
         val remoteOrderId = card.id.toLongOrNull()?.takeIf { it > 0 } ?: return null
-        val attributes = card.attributes
-        val status = attributes["status"]
-            ?: card.subtitle
-            ?: card.badges.firstOrNull()
-            ?: ""
+        val details = card.details as? ShowCardDetails.Order ?: return null
 
         return AssistantCard.Order(
             remoteOrderId = remoteOrderId,
             number = card.title,
-            status = status,
-            total = listOfNotBlank(attributes["total"], attributes["currency"]).joinToString(" "),
-            customerName = attributes["customer_name"].orEmpty(),
-            date = attributes["date_created"].orEmpty(),
+            status = details.status.orEmpty(),
+            total = listOfNotBlank(details.total, details.currency).joinToString(" "),
+            customerName = details.customerName.orEmpty(),
+            date = details.dateCreated.orEmpty(),
         )
     }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardRenderer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardRenderer.kt
@@ -1,0 +1,13 @@
+package com.woocommerce.android.aiassistant.ui.cards
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+interface AssistantCardRenderer {
+    @Composable
+    fun OrderCard(
+        card: AssistantCard.Order,
+        onAction: (AssistantCardAction) -> Unit,
+        modifier: Modifier,
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapper.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapper.kt
@@ -1,0 +1,9 @@
+package com.woocommerce.android.aiassistant.ui.cards
+
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+import com.woocommerce.android.aiassistant.ui.AssistantUiSegment
+
+internal object AssistantCardSegmentMapper {
+    fun toSegments(payload: ShowCardsUiStructured): List<AssistantUiSegment.Card> =
+        AssistantCardPayloadParser.parse(payload).map(AssistantUiSegment::Card)
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -84,7 +84,15 @@ class ShowCardsToolHandlerTest {
 
         val summary = firstResolvedSummary(result)
 
-        assertThat(summary.keys).containsExactly("id", "number", "status", "total", "currency", "date_created")
+        assertThat(summary.keys).containsExactly(
+            "id",
+            "number",
+            "status",
+            "total",
+            "currency",
+            "date_created",
+            "customer_name",
+        )
     }
 
     @Test
@@ -384,6 +392,7 @@ class ShowCardsToolHandlerTest {
                     total = "12.34",
                     currency = "USD",
                     dateCreated = "2026-05-01T10:00:00Z",
+                    customerName = "Jane Doe",
                 )
             ).jsonObject,
             card = ShowCardPayload(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -149,6 +149,7 @@ class ShowCardsToolHandlerTest {
         assertThat(details.total).isEqualTo("12.34")
         assertThat(details.currency).isEqualTo("USD")
         assertThat(details.dateCreated).isEqualTo("2026-05-01T10:00:00Z")
+        assertThat(details.customerName).isEqualTo("Jane Doe")
         assertThat(uiCards(result).single().jsonObject.keys).doesNotContain("subtitle", "badges", "attributes")
         assertThat(assertSuccess(result).structured.toString()).doesNotContain("details")
     }
@@ -404,6 +405,7 @@ class ShowCardsToolHandlerTest {
                     total = "12.34",
                     currency = "USD",
                     dateCreated = "2026-05-01T10:00:00Z",
+                    customerName = "Jane Doe",
                 ),
             )
         )

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
@@ -114,7 +114,9 @@ class ShowCardsResolverTest {
             "total",
             "currency",
             "date_created",
+            "customer_name",
         )
+        assertThat(result[0].summary.getValue("customer_name").jsonPrimitive.content).isEqualTo("Jane Doe")
         assertThat(result[0].card.family).isEqualTo("order")
         assertThat(result[0].card.id).isEqualTo("1")
         assertThat(result[0].card.title).isEqualTo("#1")
@@ -123,6 +125,7 @@ class ShowCardsResolverTest {
         assertThat(orderDetails.total).isEqualTo("12.34")
         assertThat(orderDetails.currency).isEqualTo("USD")
         assertThat(orderDetails.dateCreated).isEqualTo("2026-05-01T10:00:00Z")
+        assertThat(orderDetails.customerName).isEqualTo("Jane Doe")
         assertThat(result[1].summary.keys).containsExactly("id", "name", "sku", "price", "stock_status")
         assertThat(result[1].card.family).isEqualTo("product")
         assertThat(result[1].card.id).isEqualTo("2")
@@ -218,6 +221,8 @@ class ShowCardsResolverTest {
         total = "12.34",
         currency = "USD",
         dateCreated = "2026-05-01T10:00:00Z",
+        billingFirstName = "Jane",
+        billingLastName = "Doe",
     )
 
     private fun product(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -207,7 +207,8 @@ class AssistantUiStateTest {
         remoteOrderId = 123L,
         number = "#1001",
         status = "processing",
-        total = "12.34 USD",
+        total = "12.34",
+        currency = "USD",
         customerName = "Jane Doe",
         date = "2026-05-01T10:00:00Z",
     )

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -173,4 +174,41 @@ class AssistantUiStateTest {
         assertThat(AssistantConfirmationCardState.CANCELLED.iconRes())
             .isEqualTo(R.drawable.ic_assistant_confirmation_cancelled)
     }
+
+    @Test
+    fun `given assistant card, when card segment is created, then card is preserved`() {
+        val card = orderCard()
+
+        val segment: AssistantUiSegment = AssistantUiSegment.Card(card)
+
+        assertThat(segment).isEqualTo(AssistantUiSegment.Card(card))
+    }
+
+    @Test
+    fun `given assistant message, when text and card segments are used, then segment order is preserved`() {
+        val card = orderCard()
+
+        val message = AssistantUiMessage(
+            id = "message-1",
+            role = AssistantUiMessage.Role.ASSISTANT,
+            segments = listOf(
+                AssistantUiSegment.Text("Here is the order."),
+                AssistantUiSegment.Card(card),
+            ),
+        )
+
+        assertThat(message.segments).containsExactly(
+            AssistantUiSegment.Text("Here is the order."),
+            AssistantUiSegment.Card(card),
+        )
+    }
+
+    private fun orderCard() = AssistantCard.Order(
+        remoteOrderId = 123L,
+        number = "#1001",
+        status = "processing",
+        total = "12.34 USD",
+        customerName = "Jane Doe",
+        date = "2026-05-01T10:00:00Z",
+    )
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardActionTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardActionTest.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.aiassistant.ui.cards
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AssistantCardActionTest {
+    @Test
+    fun `given open order action, when created, then remote order id is preserved`() {
+        val action: AssistantCardAction = AssistantCardAction.OpenOrder(remoteOrderId = 123L)
+
+        assertThat(action).isEqualTo(AssistantCardAction.OpenOrder(remoteOrderId = 123L))
+    }
+
+    @Test
+    fun `given open product action, when created, then remote product id is preserved`() {
+        val action: AssistantCardAction = AssistantCardAction.OpenProduct(remoteProductId = 456L)
+
+        assertThat(action).isEqualTo(AssistantCardAction.OpenProduct(remoteProductId = 456L))
+    }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
@@ -1,0 +1,107 @@
+package com.woocommerce.android.aiassistant.ui.cards
+
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AssistantCardPayloadParserTest {
+    @Test
+    fun `given order payload, when parsed, then order card contains displayed fields`() {
+        val cards = AssistantCardPayloadParser.parse(
+            ShowCardsUiStructured(
+                cards = listOf(
+                    ShowCardPayload(
+                        family = "order",
+                        id = "123",
+                        title = "#1001",
+                        subtitle = "processing",
+                        badges = listOf("processing"),
+                        attributes = mapOf(
+                            "status" to "processing",
+                            "total" to "12.34",
+                            "currency" to "USD",
+                            "date_created" to "2026-05-01T10:00:00Z",
+                            "customer_name" to "Jane Doe",
+                        ),
+                    )
+                )
+            )
+        )
+
+        assertThat(cards).containsExactly(
+            AssistantCard.Order(
+                remoteOrderId = 123L,
+                number = "#1001",
+                status = "processing",
+                total = "12.34 USD",
+                customerName = "Jane Doe",
+                date = "2026-05-01T10:00:00Z",
+            )
+        )
+    }
+
+    @Test
+    fun `given order payload without status attribute, when parsed, then subtitle is used`() {
+        val cards = AssistantCardPayloadParser.parse(
+            ShowCardsUiStructured(
+                cards = listOf(
+                    ShowCardPayload(
+                        family = "order",
+                        id = "123",
+                        title = "#1001",
+                        subtitle = "completed",
+                        attributes = mapOf("total" to "12.34"),
+                    )
+                )
+            )
+        )
+
+        assertThat(cards.single()).isEqualTo(
+            AssistantCard.Order(
+                remoteOrderId = 123L,
+                number = "#1001",
+                status = "completed",
+                total = "12.34",
+                customerName = "",
+                date = "",
+            )
+        )
+    }
+
+    @Test
+    fun `given product and invalid order payloads, when parsed, then they are ignored`() {
+        val cards = AssistantCardPayloadParser.parse(
+            ShowCardsUiStructured(
+                cards = listOf(
+                    ShowCardPayload(family = "product", id = "456", title = "Socks"),
+                    ShowCardPayload(family = "order", id = "not-a-number", title = "#bad"),
+                    ShowCardPayload(family = "order", id = "0", title = "#0"),
+                )
+            )
+        )
+
+        assertThat(cards).isEmpty()
+    }
+
+    @Test
+    fun `given multiple order payloads, when parsed, then input order is preserved`() {
+        val cards = AssistantCardPayloadParser.parse(
+            ShowCardsUiStructured(
+                cards = listOf(
+                    orderPayload(id = "1", title = "#1"),
+                    orderPayload(id = "2", title = "#2"),
+                )
+            )
+        )
+
+        assertThat(cards.map { (it as AssistantCard.Order).remoteOrderId }).containsExactly(1L, 2L)
+    }
+
+    private fun orderPayload(id: String, title: String) = ShowCardPayload(
+        family = "order",
+        id = id,
+        title = title,
+        attributes = mapOf("status" to "processing"),
+    )
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.aiassistant.ui.cards
 
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardDetails
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
 import org.assertj.core.api.Assertions.assertThat
@@ -15,14 +16,12 @@ class AssistantCardPayloadParserTest {
                         family = "order",
                         id = "123",
                         title = "#1001",
-                        subtitle = "processing",
-                        badges = listOf("processing"),
-                        attributes = mapOf(
-                            "status" to "processing",
-                            "total" to "12.34",
-                            "currency" to "USD",
-                            "date_created" to "2026-05-01T10:00:00Z",
-                            "customer_name" to "Jane Doe",
+                        details = ShowCardDetails.Order(
+                            status = "processing",
+                            total = "12.34",
+                            currency = "USD",
+                            dateCreated = "2026-05-01T10:00:00Z",
+                            customerName = "Jane Doe",
                         ),
                     )
                 )
@@ -42,7 +41,7 @@ class AssistantCardPayloadParserTest {
     }
 
     @Test
-    fun `given order payload without status attribute, when parsed, then subtitle is used`() {
+    fun `given order payload without status detail, when parsed, then status is empty`() {
         val cards = AssistantCardPayloadParser.parse(
             ShowCardsUiStructured(
                 cards = listOf(
@@ -50,8 +49,7 @@ class AssistantCardPayloadParserTest {
                         family = "order",
                         id = "123",
                         title = "#1001",
-                        subtitle = "completed",
-                        attributes = mapOf("total" to "12.34"),
+                        details = ShowCardDetails.Order(total = "12.34"),
                     )
                 )
             )
@@ -61,7 +59,7 @@ class AssistantCardPayloadParserTest {
             AssistantCard.Order(
                 remoteOrderId = 123L,
                 number = "#1001",
-                status = "completed",
+                status = "",
                 total = "12.34",
                 customerName = "",
                 date = "",
@@ -74,9 +72,24 @@ class AssistantCardPayloadParserTest {
         val cards = AssistantCardPayloadParser.parse(
             ShowCardsUiStructured(
                 cards = listOf(
-                    ShowCardPayload(family = "product", id = "456", title = "Socks"),
-                    ShowCardPayload(family = "order", id = "not-a-number", title = "#bad"),
-                    ShowCardPayload(family = "order", id = "0", title = "#0"),
+                    ShowCardPayload(
+                        family = "product",
+                        id = "456",
+                        title = "Socks",
+                        details = ShowCardDetails.Product(),
+                    ),
+                    ShowCardPayload(
+                        family = "order",
+                        id = "not-a-number",
+                        title = "#bad",
+                        details = ShowCardDetails.Order(),
+                    ),
+                    ShowCardPayload(
+                        family = "order",
+                        id = "0",
+                        title = "#0",
+                        details = ShowCardDetails.Order(),
+                    ),
                 )
             )
         )
@@ -102,6 +115,6 @@ class AssistantCardPayloadParserTest {
         family = "order",
         id = id,
         title = title,
-        attributes = mapOf("status" to "processing"),
+        details = ShowCardDetails.Order(status = "processing"),
     )
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
@@ -33,7 +33,8 @@ class AssistantCardPayloadParserTest {
                 remoteOrderId = 123L,
                 number = "#1001",
                 status = "processing",
-                total = "12.34 USD",
+                total = "12.34",
+                currency = "USD",
                 customerName = "Jane Doe",
                 date = "2026-05-01T10:00:00Z",
             )
@@ -61,6 +62,7 @@ class AssistantCardPayloadParserTest {
                 number = "#1001",
                 status = "",
                 total = "12.34",
+                currency = "",
                 customerName = "",
                 date = "",
             )

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
@@ -25,7 +25,8 @@ class AssistantCardSegmentMapperTest {
                     remoteOrderId = 1L,
                     number = "#1",
                     status = "processing",
-                    total = "12.34 USD",
+                    total = "12.34",
+                    currency = "USD",
                     customerName = "Jane Doe",
                     date = "2026-05-01T10:00:00Z",
                 )
@@ -35,7 +36,8 @@ class AssistantCardSegmentMapperTest {
                     remoteOrderId = 2L,
                     number = "#2",
                     status = "processing",
-                    total = "12.34 USD",
+                    total = "12.34",
+                    currency = "USD",
                     customerName = "Jane Doe",
                     date = "2026-05-01T10:00:00Z",
                 )

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
@@ -1,0 +1,71 @@
+package com.woocommerce.android.aiassistant.ui.cards
+
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+import com.woocommerce.android.aiassistant.ui.AssistantUiSegment
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AssistantCardSegmentMapperTest {
+    @Test
+    fun `given show cards payload, when mapped, then card segments preserve parsed card order`() {
+        val segments = AssistantCardSegmentMapper.toSegments(
+            ShowCardsUiStructured(
+                cards = listOf(
+                    orderPayload(id = "1", title = "#1"),
+                    orderPayload(id = "2", title = "#2"),
+                )
+            )
+        )
+
+        assertThat(segments).containsExactly(
+            AssistantUiSegment.Card(
+                AssistantCard.Order(
+                    remoteOrderId = 1L,
+                    number = "#1",
+                    status = "processing",
+                    total = "12.34 USD",
+                    customerName = "Jane Doe",
+                    date = "2026-05-01T10:00:00Z",
+                )
+            ),
+            AssistantUiSegment.Card(
+                AssistantCard.Order(
+                    remoteOrderId = 2L,
+                    number = "#2",
+                    status = "processing",
+                    total = "12.34 USD",
+                    customerName = "Jane Doe",
+                    date = "2026-05-01T10:00:00Z",
+                )
+            ),
+        )
+    }
+
+    @Test
+    fun `given unsupported payload, when mapped, then no segments are returned`() {
+        val segments = AssistantCardSegmentMapper.toSegments(
+            ShowCardsUiStructured(
+                cards = listOf(
+                    ShowCardPayload(family = "product", id = "456", title = "Socks"),
+                    ShowCardPayload(family = "order", id = "not-a-number", title = "#bad"),
+                )
+            )
+        )
+
+        assertThat(segments).isEmpty()
+    }
+
+    private fun orderPayload(id: String, title: String) = ShowCardPayload(
+        family = "order",
+        id = id,
+        title = title,
+        attributes = mapOf(
+            "status" to "processing",
+            "total" to "12.34",
+            "currency" to "USD",
+            "date_created" to "2026-05-01T10:00:00Z",
+            "customer_name" to "Jane Doe",
+        ),
+    )
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.aiassistant.ui.cards
 
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardDetails
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
 import com.woocommerce.android.aiassistant.ui.AssistantUiSegment
@@ -47,8 +48,18 @@ class AssistantCardSegmentMapperTest {
         val segments = AssistantCardSegmentMapper.toSegments(
             ShowCardsUiStructured(
                 cards = listOf(
-                    ShowCardPayload(family = "product", id = "456", title = "Socks"),
-                    ShowCardPayload(family = "order", id = "not-a-number", title = "#bad"),
+                    ShowCardPayload(
+                        family = "product",
+                        id = "456",
+                        title = "Socks",
+                        details = ShowCardDetails.Product(),
+                    ),
+                    ShowCardPayload(
+                        family = "order",
+                        id = "not-a-number",
+                        title = "#bad",
+                        details = ShowCardDetails.Order(),
+                    ),
                 )
             )
         )
@@ -60,12 +71,12 @@ class AssistantCardSegmentMapperTest {
         family = "order",
         id = id,
         title = title,
-        attributes = mapOf(
-            "status" to "processing",
-            "total" to "12.34",
-            "currency" to "USD",
-            "date_created" to "2026-05-01T10:00:00Z",
-            "customer_name" to "Jane Doe",
+        details = ShowCardDetails.Order(
+            status = "processing",
+            total = "12.34",
+            currency = "USD",
+            dateCreated = "2026-05-01T10:00:00Z",
+            customerName = "Jane Doe",
         ),
     )
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2908

This implements assistant order-card rendering for `show_cards` UI payloads while reusing the WooCommerce app's host-owned order row UI through an adapter. The assistant module owns the card protocol, payload parsing, renderer interface, and typed card actions; the host app owns WooCommerce-specific Compose rendering and navigation.

What changed:
- Added the assistant-owned card contract: `AssistantCard`, `AssistantCardAction`, `AssistantCardPayloadParser`, and `AssistantCardRenderer`.
- Parse `ShowCardsUiStructured` order payloads into stateless `AssistantCard.Order` models with status, total, customer, date, order number, and remote order ID.
- Added `customer_name` to the order summary payload produced for assistant cards.
- Extracted the existing dashboard order row into reusable `OrderSummaryRow` / `OrderSummaryRowModel` in `:WooCommerce`.
- Made `OrderSummaryRow` responsive to its own measured width using native Compose layout primitives, preserving the dashboard arrangement at dashboard/card widths and using the compact metadata arrangement only when the component is narrow.
- Added `WooAssistantCardRenderer`, which adapts assistant order cards to the reused host order row UI and emits `AssistantCardAction.OpenOrder(remoteOrderId)` when tapped.
- Added host navigation mapping for assistant card actions so `:WooCommerce` maps `OpenOrder` and `OpenProduct` to real app navigation.

Stack and compatibility notes:
- This PR is stacked on WOOMOB-2915, which is based on the WOOMOB-2966 show-cards resolver branch.
- To fit the WOOMOB-2915 transcript model, this PR also adds `AssistantUiSegment.Card` and `AssistantCardSegmentMapper` so parsed cards can live alongside text and confirmation segments.
- WOOMOB-2967 runtime delivery is intentionally out of scope here. On this base, `LoopEvent.ToolCallFinished` is still ignored by `AgenticLoopAssistantRuntime`, so this PR does not modify `AssistantRuntime`, `AgenticLoopAssistantRuntime`, or `AssistantViewModel` delivery behavior.
- The `:libs:ai-assistant:feature` module remains host-agnostic; no reverse dependency on `:WooCommerce` is introduced.

Validation performed:
- Focused assistant card parser/action/segment tests passed.
- Host renderer and navigation mapper tests passed.
- Wasabi debug Kotlin compile passed.
- Wasabi debug app assemble passed.
- Wasabi debug androidTest APK assemble passed.
- `detektAll --auto-correct` passed.
- `lintWasabiRelease` passed.
- Connected `OrderSummaryRowTest` passed on `Pixel_3a_API_28_AOSP`, covering wide dashboard and narrow assistant row behavior.
- Before/after dashboard screenshots on the same emulator/store showed no visible dashboard order-row layout regression.
- Boundary scans showed no host UI/navigation dependencies in `:libs:ai-assistant:feature`.

### Test Steps
Non regression only until WOOMOB-2967 delivers `show_cards` UI payloads into assistant messages.

1. Build and install the Wasabi debug app.
2. Open the dashboard with a store that has recent orders and the Most recent orders section enabled.
3. Confirm the recent order rows still show order number/date on the left/top, status/POS tags on the right/top, customer below the number, and total right-aligned below the status row.
4. Tap a dashboard order and confirm it still opens order details.
5. Open the assistant screen from the More menu and confirm the chat screen still opens, sends text messages, and handles back navigation as before.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
