### PR TITLE
[WOOMOB-2915] Show unsafe tool confirmations inline

### DIFF
--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -271,7 +271,6 @@ class AgenticLoopImpl(
         outcome.completed.forEach { completed ->
             newTurnMessages.add(completed.toToolMessage())
         }
-        emit(LoopEvent.Failed(AssistantError.Cancelled))
         emit(LoopEvent.Finished(LoopOutcome.STOPPED, history + newTurnMessages, retryAvailable = false))
     }
 

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -663,7 +663,8 @@ class AgenticLoopImplTest {
         }
 
     @Test
-    fun `given UNSAFE tool is cancelled, when loop awaits confirmation, then cancelled error is emitted and history is clean`() = runTest {
+    fun `given UNSAFE tool is cancelled, when loop awaits confirmation, then turn stops cleanly and history is clean`() =
+        runTest {
         val unsafeDescriptor = ToolDescriptor(
             name = "orders_update",
             description = "Updates an order",
@@ -724,8 +725,7 @@ class AgenticLoopImplTest {
 
         assertThat(events.filterIsInstance<LoopEvent.ConfirmationResolved>().single().result.decision)
             .isEqualTo(ConfirmationDecision.CANCELLED)
-        assertThat(events.filterIsInstance<LoopEvent.Failed>().single().error)
-            .isEqualTo(AssistantError.Cancelled)
+        assertThat(events.filterIsInstance<LoopEvent.Failed>()).isEmpty()
         assertThat(events.filterIsInstance<LoopEvent.ToolCallStarted>()).isEmpty()
         assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>()).isEmpty()
         assertThat(registryExecuted).isFalse
@@ -733,6 +733,7 @@ class AgenticLoopImplTest {
         val finished = events.filterIsInstance<LoopEvent.Finished>().last()
         assertThat(finished.outcome).isEqualTo(LoopOutcome.STOPPED)
         assertThat(finished.retryAvailable).isFalse
+        assertThat(finished.error).isNull()
         assertThat(finished.updatedHistory.filterIsInstance<AssistantMessage.Tool>()).isEmpty()
         val assistantMessages = finished.updatedHistory.filterIsInstance<AssistantMessage.Assistant>()
         assertThat(assistantMessages.flatMap { it.toolCalls }).isEmpty()
@@ -740,7 +741,8 @@ class AgenticLoopImplTest {
     }
 
     @Test
-    fun `given safe tool succeeds before unsafe tool, when unsafe is cancelled, then history is preserved`() = runTest {
+    fun `given safe tool succeeds before unsafe tool, when unsafe is cancelled, then history is preserved cleanly`() =
+        runTest {
         val unsafeDescriptor = ToolDescriptor(
             name = "orders_update",
             description = "Updates an order",
@@ -809,11 +811,11 @@ class AgenticLoopImplTest {
             .containsExactly("safe_1")
         assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>().map { it.result.toolCallId })
             .containsExactly("safe_1")
-        assertThat(events.filterIsInstance<LoopEvent.Failed>().single().error)
-            .isEqualTo(AssistantError.Cancelled)
+        assertThat(events.filterIsInstance<LoopEvent.Failed>()).isEmpty()
         val finished = events.filterIsInstance<LoopEvent.Finished>().last()
         assertThat(finished.outcome).isEqualTo(LoopOutcome.STOPPED)
         assertThat(finished.retryAvailable).isFalse
+        assertThat(finished.error).isNull()
         assertThat(secondModelTurnRequested).isFalse
 
         val assistantToolCalls = finished.updatedHistory.filterIsInstance<AssistantMessage.Assistant>()

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -665,170 +665,183 @@ class AgenticLoopImplTest {
     @Test
     fun `given UNSAFE tool is cancelled, when loop awaits confirmation, then turn stops cleanly and history is clean`() =
         runTest {
-        val unsafeDescriptor = ToolDescriptor(
-            name = "orders_update",
-            description = "Updates an order",
-            inputSchema = buildJsonObject { },
-            safetyLevel = ToolSafetyLevel.UNSAFE,
-        )
-        var registryExecuted = false
-        var secondModelTurnRequested = false
-        val service = object : ChatService {
-            private var count = 0
+            val unsafeDescriptor = ToolDescriptor(
+                name = "orders_update",
+                description = "Updates an order",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.UNSAFE,
+            )
+            var registryExecuted = false
+            var secondModelTurnRequested = false
+            val service = object : ChatService {
+                private var count = 0
 
-            override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> {
-                count++
-                return if (count == 1) {
-                    flow {
-                        emit(
-                            AssistantEvent.ToolCallDelta(
-                                index = 0,
-                                id = "call_1",
-                                name = "orders_update",
-                                argumentsDelta = """{"id":42,"status":"processing"}""",
+                override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> {
+                    count++
+                    return if (count == 1) {
+                        flow {
+                            emit(
+                                AssistantEvent.ToolCallDelta(
+                                    index = 0,
+                                    id = "call_1",
+                                    name = "orders_update",
+                                    argumentsDelta = """{"id":42,"status":"processing"}""",
+                                )
                             )
-                        )
-                        emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
+                            emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
+                        }
+                    } else {
+                        secondModelTurnRequested = true
+                        flowOf(AssistantEvent.Finish(FinishReason.STOP))
                     }
-                } else {
-                    secondModelTurnRequested = true
-                    flowOf(AssistantEvent.Finish(FinishReason.STOP))
                 }
             }
-        }
-        val registry = object : ToolRegistry {
-            override fun descriptors() = listOf(unsafeDescriptor)
-            override suspend fun execute(call: ToolCall): ToolResult {
-                registryExecuted = true
-                return ToolResult.Success(call.id, buildJsonObject { put("ok", true) })
+            val registry = object : ToolRegistry {
+                override fun descriptors() = listOf(unsafeDescriptor)
+
+                override suspend fun execute(call: ToolCall): ToolResult {
+                    registryExecuted = true
+                    return ToolResult.Success(call.id, buildJsonObject { put("ok", true) })
+                }
             }
+            val safetyOrchestrator = SafetyOrchestratorImpl()
+            val loop = AgenticLoopImpl(
+                service,
+                registry,
+                ConservativeRetryPolicy,
+                passThroughBudgeter(),
+                safetyOrchestrator,
+                json,
+            )
+            val events = mutableListOf<LoopEvent>()
+
+            val job = launch {
+                loop.runTurn(
+                    conversationId = "conv",
+                    userMessage = "go",
+                    history = history,
+                    context = contextWithTools(unsafeDescriptor),
+                ).toList(events)
+            }
+
+            runCurrent()
+            val request = events.filterIsInstance<LoopEvent.ConfirmationRequested>().single().request
+            safetyOrchestrator.cancel(request.id)
+            advanceUntilIdle()
+
+            assertThat(events.filterIsInstance<LoopEvent.ConfirmationResolved>().single().result.decision)
+                .isEqualTo(ConfirmationDecision.CANCELLED)
+            assertThat(events.filterIsInstance<LoopEvent.Failed>()).isEmpty()
+            assertThat(events.filterIsInstance<LoopEvent.ToolCallStarted>()).isEmpty()
+            assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>()).isEmpty()
+            assertThat(registryExecuted).isFalse
+            assertThat(secondModelTurnRequested).isFalse()
+
+            val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+            assertThat(finished.outcome).isEqualTo(LoopOutcome.STOPPED)
+            assertThat(finished.retryAvailable).isFalse()
+            assertThat(finished.error).isNull()
+            assertThat(finished.updatedHistory.filterIsInstance<AssistantMessage.Tool>()).isEmpty()
+            val assistantMessages = finished.updatedHistory.filterIsInstance<AssistantMessage.Assistant>()
+            assertThat(assistantMessages.flatMap { it.toolCalls }).isEmpty()
+            job.cancel()
         }
-        val safetyOrchestrator = SafetyOrchestratorImpl()
-        val loop = AgenticLoopImpl(
-            service,
-            registry,
-            ConservativeRetryPolicy,
-            passThroughBudgeter(),
-            safetyOrchestrator,
-            json,
-        )
-        val events = mutableListOf<LoopEvent>()
-
-        val job = launch {
-            loop.runTurn("conv", "go", history, contextWithTools(unsafeDescriptor)).toList(events)
-        }
-
-        runCurrent()
-        val request = events.filterIsInstance<LoopEvent.ConfirmationRequested>().single().request
-        safetyOrchestrator.cancel(request.id)
-        advanceUntilIdle()
-
-        assertThat(events.filterIsInstance<LoopEvent.ConfirmationResolved>().single().result.decision)
-            .isEqualTo(ConfirmationDecision.CANCELLED)
-        assertThat(events.filterIsInstance<LoopEvent.Failed>()).isEmpty()
-        assertThat(events.filterIsInstance<LoopEvent.ToolCallStarted>()).isEmpty()
-        assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>()).isEmpty()
-        assertThat(registryExecuted).isFalse
-        assertThat(secondModelTurnRequested).isFalse
-        val finished = events.filterIsInstance<LoopEvent.Finished>().last()
-        assertThat(finished.outcome).isEqualTo(LoopOutcome.STOPPED)
-        assertThat(finished.retryAvailable).isFalse
-        assertThat(finished.error).isNull()
-        assertThat(finished.updatedHistory.filterIsInstance<AssistantMessage.Tool>()).isEmpty()
-        val assistantMessages = finished.updatedHistory.filterIsInstance<AssistantMessage.Assistant>()
-        assertThat(assistantMessages.flatMap { it.toolCalls }).isEmpty()
-        job.cancel()
-    }
 
     @Test
     fun `given safe tool succeeds before unsafe tool, when unsafe is cancelled, then history is preserved cleanly`() =
         runTest {
-        val unsafeDescriptor = ToolDescriptor(
-            name = "orders_update",
-            description = "Updates an order",
-            inputSchema = buildJsonObject { },
-            safetyLevel = ToolSafetyLevel.UNSAFE,
-        )
-        var secondModelTurnRequested = false
-        val service = object : ChatService {
-            private var count = 0
+            val unsafeDescriptor = ToolDescriptor(
+                name = "orders_update",
+                description = "Updates an order",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.UNSAFE,
+            )
+            var secondModelTurnRequested = false
+            val service = object : ChatService {
+                private var count = 0
 
-            override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> {
-                count++
-                return if (count == 1) {
-                    flow {
-                        emit(AssistantEvent.TextDelta("I'll do both."))
-                        emit(
-                            AssistantEvent.ToolCallDelta(
-                                index = 0,
-                                id = "safe_1",
-                                name = "echo",
-                                argumentsDelta = """{"msg":"hello"}""",
+                override fun streamTurn(request: ChatRequest): Flow<AssistantEvent> {
+                    count++
+                    return if (count == 1) {
+                        flow {
+                            emit(AssistantEvent.TextDelta("I'll do both."))
+                            emit(
+                                AssistantEvent.ToolCallDelta(
+                                    index = 0,
+                                    id = "safe_1",
+                                    name = "echo",
+                                    argumentsDelta = """{"msg":"hello"}""",
+                                )
                             )
-                        )
-                        emit(
-                            AssistantEvent.ToolCallDelta(
-                                index = 1,
-                                id = "unsafe_1",
-                                name = "orders_update",
-                                argumentsDelta = """{"id":42,"status":"processing"}""",
+                            emit(
+                                AssistantEvent.ToolCallDelta(
+                                    index = 1,
+                                    id = "unsafe_1",
+                                    name = "orders_update",
+                                    argumentsDelta = """{"id":42,"status":"processing"}""",
+                                )
                             )
-                        )
-                        emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
+                            emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
+                        }
+                    } else {
+                        secondModelTurnRequested = true
+                        flowOf(AssistantEvent.Finish(FinishReason.STOP))
                     }
-                } else {
-                    secondModelTurnRequested = true
-                    flowOf(AssistantEvent.Finish(FinishReason.STOP))
                 }
             }
+            val registry = object : ToolRegistry {
+                override fun descriptors() = listOf(safeEchoDescriptor(), unsafeDescriptor)
+
+                override suspend fun execute(call: ToolCall): ToolResult =
+                    ToolResult.Success(call.id, buildJsonObject { put("echoed", "hello") })
+            }
+            val safetyOrchestrator = SafetyOrchestratorImpl()
+            val loop = AgenticLoopImpl(
+                service,
+                registry,
+                ConservativeRetryPolicy,
+                passThroughBudgeter(),
+                safetyOrchestrator,
+                json,
+            )
+            val events = mutableListOf<LoopEvent>()
+
+            val job = launch {
+                loop.runTurn(
+                    conversationId = "conv",
+                    userMessage = "go",
+                    history = history,
+                    context = contextWithTools(safeEchoDescriptor(), unsafeDescriptor),
+                ).toList(events)
+            }
+
+            runCurrent()
+            val request = events.filterIsInstance<LoopEvent.ConfirmationRequested>().single().request
+            safetyOrchestrator.cancel(request.id)
+            advanceUntilIdle()
+
+            assertThat(events.filterIsInstance<LoopEvent.ToolCallStarted>().map { it.call.id })
+                .containsExactly("safe_1")
+            assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>().map { it.result.toolCallId })
+                .containsExactly("safe_1")
+            assertThat(events.filterIsInstance<LoopEvent.Failed>()).isEmpty()
+            val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+            assertThat(finished.outcome).isEqualTo(LoopOutcome.STOPPED)
+            assertThat(finished.retryAvailable).isFalse
+            assertThat(finished.error).isNull()
+            assertThat(secondModelTurnRequested).isFalse
+
+            val assistantToolCalls = finished.updatedHistory.filterIsInstance<AssistantMessage.Assistant>()
+                .flatMap { it.toolCalls }
+            assertThat(assistantToolCalls.map { it.id }).containsExactly("safe_1")
+            assertThat(assistantToolCalls.map { it.id }).doesNotContain("unsafe_1")
+
+            val toolMessages = finished.updatedHistory.filterIsInstance<AssistantMessage.Tool>()
+            assertThat(toolMessages.map { it.toolCallId }).containsExactly("safe_1")
+            assertThat(toolMessages.map { it.toolCallId }).doesNotContain("unsafe_1")
+            assertThat(toolMessages.single().content).contains("echoed")
+            job.cancel()
         }
-        val registry = object : ToolRegistry {
-            override fun descriptors() = listOf(safeEchoDescriptor(), unsafeDescriptor)
-            override suspend fun execute(call: ToolCall): ToolResult =
-                ToolResult.Success(call.id, buildJsonObject { put("echoed", "hello") })
-        }
-        val safetyOrchestrator = SafetyOrchestratorImpl()
-        val loop = AgenticLoopImpl(
-            service,
-            registry,
-            ConservativeRetryPolicy,
-            passThroughBudgeter(),
-            safetyOrchestrator,
-            json,
-        )
-        val events = mutableListOf<LoopEvent>()
-
-        val job = launch {
-            loop.runTurn("conv", "go", history, contextWithTools(safeEchoDescriptor(), unsafeDescriptor)).toList(events)
-        }
-
-        runCurrent()
-        val request = events.filterIsInstance<LoopEvent.ConfirmationRequested>().single().request
-        safetyOrchestrator.cancel(request.id)
-        advanceUntilIdle()
-
-        assertThat(events.filterIsInstance<LoopEvent.ToolCallStarted>().map { it.call.id })
-            .containsExactly("safe_1")
-        assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>().map { it.result.toolCallId })
-            .containsExactly("safe_1")
-        assertThat(events.filterIsInstance<LoopEvent.Failed>()).isEmpty()
-        val finished = events.filterIsInstance<LoopEvent.Finished>().last()
-        assertThat(finished.outcome).isEqualTo(LoopOutcome.STOPPED)
-        assertThat(finished.retryAvailable).isFalse
-        assertThat(finished.error).isNull()
-        assertThat(secondModelTurnRequested).isFalse
-
-        val assistantToolCalls = finished.updatedHistory.filterIsInstance<AssistantMessage.Assistant>()
-            .flatMap { it.toolCalls }
-        assertThat(assistantToolCalls.map { it.id }).containsExactly("safe_1")
-        assertThat(assistantToolCalls.map { it.id }).doesNotContain("unsafe_1")
-
-        val toolMessages = finished.updatedHistory.filterIsInstance<AssistantMessage.Tool>()
-        assertThat(toolMessages.map { it.toolCallId }).containsExactly("safe_1")
-        assertThat(toolMessages.map { it.toolCallId }).doesNotContain("unsafe_1")
-        assertThat(toolMessages.single().content).contains("echoed")
-        job.cancel()
-    }
 
     @Test
     fun `given budgeter trims history, when running turn, then model receives only budgeted messages`() = runTest {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/openai/OpenAiMapping.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/chat/openai/OpenAiMapping.kt
@@ -20,7 +20,9 @@ internal fun AssistantMessage.toOpenAi(): OpenAiMessage = when (this) {
     is AssistantMessage.System -> OpenAiMessage.System(content = content)
     is AssistantMessage.User -> OpenAiMessage.User(content = content)
     is AssistantMessage.Assistant -> OpenAiMessage.Assistant(
-        content = content,
+        // Jetpack AI rejects assistant tool-call replay messages when content is omitted/null.
+        // send an empty string instead.
+        content = content ?: "",
         toolCalls = toolCalls.takeIf { it.isNotEmpty() }?.map(ToolCall::toOpenAi),
     )
     is AssistantMessage.Tool -> OpenAiMessage.Tool(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
@@ -11,6 +11,8 @@ import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
 import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
 import com.woocommerce.android.aiassistant.safety.ConfirmationPreviewRenderer
 import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationPreviewBuilder
+import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
+import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCardState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -59,7 +61,7 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
                     AssistantRuntimeEvent.AssistantTextDelta(event.text)
                 )
                 is LoopEvent.ConfirmationRequested -> emit(
-                    AssistantRuntimeEvent.AwaitingConfirmation(event.request.toPendingConfirmation())
+                    AssistantRuntimeEvent.AwaitingConfirmation(event.request.toConfirmationCard())
                 )
                 is LoopEvent.Finished -> {
                     emit(
@@ -80,13 +82,14 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
         }
     }
 
-    private fun ConfirmationRequest.toPendingConfirmation() = AssistantPendingConfirmation(
-        id = id,
+    private fun ConfirmationRequest.toConfirmationCard() = AssistantConfirmationCard(
+        confirmationId = id,
         toolCall = ToolCall(
             id = toolCallId,
             name = toolName,
             arguments = arguments,
         ),
+        state = AssistantConfirmationCardState.PENDING,
         preview = confirmationPreviewRenderer.render(confirmationPreviewBuilder.build(this)),
     )
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.aiassistant.core.loop.AgenticLoop
 import com.woocommerce.android.aiassistant.core.loop.LoopEvent
 import com.woocommerce.android.aiassistant.core.loop.SessionContext
 import com.woocommerce.android.aiassistant.core.loop.ToolCatalogSelector
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
 import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
 import com.woocommerce.android.aiassistant.safety.ConfirmationSnapshot
@@ -35,16 +36,14 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
 
     override suspend fun cancelTurn(conversationId: String) = Unit
 
-    override suspend fun confirmWrite(confirmationId: String): AssistantRuntimeConfirmationResult =
-        if (safetyOrchestrator.confirm(confirmationId)) {
-            AssistantRuntimeConfirmationResult.Accepted
+    override suspend fun resolveConfirmation(
+        result: ConfirmationResult,
+    ): AssistantRuntimeConfirmationDispatchResult =
+        if (safetyOrchestrator.resolve(result)) {
+            AssistantRuntimeConfirmationDispatchResult.Accepted
         } else {
-            AssistantRuntimeConfirmationResult.Deferred
+            AssistantRuntimeConfirmationDispatchResult.Deferred
         }
-
-    override suspend fun cancelWrite(confirmationId: String) {
-        safetyOrchestrator.cancel(confirmationId)
-    }
 
     private fun runTurn(request: AssistantTurnRequest): Flow<AssistantRuntimeEvent> = flow {
         val context = SessionContext(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
@@ -7,13 +7,13 @@ import com.woocommerce.android.aiassistant.core.loop.AgenticLoop
 import com.woocommerce.android.aiassistant.core.loop.LoopEvent
 import com.woocommerce.android.aiassistant.core.loop.SessionContext
 import com.woocommerce.android.aiassistant.core.loop.ToolCatalogSelector
-import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
-import com.woocommerce.android.aiassistant.safety.ConfirmationSnapshot
 import com.woocommerce.android.aiassistant.safety.ConfirmationPreviewRenderer
-import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationSnapshotResolver
+import com.woocommerce.android.aiassistant.safety.ConfirmationSnapshot
 import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationPreviewBuilder
+import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationSnapshotResolver
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCardState
 import kotlinx.coroutines.flow.Flow
@@ -91,15 +91,16 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
         }
     }
 
-    private fun ConfirmationRequest.toConfirmationCard(snapshot: ConfirmationSnapshot?) =
-        AssistantConfirmationCard(
-        confirmationId = id,
-        toolCall = ToolCall(
-            id = toolCallId,
-            name = toolName,
-            arguments = arguments,
-        ),
-        state = AssistantConfirmationCardState.PENDING,
-        preview = confirmationPreviewRenderer.render(confirmationPreviewBuilder.build(this, snapshot)),
-    )
+    private fun ConfirmationRequest.toConfirmationCard(snapshot: ConfirmationSnapshot?): AssistantConfirmationCard {
+        return AssistantConfirmationCard(
+            confirmationId = id,
+            toolCall = ToolCall(
+                id = toolCallId,
+                name = toolName,
+                arguments = arguments,
+            ),
+            state = AssistantConfirmationCardState.PENDING,
+            preview = confirmationPreviewRenderer.render(confirmationPreviewBuilder.build(this, snapshot)),
+        )
+    }
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
@@ -83,7 +83,9 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
                     pendingError = null
                 }
                 is LoopEvent.Failed -> pendingError = event.error
-                is LoopEvent.ConfirmationResolved,
+                is LoopEvent.ConfirmationResolved -> emit(
+                    AssistantRuntimeEvent.ConfirmationResolved(event.result)
+                )
                 is LoopEvent.ToolCallFinished,
                 is LoopEvent.ToolCallStarted -> Unit
             }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
@@ -9,7 +9,9 @@ import com.woocommerce.android.aiassistant.core.loop.SessionContext
 import com.woocommerce.android.aiassistant.core.loop.ToolCatalogSelector
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
 import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
+import com.woocommerce.android.aiassistant.safety.ConfirmationSnapshot
 import com.woocommerce.android.aiassistant.safety.ConfirmationPreviewRenderer
+import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationSnapshotResolver
 import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationPreviewBuilder
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCardState
@@ -24,6 +26,7 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
     private val safetyOrchestrator: SafetyOrchestrator,
     private val confirmationPreviewBuilder: WooCommerceConfirmationPreviewBuilder,
     private val confirmationPreviewRenderer: ConfirmationPreviewRenderer,
+    private val confirmationSnapshotResolver: WooCommerceConfirmationSnapshotResolver,
 ) : AssistantRuntime {
 
     override fun startTurn(request: AssistantTurnRequest): Flow<AssistantRuntimeEvent> = runTurn(request)
@@ -60,9 +63,14 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
                 is LoopEvent.AssistantTextDelta -> emit(
                     AssistantRuntimeEvent.AssistantTextDelta(event.text)
                 )
-                is LoopEvent.ConfirmationRequested -> emit(
-                    AssistantRuntimeEvent.AwaitingConfirmation(event.request.toConfirmationCard())
-                )
+                is LoopEvent.ConfirmationRequested -> {
+                    val snapshot = confirmationSnapshotResolver.resolve(event.request)
+                    emit(
+                        AssistantRuntimeEvent.AwaitingConfirmation(
+                            event.request.toConfirmationCard(snapshot)
+                        )
+                    )
+                }
                 is LoopEvent.Finished -> {
                     emit(
                         AssistantRuntimeEvent.Finished(
@@ -82,7 +90,8 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
         }
     }
 
-    private fun ConfirmationRequest.toConfirmationCard() = AssistantConfirmationCard(
+    private fun ConfirmationRequest.toConfirmationCard(snapshot: ConfirmationSnapshot?) =
+        AssistantConfirmationCard(
         confirmationId = id,
         toolCall = ToolCall(
             id = toolCallId,
@@ -90,6 +99,6 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
             arguments = arguments,
         ),
         state = AssistantConfirmationCardState.PENDING,
-        preview = confirmationPreviewRenderer.render(confirmationPreviewBuilder.build(this)),
+        preview = confirmationPreviewRenderer.render(confirmationPreviewBuilder.build(this, snapshot)),
     )
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
 import com.woocommerce.android.aiassistant.core.loop.ToolScope
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
 import kotlinx.coroutines.flow.Flow
 
@@ -32,6 +33,10 @@ sealed interface AssistantRuntimeEvent {
 
     data class AwaitingConfirmation(
         val confirmation: AssistantConfirmationCard,
+    ) : AssistantRuntimeEvent
+
+    data class ConfirmationResolved(
+        val result: ConfirmationResult,
     ) : AssistantRuntimeEvent
 
     data class Finished(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
@@ -15,9 +15,7 @@ interface AssistantRuntime {
 
     suspend fun cancelTurn(conversationId: String)
 
-    suspend fun confirmWrite(confirmationId: String): AssistantRuntimeConfirmationResult
-
-    suspend fun cancelWrite(confirmationId: String)
+    suspend fun resolveConfirmation(result: ConfirmationResult): AssistantRuntimeConfirmationDispatchResult
 }
 
 data class AssistantTurnRequest(
@@ -47,7 +45,7 @@ sealed interface AssistantRuntimeEvent {
     ) : AssistantRuntimeEvent
 }
 
-sealed interface AssistantRuntimeConfirmationResult {
-    data object Accepted : AssistantRuntimeConfirmationResult
-    data object Deferred : AssistantRuntimeConfirmationResult
+sealed interface AssistantRuntimeConfirmationDispatchResult {
+    data object Accepted : AssistantRuntimeConfirmationDispatchResult
+    data object Deferred : AssistantRuntimeConfirmationDispatchResult
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
@@ -2,10 +2,9 @@ package com.woocommerce.android.aiassistant.runtime
 
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
-import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
 import com.woocommerce.android.aiassistant.core.loop.ToolScope
-import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreview
+import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
 import kotlinx.coroutines.flow.Flow
 
 interface AssistantRuntime {
@@ -32,7 +31,7 @@ sealed interface AssistantRuntimeEvent {
     data class AssistantTextDelta(val text: String) : AssistantRuntimeEvent
 
     data class AwaitingConfirmation(
-        val confirmation: AssistantPendingConfirmation,
+        val confirmation: AssistantConfirmationCard,
     ) : AssistantRuntimeEvent
 
     data class Finished(
@@ -42,12 +41,6 @@ sealed interface AssistantRuntimeEvent {
         val error: AssistantError? = null,
     ) : AssistantRuntimeEvent
 }
-
-data class AssistantPendingConfirmation(
-    val id: String,
-    val toolCall: ToolCall,
-    val preview: RenderedConfirmationPreview? = null,
-)
 
 sealed interface AssistantRuntimeConfirmationResult {
     data object Accepted : AssistantRuntimeConfirmationResult

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreview.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreview.kt
@@ -3,32 +3,23 @@ package com.woocommerce.android.aiassistant.safety
 import androidx.annotation.StringRes
 
 internal data class ConfirmationPreview(
-    val summary: ConfirmationPreviewText,
-    val rows: List<ConfirmationPreviewRow> = emptyList(),
+    val message: ConfirmationPreviewText,
+    val fields: List<ConfirmationPreviewField> = emptyList(),
     val isBulk: Boolean = false,
 ) {
-    constructor(
-        message: ConfirmationPreviewText,
-        fields: List<ConfirmationPreviewField> = emptyList(),
-    ) : this(
-        summary = message,
-        rows = fields,
-    )
+    val summary: ConfirmationPreviewText
+        get() = message
 
-    val message: ConfirmationPreviewText
-        get() = summary
-
-    val fields: List<ConfirmationPreviewField>
-        get() = rows
+    val rows: List<ConfirmationPreviewField>
+        get() = fields
 }
 
-internal data class ConfirmationPreviewRow(
+internal data class ConfirmationPreviewField(
     val name: String,
     val label: ConfirmationPreviewText,
     val value: ConfirmationPreviewText,
+    val beforeValue: ConfirmationPreviewText? = null,
 )
-
-internal typealias ConfirmationPreviewField = ConfirmationPreviewRow
 
 internal sealed interface ConfirmationPreviewText {
     data class Raw(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreview.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreview.kt
@@ -3,15 +3,32 @@ package com.woocommerce.android.aiassistant.safety
 import androidx.annotation.StringRes
 
 internal data class ConfirmationPreview(
-    val message: ConfirmationPreviewText,
-    val fields: List<ConfirmationPreviewField> = emptyList(),
-)
+    val summary: ConfirmationPreviewText,
+    val rows: List<ConfirmationPreviewRow> = emptyList(),
+    val isBulk: Boolean = false,
+) {
+    constructor(
+        message: ConfirmationPreviewText,
+        fields: List<ConfirmationPreviewField> = emptyList(),
+    ) : this(
+        summary = message,
+        rows = fields,
+    )
 
-internal data class ConfirmationPreviewField(
+    val message: ConfirmationPreviewText
+        get() = summary
+
+    val fields: List<ConfirmationPreviewField>
+        get() = rows
+}
+
+internal data class ConfirmationPreviewRow(
     val name: String,
     val label: ConfirmationPreviewText,
     val value: ConfirmationPreviewText,
 )
+
+internal typealias ConfirmationPreviewField = ConfirmationPreviewRow
 
 internal sealed interface ConfirmationPreviewText {
     data class Raw(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
@@ -59,8 +59,7 @@ data class RenderedConfirmationDiffRow(
     val label: String,
     val value: String,
     val beforeValue: String? = null,
-)
-{
+) {
     val afterValue: String
         get() = value
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
@@ -9,14 +9,15 @@ internal class ConfirmationPreviewRenderer @Inject constructor(
 ) {
     fun render(preview: ConfirmationPreview): RenderedConfirmationPreview =
         RenderedConfirmationPreview(
-            message = render(preview.message),
-            fields = preview.fields.map {
-                RenderedConfirmationPreviewField(
+            summary = render(preview.summary),
+            rows = preview.rows.map {
+                RenderedConfirmationDiffRow(
                     name = it.name,
                     label = render(it.label),
                     value = render(it.value),
                 )
             },
+            isBulk = preview.isBulk,
         )
 
     @Suppress("SpreadOperator")
@@ -35,12 +36,30 @@ internal class ConfirmationPreviewRenderer @Inject constructor(
 }
 
 data class RenderedConfirmationPreview(
-    val message: String,
-    val fields: List<RenderedConfirmationPreviewField>,
-)
+    val summary: String,
+    val rows: List<RenderedConfirmationDiffRow>,
+    val isBulk: Boolean,
+) {
+    constructor(
+        message: String,
+        fields: List<RenderedConfirmationPreviewField>,
+    ) : this(
+        summary = message,
+        rows = fields,
+        isBulk = false,
+    )
 
-data class RenderedConfirmationPreviewField(
+    val message: String
+        get() = summary
+
+    val fields: List<RenderedConfirmationPreviewField>
+        get() = rows
+}
+
+data class RenderedConfirmationDiffRow(
     val name: String,
     val label: String,
     val value: String,
 )
+
+typealias RenderedConfirmationPreviewField = RenderedConfirmationDiffRow

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
@@ -9,12 +9,13 @@ internal class ConfirmationPreviewRenderer @Inject constructor(
 ) {
     fun render(preview: ConfirmationPreview): RenderedConfirmationPreview =
         RenderedConfirmationPreview(
-            summary = render(preview.summary),
-            rows = preview.rows.map {
+            message = render(preview.summary),
+            fields = preview.rows.map {
                 RenderedConfirmationDiffRow(
                     name = it.name,
                     label = render(it.label),
                     value = render(it.value),
+                    beforeValue = it.beforeValue?.let(::render),
                 )
             },
             isBulk = preview.isBulk,
@@ -36,30 +37,32 @@ internal class ConfirmationPreviewRenderer @Inject constructor(
 }
 
 data class RenderedConfirmationPreview(
-    val summary: String,
-    val rows: List<RenderedConfirmationDiffRow>,
+    val message: String,
+    val fields: List<RenderedConfirmationDiffRow>,
     val isBulk: Boolean,
 ) {
-    constructor(
-        message: String,
-        fields: List<RenderedConfirmationPreviewField>,
-    ) : this(
-        summary = message,
-        rows = fields,
+    constructor(message: String, fields: List<RenderedConfirmationPreviewField>) : this(
+        message = message,
+        fields = fields,
         isBulk = false,
     )
 
-    val message: String
-        get() = summary
+    val summary: String
+        get() = message
 
-    val fields: List<RenderedConfirmationPreviewField>
-        get() = rows
+    val rows: List<RenderedConfirmationPreviewField>
+        get() = fields
 }
 
 data class RenderedConfirmationDiffRow(
     val name: String,
     val label: String,
     val value: String,
+    val beforeValue: String? = null,
 )
+{
+    val afterValue: String
+        get() = value
+}
 
 typealias RenderedConfirmationPreviewField = RenderedConfirmationDiffRow

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
@@ -17,30 +17,46 @@ import kotlinx.serialization.json.longOrNull
 import javax.inject.Inject
 
 internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
-    fun build(request: ConfirmationRequest): ConfirmationPreview = build(request.toolName, request.arguments)
+    fun build(
+        request: ConfirmationRequest,
+        snapshot: ConfirmationSnapshot? = null,
+    ): ConfirmationPreview = build(request.toolName, request.arguments, snapshot)
 
-    fun build(call: ToolCall): ConfirmationPreview = build(call.name, call.arguments)
+    fun build(
+        call: ToolCall,
+        snapshot: ConfirmationSnapshot? = null,
+    ): ConfirmationPreview = build(call.name, call.arguments, snapshot)
 
     fun build(
         toolName: String,
         arguments: JsonObject,
+        snapshot: ConfirmationSnapshot? = null,
     ): ConfirmationPreview = when (toolName) {
-        ORDERS_UPDATE -> ordersUpdate(arguments)
+        ORDERS_UPDATE -> ordersUpdate(arguments, snapshot)
         ORDERS_BULK_UPDATE -> ordersBulkUpdate(arguments)
-        PRODUCTS_UPDATE -> productsUpdate(arguments)
+        PRODUCTS_UPDATE -> productsUpdate(arguments, snapshot)
         PRODUCTS_BULK_UPDATE -> productsBulkUpdate(arguments)
-        PRODUCT_VARIATIONS_UPDATE -> productVariationsUpdate(arguments)
+        PRODUCT_VARIATIONS_UPDATE -> productVariationsUpdate(arguments, snapshot)
         else -> genericPreview(toolName)
     }
 
     fun supportsDedicatedPreview(toolName: String): Boolean = toolName in DEDICATED_TOOL_NAMES
 
-    private fun ordersUpdate(arguments: JsonObject): ConfirmationPreview {
+    private fun ordersUpdate(arguments: JsonObject, snapshot: ConfirmationSnapshot?): ConfirmationPreview {
         val id = arguments.longValue("id")
             ?: return ConfirmationPreview(string(R.string.ai_assistant_confirmation_order_update_generic))
         val status = arguments.stringValue("status")
         val fields = buildList {
-            status?.let { add(textField("status", it, R.string.ai_assistant_confirmation_field_status)) }
+            status?.let {
+                add(
+                    textField(
+                        name = "status",
+                        value = it,
+                        label = R.string.ai_assistant_confirmation_field_status,
+                        beforeValue = snapshot?.currentValues?.get("status"),
+                    )
+                )
+            }
         }
 
         if (status != null) {
@@ -100,21 +116,21 @@ internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
                 },
         )
         return ConfirmationPreview(
-            summary = quantity(
+            message = quantity(
                 quantity = ids.size,
                 singular = R.string.ai_assistant_confirmation_orders_bulk_update_summary_single,
                 multiple = R.string.ai_assistant_confirmation_orders_bulk_update_summary_multiple,
                 summary,
             ),
-            rows = fields,
+            fields = fields,
             isBulk = true,
         )
     }
 
-    private fun productsUpdate(arguments: JsonObject): ConfirmationPreview {
+    private fun productsUpdate(arguments: JsonObject, snapshot: ConfirmationSnapshot?): ConfirmationPreview {
         val id = arguments.longValue("id")
             ?: return ConfirmationPreview(string(R.string.ai_assistant_confirmation_product_update_generic))
-        val fields = productFields(arguments)
+        val fields = productFields(arguments, snapshot)
         return ConfirmationPreview(
             message = string(
                 R.string.ai_assistant_confirmation_product_update_summary,
@@ -130,20 +146,20 @@ internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
             ?: return ConfirmationPreview(string(R.string.ai_assistant_confirmation_products_bulk_update_generic))
         val patch = arguments.objectValue("patch")
             ?: return ConfirmationPreview(string(R.string.ai_assistant_confirmation_products_bulk_update_generic))
-        val fields = productFields(patch)
+        val fields = productFields(patch, snapshot = null)
         return ConfirmationPreview(
-            summary = quantity(
+            message = quantity(
                 quantity = ids.size,
                 singular = R.string.ai_assistant_confirmation_products_bulk_update_summary_single,
                 multiple = R.string.ai_assistant_confirmation_products_bulk_update_summary_multiple,
                 fields.toChangeSummary(),
             ),
-            rows = fields,
+            fields = fields,
             isBulk = true,
         )
     }
 
-    private fun productVariationsUpdate(arguments: JsonObject): ConfirmationPreview {
+    private fun productVariationsUpdate(arguments: JsonObject, snapshot: ConfirmationSnapshot?): ConfirmationPreview {
         val productId = arguments.longValue("product_id")
             ?: return ConfirmationPreview(
                 string(R.string.ai_assistant_confirmation_product_variation_update_generic)
@@ -152,7 +168,7 @@ internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
             ?: return ConfirmationPreview(
                 string(R.string.ai_assistant_confirmation_product_variation_update_generic)
             )
-        val fields = variationFields(arguments)
+        val fields = variationFields(arguments, snapshot)
         return ConfirmationPreview(
             message = string(
                 R.string.ai_assistant_confirmation_product_variation_update_summary,
@@ -164,28 +180,65 @@ internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
         )
     }
 
-    private fun productFields(arguments: JsonObject): List<ConfirmationPreviewField> =
-        productOrVariationFields(arguments, includeName = true, includeStockStatus = false, includeSku = false)
+    private fun productFields(
+        arguments: JsonObject,
+        snapshot: ConfirmationSnapshot?,
+    ): List<ConfirmationPreviewField> =
+        productOrVariationFields(
+            arguments = arguments,
+            snapshot = snapshot,
+            includeName = true,
+            includeStockStatus = false,
+            includeSku = false,
+        )
 
-    private fun variationFields(arguments: JsonObject): List<ConfirmationPreviewField> =
-        productOrVariationFields(arguments, includeName = false, includeStockStatus = true, includeSku = true)
+    private fun variationFields(
+        arguments: JsonObject,
+        snapshot: ConfirmationSnapshot?,
+    ): List<ConfirmationPreviewField> =
+        productOrVariationFields(
+            arguments = arguments,
+            snapshot = snapshot,
+            includeName = false,
+            includeStockStatus = true,
+            includeSku = true,
+        )
 
     private fun productOrVariationFields(
         arguments: JsonObject,
+        snapshot: ConfirmationSnapshot?,
         includeName: Boolean,
         includeStockStatus: Boolean,
         includeSku: Boolean,
     ): List<ConfirmationPreviewField> = buildList {
         arguments.stringValue("name")
             ?.takeIf { includeName }
-            ?.let { add(textField("name", it, R.string.ai_assistant_confirmation_field_name)) }
+            ?.let {
+                add(textField("name", it, R.string.ai_assistant_confirmation_field_name, snapshot?.currentValues?.get("name")))
+            }
         arguments.stringValue("regular_price")
-            ?.let { add(textField("regular_price", it, R.string.ai_assistant_confirmation_field_regular_price)) }
+            ?.let {
+                add(
+                    textField(
+                        "regular_price",
+                        it,
+                        R.string.ai_assistant_confirmation_field_regular_price,
+                        snapshot?.currentValues?.get("regular_price"),
+                    )
+                )
+            }
         arguments.stringValue("sale_price")
             ?.let {
                 val value = it.takeIf { price -> price.isNotEmpty() }?.let(::raw)
                     ?: string(R.string.ai_assistant_confirmation_field_value_off)
-                add(messageField("sale_price", value, R.string.ai_assistant_confirmation_field_sale_price))
+                add(
+                    messageField(
+                        name = "sale_price",
+                        value = value,
+                        label = R.string.ai_assistant_confirmation_field_sale_price,
+                        beforeValue = snapshot?.currentValues?.get("sale_price")?.let(::salePriceValue),
+                    )
+                )
             }
         arguments.intValue("stock_quantity")
             ?.let {
@@ -194,17 +247,31 @@ internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
                         name = "stock_quantity",
                         value = it.toString(),
                         label = R.string.ai_assistant_confirmation_field_stock_quantity,
+                        beforeValue = snapshot?.currentValues?.get("stock_quantity"),
                     )
                 )
             }
         arguments.stringValue("stock_status")
             ?.takeIf { includeStockStatus }
-            ?.let { add(textField("stock_status", it, R.string.ai_assistant_confirmation_field_stock_status)) }
+            ?.let {
+                add(
+                    textField(
+                        "stock_status",
+                        it,
+                        R.string.ai_assistant_confirmation_field_stock_status,
+                        snapshot?.currentValues?.get("stock_status"),
+                    )
+                )
+            }
         arguments.stringValue("status")
-            ?.let { add(textField("status", it, R.string.ai_assistant_confirmation_field_status)) }
+            ?.let {
+                add(textField("status", it, R.string.ai_assistant_confirmation_field_status, snapshot?.currentValues?.get("status")))
+            }
         arguments.stringValue("sku")
             ?.takeIf { includeSku }
-            ?.let { add(textField("sku", it, R.string.ai_assistant_confirmation_field_sku)) }
+            ?.let {
+                add(textField("sku", it, R.string.ai_assistant_confirmation_field_sku, snapshot?.currentValues?.get("sku")))
+            }
     }
 
     private fun genericPreview(toolName: String): ConfirmationPreview =
@@ -253,21 +320,34 @@ internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
         name: String,
         value: String,
         @StringRes label: Int,
+        beforeValue: String? = null,
     ): ConfirmationPreviewField = messageField(
         name = name,
         value = raw(value),
         label = label,
+        beforeValue = beforeValue?.let { previewValue(name, it) },
     )
 
     private fun messageField(
         name: String,
         value: ConfirmationPreviewText,
         @StringRes label: Int,
+        beforeValue: ConfirmationPreviewText? = null,
     ): ConfirmationPreviewField = ConfirmationPreviewField(
         name = name,
         value = value,
         label = string(label),
+        beforeValue = beforeValue,
     )
+
+    private fun salePriceValue(value: String): ConfirmationPreviewText =
+        value.takeIf { it.isNotEmpty() }?.let(::raw)
+            ?: string(R.string.ai_assistant_confirmation_field_value_off)
+
+    private fun previewValue(name: String, value: String): ConfirmationPreviewText = when (name) {
+        "sale_price" -> salePriceValue(value)
+        else -> raw(value)
+    }
 
     private fun List<ConfirmationPreviewText>.toLocalizedList(): ConfirmationPreviewText =
         reduceOrNull { left, right ->

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
@@ -100,13 +100,14 @@ internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
                 },
         )
         return ConfirmationPreview(
-            message = quantity(
+            summary = quantity(
                 quantity = ids.size,
                 singular = R.string.ai_assistant_confirmation_orders_bulk_update_summary_single,
                 multiple = R.string.ai_assistant_confirmation_orders_bulk_update_summary_multiple,
                 summary,
             ),
-            fields = fields,
+            rows = fields,
+            isBulk = true,
         )
     }
 
@@ -131,13 +132,14 @@ internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
             ?: return ConfirmationPreview(string(R.string.ai_assistant_confirmation_products_bulk_update_generic))
         val fields = productFields(patch)
         return ConfirmationPreview(
-            message = quantity(
+            summary = quantity(
                 quantity = ids.size,
                 singular = R.string.ai_assistant_confirmation_products_bulk_update_summary_single,
                 multiple = R.string.ai_assistant_confirmation_products_bulk_update_summary_multiple,
                 fields.toChangeSummary(),
             ),
-            fields = fields,
+            rows = fields,
+            isBulk = true,
         )
     }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
@@ -211,66 +211,108 @@ internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
         includeStockStatus: Boolean,
         includeSku: Boolean,
     ): List<ConfirmationPreviewField> = buildList {
+        addOptionalNameField(arguments, snapshot, includeName)
+        addOptionalTextField(
+            arguments = arguments,
+            snapshot = snapshot,
+            key = "regular_price",
+            label = R.string.ai_assistant_confirmation_field_regular_price,
+        )
+        addOptionalSalePriceField(arguments, snapshot)
+        addOptionalStockQuantityField(arguments, snapshot)
+        addOptionalTextField(
+            arguments = arguments,
+            snapshot = snapshot,
+            key = "stock_status",
+            label = R.string.ai_assistant_confirmation_field_stock_status,
+            include = includeStockStatus,
+        )
+        addOptionalTextField(
+            arguments = arguments,
+            snapshot = snapshot,
+            key = "status",
+            label = R.string.ai_assistant_confirmation_field_status,
+        )
+        addOptionalTextField(
+            arguments = arguments,
+            snapshot = snapshot,
+            key = "sku",
+            label = R.string.ai_assistant_confirmation_field_sku,
+            include = includeSku,
+        )
+    }
+
+    private fun MutableList<ConfirmationPreviewField>.addOptionalNameField(
+        arguments: JsonObject,
+        snapshot: ConfirmationSnapshot?,
+        includeName: Boolean,
+    ) {
         arguments.stringValue("name")
             ?.takeIf { includeName }
-            ?.let {
-                add(textField("name", it, R.string.ai_assistant_confirmation_field_name, snapshot?.currentValues?.get("name")))
-            }
-        arguments.stringValue("regular_price")
-            ?.let {
+            ?.let { name ->
                 add(
                     textField(
-                        "regular_price",
-                        it,
-                        R.string.ai_assistant_confirmation_field_regular_price,
-                        snapshot?.currentValues?.get("regular_price"),
+                        name = "name",
+                        value = name,
+                        label = R.string.ai_assistant_confirmation_field_name,
+                        beforeValue = snapshot?.currentValues?.get("name"),
                     )
                 )
             }
-        arguments.stringValue("sale_price")
-            ?.let {
-                val value = it.takeIf { price -> price.isNotEmpty() }?.let(::raw)
-                    ?: string(R.string.ai_assistant_confirmation_field_value_off)
+    }
+
+    private fun MutableList<ConfirmationPreviewField>.addOptionalSalePriceField(
+        arguments: JsonObject,
+        snapshot: ConfirmationSnapshot?,
+    ) {
+        arguments.stringValue("sale_price")?.let { salePrice ->
+            val value = salePrice.takeIf { it.isNotEmpty() }?.let(::raw)
+                ?: string(R.string.ai_assistant_confirmation_field_value_off)
+            add(
+                messageField(
+                    name = "sale_price",
+                    value = value,
+                    label = R.string.ai_assistant_confirmation_field_sale_price,
+                    beforeValue = snapshot?.currentValues?.get("sale_price")?.let(::salePriceValue),
+                )
+            )
+        }
+    }
+
+    private fun MutableList<ConfirmationPreviewField>.addOptionalStockQuantityField(
+        arguments: JsonObject,
+        snapshot: ConfirmationSnapshot?,
+    ) {
+        arguments.intValue("stock_quantity")?.let { stockQuantity ->
+            add(
+                textField(
+                    name = "stock_quantity",
+                    value = stockQuantity.toString(),
+                    label = R.string.ai_assistant_confirmation_field_stock_quantity,
+                    beforeValue = snapshot?.currentValues?.get("stock_quantity"),
+                )
+            )
+        }
+    }
+
+    private fun MutableList<ConfirmationPreviewField>.addOptionalTextField(
+        arguments: JsonObject,
+        snapshot: ConfirmationSnapshot?,
+        key: String,
+        label: Int,
+        include: Boolean = true,
+    ) {
+        arguments.stringValue(key)
+            ?.takeIf { include }
+            ?.let { value ->
                 add(
-                    messageField(
-                        name = "sale_price",
+                    textField(
+                        name = key,
                         value = value,
-                        label = R.string.ai_assistant_confirmation_field_sale_price,
-                        beforeValue = snapshot?.currentValues?.get("sale_price")?.let(::salePriceValue),
+                        label = label,
+                        beforeValue = snapshot?.currentValues?.get(key),
                     )
                 )
-            }
-        arguments.intValue("stock_quantity")
-            ?.let {
-                add(
-                    textField(
-                        name = "stock_quantity",
-                        value = it.toString(),
-                        label = R.string.ai_assistant_confirmation_field_stock_quantity,
-                        beforeValue = snapshot?.currentValues?.get("stock_quantity"),
-                    )
-                )
-            }
-        arguments.stringValue("stock_status")
-            ?.takeIf { includeStockStatus }
-            ?.let {
-                add(
-                    textField(
-                        "stock_status",
-                        it,
-                        R.string.ai_assistant_confirmation_field_stock_status,
-                        snapshot?.currentValues?.get("stock_status"),
-                    )
-                )
-            }
-        arguments.stringValue("status")
-            ?.let {
-                add(textField("status", it, R.string.ai_assistant_confirmation_field_status, snapshot?.currentValues?.get("status")))
-            }
-        arguments.stringValue("sku")
-            ?.takeIf { includeSku }
-            ?.let {
-                add(textField("sku", it, R.string.ai_assistant_confirmation_field_sku, snapshot?.currentValues?.get("sku")))
             }
     }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationSnapshotResolver.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationSnapshotResolver.kt
@@ -1,0 +1,79 @@
+package com.woocommerce.android.aiassistant.safety
+
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
+import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
+import com.woocommerce.android.aiassistant.tools.products.AIProductVariationsDataSource
+import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import javax.inject.Inject
+
+internal data class ConfirmationSnapshot(
+    val currentValues: Map<String, String>,
+)
+
+internal open class WooCommerceConfirmationSnapshotResolver @Inject constructor(
+    private val ordersDataSource: AIOrdersDataSource,
+    private val productsDataSource: AIProductsDataSource,
+    private val variationsDataSource: AIProductVariationsDataSource,
+) {
+    open suspend fun resolve(request: ConfirmationRequest): ConfirmationSnapshot? = when (request.toolName) {
+        ORDERS_UPDATE -> request.arguments.longValue("id")
+            ?.let { orderId -> ordersDataSource.getOrder(orderId).getOrNull() }
+            ?.let { order ->
+                ConfirmationSnapshot(
+                    currentValues = mapOf(
+                        "status" to order.status,
+                    )
+                )
+            }
+        PRODUCTS_UPDATE -> request.arguments.longValue("id")
+            ?.let { productId -> productsDataSource.getProduct(productId).getOrNull() }
+            ?.let { product ->
+                ConfirmationSnapshot(
+                    currentValues = buildMap {
+                        put("name", product.name)
+                        put("regular_price", product.regularPrice)
+                        put("sale_price", product.salePrice)
+                        put("stock_quantity", product.stockQuantity.toInt().toString())
+                        put("status", product.status)
+                    }
+                )
+            }
+        PRODUCT_VARIATIONS_UPDATE -> {
+            val productId = request.arguments.longValue("product_id")
+            val variationId = request.arguments.longValue("id")
+            if (productId == null || variationId == null) {
+                null
+            } else {
+                variationsDataSource.getVariation(productId, variationId).getOrNull()?.let { variation ->
+                    ConfirmationSnapshot(
+                        currentValues = buildMap {
+                            put("regular_price", variation.regularPrice)
+                            put("sale_price", variation.salePrice)
+                            put("stock_quantity", variation.stockQuantity.toInt().toString())
+                            put("stock_status", variation.stockStatus)
+                            put("sku", variation.sku)
+                            put("status", variation.status)
+                        }
+                    )
+                }
+            }
+        }
+        else -> null
+    }
+
+    private fun JsonObject.longValue(name: String): Long? =
+        this[name]?.asJsonPrimitiveOrNull()?.longOrNull
+
+    private fun JsonElement.asJsonPrimitiveOrNull(): JsonPrimitive? = runCatching { jsonPrimitive }.getOrNull()
+
+    private companion object {
+        const val ORDERS_UPDATE = "orders_update"
+        const val PRODUCTS_UPDATE = "products_update"
+        const val PRODUCT_VARIATIONS_UPDATE = "product_variations_update"
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationSnapshotResolver.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationSnapshotResolver.kt
@@ -26,7 +26,7 @@ internal open class WooCommerceConfirmationSnapshotResolver @Inject constructor(
             ?.let { order ->
                 ConfirmationSnapshot(
                     currentValues = mapOf(
-                        "status" to order.status,
+                        "status" to order.status.normalizedOrderStatus(),
                     )
                 )
             }
@@ -38,7 +38,7 @@ internal open class WooCommerceConfirmationSnapshotResolver @Inject constructor(
                         put("name", product.name)
                         put("regular_price", product.regularPrice)
                         put("sale_price", product.salePrice)
-                        put("stock_quantity", product.stockQuantity.toInt().toString())
+                        put("stock_quantity", product.stockQuantity.formatStockQuantity())
                         put("status", product.status)
                     }
                 )
@@ -54,7 +54,7 @@ internal open class WooCommerceConfirmationSnapshotResolver @Inject constructor(
                         currentValues = buildMap {
                             put("regular_price", variation.regularPrice)
                             put("sale_price", variation.salePrice)
-                            put("stock_quantity", variation.stockQuantity.toInt().toString())
+                            put("stock_quantity", variation.stockQuantity.formatStockQuantity())
                             put("stock_status", variation.stockStatus)
                             put("sku", variation.sku)
                             put("status", variation.status)
@@ -70,6 +70,11 @@ internal open class WooCommerceConfirmationSnapshotResolver @Inject constructor(
         this[name]?.asJsonPrimitiveOrNull()?.longOrNull
 
     private fun JsonElement.asJsonPrimitiveOrNull(): JsonPrimitive? = runCatching { jsonPrimitive }.getOrNull()
+
+    private fun Double.formatStockQuantity(): String =
+        if (rem(1.0) == 0.0) toLong().toString() else toString()
+
+    private fun String.normalizedOrderStatus(): String = removePrefix("wc-")
 
     private companion object {
         const val ORDERS_UPDATE = "orders_update"

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSource.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSource.kt
@@ -76,7 +76,6 @@ internal class AIOrdersDataSource @Inject constructor(
 
     suspend fun getOrder(orderId: Long): Result<OrderEntity> {
         val site = selectedSite.get()
-        orderStore.getOrderByIdAndSite(orderId, site)?.let { return Result.success(it) }
         val result = orderStore.fetchSingleOrderSync(site, orderId)
         return if (result.isError) {
             Result.failure(OnChangedException(result.error))

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSource.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSource.kt
@@ -76,6 +76,7 @@ internal class AIOrdersDataSource @Inject constructor(
 
     suspend fun getOrder(orderId: Long): Result<OrderEntity> {
         val site = selectedSite.get()
+        orderStore.getOrderByIdAndSite(orderId, site)?.let { return Result.success(it) }
         val result = orderStore.fetchSingleOrderSync(site, orderId)
         return if (result.isError) {
             Result.failure(OnChangedException(result.error))

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -406,20 +406,37 @@ private fun AssistantConfirmationCardSegment(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                painter = painterResource(confirmation.state.iconRes()),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Text(
+                text = stringResource(confirmation.state.eyebrowRes()),
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
         Text(
-            text = confirmation.preview?.message
+            text = confirmation.preview?.summary
                 ?: stringResource(R.string.assistant_chat_confirm_tool, confirmation.toolCall.name),
             color = MaterialTheme.colorScheme.onSecondaryContainer,
             style = MaterialTheme.typography.titleSmall,
         )
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Button(onClick = onConfirmWrite) {
-                Text(stringResource(R.string.assistant_chat_confirm))
-            }
-            OutlinedButton(onClick = onCancelWrite) {
-                Text(stringResource(R.string.assistant_chat_cancel))
+        if (confirmation.state == AssistantConfirmationCardState.PENDING) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Button(onClick = onConfirmWrite) {
+                    Text(stringResource(R.string.assistant_chat_confirm))
+                }
+                OutlinedButton(onClick = onCancelWrite) {
+                    Text(stringResource(R.string.assistant_chat_cancel))
+                }
             }
         }
     }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -48,6 +49,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -57,6 +59,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreview
+import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreviewField
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -433,65 +437,91 @@ private fun AssistantConfirmationCardSegment(
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
 ) {
-    Column(
+    val colors = confirmation.state.confirmationCardColors()
+    val shape = RoundedCornerShape(12.dp)
+
+    Surface(
         modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.secondaryContainer)
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+            .fillMaxWidth(),
+        shape = shape,
+        color = colors.container,
+        border = BorderStroke(1.dp, colors.border),
     ) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Icon(
-                painter = painterResource(confirmation.state.iconRes()),
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSecondaryContainer,
-            )
-            Text(
-                text = stringResource(confirmation.state.eyebrowRes()),
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
-                style = MaterialTheme.typography.labelMedium,
-            )
-        }
-        Text(
-            text = confirmation.preview?.summary
-                ?: stringResource(R.string.assistant_chat_confirm_tool, confirmation.toolCall.name),
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
-            style = MaterialTheme.typography.titleSmall,
-        )
-        confirmation.preview?.rows?.forEach { row ->
-            Column(
-                verticalArrangement = Arrangement.spacedBy(4.dp),
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    text = row.label,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    style = MaterialTheme.typography.labelMedium,
+                Icon(
+                    painter = painterResource(confirmation.state.iconRes()),
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = colors.accent,
                 )
-                row.beforeValue?.let { beforeValue ->
-                    ConfirmationDiffLine(
-                        prefix = stringResource(R.string.assistant_confirmation_now),
-                        value = beforeValue,
-                        strikethrough = true,
-                    )
-                }
-                ConfirmationDiffLine(
-                    prefix = stringResource(R.string.assistant_confirmation_after),
-                    value = row.afterValue,
+                Text(
+                    text = stringResource(confirmation.state.eyebrowRes()),
+                    color = colors.accent,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
                 )
             }
-        }
-        if (confirmation.state == AssistantConfirmationCardState.PENDING) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Button(onClick = onConfirmWrite) {
-                    Text(stringResource(R.string.assistant_chat_confirm))
-                }
-                OutlinedButton(onClick = onCancelWrite) {
-                    Text(stringResource(R.string.assistant_chat_cancel))
+            Text(
+                text = confirmation.preview?.summary
+                    ?: stringResource(R.string.assistant_chat_confirm_tool, confirmation.toolCall.name),
+                color = colors.title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            confirmation.preview?.rows?.forEach { row ->
+                ConfirmationDiffRow(
+                    row = row,
+                    colors = colors,
+                )
+            }
+            if (confirmation.state == AssistantConfirmationCardState.PENDING) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    OutlinedButton(
+                        onClick = onCancelWrite,
+                        modifier = Modifier
+                            .weight(1f)
+                            .heightIn(min = 48.dp),
+                        shape = RoundedCornerShape(10.dp),
+                        border = BorderStroke(1.dp, colors.border),
+                        colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.title),
+                        contentPadding = PaddingValues(horizontal = 8.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.assistant_chat_cancel),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                    Button(
+                        onClick = onConfirmWrite,
+                        modifier = Modifier
+                            .weight(1f)
+                            .heightIn(min = 48.dp),
+                        shape = RoundedCornerShape(10.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary,
+                            contentColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                        contentPadding = PaddingValues(horizontal = 8.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.assistant_chat_confirm),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
                 }
             }
         }
@@ -499,28 +529,110 @@ private fun AssistantConfirmationCardSegment(
 }
 
 @Composable
+private fun ConfirmationDiffRow(
+    row: RenderedConfirmationPreviewField,
+    colors: AssistantConfirmationCardColors,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.55f), RoundedCornerShape(8.dp))
+            .border(1.dp, colors.border.copy(alpha = 0.45f), RoundedCornerShape(8.dp))
+            .padding(10.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = row.label,
+            color = colors.label,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        row.beforeValue?.let { beforeValue ->
+            ConfirmationDiffLine(
+                prefix = stringResource(R.string.assistant_confirmation_now),
+                value = beforeValue,
+                colors = colors,
+                strikethrough = true,
+            )
+        }
+        ConfirmationDiffLine(
+            prefix = stringResource(R.string.assistant_confirmation_after),
+            value = row.afterValue,
+            colors = colors,
+        )
+    }
+}
+
+@Composable
 private fun ConfirmationDiffLine(
     prefix: String,
     value: String,
+    colors: AssistantConfirmationCardColors,
     strikethrough: Boolean = false,
 ) {
     Row(
+        modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = Alignment.Top,
     ) {
         Text(
             text = prefix,
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.widthIn(min = 40.dp),
+            color = colors.label,
             style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
         )
         Text(
             text = value,
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.weight(1f),
+            color = if (strikethrough) colors.label else colors.value,
             style = MaterialTheme.typography.bodySmall,
+            fontWeight = if (strikethrough) FontWeight.Normal else FontWeight.SemiBold,
             textDecoration = if (strikethrough) TextDecoration.LineThrough else null,
         )
     }
 }
+
+@Composable
+private fun AssistantConfirmationCardState.confirmationCardColors(): AssistantConfirmationCardColors {
+    val colorScheme = MaterialTheme.colorScheme
+
+    return when (this) {
+        AssistantConfirmationCardState.PENDING -> AssistantConfirmationCardColors(
+            container = colorScheme.surfaceContainerHigh,
+            border = colorScheme.primary.copy(alpha = 0.28f),
+            accent = colorScheme.primary,
+            title = colorScheme.onSurface,
+            label = colorScheme.onSurfaceVariant,
+            value = colorScheme.onSurface,
+        )
+        AssistantConfirmationCardState.CONFIRMED -> AssistantConfirmationCardColors(
+            container = colorScheme.surfaceContainerHigh,
+            border = colorScheme.outlineVariant,
+            accent = colorScheme.primary,
+            title = colorScheme.onSurface,
+            label = colorScheme.onSurfaceVariant,
+            value = colorScheme.onSurface,
+        )
+        AssistantConfirmationCardState.CANCELLED -> AssistantConfirmationCardColors(
+            container = colorScheme.surfaceContainerLow,
+            border = colorScheme.outlineVariant,
+            accent = colorScheme.onSurfaceVariant,
+            title = colorScheme.onSurfaceVariant,
+            label = colorScheme.onSurfaceVariant,
+            value = colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private data class AssistantConfirmationCardColors(
+    val container: Color,
+    val border: Color,
+    val accent: Color,
+    val title: Color,
+    val label: Color,
+    val value: Color,
+)
 
 @Composable
 private fun AssistantComposer(
@@ -622,26 +734,29 @@ private fun AssistantChatScreenPreview() {
 }
 
 @Preview(showBackground = true, widthDp = 390, heightDp = 720)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 720, uiMode = UI_MODE_NIGHT_YES)
+@Preview(name = "Large Font", showBackground = true, widthDp = 390, heightDp = 720, fontScale = 1.5f)
 @Composable
 private fun AssistantChatScreenConfirmationPreview() {
     AssistantChatScreen(
         state = AssistantUiState(
             messages = listOf(
-                AssistantUiMessage("preview-1", AssistantUiMessage.Role.USER, "Cancel order 123"),
+                AssistantUiMessage("preview-1", AssistantUiMessage.Role.USER, "Mark order 3479 as completed"),
                 AssistantUiMessage(
                     id = "preview-2",
                     role = AssistantUiMessage.Role.ASSISTANT,
                     segments = listOf(
-                        AssistantUiSegment.Text("I need confirmation first."),
+                        AssistantUiSegment.Text("I'll mark order #3479 as completed."),
                         AssistantUiSegment.ConfirmationCard(
                             AssistantConfirmationCard(
                                 confirmationId = "confirmation-preview",
                                 toolCall = ToolCall(
                                     id = "call-preview",
                                     name = "orders_update",
-                                    arguments = buildJsonObject { put("id", 123) },
+                                    arguments = buildJsonObject { put("id", 3479) },
                                 ),
                                 state = AssistantConfirmationCardState.PENDING,
+                                preview = sampleConfirmationPreview(),
                             )
                         ),
                     ),
@@ -660,3 +775,15 @@ private fun AssistantChatScreenConfirmationPreview() {
         onBack = {},
     )
 }
+
+private fun sampleConfirmationPreview() = RenderedConfirmationPreview(
+    message = "Update order #3479",
+    fields = listOf(
+        RenderedConfirmationPreviewField(
+            name = "status",
+            label = "Status",
+            beforeValue = "Processing",
+            value = "Completed",
+        )
+    ),
+)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
-import com.woocommerce.android.aiassistant.runtime.AssistantPendingConfirmation
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -137,13 +136,11 @@ fun AssistantChatScreen(
             AssistantMessageThread(
                 messages = state.messages,
                 onRetry = onRetry,
-                modifier = Modifier.weight(1f),
-            )
-            AssistantStatusPanel(
-                state = state,
                 onConfirmWrite = onConfirmWrite,
                 onCancelWrite = onCancelWrite,
+                modifier = Modifier.weight(1f),
             )
+            AssistantStatusPanel(state = state)
             AssistantComposer(
                 inputText = inputText,
                 onInputTextChange = onInputTextChange,
@@ -218,10 +215,12 @@ private fun AssistantStatusLabel(status: AssistantUiStatus) {
 private fun AssistantMessageThread(
     messages: List<AssistantUiMessage>,
     onRetry: () -> Unit,
+    onConfirmWrite: () -> Unit,
+    onCancelWrite: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
-    LaunchedEffect(messages.size, messages.lastOrNull()?.text) {
+    LaunchedEffect(messages.size, messages.lastOrNull()?.segments) {
         if (messages.isNotEmpty()) {
             listState.animateScrollToItem(messages.lastIndex)
         }
@@ -240,6 +239,8 @@ private fun AssistantMessageThread(
             AssistantMessageBubble(
                 message = message,
                 onRetry = onRetry,
+                onConfirmWrite = onConfirmWrite,
+                onCancelWrite = onCancelWrite,
             )
         }
     }
@@ -249,6 +250,8 @@ private fun AssistantMessageThread(
 private fun AssistantMessageBubble(
     message: AssistantUiMessage,
     onRetry: () -> Unit,
+    onConfirmWrite: () -> Unit,
+    onCancelWrite: () -> Unit,
 ) {
     val isUser = message.role == AssistantUiMessage.Role.USER
     val messageText = message.text.ifEmpty { " " }
@@ -298,13 +301,24 @@ private fun AssistantMessageBubble(
             Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                if (message.text.isNotEmpty()) {
-                    Text(
-                        text = message.text,
-                        color = textColor,
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = if (isUser) TextAlign.End else TextAlign.Start,
-                    )
+                message.segments.forEach { segment ->
+                    when (segment) {
+                        is AssistantUiSegment.ConfirmationCard -> AssistantConfirmationCardSegment(
+                            confirmation = segment.model,
+                            onConfirmWrite = onConfirmWrite,
+                            onCancelWrite = onCancelWrite,
+                        )
+                        is AssistantUiSegment.Text -> {
+                            if (segment.text.isNotEmpty()) {
+                                Text(
+                                    text = segment.text,
+                                    color = textColor,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    textAlign = if (isUser) TextAlign.End else TextAlign.Start,
+                                )
+                            }
+                        }
+                    }
                 }
                 message.error?.let { error ->
                     AssistantInlineError(
@@ -312,7 +326,7 @@ private fun AssistantMessageBubble(
                         onRetry = onRetry,
                     )
                 }
-                if (message.text.isEmpty() && message.error == null) {
+                if (message.segments.all { it is AssistantUiSegment.Text && it.text.isEmpty() } && message.error == null) {
                     Text(
                         text = " ",
                         color = textColor,
@@ -348,17 +362,9 @@ private fun AssistantInlineError(
 @Composable
 private fun AssistantStatusPanel(
     state: AssistantUiState,
-    onConfirmWrite: () -> Unit,
-    onCancelWrite: () -> Unit,
 ) {
     when (state.status) {
-        AssistantUiStatus.AWAITING_CONFIRMATION -> state.pendingConfirmation?.let {
-            AssistantConfirmationPanel(
-                confirmation = it,
-                onConfirmWrite = onConfirmWrite,
-                onCancelWrite = onCancelWrite,
-            )
-        }
+        AssistantUiStatus.AWAITING_CONFIRMATION -> Unit
         AssistantUiStatus.ERROR -> {
             if (state.shouldShowFallbackError) {
                 AssistantFallbackErrorPanel(error = state.error)
@@ -388,8 +394,8 @@ private fun AssistantFallbackErrorPanel(error: AssistantUiError?) {
 }
 
 @Composable
-private fun AssistantConfirmationPanel(
-    confirmation: AssistantPendingConfirmation,
+private fun AssistantConfirmationCardSegment(
+    confirmation: AssistantConfirmationCard,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
 ) {
@@ -524,17 +530,27 @@ private fun AssistantChatScreenConfirmationPreview() {
         state = AssistantUiState(
             messages = listOf(
                 AssistantUiMessage("preview-1", AssistantUiMessage.Role.USER, "Cancel order 123"),
-                AssistantUiMessage("preview-2", AssistantUiMessage.Role.ASSISTANT, "I need confirmation first."),
-            ),
-            status = AssistantUiStatus.AWAITING_CONFIRMATION,
-            pendingConfirmation = AssistantPendingConfirmation(
-                id = "confirmation-preview",
-                toolCall = ToolCall(
-                    id = "call-preview",
-                    name = "orders_update",
-                    arguments = buildJsonObject { put("id", 123) },
+                AssistantUiMessage(
+                    id = "preview-2",
+                    role = AssistantUiMessage.Role.ASSISTANT,
+                    segments = listOf(
+                        AssistantUiSegment.Text("I need confirmation first."),
+                        AssistantUiSegment.ConfirmationCard(
+                            AssistantConfirmationCard(
+                                confirmationId = "confirmation-preview",
+                                toolCall = ToolCall(
+                                    id = "call-preview",
+                                    name = "orders_update",
+                                    arguments = buildJsonObject { put("id", 123) },
+                                ),
+                                state = AssistantConfirmationCardState.PENDING,
+                            )
+                        ),
+                    ),
                 ),
             ),
+            status = AssistantUiStatus.AWAITING_CONFIRMATION,
+            activeConfirmationId = "confirmation-preview",
         ),
         inputText = "",
         onInputTextChange = {},

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -43,13 +43,14 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -303,32 +304,20 @@ private fun AssistantMessageBubble(
             Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                message.segments.forEach { segment ->
-                    when (segment) {
-                        is AssistantUiSegment.ConfirmationCard -> AssistantConfirmationCardSegment(
-                            confirmation = segment.model,
-                            onConfirmWrite = onConfirmWrite,
-                            onCancelWrite = onCancelWrite,
-                        )
-                        is AssistantUiSegment.Text -> {
-                            if (segment.text.isNotEmpty()) {
-                                Text(
-                                    text = segment.text,
-                                    color = textColor,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    textAlign = if (isUser) TextAlign.End else TextAlign.Start,
-                                )
-                            }
-                        }
-                    }
-                }
+                AssistantMessageSegments(
+                    message = message,
+                    textColor = textColor,
+                    isUser = isUser,
+                    onConfirmWrite = onConfirmWrite,
+                    onCancelWrite = onCancelWrite,
+                )
                 message.error?.let { error ->
                     AssistantInlineError(
                         error = error,
                         onRetry = onRetry,
                     )
                 }
-                if (message.segments.all { it is AssistantUiSegment.Text && it.text.isEmpty() } && message.error == null) {
+                if (message.shouldShowEmptyPlaceholder()) {
                     Text(
                         text = " ",
                         color = textColor,
@@ -338,6 +327,46 @@ private fun AssistantMessageBubble(
             }
         }
     }
+}
+
+@Composable
+private fun AssistantMessageSegments(
+    message: AssistantUiMessage,
+    textColor: Color,
+    isUser: Boolean,
+    onConfirmWrite: () -> Unit,
+    onCancelWrite: () -> Unit,
+) {
+    message.segments.forEach { segment ->
+        when (segment) {
+            is AssistantUiSegment.ConfirmationCard -> AssistantConfirmationCardSegment(
+                confirmation = segment.model,
+                onConfirmWrite = onConfirmWrite,
+                onCancelWrite = onCancelWrite,
+            )
+            is AssistantUiSegment.Text -> AssistantMessageTextSegment(
+                text = segment.text,
+                textColor = textColor,
+                isUser = isUser,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AssistantMessageTextSegment(
+    text: String,
+    textColor: Color,
+    isUser: Boolean,
+) {
+    if (text.isEmpty()) return
+
+    Text(
+        text = text,
+        color = textColor,
+        style = MaterialTheme.typography.bodyMedium,
+        textAlign = if (isUser) TextAlign.End else TextAlign.Start,
+    )
 }
 
 @Composable
@@ -360,6 +389,9 @@ private fun AssistantInlineError(
         }
     }
 }
+
+private fun AssistantUiMessage.shouldShowEmptyPlaceholder(): Boolean =
+    segments.all { it is AssistantUiSegment.Text && it.text.isEmpty() } && error == null
 
 @Composable
 private fun AssistantStatusPanel(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -146,6 +146,7 @@ fun AssistantChatScreen(
                 inputText = inputText,
                 onInputTextChange = onInputTextChange,
                 isTurnActive = state.isTurnActive,
+                shouldShowStopControl = state.shouldShowStopControl,
                 onSendMessage = onSendMessage,
                 onCancelTurn = onCancelTurn,
             )
@@ -494,6 +495,7 @@ private fun AssistantComposer(
     inputText: String,
     onInputTextChange: (String) -> Unit,
     isTurnActive: Boolean,
+    shouldShowStopControl: Boolean,
     onSendMessage: () -> Unit,
     onCancelTurn: () -> Unit,
 ) {
@@ -527,7 +529,7 @@ private fun AssistantComposer(
                         }
                     ),
                 )
-                if (isTurnActive) {
+                if (shouldShowStopControl) {
                     Button(
                         onClick = onCancelTurn,
                         modifier = Modifier.heightIn(min = 56.dp),

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -427,6 +428,28 @@ private fun AssistantConfirmationCardSegment(
             color = MaterialTheme.colorScheme.onSecondaryContainer,
             style = MaterialTheme.typography.titleSmall,
         )
+        confirmation.preview?.rows?.forEach { row ->
+            Column(
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = row.label,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    style = MaterialTheme.typography.labelMedium,
+                )
+                row.beforeValue?.let { beforeValue ->
+                    ConfirmationDiffLine(
+                        prefix = stringResource(R.string.assistant_confirmation_now),
+                        value = beforeValue,
+                        strikethrough = true,
+                    )
+                }
+                ConfirmationDiffLine(
+                    prefix = stringResource(R.string.assistant_confirmation_after),
+                    value = row.afterValue,
+                )
+            }
+        }
         if (confirmation.state == AssistantConfirmationCardState.PENDING) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -439,6 +462,30 @@ private fun AssistantConfirmationCardSegment(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun ConfirmationDiffLine(
+    prefix: String,
+    value: String,
+    strikethrough: Boolean = false,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = prefix,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(
+            text = value,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            style = MaterialTheme.typography.bodySmall,
+            textDecoration = if (strikethrough) TextDecoration.LineThrough else null,
+        )
     }
 }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.aiassistant.ui
 
-import androidx.annotation.StringRes
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.ToolCall

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -3,14 +3,15 @@ package com.woocommerce.android.aiassistant.ui
 import androidx.annotation.StringRes
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
-import com.woocommerce.android.aiassistant.runtime.AssistantPendingConfirmation
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreview
 
 data class AssistantUiState(
     val messages: List<AssistantUiMessage> = emptyList(),
     val status: AssistantUiStatus = AssistantUiStatus.IDLE,
     val error: AssistantUiError? = null,
     val canRetry: Boolean = false,
-    val pendingConfirmation: AssistantPendingConfirmation? = null,
+    val activeConfirmationId: String? = null,
     val pendingNavigation: AssistantPendingNavigation? = null,
 ) {
     val isStreaming: Boolean
@@ -36,13 +37,47 @@ enum class AssistantUiStatus {
 data class AssistantUiMessage(
     val id: String,
     val role: Role,
-    val text: String,
+    val segments: List<AssistantUiSegment>,
     val error: AssistantMessageError? = null,
 ) {
+    constructor(
+        id: String,
+        role: Role,
+        text: String,
+        error: AssistantMessageError? = null,
+    ) : this(
+        id = id,
+        role = role,
+        segments = listOf(AssistantUiSegment.Text(text)),
+        error = error,
+    )
+
+    val text: String
+        get() = segments.filterIsInstance<AssistantUiSegment.Text>().joinToString(separator = "") { it.text }
+
     enum class Role {
         USER,
         ASSISTANT,
     }
+}
+
+sealed interface AssistantUiSegment {
+    data class Text(val text: String) : AssistantUiSegment
+
+    data class ConfirmationCard(val model: AssistantConfirmationCard) : AssistantUiSegment
+}
+
+data class AssistantConfirmationCard(
+    val confirmationId: String,
+    val toolCall: ToolCall,
+    val state: AssistantConfirmationCardState,
+    val preview: RenderedConfirmationPreview? = null,
+)
+
+enum class AssistantConfirmationCardState {
+    PENDING,
+    CONFIRMED,
+    CANCELLED,
 }
 
 data class AssistantMessageError(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.aiassistant.ui
 
 import androidx.annotation.StringRes
+import androidx.annotation.DrawableRes
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
@@ -78,6 +79,20 @@ enum class AssistantConfirmationCardState {
     PENDING,
     CONFIRMED,
     CANCELLED,
+}
+
+@StringRes
+internal fun AssistantConfirmationCardState.eyebrowRes(): Int = when (this) {
+    AssistantConfirmationCardState.PENDING -> R.string.assistant_confirmation_eyebrow_pending
+    AssistantConfirmationCardState.CONFIRMED -> R.string.assistant_confirmation_eyebrow_confirmed
+    AssistantConfirmationCardState.CANCELLED -> R.string.assistant_confirmation_eyebrow_cancelled
+}
+
+@DrawableRes
+internal fun AssistantConfirmationCardState.iconRes(): Int = when (this) {
+    AssistantConfirmationCardState.PENDING -> R.drawable.ic_assistant_confirmation_pending
+    AssistantConfirmationCardState.CONFIRMED -> R.drawable.ic_assistant_confirmation_confirmed
+    AssistantConfirmationCardState.CANCELLED -> R.drawable.ic_assistant_confirmation_cancelled
 }
 
 data class AssistantMessageError(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -22,6 +22,9 @@ data class AssistantUiState(
         get() = status == AssistantUiStatus.STREAMING ||
             status == AssistantUiStatus.AWAITING_CONFIRMATION
 
+    val shouldShowStopControl: Boolean
+        get() = status == AssistantUiStatus.STREAMING
+
     val shouldShowFallbackError: Boolean
         get() = status == AssistantUiStatus.ERROR &&
             error != null &&

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -370,14 +370,13 @@ class AssistantViewModel @AssistedInject constructor(
     }
 
     private fun AssistantUiMessage.appendText(delta: String): AssistantUiMessage {
-        val firstTextIndex = segments.indexOfFirst { it is AssistantUiSegment.Text }
-        if (firstTextIndex == -1) {
-            return copy(segments = listOf(AssistantUiSegment.Text(delta)) + segments)
+        val lastSegment = segments.lastOrNull()
+        if (lastSegment !is AssistantUiSegment.Text) {
+            return copy(segments = segments + AssistantUiSegment.Text(delta))
         }
 
         val updatedSegments = segments.toMutableList()
-        val currentText = updatedSegments[firstTextIndex] as AssistantUiSegment.Text
-        updatedSegments[firstTextIndex] = currentText.copy(text = currentText.text + delta)
+        updatedSegments[updatedSegments.lastIndex] = lastSegment.copy(text = lastSegment.text + delta)
         return copy(segments = updatedSegments)
     }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -70,13 +70,13 @@ class AssistantViewModel @AssistedInject constructor(
                 status = AssistantUiStatus.ERROR,
                 error = AssistantError.Cancelled.toAssistantUiError(),
                 canRetry = false,
-                pendingConfirmation = null,
+                activeConfirmationId = null,
             )
         }
     }
 
     fun onConfirmWrite() {
-        val confirmationId = _uiState.value.pendingConfirmation?.id ?: return
+        val confirmationId = _uiState.value.activeConfirmationId ?: return
         viewModelScope.launch {
             when (runtime.confirmWrite(confirmationId)) {
                 AssistantRuntimeConfirmationResult.Accepted -> {
@@ -85,7 +85,7 @@ class AssistantViewModel @AssistedInject constructor(
                             status = AssistantUiStatus.STREAMING,
                             error = null,
                             canRetry = false,
-                            pendingConfirmation = null,
+                            activeConfirmationId = null,
                         )
                     }
                 }
@@ -96,7 +96,7 @@ class AssistantViewModel @AssistedInject constructor(
                             status = AssistantUiStatus.ERROR,
                             error = AssistantUiError.CONFIRMATION_DEFERRED,
                             canRetry = false,
-                            pendingConfirmation = null,
+                            activeConfirmationId = null,
                         )
                     }
                 }
@@ -105,7 +105,7 @@ class AssistantViewModel @AssistedInject constructor(
     }
 
     fun onCancelWrite() {
-        val confirmationId = _uiState.value.pendingConfirmation?.id ?: return
+        val confirmationId = _uiState.value.activeConfirmationId ?: return
         viewModelScope.launch {
             runtime.cancelWrite(confirmationId)
             _uiState.update {
@@ -113,7 +113,7 @@ class AssistantViewModel @AssistedInject constructor(
                     status = AssistantUiStatus.IDLE,
                     error = null,
                     canRetry = false,
-                    pendingConfirmation = null,
+                    activeConfirmationId = null,
                 )
             }
         }
@@ -146,7 +146,7 @@ class AssistantViewModel @AssistedInject constructor(
                 status = AssistantUiStatus.STREAMING,
                 error = null,
                 canRetry = false,
-                pendingConfirmation = null,
+                activeConfirmationId = null,
             )
         }
 
@@ -169,10 +169,15 @@ class AssistantViewModel @AssistedInject constructor(
             is AssistantRuntimeEvent.AwaitingConfirmation -> {
                 _uiState.update {
                     it.copy(
+                        messages = it.messages.withConfirmationCard(
+                            activeMessageId = activeAssistantMessageId,
+                            confirmation = event.confirmation,
+                            nextId = idGenerator::nextId,
+                        ),
                         status = AssistantUiStatus.AWAITING_CONFIRMATION,
                         error = null,
                         canRetry = false,
-                        pendingConfirmation = event.confirmation,
+                        activeConfirmationId = event.confirmation.confirmationId,
                     )
                 }
             }
@@ -193,7 +198,7 @@ class AssistantViewModel @AssistedInject constructor(
                         status = event.toAssistantUiStatus(),
                         error = event.toAssistantUiError(),
                         canRetry = canRetry,
-                        pendingConfirmation = null,
+                        activeConfirmationId = null,
                     )
                 }
             }
@@ -222,7 +227,7 @@ class AssistantViewModel @AssistedInject constructor(
             state.copy(
                 messages = state.messages.map { message ->
                     if (message.id == messageId) {
-                        message.copy(text = message.text + delta)
+                        message.appendText(delta)
                     } else {
                         message
                     }
@@ -283,7 +288,7 @@ class AssistantViewModel @AssistedInject constructor(
             return this + AssistantUiMessage(
                 id = nextId(),
                 role = AssistantUiMessage.Role.ASSISTANT,
-                text = "",
+                segments = listOf(AssistantUiSegment.Text("")),
                 error = messageError,
             )
         }
@@ -295,6 +300,54 @@ class AssistantViewModel @AssistedInject constructor(
                 message
             }
         }
+    }
+
+    private fun List<AssistantUiMessage>.withConfirmationCard(
+        activeMessageId: String?,
+        confirmation: AssistantConfirmationCard,
+        nextId: () -> String,
+    ): List<AssistantUiMessage> {
+        val targetId = activeMessageId
+        if (targetId == null) {
+            return this + AssistantUiMessage(
+                id = nextId(),
+                role = AssistantUiMessage.Role.ASSISTANT,
+                segments = listOf(
+                    AssistantUiSegment.Text(""),
+                    AssistantUiSegment.ConfirmationCard(confirmation),
+                ),
+            )
+        }
+
+        return map { message ->
+            if (message.id == targetId) {
+                message.appendConfirmationCard(confirmation)
+            } else {
+                message
+            }
+        }
+    }
+
+    private fun AssistantUiMessage.appendText(delta: String): AssistantUiMessage {
+        val firstTextIndex = segments.indexOfFirst { it is AssistantUiSegment.Text }
+        if (firstTextIndex == -1) {
+            return copy(segments = listOf(AssistantUiSegment.Text(delta)) + segments)
+        }
+
+        val updatedSegments = segments.toMutableList()
+        val currentText = updatedSegments[firstTextIndex] as AssistantUiSegment.Text
+        updatedSegments[firstTextIndex] = currentText.copy(text = currentText.text + delta)
+        return copy(segments = updatedSegments)
+    }
+
+    private fun AssistantUiMessage.appendConfirmationCard(
+        confirmation: AssistantConfirmationCard,
+    ): AssistantUiMessage {
+        val updatedSegments = segments.filterNot {
+            it is AssistantUiSegment.ConfirmationCard &&
+                it.model.confirmationId == confirmation.confirmationId
+        } + AssistantUiSegment.ConfirmationCard(confirmation)
+        return copy(segments = updatedSegments)
     }
 
     @AssistedFactory

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -121,7 +121,6 @@ class AssistantViewModel @AssistedInject constructor(
                 AssistantRuntimeConfirmationDispatchResult.Accepted -> {
                     _uiState.update {
                         it.copy(
-                            status = AssistantUiStatus.IDLE,
                             error = null,
                             canRetry = false,
                             activeConfirmationId = null,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
 import com.woocommerce.android.aiassistant.core.loop.ToolScope
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationDecision
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
@@ -181,6 +182,16 @@ class AssistantViewModel @AssistedInject constructor(
                     )
                 }
             }
+            is AssistantRuntimeEvent.ConfirmationResolved -> {
+                _uiState.update { state ->
+                    state.copy(
+                        messages = state.messages.withUpdatedConfirmationCard(
+                            confirmationId = event.result.requestId,
+                            state = event.result.decision.toCardState(),
+                        )
+                    )
+                }
+            }
             is AssistantRuntimeEvent.Finished -> {
                 val activeMessageId = activeAssistantMessageId
                 val normalizedError = event.normalizedAssistantError()
@@ -348,6 +359,28 @@ class AssistantViewModel @AssistedInject constructor(
                 it.model.confirmationId == confirmation.confirmationId
         } + AssistantUiSegment.ConfirmationCard(confirmation)
         return copy(segments = updatedSegments)
+    }
+
+    private fun List<AssistantUiMessage>.withUpdatedConfirmationCard(
+        confirmationId: String,
+        state: AssistantConfirmationCardState,
+    ): List<AssistantUiMessage> = map { message ->
+        message.copy(
+            segments = message.segments.map { segment ->
+                if (segment is AssistantUiSegment.ConfirmationCard &&
+                    segment.model.confirmationId == confirmationId
+                ) {
+                    segment.copy(model = segment.model.copy(state = state))
+                } else {
+                    segment
+                }
+            }
+        )
+    }
+
+    private fun ConfirmationDecision.toCardState(): AssistantConfirmationCardState = when (this) {
+        ConfirmationDecision.CONFIRMED -> AssistantConfirmationCardState.CONFIRMED
+        ConfirmationDecision.CANCELLED -> AssistantConfirmationCardState.CANCELLED
     }
 
     @AssistedFactory

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -59,6 +59,10 @@ class AssistantViewModel @AssistedInject constructor(
 
     fun onCancelTurn() {
         if (!_uiState.value.isTurnActive) return
+        if (_uiState.value.activeConfirmationId != null) {
+            cancelOpenConfirmationSegments()
+            return
+        }
 
         preserveCancelledTurnInHistory()
         turnJob?.cancel()
@@ -111,35 +115,7 @@ class AssistantViewModel @AssistedInject constructor(
     }
 
     fun onCancelWrite() {
-        val confirmationId = _uiState.value.activeConfirmationId ?: return
-        viewModelScope.launch {
-            when (
-                runtime.resolveConfirmation(
-                    ConfirmationResult(confirmationId, ConfirmationDecision.CANCELLED)
-                )
-            ) {
-                AssistantRuntimeConfirmationDispatchResult.Accepted -> {
-                    _uiState.update {
-                        it.copy(
-                            error = null,
-                            canRetry = false,
-                            activeConfirmationId = null,
-                        )
-                    }
-                }
-                AssistantRuntimeConfirmationDispatchResult.Deferred -> {
-                    activeAssistantMessageId = null
-                    _uiState.update {
-                        it.copy(
-                            status = AssistantUiStatus.ERROR,
-                            error = AssistantUiError.CONFIRMATION_DEFERRED,
-                            canRetry = false,
-                            activeConfirmationId = null,
-                        )
-                    }
-                }
-            }
-        }
+        cancelOpenConfirmationSegments()
     }
 
     private fun startTurn(message: String, isRetry: Boolean) {
@@ -252,6 +228,38 @@ class AssistantViewModel @AssistedInject constructor(
             }
         }
         history = lastTurnBaseHistory + cancelledTurnHistory
+    }
+
+    private fun cancelOpenConfirmationSegments() {
+        val confirmationId = _uiState.value.activeConfirmationId ?: return
+        viewModelScope.launch {
+            when (
+                runtime.resolveConfirmation(
+                    ConfirmationResult(confirmationId, ConfirmationDecision.CANCELLED)
+                )
+            ) {
+                AssistantRuntimeConfirmationDispatchResult.Accepted -> {
+                    _uiState.update {
+                        it.copy(
+                            error = null,
+                            canRetry = false,
+                            activeConfirmationId = null,
+                        )
+                    }
+                }
+                AssistantRuntimeConfirmationDispatchResult.Deferred -> {
+                    activeAssistantMessageId = null
+                    _uiState.update {
+                        it.copy(
+                            status = AssistantUiStatus.ERROR,
+                            error = AssistantUiError.CONFIRMATION_DEFERRED,
+                            canRetry = false,
+                            activeConfirmationId = null,
+                        )
+                    }
+                }
+            }
+        }
     }
 
     private fun appendAssistantText(delta: String) {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -7,8 +7,9 @@ import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
 import com.woocommerce.android.aiassistant.core.loop.ToolScope
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationDecision
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
-import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationResult
+import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationDispatchResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
 import com.woocommerce.android.aiassistant.runtime.AssistantTurnRequest
 import com.woocommerce.android.tools.SelectedSite
@@ -79,8 +80,12 @@ class AssistantViewModel @AssistedInject constructor(
     fun onConfirmWrite() {
         val confirmationId = _uiState.value.activeConfirmationId ?: return
         viewModelScope.launch {
-            when (runtime.confirmWrite(confirmationId)) {
-                AssistantRuntimeConfirmationResult.Accepted -> {
+            when (
+                runtime.resolveConfirmation(
+                    ConfirmationResult(confirmationId, ConfirmationDecision.CONFIRMED)
+                )
+            ) {
+                AssistantRuntimeConfirmationDispatchResult.Accepted -> {
                     _uiState.update {
                         it.copy(
                             status = AssistantUiStatus.STREAMING,
@@ -90,7 +95,7 @@ class AssistantViewModel @AssistedInject constructor(
                         )
                     }
                 }
-                AssistantRuntimeConfirmationResult.Deferred -> {
+                AssistantRuntimeConfirmationDispatchResult.Deferred -> {
                     activeAssistantMessageId = null
                     _uiState.update {
                         it.copy(
@@ -108,14 +113,32 @@ class AssistantViewModel @AssistedInject constructor(
     fun onCancelWrite() {
         val confirmationId = _uiState.value.activeConfirmationId ?: return
         viewModelScope.launch {
-            runtime.cancelWrite(confirmationId)
-            _uiState.update {
-                it.copy(
-                    status = AssistantUiStatus.IDLE,
-                    error = null,
-                    canRetry = false,
-                    activeConfirmationId = null,
+            when (
+                runtime.resolveConfirmation(
+                    ConfirmationResult(confirmationId, ConfirmationDecision.CANCELLED)
                 )
+            ) {
+                AssistantRuntimeConfirmationDispatchResult.Accepted -> {
+                    _uiState.update {
+                        it.copy(
+                            status = AssistantUiStatus.IDLE,
+                            error = null,
+                            canRetry = false,
+                            activeConfirmationId = null,
+                        )
+                    }
+                }
+                AssistantRuntimeConfirmationDispatchResult.Deferred -> {
+                    activeAssistantMessageId = null
+                    _uiState.update {
+                        it.copy(
+                            status = AssistantUiStatus.ERROR,
+                            error = AssistantUiError.CONFIRMATION_DEFERRED,
+                            canRetry = false,
+                            activeConfirmationId = null,
+                        )
+                    }
+                }
             }
         }
     }

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_cancelled.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_cancelled.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M10,2.5A7.5,7.5 0,1 1,10 17.5A7.5,7.5 0,0 1,10 2.5Z"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.7" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M7.1,7.1L12.9,12.9"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.7" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M12.9,7.1L7.1,12.9"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.7" />
+</vector>

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_confirmed.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_confirmed.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M10,2.5A7.5,7.5 0,1 1,10 17.5A7.5,7.5 0,0 1,10 2.5Z"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.7" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M6.4,10.3L8.8,12.7L13.7,7.8"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.7" />
+</vector>

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_pending.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_pending.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M10,2.5A7.5,7.5 0,1 1,10 17.5A7.5,7.5 0,0 1,10 2.5Z"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.7" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M10,6.2V10.3L12.8,12.1"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.7" />
+</vector>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -39,6 +39,11 @@
     <string name="ai_assistant_confirmation_field_value_updated">Updated</string>
     <string name="ai_assistant_confirmation_field_value_off">Off</string>
     <string name="ai_assistant_confirmation_message_list_separator">%1$s, %2$s</string>
+    <string name="assistant_confirmation_eyebrow_pending">Pending change</string>
+    <string name="assistant_confirmation_eyebrow_confirmed">Confirmed</string>
+    <string name="assistant_confirmation_eyebrow_cancelled">Cancelled</string>
+    <string name="assistant_confirmation_now">Now</string>
+    <string name="assistant_confirmation_after">After</string>
     <string name="assistant_chat_title">AI Assistant</string>
     <string name="assistant_chat_status_idle">Ready</string>
     <string name="assistant_chat_status_streaming">Working</string>

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/JetpackAiChatServiceTest.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -79,7 +80,7 @@ class JetpackAiChatServiceTest {
     }
 
     @Test
-    fun `given assistant tool calls with null content, when sent, then request omits assistant content`() = runTest {
+    fun `given assistant tool calls with null content, when sent, then request uses empty assistant content for backend compatibility`() = runTest {
         server.enqueue(sseResponse(SAMPLE_SSE_BODY))
 
         val service = newService()
@@ -106,7 +107,7 @@ class JetpackAiChatServiceTest {
         val body = Json.parseToJsonElement(recorded.body.readUtf8()).jsonObject
         val assistantMessage = body.getValue("messages").jsonArray.single().jsonObject
 
-        assertThat(assistantMessage).doesNotContainKey("content")
+        assertThat(assistantMessage.getValue("content").jsonPrimitive.content).isEmpty()
         assertThat(assistantMessage.getValue("tool_calls").jsonArray).hasSize(1)
     }
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/openai/OpenAiMappingTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/chat/openai/OpenAiMappingTest.kt
@@ -70,7 +70,7 @@ class OpenAiMappingTest {
         assertThat(systemMessage.getValue("role").jsonPrimitive.content).isEqualTo("system")
         assertThat(userMessage.getValue("role").jsonPrimitive.content).isEqualTo("user")
         assertThat(assistantMessage.getValue("role").jsonPrimitive.content).isEqualTo("assistant")
-        assertThat(assistantMessage).doesNotContainKey("content")
+        assertThat(assistantMessage.getValue("content").jsonPrimitive.content).isEmpty()
         assertThat(
             assistantMessage.getValue("tool_calls").jsonArray.single().jsonObject
                 .getValue("function").jsonObject

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -170,37 +170,38 @@ class AgenticLoopAssistantRuntimeTest {
     }
 
     @Test
-    fun `when write is confirmed, then runtime resolves safety confirmation`() = runTest {
+    fun `when confirmation is resolved, then runtime forwards the core confirmation result to safety orchestrator`() =
+        runTest {
         val safetyOrchestrator = FakeSafetyOrchestrator()
         val runtime = runtime(safetyOrchestrator = safetyOrchestrator)
+        val result = ConfirmationResult("confirmation-1", ConfirmationDecision.CONFIRMED)
 
-        val result = runtime.confirmWrite("confirmation-1")
+        val dispatchResult = runtime.resolveConfirmation(result)
 
-        assertThat(result).isEqualTo(AssistantRuntimeConfirmationResult.Accepted)
-        assertThat(safetyOrchestrator.results).containsExactly(
-            ConfirmationResult("confirmation-1", ConfirmationDecision.CONFIRMED)
-        )
+        assertThat(dispatchResult).isEqualTo(AssistantRuntimeConfirmationDispatchResult.Accepted)
+        assertThat(safetyOrchestrator.results).containsExactly(result)
     }
 
     @Test
     fun `when confirmation is missing, then runtime reports deferred confirmation`() = runTest {
         val runtime = runtime(safetyOrchestrator = FakeSafetyOrchestrator(resolveResult = false))
+        val result = ConfirmationResult("missing", ConfirmationDecision.CONFIRMED)
 
-        val result = runtime.confirmWrite("missing")
+        val dispatchResult = runtime.resolveConfirmation(result)
 
-        assertThat(result).isEqualTo(AssistantRuntimeConfirmationResult.Deferred)
+        assertThat(dispatchResult).isEqualTo(AssistantRuntimeConfirmationDispatchResult.Deferred)
     }
 
     @Test
-    fun `when write is cancelled, then runtime cancels safety confirmation`() = runTest {
+    fun `when cancelled confirmation is resolved, then runtime forwards the cancellation result to safety orchestrator`() =
+        runTest {
         val safetyOrchestrator = FakeSafetyOrchestrator()
         val runtime = runtime(safetyOrchestrator = safetyOrchestrator)
+        val result = ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
 
-        runtime.cancelWrite("confirmation-1")
+        runtime.resolveConfirmation(result)
 
-        assertThat(safetyOrchestrator.results).containsExactly(
-            ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
-        )
+        assertThat(safetyOrchestrator.results).containsExactly(result)
     }
 
     private fun runtime(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -25,6 +25,8 @@ import com.woocommerce.android.aiassistant.safety.ConfirmationPreviewRenderer
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreview
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreviewField
 import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationPreviewBuilder
+import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
+import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCardState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -94,7 +96,7 @@ class AgenticLoopAssistantRuntimeTest {
     }
 
     @Test
-    fun `when loop requests confirmation, then runtime emits pending confirmation`() = runTest {
+    fun `when loop requests confirmation, then runtime emits inline confirmation card data`() = runTest {
         val request = ConfirmationRequest(
             id = "confirmation-1",
             toolCallId = "call-1",
@@ -113,8 +115,8 @@ class AgenticLoopAssistantRuntimeTest {
 
         assertThat(events).containsExactly(
             AssistantRuntimeEvent.AwaitingConfirmation(
-                AssistantPendingConfirmation(
-                    id = "confirmation-1",
+                AssistantConfirmationCard(
+                    confirmationId = "confirmation-1",
                     toolCall = ToolCall(
                         id = "call-1",
                         name = "orders_update",
@@ -123,6 +125,7 @@ class AgenticLoopAssistantRuntimeTest {
                             put("status", "processing")
                         },
                     ),
+                    state = AssistantConfirmationCardState.PENDING,
                     preview = RenderedConfirmationPreview(
                         message = "Set order #123 to processing (emails the customer)",
                         fields = listOf(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -170,6 +170,39 @@ class AgenticLoopAssistantRuntimeTest {
     }
 
     @Test
+    fun `when loop stops cleanly after confirmation cancel, then runtime finish has no cancelled error`() = runTest {
+        val updatedHistory = listOf(
+            AssistantMessage.User("Cancel order 123"),
+            AssistantMessage.Assistant("I can do that"),
+        )
+        val resolved = ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
+        val runtime = runtime(
+            agenticLoop = FakeAgenticLoop(
+                events = listOf(
+                    LoopEvent.ConfirmationResolved(resolved),
+                    LoopEvent.Finished(
+                        outcome = LoopOutcome.STOPPED,
+                        updatedHistory = updatedHistory,
+                        retryAvailable = false,
+                    )
+                )
+            ),
+        )
+
+        val events = runtime.startTurn(givenTurnRequest()).toList()
+
+        assertThat(events).containsExactly(
+            AssistantRuntimeEvent.ConfirmationResolved(resolved),
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.STOPPED,
+                updatedHistory = updatedHistory,
+                retryAvailable = false,
+                error = null,
+            )
+        )
+    }
+
+    @Test
     fun `when confirmation is resolved, then runtime forwards the core confirmation result to safety orchestrator`() =
         runTest {
         val safetyOrchestrator = FakeSafetyOrchestrator()

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -21,12 +21,12 @@ import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 import com.woocommerce.android.aiassistant.core.safety.SafetyDecision
 import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
-import com.woocommerce.android.aiassistant.safety.ConfirmationSnapshot
 import com.woocommerce.android.aiassistant.safety.ConfirmationPreviewRenderer
+import com.woocommerce.android.aiassistant.safety.ConfirmationSnapshot
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreview
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreviewField
-import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationSnapshotResolver
 import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationPreviewBuilder
+import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationSnapshotResolver
 import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
 import com.woocommerce.android.aiassistant.tools.products.AIProductVariationsDataSource
 import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
@@ -205,15 +205,15 @@ class AgenticLoopAssistantRuntimeTest {
     @Test
     fun `when confirmation is resolved, then runtime forwards the core confirmation result to safety orchestrator`() =
         runTest {
-        val safetyOrchestrator = FakeSafetyOrchestrator()
-        val runtime = runtime(safetyOrchestrator = safetyOrchestrator)
-        val result = ConfirmationResult("confirmation-1", ConfirmationDecision.CONFIRMED)
+            val safetyOrchestrator = FakeSafetyOrchestrator()
+            val runtime = runtime(safetyOrchestrator = safetyOrchestrator)
+            val result = ConfirmationResult("confirmation-1", ConfirmationDecision.CONFIRMED)
 
-        val dispatchResult = runtime.resolveConfirmation(result)
+            val dispatchResult = runtime.resolveConfirmation(result)
 
-        assertThat(dispatchResult).isEqualTo(AssistantRuntimeConfirmationDispatchResult.Accepted)
-        assertThat(safetyOrchestrator.results).containsExactly(result)
-    }
+            assertThat(dispatchResult).isEqualTo(AssistantRuntimeConfirmationDispatchResult.Accepted)
+            assertThat(safetyOrchestrator.results).containsExactly(result)
+        }
 
     @Test
     fun `when confirmation is missing, then runtime reports deferred confirmation`() = runTest {
@@ -228,14 +228,14 @@ class AgenticLoopAssistantRuntimeTest {
     @Test
     fun `when cancelled confirmation is resolved, then runtime forwards the cancellation result to safety orchestrator`() =
         runTest {
-        val safetyOrchestrator = FakeSafetyOrchestrator()
-        val runtime = runtime(safetyOrchestrator = safetyOrchestrator)
-        val result = ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
+            val safetyOrchestrator = FakeSafetyOrchestrator()
+            val runtime = runtime(safetyOrchestrator = safetyOrchestrator)
+            val result = ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
 
-        runtime.resolveConfirmation(result)
+            runtime.resolveConfirmation(result)
 
-        assertThat(safetyOrchestrator.results).containsExactly(result)
-    }
+            assertThat(safetyOrchestrator.results).containsExactly(result)
+        }
 
     private fun runtime(
         agenticLoop: AgenticLoop = FakeAgenticLoop(events = emptyList()),

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -21,10 +21,15 @@ import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 import com.woocommerce.android.aiassistant.core.safety.SafetyDecision
 import com.woocommerce.android.aiassistant.core.safety.SafetyOrchestrator
+import com.woocommerce.android.aiassistant.safety.ConfirmationSnapshot
 import com.woocommerce.android.aiassistant.safety.ConfirmationPreviewRenderer
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreview
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreviewField
+import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationSnapshotResolver
 import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationPreviewBuilder
+import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
+import com.woocommerce.android.aiassistant.tools.products.AIProductVariationsDataSource
+import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCardState
 import kotlinx.coroutines.flow.Flow
@@ -36,6 +41,7 @@ import kotlinx.serialization.json.put
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -107,8 +113,14 @@ class AgenticLoopAssistantRuntimeTest {
             },
             safetyLevel = ToolSafetyLevel.UNSAFE,
         )
+        val snapshot = ConfirmationSnapshot(
+            currentValues = mapOf(
+                "status" to "pending",
+            )
+        )
         val runtime = runtime(
             agenticLoop = FakeAgenticLoop(events = listOf(LoopEvent.ConfirmationRequested(request))),
+            snapshotResolver = FakeSnapshotResolver(snapshot),
         )
 
         val events = runtime.startTurn(givenTurnRequest()).toList()
@@ -133,8 +145,10 @@ class AgenticLoopAssistantRuntimeTest {
                                 name = "status",
                                 label = "Status",
                                 value = "processing",
+                                beforeValue = "pending",
                             )
                         ),
+                        isBulk = false,
                     ),
                 )
             )
@@ -178,6 +192,7 @@ class AgenticLoopAssistantRuntimeTest {
     private fun runtime(
         agenticLoop: AgenticLoop = FakeAgenticLoop(events = emptyList()),
         safetyOrchestrator: SafetyOrchestrator = FakeSafetyOrchestrator(),
+        snapshotResolver: WooCommerceConfirmationSnapshotResolver = FakeSnapshotResolver(),
     ) = AgenticLoopAssistantRuntime(
         agenticLoop = agenticLoop,
         toolRegistry = EmptyToolRegistry,
@@ -185,6 +200,7 @@ class AgenticLoopAssistantRuntimeTest {
         safetyOrchestrator = safetyOrchestrator,
         confirmationPreviewBuilder = WooCommerceConfirmationPreviewBuilder(),
         confirmationPreviewRenderer = ConfirmationPreviewRenderer(ApplicationProvider.getApplicationContext<Context>()),
+        confirmationSnapshotResolver = snapshotResolver,
     )
 
     private fun givenTurnRequest() = AssistantTurnRequest(
@@ -235,5 +251,15 @@ class AgenticLoopAssistantRuntimeTest {
         }
 
         override fun cancelPending(requestId: String): Boolean = false
+    }
+
+    private class FakeSnapshotResolver(
+        private val snapshot: ConfirmationSnapshot? = null,
+    ) : WooCommerceConfirmationSnapshotResolver(
+        ordersDataSource = mock<AIOrdersDataSource>(),
+        productsDataSource = mock<AIProductsDataSource>(),
+        variationsDataSource = mock<AIProductVariationsDataSource>(),
+    ) {
+        override suspend fun resolve(request: ConfirmationRequest): ConfirmationSnapshot? = snapshot
     }
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -156,6 +156,20 @@ class AgenticLoopAssistantRuntimeTest {
     }
 
     @Test
+    fun `when loop resolves confirmation, then runtime forwards the resolution event`() = runTest {
+        val resolved = ConfirmationResult("confirmation-1", ConfirmationDecision.CONFIRMED)
+        val runtime = runtime(
+            agenticLoop = FakeAgenticLoop(events = listOf(LoopEvent.ConfirmationResolved(resolved))),
+        )
+
+        val events = runtime.startTurn(givenTurnRequest()).toList()
+
+        assertThat(events).containsExactly(
+            AssistantRuntimeEvent.ConfirmationResolved(resolved)
+        )
+    }
+
+    @Test
     fun `when write is confirmed, then runtime resolves safety confirmation`() = runTest {
         val safetyOrchestrator = FakeSafetyOrchestrator()
         val runtime = runtime(safetyOrchestrator = safetyOrchestrator)

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilderTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilderTest.kt
@@ -25,6 +25,13 @@ class WooCommerceConfirmationPreviewBuilderTest {
 
         val preview = builder.build(call)
 
+        assertThat(preview.summary).isEqualTo(
+            string(
+                R.string.ai_assistant_confirmation_order_set_status_emails_customer,
+                raw("42"),
+                raw("processing"),
+            )
+        )
         assertThat(preview.message).isEqualTo(
             string(
                 R.string.ai_assistant_confirmation_order_set_status_emails_customer,
@@ -96,6 +103,7 @@ class WooCommerceConfirmationPreviewBuilderTest {
 
         val preview = builder.build(call)
 
+        assertThat(preview.isBulk).isTrue()
         val summary = string(
             R.string.ai_assistant_confirmation_change_summary_status_emails_customers,
             raw("completed"),

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilderTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilderTest.kt
@@ -291,6 +291,89 @@ class WooCommerceConfirmationPreviewBuilderTest {
     }
 
     @Test
+    fun `given order update and current snapshot, when preview is built, then before and after values are included`() {
+        val preview = builder.build(
+            toolCall(
+                name = "orders_update",
+                arguments = buildJsonObject {
+                    put("id", 42)
+                    put("status", "processing")
+                },
+            ),
+            snapshot = ConfirmationSnapshot(
+                currentValues = mapOf(
+                    "status" to "pending",
+                )
+            ),
+        )
+
+        assertThat(preview.rows).containsExactly(
+            ConfirmationPreviewField(
+                name = "status",
+                label = label(R.string.ai_assistant_confirmation_field_status),
+                value = raw("processing"),
+                beforeValue = raw("pending"),
+            )
+        )
+        assertThat(preview.isBulk).isFalse()
+    }
+
+    @Test
+    fun `given product update and current snapshot, when preview is built, then before and after values are included`() {
+        val preview = builder.build(
+            toolCall(
+                name = "products_update",
+                arguments = buildJsonObject {
+                    put("id", 7)
+                    put("regular_price", "24.99")
+                },
+            ),
+            snapshot = ConfirmationSnapshot(
+                currentValues = mapOf(
+                    "regular_price" to "19.99",
+                )
+            ),
+        )
+
+        assertThat(preview.rows).containsExactly(
+            ConfirmationPreviewField(
+                name = "regular_price",
+                label = label(R.string.ai_assistant_confirmation_field_regular_price),
+                value = raw("24.99"),
+                beforeValue = raw("19.99"),
+            )
+        )
+    }
+
+    @Test
+    fun `given variation update and current snapshot, when preview is built, then before and after values are included`() {
+        val preview = builder.build(
+            toolCall(
+                name = "product_variations_update",
+                arguments = buildJsonObject {
+                    put("product_id", 7)
+                    put("id", 8)
+                    put("sku", "VAR-8")
+                },
+            ),
+            snapshot = ConfirmationSnapshot(
+                currentValues = mapOf(
+                    "sku" to "VAR-7",
+                )
+            ),
+        )
+
+        assertThat(preview.rows).containsExactly(
+            ConfirmationPreviewField(
+                name = "sku",
+                label = label(R.string.ai_assistant_confirmation_field_sku),
+                value = raw("VAR-8"),
+                beforeValue = raw("VAR-7"),
+            )
+        )
+    }
+
+    @Test
     fun `given unknown tool, when preview is built, then raw arguments are omitted`() {
         val call = toolCall(
             name = "custom_tool",
@@ -487,6 +570,27 @@ class WooCommerceConfirmationPreviewBuilderTest {
             )
         )
         assertThat(productPreview.fields).isEmpty()
+    }
+
+    @Test
+    fun `given bulk update with a single id, when preview is built, then before values stay absent`() {
+        val preview = builder.build(
+            toolCall(
+                name = "products_bulk_update",
+                arguments = buildJsonObject {
+                    put("ids", JsonArray(listOf(JsonPrimitive(7))))
+                    put(
+                        "patch",
+                        buildJsonObject {
+                            put("status", "draft")
+                        },
+                    )
+                },
+            )
+        )
+
+        assertThat(preview.isBulk).isTrue()
+        assertThat(preview.rows.single().beforeValue).isNull()
     }
 
     private fun toolCall(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
@@ -66,7 +66,12 @@ class WooCommerceConfirmationPreviewRendererTest {
                     put("id", 42)
                     put("status", "processing")
                 },
-            )
+            ),
+            snapshot = ConfirmationSnapshot(
+                currentValues = mapOf(
+                    "status" to "pending",
+                )
+            ),
         )
 
         val rendered = renderer.render(preview)
@@ -77,9 +82,34 @@ class WooCommerceConfirmationPreviewRendererTest {
                 name = "status",
                 label = context.getString(R.string.ai_assistant_confirmation_field_status),
                 value = "processing",
+                beforeValue = "pending",
             )
         )
         assertThat(rendered.isBulk).isFalse()
+    }
+
+    @Test
+    fun `given bulk update, when preview is rendered, then before values stay absent`() {
+        val preview = builder.build(
+            toolCall(
+                name = "products_bulk_update",
+                arguments = buildJsonObject {
+                    put("ids", JsonArray(listOf(JsonPrimitive(7))))
+                    put(
+                        "patch",
+                        buildJsonObject {
+                            put("status", "draft")
+                        },
+                    )
+                },
+            )
+        )
+
+        val rendered = renderer.render(preview)
+
+        assertThat(rendered.isBulk).isTrue()
+        assertThat(rendered.rows.single().beforeValue).isNull()
+        assertThat(rendered.rows.single().afterValue).isEqualTo("draft")
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
@@ -34,6 +34,13 @@ class WooCommerceConfirmationPreviewRendererTest {
 
         val rendered = renderer.render(preview)
 
+        assertThat(rendered.summary).isEqualTo(
+            context.getString(
+                R.string.ai_assistant_confirmation_order_set_status_emails_customer,
+                "42",
+                "processing",
+            )
+        )
         assertThat(rendered.message).isEqualTo(
             context.getString(
                 R.string.ai_assistant_confirmation_order_set_status_emails_customer,
@@ -48,6 +55,31 @@ class WooCommerceConfirmationPreviewRendererTest {
                 value = "processing",
             )
         )
+    }
+
+    @Test
+    fun `given order status update, when preview is rendered, then summary and rows are exposed for inline cards`() {
+        val preview = builder.build(
+            toolCall(
+                name = "orders_update",
+                arguments = buildJsonObject {
+                    put("id", 42)
+                    put("status", "processing")
+                },
+            )
+        )
+
+        val rendered = renderer.render(preview)
+
+        assertThat(rendered.summary).isEqualTo("Set order #42 to processing (emails the customer)")
+        assertThat(rendered.rows).containsExactly(
+            RenderedConfirmationDiffRow(
+                name = "status",
+                label = context.getString(R.string.ai_assistant_confirmation_field_status),
+                value = "processing",
+            )
+        )
+        assertThat(rendered.isBulk).isFalse()
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationSnapshotResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationSnapshotResolverTest.kt
@@ -1,0 +1,155 @@
+package com.woocommerce.android.aiassistant.safety
+
+import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationRequest
+import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
+import com.woocommerce.android.aiassistant.tools.products.AIProductVariationsDataSource
+import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
+import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.WCProductVariationModel
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
+
+class WooCommerceConfirmationSnapshotResolverTest {
+    private val ordersDataSource: AIOrdersDataSource = mock()
+    private val productsDataSource: AIProductsDataSource = mock()
+    private val variationsDataSource: AIProductVariationsDataSource = mock()
+
+    private val resolver = WooCommerceConfirmationSnapshotResolver(
+        ordersDataSource = ordersDataSource,
+        productsDataSource = productsDataSource,
+        variationsDataSource = variationsDataSource,
+    )
+
+    @Test
+    fun `given order update, when resolving snapshot, then current order fields are returned`() = runTest {
+        val order = OrderEntity(localSiteId = LocalId(1), orderId = 42L, status = "pending")
+        val request = confirmationRequest(
+            toolName = "orders_update",
+            arguments = buildJsonObject {
+                put("id", 42)
+                put("status", "processing")
+            },
+        )
+        val orderDataSource: AIOrdersDataSource = mock()
+
+        val resolver = WooCommerceConfirmationSnapshotResolver(
+            ordersDataSource = orderDataSource,
+            productsDataSource = productsDataSource,
+            variationsDataSource = variationsDataSource,
+        )
+        whenever(orderDataSource.getOrder(42L)).thenReturn(Result.success(order))
+
+        val snapshot = resolver.resolve(request)
+
+        assertThat(requireNotNull(snapshot).currentValues).isEqualTo(mapOf("status" to "pending"))
+    }
+
+    @Test
+    fun `given product update, when resolving snapshot, then current product fields are returned`() = runTest {
+        val product = WCProductModel(
+            remoteId = RemoteId(7L),
+            regularPrice = "19.99",
+            salePrice = "",
+            stockQuantity = 5.0,
+            status = "publish",
+            name = "Current name",
+        )
+        val productDataSource: AIProductsDataSource = mock()
+        val resolver = WooCommerceConfirmationSnapshotResolver(
+            ordersDataSource = ordersDataSource,
+            productsDataSource = productDataSource,
+            variationsDataSource = variationsDataSource,
+        )
+        whenever(productDataSource.getProduct(7L)).thenReturn(Result.success(product))
+
+        val snapshot = resolver.resolve(
+            confirmationRequest(
+                toolName = "products_update",
+                arguments = buildJsonObject {
+                    put("id", 7)
+                    put("regular_price", "24.99")
+                },
+            )
+        )
+
+        assertThat(requireNotNull(snapshot).currentValues).containsEntry("regular_price", "19.99")
+        assertThat(requireNotNull(snapshot).currentValues).containsEntry("name", "Current name")
+    }
+
+    @Test
+    fun `given variation update, when resolving snapshot, then current variation fields are returned`() = runTest {
+        val variation = WCProductVariationModel(
+            remoteProductId = RemoteId(7L),
+            remoteVariationId = RemoteId(8L),
+            sku = "VAR-7",
+            regularPrice = "19.99",
+            salePrice = "",
+            stockQuantity = 3.0,
+            stockStatus = "instock",
+            status = "publish",
+        )
+        val variationDataSource: AIProductVariationsDataSource = mock()
+        val resolver = WooCommerceConfirmationSnapshotResolver(
+            ordersDataSource = ordersDataSource,
+            productsDataSource = productsDataSource,
+            variationsDataSource = variationDataSource,
+        )
+        whenever(variationDataSource.getVariation(7L, 8L)).thenReturn(Result.success(variation))
+
+        val snapshot = resolver.resolve(
+            confirmationRequest(
+                toolName = "product_variations_update",
+                arguments = buildJsonObject {
+                    put("product_id", 7)
+                    put("id", 8)
+                    put("sku", "VAR-8")
+                },
+            )
+        )
+
+        assertThat(requireNotNull(snapshot).currentValues).containsEntry("sku", "VAR-7")
+        assertThat(requireNotNull(snapshot).currentValues).containsEntry("stock_status", "instock")
+    }
+
+    @Test
+    fun `given bulk update, when resolving snapshot, then no fetch is performed`() = runTest {
+        val snapshot = resolver.resolve(
+            confirmationRequest(
+                toolName = "products_bulk_update",
+                arguments = buildJsonObject {
+                    put("ids", JsonArray(listOf(JsonPrimitive(7), JsonPrimitive(8))))
+                    put("patch", buildJsonObject { put("status", "draft") })
+                },
+            )
+        )
+
+        assertThat(snapshot).isNull()
+        verify(ordersDataSource, never()).getOrder(org.mockito.kotlin.any())
+        verify(productsDataSource, never()).getProduct(org.mockito.kotlin.any())
+        verify(variationsDataSource, never()).getVariation(org.mockito.kotlin.any(), org.mockito.kotlin.any())
+    }
+
+    private fun confirmationRequest(
+        toolName: String,
+        arguments: kotlinx.serialization.json.JsonObject,
+    ) = ConfirmationRequest(
+        id = "confirmation-1",
+        toolCallId = "call-1",
+        toolName = toolName,
+        arguments = arguments,
+        safetyLevel = ToolSafetyLevel.UNSAFE,
+    )
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationSnapshotResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationSnapshotResolverTest.kt
@@ -35,7 +35,7 @@ class WooCommerceConfirmationSnapshotResolverTest {
 
     @Test
     fun `given order update, when resolving snapshot, then current order fields are returned`() = runTest {
-        val order = OrderEntity(localSiteId = LocalId(1), orderId = 42L, status = "pending")
+        val order = OrderEntity(localSiteId = LocalId(1), orderId = 42L, status = "wc-pending")
         val request = confirmationRequest(
             toolName = "orders_update",
             arguments = buildJsonObject {
@@ -63,7 +63,7 @@ class WooCommerceConfirmationSnapshotResolverTest {
             remoteId = RemoteId(7L),
             regularPrice = "19.99",
             salePrice = "",
-            stockQuantity = 5.0,
+            stockQuantity = 5.5,
             status = "publish",
             name = "Current name",
         )
@@ -87,6 +87,7 @@ class WooCommerceConfirmationSnapshotResolverTest {
 
         assertThat(requireNotNull(snapshot).currentValues).containsEntry("regular_price", "19.99")
         assertThat(requireNotNull(snapshot).currentValues).containsEntry("name", "Current name")
+        assertThat(requireNotNull(snapshot).currentValues).containsEntry("stock_quantity", "5.5")
     }
 
     @Test
@@ -97,7 +98,7 @@ class WooCommerceConfirmationSnapshotResolverTest {
             sku = "VAR-7",
             regularPrice = "19.99",
             salePrice = "",
-            stockQuantity = 3.0,
+            stockQuantity = 3.5,
             stockStatus = "instock",
             status = "publish",
         )
@@ -121,6 +122,7 @@ class WooCommerceConfirmationSnapshotResolverTest {
         )
 
         assertThat(requireNotNull(snapshot).currentValues).containsEntry("sku", "VAR-7")
+        assertThat(requireNotNull(snapshot).currentValues).containsEntry("stock_quantity", "3.5")
         assertThat(requireNotNull(snapshot).currentValues).containsEntry("stock_status", "instock")
     }
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSourceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSourceTest.kt
@@ -174,6 +174,19 @@ class AIOrdersDataSourceTest {
         }
 
     @Test
+    fun `given order is cached, when getOrder is called, then fetchSingleOrderSync is not called`() =
+        runTest {
+            val entity = OrderEntity(localSiteId = LocalId(1), orderId = 123L, status = "pending")
+            whenever(orderStore.getOrderByIdAndSite(123L, site)).thenReturn(entity)
+
+            val result = dataSource.getOrder(orderId = 123L)
+
+            assertThat(result.isSuccess).isTrue
+            assertThat(result.getOrThrow()).isEqualTo(entity)
+            verify(orderStore, org.mockito.kotlin.never()).fetchSingleOrderSync(site, 123L)
+        }
+
+    @Test
     fun `when getOrder is called, then fetchSingleOrderSync is called`() =
         runTest {
             val entity = OrderEntity(localSiteId = LocalId(1), orderId = 123L)

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSourceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/AIOrdersDataSourceTest.kt
@@ -174,23 +174,24 @@ class AIOrdersDataSourceTest {
         }
 
     @Test
-    fun `given order is cached, when getOrder is called, then fetchSingleOrderSync is not called`() =
+    fun `given order is cached, when getOrder is called, then fresh order is fetched`() =
         runTest {
-            val entity = OrderEntity(localSiteId = LocalId(1), orderId = 123L, status = "pending")
-            whenever(orderStore.getOrderByIdAndSite(123L, site)).thenReturn(entity)
+            val cachedEntity = OrderEntity(localSiteId = LocalId(1), orderId = 123L, status = "pending")
+            val freshEntity = OrderEntity(localSiteId = LocalId(1), orderId = 123L, status = "processing")
+            whenever(orderStore.getOrderByIdAndSite(123L, site)).thenReturn(cachedEntity)
+            whenever(orderStore.fetchSingleOrderSync(site, 123L)).thenReturn(WooResult(freshEntity))
 
             val result = dataSource.getOrder(orderId = 123L)
 
             assertThat(result.isSuccess).isTrue
-            assertThat(result.getOrThrow()).isEqualTo(entity)
-            verify(orderStore, org.mockito.kotlin.never()).fetchSingleOrderSync(site, 123L)
+            assertThat(result.getOrThrow()).isEqualTo(freshEntity)
+            verify(orderStore).fetchSingleOrderSync(site, 123L)
         }
 
     @Test
     fun `when getOrder is called, then fetchSingleOrderSync is called`() =
         runTest {
             val entity = OrderEntity(localSiteId = LocalId(1), orderId = 123L)
-            whenever(orderStore.getOrderByIdAndSite(123L, site)).thenReturn(null)
             whenever(orderStore.fetchSingleOrderSync(site, 123L)).thenReturn(WooResult(entity))
 
             val result = dataSource.getOrder(orderId = 123L)
@@ -203,7 +204,6 @@ class AIOrdersDataSourceTest {
     @Test
     fun `given network returns an error, when getOrder is called, then a failure result is returned`() =
         runTest {
-            whenever(orderStore.getOrderByIdAndSite(123L, site)).thenReturn(null)
             whenever(orderStore.fetchSingleOrderSync(site, 123L))
                 .thenReturn(WooResult(WooError(WooErrorType.API_ERROR, GenericErrorType.SERVER_ERROR, "boom")))
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -131,6 +131,20 @@ class AssistantUiStateTest {
     }
 
     @Test
+    fun `when turn is streaming, then stop control is visible`() {
+        val state = AssistantUiState(status = AssistantUiStatus.STREAMING)
+
+        assertThat(state.shouldShowStopControl).isTrue()
+    }
+
+    @Test
+    fun `when turn is awaiting confirmation, then stop control is hidden`() {
+        val state = AssistantUiState(status = AssistantUiStatus.AWAITING_CONFIRMATION)
+
+        assertThat(state.shouldShowStopControl).isFalse()
+    }
+
+    @Test
     fun `when status is idle, then turn is not active`() {
         val state = AssistantUiState(status = AssistantUiStatus.IDLE)
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -143,4 +143,20 @@ class AssistantUiStateTest {
 
         assertThat(state.isTurnActive).isFalse()
     }
+
+    @Test
+    fun `given confirmation card state, when resolving chrome resources, then eyebrow and icon are mapped`() {
+        assertThat(AssistantConfirmationCardState.PENDING.eyebrowRes())
+            .isEqualTo(R.string.assistant_confirmation_eyebrow_pending)
+        assertThat(AssistantConfirmationCardState.PENDING.iconRes())
+            .isEqualTo(R.drawable.ic_assistant_confirmation_pending)
+        assertThat(AssistantConfirmationCardState.CONFIRMED.eyebrowRes())
+            .isEqualTo(R.string.assistant_confirmation_eyebrow_confirmed)
+        assertThat(AssistantConfirmationCardState.CONFIRMED.iconRes())
+            .isEqualTo(R.drawable.ic_assistant_confirmation_confirmed)
+        assertThat(AssistantConfirmationCardState.CANCELLED.eyebrowRes())
+            .isEqualTo(R.string.assistant_confirmation_eyebrow_cancelled)
+        assertThat(AssistantConfirmationCardState.CANCELLED.iconRes())
+            .isEqualTo(R.drawable.ic_assistant_confirmation_cancelled)
+    }
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -9,7 +9,7 @@ import com.woocommerce.android.aiassistant.core.loop.ToolScope
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationDecision
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
-import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationResult
+import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationDispatchResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
 import com.woocommerce.android.aiassistant.runtime.AssistantTurnRequest
 import com.woocommerce.android.tools.SelectedSite
@@ -683,7 +683,9 @@ class AssistantViewModelTest {
         viewModel.onConfirmWrite()
         advanceUntilIdle()
 
-        assertThat(runtime.confirmedConfirmationIds).containsExactly("confirmation-1")
+        assertThat(runtime.results).containsExactly(
+            ConfirmationResult("confirmation-1", ConfirmationDecision.CONFIRMED)
+        )
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.STREAMING)
         assertThat(viewModel.uiState.value.error).isNull()
         assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
@@ -772,7 +774,7 @@ class AssistantViewModelTest {
 
     @Test
     fun `given pending confirmation, when confirm is deferred, then state exposes error`() = runTest {
-        runtime.confirmationResult = AssistantRuntimeConfirmationResult.Deferred
+        runtime.confirmationResult = AssistantRuntimeConfirmationDispatchResult.Deferred
         viewModel.onSendMessage("Cancel order 123")
         runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
         advanceUntilIdle()
@@ -780,7 +782,9 @@ class AssistantViewModelTest {
         viewModel.onConfirmWrite()
         advanceUntilIdle()
 
-        assertThat(runtime.confirmedConfirmationIds).containsExactly("confirmation-1")
+        assertThat(runtime.results).containsExactly(
+            ConfirmationResult("confirmation-1", ConfirmationDecision.CONFIRMED)
+        )
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.ERROR)
         assertThat(viewModel.uiState.value.error).isEqualTo(AssistantUiError.CONFIRMATION_DEFERRED)
         assertThat(viewModel.uiState.value.shouldShowFallbackError).isTrue()
@@ -799,7 +803,9 @@ class AssistantViewModelTest {
         viewModel.onCancelWrite()
         advanceUntilIdle()
 
-        assertThat(runtime.cancelledConfirmationIds).containsExactly("confirmation-1")
+        assertThat(runtime.results).containsExactly(
+            ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
+        )
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.IDLE)
         assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
     }
@@ -818,9 +824,9 @@ class AssistantViewModelTest {
         val startRequests = mutableListOf<AssistantTurnRequest>()
         val retryRequests = mutableListOf<AssistantTurnRequest>()
         val cancelledConversationIds = mutableListOf<String>()
-        val confirmedConfirmationIds = mutableListOf<String>()
-        val cancelledConfirmationIds = mutableListOf<String>()
-        var confirmationResult: AssistantRuntimeConfirmationResult = AssistantRuntimeConfirmationResult.Accepted
+        val results = mutableListOf<ConfirmationResult>()
+        var confirmationResult: AssistantRuntimeConfirmationDispatchResult =
+            AssistantRuntimeConfirmationDispatchResult.Accepted
 
         private val events = MutableSharedFlow<AssistantRuntimeEvent>(extraBufferCapacity = 10)
 
@@ -838,13 +844,11 @@ class AssistantViewModelTest {
             cancelledConversationIds += conversationId
         }
 
-        override suspend fun confirmWrite(confirmationId: String): AssistantRuntimeConfirmationResult {
-            confirmedConfirmationIds += confirmationId
+        override suspend fun resolveConfirmation(
+            result: ConfirmationResult,
+        ): AssistantRuntimeConfirmationDispatchResult {
+            results += result
             return confirmationResult
-        }
-
-        override suspend fun cancelWrite(confirmationId: String) {
-            cancelledConfirmationIds += confirmationId
         }
 
         suspend fun emit(event: AssistantRuntimeEvent) {

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -692,13 +692,19 @@ class AssistantViewModelTest {
     }
 
     @Test
-    fun `given confirmed write, when assistant text resumes, then existing assistant bubble grows`() = runTest {
+    fun `given confirmed write, when assistant text resumes, then text is appended after confirmation card`() = runTest {
         viewModel.onSendMessage("Cancel order 123")
         val activeBubbleId = viewModel.uiState.value.messages.last().id
+        runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("I'll update that order."))
         runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
         advanceUntilIdle()
 
         viewModel.onConfirmWrite()
+        runtime.emit(
+            AssistantRuntimeEvent.ConfirmationResolved(
+                ConfirmationResult("confirmation-1", ConfirmationDecision.CONFIRMED)
+            )
+        )
         runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("Order updated"))
         advanceUntilIdle()
 
@@ -707,8 +713,11 @@ class AssistantViewModelTest {
                 id = activeBubbleId,
                 role = AssistantUiMessage.Role.ASSISTANT,
                 segments = listOf(
+                    AssistantUiSegment.Text("I'll update that order."),
+                    AssistantUiSegment.ConfirmationCard(
+                        givenConfirmationCard().copy(state = AssistantConfirmationCardState.CONFIRMED)
+                    ),
                     AssistantUiSegment.Text("Order updated"),
-                    AssistantUiSegment.ConfirmationCard(givenConfirmationCard()),
                 ),
             )
         )

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -800,21 +800,21 @@ class AssistantViewModelTest {
     @Test
     fun `given pending confirmation, when cancel write is requested, then runtime cancel is dispatched without ending turn`() =
         runTest {
-        viewModel.onSendMessage("Cancel order 123")
-        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
-        advanceUntilIdle()
+            viewModel.onSendMessage("Cancel order 123")
+            runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
+            advanceUntilIdle()
 
-        viewModel.onCancelWrite()
-        advanceUntilIdle()
+            viewModel.onCancelWrite()
+            advanceUntilIdle()
 
-        assertThat(runtime.results).containsExactly(
-            ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
-        )
-        assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.AWAITING_CONFIRMATION)
-        assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
-        assertThat(viewModel.uiState.value.error).isNull()
-        assertThat(viewModel.uiState.value.isTurnActive).isTrue()
-    }
+            assertThat(runtime.results).containsExactly(
+                ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
+            )
+            assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.AWAITING_CONFIRMATION)
+            assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
+            assertThat(viewModel.uiState.value.error).isNull()
+            assertThat(viewModel.uiState.value.isTurnActive).isTrue()
+        }
 
     @Test
     fun `given pending confirmation, when conversation cancel is requested, then confirmation is cancelled and transcript stays active until finish`() =

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -765,6 +765,9 @@ class AssistantViewModelTest {
         )
         advanceUntilIdle()
 
+        assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.IDLE)
+        assertThat(viewModel.uiState.value.error).isNull()
+        assertThat(viewModel.uiState.value.shouldShowFallbackError).isFalse()
         assertThat(viewModel.uiState.value.messages.last().segments).contains(
             AssistantUiSegment.ConfirmationCard(
                 givenConfirmationCard().copy(state = AssistantConfirmationCardState.CANCELLED)
@@ -795,7 +798,8 @@ class AssistantViewModelTest {
     }
 
     @Test
-    fun `given pending confirmation, when cancel write is requested, then runtime cancel write is called`() = runTest {
+    fun `given pending confirmation, when cancel write is requested, then runtime cancel is dispatched without ending turn`() =
+        runTest {
         viewModel.onSendMessage("Cancel order 123")
         runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
         advanceUntilIdle()
@@ -806,8 +810,10 @@ class AssistantViewModelTest {
         assertThat(runtime.results).containsExactly(
             ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
         )
-        assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.IDLE)
+        assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.AWAITING_CONFIRMATION)
         assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
+        assertThat(viewModel.uiState.value.error).isNull()
+        assertThat(viewModel.uiState.value.isTurnActive).isTrue()
     }
 
     private fun givenConfirmationCard() = AssistantConfirmationCard(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
 import com.woocommerce.android.aiassistant.core.loop.ToolScope
-import com.woocommerce.android.aiassistant.runtime.AssistantPendingConfirmation
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
@@ -62,7 +61,7 @@ class AssistantViewModelTest {
     fun `when initialized, then state is idle`() {
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.IDLE)
         assertThat(viewModel.uiState.value.messages).isEmpty()
-        assertThat(viewModel.uiState.value.pendingConfirmation).isNull()
+        assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
         assertThat(viewModel.uiState.value.error).isNull()
     }
 
@@ -488,22 +487,27 @@ class AssistantViewModelTest {
     }
 
     @Test
-    fun `when runtime awaits confirmation, then state exposes pending confirmation`() = runTest {
+    fun `when runtime awaits confirmation, then assistant message gains inline confirmation segment`() = runTest {
         viewModel.onSendMessage("Cancel order 123")
-        val confirmation = AssistantPendingConfirmation(
-            id = "confirmation-1",
+        val confirmation = AssistantConfirmationCard(
+            confirmationId = "confirmation-1",
             toolCall = ToolCall(
                 id = "call-1",
                 name = "orders_update",
                 arguments = buildJsonObject { put("id", 123) },
             ),
+            state = AssistantConfirmationCardState.PENDING,
         )
 
         runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(confirmation))
         advanceUntilIdle()
 
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.AWAITING_CONFIRMATION)
-        assertThat(viewModel.uiState.value.pendingConfirmation).isEqualTo(confirmation)
+        assertThat(viewModel.uiState.value.activeConfirmationId).isEqualTo("confirmation-1")
+        assertThat(viewModel.uiState.value.messages.last().segments).containsExactly(
+            AssistantUiSegment.Text(""),
+            AssistantUiSegment.ConfirmationCard(confirmation),
+        )
     }
 
     @Test
@@ -521,7 +525,7 @@ class AssistantViewModelTest {
             .isEqualTo(R.string.assistant_chat_error_cancelled)
         assertThat(viewModel.uiState.value.messages.last().error).isNull()
         assertThat(viewModel.uiState.value.canRetry).isFalse()
-        assertThat(viewModel.uiState.value.pendingConfirmation).isNull()
+        assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
         assertThat(viewModel.uiState.value.isTurnActive).isFalse()
     }
 
@@ -638,7 +642,7 @@ class AssistantViewModelTest {
     @Test
     fun `given awaiting confirmation, when another message is sent, then second turn is ignored`() = runTest {
         viewModel.onSendMessage("Cancel order 123")
-        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenPendingConfirmation()))
+        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
         advanceUntilIdle()
 
         viewModel.onSendMessage("Second")
@@ -654,7 +658,7 @@ class AssistantViewModelTest {
             )
         )
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.AWAITING_CONFIRMATION)
-        assertThat(viewModel.uiState.value.pendingConfirmation).isEqualTo(givenPendingConfirmation())
+        assertThat(viewModel.uiState.value.activeConfirmationId).isEqualTo("confirmation-1")
     }
 
     @Test
@@ -671,7 +675,7 @@ class AssistantViewModelTest {
     @Test
     fun `given pending confirmation, when confirm write is requested, then runtime confirm is called`() = runTest {
         viewModel.onSendMessage("Cancel order 123")
-        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenPendingConfirmation()))
+        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
         advanceUntilIdle()
 
         viewModel.onConfirmWrite()
@@ -680,14 +684,14 @@ class AssistantViewModelTest {
         assertThat(runtime.confirmedConfirmationIds).containsExactly("confirmation-1")
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.STREAMING)
         assertThat(viewModel.uiState.value.error).isNull()
-        assertThat(viewModel.uiState.value.pendingConfirmation).isNull()
+        assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
     }
 
     @Test
     fun `given confirmed write, when assistant text resumes, then existing assistant bubble grows`() = runTest {
         viewModel.onSendMessage("Cancel order 123")
         val activeBubbleId = viewModel.uiState.value.messages.last().id
-        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenPendingConfirmation()))
+        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
         advanceUntilIdle()
 
         viewModel.onConfirmWrite()
@@ -698,7 +702,10 @@ class AssistantViewModelTest {
             AssistantUiMessage(
                 id = activeBubbleId,
                 role = AssistantUiMessage.Role.ASSISTANT,
-                text = "Order updated",
+                segments = listOf(
+                    AssistantUiSegment.Text("Order updated"),
+                    AssistantUiSegment.ConfirmationCard(givenConfirmationCard()),
+                ),
             )
         )
     }
@@ -707,7 +714,7 @@ class AssistantViewModelTest {
     fun `given pending confirmation, when confirm is deferred, then state exposes error`() = runTest {
         runtime.confirmationResult = AssistantRuntimeConfirmationResult.Deferred
         viewModel.onSendMessage("Cancel order 123")
-        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenPendingConfirmation()))
+        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
         advanceUntilIdle()
 
         viewModel.onConfirmWrite()
@@ -720,13 +727,13 @@ class AssistantViewModelTest {
         assertThat(requireNotNull(viewModel.uiState.value.error).toMessageRes())
             .isEqualTo(R.string.assistant_chat_error_confirmation_deferred)
         assertThat(viewModel.uiState.value.messages.last().error).isNull()
-        assertThat(viewModel.uiState.value.pendingConfirmation).isNull()
+        assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
     }
 
     @Test
     fun `given pending confirmation, when cancel write is requested, then runtime cancel write is called`() = runTest {
         viewModel.onSendMessage("Cancel order 123")
-        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenPendingConfirmation()))
+        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
         advanceUntilIdle()
 
         viewModel.onCancelWrite()
@@ -734,16 +741,17 @@ class AssistantViewModelTest {
 
         assertThat(runtime.cancelledConfirmationIds).containsExactly("confirmation-1")
         assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.IDLE)
-        assertThat(viewModel.uiState.value.pendingConfirmation).isNull()
+        assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
     }
 
-    private fun givenPendingConfirmation() = AssistantPendingConfirmation(
-        id = "confirmation-1",
+    private fun givenConfirmationCard() = AssistantConfirmationCard(
+        confirmationId = "confirmation-1",
         toolCall = ToolCall(
             id = "call-1",
             name = "orders_update",
             arguments = buildJsonObject { put("id", 123) },
         ),
+        state = AssistantConfirmationCardState.PENDING,
     )
 
     private class FakeAssistantRuntime : AssistantRuntime {

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -816,6 +816,48 @@ class AssistantViewModelTest {
         assertThat(viewModel.uiState.value.isTurnActive).isTrue()
     }
 
+    @Test
+    fun `given pending confirmation, when conversation cancel is requested, then confirmation is cancelled and transcript stays active until finish`() =
+        runTest {
+            viewModel.onSendMessage("Cancel order 123")
+            runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
+            advanceUntilIdle()
+
+            viewModel.onCancelTurn()
+            advanceUntilIdle()
+
+            assertThat(runtime.results).containsExactly(
+                ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
+            )
+            assertThat(runtime.cancelledConversationIds).isEmpty()
+            assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.AWAITING_CONFIRMATION)
+            assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
+            assertThat(viewModel.uiState.value.error).isNull()
+
+            runtime.emit(
+                AssistantRuntimeEvent.ConfirmationResolved(
+                    ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
+                )
+            )
+            runtime.emit(
+                AssistantRuntimeEvent.Finished(
+                    outcome = LoopOutcome.STOPPED,
+                    updatedHistory = listOf(
+                        AssistantMessage.User("Cancel order 123"),
+                    ),
+                )
+            )
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.IDLE)
+            assertThat(viewModel.uiState.value.error).isNull()
+            assertThat(viewModel.uiState.value.messages.last().segments).contains(
+                AssistantUiSegment.ConfirmationCard(
+                    givenConfirmationCard().copy(state = AssistantConfirmationCardState.CANCELLED)
+                )
+            )
+        }
+
     private fun givenConfirmationCard() = AssistantConfirmationCard(
         confirmationId = "confirmation-1",
         toolCall = ToolCall(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -6,6 +6,8 @@ import com.woocommerce.android.aiassistant.core.chat.AssistantMessage
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
 import com.woocommerce.android.aiassistant.core.loop.ToolScope
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationDecision
+import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
@@ -706,6 +708,64 @@ class AssistantViewModelTest {
                     AssistantUiSegment.Text("Order updated"),
                     AssistantUiSegment.ConfirmationCard(givenConfirmationCard()),
                 ),
+            )
+        )
+    }
+
+    @Test
+    fun `given confirmed confirmation resolves, when turn later finishes, then confirmed card stays in transcript`() = runTest {
+        viewModel.onSendMessage("Cancel order 123")
+        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
+        advanceUntilIdle()
+
+        viewModel.onConfirmWrite()
+        runtime.emit(
+            AssistantRuntimeEvent.ConfirmationResolved(
+                ConfirmationResult("confirmation-1", ConfirmationDecision.CONFIRMED)
+            )
+        )
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.COMPLETED,
+                updatedHistory = listOf(
+                    AssistantMessage.User("Cancel order 123"),
+                    AssistantMessage.Assistant("Done"),
+                ),
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.messages.last().segments).contains(
+            AssistantUiSegment.ConfirmationCard(
+                givenConfirmationCard().copy(state = AssistantConfirmationCardState.CONFIRMED)
+            )
+        )
+    }
+
+    @Test
+    fun `given cancelled confirmation resolves, when turn stops, then cancelled card stays in transcript`() = runTest {
+        viewModel.onSendMessage("Cancel order 123")
+        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
+        advanceUntilIdle()
+
+        runtime.emit(
+            AssistantRuntimeEvent.ConfirmationResolved(
+                ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
+            )
+        )
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.STOPPED,
+                updatedHistory = listOf(
+                    AssistantMessage.User("Cancel order 123"),
+                ),
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.messages.last().segments).contains(
+            AssistantUiSegment.ConfirmationCard(
+                givenConfirmationCard().copy(state = AssistantConfirmationCardState.CANCELLED)
             )
         )
     }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2915

This PR implements inline confirmation cards for unsafe AI Assistant write tools. Instead of showing confirmation in a separate panel, the assistant now keeps the confirmation request and its final state inside the transcript. The interaction is intentionally close to the iOS direction in https://github.com/woocommerce/woocommerce-ios/pull/17027, while staying within the Android assistant runtime and Compose UI model.

#### What changes for users

When the assistant needs approval before running an unsafe write, merchants now see a durable card in the conversation with a `Pending change` state, a readable summary, and Cancel / Confirm actions. After the merchant decides, the same card remains in the transcript as either `Confirmed` or `Cancelled`, so the conversation keeps a record of what happened.

For single-record order, product, and variation updates, the card can show the current value under **Now** and the proposed value under **After**. Bulk updates intentionally show the proposed **After** values only. While a confirmation card is pending, the composer stop control is hidden so the card actions are the clear decision point.

The card UI was also polished to better match the iOS feel without pixel matching: it uses Material 3 / WooTheme color tokens, a bordered card surface, clearer field rows, state icons, and stable equal-width Cancel / Confirm actions.

#### Runtime and UI behavior

The assistant transcript now supports segmented messages, so one assistant message can contain streamed text, an inline confirmation card, and follow-up text that arrives after the confirmation resolves. Confirmation cards carry their own `Pending`, `Confirmed`, and `Cancelled` state instead of relying on a separate top-level pending panel.

Confirm and Cancel both go through the core `ConfirmationResult` path. Cancelling from the card, stopping while a confirmation is open, or resetting an open gate resolves the pending confirmation as `Cancelled` without running the write. Confirmed cards stay in place and later assistant text is appended after the card.

Confirmation previews now build localized summaries and field rows for order, product, product variation, and bulk update tools. Single-record snapshots fetch fresh order data for current values, normalize `wc-` order status prefixes, and preserve fractional stock quantities.

This PR also normalizes assistant replay payloads for Jetpack AI by sending empty assistant content for tool-call-only replay messages, which matches the backend contract while preserving normal assistant text content.

#### Dependency notes

This PR is stacked on `issue/WOOMOB-2966-implement-show-cards-reference-resolver`, so the GitHub diff shows the WOOMOB-2915 confirmation-card work on top of that branch.

#### Tests added or updated

This PR adds focused coverage for:

- core loop confirmation request / resolution behavior
- runtime confirmation dispatch and cancellation handling
- preview building and rendering for single-record and bulk updates
- snapshot resolution for current order, product, and variation values
- fresh order reads for confirmation snapshots
- transcript segment ordering around pending, confirmed, and cancelled cards
- hiding the stop control while a confirmation card is pending
- Jetpack AI / OpenAI request mapping for tool-call-only assistant replay messages

### Test Steps
1. Build and install the app from this branch, then open the AI Assistant on a store that can use write-capable assistant tools.
2. Ask the assistant to update a single order, for example changing an order status.
3. Verify the confirmation appears inline in the assistant transcript with `Pending change`, a state icon, a clear summary, Now / After rows, and Cancel / Confirm actions.
4. Verify there is no modal, bottom sheet, or separate confirmation panel, and that the stop control is hidden while the confirmation card is pending.
5. Tap Cancel and verify the card remains in the transcript as `Cancelled`, the turn ends cleanly, and the order is not changed.
6. Repeat the single-order update and tap Confirm. Verify the card changes to `Confirmed`, the assistant continues after the card, and the order change is applied.
7. Ask for a single product or variation update that changes price, stock, SKU, or status. Verify the card shows current values under Now and proposed values under After.
8. Ask for a bulk order or product update. Verify the card uses a bulk summary and only shows the proposed After values.
9. Start another unsafe update and use the conversation cancel/reset path while the card is pending. Verify the pending card resolves to `Cancelled` and no write occurs.

### Images/gif

https://github.com/user-attachments/assets/6993be7d-3276-47f4-a8e6-77154f0b36ee



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.