### PR TITLE
Replace POS reader-disconnected fullscreen error with payment-method row

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCheckoutPaymentButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCheckoutPaymentButtons.kt
@@ -1,0 +1,47 @@
+package com.woocommerce.android.ui.woopos.home.totals
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
+
+@Composable
+internal fun WooPosCheckoutPaymentButtons(
+    methods: List<WooPosPaymentMethod>,
+    onMethodClicked: (WooPosPaymentMethod) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isPhone = currentWooPosBreakpoint() == WooPosBreakpoint.Phone
+    val outerPaddingModifier = if (isPhone) {
+        Modifier.padding(WooPosSpacing.Large.value)
+    } else {
+        Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(outerPaddingModifier)
+            .navigationBarsPadding(),
+        horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
+    ) {
+        methods.forEach { method ->
+            WooPosOutlinedButton(
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag(method.testTag()),
+                text = stringResource(method.labelRes()),
+                onClick = { onMethodClicked(method) },
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCheckoutPaymentButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCheckoutPaymentButtons.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
@@ -27,21 +28,24 @@ internal fun WooPosCheckoutPaymentButtons(
         Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
     }
 
-    Row(
+    Column(
         modifier = modifier
             .fillMaxWidth()
             .then(outerPaddingModifier)
             .navigationBarsPadding(),
-        horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
+        verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
     ) {
-        methods.forEach { method ->
-            WooPosOutlinedButton(
-                modifier = Modifier
-                    .weight(1f)
-                    .testTag(method.testTag()),
-                text = stringResource(method.labelRes()),
-                onClick = { onMethodClicked(method) },
-            )
+        methods.forEachIndexed { index, method ->
+            val buttonModifier = Modifier
+                .fillMaxWidth()
+                .testTag(method.testTag())
+            val text = stringResource(method.labelRes())
+            val onClick = { onMethodClicked(method) }
+            if (index == 0) {
+                WooPosButton(modifier = buttonModifier, text = text, onClick = onClick)
+            } else {
+                WooPosOutlinedButton(modifier = buttonModifier, text = text, onClick = onClick)
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosPaymentMethod.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosPaymentMethod.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.woopos.home.totals
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.util.WooPosTestTags
+
+internal enum class WooPosPaymentMethod {
+    CARD_READER,
+    CASH,
+}
+
+internal fun WooPosPaymentMethod.labelRes(): Int = when (this) {
+    WooPosPaymentMethod.CARD_READER -> R.string.woopos_payment_method_card_reader_label
+    WooPosPaymentMethod.CASH -> R.string.woopos_payment_take_cash_payment_label
+}
+
+internal fun WooPosPaymentMethod.testTag(): String = when (this) {
+    WooPosPaymentMethod.CARD_READER -> WooPosTestTags.CARD_READER_PAYMENT_BUTTON
+    WooPosPaymentMethod.CASH -> WooPosTestTags.CASH_PAYMENT_BUTTON
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,7 +29,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -44,17 +42,14 @@ import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCircularLoadingIndicator
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreen
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreenButtonState
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIcons
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
@@ -65,7 +60,6 @@ import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewState.Total
 import com.woocommerce.android.ui.woopos.home.totals.payment.failed.WooPosPaymentFailedScreen
 import com.woocommerce.android.ui.woopos.home.totals.payment.inprogress.WooPosPaymentInProgressScreen
 import com.woocommerce.android.ui.woopos.home.totals.payment.success.WooPosPaymentSuccessScreen
-import com.woocommerce.android.ui.woopos.util.WooPosTestTags
 
 @Composable
 fun WooPosTotalsScreen(
@@ -197,9 +191,7 @@ private fun TotalsLoaded(
                 verticalArrangement = Arrangement.Center,
             ) {
                 when (val readerStatus = state.readerStatus) {
-                    is WooPosTotalsViewState.ReaderStatus.Disconnected -> {
-                        ReaderDisconnected(status = readerStatus, onUIEvent = onUIEvent)
-                    }
+                    is WooPosTotalsViewState.ReaderStatus.Disconnected -> Unit
                     is WooPosTotalsViewState.ReaderStatus.Preparing -> {
                         PreparingReader(
                             title = readerStatus.title,
@@ -241,21 +233,20 @@ private fun TotalsLoaded(
             Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
         }
 
-        val isPhone = currentWooPosBreakpoint() == WooPosBreakpoint.Phone
-        WooPosOutlinedButton(
-            text = stringResource(R.string.woopos_payment_take_cash_payment_label),
-            onClick = { onUIEvent(WooPosTotalsUIEvent.OnCashPaymentClicked) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .then(
-                    if (isPhone) {
-                        Modifier.padding(WooPosSpacing.Large.value)
-                    } else {
-                        Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
-                    }
-                )
-                .navigationBarsPadding()
-                .testTag(WooPosTestTags.CASH_PAYMENT_BUTTON)
+        val isReaderDisconnected = state.readerStatus is WooPosTotalsViewState.ReaderStatus.Disconnected
+        val methods = if (isReaderDisconnected) {
+            listOf(WooPosPaymentMethod.CARD_READER, WooPosPaymentMethod.CASH)
+        } else {
+            listOf(WooPosPaymentMethod.CASH)
+        }
+        WooPosCheckoutPaymentButtons(
+            methods = methods,
+            onMethodClicked = { method ->
+                when (method) {
+                    WooPosPaymentMethod.CARD_READER -> onUIEvent(WooPosTotalsUIEvent.ConnectReaderClicked)
+                    WooPosPaymentMethod.CASH -> onUIEvent(WooPosTotalsUIEvent.OnCashPaymentClicked)
+                }
+            },
         )
     }
 }
@@ -300,48 +291,6 @@ private fun ReaderReadyForPayment(readerStatus: WooPosTotalsViewState.ReaderStat
         textAlign = TextAlign.Center,
         modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
     )
-}
-
-@Composable
-private fun ReaderDisconnected(
-    modifier: Modifier = Modifier,
-    status: WooPosTotalsViewState.ReaderStatus.Disconnected,
-    onUIEvent: (WooPosTotalsUIEvent) -> Unit,
-) {
-    Column(
-        modifier = modifier.padding(WooPosSpacing.XLarge.value),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.SpaceEvenly,
-    ) {
-        Image(
-            modifier = Modifier.size(140.dp.toAdaptiveComponentSize()),
-            imageVector = WooPosIcons.CardReaderNotConnected,
-            contentDescription = stringResource(id = R.string.woopos_reader_not_connected_description),
-        )
-
-        Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
-
-        WooPosText(
-            text = status.title,
-            style = WooPosTypography.Heading,
-            fontWeight = FontWeight.Bold,
-        )
-
-        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
-
-        WooPosText(
-            text = status.subtitle,
-            style = WooPosTypography.BodyLarge,
-        )
-        Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
-        WooPosButton(
-            text = status.actionButtonLabel,
-            onClick = { onUIEvent(WooPosTotalsUIEvent.ConnectReaderClicked) },
-            modifier = Modifier
-                .adaptiveContentWidth()
-                .height(WooPosComponentSize.Small.value)
-        )
-    }
 }
 
 @Composable
@@ -619,19 +568,6 @@ fun WooPosTotalsScreenPreviewForFreeOrders() {
             ),
             onUIEvent = {},
         )
-    }
-}
-
-@Composable
-@WooPosPreview
-fun TotalsErrorPreview() {
-    val readerStatus = WooPosTotalsViewState.ReaderStatus.Disconnected(
-        title = "Reader not connected",
-        subtitle = "To process this payment, please connect your reader.",
-        actionButtonLabel = "Connect to a reader",
-    )
-    WooPosTheme {
-        ReaderDisconnected(modifier = Modifier, status = readerStatus) {}
     }
 }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3753,6 +3753,7 @@
     <string name="woopos_payment_tax_label">Taxes</string>
     <string name="woopos_payment_total_label">Total</string>
     <string name="woopos_payment_take_cash_payment_label">Cash payment</string>
+    <string name="woopos_payment_method_card_reader_label">Card reader</string>
     <string name="woopos_totals_main_error_label">Couldn\'t load totals</string>
     <string name="woopos_totals_coupons_validation_failed_edit_order">Edit order</string>
     <string name="woopos_totals_coupons_validation_failed_remove_coupons">Remove coupons</string>

--- a/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
+++ b/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
@@ -4,6 +4,7 @@ object WooPosTestTags {
     const val PRODUCT_ITEM = "woo_pos_product_item"
     const val CHECKOUT_BUTTON = "woo_pos_checkout_button"
     const val CASH_PAYMENT_BUTTON = "woo_pos_cash_payment_button"
+    const val CARD_READER_PAYMENT_BUTTON = "woo_pos_card_reader_payment_button"
     const val COMPLETE_PAYMENT_BUTTON = "woo_pos_complete_payment_button"
     const val NEW_ORDER_BUTTON = "woo_pos_new_order_button"
     const val SUCCESS_CHECKMARK_ICON = "woo_pos_success_checkmark_icon"


### PR DESCRIPTION
### Description

Reshapes the bottom of the POS checkout (`WooPosTotalsScreen`) from a single full-width action into a two-button payment-method row. With this change:

- When the card reader is **connected**, the existing single `Cash` button is replaced with a row hosted by a new `WooPosCheckoutPaymentButtons` composable (today: `Cash` only — but the row is now the seam every method plugs into).
- When the card reader is **disconnected**, the full-screen "reader not connected" error UI is removed entirely. The totals stay visible and a `Card reader` / `Cash` button row sits beneath them, so the merchant can choose to connect a reader or take cash without leaving the totals view.

This is a foundation change: it unblocks the gated Tap to Pay entry point that ships in the stacked follow-up PR. No payment-collection logic moves; existing UI events (`OnCashPaymentClicked`, `ConnectReaderClicked`) are reused unchanged.

### Test Steps

1. Install a debug build on a phone or tablet: `./gradlew :WooCommerce:installWasabiDebug`.
2. Open POS, add an item, navigate to Checkout.
3. **Reader disconnected** (no card reader paired): verify totals are visible and that a button row below them shows `Card reader` (primary on tablet / secondary on phone) and `Cash`. Tap `Card reader` → existing connect-reader flow opens. Tap `Cash` → existing cash-payment flow opens. Confirm the previous full-screen "reader not connected" error is no longer shown.
4. **Reader connected** (Bluetooth reader paired): verify the totals + the existing "ready for payment" UI are unchanged, and that the bottom action is the same `Cash` button as before (still single full-width).
5. Verify Compose previews in `WooPosTotalsScreen.kt` render correctly in Android Studio.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.