### PR TITLE
[WOOMOB-2909] Implement product card Compose component

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
@@ -1,8 +1,11 @@
 package com.woocommerce.android.ui.aiassistant
 
+import android.content.Context
 import androidx.annotation.ColorRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
@@ -11,7 +14,12 @@ import com.woocommerce.android.ciab.CIABOrderStatusMapper
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.compose.OrderSummaryRow
 import com.woocommerce.android.ui.orders.compose.OrderSummaryRowModel
+import com.woocommerce.android.ui.products.ProductStatus
+import com.woocommerce.android.ui.products.ProductStockStatus
+import com.woocommerce.android.ui.products.compose.ProductSummaryRow
+import com.woocommerce.android.ui.products.compose.ProductSummaryRowInfo
 import com.woocommerce.android.util.CurrencyFormatter
+import java.math.BigDecimal
 
 class WooAssistantCardRenderer(
     private val currencyFormatter: CurrencyFormatter,
@@ -28,9 +36,34 @@ class WooAssistantCardRenderer(
             modifier = modifier,
         )
     }
+
+    @Composable
+    override fun ProductCard(
+        card: AssistantCard.Product,
+        onAction: (AssistantCardAction) -> Unit,
+        modifier: Modifier,
+    ) {
+        val context = LocalContext.current
+        ProductSummaryRow(
+            title = card.name,
+            imageUrl = card.imageUrl,
+            onClick = { onAction(card.toOpenProductAction()) },
+            modifier = modifier,
+            imageContentDescription = stringResource(R.string.product_image_content_description),
+        ) {
+            ProductSummaryRowInfo(card.toStockStatusPriceText(context, currencyFormatter))
+            card.sku
+                .takeIf { it.isNotBlank() }
+                ?.let { sku ->
+                    ProductSummaryRowInfo(context.getString(R.string.orderdetail_product_lineitem_sku_value, sku))
+                }
+        }
+    }
 }
 
 internal fun AssistantCard.Order.toOpenOrderAction() = AssistantCardAction.OpenOrder(remoteOrderId)
+
+internal fun AssistantCard.Product.toOpenProductAction() = AssistantCardAction.OpenProduct(remoteProductId)
 
 internal fun AssistantCard.Order.toOrderSummaryRowModel(currencyFormatter: CurrencyFormatter) = OrderSummaryRowModel(
     number = number,
@@ -48,6 +81,29 @@ private fun AssistantCard.Order.formatTotalPrice(currencyFormatter: CurrencyForm
         currency.isBlank() -> total
         else -> currencyFormatter.formatCurrency(total, currency)
     }
+
+private fun AssistantCard.Product.toStockStatusPriceText(
+    context: Context,
+    currencyFormatter: CurrencyFormatter,
+): String {
+    val productStatus = ProductStatus.fromString(status)
+        ?.takeIf { it != ProductStatus.PUBLISH }
+        ?.toLocalizedString(context)
+    val stock = ProductStockStatus.stockStatusToDisplayString(
+        context,
+        ProductStockStatus.fromString(stockStatus),
+    )
+    val formattedPrice = formatProductPrice(currencyFormatter)
+
+    return listOfNotNull(productStatus, stock, formattedPrice)
+        .filter { it.isNotBlank() }
+        .joinToString(separator = " \u2022 ")
+}
+
+internal fun AssistantCard.Product.formatProductPrice(currencyFormatter: CurrencyFormatter): String =
+    price.toBigDecimalOrNull()
+        ?.let { amount: BigDecimal -> currencyFormatter.buildBigDecimalFormatter()(amount) }
+        ?: price
 
 @ColorRes
 private fun String.toOrderStatusColor(): Int =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
@@ -5,7 +5,6 @@ import androidx.annotation.ColorRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
@@ -44,26 +43,47 @@ class WooAssistantCardRenderer(
         modifier: Modifier,
     ) {
         val context = LocalContext.current
+        val rowModel = card.toProductSummaryRowModel(context, currencyFormatter)
         ProductSummaryRow(
-            title = card.name,
-            imageUrl = card.imageUrl,
-            onClick = { onAction(card.toOpenProductAction()) },
+            title = rowModel.title,
+            imageUrl = rowModel.imageUrl,
+            onClick = card.toProductCardClick(onAction),
             modifier = modifier,
-            imageContentDescription = stringResource(R.string.product_image_content_description),
         ) {
-            ProductSummaryRowInfo(card.toStockStatusPriceText(context, currencyFormatter))
-            card.sku
-                .takeIf { it.isNotBlank() }
-                ?.let { sku ->
-                    ProductSummaryRowInfo(context.getString(R.string.orderdetail_product_lineitem_sku_value, sku))
-                }
+            ProductSummaryRowInfo(rowModel.stockStatusPriceText)
+            rowModel.skuText?.let { sku -> ProductSummaryRowInfo(sku) }
         }
     }
 }
 
+internal data class AssistantProductSummaryRowModel(
+    val title: String,
+    val imageUrl: String,
+    val stockStatusPriceText: String,
+    val skuText: String?,
+)
+
 internal fun AssistantCard.Order.toOpenOrderAction() = AssistantCardAction.OpenOrder(remoteOrderId)
 
 internal fun AssistantCard.Product.toOpenProductAction() = AssistantCardAction.OpenProduct(remoteProductId)
+
+internal fun AssistantCard.Product.toProductCardClick(
+    onAction: (AssistantCardAction) -> Unit,
+): () -> Unit = {
+    onAction(toOpenProductAction())
+}
+
+internal fun AssistantCard.Product.toProductSummaryRowModel(
+    context: Context,
+    currencyFormatter: CurrencyFormatter,
+) = AssistantProductSummaryRowModel(
+    title = name,
+    imageUrl = imageUrl,
+    stockStatusPriceText = toStockStatusPriceText(context, currencyFormatter),
+    skuText = sku
+        .takeIf { it.isNotBlank() }
+        ?.let { context.getString(R.string.orderdetail_product_lineitem_sku_value, it) },
+)
 
 internal fun AssistantCard.Order.toOrderSummaryRowModel(currencyFormatter: CurrencyFormatter) = OrderSummaryRowModel(
     number = number,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.LiveData
@@ -260,6 +261,10 @@ fun ProductStockRow(
         onClick = { onItemClicked(product) },
         displayDivider = displayDivider,
         modifier = modifier,
+        contentVerticalArrangement = Arrangement.Top,
+        dividerContent = {
+            Divider(modifier = Modifier.padding(top = 8.dp))
+        },
         trailingContent = {
             Text(
                 text = product.stockQuantity,
@@ -274,6 +279,10 @@ fun ProductStockRow(
                 else -> stringResource(R.string.dashboard_product_stock_sales_last_30_days, product.itemsSold)
             },
             modifier = Modifier.padding(bottom = 8.dp),
+            color = colorResource(id = R.color.color_on_surface_medium_selector),
+            maxLines = Int.MAX_VALUE,
+            overflow = TextOverflow.Clip,
+            style = MaterialTheme.typography.body2,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
@@ -1,11 +1,9 @@
 package com.woocommerce.android.ui.dashboard.stock
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -26,7 +24,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.LiveData
@@ -37,7 +34,6 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.ui.compose.animations.SkeletonView
-import com.woocommerce.android.ui.compose.component.ProductThumbnail
 import com.woocommerce.android.ui.compose.rememberNavController
 import com.woocommerce.android.ui.dashboard.DashboardFilterableCardHeader
 import com.woocommerce.android.ui.dashboard.DashboardViewModel
@@ -48,6 +44,8 @@ import com.woocommerce.android.ui.dashboard.WidgetError
 import com.woocommerce.android.ui.dashboard.defaultHideMenuEntry
 import com.woocommerce.android.ui.dashboard.stock.DashboardProductStockViewModel.OpenProductDetail
 import com.woocommerce.android.ui.products.ProductStockStatus
+import com.woocommerce.android.ui.products.compose.ProductSummaryRow
+import com.woocommerce.android.ui.products.compose.ProductSummaryRowInfo
 import com.woocommerce.android.ui.products.details.ProductDetailFragment.Mode.ShowProduct
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 
@@ -256,49 +254,27 @@ fun ProductStockRow(
     displayDivider: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable { onItemClicked(product) }
-            .padding(horizontal = 16.dp),
-        verticalAlignment = Alignment.Top
-    ) {
-        ProductThumbnail(
-            imageUrl = product.imageUrl ?: "",
-            contentDescription = stringResource(id = R.string.product_image_content_description),
-            modifier = Modifier.padding(top = 12.dp)
-        )
-        Column(modifier = Modifier.padding(start = 8.dp)) {
-            Spacer(modifier = Modifier.height(8.dp))
-            Row(modifier = Modifier.padding(bottom = 4.dp)) {
-                Text(
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(end = 8.dp),
-                    text = product.name,
-                    style = MaterialTheme.typography.subtitle1,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Text(
-                    text = product.stockQuantity,
-                    style = MaterialTheme.typography.subtitle1,
-                    color = colorResource(id = R.color.color_error)
-                )
-            }
+    ProductSummaryRow(
+        title = product.name,
+        imageUrl = product.imageUrl,
+        onClick = { onItemClicked(product) },
+        displayDivider = displayDivider,
+        modifier = modifier,
+        trailingContent = {
             Text(
-                modifier = Modifier.padding(bottom = 8.dp),
-                text = when {
-                    product.itemsSold == 0 -> stringResource(R.string.dashboard_product_stock_no_sales_last_30_days)
-                    else -> stringResource(R.string.dashboard_product_stock_sales_last_30_days, product.itemsSold)
-                },
-                style = MaterialTheme.typography.body2,
-                color = colorResource(id = R.color.color_on_surface_medium_selector)
+                text = product.stockQuantity,
+                color = colorResource(id = R.color.color_error),
+                style = MaterialTheme.typography.subtitle1,
             )
-            if (displayDivider) {
-                Divider(modifier = Modifier.padding(top = 8.dp))
-            }
-        }
+        },
+    ) {
+        ProductSummaryRowInfo(
+            text = when {
+                product.itemsSold == 0 -> stringResource(R.string.dashboard_product_stock_no_sales_last_30_days)
+                else -> stringResource(R.string.dashboard_product_stock_sales_last_30_days, product.itemsSold)
+            },
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/compose/ProductSummaryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/compose/ProductSummaryRow.kt
@@ -16,9 +16,12 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
@@ -34,6 +37,8 @@ fun ProductSummaryRow(
     enabled: Boolean = true,
     displayDivider: Boolean = false,
     imageContentDescription: String = stringResource(id = R.string.product_image_content_description),
+    contentVerticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(4.dp),
+    dividerContent: @Composable (() -> Unit)? = null,
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
     subtitle: @Composable ColumnScope.() -> Unit,
 ) {
@@ -53,7 +58,7 @@ fun ProductSummaryRow(
             modifier = Modifier
                 .weight(1f)
                 .padding(start = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
+            verticalArrangement = contentVerticalArrangement,
         ) {
             Spacer(modifier = Modifier.height(8.dp))
             Row(
@@ -74,10 +79,7 @@ fun ProductSummaryRow(
             }
             subtitle()
             if (displayDivider) {
-                Divider(
-                    modifier = Modifier.padding(top = 4.dp),
-                    color = colorResource(id = R.color.divider_color),
-                )
+                dividerContent?.invoke() ?: ProductSummaryRowDivider()
             }
         }
     }
@@ -87,14 +89,28 @@ fun ProductSummaryRow(
 fun ProductSummaryRowInfo(
     text: String,
     modifier: Modifier = Modifier,
+    color: Color = colorResource(id = R.color.color_on_surface_medium),
+    maxLines: Int = 1,
+    overflow: TextOverflow = TextOverflow.Ellipsis,
+    style: TextStyle = MaterialTheme.typography.caption,
 ) {
     Text(
         modifier = modifier,
         text = text,
-        color = colorResource(id = R.color.color_on_surface_medium),
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-        style = MaterialTheme.typography.caption,
+        color = color,
+        maxLines = maxLines,
+        overflow = overflow,
+        style = style,
+    )
+}
+
+@Composable
+private fun ProductSummaryRowDivider(
+    topPadding: Dp = 4.dp,
+) {
+    Divider(
+        modifier = Modifier.padding(top = topPadding),
+        color = colorResource(id = R.color.divider_color),
     )
 }
 
@@ -104,7 +120,7 @@ private fun ProductSummaryRowPreview() {
     WooThemeWithBackground {
         ProductSummaryRow(
             title = "Woo socks",
-            imageUrl = null,
+            imageUrl = "https://example.com/socks.png",
             onClick = {},
         ) {
             ProductSummaryRowInfo("In stock \u2022 \$9.99")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/compose/ProductSummaryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/compose/ProductSummaryRow.kt
@@ -1,0 +1,114 @@
+package com.woocommerce.android.ui.products.compose
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.ProductThumbnail
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+
+@Composable
+fun ProductSummaryRow(
+    title: String,
+    imageUrl: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    displayDivider: Boolean = false,
+    imageContentDescription: String = stringResource(id = R.string.product_image_content_description),
+    trailingContent: (@Composable RowScope.() -> Unit)? = null,
+    subtitle: @Composable ColumnScope.() -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        ProductThumbnail(
+            imageUrl = imageUrl.orEmpty(),
+            contentDescription = imageContentDescription,
+            modifier = Modifier.padding(top = 12.dp),
+        )
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.padding(bottom = 4.dp),
+                verticalAlignment = Alignment.Top,
+            ) {
+                Text(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(end = if (trailingContent == null) 0.dp else 8.dp),
+                    text = title,
+                    color = MaterialTheme.colors.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.subtitle1,
+                )
+                trailingContent?.invoke(this)
+            }
+            subtitle()
+            if (displayDivider) {
+                Divider(
+                    modifier = Modifier.padding(top = 4.dp),
+                    color = colorResource(id = R.color.divider_color),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ProductSummaryRowInfo(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        modifier = modifier,
+        text = text,
+        color = colorResource(id = R.color.color_on_surface_medium),
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        style = MaterialTheme.typography.caption,
+    )
+}
+
+@LightDarkThemePreviews
+@Composable
+private fun ProductSummaryRowPreview() {
+    WooThemeWithBackground {
+        ProductSummaryRow(
+            title = "Woo socks",
+            imageUrl = null,
+            onClick = {},
+        ) {
+            ProductSummaryRowInfo("In stock \u2022 \$9.99")
+            ProductSummaryRowInfo("SKU: woo-socks")
+        }
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
@@ -9,6 +9,7 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.math.BigDecimal
 
 class WooAssistantCardRendererTest {
     private val currencyFormatter: CurrencyFormatter = mock()
@@ -44,6 +45,30 @@ class WooAssistantCardRendererTest {
     }
 
     @Test
+    fun `given assistant product card, when action helper is used, then open product id is used`() {
+        val action = productCard().toOpenProductAction()
+
+        assertThat(action).isEqualTo(AssistantCardAction.OpenProduct(remoteProductId = 456L))
+    }
+
+    @Test
+    fun `given assistant product card, when price is numeric, then host formatter formats it`() {
+        val decimalFormatter: (BigDecimal) -> String = { amount -> "\$${amount.toPlainString()}" }
+        whenever(currencyFormatter.buildBigDecimalFormatter()).thenReturn(decimalFormatter)
+
+        val price = productCard(price = "9.99").formatProductPrice(currencyFormatter)
+
+        assertThat(price).isEqualTo("$9.99")
+    }
+
+    @Test
+    fun `given assistant product card, when price is not numeric, then raw price is used`() {
+        val price = productCard(price = "Free").formatProductPrice(currencyFormatter)
+
+        assertThat(price).isEqualTo("Free")
+    }
+
+    @Test
     fun `given ciab open status, when mapped, then processing color is used like dashboard orders`() {
         val model = orderCard(status = "open", currency = "").toOrderSummaryRowModel(currencyFormatter)
 
@@ -61,5 +86,17 @@ class WooAssistantCardRendererTest {
         currency = currency,
         customerName = "Jane Doe",
         date = "2026-05-01T10:00:00Z",
+    )
+
+    private fun productCard(
+        price: String = "9.99",
+    ) = AssistantCard.Product(
+        remoteProductId = 456L,
+        name = "Socks",
+        sku = "woo-socks",
+        price = price,
+        stockStatus = "instock",
+        status = "publish",
+        imageUrl = "https://example.com/socks.png",
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.aiassistant
 
+import android.content.Context
 import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
@@ -49,6 +50,36 @@ class WooAssistantCardRendererTest {
         val action = productCard().toOpenProductAction()
 
         assertThat(action).isEqualTo(AssistantCardAction.OpenProduct(remoteProductId = 456L))
+    }
+
+    @Test
+    fun `given assistant product card, when click helper is invoked, then open product action is emitted`() {
+        val actions = mutableListOf<AssistantCardAction>()
+
+        productCard().toProductCardClick(actions::add).invoke()
+
+        assertThat(actions).containsExactly(AssistantCardAction.OpenProduct(remoteProductId = 456L))
+    }
+
+    @Test
+    fun `given assistant product card, when row model is built, then product image url is preserved`() {
+        val context: Context = mock()
+        val decimalFormatter: (BigDecimal) -> String = { amount -> "\$${amount.toPlainString()}" }
+        whenever(context.getString(R.string.product_stock_status_instock)).thenReturn("In stock")
+        whenever(context.getString(R.string.orderdetail_product_lineitem_sku_value, "woo-socks"))
+            .thenReturn("SKU: woo-socks")
+        whenever(currencyFormatter.buildBigDecimalFormatter()).thenReturn(decimalFormatter)
+
+        val model = productCard().toProductSummaryRowModel(context, currencyFormatter)
+
+        assertThat(model).isEqualTo(
+            AssistantProductSummaryRowModel(
+                title = "Socks",
+                imageUrl = "https://example.com/socks.png",
+                stockStatusPriceText = "In stock \u2022 \$9.99",
+                skuText = "SKU: woo-socks",
+            )
+        )
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
@@ -142,5 +142,6 @@ internal sealed interface ShowCardDetails {
         val price: String? = null,
         @SerialName("stock_status") val stockStatus: String? = null,
         val status: String? = null,
+        @SerialName("image_url") val imageUrl: String? = null,
     ) : ShowCardDetails
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
@@ -131,6 +131,7 @@ internal class DefaultShowCardsResolver @Inject constructor(
                 price = price.takeIf { it.isNotBlank() },
                 stockStatus = stockStatus.takeIf { it.isNotBlank() },
                 status = status.takeIf { it.isNotBlank() },
+                imageUrl = getFirstImageUrl()?.takeIf { it.isNotBlank() },
             ),
         ),
     )

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -924,7 +924,7 @@ private fun sampleProductCard() = AssistantCard.Product(
     price = "9.99",
     stockStatus = "instock",
     status = "publish",
-    imageUrl = "",
+    imageUrl = "https://example.com/socks.png",
 )
 
 private val AssistantCard.Order.unformattedTotal: String

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -401,6 +401,7 @@ private fun AssistantCardSegment(
             onAction = onCardAction,
             modifier = Modifier.fillMaxWidth(),
         )
+        is AssistantCard.Product -> Unit
     }
 }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -401,7 +401,11 @@ private fun AssistantCardSegment(
             onAction = onCardAction,
             modifier = Modifier.fillMaxWidth(),
         )
-        is AssistantCard.Product -> Unit
+        is AssistantCard.Product -> assistantCardRenderer.ProductCard(
+            card = card,
+            onAction = onCardAction,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }
 
@@ -774,6 +778,8 @@ private fun AssistantChatScreenPreview() {
                     segments = listOf(
                         AssistantUiSegment.Text("Here is order #3479."),
                         AssistantUiSegment.Card(sampleOrderCard()),
+                        AssistantUiSegment.Text("Here is a matching product."),
+                        AssistantUiSegment.Card(sampleProductCard()),
                     ),
                 ),
             )
@@ -866,6 +872,39 @@ private object PreviewAssistantCardRenderer : AssistantCardRenderer {
             }
         }
     }
+
+    @Composable
+    override fun ProductCard(
+        card: AssistantCard.Product,
+        onAction: (AssistantCardAction) -> Unit,
+        modifier: Modifier,
+    ) {
+        Surface(
+            modifier = modifier,
+            shape = RoundedCornerShape(12.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        ) {
+            Column(
+                modifier = Modifier.padding(14.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = card.name,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = listOf(card.stockStatus, card.price)
+                        .filter { it.isNotBlank() }
+                        .joinToString(" - "),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
 }
 
 private fun sampleOrderCard() = AssistantCard.Order(
@@ -876,6 +915,16 @@ private fun sampleOrderCard() = AssistantCard.Order(
     currency = "USD",
     customerName = "Jane Doe",
     date = "2026-05-01T10:00:00Z",
+)
+
+private fun sampleProductCard() = AssistantCard.Product(
+    remoteProductId = 456L,
+    name = "Woo socks",
+    sku = "woo-socks",
+    price = "9.99",
+    stockStatus = "instock",
+    status = "publish",
+    imageUrl = "",
 )
 
 private val AssistantCard.Order.unformattedTotal: String

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCard.kt
@@ -10,4 +10,14 @@ sealed interface AssistantCard {
         val customerName: String,
         val date: String,
     ) : AssistantCard
+
+    data class Product(
+        val remoteProductId: Long,
+        val name: String,
+        val sku: String,
+        val price: String,
+        val stockStatus: String,
+        val status: String,
+        val imageUrl: String,
+    ) : AssistantCard
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
@@ -8,9 +8,14 @@ internal object AssistantCardPayloadParser {
     fun parse(payload: ShowCardsUiStructured): List<AssistantCard> =
         payload.cards.mapNotNull(::parseCard)
 
-    private fun parseCard(card: ShowCardPayload): AssistantCard? {
-        if (card.family != ORDER_FAMILY) return null
+    private fun parseCard(card: ShowCardPayload): AssistantCard? =
+        when (card.family) {
+            ORDER_FAMILY -> parseOrderCard(card)
+            PRODUCT_FAMILY -> parseProductCard(card)
+            else -> null
+        }
 
+    private fun parseOrderCard(card: ShowCardPayload): AssistantCard? {
         val remoteOrderId = card.id.toLongOrNull()?.takeIf { it > 0 } ?: return null
         val details = card.details as? ShowCardDetails.Order ?: return null
 
@@ -25,5 +30,21 @@ internal object AssistantCardPayloadParser {
         )
     }
 
+    private fun parseProductCard(card: ShowCardPayload): AssistantCard? {
+        val remoteProductId = card.id.toLongOrNull()?.takeIf { it > 0 } ?: return null
+        val details = card.details as? ShowCardDetails.Product ?: return null
+
+        return AssistantCard.Product(
+            remoteProductId = remoteProductId,
+            name = card.title,
+            sku = details.sku.orEmpty(),
+            price = details.price.orEmpty(),
+            stockStatus = details.stockStatus.orEmpty(),
+            status = details.status.orEmpty(),
+            imageUrl = details.imageUrl.orEmpty(),
+        )
+    }
+
     private const val ORDER_FAMILY = "order"
+    private const val PRODUCT_FAMILY = "product"
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardRenderer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardRenderer.kt
@@ -10,4 +10,11 @@ interface AssistantCardRenderer {
         onAction: (AssistantCardAction) -> Unit,
         modifier: Modifier,
     )
+
+    @Composable
+    fun ProductCard(
+        card: AssistantCard.Product,
+        onAction: (AssistantCardAction) -> Unit,
+        modifier: Modifier,
+    )
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -171,8 +171,10 @@ class ShowCardsToolHandlerTest {
         assertThat(details.price).isEqualTo("9.99")
         assertThat(details.stockStatus).isEqualTo("instock")
         assertThat(details.status).isEqualTo("publish")
+        assertThat(details.imageUrl).isEqualTo(PRODUCT_IMAGE_URL)
         assertThat(uiCards(result).single().jsonObject.keys).doesNotContain("subtitle", "badges", "attributes")
         assertThat(assertSuccess(result).structured.toString()).doesNotContain("details")
+        assertThat(assertSuccess(result).structured.toString()).doesNotContain("image_url")
     }
 
     @Test
@@ -434,6 +436,7 @@ class ShowCardsToolHandlerTest {
                     price = "9.99",
                     stockStatus = "instock",
                     status = "publish",
+                    imageUrl = PRODUCT_IMAGE_URL,
                 ),
             )
         )
@@ -494,5 +497,9 @@ class ShowCardsToolHandlerTest {
     private object ThrowingResolver : ShowCardsResolver {
         override suspend fun resolve(refs: List<ValidatedRef>): List<ShowCardsResolution> =
             error("Resolver failed")
+    }
+
+    private companion object {
+        private const val PRODUCT_IMAGE_URL = "https://example.com/socks.png"
     }
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
@@ -135,6 +135,7 @@ class ShowCardsResolverTest {
         assertThat(productDetails.price).isEqualTo("9.99")
         assertThat(productDetails.stockStatus).isEqualTo("instock")
         assertThat(productDetails.status).isEqualTo("publish")
+        assertThat(productDetails.imageUrl).isEqualTo(PRODUCT_IMAGE_URL)
     }
 
     @Test
@@ -235,5 +236,10 @@ class ShowCardsResolverTest {
         price = "9.99",
         stockStatus = "instock",
         status = "publish",
+        images = """[{"id":7,"src":"$PRODUCT_IMAGE_URL"}]""",
     )
+
+    private companion object {
+        private const val PRODUCT_IMAGE_URL = "https://example.com/socks.png"
+    }
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
@@ -70,7 +70,7 @@ class AssistantCardPayloadParserTest {
     }
 
     @Test
-    fun `given product and invalid order payloads, when parsed, then they are ignored`() {
+    fun `given product payload, when parsed, then product card contains displayed fields`() {
         val cards = AssistantCardPayloadParser.parse(
             ShowCardsUiStructured(
                 cards = listOf(
@@ -78,13 +78,47 @@ class AssistantCardPayloadParserTest {
                         family = "product",
                         id = "456",
                         title = "Socks",
+                        details = ShowCardDetails.Product(
+                            sku = "woo-socks",
+                            price = "9.99",
+                            stockStatus = "instock",
+                            status = "publish",
+                            imageUrl = "https://example.com/socks.png",
+                        ),
+                    )
+                )
+            )
+        )
+
+        assertThat(cards).containsExactly(
+            AssistantCard.Product(
+                remoteProductId = 456L,
+                name = "Socks",
+                sku = "woo-socks",
+                price = "9.99",
+                stockStatus = "instock",
+                status = "publish",
+                imageUrl = "https://example.com/socks.png",
+            )
+        )
+    }
+
+    @Test
+    fun `given unsupported and invalid payloads, when parsed, then they are ignored`() {
+        val cards = AssistantCardPayloadParser.parse(
+            ShowCardsUiStructured(
+                cards = listOf(
+                    ShowCardPayload(
+                        family = "customer",
+                        id = "456",
+                        title = "Customer",
                         details = ShowCardDetails.Product(),
                     ),
                     ShowCardPayload(
-                        family = "order",
+                        family = "product",
                         id = "not-a-number",
-                        title = "#bad",
-                        details = ShowCardDetails.Order(),
+                        title = "Bad product",
+                        details = ShowCardDetails.Product(),
                     ),
                     ShowCardPayload(
                         family = "order",

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
@@ -9,12 +9,12 @@ import org.junit.Test
 
 class AssistantCardSegmentMapperTest {
     @Test
-    fun `given show cards payload, when mapped, then card segments preserve parsed card order`() {
+    fun `given order and product payloads, when mapped, then card segments preserve parsed card order`() {
         val segments = AssistantCardSegmentMapper.toSegments(
             ShowCardsUiStructured(
                 cards = listOf(
                     orderPayload(id = "1", title = "#1"),
-                    orderPayload(id = "2", title = "#2"),
+                    productPayload(id = "2", title = "Socks"),
                 )
             )
         )
@@ -32,14 +32,14 @@ class AssistantCardSegmentMapperTest {
                 )
             ),
             AssistantUiSegment.Card(
-                AssistantCard.Order(
-                    remoteOrderId = 2L,
-                    number = "#2",
-                    status = "processing",
-                    total = "12.34",
-                    currency = "USD",
-                    customerName = "Jane Doe",
-                    date = "2026-05-01T10:00:00Z",
+                AssistantCard.Product(
+                    remoteProductId = 2L,
+                    name = "Socks",
+                    sku = "woo-socks",
+                    price = "9.99",
+                    stockStatus = "instock",
+                    status = "publish",
+                    imageUrl = "https://example.com/socks.png",
                 )
             ),
         )
@@ -51,9 +51,9 @@ class AssistantCardSegmentMapperTest {
             ShowCardsUiStructured(
                 cards = listOf(
                     ShowCardPayload(
-                        family = "product",
+                        family = "customer",
                         id = "456",
-                        title = "Socks",
+                        title = "Customer",
                         details = ShowCardDetails.Product(),
                     ),
                     ShowCardPayload(
@@ -79,6 +79,19 @@ class AssistantCardSegmentMapperTest {
             currency = "USD",
             dateCreated = "2026-05-01T10:00:00Z",
             customerName = "Jane Doe",
+        ),
+    )
+
+    private fun productPayload(id: String, title: String) = ShowCardPayload(
+        family = "product",
+        id = id,
+        title = title,
+        details = ShowCardDetails.Product(
+            sku = "woo-socks",
+            price = "9.99",
+            stockStatus = "instock",
+            status = "publish",
+            imageUrl = "https://example.com/socks.png",
         ),
     )
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2909

This PR implements assistant product-card rendering for `show_cards` UI payloads, following the same assistant-owned contract and host renderer pattern introduced for order cards in #15806. The assistant module owns the product card protocol, payload parsing, renderer interface, and typed card actions; the WooCommerce host app owns product UI reuse and navigation.

#### What changed

Product references returned by `show_cards` can now be parsed into stateless `AssistantCard.Product` models with the fields the card needs to render: product name, price, stock status, SKU, image URL, status, and remote product ID.

The product UI payload now includes app-owned image data through `uiStructured.details.image_url`. The compact model-visible `structured` payload remains intentionally small and still excludes image data, so the assistant can render richer local UI without sending full render payloads back into model history.

The assistant chat renderer contract now includes `ProductCard(card, onAction, modifier)`. The host app implements that callback in `WooAssistantCardRenderer`, maps product cards into a reusable host row model, and emits `AssistantCardAction.OpenProduct(remoteProductId)` when the row is tapped.

#### Host UI reuse and boundaries

This PR extracts the reusable row shape from the dashboard product stock card into `ProductSummaryRow`, reusing the existing `ProductThumbnail` primitive and keeping product-specific rendering in `:WooCommerce`. The dashboard `ProductStockRow` now delegates to that shared row while preserving its previous stock quantity, sales subtitle typography, wrapping, divider spacing, and disabled-state color behavior.

The product selector row was reviewed as a reuse candidate, but it includes selector-specific affordances such as checkbox / action controls, so this PR keeps it out of the assistant path. The new `ProductSummaryRow` is general enough for Product Selector to wrap later if that becomes useful.

No reverse dependency is introduced: `:libs:ai-assistant:feature` has no dependency on `:WooCommerce` and does not import host product UI. Runtime `uiStructured` propagation through the assistant ViewModel/runtime is intentionally out of scope for this slice.

#### Tests added or updated

This PR adds focused coverage for:

- parsing typed product card payloads into `AssistantCard.Product`
- preserving order/product card segment mapping
- adding product image data to UI-only `show_cards` details while keeping compact `structured` image-free
- preserving the product image URL through the host renderer row model
- emitting `AssistantCardAction.OpenProduct` from the renderer click callback
- formatting product price through the host currency formatter, with raw fallback behavior
- preserving existing product-detail navigation for `OpenProduct`

### Test Steps
Non-regression only until a follow-up runtime slice delivers `show_cards` UI payloads into assistant messages.

1. Build and install the Wasabi debug app from this branch.
2. Open the dashboard on a store that shows product stock rows.
3. Confirm product stock rows still show the product image, product title, stock quantity, sales subtitle, and divider with the same visual hierarchy as before.
4. Open the AI Assistant from the More menu.
5. Confirm the assistant chat screen still opens, sends normal text messages, and handles back navigation as before.
6. There is no direct runtime product-card flow to tap on this base branch; product-card parsing, image propagation, host row mapping, and `OpenProduct` click behavior are covered by focused unit tests and previews.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.