### PR TITLE
[RSM-1628] Add cha-ching restore action to New Orders settings

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsFragment.kt
@@ -25,6 +25,7 @@ class NewOrderNotificationSettingsFragment : BaseFragment() {
 
     override fun onResume() {
         super.onResume()
+        viewModel.refreshNotificationSettings()
         AnalyticsTracker.trackViewShown(this)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsFragment.kt
@@ -8,12 +8,18 @@ import androidx.fragment.app.viewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.ui.base.BaseFragment
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.viewmodel.MultiLiveEvent
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class NewOrderNotificationSettingsFragment : BaseFragment() {
     private val viewModel: NewOrderNotificationSettingsViewModel by viewModels()
+
+    @Inject
+    lateinit var uiMessageResolver: UIMessageResolver
 
     override fun getFragmentTitle() = getString(R.string.settings_notifs_new_orders)
 
@@ -23,9 +29,25 @@ class NewOrderNotificationSettingsFragment : BaseFragment() {
         }
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        observeEvents()
+    }
+
     override fun onResume() {
         super.onResume()
         viewModel.refreshNotificationSettings()
         AnalyticsTracker.trackViewShown(this)
+    }
+
+    private fun observeEvents() {
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.ShowActionStringSnackbar -> uiMessageResolver.showActionSnack(
+                    event.message,
+                    event.actionText,
+                    event.action
+                )
+            }
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsScreen.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.prefs.notifications
 
 import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,6 +12,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
@@ -37,7 +39,8 @@ fun NewOrderNotificationSettingsScreen(viewModel: NewOrderNotificationSettingsVi
             viewState = viewState,
             onNotificationsEnabledChanged = viewModel::onNotificationsEnabledChanged,
             onNotificationPreferenceChanged = viewModel::onNotificationPreferenceChanged,
-            onThresholdAmountChanged = viewModel::onThresholdAmountChanged
+            onThresholdAmountChanged = viewModel::onThresholdAmountChanged,
+            onEnableChaChingSoundClicked = viewModel::onEnableChaChingSoundClicked
         )
     }
 }
@@ -47,7 +50,8 @@ fun NewOrderNotificationSettingsScreen(
     viewState: ViewState,
     onNotificationsEnabledChanged: (Boolean) -> Unit,
     onNotificationPreferenceChanged: (NotificationPreference) -> Unit,
-    onThresholdAmountChanged: (BigDecimal) -> Unit
+    onThresholdAmountChanged: (BigDecimal) -> Unit,
+    onEnableChaChingSoundClicked: () -> Unit
 ) {
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
@@ -65,6 +69,22 @@ fun NewOrderNotificationSettingsScreen(
                 isEnabled = viewState.notificationsEnabled,
                 onEnabledChanged = onNotificationsEnabledChanged
             )
+            AnimatedVisibility(
+                visible = viewState.newOrderNotificationSoundStatus != NewOrderNotificationSoundStatus.DEFAULT
+            ) {
+                val subtitle = if (
+                    viewState.newOrderNotificationSoundStatus == NewOrderNotificationSoundStatus.DISABLED
+                ) {
+                    R.string.settings_notifs_enable_chaching_sound_description
+                } else {
+                    R.string.settings_notifs_restore_chaching_sound_description
+                }
+                NotificationSettingsAction(
+                    title = stringResource(R.string.settings_notifs_enable_chaching_sound),
+                    subtitle = stringResource(subtitle),
+                    onClick = onEnableChaChingSoundClicked
+                )
+            }
             SettingsSectionHeader(
                 text = stringResource(R.string.settings_notifs_notify_me_for),
                 modifier = Modifier.padding(start = 16.dp, top = 24.dp, end = 16.dp)
@@ -118,6 +138,30 @@ private fun ThresholdAmountField(
 }
 
 @Composable
+private fun NotificationSettingsAction(
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(16.dp)
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium
+        )
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun NewOrderNotificationSettingsScreenPreview() {
@@ -130,7 +174,8 @@ private fun NewOrderNotificationSettingsScreenPreview() {
             ),
             onNotificationsEnabledChanged = {},
             onNotificationPreferenceChanged = {},
-            onThresholdAmountChanged = {}
+            onThresholdAmountChanged = {},
+            onEnableChaChingSoundClicked = {}
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsScreen.kt
@@ -2,16 +2,19 @@ package com.woocommerce.android.ui.prefs.notifications
 
 import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
@@ -63,12 +66,6 @@ fun NewOrderNotificationSettingsScreen(
                 .padding(paddingValues)
                 .verticalScroll(rememberScrollState())
         ) {
-            EnableNotificationsCard(
-                title = stringResource(R.string.settings_notifs_new_orders_enable_title),
-                description = stringResource(R.string.settings_notifs_new_orders_enable_description),
-                isEnabled = viewState.notificationsEnabled,
-                onEnabledChanged = onNotificationsEnabledChanged
-            )
             AnimatedVisibility(
                 visible = viewState.newOrderNotificationSoundStatus != NewOrderNotificationSoundStatus.DEFAULT
             ) {
@@ -85,6 +82,12 @@ fun NewOrderNotificationSettingsScreen(
                     onClick = onEnableChaChingSoundClicked
                 )
             }
+            EnableNotificationsCard(
+                title = stringResource(R.string.settings_notifs_new_orders_enable_title),
+                description = stringResource(R.string.settings_notifs_new_orders_enable_description),
+                isEnabled = viewState.notificationsEnabled,
+                onEnabledChanged = onNotificationsEnabledChanged
+            )
             SettingsSectionHeader(
                 text = stringResource(R.string.settings_notifs_notify_me_for),
                 modifier = Modifier.padding(start = 16.dp, top = 24.dp, end = 16.dp)
@@ -144,20 +147,30 @@ private fun NotificationSettingsAction(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
+    Surface(
+        onClick = onClick,
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(16.dp)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        shape = RoundedCornerShape(8.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        color = MaterialTheme.colorScheme.surface
     ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleMedium
-        )
-        Text(
-            text = subtitle,
-            style = MaterialTheme.typography.bodyMedium
-        )
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
+import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
 import com.woocommerce.android.ui.compose.component.BigDecimalTextFieldValueMapper
 import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
@@ -124,7 +125,8 @@ private fun NewOrderNotificationSettingsScreenPreview() {
         NewOrderNotificationSettingsScreen(
             viewState = ViewState(
                 notificationPreference = NotificationPreference.HighValueOrders,
-                currencySymbol = "$"
+                currencySymbol = "$",
+                newOrderNotificationSoundStatus = NewOrderNotificationSoundStatus.SOUND_MODIFIED
             ),
             onNotificationsEnabledChanged = {},
             onNotificationPreferenceChanged = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModel.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.prefs.notifications
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.notifications.NotificationChannelsHandler
+import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,13 +15,15 @@ import javax.inject.Inject
 @HiltViewModel
 class NewOrderNotificationSettingsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    parameterRepository: ParameterRepository
+    parameterRepository: ParameterRepository,
+    private val notificationChannelsHandler: NotificationChannelsHandler
 ) : ScopedViewModel(savedStateHandle) {
     private val currencyParameters = parameterRepository.getParameters()
 
     private val _viewState = MutableStateFlow(
         ViewState(
-            currencySymbol = currencyParameters.currencySymbol.orEmpty()
+            currencySymbol = currencyParameters.currencySymbol.orEmpty(),
+            newOrderNotificationSoundStatus = notificationChannelsHandler.checkNewOrderNotificationSound()
         )
     )
     val viewState = _viewState.asLiveData()
@@ -40,7 +44,8 @@ class NewOrderNotificationSettingsViewModel @Inject constructor(
         val notificationsEnabled: Boolean = true,
         val notificationPreference: NotificationPreference = NotificationPreference.AllOrders,
         val thresholdAmount: BigDecimal = BigDecimal(DEFAULT_THRESHOLD_AMOUNT),
-        val currencySymbol: String
+        val currencySymbol: String,
+        val newOrderNotificationSoundStatus: NewOrderNotificationSoundStatus
     )
 
     enum class NotificationPreference {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModel.kt
@@ -40,6 +40,12 @@ class NewOrderNotificationSettingsViewModel @Inject constructor(
         _viewState.update { it.copy(thresholdAmount = amount) }
     }
 
+    fun refreshNotificationSettings() {
+        _viewState.update {
+            it.copy(newOrderNotificationSoundStatus = notificationChannelsHandler.checkNewOrderNotificationSound())
+        }
+    }
+
     data class ViewState(
         val notificationsEnabled: Boolean = true,
         val notificationPreference: NotificationPreference = NotificationPreference.AllOrders,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModel.kt
@@ -2,21 +2,34 @@ package com.woocommerce.android.ui.prefs.notifications
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
+import com.woocommerce.android.notifications.ShowTestNotification
 import com.woocommerce.android.ui.products.ParameterRepository
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @HiltViewModel
 class NewOrderNotificationSettingsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     parameterRepository: ParameterRepository,
-    private val notificationChannelsHandler: NotificationChannelsHandler
+    private val resourceProvider: ResourceProvider,
+    private val notificationChannelsHandler: NotificationChannelsHandler,
+    private val showTestNotification: ShowTestNotification,
+    private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val currencyParameters = parameterRepository.getParameters()
 
@@ -44,6 +57,33 @@ class NewOrderNotificationSettingsViewModel @Inject constructor(
         _viewState.update {
             it.copy(newOrderNotificationSoundStatus = notificationChannelsHandler.checkNewOrderNotificationSound())
         }
+    }
+
+    fun onEnableChaChingSoundClicked() {
+        analyticsTracker.track(
+            AnalyticsEvent.NEW_ORDER_PUSH_NOTIFICATION_FIX_TAPPED,
+            mapOf(AnalyticsTracker.KEY_SOURCE to "new_order_settings")
+        )
+        notificationChannelsHandler.recreateNotificationChannel(NotificationChannelType.NEW_ORDER)
+        triggerEvent(
+            MultiLiveEvent.Event.ShowActionStringSnackbar(
+                message = resourceProvider.getString(R.string.cha_ching_sound_succcess_snackbar),
+                actionText = resourceProvider.getString(R.string.cha_ching_sound_succcess_snackbar_action),
+                action = {
+                    launch {
+                        showTestNotification(
+                            title = resourceProvider.getString(R.string.cha_ching_sound_test_notification_title),
+                            message = resourceProvider.getString(
+                                R.string.cha_ching_sound_test_notification_message
+                            ),
+                            channelType = NotificationChannelType.NEW_ORDER,
+                            dismissDelay = 10.seconds
+                        )
+                    }
+                }
+            )
+        )
+        refreshNotificationSettings()
     }
 
     data class ViewState(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
@@ -97,9 +97,9 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
         assertThat(viewModel.viewState.getOrAwaitValue().thresholdAmount)
             .isEqualTo(BigDecimal(750))
     }
-    
-     @Test
-     fun `when high value threshold amount is below minimum, then use minimum amount`() = testBlocking {
+
+    @Test
+    fun `when high value threshold amount is below minimum, then use minimum amount`() = testBlocking {
         setup()
 
         viewModel.onThresholdAmountChanged(BigDecimal.ZERO)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
@@ -1,23 +1,40 @@
 package com.woocommerce.android.ui.prefs.notifications
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.analytics.AnalyticsTracker
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.NotificationChannelsHandler
+import com.woocommerce.android.notifications.ShowTestNotification
 import com.woocommerce.android.ui.prefs.notifications.NewOrderNotificationSettingsViewModel.NotificationPreference
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.Mockito.mockingDetails
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
     private val parameterRepository: ParameterRepository = mock()
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) } doAnswer { it.arguments[0].toString() }
+    }
     private val notificationChannelsHandler: NotificationChannelsHandler = mock()
+    private val showTestNotification: ShowTestNotification = mock()
+    private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private lateinit var viewModel: NewOrderNotificationSettingsViewModel
 
     private fun setup(prepareMocks: () -> Unit = {}) {
@@ -37,7 +54,10 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
         viewModel = NewOrderNotificationSettingsViewModel(
             savedStateHandle = SavedStateHandle(),
             parameterRepository = parameterRepository,
-            notificationChannelsHandler = notificationChannelsHandler
+            resourceProvider = resourceProvider,
+            notificationChannelsHandler = notificationChannelsHandler,
+            showTestNotification = showTestNotification,
+            analyticsTracker = analyticsTracker
         )
     }
 
@@ -102,5 +122,54 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.viewState.getOrAwaitValue().newOrderNotificationSoundStatus)
             .isEqualTo(NotificationChannelsHandler.NewOrderNotificationSoundStatus.DISABLED)
+    }
+
+    @Test
+    fun `when enable cha ching sound is clicked, then recreate notification channel`() = testBlocking {
+        setup()
+
+        viewModel.onEnableChaChingSoundClicked()
+
+        verify(notificationChannelsHandler).recreateNotificationChannel(NotificationChannelType.NEW_ORDER)
+    }
+
+    @Test
+    fun `when enable cha ching sound is clicked, then track source`() = testBlocking {
+        setup()
+
+        viewModel.onEnableChaChingSoundClicked()
+
+        verify(analyticsTracker).track(
+            AnalyticsEvent.NEW_ORDER_PUSH_NOTIFICATION_FIX_TAPPED,
+            mapOf(AnalyticsTracker.KEY_SOURCE to "new_order_settings")
+        )
+    }
+
+    @Test
+    fun `when enable cha ching sound is clicked, then show success snackbar`() = testBlocking {
+        setup()
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onEnableChaChingSoundClicked()
+        }.last()
+
+        val snackbar = event as Event.ShowActionStringSnackbar
+        assertThat(snackbar.message).isNotBlank()
+        assertThat(snackbar.actionText).isNotBlank()
+    }
+
+    @Test
+    fun `when test sound is clicked, then show test notification`() = testBlocking {
+        setup()
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onEnableChaChingSoundClicked()
+        }.last()
+        (event as Event.ShowActionStringSnackbar).action.onClick(null)
+
+        val invocation = mockingDetails(showTestNotification).invocations.single()
+        assertThat(invocation.arguments[0]).isInstanceOf(String::class.java)
+        assertThat(invocation.arguments[1]).isInstanceOf(String::class.java)
+        assertThat(invocation.arguments[2]).isEqualTo(NotificationChannelType.NEW_ORDER)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.prefs.notifications
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.ui.prefs.notifications.NewOrderNotificationSettingsViewModel.NotificationPreference
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
@@ -16,9 +17,10 @@ import java.math.BigDecimal
 @OptIn(ExperimentalCoroutinesApi::class)
 class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
     private val parameterRepository: ParameterRepository = mock()
+    private val notificationChannelsHandler: NotificationChannelsHandler = mock()
     private lateinit var viewModel: NewOrderNotificationSettingsViewModel
 
-    private fun setup() {
+    private fun setup(prepareMocks: () -> Unit = {}) {
         whenever(parameterRepository.getParameters()).thenReturn(
             SiteParameters(
                 currencyCode = "USD",
@@ -29,9 +31,13 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
                 gmtOffset = 0f
             )
         )
+        whenever(notificationChannelsHandler.checkNewOrderNotificationSound())
+            .thenReturn(NotificationChannelsHandler.NewOrderNotificationSoundStatus.DEFAULT)
+        prepareMocks()
         viewModel = NewOrderNotificationSettingsViewModel(
             savedStateHandle = SavedStateHandle(),
-            parameterRepository = parameterRepository
+            parameterRepository = parameterRepository,
+            notificationChannelsHandler = notificationChannelsHandler
         )
     }
 
@@ -70,5 +76,16 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.viewState.getOrAwaitValue().thresholdAmount)
             .isEqualTo(BigDecimal(750))
+    }
+
+    @Test
+    fun `given cha ching sound is modified, when view is loaded, then expose modified state`() = testBlocking {
+        val status = NotificationChannelsHandler.NewOrderNotificationSoundStatus.SOUND_MODIFIED
+        setup {
+            whenever(notificationChannelsHandler.checkNewOrderNotificationSound()).thenReturn(status)
+        }
+
+        assertThat(viewModel.viewState.getOrAwaitValue().newOrderNotificationSoundStatus)
+            .isEqualTo(status)
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
@@ -88,4 +88,19 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
         assertThat(viewModel.viewState.getOrAwaitValue().newOrderNotificationSoundStatus)
             .isEqualTo(status)
     }
+
+    @Test
+    fun `when notification settings are refreshed, then update cha ching sound state`() = testBlocking {
+        setup {
+            whenever(notificationChannelsHandler.checkNewOrderNotificationSound()).thenReturn(
+                NotificationChannelsHandler.NewOrderNotificationSoundStatus.DEFAULT,
+                NotificationChannelsHandler.NewOrderNotificationSoundStatus.DISABLED
+            )
+        }
+
+        viewModel.refreshNotificationSettings()
+
+        assertThat(viewModel.viewState.getOrAwaitValue().newOrderNotificationSoundStatus)
+            .isEqualTo(NotificationChannelsHandler.NewOrderNotificationSoundStatus.DISABLED)
+    }
 }


### PR DESCRIPTION
### Description
Fixes RSM-1628

Stacked on #15808.

Adds the existing Cha-Ching sound restore action to the New Orders notification settings screen. The screen now reads and refreshes the New Order notification channel sound state, then shows the action above the “Notify me for” section when the sound is disabled or changed from the default.

### Test Steps
1. Open Settings > Notifications > New Orders on a Woo-driven store.
2. Change the New Orders notification channel sound in Android system settings so it is disabled or no longer uses the default sound.
3. Return to the New Orders notification settings screen.
4. Confirm the Cha-Ching restore action appears above the “Notify me for” section.
5. Tap the action and confirm the success snackbar appears.
6. Return to the screen and confirm the action is no longer shown once the channel uses the default sound again.

### Images/gif
<img width="300" alt="Screenshot_20260504_160556" src="https://github.com/user-attachments/assets/9c514b0a-8ef7-4a93-9f34-99184e62d3ae" /> <img width="300" alt="Screenshot_20260504_160604" src="https://github.com/user-attachments/assets/e5da2182-f8d2-4132-bd65-c9d2055db768" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.