### PR TITLE
Add gated Tap to Pay entry point in POS checkout

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosIsTapToPayAvailable.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosIsTapToPayAvailable.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.ui.woopos.cardreader
+
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
+import com.woocommerce.android.ui.payments.taptopay.isAvailable
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import javax.inject.Inject
+
+class WooPosIsTapToPayAvailable @Inject constructor(
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
+    private val featureFlagRepository: FeatureFlagRepository,
+) {
+    operator fun invoke(): Boolean =
+        featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_TAP_TO_PAY) &&
+            tapToPayAvailabilityStatus().isAvailable
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosAllPaymentMethodsDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosAllPaymentMethodsDialog.kt
@@ -1,0 +1,61 @@
+package com.woocommerce.android.ui.woopos.home.totals
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+
+@Composable
+internal fun WooPosAllPaymentMethodsDialog(
+    isVisible: Boolean,
+    methods: List<WooPosPaymentMethod>,
+    onMethodClicked: (WooPosPaymentMethod) -> Unit,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    WooPosDialogWrapper(
+        modifier = modifier,
+        isVisible = isVisible,
+        dialogBackgroundContentDescription = stringResource(
+            R.string.woopos_payment_method_picker_dialog_title
+        ),
+        onCloseClick = onDismissRequest,
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            WooPosText(
+                text = stringResource(R.string.woopos_payment_method_picker_dialog_title),
+                style = WooPosTypography.Heading,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
+            methods.forEach { method ->
+                WooPosOutlinedButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(method.testTag()),
+                    text = stringResource(method.labelRes()),
+                    onClick = { onMethodClicked(method) },
+                )
+                Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+            }
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCheckoutPaymentButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCheckoutPaymentButtons.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.woopos.home.totals
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -9,15 +10,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
+import com.woocommerce.android.ui.woopos.util.WooPosTestTags
 
 @Composable
 internal fun WooPosCheckoutPaymentButtons(
-    methods: List<WooPosPaymentMethod>,
+    readerStatus: WooPosTotalsViewState.ReaderStatus,
+    isTapToPayAvailable: Boolean,
     onMethodClicked: (WooPosPaymentMethod) -> Unit,
+    onShowAllMethods: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isPhone = currentWooPosBreakpoint() == WooPosBreakpoint.Phone
@@ -26,6 +31,11 @@ internal fun WooPosCheckoutPaymentButtons(
     } else {
         Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
     }
+    val layout = derivePaymentButtonsLayout(
+        formFactor = if (isPhone) WooPosFormFactor.PHONE else WooPosFormFactor.TABLET,
+        readerStatus = readerStatus,
+        isTapToPayAvailable = isTapToPayAvailable,
+    )
 
     Row(
         modifier = modifier
@@ -34,14 +44,97 @@ internal fun WooPosCheckoutPaymentButtons(
             .navigationBarsPadding(),
         horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
     ) {
-        methods.forEach { method ->
-            WooPosOutlinedButton(
-                modifier = Modifier
-                    .weight(1f)
-                    .testTag(method.testTag()),
-                text = stringResource(method.labelRes()),
-                onClick = { onMethodClicked(method) },
-            )
+        when (layout) {
+            is WooPosPaymentButtonsLayout.Single -> {
+                MethodButton(method = layout.primary, onClick = { onMethodClicked(layout.primary) })
+            }
+            is WooPosPaymentButtonsLayout.Pair -> {
+                MethodButton(method = layout.primary, onClick = { onMethodClicked(layout.primary) })
+                MethodButton(method = layout.secondary, onClick = { onMethodClicked(layout.secondary) })
+            }
+            is WooPosPaymentButtonsLayout.WithOverflow -> {
+                MethodButton(method = layout.primary, onClick = { onMethodClicked(layout.primary) })
+                AllPaymentMethodsButton(onClick = onShowAllMethods)
+            }
         }
     }
+}
+
+@Composable
+private fun RowScope.MethodButton(
+    method: WooPosPaymentMethod,
+    onClick: () -> Unit,
+) {
+    WooPosOutlinedButton(
+        modifier = Modifier
+            .weight(1f)
+            .testTag(method.testTag()),
+        text = stringResource(method.labelRes()),
+        onClick = onClick,
+    )
+}
+
+@Composable
+private fun RowScope.AllPaymentMethodsButton(onClick: () -> Unit) {
+    WooPosOutlinedButton(
+        modifier = Modifier
+            .weight(1f)
+            .testTag(WooPosTestTags.ALL_PAYMENT_METHODS_BUTTON),
+        text = stringResource(R.string.woopos_payment_method_all_methods_label),
+        onClick = onClick,
+    )
+}
+
+internal sealed interface WooPosPaymentButtonsLayout {
+    data class Single(val primary: WooPosPaymentMethod) : WooPosPaymentButtonsLayout
+    data class Pair(val primary: WooPosPaymentMethod, val secondary: WooPosPaymentMethod) : WooPosPaymentButtonsLayout
+    data class WithOverflow(val primary: WooPosPaymentMethod) : WooPosPaymentButtonsLayout
+}
+
+internal enum class WooPosFormFactor { PHONE, TABLET }
+
+private const val OVERFLOW_THRESHOLD = 3
+
+internal fun derivePaymentButtonsLayout(
+    formFactor: WooPosFormFactor,
+    readerStatus: WooPosTotalsViewState.ReaderStatus,
+    isTapToPayAvailable: Boolean,
+): WooPosPaymentButtonsLayout {
+    val methods = availableMethods(readerStatus, isTapToPayAvailable)
+    if (methods.size == 1) return WooPosPaymentButtonsLayout.Single(methods.single())
+    val primary = pickPrimary(formFactor, methods)
+    if (methods.size >= OVERFLOW_THRESHOLD) return WooPosPaymentButtonsLayout.WithOverflow(primary)
+    val secondary = methods.first { it != primary }
+    return WooPosPaymentButtonsLayout.Pair(primary, secondary)
+}
+
+private fun availableMethods(
+    readerStatus: WooPosTotalsViewState.ReaderStatus,
+    isTapToPayAvailable: Boolean,
+): List<WooPosPaymentMethod> {
+    val isReaderDisconnected = readerStatus is WooPosTotalsViewState.ReaderStatus.Disconnected
+    return buildList {
+        if (isReaderDisconnected) add(WooPosPaymentMethod.CARD_READER)
+        if (isTapToPayAvailable) add(WooPosPaymentMethod.TAP_TO_PAY)
+        add(WooPosPaymentMethod.CASH)
+    }
+}
+
+private fun pickPrimary(
+    formFactor: WooPosFormFactor,
+    methods: List<WooPosPaymentMethod>,
+): WooPosPaymentMethod {
+    val preference = when (formFactor) {
+        WooPosFormFactor.PHONE -> listOf(
+            WooPosPaymentMethod.TAP_TO_PAY,
+            WooPosPaymentMethod.CARD_READER,
+            WooPosPaymentMethod.CASH,
+        )
+        WooPosFormFactor.TABLET -> listOf(
+            WooPosPaymentMethod.CARD_READER,
+            WooPosPaymentMethod.CASH,
+            WooPosPaymentMethod.TAP_TO_PAY,
+        )
+    }
+    return preference.first { it in methods }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosPaymentMethod.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosPaymentMethod.kt
@@ -5,15 +5,18 @@ import com.woocommerce.android.ui.woopos.util.WooPosTestTags
 
 internal enum class WooPosPaymentMethod {
     CARD_READER,
+    TAP_TO_PAY,
     CASH,
 }
 
 internal fun WooPosPaymentMethod.labelRes(): Int = when (this) {
     WooPosPaymentMethod.CARD_READER -> R.string.woopos_payment_method_card_reader_label
+    WooPosPaymentMethod.TAP_TO_PAY -> R.string.woopos_payment_method_tap_to_pay_label
     WooPosPaymentMethod.CASH -> R.string.woopos_payment_take_cash_payment_label
 }
 
 internal fun WooPosPaymentMethod.testTag(): String = when (this) {
     WooPosPaymentMethod.CARD_READER -> WooPosTestTags.CARD_READER_PAYMENT_BUTTON
+    WooPosPaymentMethod.TAP_TO_PAY -> WooPosTestTags.TAP_TO_PAY_PAYMENT_BUTTON
     WooPosPaymentMethod.CASH -> WooPosTestTags.CASH_PAYMENT_BUTTON
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsAnalyticsTracker.kt
@@ -98,6 +98,10 @@ class WooPosTotalsAnalyticsTracker @Inject constructor(
         analyticsTracker.track(WooPosAnalyticsEvent.Event.CheckoutCashPaymentTapped)
     }
 
+    suspend fun trackTapToPayEntryPointTapped() {
+        analyticsTracker.track(WooPosAnalyticsEvent.Event.TapToPayEntryPointTapped)
+    }
+
     suspend fun trackCheckoutOutdatedItemDetectedScreenShown() {
         val syncStrategy = productsDataSource.getCurrentSyncStrategy()
         analyticsTracker.track(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -233,22 +233,36 @@ private fun TotalsLoaded(
             Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
         }
 
-        val isReaderDisconnected = state.readerStatus is WooPosTotalsViewState.ReaderStatus.Disconnected
-        val methods = if (isReaderDisconnected) {
-            listOf(WooPosPaymentMethod.CARD_READER, WooPosPaymentMethod.CASH)
-        } else {
-            listOf(WooPosPaymentMethod.CASH)
-        }
         WooPosCheckoutPaymentButtons(
-            methods = methods,
-            onMethodClicked = { method ->
-                when (method) {
-                    WooPosPaymentMethod.CARD_READER -> onUIEvent(WooPosTotalsUIEvent.ConnectReaderClicked)
-                    WooPosPaymentMethod.CASH -> onUIEvent(WooPosTotalsUIEvent.OnCashPaymentClicked)
-                }
-            },
+            readerStatus = state.readerStatus,
+            isTapToPayAvailable = state.isTapToPayAvailable,
+            onMethodClicked = { method -> onUIEvent(method.toUIEvent()) },
+            onShowAllMethods = { onUIEvent(WooPosTotalsUIEvent.OnAllPaymentMethodsVisibilityChanged(true)) },
         )
     }
+
+    val allMethods = buildList {
+        if (state.readerStatus is WooPosTotalsViewState.ReaderStatus.Disconnected) {
+            add(WooPosPaymentMethod.CARD_READER)
+        }
+        if (state.isTapToPayAvailable) add(WooPosPaymentMethod.TAP_TO_PAY)
+        add(WooPosPaymentMethod.CASH)
+    }
+    WooPosAllPaymentMethodsDialog(
+        isVisible = state.isAllPaymentMethodsDialogVisible,
+        methods = allMethods,
+        onMethodClicked = { method ->
+            onUIEvent(WooPosTotalsUIEvent.OnAllPaymentMethodsVisibilityChanged(false))
+            onUIEvent(method.toUIEvent())
+        },
+        onDismissRequest = { onUIEvent(WooPosTotalsUIEvent.OnAllPaymentMethodsVisibilityChanged(false)) },
+    )
+}
+
+private fun WooPosPaymentMethod.toUIEvent(): WooPosTotalsUIEvent = when (this) {
+    WooPosPaymentMethod.CARD_READER -> WooPosTotalsUIEvent.ConnectReaderClicked
+    WooPosPaymentMethod.TAP_TO_PAY -> WooPosTotalsUIEvent.OnTapToPayClicked
+    WooPosPaymentMethod.CASH -> WooPosTotalsUIEvent.OnCashPaymentClicked
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
@@ -11,6 +11,8 @@ sealed class WooPosTotalsUIEvent {
     data object RetryOrderCreationClicked : WooPosTotalsUIEvent()
     data object OnStartReceiptFlowClicked : WooPosTotalsUIEvent()
     data object OnCashPaymentClicked : WooPosTotalsUIEvent()
+    data object OnTapToPayClicked : WooPosTotalsUIEvent()
+    data class OnAllPaymentMethodsVisibilityChanged(val isVisible: Boolean) : WooPosTotalsUIEvent()
     data object ConnectReaderClicked : WooPosTotalsUIEvent()
     data object OnBackClicked : WooPosTotalsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -15,7 +15,10 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowP
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
+import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosIsTapToPayAvailable
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
@@ -67,12 +70,16 @@ class WooPosTotalsViewModel @Inject constructor(
     private val totalsAnalyticsTracker: WooPosTotalsAnalyticsTracker,
     private val wooPosLogWrapper: WooPosLogWrapper,
     private val performIncrementalSyncUseCase: WooPosPerformLocalCatalogIncrementalSync,
+    private val isTapToPayAvailable: WooPosIsTapToPayAvailable,
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus,
+    private val paymentsFlowTracker: PaymentsFlowTracker,
     savedState: SavedStateHandle,
 ) : ViewModel() {
 
     private companion object {
         private const val EMPTY_ORDER_ID = -1L
         private const val KEY_STATE = "woo_pos_totals_data_state"
+        private const val TAP_TO_PAY_SOURCE = "woo_pos_checkout"
         private val InitialState = WooPosTotalsViewState.Loading
     }
 
@@ -110,6 +117,9 @@ class WooPosTotalsViewModel @Inject constructor(
     init {
         listenUpEvents()
         observeCardReaderStatus()
+        (tapToPayAvailabilityStatus() as? TapToPayAvailabilityStatus.Result.NotAvailable)?.let {
+            paymentsFlowTracker.trackTapToPayNotAvailableReason(it, TAP_TO_PAY_SOURCE)
+        }
     }
 
     private fun observeCardReaderStatus() {
@@ -171,6 +181,9 @@ class WooPosTotalsViewModel @Inject constructor(
 
             WooPosTotalsUIEvent.OnCashPaymentClicked -> handleCashPaymentClicked()
 
+            WooPosTotalsUIEvent.OnTapToPayClicked,
+            is WooPosTotalsUIEvent.OnAllPaymentMethodsVisibilityChanged -> handleNewPaymentMethodEvent(event)
+
             WooPosTotalsUIEvent.GoBackToCheckoutAfterFailedPayment -> handleGoBackToCheckoutClickedWhenPaymentFailed()
 
             WooPosTotalsUIEvent.RetryFailedTransactionClicked -> handleRetryFailedTransactionClicked()
@@ -207,6 +220,20 @@ class WooPosTotalsViewModel @Inject constructor(
         childrenToParentEventSender.sendToParent(
             ToCashPayment(dataState.value.orderId)
         )
+    }
+
+    private fun handleNewPaymentMethodEvent(event: WooPosTotalsUIEvent) {
+        when (event) {
+            WooPosTotalsUIEvent.OnTapToPayClicked -> viewModelScope.launch {
+                totalsAnalyticsTracker.trackTapToPayEntryPointTapped()
+                wooPosLogWrapper.d("Tap to Pay tapped in checkout. Payment flow not yet wired.")
+            }
+            is WooPosTotalsUIEvent.OnAllPaymentMethodsVisibilityChanged -> {
+                val checkout = uiState.value as? WooPosTotalsViewState.Checkout ?: return
+                uiState.value = checkout.copy(isAllPaymentMethodsDialogVisible = event.isVisible)
+            }
+            else -> Unit
+        }
     }
 
     private fun handleGoBackToCheckoutClickedWhenPaymentFailed() {
@@ -723,6 +750,7 @@ class WooPosTotalsViewModel @Inject constructor(
                 orderTotalText = priceFormat(totalAmount),
             ),
             readerStatus = readerStatus,
+            isTapToPayAvailable = isTapToPayAvailable(),
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
@@ -10,6 +10,8 @@ sealed class WooPosTotalsViewState : Parcelable {
     data class Checkout(
         val totals: Totals,
         val readerStatus: ReaderStatus,
+        val isTapToPayAvailable: Boolean = false,
+        val isAllPaymentMethodsDialogVisible: Boolean = false,
     ) : WooPosTotalsViewState()
 
     sealed class Totals : Parcelable {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -91,6 +91,10 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "checkout_cash_payment_tapped"
         }
 
+        data object TapToPayEntryPointTapped : Event() {
+            override val name: String = "checkout_tap_to_pay_payment_tapped"
+        }
+
         data object CashPaymentTapped : Event() {
             override val name: String = "cash_payment_tapped"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -20,6 +20,7 @@ enum class FeatureFlag(
     LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES("woo_notification_1d_after_free_trial_expires"),
     WOO_POS("woo_pos"),
     WOO_POS_PHONE("woo_pos_phone", localValue = PackageUtils.isDebugBuild()),
+    WOO_POS_TAP_TO_PAY("woo_pos_tap_to_pay", localValue = PackageUtils.isDebugBuild()),
     APP_PASSWORDS_FOR_JETPACK_SITES("woo_app_passwords_for_jetpack_sites"),
     WOO_POS_LOCAL_CATALOG_M1("woo_pos_local_catalog_m1"),
     WOO_POS_TABLET_PROMO_BANNER("woo_pos_tablet_promo_banner"),

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3754,6 +3754,9 @@
     <string name="woopos_payment_total_label">Total</string>
     <string name="woopos_payment_take_cash_payment_label">Cash payment</string>
     <string name="woopos_payment_method_card_reader_label">Card reader</string>
+    <string name="woopos_payment_method_tap_to_pay_label">Tap to Pay</string>
+    <string name="woopos_payment_method_all_methods_label">All payment methods</string>
+    <string name="woopos_payment_method_picker_dialog_title">Choose payment method</string>
     <string name="woopos_totals_main_error_label">Couldn\'t load totals</string>
     <string name="woopos_totals_coupons_validation_failed_edit_order">Edit order</string>
     <string name="woopos_totals_coupons_validation_failed_remove_coupons">Remove coupons</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosIsTapToPayAvailableTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosIsTapToPayAvailableTest.kt
@@ -1,0 +1,62 @@
+package com.woocommerce.android.ui.woopos.cardreader
+
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
+import com.woocommerce.android.util.FeatureFlag
+import com.woocommerce.android.util.FeatureFlagRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class WooPosIsTapToPayAvailableTest {
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock()
+    private val featureFlagRepository: FeatureFlagRepository = mock()
+
+    private val sut = WooPosIsTapToPayAvailable(tapToPayAvailabilityStatus, featureFlagRepository)
+
+    @Test
+    fun `given flag off, when invoked, then returns false regardless of availability`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_TAP_TO_PAY)).thenReturn(false)
+        whenever(tapToPayAvailabilityStatus.invoke()).thenReturn(TapToPayAvailabilityStatus.Result.Available)
+
+        assertThat(sut()).isFalse()
+    }
+
+    @Test
+    fun `given flag on and Available, when invoked, then returns true`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_TAP_TO_PAY)).thenReturn(true)
+        whenever(tapToPayAvailabilityStatus.invoke()).thenReturn(TapToPayAvailabilityStatus.Result.Available)
+
+        assertThat(sut()).isTrue()
+    }
+
+    @Test
+    fun `given flag on but Hidden, when invoked, then returns false`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_TAP_TO_PAY)).thenReturn(true)
+        whenever(tapToPayAvailabilityStatus.invoke()).thenReturn(TapToPayAvailabilityStatus.Result.Hidden)
+
+        assertThat(sut()).isFalse()
+    }
+
+    @Test
+    fun `given flag on but country not supported, when invoked, then returns false`() {
+        val unavailable: TapToPayAvailabilityStatus = mock {
+            on { invoke() } doReturn TapToPayAvailabilityStatus.Result.NotAvailable.CountryNotSupported
+        }
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_TAP_TO_PAY)).thenReturn(true)
+
+        val sutForUnavailable = WooPosIsTapToPayAvailable(unavailable, featureFlagRepository)
+
+        assertThat(sutForUnavailable()).isFalse()
+    }
+
+    @Test
+    fun `given flag on but NFC missing, when invoked, then returns false`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_TAP_TO_PAY)).thenReturn(true)
+        whenever(tapToPayAvailabilityStatus.invoke())
+            .thenReturn(TapToPayAvailabilityStatus.Result.NotAvailable.NfcNotAvailable)
+
+        assertThat(sut()).isFalse()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/DerivePaymentButtonsLayoutTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/DerivePaymentButtonsLayoutTest.kt
@@ -1,0 +1,77 @@
+package com.woocommerce.android.ui.woopos.home.totals
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class DerivePaymentButtonsLayoutTest {
+    private val connected = WooPosTotalsViewState.ReaderStatus.ReadyForPayment("ready", "tap")
+    private val disconnected = WooPosTotalsViewState.ReaderStatus.Disconnected("title", "subtitle", "cta")
+
+    @Test
+    fun `given phone with reader connected and ttp available, when deriving layout, then primary is TTP and secondary is Cash`() {
+        val layout = derivePaymentButtonsLayout(WooPosFormFactor.PHONE, connected, isTapToPayAvailable = true)
+        assertThat(layout).isEqualTo(
+            WooPosPaymentButtonsLayout.Pair(
+                WooPosPaymentMethod.TAP_TO_PAY,
+                WooPosPaymentMethod.CASH
+            )
+        )
+    }
+
+    @Test
+    fun `given phone with reader connected and ttp unavailable, when deriving layout, then a single Cash button is returned`() {
+        val layout = derivePaymentButtonsLayout(WooPosFormFactor.PHONE, connected, isTapToPayAvailable = false)
+        assertThat(layout).isEqualTo(WooPosPaymentButtonsLayout.Single(WooPosPaymentMethod.CASH))
+    }
+
+    @Test
+    fun `given phone with reader disconnected and ttp available, when deriving layout, then primary is TTP with overflow secondary`() {
+        val layout = derivePaymentButtonsLayout(WooPosFormFactor.PHONE, disconnected, isTapToPayAvailable = true)
+        assertThat(layout).isEqualTo(WooPosPaymentButtonsLayout.WithOverflow(WooPosPaymentMethod.TAP_TO_PAY))
+    }
+
+    @Test
+    fun `given phone with reader disconnected and ttp unavailable, when deriving layout, then primary is CardReader and secondary is Cash`() {
+        val layout = derivePaymentButtonsLayout(WooPosFormFactor.PHONE, disconnected, isTapToPayAvailable = false)
+        assertThat(layout).isEqualTo(
+            WooPosPaymentButtonsLayout.Pair(
+                WooPosPaymentMethod.CARD_READER,
+                WooPosPaymentMethod.CASH
+            )
+        )
+    }
+
+    @Test
+    fun `given tablet with reader connected and ttp available, when deriving layout, then primary is Cash and secondary is TTP`() {
+        val layout = derivePaymentButtonsLayout(WooPosFormFactor.TABLET, connected, isTapToPayAvailable = true)
+        assertThat(layout).isEqualTo(
+            WooPosPaymentButtonsLayout.Pair(
+                WooPosPaymentMethod.CASH,
+                WooPosPaymentMethod.TAP_TO_PAY
+            )
+        )
+    }
+
+    @Test
+    fun `given tablet with reader connected and ttp unavailable, when deriving layout, then a single Cash button is returned`() {
+        val layout = derivePaymentButtonsLayout(WooPosFormFactor.TABLET, connected, isTapToPayAvailable = false)
+        assertThat(layout).isEqualTo(WooPosPaymentButtonsLayout.Single(WooPosPaymentMethod.CASH))
+    }
+
+    @Test
+    fun `given tablet with reader disconnected and ttp available, when deriving layout, then primary is CardReader with overflow secondary`() {
+        val layout = derivePaymentButtonsLayout(WooPosFormFactor.TABLET, disconnected, isTapToPayAvailable = true)
+        assertThat(layout).isEqualTo(WooPosPaymentButtonsLayout.WithOverflow(WooPosPaymentMethod.CARD_READER))
+    }
+
+    @Test
+    fun `given tablet with reader disconnected and ttp unavailable, when deriving layout, then primary is CardReader and secondary is Cash`() {
+        val layout = derivePaymentButtonsLayout(WooPosFormFactor.TABLET, disconnected, isTapToPayAvailable = false)
+        assertThat(layout).isEqualTo(
+            WooPosPaymentButtonsLayout.Pair(
+                WooPosPaymentMethod.CARD_READER,
+                WooPosPaymentMethod.CASH
+            )
+        )
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -29,9 +29,11 @@ import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardRea
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderTrackCanceledFlowAction
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptShare
+import com.woocommerce.android.ui.payments.taptopay.TapToPayAvailabilityStatus
 import com.woocommerce.android.ui.payments.tracking.CardReaderTrackingInfoKeeper
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
+import com.woocommerce.android.ui.woopos.cardreader.WooPosIsTapToPayAvailable
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.BackFromCheckoutToCartClicked
@@ -73,6 +75,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -159,6 +162,10 @@ class WooPosTotalsViewModelTest {
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val performIncrementalSyncUseCase: WooPosPerformLocalCatalogIncrementalSync = mock()
     private val productsDataSource: WooPosProductsDataSource = mock()
+    private val isTapToPayAvailable: WooPosIsTapToPayAvailable = mock()
+    private val tapToPayAvailabilityStatus: TapToPayAvailabilityStatus = mock {
+        on { invoke() } doReturn TapToPayAvailabilityStatus.Result.Hidden
+    }
 
     private companion object {
         private const val EMPTY_ORDER_ID = -1L
@@ -1942,6 +1949,101 @@ class WooPosTotalsViewModelTest {
             )
         }
 
+    @Test
+    fun `given TTP available, when checkout shown, then state isTapToPayAvailable is true`() = runTest {
+        // GIVEN
+        whenever(isTapToPayAvailable.invoke()).thenReturn(true)
+
+        // WHEN
+        val viewModel = createViewModelAndSetupForSuccessfulOrderCreation()
+
+        // THEN
+        val state = viewModel.state.value as WooPosTotalsViewState.Checkout
+        assertThat(state.isTapToPayAvailable).isTrue()
+    }
+
+    @Test
+    fun `given TTP unavailable, when checkout shown, then state isTapToPayAvailable is false`() = runTest {
+        // GIVEN
+        whenever(isTapToPayAvailable.invoke()).thenReturn(false)
+
+        // WHEN
+        val viewModel = createViewModelAndSetupForSuccessfulOrderCreation()
+
+        // THEN
+        val state = viewModel.state.value as WooPosTotalsViewState.Checkout
+        assertThat(state.isTapToPayAvailable).isFalse()
+    }
+
+    @Test
+    fun `when OnTapToPayClicked, then track entry-point analytics and do not navigate`() = runTest {
+        // GIVEN
+        val viewModel = createViewModelAndSetupForSuccessfulOrderCreation()
+        clearInvocations(childrenToParentEventSender)
+        clearInvocations(analyticsTracker)
+
+        // WHEN
+        viewModel.onUIEvent(WooPosTotalsUIEvent.OnTapToPayClicked)
+
+        // THEN
+        verify(analyticsTracker).track(WooPosAnalyticsEvent.Event.TapToPayEntryPointTapped)
+        verify(childrenToParentEventSender, never()).sendToParent(any())
+    }
+
+    @Test
+    fun `when OnAllPaymentMethodsVisibilityChanged true, then dialog flag flips to visible`() = runTest {
+        // GIVEN
+        val viewModel = createViewModelAndSetupForSuccessfulOrderCreation()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosTotalsUIEvent.OnAllPaymentMethodsVisibilityChanged(true))
+
+        // THEN
+        val state = viewModel.state.value as WooPosTotalsViewState.Checkout
+        assertThat(state.isAllPaymentMethodsDialogVisible).isTrue()
+    }
+
+    @Test
+    fun `given dialog visible, when OnAllPaymentMethodsVisibilityChanged false, then dialog flag flips back`() = runTest {
+        // GIVEN
+        val viewModel = createViewModelAndSetupForSuccessfulOrderCreation()
+        viewModel.onUIEvent(WooPosTotalsUIEvent.OnAllPaymentMethodsVisibilityChanged(true))
+
+        // WHEN
+        viewModel.onUIEvent(WooPosTotalsUIEvent.OnAllPaymentMethodsVisibilityChanged(false))
+
+        // THEN
+        val state = viewModel.state.value as WooPosTotalsViewState.Checkout
+        assertThat(state.isAllPaymentMethodsDialogVisible).isFalse()
+    }
+
+    @Test
+    fun `given TTP NotAvailable, when ViewModel created, then NotAvailable reason tracked once`() = runTest {
+        // GIVEN
+        val notAvailable = TapToPayAvailabilityStatus.Result.NotAvailable.NfcNotAvailable
+        whenever(tapToPayAvailabilityStatus.invoke()).thenReturn(notAvailable)
+        clearInvocations(tracker)
+
+        // WHEN
+        createViewModelAndSetupForSuccessfulOrderCreation()
+
+        // THEN
+        verify(tracker).trackTapToPayNotAvailableReason(notAvailable, "woo_pos_checkout")
+    }
+
+    @Test
+    fun `given TTP Available, when ViewModel created, then NotAvailable reason not tracked`() = runTest {
+        // GIVEN
+        whenever(tapToPayAvailabilityStatus.invoke()).thenReturn(TapToPayAvailabilityStatus.Result.Available)
+        clearInvocations(tracker)
+
+        // WHEN
+        createViewModelAndSetupForSuccessfulOrderCreation()
+
+        // THEN
+        verify(tracker, never()).trackTapToPayNotAvailableReason(any(), any())
+    }
+
     private fun mockPaymentFailedTexts() {
         whenever(resourceProvider.getString(R.string.woopos_success_totals_payment_processing_title))
             .thenReturn("Processing payment")
@@ -2093,5 +2195,8 @@ class WooPosTotalsViewModelTest {
         ),
         wooPosLogWrapper = wooPosLogWrapper,
         performIncrementalSyncUseCase = performIncrementalSyncUseCase,
+        isTapToPayAvailable = isTapToPayAvailable,
+        tapToPayAvailabilityStatus = tapToPayAvailabilityStatus,
+        paymentsFlowTracker = tracker,
     )
 }

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -62,6 +62,7 @@
     <ID>ForbiddenComment:ShippingCarrierRatesViewModel.kt$ShippingCarrierRatesViewModel$// TODO: Once we start supporting countries other than the US, we'll need to verify what currency the shipping labels purchases use</ID>
     <ID>FunctionOnlyReturningConstant:Screen.kt$Screen.Companion$fun isVisible(): Boolean</ID>
     <ID>LargeClass:ProductDetailViewModel.kt$ProductDetailViewModel : ScopedViewModel</ID>
+    <ID>LargeClass:WooPosTotalsViewModel.kt$WooPosTotalsViewModel : ViewModel</ID>
     <ID>LongMethod:AddOrderShipmentTrackingFragment.kt$AddOrderShipmentTrackingFragment$private fun setupObservers(binding: FragmentAddShipmentTrackingBinding)</ID>
     <ID>LongMethod:CardReaderDetailFragment.kt$CardReaderDetailFragment$private fun observeViewState(binding: FragmentCardReaderDetailBinding)</ID>
     <ID>LongMethod:CreateShippingLabelFragment.kt$CreateShippingLabelFragment$private fun subscribeObservers(binding: FragmentCreateShippingLabelBinding)</ID>

--- a/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
+++ b/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
@@ -5,6 +5,8 @@ object WooPosTestTags {
     const val CHECKOUT_BUTTON = "woo_pos_checkout_button"
     const val CASH_PAYMENT_BUTTON = "woo_pos_cash_payment_button"
     const val CARD_READER_PAYMENT_BUTTON = "woo_pos_card_reader_payment_button"
+    const val TAP_TO_PAY_PAYMENT_BUTTON = "woo_pos_tap_to_pay_payment_button"
+    const val ALL_PAYMENT_METHODS_BUTTON = "woo_pos_all_payment_methods_button"
     const val COMPLETE_PAYMENT_BUTTON = "woo_pos_complete_payment_button"
     const val NEW_ORDER_BUTTON = "woo_pos_new_order_button"
     const val SUCCESS_CHECKMARK_ICON = "woo_pos_success_checkmark_icon"


### PR DESCRIPTION
### Description

Stacked on top of #15811 (`issue/pos-checkout-payment-row`). Please review and merge that PR first.

Adds a gated **Tap to Pay** entry point to the POS checkout. The TTP click itself is intentionally a **no-op stub** in this PR — payment-collection plumbing lands in a follow-up PR. The POC branch `issue/pos-tap-to-pay` (which wires the full TTP flow) remains for reference.

#### What this PR does

- **New feature flag** `WOO_POS_TAP_TO_PAY` (defaults to enabled in debug builds via `PackageUtils.isDebugBuild()`).
- **New gating wrapper** `WooPosIsTapToPayAvailable` — composes the POS flag with the main app's existing `TapToPayAvailabilityStatus`, so POS reuses the source-of-truth gating used by the main app's "Order creation > Collect payment" flow: CIAB IPP feature → Android R+ → Google Play Services → NFC hardware → store country in [US, CA, GB]. The two surfaces will never disagree on whether a device qualifies.
- **Payment-method row** in `WooPosCheckoutPaymentButtons` is upgraded to a primary/secondary derivation that depends on form factor, reader-connection state, and TTP availability:
  - Phone primary order: `TTP > CardReader > Cash`.
  - Tablet primary order: `CardReader > Cash` (TTP is never primary on tablet).
  - When the disconnected state has 3 methods (CR + TTP + Cash), the secondary slot becomes an "All payment methods" button that opens an overlay listing every method.
- **All-payment-methods overlay** uses the existing `WooPosDialogWrapper`, which already adapts phone (full-screen) vs tablet (centered modal).
- **Analytics**:
  - On `Checkout` entry, if `TapToPayAvailabilityStatus()` returns `NotAvailable.*`, fire `PaymentsFlowTracker.trackTapToPayNotAvailableReason(reason, source = "woo_pos_checkout")`. POS already overrides `CARD_PRESENT_TAP_TO_PAY_NOT_AVAILABLE` via `WooPosPaymentsFlowTrackerEventProvider`, so attribution is correct. Mirrors `SelectPaymentMethodViewModel.isTapToPayAvailable()` in the main app.
  - New POS event `WooPosAnalyticsEvent.Event.TapToPayEntryPointTapped` fires on TTP button tap.
- **TTP click handler**: logs a TODO and emits the analytics event. No navigation, no card-payment flow.

#### Out of scope (deferred to a follow-up PR)

- `ToTapToPay` parent-child navigation event, route in `WooPosRootHost`, `WooPosCardPaymentViewModel` TTP-mode plumbing.
- Porting `TTPPaymentProgressDelegate`, the dynamic-reader-type changes in `WooPosCardReaderPaymentControllerFactory`, or the `connectTapToPay()`/location-permission flow from the POC.
- TTP-specific error strings.

LOC vs `trunk` (non-test): +256 / −22. One detekt baseline entry was added for `WooPosTotalsViewModel.kt`'s existing `LargeClass` finding (splitting that VM is out of scope for this PR).

### Test Steps

Install a debug build (`./gradlew :WooCommerce:installWasabiDebug`) and run on a supported country/device (US/CA/GB, NFC, Android R+).

1. **Phone, reader disconnected, TTP available**: open POS → checkout. Totals visible; primary button = `Tap to Pay`, secondary = `All payment methods`. Tap secondary → overlay opens with `Card reader`, `Tap to Pay`, `Cash`. Verify each routes correctly:
   - `Cash` → existing cash flow
   - `Card reader` → existing connect-reader flow
   - `Tap to Pay` → no navigation; check `logcat` for the TODO line and verify `TapToPayEntryPointTapped` analytics fires
2. **Phone, reader disconnected, TTP unavailable** (e.g. switch store country to France): primary = `Card reader`, secondary = `Cash`. No TTP anywhere.
3. **Phone, reader connected, TTP available**: primary = `Tap to Pay`, secondary = `Cash`.
4. **Phone, reader connected, TTP unavailable**: single full-width `Cash` button.
5. **Tablet, reader disconnected, TTP available**: primary = `Card reader`, secondary = `All payment methods`.
6. **Tablet, reader connected, TTP available**: primary = `Cash`, secondary = `Tap to Pay`.
7. **Tablet, reader connected, TTP unavailable**: single `Cash` button.
8. **Country gating**: switch to a non-supported country (e.g. France) → TTP disappears from primary, secondary, and the overlay.
9. **Device gating**: on an emulator without NFC → TTP is hidden.
10. **Flag off**: disable `WOO_POS_TAP_TO_PAY` (Settings → Experimental features) → TTP disappears regardless of country/device.
11. **Analytics**: verify `CARD_PRESENT_TAP_TO_PAY_NOT_AVAILABLE` fires once with `source=woo_pos_checkout` and a correct `reason` when entering checkout on an unsupported device, and `TapToPayEntryPointTapped` fires on TTP click.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.