### PR TITLE
[WOOMOB-2970] Add typing and tool activity indicators to assistant chat

### DIFF
--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
@@ -85,8 +85,17 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
                 is LoopEvent.ConfirmationResolved -> emit(
                     AssistantRuntimeEvent.ConfirmationResolved(event.result)
                 )
-                is LoopEvent.ToolCallFinished,
-                is LoopEvent.ToolCallStarted -> Unit
+                is LoopEvent.ToolCallStarted -> emit(
+                    AssistantRuntimeEvent.ToolCallStarted(
+                        toolCallId = event.call.id,
+                        toolName = event.call.name,
+                    )
+                )
+                is LoopEvent.ToolCallFinished -> emit(
+                    AssistantRuntimeEvent.ToolCallFinished(
+                        toolCallId = event.result.toolCallId,
+                    )
+                )
             }
         }
     }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
@@ -29,6 +29,15 @@ data class AssistantTurnRequest(
 sealed interface AssistantRuntimeEvent {
     data class AssistantTextDelta(val text: String) : AssistantRuntimeEvent
 
+    data class ToolCallStarted(
+        val toolCallId: String,
+        val toolName: String,
+    ) : AssistantRuntimeEvent
+
+    data class ToolCallFinished(
+        val toolCallId: String,
+    ) : AssistantRuntimeEvent
+
     data class AwaitingConfirmation(
         val confirmation: AssistantConfirmationCard,
     ) : AssistantRuntimeEvent

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -153,7 +153,7 @@ fun AssistantChatScreen(
                 .imePadding(),
         ) {
             AssistantMessageThread(
-                messages = state.messages,
+                state = state,
                 onRetry = onRetry,
                 onConfirmWrite = onConfirmWrite,
                 onCancelWrite = onCancelWrite,
@@ -235,7 +235,7 @@ private fun AssistantStatusLabel(status: AssistantUiStatus) {
 
 @Composable
 private fun AssistantMessageThread(
-    messages: List<AssistantUiMessage>,
+    state: AssistantUiState,
     onRetry: () -> Unit,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
@@ -243,8 +243,9 @@ private fun AssistantMessageThread(
     onCardAction: (AssistantCardAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val messages = state.messages
     val listState = rememberLazyListState()
-    LaunchedEffect(messages.size, messages.lastOrNull()?.segments) {
+    LaunchedEffect(messages.size, messages.lastOrNull()?.segments, state.activeAssistantMessageId) {
         if (messages.isNotEmpty()) {
             listState.animateScrollToItem(messages.lastIndex)
         }
@@ -262,6 +263,7 @@ private fun AssistantMessageThread(
         ) { message ->
             AssistantMessageBubble(
                 message = message,
+                showTypingIndicator = state.shouldShowTypingIndicator(message),
                 onRetry = onRetry,
                 onConfirmWrite = onConfirmWrite,
                 onCancelWrite = onCancelWrite,
@@ -275,6 +277,7 @@ private fun AssistantMessageThread(
 @Composable
 private fun AssistantMessageBubble(
     message: AssistantUiMessage,
+    showTypingIndicator: Boolean,
     onRetry: () -> Unit,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
@@ -283,10 +286,10 @@ private fun AssistantMessageBubble(
 ) {
     val isUser = message.role == AssistantUiMessage.Role.USER
     val messageText = message.text.ifEmpty { " " }
-    val messageContentDescription = if (isUser) {
-        stringResource(R.string.assistant_chat_message_user_content_description, messageText)
-    } else {
-        stringResource(R.string.assistant_chat_message_assistant_content_description, messageText)
+    val messageContentDescription = when {
+        isUser -> stringResource(R.string.assistant_chat_message_user_content_description, messageText)
+        showTypingIndicator -> stringResource(R.string.assistant_chat_typing_content_description)
+        else -> stringResource(R.string.assistant_chat_message_assistant_content_description, messageText)
     }
     val bubbleColor = if (isUser) {
         MaterialTheme.colorScheme.primary
@@ -308,7 +311,7 @@ private fun AssistantMessageBubble(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .semantics { contentDescription = messageContentDescription },
+            .semantics(mergeDescendants = true) { contentDescription = messageContentDescription },
         horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
     ) {
         Box(
@@ -344,7 +347,9 @@ private fun AssistantMessageBubble(
                         onRetry = onRetry,
                     )
                 }
-                if (message.shouldShowEmptyPlaceholder()) {
+                if (showTypingIndicator) {
+                    AssistantTypingIndicator()
+                } else if (message.shouldShowEmptyPlaceholder()) {
                     Text(
                         text = " ",
                         color = textColor,
@@ -354,6 +359,15 @@ private fun AssistantMessageBubble(
             }
         }
     }
+}
+
+@Composable
+private fun AssistantTypingIndicator() {
+    Text(
+        text = stringResource(R.string.assistant_chat_typing_indicator),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodyMedium,
+    )
 }
 
 @Composable
@@ -760,6 +774,30 @@ private fun AssistantUiStatus.toHeaderText(): String = when (this) {
         R.string.assistant_chat_status_awaiting_confirmation
     )
     AssistantUiStatus.ERROR -> stringResource(R.string.assistant_chat_status_error)
+}
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 720)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 720, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantChatScreenTypingPreview() {
+    AssistantChatScreen(
+        state = AssistantUiState(
+            messages = listOf(
+                AssistantUiMessage("preview-1", AssistantUiMessage.Role.USER, "Show today's sales"),
+                AssistantUiMessage("preview-2", AssistantUiMessage.Role.ASSISTANT, ""),
+            ),
+            status = AssistantUiStatus.STREAMING,
+            activeAssistantMessageId = "preview-2",
+        ),
+        inputText = "",
+        onInputTextChange = {},
+        onSendMessage = {},
+        onCancelTurn = {},
+        onRetry = {},
+        onConfirmWrite = {},
+        onCancelWrite = {},
+        onBack = {},
+    )
 }
 
 @Preview(showBackground = true, widthDp = 390, heightDp = 720)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -288,6 +289,7 @@ private fun AssistantMessageBubble(
         message = message,
         showTypingIndicator = showTypingIndicator,
     )
+    val showBubbleChrome = !message.isStandaloneToolActivity()
 
     Row(
         modifier = Modifier
@@ -298,16 +300,27 @@ private fun AssistantMessageBubble(
         Box(
             modifier = Modifier
                 .widthIn(max = 360.dp)
-                .heightIn(min = 40.dp)
-                .background(chrome.bubbleColor, chrome.shape)
                 .then(
-                    if (chrome.isUser) {
+                    if (showBubbleChrome) {
                         Modifier
+                            .heightIn(min = 40.dp)
+                            .background(chrome.bubbleColor, chrome.shape)
+                            .then(
+                                if (chrome.isUser) {
+                                    Modifier
+                                } else {
+                                    Modifier.border(
+                                        width = 1.dp,
+                                        color = MaterialTheme.colorScheme.outlineVariant,
+                                        shape = chrome.shape,
+                                    )
+                                }
+                            )
+                            .padding(horizontal = 14.dp, vertical = 10.dp)
                     } else {
-                        Modifier.border(1.dp, MaterialTheme.colorScheme.outlineVariant, chrome.shape)
+                        Modifier
                     }
-                )
-                .padding(horizontal = 14.dp, vertical = 10.dp),
+                ),
             contentAlignment = Alignment.CenterStart,
         ) {
             Column(
@@ -409,12 +422,23 @@ private data class AssistantMessageBubbleChrome(
 
 @Composable
 private fun AssistantTypingIndicator() {
-    Text(
-        text = stringResource(R.string.assistant_chat_typing_indicator),
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        style = MaterialTheme.typography.bodyMedium,
-    )
+    Row(
+        modifier = Modifier.padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val dotColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+        repeat(TYPING_INDICATOR_DOT_COUNT) {
+            Box(
+                modifier = Modifier
+                    .size(6.dp)
+                    .background(color = dotColor, shape = CircleShape),
+            )
+        }
+    }
 }
+
+private const val TYPING_INDICATOR_DOT_COUNT = 3
 
 @Composable
 private fun AssistantMessageSegments(
@@ -452,23 +476,19 @@ private fun AssistantMessageSegments(
 private fun AssistantToolActivityPill(activity: AssistantToolActivity) {
     val label = stringResource(activity.labelRes())
     Surface(
-        shape = RoundedCornerShape(50),
+        shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Box(
-                modifier = Modifier
-                    .size(7.dp)
-                    .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(50)),
-            )
+            ToolActivityProgressDots()
             Text(
                 text = label,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.labelMedium,
@@ -497,6 +517,23 @@ private fun AssistantCardSegment(
             onAction = onCardAction,
             modifier = Modifier.fillMaxWidth(),
         )
+    }
+}
+
+@Composable
+private fun ToolActivityProgressDots() {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val dotColor = MaterialTheme.colorScheme.primary
+        repeat(TYPING_INDICATOR_DOT_COUNT) {
+            Box(
+                modifier = Modifier
+                    .size(4.dp)
+                    .background(color = dotColor, shape = CircleShape),
+            )
+        }
     }
 }
 
@@ -539,6 +576,12 @@ private fun AssistantInlineError(
 
 private fun AssistantUiMessage.shouldShowEmptyPlaceholder(): Boolean =
     segments.all { it is AssistantUiSegment.Text && it.text.isEmpty() } && error == null
+
+private fun AssistantUiMessage.isStandaloneToolActivity(): Boolean =
+    role == AssistantUiMessage.Role.ASSISTANT &&
+        error == null &&
+        segments.isNotEmpty() &&
+        segments.all { it is AssistantUiSegment.ToolActivity }
 
 @Composable
 private fun AssistantStatusPanel(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -11,26 +11,17 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -45,15 +36,11 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -65,6 +52,10 @@ import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreviewFie
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardRenderer
+import com.woocommerce.android.aiassistant.ui.components.AssistantComposer
+import com.woocommerce.android.aiassistant.ui.components.AssistantConfirmationCardSegment
+import com.woocommerce.android.aiassistant.ui.components.AssistantToolActivityPill
+import com.woocommerce.android.aiassistant.ui.components.AssistantTypingIndicator
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -216,9 +207,7 @@ private fun AssistantStatusLabel(status: AssistantUiStatus) {
         modifier = Modifier
             .padding(end = 12.dp)
             .widthIn(max = 156.dp)
-            .semantics {
-                contentDescription = statusContentDescription
-            },
+            .semantics { contentDescription = statusContentDescription },
         shape = RoundedCornerShape(50),
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
@@ -244,11 +233,17 @@ private fun AssistantMessageThread(
     onCardAction: (AssistantCardAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val messages = state.messages
+    val visibleMessages = state.messages.filter { it.hasVisibleContent() }
+    val showTypingIndicator = state.shouldShowTypingIndicator
     val listState = rememberLazyListState()
-    LaunchedEffect(messages.size, messages.lastOrNull()?.segments, state.activeAssistantMessageId) {
-        if (messages.isNotEmpty()) {
-            listState.animateScrollToItem(messages.lastIndex)
+    LaunchedEffect(
+        visibleMessages.size,
+        visibleMessages.lastOrNull()?.segments,
+        showTypingIndicator,
+    ) {
+        val totalItems = visibleMessages.size + if (showTypingIndicator) 1 else 0
+        if (totalItems > 0) {
+            listState.animateScrollToItem(totalItems - 1)
         }
     }
 
@@ -259,12 +254,11 @@ private fun AssistantMessageThread(
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 18.dp),
     ) {
         items(
-            items = messages,
+            items = visibleMessages,
             key = { it.id },
         ) { message ->
             AssistantMessageBubble(
                 message = message,
-                showTypingIndicator = state.shouldShowTypingIndicator(message),
                 onRetry = onRetry,
                 onConfirmWrite = onConfirmWrite,
                 onCancelWrite = onCancelWrite,
@@ -272,229 +266,92 @@ private fun AssistantMessageThread(
                 onCardAction = onCardAction,
             )
         }
+        if (showTypingIndicator) {
+            item(key = TYPING_INDICATOR_ITEM_KEY) {
+                AssistantTypingIndicator()
+            }
+        }
     }
 }
+
+private const val TYPING_INDICATOR_ITEM_KEY = "assistant-typing-indicator"
+
+private fun AssistantUiMessage.hasVisibleContent(): Boolean =
+    role == AssistantUiMessage.Role.USER ||
+        error != null ||
+        hasVisibleAssistantContent
 
 @Composable
 private fun AssistantMessageBubble(
     message: AssistantUiMessage,
-    showTypingIndicator: Boolean,
     onRetry: () -> Unit,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
     assistantCardRenderer: AssistantCardRenderer?,
     onCardAction: (AssistantCardAction) -> Unit,
 ) {
-    val chrome = assistantMessageBubbleChrome(
-        message = message,
-        showTypingIndicator = showTypingIndicator,
-    )
-    val showBubbleChrome = !message.isStandaloneToolActivity()
+    val isUser = message.role == AssistantUiMessage.Role.USER
+    val rowArrangement = if (isUser) Arrangement.End else Arrangement.Start
+    val description = message.contentDescription(isUser = isUser)
 
-    Row(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
-            .semantics(mergeDescendants = true) { contentDescription = chrome.contentDescription },
-        horizontalArrangement = if (chrome.isUser) Arrangement.End else Arrangement.Start,
+            .semantics(mergeDescendants = true) { contentDescription = description },
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Box(
-            modifier = Modifier
-                .widthIn(max = 360.dp)
-                .then(
-                    if (showBubbleChrome) {
-                        Modifier
-                            .heightIn(min = 40.dp)
-                            .background(chrome.bubbleColor, chrome.shape)
-                            .then(
-                                if (chrome.isUser) {
-                                    Modifier
-                                } else {
-                                    Modifier.border(
-                                        width = 1.dp,
-                                        color = MaterialTheme.colorScheme.outlineVariant,
-                                        shape = chrome.shape,
-                                    )
-                                }
-                            )
-                            .padding(horizontal = 14.dp, vertical = 10.dp)
-                    } else {
-                        Modifier
-                    }
-                ),
-            contentAlignment = Alignment.CenterStart,
-        ) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+        message.segments.forEach { segment ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = rowArrangement,
             ) {
-                AssistantMessageSegments(
-                    message = message,
-                    textColor = chrome.textColor,
-                    isUser = chrome.isUser,
+                AssistantMessageSegment(
+                    segment = segment,
+                    isUser = isUser,
                     onConfirmWrite = onConfirmWrite,
                     onCancelWrite = onCancelWrite,
                     assistantCardRenderer = assistantCardRenderer,
                     onCardAction = onCardAction,
                 )
-                message.error?.let { error ->
-                    AssistantInlineError(
-                        error = error,
-                        onRetry = onRetry,
-                    )
-                }
-                if (showTypingIndicator) {
-                    AssistantTypingIndicator()
-                } else if (message.shouldShowEmptyPlaceholder()) {
-                    Text(
-                        text = " ",
-                        color = chrome.textColor,
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
+            }
+        }
+        message.error?.let { error ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = rowArrangement,
+            ) {
+                AssistantInlineError(error = error, onRetry = onRetry)
             }
         }
     }
 }
 
 @Composable
-private fun assistantMessageBubbleChrome(
-    message: AssistantUiMessage,
-    showTypingIndicator: Boolean,
-): AssistantMessageBubbleChrome {
-    val isUser = message.role == AssistantUiMessage.Role.USER
-    val bubbleColor = if (isUser) {
-        MaterialTheme.colorScheme.primary
-    } else {
-        MaterialTheme.colorScheme.surface
-    }
-    val textColor = if (isUser) {
-        MaterialTheme.colorScheme.onPrimary
-    } else {
-        MaterialTheme.colorScheme.onSurface
-    }
-
-    return AssistantMessageBubbleChrome(
-        isUser = isUser,
-        contentDescription = message.contentDescription(
-            isUser = isUser,
-            showTypingIndicator = showTypingIndicator,
-        ),
-        bubbleColor = bubbleColor,
-        textColor = textColor,
-        shape = RoundedCornerShape(
-            topStart = 16.dp,
-            topEnd = 16.dp,
-            bottomStart = if (isUser) 16.dp else 4.dp,
-            bottomEnd = if (isUser) 4.dp else 16.dp,
-        ),
-    )
-}
-
-@Composable
-private fun AssistantUiMessage.contentDescription(
-    isUser: Boolean,
-    showTypingIndicator: Boolean,
-): String {
-    val messageText = text.ifEmpty { " " }
-    val toolActivityLabel = segments
-        .filterIsInstance<AssistantUiSegment.ToolActivity>()
-        .lastOrNull()
-        ?.activity
-        ?.let { stringResource(it.labelRes()) }
-
-    return when {
-        isUser -> stringResource(R.string.assistant_chat_message_user_content_description, messageText)
-        showTypingIndicator -> stringResource(R.string.assistant_chat_typing_content_description)
-        toolActivityLabel != null -> stringResource(
-            R.string.assistant_chat_tool_activity_content_description,
-            toolActivityLabel,
-        )
-        else -> stringResource(R.string.assistant_chat_message_assistant_content_description, messageText)
-    }
-}
-
-private data class AssistantMessageBubbleChrome(
-    val isUser: Boolean,
-    val contentDescription: String,
-    val bubbleColor: Color,
-    val textColor: Color,
-    val shape: RoundedCornerShape,
-)
-
-@Composable
-private fun AssistantTypingIndicator() {
-    Row(
-        modifier = Modifier.padding(vertical = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        val dotColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-        repeat(TYPING_INDICATOR_DOT_COUNT) {
-            Box(
-                modifier = Modifier
-                    .size(6.dp)
-                    .background(color = dotColor, shape = CircleShape),
-            )
-        }
-    }
-}
-
-private const val TYPING_INDICATOR_DOT_COUNT = 3
-
-@Composable
-private fun AssistantMessageSegments(
-    message: AssistantUiMessage,
-    textColor: Color,
+private fun AssistantMessageSegment(
+    segment: AssistantUiSegment,
     isUser: Boolean,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
     assistantCardRenderer: AssistantCardRenderer?,
     onCardAction: (AssistantCardAction) -> Unit,
 ) {
-    message.segments.forEach { segment ->
-        when (segment) {
-            is AssistantUiSegment.ConfirmationCard -> AssistantConfirmationCardSegment(
-                confirmation = segment.model,
-                onConfirmWrite = onConfirmWrite,
-                onCancelWrite = onCancelWrite,
-            )
-            is AssistantUiSegment.Card -> AssistantCardSegment(
-                card = segment.card,
-                assistantCardRenderer = assistantCardRenderer,
-                onCardAction = onCardAction,
-            )
-            is AssistantUiSegment.Text -> AssistantMessageTextSegment(
-                text = segment.text,
-                textColor = textColor,
-                isUser = isUser,
-            )
-            is AssistantUiSegment.ToolActivity -> AssistantToolActivityPill(segment.activity)
+    when (segment) {
+        is AssistantUiSegment.Text -> {
+            if (segment.text.isNotEmpty()) {
+                AssistantTextBubble(text = segment.text, isUser = isUser)
+            }
         }
-    }
-}
-
-@Composable
-private fun AssistantToolActivityPill(activity: AssistantToolActivity) {
-    val label = stringResource(activity.labelRes())
-    Surface(
-        shape = RoundedCornerShape(12.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHighest,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            ToolActivityProgressDots()
-            Text(
-                text = label,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.Medium,
-            )
-        }
+        is AssistantUiSegment.Card -> AssistantCardSegment(
+            card = segment.card,
+            assistantCardRenderer = assistantCardRenderer,
+            onCardAction = onCardAction,
+        )
+        is AssistantUiSegment.ToolActivity -> AssistantToolActivityPill(activity = segment.activity)
+        is AssistantUiSegment.ConfirmationCard -> AssistantConfirmationCardSegment(
+            confirmation = segment.model,
+            onConfirmWrite = onConfirmWrite,
+            onCancelWrite = onCancelWrite,
+        )
     }
 }
 
@@ -521,36 +378,67 @@ private fun AssistantCardSegment(
 }
 
 @Composable
-private fun ToolActivityProgressDots() {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(2.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        val dotColor = MaterialTheme.colorScheme.primary
-        repeat(TYPING_INDICATOR_DOT_COUNT) {
-            Box(
-                modifier = Modifier
-                    .size(4.dp)
-                    .background(color = dotColor, shape = CircleShape),
+private fun AssistantTextBubble(text: String, isUser: Boolean) {
+    val bubbleColor = if (isUser) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    val textColor = if (isUser) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+    val shape = RoundedCornerShape(
+        topStart = 16.dp,
+        topEnd = 16.dp,
+        bottomStart = if (isUser) 16.dp else 4.dp,
+        bottomEnd = if (isUser) 4.dp else 16.dp,
+    )
+
+    Box(
+        modifier = Modifier
+            .widthIn(max = 360.dp)
+            .background(bubbleColor, shape)
+            .then(
+                if (isUser) {
+                    Modifier
+                } else {
+                    Modifier.border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                        shape = shape,
+                    )
+                }
             )
-        }
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+    ) {
+        Text(
+            text = text,
+            color = textColor,
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = if (isUser) TextAlign.End else TextAlign.Start,
+        )
     }
 }
 
 @Composable
-private fun AssistantMessageTextSegment(
-    text: String,
-    textColor: Color,
-    isUser: Boolean,
-) {
-    if (text.isEmpty()) return
+private fun AssistantUiMessage.contentDescription(isUser: Boolean): String {
+    val messageText = text.ifEmpty { " " }
+    val toolActivityLabel = segments
+        .filterIsInstance<AssistantUiSegment.ToolActivity>()
+        .lastOrNull()
+        ?.activity
+        ?.let { stringResource(it.labelRes()) }
 
-    Text(
-        text = text,
-        color = textColor,
-        style = MaterialTheme.typography.bodyMedium,
-        textAlign = if (isUser) TextAlign.End else TextAlign.Start,
-    )
+    return when {
+        isUser -> stringResource(R.string.assistant_chat_message_user_content_description, messageText)
+        toolActivityLabel != null && text.isEmpty() -> stringResource(
+            R.string.assistant_chat_tool_activity_content_description,
+            toolActivityLabel,
+        )
+        else -> stringResource(R.string.assistant_chat_message_assistant_content_description, messageText)
+    }
 }
 
 @Composable
@@ -574,19 +462,8 @@ private fun AssistantInlineError(
     }
 }
 
-private fun AssistantUiMessage.shouldShowEmptyPlaceholder(): Boolean =
-    segments.all { it is AssistantUiSegment.Text && it.text.isEmpty() } && error == null
-
-private fun AssistantUiMessage.isStandaloneToolActivity(): Boolean =
-    role == AssistantUiMessage.Role.ASSISTANT &&
-        error == null &&
-        segments.isNotEmpty() &&
-        segments.all { it is AssistantUiSegment.ToolActivity }
-
 @Composable
-private fun AssistantStatusPanel(
-    state: AssistantUiState,
-) {
+private fun AssistantStatusPanel(state: AssistantUiState) {
     when (state.status) {
         AssistantUiStatus.AWAITING_CONFIRMATION -> Unit
         AssistantUiStatus.ERROR -> {
@@ -614,275 +491,6 @@ private fun AssistantFallbackErrorPanel(error: AssistantUiError?) {
             color = MaterialTheme.colorScheme.onErrorContainer,
             style = MaterialTheme.typography.bodyMedium,
         )
-    }
-}
-
-@Composable
-private fun AssistantConfirmationCardSegment(
-    confirmation: AssistantConfirmationCard,
-    onConfirmWrite: () -> Unit,
-    onCancelWrite: () -> Unit,
-) {
-    val colors = confirmation.state.confirmationCardColors()
-    val shape = RoundedCornerShape(12.dp)
-
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth(),
-        shape = shape,
-        color = colors.container,
-        border = BorderStroke(1.dp, colors.border),
-    ) {
-        Column(
-            modifier = Modifier.padding(14.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    painter = painterResource(confirmation.state.iconRes()),
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                    tint = colors.accent,
-                )
-                Text(
-                    text = stringResource(confirmation.state.eyebrowRes()),
-                    color = colors.accent,
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
-            }
-            Text(
-                text = confirmation.preview?.summary
-                    ?: stringResource(R.string.assistant_chat_confirm_tool, confirmation.toolCall.name),
-                color = colors.title,
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.SemiBold,
-            )
-            confirmation.preview?.rows?.forEach { row ->
-                ConfirmationDiffRow(
-                    row = row,
-                    colors = colors,
-                )
-            }
-            if (confirmation.state == AssistantConfirmationCardState.PENDING) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    OutlinedButton(
-                        onClick = onCancelWrite,
-                        modifier = Modifier
-                            .weight(1f)
-                            .heightIn(min = 48.dp),
-                        shape = RoundedCornerShape(10.dp),
-                        border = BorderStroke(1.dp, colors.border),
-                        colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.title),
-                        contentPadding = PaddingValues(horizontal = 8.dp),
-                    ) {
-                        Text(
-                            text = stringResource(R.string.assistant_chat_cancel),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                    }
-                    Button(
-                        onClick = onConfirmWrite,
-                        modifier = Modifier
-                            .weight(1f)
-                            .heightIn(min = 48.dp),
-                        shape = RoundedCornerShape(10.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                            contentColor = MaterialTheme.colorScheme.onPrimary,
-                        ),
-                        contentPadding = PaddingValues(horizontal = 8.dp),
-                    ) {
-                        Text(
-                            text = stringResource(R.string.assistant_chat_confirm),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ConfirmationDiffRow(
-    row: RenderedConfirmationPreviewField,
-    colors: AssistantConfirmationCardColors,
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.55f), RoundedCornerShape(8.dp))
-            .border(1.dp, colors.border.copy(alpha = 0.45f), RoundedCornerShape(8.dp))
-            .padding(10.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        Text(
-            text = row.label,
-            color = colors.label,
-            style = MaterialTheme.typography.labelMedium,
-            fontWeight = FontWeight.SemiBold,
-        )
-        row.beforeValue?.let { beforeValue ->
-            ConfirmationDiffLine(
-                prefix = stringResource(R.string.assistant_confirmation_now),
-                value = beforeValue,
-                colors = colors,
-                strikethrough = true,
-            )
-        }
-        ConfirmationDiffLine(
-            prefix = stringResource(R.string.assistant_confirmation_after),
-            value = row.afterValue,
-            colors = colors,
-        )
-    }
-}
-
-@Composable
-private fun ConfirmationDiffLine(
-    prefix: String,
-    value: String,
-    colors: AssistantConfirmationCardColors,
-    strikethrough: Boolean = false,
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        verticalAlignment = Alignment.Top,
-    ) {
-        Text(
-            text = prefix,
-            modifier = Modifier.widthIn(min = 40.dp),
-            color = colors.label,
-            style = MaterialTheme.typography.bodySmall,
-            fontWeight = FontWeight.Medium,
-        )
-        Text(
-            text = value,
-            modifier = Modifier.weight(1f),
-            color = if (strikethrough) colors.label else colors.value,
-            style = MaterialTheme.typography.bodySmall,
-            fontWeight = if (strikethrough) FontWeight.Normal else FontWeight.SemiBold,
-            textDecoration = if (strikethrough) TextDecoration.LineThrough else null,
-        )
-    }
-}
-
-@Composable
-private fun AssistantConfirmationCardState.confirmationCardColors(): AssistantConfirmationCardColors {
-    val colorScheme = MaterialTheme.colorScheme
-
-    return when (this) {
-        AssistantConfirmationCardState.PENDING -> AssistantConfirmationCardColors(
-            container = colorScheme.surfaceContainerHigh,
-            border = colorScheme.primary.copy(alpha = 0.28f),
-            accent = colorScheme.primary,
-            title = colorScheme.onSurface,
-            label = colorScheme.onSurfaceVariant,
-            value = colorScheme.onSurface,
-        )
-        AssistantConfirmationCardState.CONFIRMED -> AssistantConfirmationCardColors(
-            container = colorScheme.surfaceContainerHigh,
-            border = colorScheme.outlineVariant,
-            accent = colorScheme.primary,
-            title = colorScheme.onSurface,
-            label = colorScheme.onSurfaceVariant,
-            value = colorScheme.onSurface,
-        )
-        AssistantConfirmationCardState.CANCELLED -> AssistantConfirmationCardColors(
-            container = colorScheme.surfaceContainerLow,
-            border = colorScheme.outlineVariant,
-            accent = colorScheme.onSurfaceVariant,
-            title = colorScheme.onSurfaceVariant,
-            label = colorScheme.onSurfaceVariant,
-            value = colorScheme.onSurfaceVariant,
-        )
-    }
-}
-
-private data class AssistantConfirmationCardColors(
-    val container: Color,
-    val border: Color,
-    val accent: Color,
-    val title: Color,
-    val label: Color,
-    val value: Color,
-)
-
-@Composable
-private fun AssistantComposer(
-    inputText: String,
-    onInputTextChange: (String) -> Unit,
-    isTurnActive: Boolean,
-    shouldShowStopControl: Boolean,
-    onSendMessage: () -> Unit,
-    onCancelTurn: () -> Unit,
-) {
-    val canSend = inputText.isNotBlank() && !isTurnActive
-    Surface(
-        color = MaterialTheme.colorScheme.surface,
-        shadowElevation = 4.dp,
-    ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                verticalAlignment = Alignment.Bottom,
-            ) {
-                OutlinedTextField(
-                    value = inputText,
-                    onValueChange = onInputTextChange,
-                    modifier = Modifier.weight(1f),
-                    minLines = 1,
-                    maxLines = 4,
-                    shape = RoundedCornerShape(12.dp),
-                    placeholder = { Text(stringResource(R.string.assistant_chat_placeholder)) },
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-                    keyboardActions = KeyboardActions(
-                        onSend = {
-                            if (canSend) {
-                                onSendMessage()
-                            }
-                        }
-                    ),
-                )
-                if (shouldShowStopControl) {
-                    Button(
-                        onClick = onCancelTurn,
-                        modifier = Modifier.heightIn(min = 56.dp),
-                        shape = RoundedCornerShape(12.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.error,
-                            contentColor = MaterialTheme.colorScheme.onError,
-                        ),
-                    ) {
-                        Text(stringResource(R.string.assistant_chat_stop))
-                    }
-                } else {
-                    Button(
-                        onClick = onSendMessage,
-                        enabled = canSend,
-                        modifier = Modifier.heightIn(min = 56.dp),
-                        shape = RoundedCornerShape(12.dp),
-                    ) {
-                        Text(stringResource(R.string.assistant_chat_send))
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -286,9 +286,18 @@ private fun AssistantMessageBubble(
 ) {
     val isUser = message.role == AssistantUiMessage.Role.USER
     val messageText = message.text.ifEmpty { " " }
+    val toolActivity = message.segments
+        .filterIsInstance<AssistantUiSegment.ToolActivity>()
+        .lastOrNull()
+        ?.activity
+    val toolActivityLabel = toolActivity?.let { stringResource(it.labelRes()) }
     val messageContentDescription = when {
         isUser -> stringResource(R.string.assistant_chat_message_user_content_description, messageText)
         showTypingIndicator -> stringResource(R.string.assistant_chat_typing_content_description)
+        toolActivityLabel != null -> stringResource(
+            R.string.assistant_chat_tool_activity_content_description,
+            toolActivityLabel,
+        )
         else -> stringResource(R.string.assistant_chat_message_assistant_content_description, messageText)
     }
     val bubbleColor = if (isUser) {
@@ -396,6 +405,37 @@ private fun AssistantMessageSegments(
                 text = segment.text,
                 textColor = textColor,
                 isUser = isUser,
+            )
+            is AssistantUiSegment.ToolActivity -> AssistantToolActivityPill(segment.activity)
+        }
+    }
+}
+
+@Composable
+private fun AssistantToolActivityPill(activity: AssistantToolActivity) {
+    val label = stringResource(activity.labelRes())
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(7.dp)
+                    .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(50)),
+            )
+            Text(
+                text = label,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Medium,
             )
         }
     }
@@ -774,6 +814,42 @@ private fun AssistantUiStatus.toHeaderText(): String = when (this) {
         R.string.assistant_chat_status_awaiting_confirmation
     )
     AssistantUiStatus.ERROR -> stringResource(R.string.assistant_chat_status_error)
+}
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 720)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 720, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantChatScreenToolActivityPreview() {
+    AssistantChatScreen(
+        state = AssistantUiState(
+            messages = listOf(
+                AssistantUiMessage("preview-1", AssistantUiMessage.Role.USER, "Find order 123"),
+                AssistantUiMessage(
+                    id = "preview-2",
+                    role = AssistantUiMessage.Role.ASSISTANT,
+                    segments = listOf(
+                        AssistantUiSegment.Text(""),
+                        AssistantUiSegment.ToolActivity(
+                            AssistantToolActivity(
+                                toolCallId = "call-preview",
+                                toolName = "orders_get",
+                            )
+                        ),
+                    ),
+                ),
+            ),
+            status = AssistantUiStatus.STREAMING,
+            activeAssistantMessageId = "preview-2",
+        ),
+        inputText = "",
+        onInputTextChange = {},
+        onSendMessage = {},
+        onCancelTurn = {},
+        onRetry = {},
+        onConfirmWrite = {},
+        onCancelWrite = {},
+        onBack = {},
+    )
 }
 
 @Preview(showBackground = true, widthDp = 390, heightDp = 720)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -284,55 +284,27 @@ private fun AssistantMessageBubble(
     assistantCardRenderer: AssistantCardRenderer?,
     onCardAction: (AssistantCardAction) -> Unit,
 ) {
-    val isUser = message.role == AssistantUiMessage.Role.USER
-    val messageText = message.text.ifEmpty { " " }
-    val toolActivity = message.segments
-        .filterIsInstance<AssistantUiSegment.ToolActivity>()
-        .lastOrNull()
-        ?.activity
-    val toolActivityLabel = toolActivity?.let { stringResource(it.labelRes()) }
-    val messageContentDescription = when {
-        isUser -> stringResource(R.string.assistant_chat_message_user_content_description, messageText)
-        showTypingIndicator -> stringResource(R.string.assistant_chat_typing_content_description)
-        toolActivityLabel != null -> stringResource(
-            R.string.assistant_chat_tool_activity_content_description,
-            toolActivityLabel,
-        )
-        else -> stringResource(R.string.assistant_chat_message_assistant_content_description, messageText)
-    }
-    val bubbleColor = if (isUser) {
-        MaterialTheme.colorScheme.primary
-    } else {
-        MaterialTheme.colorScheme.surface
-    }
-    val textColor = if (isUser) {
-        MaterialTheme.colorScheme.onPrimary
-    } else {
-        MaterialTheme.colorScheme.onSurface
-    }
-    val shape = RoundedCornerShape(
-        topStart = 16.dp,
-        topEnd = 16.dp,
-        bottomStart = if (isUser) 16.dp else 4.dp,
-        bottomEnd = if (isUser) 4.dp else 16.dp,
+    val chrome = assistantMessageBubbleChrome(
+        message = message,
+        showTypingIndicator = showTypingIndicator,
     )
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .semantics(mergeDescendants = true) { contentDescription = messageContentDescription },
-        horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
+            .semantics(mergeDescendants = true) { contentDescription = chrome.contentDescription },
+        horizontalArrangement = if (chrome.isUser) Arrangement.End else Arrangement.Start,
     ) {
         Box(
             modifier = Modifier
                 .widthIn(max = 360.dp)
                 .heightIn(min = 40.dp)
-                .background(bubbleColor, shape)
+                .background(chrome.bubbleColor, chrome.shape)
                 .then(
-                    if (isUser) {
+                    if (chrome.isUser) {
                         Modifier
                     } else {
-                        Modifier.border(1.dp, MaterialTheme.colorScheme.outlineVariant, shape)
+                        Modifier.border(1.dp, MaterialTheme.colorScheme.outlineVariant, chrome.shape)
                     }
                 )
                 .padding(horizontal = 14.dp, vertical = 10.dp),
@@ -343,8 +315,8 @@ private fun AssistantMessageBubble(
             ) {
                 AssistantMessageSegments(
                     message = message,
-                    textColor = textColor,
-                    isUser = isUser,
+                    textColor = chrome.textColor,
+                    isUser = chrome.isUser,
                     onConfirmWrite = onConfirmWrite,
                     onCancelWrite = onCancelWrite,
                     assistantCardRenderer = assistantCardRenderer,
@@ -361,7 +333,7 @@ private fun AssistantMessageBubble(
                 } else if (message.shouldShowEmptyPlaceholder()) {
                     Text(
                         text = " ",
-                        color = textColor,
+                        color = chrome.textColor,
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 }
@@ -369,6 +341,71 @@ private fun AssistantMessageBubble(
         }
     }
 }
+
+@Composable
+private fun assistantMessageBubbleChrome(
+    message: AssistantUiMessage,
+    showTypingIndicator: Boolean,
+): AssistantMessageBubbleChrome {
+    val isUser = message.role == AssistantUiMessage.Role.USER
+    val bubbleColor = if (isUser) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    val textColor = if (isUser) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+
+    return AssistantMessageBubbleChrome(
+        isUser = isUser,
+        contentDescription = message.contentDescription(
+            isUser = isUser,
+            showTypingIndicator = showTypingIndicator,
+        ),
+        bubbleColor = bubbleColor,
+        textColor = textColor,
+        shape = RoundedCornerShape(
+            topStart = 16.dp,
+            topEnd = 16.dp,
+            bottomStart = if (isUser) 16.dp else 4.dp,
+            bottomEnd = if (isUser) 4.dp else 16.dp,
+        ),
+    )
+}
+
+@Composable
+private fun AssistantUiMessage.contentDescription(
+    isUser: Boolean,
+    showTypingIndicator: Boolean,
+): String {
+    val messageText = text.ifEmpty { " " }
+    val toolActivityLabel = segments
+        .filterIsInstance<AssistantUiSegment.ToolActivity>()
+        .lastOrNull()
+        ?.activity
+        ?.let { stringResource(it.labelRes()) }
+
+    return when {
+        isUser -> stringResource(R.string.assistant_chat_message_user_content_description, messageText)
+        showTypingIndicator -> stringResource(R.string.assistant_chat_typing_content_description)
+        toolActivityLabel != null -> stringResource(
+            R.string.assistant_chat_tool_activity_content_description,
+            toolActivityLabel,
+        )
+        else -> stringResource(R.string.assistant_chat_message_assistant_content_description, messageText)
+    }
+}
+
+private data class AssistantMessageBubbleChrome(
+    val isUser: Boolean,
+    val contentDescription: String,
+    val bubbleColor: Color,
+    val textColor: Color,
+    val shape: RoundedCornerShape,
+)
 
 @Composable
 private fun AssistantTypingIndicator() {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -67,12 +67,19 @@ data class AssistantUiMessage(
     }
 }
 
+data class AssistantToolActivity(
+    val toolCallId: String,
+    val toolName: String,
+)
+
 sealed interface AssistantUiSegment {
     data class Text(val text: String) : AssistantUiSegment
 
     data class ConfirmationCard(val model: AssistantConfirmationCard) : AssistantUiSegment
 
     data class Card(val card: AssistantCard) : AssistantUiSegment
+
+    data class ToolActivity(val activity: AssistantToolActivity) : AssistantUiSegment
 }
 
 internal fun AssistantUiState.shouldShowTypingIndicator(message: AssistantUiMessage): Boolean =
@@ -87,8 +94,29 @@ private val AssistantUiMessage.hasVisibleAssistantContent: Boolean
         when (segment) {
             is AssistantUiSegment.Text -> segment.text.isNotEmpty()
             is AssistantUiSegment.ConfirmationCard -> true
+            is AssistantUiSegment.Card -> true
+            is AssistantUiSegment.ToolActivity -> true
         }
     }
+
+@StringRes
+internal fun AssistantToolActivity.labelRes(): Int = when (toolName) {
+    "orders_list",
+    "orders_get" -> R.string.assistant_chat_tool_activity_orders_read
+    "orders_update",
+    "orders_bulk_update" -> R.string.assistant_chat_tool_activity_orders_write
+    "products_list",
+    "products_get",
+    "product_variations_list" -> R.string.assistant_chat_tool_activity_products_read
+    "products_update",
+    "products_bulk_update",
+    "product_variations_update" -> R.string.assistant_chat_tool_activity_products_write
+    "analytics_orders",
+    "analytics_revenue" -> R.string.assistant_chat_tool_activity_analytics
+    "customers_list" -> R.string.assistant_chat_tool_activity_customers
+    "show_cards" -> R.string.assistant_chat_tool_activity_cards
+    else -> R.string.assistant_chat_tool_activity_generic
+}
 
 data class AssistantConfirmationCard(
     val confirmationId: String,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -31,6 +31,22 @@ data class AssistantUiState(
         get() = status == AssistantUiStatus.ERROR &&
             error != null &&
             messages.lastOrNull()?.error == null
+
+    /**
+     * Mirrors iOS `streamingState == .sending`: dots are visible from submit until the active assistant
+     * message starts streaming actual text. Tool activity segments don't count as "text", so the dots
+     * stay visible during pre-text tool calls and disappear only once the model emits its first text
+     * token. Within a single message text is appended monotonically, so once dots hide they don't bounce
+     * back for that turn.
+     */
+    val shouldShowTypingIndicator: Boolean
+        get() = status == AssistantUiStatus.STREAMING && !activeAssistantHasStreamedText
+
+    private val activeAssistantHasStreamedText: Boolean
+        get() {
+            val active = messages.firstOrNull { it.id == activeAssistantMessageId } ?: return false
+            return active.segments.any { it is AssistantUiSegment.Text && it.text.isNotEmpty() }
+        }
 }
 
 enum class AssistantUiStatus {
@@ -82,14 +98,7 @@ sealed interface AssistantUiSegment {
     data class ToolActivity(val activity: AssistantToolActivity) : AssistantUiSegment
 }
 
-internal fun AssistantUiState.shouldShowTypingIndicator(message: AssistantUiMessage): Boolean =
-    status == AssistantUiStatus.STREAMING &&
-        message.id == activeAssistantMessageId &&
-        message.role == AssistantUiMessage.Role.ASSISTANT &&
-        message.error == null &&
-        message.hasVisibleAssistantContent.not()
-
-private val AssistantUiMessage.hasVisibleAssistantContent: Boolean
+internal val AssistantUiMessage.hasVisibleAssistantContent: Boolean
     get() = segments.any { segment ->
         when (segment) {
             is AssistantUiSegment.Text -> segment.text.isNotEmpty()

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -86,7 +86,13 @@ data class AssistantUiMessage(
 data class AssistantToolActivity(
     val toolCallId: String,
     val toolName: String,
-)
+    val status: Status = Status.RUNNING,
+) {
+    enum class Status {
+        RUNNING,
+        COMPLETED,
+    }
+}
 
 sealed interface AssistantUiSegment {
     data class Text(val text: String) : AssistantUiSegment

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -14,6 +14,7 @@ data class AssistantUiState(
     val error: AssistantUiError? = null,
     val canRetry: Boolean = false,
     val activeConfirmationId: String? = null,
+    val activeAssistantMessageId: String? = null,
     val pendingNavigation: AssistantPendingNavigation? = null,
 ) {
     val isStreaming: Boolean
@@ -73,6 +74,21 @@ sealed interface AssistantUiSegment {
 
     data class Card(val card: AssistantCard) : AssistantUiSegment
 }
+
+internal fun AssistantUiState.shouldShowTypingIndicator(message: AssistantUiMessage): Boolean =
+    status == AssistantUiStatus.STREAMING &&
+        message.id == activeAssistantMessageId &&
+        message.role == AssistantUiMessage.Role.ASSISTANT &&
+        message.error == null &&
+        message.hasVisibleAssistantContent.not()
+
+private val AssistantUiMessage.hasVisibleAssistantContent: Boolean
+    get() = segments.any { segment ->
+        when (segment) {
+            is AssistantUiSegment.Text -> segment.text.isNotEmpty()
+            is AssistantUiSegment.ConfirmationCard -> true
+        }
+    }
 
 data class AssistantConfirmationCard(
     val confirmationId: String,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -73,6 +73,7 @@ class AssistantViewModel @AssistedInject constructor(
         }
         _uiState.update {
             it.copy(
+                messages = it.messages.withoutTransientActivity(),
                 status = AssistantUiStatus.ERROR,
                 error = AssistantError.Cancelled.toAssistantUiError(),
                 canRetry = false,
@@ -104,6 +105,7 @@ class AssistantViewModel @AssistedInject constructor(
                     activeAssistantMessageId = null
                     _uiState.update {
                         it.copy(
+                            messages = it.messages.withoutTransientActivity(),
                             status = AssistantUiStatus.ERROR,
                             error = AssistantUiError.CONFIRMATION_DEFERRED,
                             canRetry = false,
@@ -143,7 +145,7 @@ class AssistantViewModel @AssistedInject constructor(
                 )
             }
             state.copy(
-                messages = state.messages.withoutRetryActions() + turnMessages,
+                messages = state.messages.withoutTransientActivity().withoutRetryActions() + turnMessages,
                 status = AssistantUiStatus.STREAMING,
                 error = null,
                 canRetry = false,
@@ -203,12 +205,14 @@ class AssistantViewModel @AssistedInject constructor(
                 history = event.updatedHistory
                 _uiState.update {
                     it.copy(
-                        messages = it.messages.withAssistantError(
-                            activeMessageId = activeMessageId,
-                            error = normalizedError,
-                            canRetry = canRetry,
-                            nextId = idGenerator::nextId,
-                        ),
+                        messages = it.messages
+                            .withoutTransientActivity()
+                            .withAssistantError(
+                                activeMessageId = activeMessageId,
+                                error = normalizedError,
+                                canRetry = canRetry,
+                                nextId = idGenerator::nextId,
+                            ),
                         status = event.toAssistantUiStatus(),
                         error = event.toAssistantUiError(),
                         canRetry = canRetry,
@@ -283,6 +287,7 @@ class AssistantViewModel @AssistedInject constructor(
                     activeAssistantMessageId = null
                     _uiState.update {
                         it.copy(
+                            messages = it.messages.withoutTransientActivity(),
                             status = AssistantUiStatus.ERROR,
                             error = AssistantUiError.CONFIRMATION_DEFERRED,
                             canRetry = false,
@@ -346,6 +351,13 @@ class AssistantViewModel @AssistedInject constructor(
             } else {
                 message
             }
+        }
+
+    private fun List<AssistantUiMessage>.withoutTransientActivity(): List<AssistantUiMessage> =
+        map { message ->
+            message.copy(
+                segments = message.segments.filterNot { it is AssistantUiSegment.ToolActivity }
+            )
         }
 
     private fun List<AssistantUiMessage>.withAssistantError(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -171,7 +171,7 @@ class AssistantViewModel @AssistedInject constructor(
         when (event) {
             is AssistantRuntimeEvent.AssistantTextDelta -> appendAssistantText(event.text)
             is AssistantRuntimeEvent.ToolCallStarted -> showToolActivity(event)
-            is AssistantRuntimeEvent.ToolCallFinished -> hideToolActivity(event.toolCallId)
+            is AssistantRuntimeEvent.ToolCallFinished -> markToolActivityCompleted(event.toolCallId)
             is AssistantRuntimeEvent.AwaitingConfirmation -> {
                 _uiState.update {
                     it.copy(
@@ -244,9 +244,11 @@ class AssistantViewModel @AssistedInject constructor(
         }
     }
 
-    private fun hideToolActivity(toolCallId: String) {
+    private fun markToolActivityCompleted(toolCallId: String) {
         _uiState.update { state ->
-            state.copy(messages = state.messages.withoutToolActivity(toolCallId))
+            state.copy(
+                messages = state.messages.withToolActivityStatus(toolCallId, AssistantToolActivity.Status.COMPLETED)
+            )
         }
     }
 
@@ -356,7 +358,10 @@ class AssistantViewModel @AssistedInject constructor(
     private fun List<AssistantUiMessage>.withoutTransientActivity(): List<AssistantUiMessage> =
         map { message ->
             message.copy(
-                segments = message.segments.filterNot { it is AssistantUiSegment.ToolActivity }
+                segments = message.segments.filterNot { segment ->
+                    segment is AssistantUiSegment.ToolActivity &&
+                        segment.activity.status == AssistantToolActivity.Status.RUNNING
+                }
             )
         }
 
@@ -432,11 +437,18 @@ class AssistantViewModel @AssistedInject constructor(
             } + AssistantUiSegment.ToolActivity(activity)
         )
 
-    private fun List<AssistantUiMessage>.withoutToolActivity(toolCallId: String): List<AssistantUiMessage> =
+    private fun List<AssistantUiMessage>.withToolActivityStatus(
+        toolCallId: String,
+        status: AssistantToolActivity.Status,
+    ): List<AssistantUiMessage> =
         map { message ->
             message.copy(
-                segments = message.segments.filterNot {
-                    it is AssistantUiSegment.ToolActivity && it.activity.toolCallId == toolCallId
+                segments = message.segments.map { segment ->
+                    if (segment is AssistantUiSegment.ToolActivity && segment.activity.toolCallId == toolCallId) {
+                        AssistantUiSegment.ToolActivity(segment.activity.copy(status = status))
+                    } else {
+                        segment
+                    }
                 }
             )
         }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -77,6 +77,7 @@ class AssistantViewModel @AssistedInject constructor(
                 error = AssistantError.Cancelled.toAssistantUiError(),
                 canRetry = false,
                 activeConfirmationId = null,
+                activeAssistantMessageId = null,
             )
         }
     }
@@ -107,6 +108,7 @@ class AssistantViewModel @AssistedInject constructor(
                             error = AssistantUiError.CONFIRMATION_DEFERRED,
                             canRetry = false,
                             activeConfirmationId = null,
+                            activeAssistantMessageId = null,
                         )
                     }
                 }
@@ -146,6 +148,7 @@ class AssistantViewModel @AssistedInject constructor(
                 error = null,
                 canRetry = false,
                 activeConfirmationId = null,
+                activeAssistantMessageId = assistantMessageId,
             )
         }
 
@@ -208,6 +211,7 @@ class AssistantViewModel @AssistedInject constructor(
                         error = event.toAssistantUiError(),
                         canRetry = canRetry,
                         activeConfirmationId = null,
+                        activeAssistantMessageId = null,
                     )
                 }
             }
@@ -255,6 +259,7 @@ class AssistantViewModel @AssistedInject constructor(
                             error = AssistantUiError.CONFIRMATION_DEFERRED,
                             canRetry = false,
                             activeConfirmationId = null,
+                            activeAssistantMessageId = null,
                         )
                     }
                 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -168,6 +168,8 @@ class AssistantViewModel @AssistedInject constructor(
     private fun reduceRuntimeEvent(event: AssistantRuntimeEvent) {
         when (event) {
             is AssistantRuntimeEvent.AssistantTextDelta -> appendAssistantText(event.text)
+            is AssistantRuntimeEvent.ToolCallStarted -> showToolActivity(event)
+            is AssistantRuntimeEvent.ToolCallFinished -> hideToolActivity(event.toolCallId)
             is AssistantRuntimeEvent.AwaitingConfirmation -> {
                 _uiState.update {
                     it.copy(
@@ -215,6 +217,32 @@ class AssistantViewModel @AssistedInject constructor(
                     )
                 }
             }
+        }
+    }
+
+    private fun showToolActivity(event: AssistantRuntimeEvent.ToolCallStarted) {
+        val messageId = activeAssistantMessageId ?: return
+        _uiState.update { state ->
+            state.copy(
+                messages = state.messages.map { message ->
+                    if (message.id == messageId) {
+                        message.withToolActivity(
+                            AssistantToolActivity(
+                                toolCallId = event.toolCallId,
+                                toolName = event.toolName,
+                            )
+                        )
+                    } else {
+                        message
+                    }
+                }
+            )
+        }
+    }
+
+    private fun hideToolActivity(toolCallId: String) {
+        _uiState.update { state ->
+            state.copy(messages = state.messages.withoutToolActivity(toolCallId))
         }
     }
 
@@ -384,6 +412,22 @@ class AssistantViewModel @AssistedInject constructor(
         updatedSegments[updatedSegments.lastIndex] = lastSegment.copy(text = lastSegment.text + delta)
         return copy(segments = updatedSegments)
     }
+
+    private fun AssistantUiMessage.withToolActivity(activity: AssistantToolActivity): AssistantUiMessage =
+        copy(
+            segments = segments.filterNot {
+                it is AssistantUiSegment.ToolActivity && it.activity.toolCallId == activity.toolCallId
+            } + AssistantUiSegment.ToolActivity(activity)
+        )
+
+    private fun List<AssistantUiMessage>.withoutToolActivity(toolCallId: String): List<AssistantUiMessage> =
+        map { message ->
+            message.copy(
+                segments = message.segments.filterNot {
+                    it is AssistantUiSegment.ToolActivity && it.activity.toolCallId == toolCallId
+                }
+            )
+        }
 
     private fun AssistantUiMessage.appendConfirmationCard(
         confirmation: AssistantConfirmationCard,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantComposer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantComposer.kt
@@ -1,0 +1,92 @@
+package com.woocommerce.android.aiassistant.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.aiassistant.R
+
+@Composable
+internal fun AssistantComposer(
+    inputText: String,
+    onInputTextChange: (String) -> Unit,
+    isTurnActive: Boolean,
+    shouldShowStopControl: Boolean,
+    onSendMessage: () -> Unit,
+    onCancelTurn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val canSend = inputText.isNotBlank() && !isTurnActive
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = 4.dp,
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                OutlinedTextField(
+                    value = inputText,
+                    onValueChange = onInputTextChange,
+                    modifier = Modifier.weight(1f),
+                    minLines = 1,
+                    maxLines = 4,
+                    shape = RoundedCornerShape(12.dp),
+                    placeholder = { Text(stringResource(R.string.assistant_chat_placeholder)) },
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                    keyboardActions = KeyboardActions(
+                        onSend = {
+                            if (canSend) {
+                                onSendMessage()
+                            }
+                        }
+                    ),
+                )
+                if (shouldShowStopControl) {
+                    Button(
+                        onClick = onCancelTurn,
+                        modifier = Modifier.heightIn(min = 56.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.onError,
+                        ),
+                    ) {
+                        Text(stringResource(R.string.assistant_chat_stop))
+                    }
+                } else {
+                    Button(
+                        onClick = onSendMessage,
+                        enabled = canSend,
+                        modifier = Modifier.heightIn(min = 56.dp),
+                        shape = RoundedCornerShape(12.dp),
+                    ) {
+                        Text(stringResource(R.string.assistant_chat_send))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
@@ -1,0 +1,259 @@
+package com.woocommerce.android.aiassistant.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.aiassistant.R
+import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreviewField
+import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
+import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCardState
+import com.woocommerce.android.aiassistant.ui.eyebrowRes
+import com.woocommerce.android.aiassistant.ui.iconRes
+
+@Composable
+internal fun AssistantConfirmationCardSegment(
+    confirmation: AssistantConfirmationCard,
+    onConfirmWrite: () -> Unit,
+    onCancelWrite: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = confirmation.state.confirmationCardColors()
+    val shape = RoundedCornerShape(12.dp)
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = shape,
+        color = colors.container,
+        border = BorderStroke(1.dp, colors.border),
+    ) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            ConfirmationCardEyebrow(state = confirmation.state, colors = colors)
+            Text(
+                text = confirmation.preview?.summary
+                    ?: stringResource(R.string.assistant_chat_confirm_tool, confirmation.toolCall.name),
+                color = colors.title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            confirmation.preview?.rows?.forEach { row ->
+                ConfirmationDiffRow(row = row, colors = colors)
+            }
+            if (confirmation.state == AssistantConfirmationCardState.PENDING) {
+                ConfirmationActions(
+                    colors = colors,
+                    onConfirmWrite = onConfirmWrite,
+                    onCancelWrite = onCancelWrite,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConfirmationCardEyebrow(
+    state: AssistantConfirmationCardState,
+    colors: AssistantConfirmationCardColors,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(state.iconRes()),
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = colors.accent,
+        )
+        Text(
+            text = stringResource(state.eyebrowRes()),
+            color = colors.accent,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+private fun ConfirmationActions(
+    colors: AssistantConfirmationCardColors,
+    onConfirmWrite: () -> Unit,
+    onCancelWrite: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OutlinedButton(
+            onClick = onCancelWrite,
+            modifier = Modifier
+                .weight(1f)
+                .heightIn(min = 48.dp),
+            shape = RoundedCornerShape(10.dp),
+            border = BorderStroke(1.dp, colors.border),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.title),
+            contentPadding = PaddingValues(horizontal = 8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.assistant_chat_cancel),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Button(
+            onClick = onConfirmWrite,
+            modifier = Modifier
+                .weight(1f)
+                .heightIn(min = 48.dp),
+            shape = RoundedCornerShape(10.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ),
+            contentPadding = PaddingValues(horizontal = 8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.assistant_chat_confirm),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConfirmationDiffRow(
+    row: RenderedConfirmationPreviewField,
+    colors: AssistantConfirmationCardColors,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.55f), RoundedCornerShape(8.dp))
+            .border(1.dp, colors.border.copy(alpha = 0.45f), RoundedCornerShape(8.dp))
+            .padding(10.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = row.label,
+            color = colors.label,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        row.beforeValue?.let { beforeValue ->
+            ConfirmationDiffLine(
+                prefix = stringResource(R.string.assistant_confirmation_now),
+                value = beforeValue,
+                colors = colors,
+                strikethrough = true,
+            )
+        }
+        ConfirmationDiffLine(
+            prefix = stringResource(R.string.assistant_confirmation_after),
+            value = row.afterValue,
+            colors = colors,
+        )
+    }
+}
+
+@Composable
+private fun ConfirmationDiffLine(
+    prefix: String,
+    value: String,
+    colors: AssistantConfirmationCardColors,
+    strikethrough: Boolean = false,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Text(
+            text = prefix,
+            modifier = Modifier.widthIn(min = 40.dp),
+            color = colors.label,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
+        )
+        Text(
+            text = value,
+            modifier = Modifier.weight(1f),
+            color = if (strikethrough) colors.label else colors.value,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = if (strikethrough) FontWeight.Normal else FontWeight.SemiBold,
+            textDecoration = if (strikethrough) TextDecoration.LineThrough else null,
+        )
+    }
+}
+
+@Composable
+private fun AssistantConfirmationCardState.confirmationCardColors(): AssistantConfirmationCardColors {
+    val colorScheme = MaterialTheme.colorScheme
+
+    return when (this) {
+        AssistantConfirmationCardState.PENDING -> AssistantConfirmationCardColors(
+            container = colorScheme.surfaceContainerHigh,
+            border = colorScheme.primary.copy(alpha = 0.28f),
+            accent = colorScheme.primary,
+            title = colorScheme.onSurface,
+            label = colorScheme.onSurfaceVariant,
+            value = colorScheme.onSurface,
+        )
+        AssistantConfirmationCardState.CONFIRMED -> AssistantConfirmationCardColors(
+            container = colorScheme.surfaceContainerHigh,
+            border = colorScheme.outlineVariant,
+            accent = colorScheme.primary,
+            title = colorScheme.onSurface,
+            label = colorScheme.onSurfaceVariant,
+            value = colorScheme.onSurface,
+        )
+        AssistantConfirmationCardState.CANCELLED -> AssistantConfirmationCardColors(
+            container = colorScheme.surfaceContainerLow,
+            border = colorScheme.outlineVariant,
+            accent = colorScheme.onSurfaceVariant,
+            title = colorScheme.onSurfaceVariant,
+            label = colorScheme.onSurfaceVariant,
+            value = colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private data class AssistantConfirmationCardColors(
+    val container: Color,
+    val border: Color,
+    val accent: Color,
+    val title: Color,
+    val label: Color,
+    val value: Color,
+)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantInFlightDots.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantInFlightDots.kt
@@ -1,0 +1,77 @@
+package com.woocommerce.android.aiassistant.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Three small dots that pulse with a staggered fade. Used as the leading affordance in the typing
+ * indicator and the tool activity pill so both in-flight surfaces share the same heartbeat.
+ *
+ * Mirrors the iOS reference: opacity 0.4 ↔ 1.0, 500ms easeInOut autoreverse, 150ms phase offset
+ * between dots.
+ */
+@Composable
+internal fun AssistantInFlightDots(
+    color: Color,
+    dotSize: Dp,
+    spacing: Dp,
+    modifier: Modifier = Modifier,
+) {
+    val transition = rememberInfiniteTransition(label = "assistant-in-flight-dots")
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(spacing),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        repeat(IN_FLIGHT_DOT_COUNT) { index ->
+            val alpha by transition.animateFloat(
+                initialValue = MIN_ALPHA,
+                targetValue = MAX_ALPHA,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(
+                        durationMillis = HALF_CYCLE_MILLIS,
+                        delayMillis = index * STAGGER_MILLIS,
+                        easing = LinearEasing,
+                    ),
+                    repeatMode = RepeatMode.Reverse,
+                ),
+                label = "assistant-in-flight-dot-$index",
+            )
+            Box(
+                modifier = Modifier
+                    .alpha(alpha)
+                    .size(dotSize)
+                    .background(color = color, shape = CircleShape),
+            )
+        }
+    }
+}
+
+internal const val IN_FLIGHT_DOT_COUNT = 3
+private const val MIN_ALPHA = 0.4f
+private const val MAX_ALPHA = 1.0f
+private const val HALF_CYCLE_MILLIS = 500
+private const val STAGGER_MILLIS = 150
+
+internal val InFlightDotsTypingSize: Dp = 6.dp
+internal val InFlightDotsTypingSpacing: Dp = 4.dp
+internal val InFlightDotsToolPillSize: Dp = 3.dp
+internal val InFlightDotsToolPillSpacing: Dp = 2.dp

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantToolActivityPill.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantToolActivityPill.kt
@@ -16,6 +16,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -36,8 +40,14 @@ internal fun AssistantToolActivityPill(
     modifier: Modifier = Modifier,
 ) {
     val label = stringResource(activity.labelRes())
+    val description = stringResource(R.string.assistant_chat_tool_activity_content_description, label)
     Surface(
-        modifier = modifier,
+        modifier = modifier.semantics {
+            contentDescription = description
+            if (activity.status == AssistantToolActivity.Status.RUNNING) {
+                liveRegion = LiveRegionMode.Polite
+            }
+        },
         shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantToolActivityPill.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantToolActivityPill.kt
@@ -5,26 +5,30 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.ui.AssistantToolActivity
 import com.woocommerce.android.aiassistant.ui.labelRes
 
 /**
  * In-thread affordance announcing the tool the assistant is running. Reads as a pill but uses a
- * 12dp rounded rectangle to match the iOS reference. The leading affordance is the same animated
- * three-dot pulse used by [AssistantTypingIndicator] so the pill carries the same heartbeat once
- * typing dots hand off to a tool call.
+ * 12dp rounded rectangle to match the iOS reference. Leading affordance is the animated three-dot
+ * pulse (matches [AssistantTypingIndicator]) while the tool runs and a static checkmark once the
+ * tool finishes — completed activities are preserved in the thread as a step history.
  */
 @Composable
 internal fun AssistantToolActivityPill(
@@ -43,11 +47,7 @@ internal fun AssistantToolActivityPill(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            AssistantInFlightDots(
-                color = MaterialTheme.colorScheme.primary,
-                dotSize = InFlightDotsToolPillSize,
-                spacing = InFlightDotsToolPillSpacing,
-            )
+            ToolActivityLeadingAffordance(status = activity.status)
             Text(
                 text = label,
                 color = MaterialTheme.colorScheme.onSurface,
@@ -60,14 +60,46 @@ internal fun AssistantToolActivityPill(
     }
 }
 
+@Composable
+private fun ToolActivityLeadingAffordance(status: AssistantToolActivity.Status) {
+    when (status) {
+        AssistantToolActivity.Status.RUNNING -> AssistantInFlightDots(
+            color = MaterialTheme.colorScheme.primary,
+            dotSize = InFlightDotsToolPillSize,
+            spacing = InFlightDotsToolPillSpacing,
+        )
+        AssistantToolActivity.Status.COMPLETED -> Icon(
+            painter = painterResource(R.drawable.ic_assistant_tool_completed),
+            contentDescription = null,
+            modifier = Modifier.size(14.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
 @Preview(showBackground = true, widthDp = 240, heightDp = 60)
 @Preview(name = "Dark", showBackground = true, widthDp = 240, heightDp = 60, uiMode = UI_MODE_NIGHT_YES)
 @Composable
-private fun AssistantToolActivityPillPreview() {
+private fun AssistantToolActivityPillRunningPreview() {
     AssistantToolActivityPill(
         activity = AssistantToolActivity(
             toolCallId = "call-preview",
             toolName = "orders_list",
+            status = AssistantToolActivity.Status.RUNNING,
+        ),
+        modifier = Modifier.padding(16.dp),
+    )
+}
+
+@Preview(showBackground = true, widthDp = 240, heightDp = 60)
+@Preview(name = "Dark", showBackground = true, widthDp = 240, heightDp = 60, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantToolActivityPillCompletedPreview() {
+    AssistantToolActivityPill(
+        activity = AssistantToolActivity(
+            toolCallId = "call-preview",
+            toolName = "orders_list",
+            status = AssistantToolActivity.Status.COMPLETED,
         ),
         modifier = Modifier.padding(16.dp),
     )

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantToolActivityPill.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantToolActivityPill.kt
@@ -1,0 +1,74 @@
+package com.woocommerce.android.aiassistant.ui.components
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.aiassistant.ui.AssistantToolActivity
+import com.woocommerce.android.aiassistant.ui.labelRes
+
+/**
+ * In-thread affordance announcing the tool the assistant is running. Reads as a pill but uses a
+ * 12dp rounded rectangle to match the iOS reference. The leading affordance is the same animated
+ * three-dot pulse used by [AssistantTypingIndicator] so the pill carries the same heartbeat once
+ * typing dots hand off to a tool call.
+ */
+@Composable
+internal fun AssistantToolActivityPill(
+    activity: AssistantToolActivity,
+    modifier: Modifier = Modifier,
+) {
+    val label = stringResource(activity.labelRes())
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AssistantInFlightDots(
+                color = MaterialTheme.colorScheme.primary,
+                dotSize = InFlightDotsToolPillSize,
+                spacing = InFlightDotsToolPillSpacing,
+            )
+            Text(
+                text = label,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 240, heightDp = 60)
+@Preview(name = "Dark", showBackground = true, widthDp = 240, heightDp = 60, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantToolActivityPillPreview() {
+    AssistantToolActivityPill(
+        activity = AssistantToolActivity(
+            toolCallId = "call-preview",
+            toolName = "orders_list",
+        ),
+        modifier = Modifier.padding(16.dp),
+    )
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantTypingIndicator.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantTypingIndicator.kt
@@ -8,7 +8,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -23,7 +25,10 @@ import com.woocommerce.android.aiassistant.R
 internal fun AssistantTypingIndicator(modifier: Modifier = Modifier) {
     val description = stringResource(R.string.assistant_chat_typing_content_description)
     Surface(
-        modifier = modifier.semantics { contentDescription = description },
+        modifier = modifier.semantics {
+            contentDescription = description
+            liveRegion = LiveRegionMode.Polite
+        },
         shape = CircleShape,
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
     ) {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantTypingIndicator.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantTypingIndicator.kt
@@ -1,0 +1,44 @@
+package com.woocommerce.android.aiassistant.ui.components
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.aiassistant.R
+
+/**
+ * Pre-text "thinking" indicator. Lives at the bottom of the message thread while the assistant is
+ * waiting on its first text token (matches iOS `streamingState == .sending`). A muted, fully-rounded
+ * pill containing three softly pulsing dots.
+ */
+@Composable
+internal fun AssistantTypingIndicator(modifier: Modifier = Modifier) {
+    val description = stringResource(R.string.assistant_chat_typing_content_description)
+    Surface(
+        modifier = modifier.semantics { contentDescription = description },
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+    ) {
+        AssistantInFlightDots(
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            dotSize = InFlightDotsTypingSize,
+            spacing = InFlightDotsTypingSpacing,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 200, heightDp = 60)
+@Preview(name = "Dark", showBackground = true, widthDp = 200, heightDp = 60, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantTypingIndicatorPreview() {
+    AssistantTypingIndicator(modifier = Modifier.padding(16.dp))
+}

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_tool_completed.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_tool_completed.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportWidth="14"
+    android:viewportHeight="14">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M2.5,7.5L5.5,10.5L11.5,3.5"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+</vector>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <string name="assistant_chat_status_content_description">Assistant status: %1$s</string>
     <string name="assistant_chat_message_user_content_description">You: %1$s</string>
     <string name="assistant_chat_message_assistant_content_description">Assistant: %1$s</string>
+    <string name="assistant_chat_typing_indicator">Thinking...</string>
+    <string name="assistant_chat_typing_content_description">Assistant is thinking</string>
     <string name="assistant_chat_placeholder">Ask about your store</string>
     <string name="assistant_chat_send">Send</string>
     <string name="assistant_chat_stop">Stop</string>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -55,6 +55,15 @@
     <string name="assistant_chat_message_assistant_content_description">Assistant: %1$s</string>
     <string name="assistant_chat_typing_indicator">Thinking...</string>
     <string name="assistant_chat_typing_content_description">Assistant is thinking</string>
+    <string name="assistant_chat_tool_activity_orders_read">Checking orders</string>
+    <string name="assistant_chat_tool_activity_orders_write">Updating orders</string>
+    <string name="assistant_chat_tool_activity_products_read">Checking products</string>
+    <string name="assistant_chat_tool_activity_products_write">Updating products</string>
+    <string name="assistant_chat_tool_activity_analytics">Checking analytics</string>
+    <string name="assistant_chat_tool_activity_customers">Checking customers</string>
+    <string name="assistant_chat_tool_activity_cards">Preparing cards</string>
+    <string name="assistant_chat_tool_activity_generic">Checking your store</string>
+    <string name="assistant_chat_tool_activity_content_description">Assistant is working: %1$s</string>
     <string name="assistant_chat_placeholder">Ask about your store</string>
     <string name="assistant_chat_send">Send</string>
     <string name="assistant_chat_stop">Stop</string>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -53,7 +53,6 @@
     <string name="assistant_chat_status_content_description">Assistant status: %1$s</string>
     <string name="assistant_chat_message_user_content_description">You: %1$s</string>
     <string name="assistant_chat_message_assistant_content_description">Assistant: %1$s</string>
-    <string name="assistant_chat_typing_indicator">Thinking...</string>
     <string name="assistant_chat_typing_content_description">Assistant is thinking</string>
     <string name="assistant_chat_tool_activity_orders_read">Checking orders</string>
     <string name="assistant_chat_tool_activity_orders_write">Updating orders</string>

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -170,6 +170,41 @@ class AgenticLoopAssistantRuntimeTest {
     }
 
     @Test
+    fun `when loop emits tool lifecycle, then runtime forwards sanitized tool activity`() = runTest {
+        val call = ToolCall(
+            id = "call-1",
+            name = "orders_get",
+            arguments = buildJsonObject {
+                put("private_order_id", 123)
+            },
+        )
+        val result = ToolResult.Success(
+            toolCallId = "call-1",
+            structured = buildJsonObject {
+                put("status", "processing")
+            },
+        )
+        val runtime = runtime(
+            agenticLoop = FakeAgenticLoop(
+                events = listOf(
+                    LoopEvent.ToolCallStarted(call),
+                    LoopEvent.ToolCallFinished(result),
+                )
+            ),
+        )
+
+        val events = runtime.startTurn(givenTurnRequest()).toList()
+
+        assertThat(events).containsExactly(
+            AssistantRuntimeEvent.ToolCallStarted(
+                toolCallId = "call-1",
+                toolName = "orders_get",
+            ),
+            AssistantRuntimeEvent.ToolCallFinished(toolCallId = "call-1"),
+        )
+    }
+
+    @Test
     fun `when loop stops cleanly after confirmation cancel, then runtime finish has no cancelled error`() = runTest {
         val updatedHistory = listOf(
             AssistantMessage.User("Cancel order 123"),

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -156,6 +156,38 @@ class AssistantUiStateTest {
     }
 
     @Test
+    fun `given known tool names, when resolving activity label, then humanized labels are returned`() {
+        val expectedLabels = mapOf(
+            "orders_list" to R.string.assistant_chat_tool_activity_orders_read,
+            "orders_get" to R.string.assistant_chat_tool_activity_orders_read,
+            "orders_update" to R.string.assistant_chat_tool_activity_orders_write,
+            "orders_bulk_update" to R.string.assistant_chat_tool_activity_orders_write,
+            "products_list" to R.string.assistant_chat_tool_activity_products_read,
+            "products_get" to R.string.assistant_chat_tool_activity_products_read,
+            "product_variations_list" to R.string.assistant_chat_tool_activity_products_read,
+            "products_update" to R.string.assistant_chat_tool_activity_products_write,
+            "products_bulk_update" to R.string.assistant_chat_tool_activity_products_write,
+            "product_variations_update" to R.string.assistant_chat_tool_activity_products_write,
+            "analytics_orders" to R.string.assistant_chat_tool_activity_analytics,
+            "analytics_revenue" to R.string.assistant_chat_tool_activity_analytics,
+            "customers_list" to R.string.assistant_chat_tool_activity_customers,
+            "show_cards" to R.string.assistant_chat_tool_activity_cards,
+        )
+
+        expectedLabels.forEach { (toolName, labelRes) ->
+            assertThat(AssistantToolActivity("call-1", toolName).labelRes())
+                .describedAs(toolName)
+                .isEqualTo(labelRes)
+        }
+    }
+
+    @Test
+    fun `given unknown tool name, when resolving activity label, then generic label is returned`() {
+        assertThat(AssistantToolActivity("call-1", "private_internal_tool").labelRes())
+            .isEqualTo(R.string.assistant_chat_tool_activity_generic)
+    }
+
+    @Test
     fun `given ui errors, when mapping to message resources, then fallback copy resources are returned`() {
         assertThat(AssistantUiError.CONFIRMATION_DEFERRED.toMessageRes())
             .isEqualTo(R.string.assistant_chat_error_confirmation_deferred)

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -108,51 +108,76 @@ class AssistantUiStateTest {
     }
 
     @Test
-    fun `given active empty assistant message, when checking typing indicator, then indicator is visible`() {
-        val message = AssistantUiMessage(
-            id = "assistant-1",
-            role = AssistantUiMessage.Role.ASSISTANT,
-            text = "",
-        )
+    fun `given streaming with active empty assistant message, when checking typing indicator, then it is visible`() {
         val state = AssistantUiState(
-            messages = listOf(message),
+            messages = listOf(
+                AssistantUiMessage("assistant-1", AssistantUiMessage.Role.ASSISTANT, ""),
+            ),
             status = AssistantUiStatus.STREAMING,
             activeAssistantMessageId = "assistant-1",
         )
 
-        assertThat(state.shouldShowTypingIndicator(message)).isTrue()
+        assertThat(state.shouldShowTypingIndicator).isTrue()
     }
 
     @Test
-    fun `given active assistant message with text, when checking typing indicator, then indicator is hidden`() {
-        val message = AssistantUiMessage(
-            id = "assistant-1",
-            role = AssistantUiMessage.Role.ASSISTANT,
-            text = "Sales are up today.",
-        )
+    fun `given streaming with active tool activity but no text, when checking typing indicator, then it is visible`() {
         val state = AssistantUiState(
-            messages = listOf(message),
+            messages = listOf(
+                AssistantUiMessage(
+                    id = "assistant-1",
+                    role = AssistantUiMessage.Role.ASSISTANT,
+                    segments = listOf(
+                        AssistantUiSegment.ToolActivity(
+                            AssistantToolActivity(toolCallId = "call-1", toolName = "orders_list"),
+                        ),
+                    ),
+                ),
+            ),
             status = AssistantUiStatus.STREAMING,
             activeAssistantMessageId = "assistant-1",
         )
 
-        assertThat(state.shouldShowTypingIndicator(message)).isFalse()
+        assertThat(state.shouldShowTypingIndicator).isTrue()
     }
 
     @Test
-    fun `given inactive empty assistant message, when checking typing indicator, then indicator is hidden`() {
-        val message = AssistantUiMessage(
-            id = "assistant-1",
-            role = AssistantUiMessage.Role.ASSISTANT,
-            text = "",
-        )
+    fun `given streaming with active assistant message that has streamed text, when checking typing indicator, then it is hidden`() {
         val state = AssistantUiState(
-            messages = listOf(message),
+            messages = listOf(
+                AssistantUiMessage("assistant-1", AssistantUiMessage.Role.ASSISTANT, "Sales are up today."),
+            ),
+            status = AssistantUiStatus.STREAMING,
+            activeAssistantMessageId = "assistant-1",
+        )
+
+        assertThat(state.shouldShowTypingIndicator).isFalse()
+    }
+
+    @Test
+    fun `given idle status, when checking typing indicator, then it is hidden`() {
+        val state = AssistantUiState(
+            messages = listOf(
+                AssistantUiMessage("assistant-1", AssistantUiMessage.Role.ASSISTANT, ""),
+            ),
             status = AssistantUiStatus.IDLE,
             activeAssistantMessageId = null,
         )
 
-        assertThat(state.shouldShowTypingIndicator(message)).isFalse()
+        assertThat(state.shouldShowTypingIndicator).isFalse()
+    }
+
+    @Test
+    fun `given awaiting confirmation, when checking typing indicator, then it is hidden`() {
+        val state = AssistantUiState(
+            messages = listOf(
+                AssistantUiMessage("assistant-1", AssistantUiMessage.Role.ASSISTANT, ""),
+            ),
+            status = AssistantUiStatus.AWAITING_CONFIRMATION,
+            activeAssistantMessageId = "assistant-1",
+        )
+
+        assertThat(state.shouldShowTypingIndicator).isFalse()
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -108,6 +108,54 @@ class AssistantUiStateTest {
     }
 
     @Test
+    fun `given active empty assistant message, when checking typing indicator, then indicator is visible`() {
+        val message = AssistantUiMessage(
+            id = "assistant-1",
+            role = AssistantUiMessage.Role.ASSISTANT,
+            text = "",
+        )
+        val state = AssistantUiState(
+            messages = listOf(message),
+            status = AssistantUiStatus.STREAMING,
+            activeAssistantMessageId = "assistant-1",
+        )
+
+        assertThat(state.shouldShowTypingIndicator(message)).isTrue()
+    }
+
+    @Test
+    fun `given active assistant message with text, when checking typing indicator, then indicator is hidden`() {
+        val message = AssistantUiMessage(
+            id = "assistant-1",
+            role = AssistantUiMessage.Role.ASSISTANT,
+            text = "Sales are up today.",
+        )
+        val state = AssistantUiState(
+            messages = listOf(message),
+            status = AssistantUiStatus.STREAMING,
+            activeAssistantMessageId = "assistant-1",
+        )
+
+        assertThat(state.shouldShowTypingIndicator(message)).isFalse()
+    }
+
+    @Test
+    fun `given inactive empty assistant message, when checking typing indicator, then indicator is hidden`() {
+        val message = AssistantUiMessage(
+            id = "assistant-1",
+            role = AssistantUiMessage.Role.ASSISTANT,
+            text = "",
+        )
+        val state = AssistantUiState(
+            messages = listOf(message),
+            status = AssistantUiStatus.IDLE,
+            activeAssistantMessageId = null,
+        )
+
+        assertThat(state.shouldShowTypingIndicator(message)).isFalse()
+    }
+
+    @Test
     fun `given ui errors, when mapping to message resources, then fallback copy resources are returned`() {
         assertThat(AssistantUiError.CONFIRMATION_DEFERRED.toMessageRes())
             .isEqualTo(R.string.assistant_chat_error_confirmation_deferred)

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -133,7 +133,7 @@ class AssistantViewModelTest {
     }
 
     @Test
-    fun `given active tool activity, when matching tool finishes, then activity segment is removed`() = runTest {
+    fun `given active tool activity, when matching tool finishes, then activity is preserved as completed`() = runTest {
         viewModel.onSendMessage("Find order 123")
         runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = "orders_get"))
         runtime.emit(AssistantRuntimeEvent.ToolCallFinished(toolCallId = "call-1"))
@@ -141,6 +141,13 @@ class AssistantViewModelTest {
 
         assertThat(viewModel.uiState.value.messages.last().segments).containsExactly(
             AssistantUiSegment.Text(""),
+            AssistantUiSegment.ToolActivity(
+                AssistantToolActivity(
+                    toolCallId = "call-1",
+                    toolName = "orders_get",
+                    status = AssistantToolActivity.Status.COMPLETED,
+                )
+            ),
         )
         assertThat(viewModel.uiState.value.shouldShowTypingIndicator).isTrue()
     }
@@ -187,7 +194,7 @@ class AssistantViewModelTest {
     }
 
     @Test
-    fun `given active tool activity, when turn completes, then transient activity is cleared`() = runTest {
+    fun `given running tool activity, when turn completes, then unfinished activity is cleared`() = runTest {
         viewModel.onSendMessage("Find order 123")
         runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = "orders_get"))
         runtime.emit(
@@ -205,6 +212,34 @@ class AssistantViewModelTest {
         assertThat(state.activeAssistantMessageId).isNull()
         assertThat(state.toolActivitySegments()).isEmpty()
         assertThat(state.shouldShowTypingIndicator).isFalse()
+    }
+
+    @Test
+    fun `given completed tool activity, when turn completes, then completed activity is preserved`() = runTest {
+        viewModel.onSendMessage("Find order 123")
+        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = "orders_get"))
+        runtime.emit(AssistantRuntimeEvent.ToolCallFinished(toolCallId = "call-1"))
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.COMPLETED,
+                updatedHistory = listOf(
+                    AssistantMessage.User("Find order 123"),
+                    AssistantMessage.Assistant("Order 123 is processing."),
+                ),
+            )
+        )
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.toolActivitySegments()).containsExactly(
+            AssistantUiSegment.ToolActivity(
+                AssistantToolActivity(
+                    toolCallId = "call-1",
+                    toolName = "orders_get",
+                    status = AssistantToolActivity.Status.COMPLETED,
+                )
+            ),
+        )
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -111,6 +111,45 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given active assistant bubble, when tool starts, then tool activity segment is shown`() = runTest {
+        viewModel.onSendMessage("Find order 123")
+
+        runtime.emit(
+            AssistantRuntimeEvent.ToolCallStarted(
+                toolCallId = "call-1",
+                toolName = "orders_get",
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.messages.last().segments).containsExactly(
+            AssistantUiSegment.Text(""),
+            AssistantUiSegment.ToolActivity(
+                AssistantToolActivity(
+                    toolCallId = "call-1",
+                    toolName = "orders_get",
+                )
+            ),
+        )
+        assertThat(viewModel.uiState.value.shouldShowTypingIndicator(viewModel.uiState.value.messages.last()))
+            .isFalse()
+    }
+
+    @Test
+    fun `given active tool activity, when matching tool finishes, then activity segment is removed`() = runTest {
+        viewModel.onSendMessage("Find order 123")
+        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = "orders_get"))
+        runtime.emit(AssistantRuntimeEvent.ToolCallFinished(toolCallId = "call-1"))
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.messages.last().segments).containsExactly(
+            AssistantUiSegment.Text(""),
+        )
+        assertThat(viewModel.uiState.value.shouldShowTypingIndicator(viewModel.uiState.value.messages.last()))
+            .isTrue()
+    }
+
+    @Test
     fun `given active assistant bubble, when text deltas arrive, then the same bubble grows`() = runTest {
         viewModel.onSendMessage("Summarize sales")
         val activeBubbleId = viewModel.uiState.value.messages.last().id

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -191,6 +191,47 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given active tool activity, when turn completes, then transient activity is cleared`() = runTest {
+        viewModel.onSendMessage("Find order 123")
+        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = "orders_get"))
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.COMPLETED,
+                updatedHistory = listOf(
+                    AssistantMessage.User("Find order 123"),
+                    AssistantMessage.Assistant("Order 123 is processing."),
+                ),
+            )
+        )
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.activeAssistantMessageId).isNull()
+        assertThat(state.toolActivitySegments()).isEmpty()
+        assertThat(state.shouldShowTypingIndicator(state.messages.last())).isFalse()
+    }
+
+    @Test
+    fun `given active tool activity, when turn fails, then transient activity is cleared`() = runTest {
+        viewModel.onSendMessage("Find order 123")
+        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = "orders_get"))
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.FAILED,
+                updatedHistory = listOf(AssistantMessage.User("Find order 123")),
+                retryAvailable = true,
+                error = AssistantError.Network,
+            )
+        )
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.activeAssistantMessageId).isNull()
+        assertThat(state.toolActivitySegments()).isEmpty()
+        assertThat(state.canRetry).isTrue()
+    }
+
+    @Test
     fun `when turn fails with retry available, then state exposes error and retry calls runtime`() = runTest {
         viewModel.onSendMessage("Hello")
         runtime.emit(
@@ -638,6 +679,21 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given active tool activity, when cancel is requested, then transient activity is cleared`() = runTest {
+        viewModel.onSendMessage("Find order 123")
+        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = "orders_get"))
+        advanceUntilIdle()
+
+        viewModel.onCancelTurn()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.activeAssistantMessageId).isNull()
+        assertThat(state.toolActivitySegments()).isEmpty()
+        assertThat(state.error).isEqualTo(AssistantUiError.CANCELLED)
+    }
+
+    @Test
     fun `given partial assistant text, when cancel is requested, then partial text remains visible`() = runTest {
         viewModel.onSendMessage("Summarize sales")
         val activeBubbleId = viewModel.uiState.value.messages.last().id
@@ -680,6 +736,29 @@ class AssistantViewModelTest {
                     ),
                 )
             )
+        }
+
+    @Test
+    fun `given failed turn with tool activity, when retry starts, then old transient activity is not replayed`() =
+        runTest {
+            viewModel.onSendMessage("Find order 123")
+            runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = "orders_get"))
+            runtime.emit(
+                AssistantRuntimeEvent.Finished(
+                    outcome = LoopOutcome.FAILED,
+                    updatedHistory = listOf(AssistantMessage.User("Find order 123")),
+                    retryAvailable = true,
+                    error = AssistantError.Network,
+                )
+            )
+            advanceUntilIdle()
+
+            viewModel.onRetry()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertThat(state.messages.dropLast(1).toolActivitySegments()).isEmpty()
+            assertThat(state.shouldShowTypingIndicator(state.messages.last())).isTrue()
         }
 
     @Test
@@ -981,6 +1060,12 @@ class AssistantViewModelTest {
             return "message-$count"
         }
     }
+
+    private fun AssistantUiState.toolActivitySegments(): List<AssistantUiSegment.ToolActivity> =
+        messages.toolActivitySegments()
+
+    private fun List<AssistantUiMessage>.toolActivitySegments(): List<AssistantUiSegment.ToolActivity> =
+        flatMap { it.segments }.filterIsInstance<AssistantUiSegment.ToolActivity>()
 
     private companion object {
         const val CONVERSATION_ID = "conversation-1"

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -96,7 +96,7 @@ class AssistantViewModelTest {
         val state = viewModel.uiState.value
         val assistantMessage = state.messages.last()
         assertThat(state.activeAssistantMessageId).isEqualTo(assistantMessage.id)
-        assertThat(state.shouldShowTypingIndicator(assistantMessage)).isTrue()
+        assertThat(state.shouldShowTypingIndicator).isTrue()
     }
 
     @Test
@@ -105,13 +105,11 @@ class AssistantViewModelTest {
         runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("Sales are up today."))
         advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        val assistantMessage = state.messages.last()
-        assertThat(state.shouldShowTypingIndicator(assistantMessage)).isFalse()
+        assertThat(viewModel.uiState.value.shouldShowTypingIndicator).isFalse()
     }
 
     @Test
-    fun `given active assistant bubble, when tool starts, then tool activity segment is shown`() = runTest {
+    fun `given active assistant bubble, when tool starts, then typing indicator stays visible`() = runTest {
         viewModel.onSendMessage("Find order 123")
 
         runtime.emit(
@@ -131,8 +129,7 @@ class AssistantViewModelTest {
                 )
             ),
         )
-        assertThat(viewModel.uiState.value.shouldShowTypingIndicator(viewModel.uiState.value.messages.last()))
-            .isFalse()
+        assertThat(viewModel.uiState.value.shouldShowTypingIndicator).isTrue()
     }
 
     @Test
@@ -145,8 +142,7 @@ class AssistantViewModelTest {
         assertThat(viewModel.uiState.value.messages.last().segments).containsExactly(
             AssistantUiSegment.Text(""),
         )
-        assertThat(viewModel.uiState.value.shouldShowTypingIndicator(viewModel.uiState.value.messages.last()))
-            .isTrue()
+        assertThat(viewModel.uiState.value.shouldShowTypingIndicator).isTrue()
     }
 
     @Test
@@ -208,7 +204,7 @@ class AssistantViewModelTest {
         val state = viewModel.uiState.value
         assertThat(state.activeAssistantMessageId).isNull()
         assertThat(state.toolActivitySegments()).isEmpty()
-        assertThat(state.shouldShowTypingIndicator(state.messages.last())).isFalse()
+        assertThat(state.shouldShowTypingIndicator).isFalse()
     }
 
     @Test
@@ -758,7 +754,7 @@ class AssistantViewModelTest {
 
             val state = viewModel.uiState.value
             assertThat(state.messages.dropLast(1).toolActivitySegments()).isEmpty()
-            assertThat(state.shouldShowTypingIndicator(state.messages.last())).isTrue()
+            assertThat(state.shouldShowTypingIndicator).isTrue()
         }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -90,6 +90,27 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `when message is sent, then empty active assistant message shows typing indicator`() = runTest {
+        viewModel.onSendMessage("Show my recent orders")
+
+        val state = viewModel.uiState.value
+        val assistantMessage = state.messages.last()
+        assertThat(state.activeAssistantMessageId).isEqualTo(assistantMessage.id)
+        assertThat(state.shouldShowTypingIndicator(assistantMessage)).isTrue()
+    }
+
+    @Test
+    fun `given active assistant bubble, when text delta arrives, then typing indicator is hidden`() = runTest {
+        viewModel.onSendMessage("Summarize sales")
+        runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("Sales are up today."))
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        val assistantMessage = state.messages.last()
+        assertThat(state.shouldShowTypingIndicator(assistantMessage)).isFalse()
+    }
+
+    @Test
     fun `given active assistant bubble, when text deltas arrive, then the same bubble grows`() = runTest {
         viewModel.onSendMessage("Summarize sales")
         val activeBubbleId = viewModel.uiState.value.messages.last().id


### PR DESCRIPTION
### Description
Fixes WOOMOB-2970

This PR adds in-flight feedback to the Android AI Assistant chat surface. It builds on the inline transcript model from WOOMOB-2915 so merchants can see when the assistant is preparing a response, when it is working with store tools, and which tool steps have completed, without exposing internal tool arguments or raw tool results.

#### What changes for users

After sending a prompt, the chat now shows a standalone typing indicator at the bottom of the transcript while the assistant is working and before any response text has streamed. The indicator uses three pulsing dots in a compact rounded surface, matching the same in-flight language used by the tool activity UI.

When the assistant starts a store tool, the transcript shows a concise activity pill such as `Checking orders`, `Updating products`, or `Checking analytics`. Running tool calls use pulsing dots. Finished tool calls stay in the transcript with a checkmark, giving the conversation a durable step history similar to the completed confirmation cards. If a turn is stopped or fails while a tool is still running, the abandoned running pill is cleared so stale activity is not left behind.

The activity labels are intentionally human-readable and sanitized. The UI does not show scratchpad text, raw tool arguments, private JSON, structured tool results, or low-level tool names for unknown tools; unknown activity falls back to generic store-checking copy.

#### Runtime and UI behavior

The assistant runtime now forwards sanitized tool lifecycle events from the existing core loop into feature UI state. `ToolCallStarted` carries only the tool call ID and tool name; `ToolCallFinished` carries only the tool call ID. The ViewModel maps those events into assistant transcript segments, derives typing state from the existing active turn state, and clears or marks tool activity based on the terminal path.

The chat UI now renders assistant message segments as first-class rows:

- text remains in assistant/user message bubbles
- typing is a standalone bottom-row indicator
- running tool activity is a standalone pill with pulsing dots
- completed tool activity is the same pill with a checkmark
- confirmation cards continue to use their own card chrome instead of being wrapped in an extra assistant bubble

This avoids nested surfaces, keeps mixed assistant text/tool/card messages readable, and preserves the transcript as the source of truth for the visible assistant flow.

Accessibility semantics are kept on the visible activity surfaces. The typing indicator exposes `Assistant is thinking`, and tool activity exposes `Assistant is working: <activity>`. The global status pill and existing Send/Stop behavior are unchanged.

#### Dependency and safety notes

All production changes are contained in `:libs:ai-assistant:feature`. There are no `:WooCommerce` host changes, no new auth path, no Jetpack AI JWT changes, no assistant protocol change, no new Gson usage for AI payloads, and no dependency-direction reversal.

This PR is stacked on `issue/WOOMOB-2915-implement-inline-confirmation-card-for-unsafe-tool-calls`, so the GitHub diff should show the typing/tool-activity work on top of the inline confirmation-card branch.

#### Tests added or updated

This PR adds focused coverage for:

- typing visibility while an active assistant response has no streamed text yet
- typing disappearing after the first assistant text token
- typing staying visible during pre-text tool activity
- sanitized runtime forwarding for tool start/finish events
- humanized activity labels for every currently mapped assistant tool family plus generic fallback
- running tool activity suppressing stale placeholders and rendering as a transcript segment
- completed tool activity being retained with `COMPLETED` status after a matching finish event
- abandoned running tool activity clearing on completion, failure, cancel/stop, and retry
- retry starting a fresh active assistant bubble without replaying old transient activity

#### Validation performed locally

```
./gradlew :libs:ai-assistant:feature:testDebugUnitTest \
  --tests "*.AgenticLoopAssistantRuntimeTest" \
  --tests "*.AssistantUiStateTest" \
  --tests "*.AssistantViewModelTest"
→ BUILD SUCCESSFUL

./gradlew :libs:ai-assistant:feature:lintDebug
→ BUILD SUCCESSFUL

./gradlew detektAll --auto-correct
→ BUILD SUCCESSFUL

./gradlew lintWasabiRelease
→ BUILD SUCCESSFUL
```

Additional static checks were run for whitespace, `FIXME`, force unwraps, wildcard imports, forbidden assistant feature-flag references, and Gson usage in AI payload code.

### Test Steps
1. Build and install the Wasabi debug app from this branch, then open the AI Assistant from the More menu on a store where assistant chat is available.
2. Send a prompt and verify a standalone three-dot typing indicator appears at the bottom of the transcript before assistant text starts streaming.
3. Ask for a store-read action, such as recent orders, and verify the chat shows a concise running tool activity pill like `Checking orders` with pulsing dots.
4. Verify the tool activity pill does not show raw arguments, scratchpad text, JSON, or private tool result details.
5. Let the turn complete and verify the finished activity remains in the transcript with a checkmark, while the assistant text continues normally and the composer returns to Send.
6. Start another request and stop it while it is running. Verify any still-running activity indicator clears and the transcript does not leave stale in-flight UI behind.
7. With TalkBack or the accessibility inspector, verify the typing indicator announces `Assistant is thinking` and the tool pill announces `Assistant is working: <activity>`.

### Images/gif
**Note about the demo:** The UI stills needs polishing, and the 5 order calls are because order_list tool now returns limited data, this will be fixed with show_cards tool, but we still may need to discuss adding more stuff to the reponse to make the model able to reason about the response.

https://github.com/user-attachments/assets/6c8968f1-b187-4374-bd90-897f03ed55f9



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.