### PR TITLE
[WOOMOB-2967] Wire show cards UI payload into assistant messages

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardRenderer
 import com.woocommerce.android.ciab.CIABOrderStatusMapper
+import com.woocommerce.android.extensions.formatToMMMdd
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.orders.compose.OrderSummaryRow
 import com.woocommerce.android.ui.orders.compose.OrderSummaryRowModel
@@ -19,6 +20,9 @@ import com.woocommerce.android.ui.products.compose.ProductSummaryRow
 import com.woocommerce.android.ui.products.compose.ProductSummaryRowInfo
 import com.woocommerce.android.util.CurrencyFormatter
 import java.math.BigDecimal
+import java.time.Instant
+import java.time.format.DateTimeParseException
+import java.util.Date
 
 class WooAssistantCardRenderer(
     private val currencyFormatter: CurrencyFormatter,
@@ -29,9 +33,10 @@ class WooAssistantCardRenderer(
         onAction: (AssistantCardAction) -> Unit,
         modifier: Modifier,
     ) {
+        val context = LocalContext.current
         OrderSummaryRow(
-            order = card.toOrderSummaryRowModel(currencyFormatter),
-            onClick = { onAction(card.toOpenOrderAction()) },
+            order = card.toOrderSummaryRowModel(context, currencyFormatter),
+            onClick = { onAction(AssistantCardAction.OpenOrder(card.remoteOrderId)) },
             modifier = modifier,
         )
     }
@@ -47,7 +52,7 @@ class WooAssistantCardRenderer(
         ProductSummaryRow(
             title = rowModel.title,
             imageUrl = rowModel.imageUrl,
-            onClick = card.toProductCardClick(onAction),
+            onClick = { onAction(AssistantCardAction.OpenProduct(card.remoteProductId)) },
             modifier = modifier,
         ) {
             ProductSummaryRowInfo(rowModel.stockStatusPriceText)
@@ -56,6 +61,57 @@ class WooAssistantCardRenderer(
     }
 }
 
+// ---------- Order card ----------
+
+internal fun AssistantCard.Order.toOrderSummaryRowModel(
+    context: Context,
+    currencyFormatter: CurrencyFormatter,
+): OrderSummaryRowModel {
+    fun formatTotalPrice(): String =
+        when {
+            total.isBlank() -> ""
+            currency.isBlank() -> total
+            else -> currencyFormatter.formatCurrency(total, currency)
+        }
+
+    fun formatDate(): String =
+        try {
+            Date.from(Instant.parse(date)).formatToMMMdd()
+        } catch (_: DateTimeParseException) {
+            date
+        }
+
+    fun resolveCustomerName(): String =
+        customerName.ifBlank { context.getString(R.string.orderdetail_customer_name_default) }
+
+    return OrderSummaryRowModel(
+        number = number,
+        date = formatDate(),
+        customerName = resolveCustomerName(),
+        status = status,
+        statusColor = resolveOrderStatusColor(status),
+        totalPrice = formatTotalPrice(),
+        isPosOrder = false,
+    )
+}
+
+@ColorRes
+private fun resolveOrderStatusColor(status: String): Int =
+    when (Order.Status.fromValue(status)) {
+        is Order.Status.Processing -> R.color.tag_bg_processing
+        is Order.Status.Completed -> R.color.tag_bg_completed
+        is Order.Status.Failed -> R.color.tag_bg_failed
+        is Order.Status.OnHold -> R.color.tag_bg_on_hold
+        is Order.Status.Custom -> if (status == CIABOrderStatusMapper.OPEN_KEY) {
+            R.color.tag_bg_processing
+        } else {
+            R.color.tag_bg_other
+        }
+        else -> R.color.tag_bg_other
+    }
+
+// ---------- Product card ----------
+
 internal data class AssistantProductSummaryRowModel(
     val title: String,
     val imageUrl: String,
@@ -63,79 +119,34 @@ internal data class AssistantProductSummaryRowModel(
     val skuText: String?,
 )
 
-internal fun AssistantCard.Order.toOpenOrderAction() = AssistantCardAction.OpenOrder(remoteOrderId)
-
-internal fun AssistantCard.Product.toOpenProductAction() = AssistantCardAction.OpenProduct(remoteProductId)
-
-internal fun AssistantCard.Product.toProductCardClick(
-    onAction: (AssistantCardAction) -> Unit,
-): () -> Unit = {
-    onAction(toOpenProductAction())
-}
-
 internal fun AssistantCard.Product.toProductSummaryRowModel(
     context: Context,
     currencyFormatter: CurrencyFormatter,
-) = AssistantProductSummaryRowModel(
-    title = name,
-    imageUrl = imageUrl,
-    stockStatusPriceText = toStockStatusPriceText(context, currencyFormatter),
-    skuText = sku
-        .takeIf { it.isNotBlank() }
-        ?.let { context.getString(R.string.orderdetail_product_lineitem_sku_value, it) },
-)
+): AssistantProductSummaryRowModel {
+    fun formatProductPrice(): String =
+        price.toBigDecimalOrNull()
+            ?.let { amount: BigDecimal -> currencyFormatter.buildBigDecimalFormatter()(amount) }
+            ?: price
 
-internal fun AssistantCard.Order.toOrderSummaryRowModel(currencyFormatter: CurrencyFormatter) = OrderSummaryRowModel(
-    number = number,
-    date = date,
-    customerName = customerName,
-    status = status,
-    statusColor = status.toOrderStatusColor(),
-    totalPrice = formatTotalPrice(currencyFormatter),
-    isPosOrder = false,
-)
-
-private fun AssistantCard.Order.formatTotalPrice(currencyFormatter: CurrencyFormatter): String =
-    when {
-        total.isBlank() -> ""
-        currency.isBlank() -> total
-        else -> currencyFormatter.formatCurrency(total, currency)
+    fun stockStatusPriceText(): String {
+        val productStatus = ProductStatus.fromString(status)
+            ?.takeIf { it != ProductStatus.PUBLISH }
+            ?.toLocalizedString(context)
+        val stock = ProductStockStatus.stockStatusToDisplayString(
+            context,
+            ProductStockStatus.fromString(stockStatus),
+        )
+        return listOfNotNull(productStatus, stock, formatProductPrice())
+            .filter { it.isNotBlank() }
+            .joinToString(separator = " \u2022 ")
     }
 
-private fun AssistantCard.Product.toStockStatusPriceText(
-    context: Context,
-    currencyFormatter: CurrencyFormatter,
-): String {
-    val productStatus = ProductStatus.fromString(status)
-        ?.takeIf { it != ProductStatus.PUBLISH }
-        ?.toLocalizedString(context)
-    val stock = ProductStockStatus.stockStatusToDisplayString(
-        context,
-        ProductStockStatus.fromString(stockStatus),
+    return AssistantProductSummaryRowModel(
+        title = name,
+        imageUrl = imageUrl,
+        stockStatusPriceText = stockStatusPriceText(),
+        skuText = sku
+            .takeIf { it.isNotBlank() }
+            ?.let { context.getString(R.string.orderdetail_product_lineitem_sku_value, it) },
     )
-    val formattedPrice = formatProductPrice(currencyFormatter)
-
-    return listOfNotNull(productStatus, stock, formattedPrice)
-        .filter { it.isNotBlank() }
-        .joinToString(separator = " \u2022 ")
 }
-
-internal fun AssistantCard.Product.formatProductPrice(currencyFormatter: CurrencyFormatter): String =
-    price.toBigDecimalOrNull()
-        ?.let { amount: BigDecimal -> currencyFormatter.buildBigDecimalFormatter()(amount) }
-        ?: price
-
-@ColorRes
-private fun String.toOrderStatusColor(): Int =
-    when (Order.Status.fromValue(this)) {
-        is Order.Status.Processing -> R.color.tag_bg_processing
-        is Order.Status.Completed -> R.color.tag_bg_completed
-        is Order.Status.Failed -> R.color.tag_bg_failed
-        is Order.Status.OnHold -> R.color.tag_bg_on_hold
-        is Order.Status.Custom -> if (this == CIABOrderStatusMapper.OPEN_KEY) {
-            R.color.tag_bg_processing
-        } else {
-            R.color.tag_bg_other
-        }
-        else -> R.color.tag_bg_other
-    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/stock/DashboardProductStockCard.kt
@@ -261,10 +261,6 @@ fun ProductStockRow(
         onClick = { onItemClicked(product) },
         displayDivider = displayDivider,
         modifier = modifier,
-        contentVerticalArrangement = Arrangement.Top,
-        dividerContent = {
-            Divider(modifier = Modifier.padding(top = 8.dp))
-        },
         trailingContent = {
             Text(
                 text = product.stockQuantity,
@@ -278,7 +274,6 @@ fun ProductStockRow(
                 product.itemsSold == 0 -> stringResource(R.string.dashboard_product_stock_no_sales_last_30_days)
                 else -> stringResource(R.string.dashboard_product_stock_sales_last_30_days, product.itemsSold)
             },
-            modifier = Modifier.padding(bottom = 8.dp),
             color = colorResource(id = R.color.color_on_surface_medium_selector),
             maxLines = Int.MAX_VALUE,
             overflow = TextOverflow.Clip,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/compose/ProductSummaryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/products/compose/ProductSummaryRow.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.component.ProductThumbnail
@@ -37,30 +36,27 @@ fun ProductSummaryRow(
     enabled: Boolean = true,
     displayDivider: Boolean = false,
     imageContentDescription: String = stringResource(id = R.string.product_image_content_description),
-    contentVerticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(4.dp),
-    dividerContent: @Composable (() -> Unit)? = null,
     trailingContent: (@Composable RowScope.() -> Unit)? = null,
-    subtitle: @Composable ColumnScope.() -> Unit,
+    supportingContent: @Composable ColumnScope.() -> Unit,
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .clickable(enabled = enabled, onClick = onClick)
             .padding(horizontal = 16.dp),
-        verticalAlignment = Alignment.Top,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         ProductThumbnail(
             imageUrl = imageUrl.orEmpty(),
             contentDescription = imageContentDescription,
-            modifier = Modifier.padding(top = 12.dp),
         )
         Column(
             modifier = Modifier
                 .weight(1f)
                 .padding(start = 8.dp),
-            verticalArrangement = contentVerticalArrangement,
+            verticalArrangement = Arrangement.Center,
         ) {
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(12.dp))
             Row(
                 modifier = Modifier.padding(bottom = 4.dp),
                 verticalAlignment = Alignment.Top,
@@ -77,9 +73,10 @@ fun ProductSummaryRow(
                 )
                 trailingContent?.invoke(this)
             }
-            subtitle()
+            supportingContent()
+            Spacer(modifier = Modifier.height(12.dp))
             if (displayDivider) {
-                dividerContent?.invoke() ?: ProductSummaryRowDivider()
+                Divider()
             }
         }
     }
@@ -101,16 +98,6 @@ fun ProductSummaryRowInfo(
         maxLines = maxLines,
         overflow = overflow,
         style = style,
-    )
-}
-
-@Composable
-private fun ProductSummaryRowDivider(
-    topPadding: Dp = 4.dp,
-) {
-    Divider(
-        modifier = Modifier.padding(top = topPadding),
-        color = colorResource(id = R.color.divider_color),
     )
 }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
+import java.util.Locale
 
 class WooAssistantCardRendererTest {
     private val currencyFormatter: CurrencyFormatter = mock()
@@ -17,9 +18,15 @@ class WooAssistantCardRendererTest {
 
     @Test
     fun `given assistant order card, when mapped, then host row model formats total with order currency`() {
+        val originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
         whenever(currencyFormatter.formatCurrency("12.34", "USD")).thenReturn("$12.34")
 
-        val model = orderCard().toOrderSummaryRowModel(context, currencyFormatter)
+        val model = try {
+            orderCard().toOrderSummaryRowModel(context, currencyFormatter)
+        } finally {
+            Locale.setDefault(originalLocale)
+        }
 
         assertThat(model.number).isEqualTo("#1001")
         assertThat(model.date).matches("^May [12]$")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRendererTest.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.aiassistant
 import android.content.Context
 import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
-import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
 import com.woocommerce.android.util.CurrencyFormatter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -14,15 +13,16 @@ import java.math.BigDecimal
 
 class WooAssistantCardRendererTest {
     private val currencyFormatter: CurrencyFormatter = mock()
+    private val context: Context = mock()
 
     @Test
     fun `given assistant order card, when mapped, then host row model formats total with order currency`() {
         whenever(currencyFormatter.formatCurrency("12.34", "USD")).thenReturn("$12.34")
 
-        val model = orderCard().toOrderSummaryRowModel(currencyFormatter)
+        val model = orderCard().toOrderSummaryRowModel(context, currencyFormatter)
 
         assertThat(model.number).isEqualTo("#1001")
-        assertThat(model.date).isEqualTo("2026-05-01T10:00:00Z")
+        assertThat(model.date).matches("^May [12]$")
         assertThat(model.customerName).isEqualTo("Jane Doe")
         assertThat(model.status).isEqualTo("processing")
         assertThat(model.statusColor).isEqualTo(R.color.tag_bg_processing)
@@ -33,32 +33,25 @@ class WooAssistantCardRendererTest {
 
     @Test
     fun `given assistant order card without currency, when mapped, then raw total is used`() {
-        val model = orderCard(currency = "").toOrderSummaryRowModel(currencyFormatter)
+        val model = orderCard(currency = "").toOrderSummaryRowModel(context, currencyFormatter)
 
         assertThat(model.totalPrice).isEqualTo("12.34")
     }
 
     @Test
-    fun `given assistant order card, when action helper is used, then open order id is used`() {
-        val action = orderCard().toOpenOrderAction()
+    fun `given assistant order card with unparseable date, when mapped, then raw date is preserved`() {
+        val model = orderCard(currency = "", date = "not-a-date").toOrderSummaryRowModel(context, currencyFormatter)
 
-        assertThat(action).isEqualTo(AssistantCardAction.OpenOrder(remoteOrderId = 123L))
+        assertThat(model.date).isEqualTo("not-a-date")
     }
 
     @Test
-    fun `given assistant product card, when action helper is used, then open product id is used`() {
-        val action = productCard().toOpenProductAction()
+    fun `given assistant order card with blank customer name, when mapped, then guest fallback is used`() {
+        whenever(context.getString(R.string.orderdetail_customer_name_default)).thenReturn("Guest")
 
-        assertThat(action).isEqualTo(AssistantCardAction.OpenProduct(remoteProductId = 456L))
-    }
+        val model = orderCard(currency = "", customerName = "").toOrderSummaryRowModel(context, currencyFormatter)
 
-    @Test
-    fun `given assistant product card, when click helper is invoked, then open product action is emitted`() {
-        val actions = mutableListOf<AssistantCardAction>()
-
-        productCard().toProductCardClick(actions::add).invoke()
-
-        assertThat(actions).containsExactly(AssistantCardAction.OpenProduct(remoteProductId = 456L))
+        assertThat(model.customerName).isEqualTo("Guest")
     }
 
     @Test
@@ -83,25 +76,18 @@ class WooAssistantCardRendererTest {
     }
 
     @Test
-    fun `given assistant product card, when price is numeric, then host formatter formats it`() {
-        val decimalFormatter: (BigDecimal) -> String = { amount -> "\$${amount.toPlainString()}" }
-        whenever(currencyFormatter.buildBigDecimalFormatter()).thenReturn(decimalFormatter)
+    fun `given assistant product card with non-numeric price, when row model is built, then raw price is used`() {
+        val context: Context = mock()
+        whenever(context.getString(R.string.product_stock_status_instock)).thenReturn("In stock")
 
-        val price = productCard(price = "9.99").formatProductPrice(currencyFormatter)
+        val model = productCard(price = "Free").toProductSummaryRowModel(context, currencyFormatter)
 
-        assertThat(price).isEqualTo("$9.99")
-    }
-
-    @Test
-    fun `given assistant product card, when price is not numeric, then raw price is used`() {
-        val price = productCard(price = "Free").formatProductPrice(currencyFormatter)
-
-        assertThat(price).isEqualTo("Free")
+        assertThat(model.stockStatusPriceText).isEqualTo("In stock \u2022 Free")
     }
 
     @Test
     fun `given ciab open status, when mapped, then processing color is used like dashboard orders`() {
-        val model = orderCard(status = "open", currency = "").toOrderSummaryRowModel(currencyFormatter)
+        val model = orderCard(status = "open", currency = "").toOrderSummaryRowModel(context, currencyFormatter)
 
         assertThat(model.statusColor).isEqualTo(R.color.tag_bg_processing)
     }
@@ -109,14 +95,16 @@ class WooAssistantCardRendererTest {
     private fun orderCard(
         status: String = "processing",
         currency: String = "USD",
+        date: String = "2026-05-01T10:00:00Z",
+        customerName: String = "Jane Doe",
     ) = AssistantCard.Order(
         remoteOrderId = 123L,
         number = "#1001",
         status = status,
         total = "12.34",
         currency = currency,
-        customerName = "Jane Doe",
-        date = "2026-05-01T10:00:00Z",
+        customerName = customerName,
+        date = date,
     )
 
     private fun productCard(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
@@ -91,27 +91,31 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
                     AssistantRuntimeEvent.ConfirmationResolved(event.result)
                 )
                 is LoopEvent.ToolCallStarted -> {
-                    toolNamesById[event.call.id] = event.call.name
-                    emit(
-                        AssistantRuntimeEvent.ToolCallStarted(
-                            toolCallId = event.call.id,
-                            toolName = event.call.name,
-                        )
-                    )
+                    emit(event.toRuntimeEvent(toolNamesById))
                 }
                 is LoopEvent.ToolCallFinished -> {
                     val toolName = toolNamesById.remove(event.result.toolCallId)
-                    emit(
-                        AssistantRuntimeEvent.ToolCallFinished(
-                            toolCallId = event.result.toolCallId,
-                        )
-                    )
-                    val cards = event.result.toShowCards(toolName)
-                    if (cards.isNotEmpty()) {
-                        emit(AssistantRuntimeEvent.CardsResolved(cards))
-                    }
+                    event.result.toRuntimeEvents(toolName).forEach { emit(it) }
                 }
             }
+        }
+    }
+
+    private fun LoopEvent.ToolCallStarted.toRuntimeEvent(
+        toolNamesById: MutableMap<String, String>,
+    ): AssistantRuntimeEvent.ToolCallStarted {
+        toolNamesById[call.id] = call.name
+        return AssistantRuntimeEvent.ToolCallStarted(
+            toolCallId = call.id,
+            toolName = call.name,
+        )
+    }
+
+    private fun ToolResult.toRuntimeEvents(toolName: String?): List<AssistantRuntimeEvent> = buildList {
+        add(AssistantRuntimeEvent.ToolCallFinished(toolCallId = toolCallId))
+        val cards = toShowCards(toolName)
+        if (cards.isNotEmpty()) {
+            add(AssistantRuntimeEvent.CardsResolved(cards))
         }
     }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.aiassistant.runtime
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
+import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.loop.AgenticLoop
 import com.woocommerce.android.aiassistant.core.loop.LoopEvent
 import com.woocommerce.android.aiassistant.core.loop.SessionContext
@@ -14,8 +15,10 @@ import com.woocommerce.android.aiassistant.safety.ConfirmationPreviewRenderer
 import com.woocommerce.android.aiassistant.safety.ConfirmationSnapshot
 import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationPreviewBuilder
 import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationSnapshotResolver
+import com.woocommerce.android.aiassistant.tools.handlers.cards.SHOW_CARDS_TOOL_NAME
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCardState
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardUiStructuredParser
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -28,6 +31,7 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
     private val confirmationPreviewBuilder: WooCommerceConfirmationPreviewBuilder,
     private val confirmationPreviewRenderer: ConfirmationPreviewRenderer,
     private val confirmationSnapshotResolver: WooCommerceConfirmationSnapshotResolver,
+    private val cardParser: AssistantCardUiStructuredParser,
 ) : AssistantRuntime {
 
     override fun startTurn(request: AssistantTurnRequest): Flow<AssistantRuntimeEvent> = runTurn(request)
@@ -51,6 +55,7 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
             catalogSnapshot = toolCatalogSelector.select(request.toolScope, toolRegistry.descriptors()),
         )
         var pendingError: AssistantError? = null
+        val toolNamesById = mutableMapOf<String, String>()
 
         agenticLoop.runTurn(
             conversationId = request.conversationId,
@@ -85,20 +90,37 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
                 is LoopEvent.ConfirmationResolved -> emit(
                     AssistantRuntimeEvent.ConfirmationResolved(event.result)
                 )
-                is LoopEvent.ToolCallStarted -> emit(
-                    AssistantRuntimeEvent.ToolCallStarted(
-                        toolCallId = event.call.id,
-                        toolName = event.call.name,
+                is LoopEvent.ToolCallStarted -> {
+                    toolNamesById[event.call.id] = event.call.name
+                    emit(
+                        AssistantRuntimeEvent.ToolCallStarted(
+                            toolCallId = event.call.id,
+                            toolName = event.call.name,
+                        )
                     )
-                )
-                is LoopEvent.ToolCallFinished -> emit(
-                    AssistantRuntimeEvent.ToolCallFinished(
-                        toolCallId = event.result.toolCallId,
+                }
+                is LoopEvent.ToolCallFinished -> {
+                    val toolName = toolNamesById.remove(event.result.toolCallId)
+                    emit(
+                        AssistantRuntimeEvent.ToolCallFinished(
+                            toolCallId = event.result.toolCallId,
+                        )
                     )
-                )
+                    val cards = event.result.toShowCards(toolName)
+                    if (cards.isNotEmpty()) {
+                        emit(AssistantRuntimeEvent.CardsResolved(cards))
+                    }
+                }
             }
         }
     }
+
+    private fun ToolResult.toShowCards(toolName: String?) =
+        if (toolName == SHOW_CARDS_TOOL_NAME && this is ToolResult.Success) {
+            cardParser.parse(uiStructured)
+        } else {
+            emptyList()
+        }
 
     private fun ConfirmationRequest.toConfirmationCard(snapshot: ConfirmationSnapshot?): AssistantConfirmationCard {
         return AssistantConfirmationCard(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntime.kt
@@ -86,7 +86,10 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
                     )
                     pendingError = null
                 }
-                is LoopEvent.Failed -> pendingError = event.error
+                is LoopEvent.Failed -> {
+                    toolNamesById.clear()
+                    pendingError = event.error
+                }
                 is LoopEvent.ConfirmationResolved -> emit(
                     AssistantRuntimeEvent.ConfirmationResolved(event.result)
                 )
@@ -115,7 +118,7 @@ internal class AgenticLoopAssistantRuntime @Inject constructor(
         add(AssistantRuntimeEvent.ToolCallFinished(toolCallId = toolCallId))
         val cards = toShowCards(toolName)
         if (cards.isNotEmpty()) {
-            add(AssistantRuntimeEvent.CardsResolved(cards))
+            add(AssistantRuntimeEvent.CardsResolved(cards.map { it.card }))
         }
     }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
@@ -6,6 +6,7 @@ import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
 import com.woocommerce.android.aiassistant.core.loop.ToolScope
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardEntry
 import kotlinx.coroutines.flow.Flow
 
 interface AssistantRuntime {
@@ -44,6 +45,10 @@ sealed interface AssistantRuntimeEvent {
 
     data class ConfirmationResolved(
         val result: ConfirmationResult,
+    ) : AssistantRuntimeEvent
+
+    data class CardsResolved(
+        val cards: List<AssistantCardEntry>,
     ) : AssistantRuntimeEvent
 
     data class Finished(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/runtime/AssistantRuntime.kt
@@ -6,7 +6,7 @@ import com.woocommerce.android.aiassistant.core.loop.LoopOutcome
 import com.woocommerce.android.aiassistant.core.loop.ToolScope
 import com.woocommerce.android.aiassistant.core.safety.ConfirmationResult
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
-import com.woocommerce.android.aiassistant.ui.cards.AssistantCardEntry
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import kotlinx.coroutines.flow.Flow
 
 interface AssistantRuntime {
@@ -48,7 +48,7 @@ sealed interface AssistantRuntimeEvent {
     ) : AssistantRuntimeEvent
 
     data class CardsResolved(
-        val cards: List<AssistantCardEntry>,
+        val cards: List<AssistantCard>,
     ) : AssistantRuntimeEvent
 
     data class Finished(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -18,6 +18,7 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolut
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsStructured
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+import com.woocommerce.android.aiassistant.tools.handlers.cards.SHOW_CARDS_TOOL_NAME
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
@@ -53,7 +54,7 @@ internal class ShowCardsToolHandler internal constructor(
     )
 
     override val descriptor = ToolDescriptor(
-        name = "show_cards",
+        name = SHOW_CARDS_TOOL_NAME,
         description = "Show entity cards in the UI for orders or products selected by the assistant.",
         inputSchema = buildJsonObject {
             put("type", "object")

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -10,6 +10,7 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.DefaultShowCards
 import com.woocommerce.android.aiassistant.tools.handlers.cards.MAX_SHOW_CARDS_REFS
 import com.woocommerce.android.aiassistant.tools.handlers.cards.MissingRef
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ResolvedRef
+import com.woocommerce.android.aiassistant.tools.handlers.cards.SHOW_CARDS_TOOL_NAME
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsArguments
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsReferenceValidator
@@ -18,7 +19,6 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolut
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsStructured
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
-import com.woocommerce.android.aiassistant.tools.handlers.cards.SHOW_CARDS_TOOL_NAME
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 internal const val MAX_SHOW_CARDS_REFS = 10
+internal const val SHOW_CARDS_TOOL_NAME = "show_cards"
 
 @Serializable
 internal data class ShowCardsArguments(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -364,19 +364,28 @@ private fun AssistantCardSegment(
 ) {
     if (assistantCardRenderer == null) return
 
-    when (card) {
-        is AssistantCard.Order -> assistantCardRenderer.OrderCard(
-            card = card,
-            onAction = onCardAction,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        is AssistantCard.Product -> assistantCardRenderer.ProductCard(
-            card = card,
-            onAction = onCardAction,
-            modifier = Modifier.fillMaxWidth(),
-        )
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(ASSISTANT_CARD_CORNER_RADIUS),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        when (card) {
+            is AssistantCard.Order -> assistantCardRenderer.OrderCard(
+                card = card,
+                onAction = onCardAction,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            is AssistantCard.Product -> assistantCardRenderer.ProductCard(
+                card = card,
+                onAction = onCardAction,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }
+
+private val ASSISTANT_CARD_CORNER_RADIUS = 12.dp
 
 @Composable
 private fun AssistantTextBubble(text: String, isUser: Boolean) {
@@ -649,30 +658,23 @@ private object PreviewAssistantCardRenderer : AssistantCardRenderer {
         onAction: (AssistantCardAction) -> Unit,
         modifier: Modifier,
     ) {
-        Surface(
-            modifier = modifier,
-            shape = RoundedCornerShape(12.dp),
-            color = MaterialTheme.colorScheme.surfaceContainerHighest,
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        Column(
+            modifier = modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            Column(
-                modifier = Modifier.padding(14.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Text(
-                    text = card.number,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(
-                    text = listOf(card.customerName, card.status, card.unformattedTotal)
-                        .filter { it.isNotBlank() }
-                        .joinToString(" - "),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
+            Text(
+                text = card.number,
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = listOf(card.customerName, card.status, card.unformattedTotal)
+                    .filter { it.isNotBlank() }
+                    .joinToString(" - "),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodySmall,
+            )
         }
     }
 
@@ -682,30 +684,23 @@ private object PreviewAssistantCardRenderer : AssistantCardRenderer {
         onAction: (AssistantCardAction) -> Unit,
         modifier: Modifier,
     ) {
-        Surface(
-            modifier = modifier,
-            shape = RoundedCornerShape(12.dp),
-            color = MaterialTheme.colorScheme.surfaceContainerHighest,
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        Column(
+            modifier = modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            Column(
-                modifier = Modifier.padding(14.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Text(
-                    text = card.name,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(
-                    text = listOf(card.stockStatus, card.price)
-                        .filter { it.isNotBlank() }
-                        .joinToString(" - "),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
+            Text(
+                text = card.name,
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = listOf(card.stockStatus, card.price)
+                    .filter { it.isNotBlank() }
+                    .joinToString(" - "),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodySmall,
+            )
         }
     }
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -12,6 +12,8 @@ import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationDispatchResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
 import com.woocommerce.android.aiassistant.runtime.AssistantTurnRequest
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardEntry
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardKey
 import com.woocommerce.android.tools.SelectedSite
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -39,6 +41,7 @@ class AssistantViewModel @AssistedInject constructor(
     private var history: List<AssistantMessage> = emptyList()
     private var lastTurnBaseHistory: List<AssistantMessage> = emptyList()
     private var lastUserMessage: String? = null
+    private val activeCardKeys = linkedSetOf<AssistantCardKey>()
 
     fun onSendMessage(message: String) {
         if (_uiState.value.isTurnActive) return
@@ -124,6 +127,7 @@ class AssistantViewModel @AssistedInject constructor(
 
     private fun startTurn(message: String, isRetry: Boolean) {
         turnJob?.cancel()
+        activeCardKeys.clear()
         if (!isRetry) {
             lastTurnBaseHistory = history
         }
@@ -197,11 +201,13 @@ class AssistantViewModel @AssistedInject constructor(
                     )
                 }
             }
+            is AssistantRuntimeEvent.CardsResolved -> appendAssistantCards(event.cards)
             is AssistantRuntimeEvent.Finished -> {
                 val activeMessageId = activeAssistantMessageId
                 val normalizedError = event.normalizedAssistantError()
                 val canRetry = event.canRetry()
                 activeAssistantMessageId = null
+                activeCardKeys.clear()
                 history = event.updatedHistory
                 _uiState.update {
                     it.copy(
@@ -299,6 +305,26 @@ class AssistantViewModel @AssistedInject constructor(
                     }
                 }
             }
+        }
+    }
+
+    private fun appendAssistantCards(entries: List<AssistantCardEntry>) {
+        val messageId = activeAssistantMessageId ?: return
+        val newSegments = entries
+            .filter { activeCardKeys.add(it.key) }
+            .map { AssistantUiSegment.Card(it.card) }
+        if (newSegments.isEmpty()) return
+
+        _uiState.update { state ->
+            state.copy(
+                messages = state.messages.map { message ->
+                    if (message.id == messageId) {
+                        message.copy(segments = message.segments + newSegments)
+                    } else {
+                        message
+                    }
+                }
+            )
         }
     }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -12,7 +12,7 @@ import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationDispatchResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
 import com.woocommerce.android.aiassistant.runtime.AssistantTurnRequest
-import com.woocommerce.android.aiassistant.ui.cards.AssistantCardEntry
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardKey
 import com.woocommerce.android.tools.SelectedSite
 import dagger.assisted.Assisted
@@ -308,11 +308,11 @@ class AssistantViewModel @AssistedInject constructor(
         }
     }
 
-    private fun appendAssistantCards(entries: List<AssistantCardEntry>) {
+    private fun appendAssistantCards(cards: List<AssistantCard>) {
         val messageId = activeAssistantMessageId ?: return
-        val newSegments = entries
-            .filter { activeCardKeys.add(it.key) }
-            .map { AssistantUiSegment.Card(it.card) }
+        val newSegments = cards
+            .filter { activeCardKeys.add(it.toCardKey()) }
+            .map { AssistantUiSegment.Card(it) }
         if (newSegments.isEmpty()) return
 
         _uiState.update { state ->
@@ -327,6 +327,12 @@ class AssistantViewModel @AssistedInject constructor(
             )
         }
     }
+
+    private fun AssistantCard.toCardKey(): AssistantCardKey =
+        when (this) {
+            is AssistantCard.Order -> AssistantCardKey(family = "order", id = remoteOrderId.toString())
+            is AssistantCard.Product -> AssistantCardKey(family = "product", id = remoteProductId.toString())
+        }
 
     private fun appendAssistantText(delta: String) {
         val messageId = activeAssistantMessageId ?: return

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardEntry.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardEntry.kt
@@ -1,0 +1,11 @@
+package com.woocommerce.android.aiassistant.ui.cards
+
+data class AssistantCardEntry(
+    val key: AssistantCardKey,
+    val card: AssistantCard,
+)
+
+data class AssistantCardKey(
+    val family: String,
+    val id: String,
+)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardEntry.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardEntry.kt
@@ -1,11 +1,11 @@
 package com.woocommerce.android.aiassistant.ui.cards
 
-data class AssistantCardEntry(
+internal data class AssistantCardEntry(
     val key: AssistantCardKey,
     val card: AssistantCard,
 )
 
-data class AssistantCardKey(
+internal data class AssistantCardKey(
     val family: String,
     val id: String,
 )

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
@@ -6,7 +6,19 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStruc
 
 internal object AssistantCardPayloadParser {
     fun parse(payload: ShowCardsUiStructured): List<AssistantCard> =
-        payload.cards.mapNotNull(::parseCard)
+        parseEntries(payload).map { it.card }
+
+    fun parseEntries(payload: ShowCardsUiStructured): List<AssistantCardEntry> =
+        payload.cards.mapNotNull(::parseEntry)
+
+    private fun parseEntry(card: ShowCardPayload): AssistantCardEntry? {
+        val parsedCard = parseCard(card) ?: return null
+
+        return AssistantCardEntry(
+            key = AssistantCardKey(family = card.family, id = card.id),
+            card = parsedCard,
+        )
+    }
 
     private fun parseCard(card: ShowCardPayload): AssistantCard? =
         when (card.family) {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardUiStructuredParser.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardUiStructuredParser.kt
@@ -1,0 +1,27 @@
+package com.woocommerce.android.aiassistant.ui.cards
+
+import com.woocommerce.android.aiassistant.di.AiAssistantJson
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import javax.inject.Inject
+
+internal class AssistantCardUiStructuredParser @Inject constructor(
+    @AiAssistantJson private val json: Json,
+) {
+    fun parse(uiStructured: JsonElement?): List<AssistantCardEntry> {
+        if (uiStructured == null) return emptyList()
+
+        val payload = try {
+            json.decodeFromJsonElement<ShowCardsUiStructured>(uiStructured)
+        } catch (_: SerializationException) {
+            return emptyList()
+        } catch (_: IllegalArgumentException) {
+            return emptyList()
+        }
+
+        return AssistantCardPayloadParser.parseEntries(payload)
+    }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -379,6 +379,39 @@ class AgenticLoopAssistantRuntimeTest {
         }
 
     @Test
+    fun `given show cards success with valid and unsupported cards, when adapted, then valid cards are emitted`() =
+        runTest {
+            val runtime = runtime(
+                agenticLoop = FakeAgenticLoop(
+                    events = listOf(
+                        LoopEvent.ToolCallStarted(showCardsCall(id = "call-partial")),
+                        LoopEvent.ToolCallFinished(
+                            ToolResult.Success(
+                                toolCallId = "call-partial",
+                                structured = buildJsonObject { put("rendered", 1) },
+                                uiStructured = showCardsUiStructured(
+                                    orderPayload(id = "123", title = "#123"),
+                                    ShowCardPayload(
+                                        family = "customer",
+                                        id = "456",
+                                        title = "Customer",
+                                        details = ShowCardDetails.Product(),
+                                    ),
+                                ),
+                            )
+                        ),
+                    )
+                )
+            )
+
+            val events = runtime.startTurn(givenTurnRequest()).toList()
+
+            assertThat(events).containsExactly(
+                AssistantRuntimeEvent.CardsResolved(listOf(expectedOrderEntry(id = "123", number = "#123")))
+            )
+        }
+
+    @Test
     fun `when cancelled confirmation is resolved, then runtime forwards the cancellation result to safety orchestrator`() =
         runTest {
             val safetyOrchestrator = FakeSafetyOrchestrator()
@@ -432,6 +465,19 @@ class AgenticLoopAssistantRuntimeTest {
             currency = "USD",
             dateCreated = "2026-05-01T10:00:00Z",
             customerName = "Jane Doe",
+        ),
+    )
+
+    private fun expectedOrderEntry(id: String, number: String) = AssistantCardEntry(
+        key = AssistantCardKey(family = "order", id = id),
+        card = AssistantCard.Order(
+            remoteOrderId = id.toLong(),
+            number = number,
+            status = "processing",
+            total = "12.34",
+            currency = "USD",
+            customerName = "Jane Doe",
+            date = "2026-05-01T10:00:00Z",
         ),
     )
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -298,7 +298,7 @@ class AgenticLoopAssistantRuntimeTest {
 
         val events = runtime.startTurn(givenTurnRequest()).toList()
 
-        assertThat(events).containsExactly(
+        assertThat(events.cardEvents()).containsExactly(
             AssistantRuntimeEvent.CardsResolved(
                 listOf(
                     AssistantCardEntry(
@@ -343,7 +343,7 @@ class AgenticLoopAssistantRuntimeTest {
 
         val events = runtime.startTurn(givenTurnRequest()).toList()
 
-        assertThat(events).isEmpty()
+        assertThat(events.cardEvents()).isEmpty()
     }
 
     @Test
@@ -370,7 +370,8 @@ class AgenticLoopAssistantRuntimeTest {
 
             val events = runtime.startTurn(givenTurnRequest()).toList()
 
-            assertThat(events).containsExactly(
+            assertThat(events.cardEvents()).isEmpty()
+            assertThat(events).contains(
                 AssistantRuntimeEvent.Finished(
                     outcome = LoopOutcome.COMPLETED,
                     updatedHistory = listOf(AssistantMessage.User("Hello")),
@@ -406,7 +407,7 @@ class AgenticLoopAssistantRuntimeTest {
 
             val events = runtime.startTurn(givenTurnRequest()).toList()
 
-            assertThat(events).containsExactly(
+            assertThat(events.cardEvents()).containsExactly(
                 AssistantRuntimeEvent.CardsResolved(listOf(expectedOrderEntry(id = "123", number = "#123")))
             )
         }
@@ -431,7 +432,8 @@ class AgenticLoopAssistantRuntimeTest {
 
         val events = runtime.startTurn(givenTurnRequest()).toList()
 
-        assertThat(events).containsExactly(
+        assertThat(events.cardEvents()).isEmpty()
+        assertThat(events).contains(
             AssistantRuntimeEvent.AssistantTextDelta("I could not find matching cards.")
         )
     }
@@ -466,7 +468,7 @@ class AgenticLoopAssistantRuntimeTest {
 
             val events = runtime.startTurn(givenTurnRequest()).toList()
 
-            assertThat(events).isEmpty()
+            assertThat(events.cardEvents()).isEmpty()
         }
 
     @Test
@@ -538,6 +540,9 @@ class AgenticLoopAssistantRuntimeTest {
             date = "2026-05-01T10:00:00Z",
         ),
     )
+
+    private fun List<AssistantRuntimeEvent>.cardEvents() =
+        filterIsInstance<AssistantRuntimeEvent.CardsResolved>()
 
     private class FakeAgenticLoop(
         private val events: List<LoopEvent>,

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -319,6 +319,34 @@ class AgenticLoopAssistantRuntimeTest {
     }
 
     @Test
+    fun `given non show cards success with card shaped uiStructured, when adapted, then cards are ignored`() = runTest {
+        val runtime = runtime(
+            agenticLoop = FakeAgenticLoop(
+                events = listOf(
+                    LoopEvent.ToolCallStarted(
+                        ToolCall(
+                            id = "call-orders",
+                            name = "orders_list",
+                            arguments = buildJsonObject {},
+                        )
+                    ),
+                    LoopEvent.ToolCallFinished(
+                        ToolResult.Success(
+                            toolCallId = "call-orders",
+                            structured = buildJsonObject { put("ok", true) },
+                            uiStructured = showCardsUiStructured(orderPayload(id = "123", title = "#123")),
+                        )
+                    ),
+                )
+            )
+        )
+
+        val events = runtime.startTurn(givenTurnRequest()).toList()
+
+        assertThat(events).isEmpty()
+    }
+
+    @Test
     fun `when cancelled confirmation is resolved, then runtime forwards the cancellation result to safety orchestrator`() =
         runTest {
             val safetyOrchestrator = FakeSafetyOrchestrator()

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -27,16 +27,25 @@ import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreview
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreviewField
 import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationPreviewBuilder
 import com.woocommerce.android.aiassistant.safety.WooCommerceConfirmationSnapshotResolver
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardDetails
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
 import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
 import com.woocommerce.android.aiassistant.tools.products.AIProductVariationsDataSource
 import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCardState
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardEntry
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardKey
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardUiStructuredParser
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.put
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -46,6 +55,12 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class AgenticLoopAssistantRuntimeTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+        explicitNulls = false
+    }
+
     @Test
     fun `when agentic loop finishes with max iterations, then runtime preserves outcome`() = runTest {
         val updatedHistory = listOf(AssistantMessage.User("Hello"))
@@ -261,6 +276,49 @@ class AgenticLoopAssistantRuntimeTest {
     }
 
     @Test
+    fun `given show cards non success and success results, when adapted, then only success emits cards`() = runTest {
+        val runtime = runtime(
+            agenticLoop = FakeAgenticLoop(
+                events = listOf(
+                    LoopEvent.ToolCallStarted(showCardsCall(id = "call-validation")),
+                    LoopEvent.ToolCallFinished(ToolResult.ValidationError("call-validation", "bad args")),
+                    LoopEvent.ToolCallStarted(showCardsCall(id = "call-success")),
+                    LoopEvent.ToolCallFinished(
+                        ToolResult.Success(
+                            toolCallId = "call-success",
+                            structured = buildJsonObject { put("rendered", 1) },
+                            uiStructured = showCardsUiStructured(orderPayload(id = "123", title = "#123")),
+                        )
+                    ),
+                    LoopEvent.ToolCallStarted(showCardsCall(id = "call-transport")),
+                    LoopEvent.ToolCallFinished(ToolResult.TransportError("call-transport", retryable = true)),
+                )
+            )
+        )
+
+        val events = runtime.startTurn(givenTurnRequest()).toList()
+
+        assertThat(events).containsExactly(
+            AssistantRuntimeEvent.CardsResolved(
+                listOf(
+                    AssistantCardEntry(
+                        key = AssistantCardKey(family = "order", id = "123"),
+                        card = AssistantCard.Order(
+                            remoteOrderId = 123L,
+                            number = "#123",
+                            status = "processing",
+                            total = "12.34",
+                            currency = "USD",
+                            customerName = "Jane Doe",
+                            date = "2026-05-01T10:00:00Z",
+                        ),
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
     fun `when cancelled confirmation is resolved, then runtime forwards the cancellation result to safety orchestrator`() =
         runTest {
             val safetyOrchestrator = FakeSafetyOrchestrator()
@@ -284,6 +342,7 @@ class AgenticLoopAssistantRuntimeTest {
         confirmationPreviewBuilder = WooCommerceConfirmationPreviewBuilder(),
         confirmationPreviewRenderer = ConfirmationPreviewRenderer(ApplicationProvider.getApplicationContext<Context>()),
         confirmationSnapshotResolver = snapshotResolver,
+        cardParser = AssistantCardUiStructuredParser(json),
     )
 
     private fun givenTurnRequest() = AssistantTurnRequest(
@@ -292,6 +351,28 @@ class AgenticLoopAssistantRuntimeTest {
         toolScope = ToolScope.GLOBAL,
         userMessage = "Hello",
         history = emptyList(),
+    )
+
+    private fun showCardsCall(id: String) = ToolCall(
+        id = id,
+        name = "show_cards",
+        arguments = buildJsonObject {},
+    )
+
+    private fun showCardsUiStructured(vararg cards: ShowCardPayload) =
+        json.encodeToJsonElement(ShowCardsUiStructured(cards = cards.toList()))
+
+    private fun orderPayload(id: String, title: String) = ShowCardPayload(
+        family = "order",
+        id = id,
+        title = title,
+        details = ShowCardDetails.Order(
+            status = "processing",
+            total = "12.34",
+            currency = "USD",
+            dateCreated = "2026-05-01T10:00:00Z",
+            customerName = "Jane Doe",
+        ),
     )
 
     private class FakeAgenticLoop(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -36,8 +36,6 @@ import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCardState
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
-import com.woocommerce.android.aiassistant.ui.cards.AssistantCardEntry
-import com.woocommerce.android.aiassistant.ui.cards.AssistantCardKey
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardUiStructuredParser
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -301,17 +299,14 @@ class AgenticLoopAssistantRuntimeTest {
         assertThat(events.cardEvents()).containsExactly(
             AssistantRuntimeEvent.CardsResolved(
                 listOf(
-                    AssistantCardEntry(
-                        key = AssistantCardKey(family = "order", id = "123"),
-                        card = AssistantCard.Order(
-                            remoteOrderId = 123L,
-                            number = "#123",
-                            status = "processing",
-                            total = "12.34",
-                            currency = "USD",
-                            customerName = "Jane Doe",
-                            date = "2026-05-01T10:00:00Z",
-                        ),
+                    AssistantCard.Order(
+                        remoteOrderId = 123L,
+                        number = "#123",
+                        status = "processing",
+                        total = "12.34",
+                        currency = "USD",
+                        customerName = "Jane Doe",
+                        date = "2026-05-01T10:00:00Z",
                     )
                 )
             )
@@ -408,7 +403,7 @@ class AgenticLoopAssistantRuntimeTest {
             val events = runtime.startTurn(givenTurnRequest()).toList()
 
             assertThat(events.cardEvents()).containsExactly(
-                AssistantRuntimeEvent.CardsResolved(listOf(expectedOrderEntry(id = "123", number = "#123")))
+                AssistantRuntimeEvent.CardsResolved(listOf(expectedOrderCard(id = "123", number = "#123")))
             )
         }
 
@@ -528,17 +523,14 @@ class AgenticLoopAssistantRuntimeTest {
         ),
     )
 
-    private fun expectedOrderEntry(id: String, number: String) = AssistantCardEntry(
-        key = AssistantCardKey(family = "order", id = id),
-        card = AssistantCard.Order(
-            remoteOrderId = id.toLong(),
-            number = number,
-            status = "processing",
-            total = "12.34",
-            currency = "USD",
-            customerName = "Jane Doe",
-            date = "2026-05-01T10:00:00Z",
-        ),
+    private fun expectedOrderCard(id: String, number: String) = AssistantCard.Order(
+        remoteOrderId = id.toLong(),
+        number = number,
+        status = "processing",
+        total = "12.34",
+        currency = "USD",
+        customerName = "Jane Doe",
+        date = "2026-05-01T10:00:00Z",
     )
 
     private fun List<AssistantRuntimeEvent>.cardEvents() =

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -347,6 +347,38 @@ class AgenticLoopAssistantRuntimeTest {
     }
 
     @Test
+    fun `given show cards success with malformed uiStructured, when adapted, then no card event is emitted`() =
+        runTest {
+            val runtime = runtime(
+                agenticLoop = FakeAgenticLoop(
+                    events = listOf(
+                        LoopEvent.ToolCallStarted(showCardsCall(id = "call-malformed")),
+                        LoopEvent.ToolCallFinished(
+                            ToolResult.Success(
+                                toolCallId = "call-malformed",
+                                structured = buildJsonObject { put("rendered", 1) },
+                                uiStructured = buildJsonObject { put("cards", "not an array") },
+                            )
+                        ),
+                        LoopEvent.Finished(
+                            outcome = LoopOutcome.COMPLETED,
+                            updatedHistory = listOf(AssistantMessage.User("Hello")),
+                        ),
+                    )
+                )
+            )
+
+            val events = runtime.startTurn(givenTurnRequest()).toList()
+
+            assertThat(events).containsExactly(
+                AssistantRuntimeEvent.Finished(
+                    outcome = LoopOutcome.COMPLETED,
+                    updatedHistory = listOf(AssistantMessage.User("Hello")),
+                )
+            )
+        }
+
+    @Test
     fun `when cancelled confirmation is resolved, then runtime forwards the cancellation result to safety orchestrator`() =
         runTest {
             val safetyOrchestrator = FakeSafetyOrchestrator()

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -437,6 +437,39 @@ class AgenticLoopAssistantRuntimeTest {
     }
 
     @Test
+    fun `given arbitrary tool success with json cards key, when adapted, then no fallback cards are emitted`() =
+        runTest {
+            val runtime = runtime(
+                agenticLoop = FakeAgenticLoop(
+                    events = listOf(
+                        LoopEvent.ToolCallStarted(
+                            ToolCall(
+                                id = "call-arbitrary",
+                                name = "analytics_revenue",
+                                arguments = buildJsonObject {},
+                            )
+                        ),
+                        LoopEvent.ToolCallFinished(
+                            ToolResult.Success(
+                                toolCallId = "call-arbitrary",
+                                structured = buildJsonObject {
+                                    put("cards", "model visible but not UI cards")
+                                },
+                                uiStructured = buildJsonObject {
+                                    put("cards", "also ignored")
+                                },
+                            )
+                        ),
+                    )
+                )
+            )
+
+            val events = runtime.startTurn(givenTurnRequest()).toList()
+
+            assertThat(events).isEmpty()
+        }
+
+    @Test
     fun `when cancelled confirmation is resolved, then runtime forwards the cancellation result to safety orchestrator`() =
         runTest {
             val safetyOrchestrator = FakeSafetyOrchestrator()

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -412,6 +412,31 @@ class AgenticLoopAssistantRuntimeTest {
         }
 
     @Test
+    fun `given show cards success with empty cards, when adapted, then no card event is emitted`() = runTest {
+        val runtime = runtime(
+            agenticLoop = FakeAgenticLoop(
+                events = listOf(
+                    LoopEvent.ToolCallStarted(showCardsCall(id = "call-empty")),
+                    LoopEvent.ToolCallFinished(
+                        ToolResult.Success(
+                            toolCallId = "call-empty",
+                            structured = buildJsonObject { put("rendered", 0) },
+                            uiStructured = showCardsUiStructured(),
+                        )
+                    ),
+                    LoopEvent.AssistantTextDelta("I could not find matching cards."),
+                )
+            )
+        )
+
+        val events = runtime.startTurn(givenTurnRequest()).toList()
+
+        assertThat(events).containsExactly(
+            AssistantRuntimeEvent.AssistantTextDelta("I could not find matching cards.")
+        )
+    }
+
+    @Test
     fun `when cancelled confirmation is resolved, then runtime forwards the cancellation result to safety orchestrator`() =
         runTest {
             val safetyOrchestrator = FakeSafetyOrchestrator()

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -12,6 +12,9 @@ import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationDispatchResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
 import com.woocommerce.android.aiassistant.runtime.AssistantTurnRequest
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardEntry
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardKey
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -645,6 +648,27 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given active assistant bubble, when card entries arrive, then card segments are appended`() = runTest {
+        viewModel.onSendMessage("Show order 123")
+        val activeBubbleId = viewModel.uiState.value.messages.last().id
+        val orderEntry = givenOrderEntry(id = "123", number = "#123")
+
+        runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(orderEntry)))
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.messages.last()).isEqualTo(
+            AssistantUiMessage(
+                id = activeBubbleId,
+                role = AssistantUiMessage.Role.ASSISTANT,
+                segments = listOf(
+                    AssistantUiSegment.Text(""),
+                    AssistantUiSegment.Card(orderEntry.card),
+                ),
+            )
+        )
+    }
+
+    @Test
     fun `when cancel is requested, then runtime is cancelled and turn is no longer active`() = runTest {
         viewModel.onSendMessage("Hello")
 
@@ -1045,6 +1069,19 @@ class AssistantViewModelTest {
             arguments = buildJsonObject { put("id", 123) },
         ),
         state = AssistantConfirmationCardState.PENDING,
+    )
+
+    private fun givenOrderEntry(id: String, number: String) = AssistantCardEntry(
+        key = AssistantCardKey(family = "order", id = id),
+        card = AssistantCard.Order(
+            remoteOrderId = id.toLong(),
+            number = number,
+            status = "processing",
+            total = "12.34",
+            currency = "USD",
+            customerName = "Jane Doe",
+            date = "2026-05-01T10:00:00Z",
+        ),
     )
 
     private class FakeAssistantRuntime : AssistantRuntime {

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -704,6 +704,26 @@ class AssistantViewModelTest {
         }
 
     @Test
+    fun `given no card event is emitted, when turn finishes, then no card segment is present`() = runTest {
+        viewModel.onSendMessage("Show missing order")
+
+        runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("I could not find that order."))
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.COMPLETED,
+                updatedHistory = listOf(
+                    AssistantMessage.User("Show missing order"),
+                    AssistantMessage.Assistant("I could not find that order."),
+                ),
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.messages.last().segments.filterIsInstance<AssistantUiSegment.Card>())
+            .isEmpty()
+    }
+
+    @Test
     fun `when cancel is requested, then runtime is cancelled and turn is no longer active`() = runTest {
         viewModel.onSendMessage("Hello")
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -760,6 +760,30 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given finished history contains card shaped tool json, when reduced, then no card segment is created`() =
+        runTest {
+            viewModel.onSendMessage("Show analytics")
+
+            runtime.emit(
+                AssistantRuntimeEvent.Finished(
+                    outcome = LoopOutcome.COMPLETED,
+                    updatedHistory = listOf(
+                        AssistantMessage.User("Show analytics"),
+                        AssistantMessage.Tool(
+                            toolCallId = "call-analytics",
+                            content = """{"cards":[{"family":"order","id":"123"}]}""",
+                        ),
+                        AssistantMessage.Assistant("Revenue is up today."),
+                    ),
+                )
+            )
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.messages.last().segments.filterIsInstance<AssistantUiSegment.Card>())
+                .isEmpty()
+        }
+
+    @Test
     fun `when cancel is requested, then runtime is cancelled and turn is no longer active`() = runTest {
         viewModel.onSendMessage("Hello")
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -669,6 +669,41 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given cards arrive between text deltas, when turn finishes, then cards stay on active assistant message`() =
+        runTest {
+            viewModel.onSendMessage("Show order 123")
+            val activeBubbleId = viewModel.uiState.value.messages.last().id
+            val orderEntry = givenOrderEntry(id = "123", number = "#123")
+
+            runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("Here is the order."))
+            runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(orderEntry)))
+            runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("Anything else?"))
+            runtime.emit(
+                AssistantRuntimeEvent.Finished(
+                    outcome = LoopOutcome.COMPLETED,
+                    updatedHistory = listOf(
+                        AssistantMessage.User("Show order 123"),
+                        AssistantMessage.Assistant("Here is the order. Anything else?"),
+                    ),
+                )
+            )
+            advanceUntilIdle()
+
+            assertThat(viewModel.uiState.value.messages.last()).isEqualTo(
+                AssistantUiMessage(
+                    id = activeBubbleId,
+                    role = AssistantUiMessage.Role.ASSISTANT,
+                    segments = listOf(
+                        AssistantUiSegment.Text("Here is the order."),
+                        AssistantUiSegment.Card(orderEntry.card),
+                        AssistantUiSegment.Text("Anything else?"),
+                    ),
+                )
+            )
+            assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.IDLE)
+        }
+
+    @Test
     fun `when cancel is requested, then runtime is cancelled and turn is no longer active`() = runTest {
         viewModel.onSendMessage("Hello")
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -13,8 +13,6 @@ import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationD
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
 import com.woocommerce.android.aiassistant.runtime.AssistantTurnRequest
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
-import com.woocommerce.android.aiassistant.ui.cards.AssistantCardEntry
-import com.woocommerce.android.aiassistant.ui.cards.AssistantCardKey
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -648,12 +646,12 @@ class AssistantViewModelTest {
     }
 
     @Test
-    fun `given active assistant bubble, when card entries arrive, then card segments are appended`() = runTest {
+    fun `given active assistant bubble, when cards arrive, then card segments are appended`() = runTest {
         viewModel.onSendMessage("Show order 123")
         val activeBubbleId = viewModel.uiState.value.messages.last().id
-        val orderEntry = givenOrderEntry(id = "123", number = "#123")
+        val orderCard = givenOrderCard(id = "123", number = "#123")
 
-        runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(orderEntry)))
+        runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(orderCard)))
         advanceUntilIdle()
 
         assertThat(viewModel.uiState.value.messages.last()).isEqualTo(
@@ -662,7 +660,7 @@ class AssistantViewModelTest {
                 role = AssistantUiMessage.Role.ASSISTANT,
                 segments = listOf(
                     AssistantUiSegment.Text(""),
-                    AssistantUiSegment.Card(orderEntry.card),
+                    AssistantUiSegment.Card(orderCard),
                 ),
             )
         )
@@ -673,10 +671,10 @@ class AssistantViewModelTest {
         runTest {
             viewModel.onSendMessage("Show order 123")
             val activeBubbleId = viewModel.uiState.value.messages.last().id
-            val orderEntry = givenOrderEntry(id = "123", number = "#123")
+            val orderCard = givenOrderCard(id = "123", number = "#123")
 
             runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("Here is the order."))
-            runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(orderEntry)))
+            runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(orderCard)))
             runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("Anything else?"))
             runtime.emit(
                 AssistantRuntimeEvent.Finished(
@@ -695,7 +693,7 @@ class AssistantViewModelTest {
                     role = AssistantUiMessage.Role.ASSISTANT,
                     segments = listOf(
                         AssistantUiSegment.Text("Here is the order."),
-                        AssistantUiSegment.Card(orderEntry.card),
+                        AssistantUiSegment.Card(orderCard),
                         AssistantUiSegment.Text("Anything else?"),
                     ),
                 )
@@ -726,9 +724,9 @@ class AssistantViewModelTest {
     @Test
     fun `given duplicate card keys across one turn, when cards arrive, then first seen cards are kept`() = runTest {
         viewModel.onSendMessage("Show matching cards")
-        val firstOrder = givenOrderEntry(id = "123", number = "#123")
-        val duplicateOrder = givenOrderEntry(id = "123", number = "#duplicate")
-        val secondOrder = givenOrderEntry(id = "456", number = "#456")
+        val firstOrder = givenOrderCard(id = "123", number = "#123")
+        val duplicateOrder = givenOrderCard(id = "123", number = "#duplicate")
+        val secondOrder = givenOrderCard(id = "456", number = "#456")
 
         runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(firstOrder)))
         runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(duplicateOrder, secondOrder)))
@@ -738,24 +736,24 @@ class AssistantViewModelTest {
             .filterIsInstance<AssistantUiSegment.Card>()
 
         assertThat(cardSegments).containsExactly(
-            AssistantUiSegment.Card(firstOrder.card),
-            AssistantUiSegment.Card(secondOrder.card),
+            AssistantUiSegment.Card(firstOrder),
+            AssistantUiSegment.Card(secondOrder),
         )
     }
 
     @Test
     fun `given same id across different families, when cards arrive, then both cards are kept`() = runTest {
         viewModel.onSendMessage("Show order and product 123")
-        val order = givenOrderEntry(id = "123", number = "#123")
-        val product = givenProductEntry(id = "123", name = "Socks")
+        val order = givenOrderCard(id = "123", number = "#123")
+        val product = givenProductCard(id = "123", name = "Socks")
 
         runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(order, product)))
         advanceUntilIdle()
 
         assertThat(viewModel.uiState.value.messages.last().segments)
             .contains(
-                AssistantUiSegment.Card(order.card),
-                AssistantUiSegment.Card(product.card),
+                AssistantUiSegment.Card(order),
+                AssistantUiSegment.Card(product),
             )
     }
 
@@ -1186,30 +1184,24 @@ class AssistantViewModelTest {
         state = AssistantConfirmationCardState.PENDING,
     )
 
-    private fun givenOrderEntry(id: String, number: String) = AssistantCardEntry(
-        key = AssistantCardKey(family = "order", id = id),
-        card = AssistantCard.Order(
-            remoteOrderId = id.toLong(),
-            number = number,
-            status = "processing",
-            total = "12.34",
-            currency = "USD",
-            customerName = "Jane Doe",
-            date = "2026-05-01T10:00:00Z",
-        ),
+    private fun givenOrderCard(id: String, number: String) = AssistantCard.Order(
+        remoteOrderId = id.toLong(),
+        number = number,
+        status = "processing",
+        total = "12.34",
+        currency = "USD",
+        customerName = "Jane Doe",
+        date = "2026-05-01T10:00:00Z",
     )
 
-    private fun givenProductEntry(id: String, name: String) = AssistantCardEntry(
-        key = AssistantCardKey(family = "product", id = id),
-        card = AssistantCard.Product(
-            remoteProductId = id.toLong(),
-            name = name,
-            sku = "woo-socks",
-            price = "9.99",
-            stockStatus = "instock",
-            status = "publish",
-            imageUrl = "https://example.com/socks.png",
-        ),
+    private fun givenProductCard(id: String, name: String) = AssistantCard.Product(
+        remoteProductId = id.toLong(),
+        name = name,
+        sku = "woo-socks",
+        price = "9.99",
+        stockStatus = "instock",
+        status = "publish",
+        imageUrl = "https://example.com/socks.png",
     )
 
     private class FakeAssistantRuntime : AssistantRuntime {

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -724,6 +724,42 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given duplicate card keys across one turn, when cards arrive, then first seen cards are kept`() = runTest {
+        viewModel.onSendMessage("Show matching cards")
+        val firstOrder = givenOrderEntry(id = "123", number = "#123")
+        val duplicateOrder = givenOrderEntry(id = "123", number = "#duplicate")
+        val secondOrder = givenOrderEntry(id = "456", number = "#456")
+
+        runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(firstOrder)))
+        runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(duplicateOrder, secondOrder)))
+        advanceUntilIdle()
+
+        val cardSegments = viewModel.uiState.value.messages.last().segments
+            .filterIsInstance<AssistantUiSegment.Card>()
+
+        assertThat(cardSegments).containsExactly(
+            AssistantUiSegment.Card(firstOrder.card),
+            AssistantUiSegment.Card(secondOrder.card),
+        )
+    }
+
+    @Test
+    fun `given same id across different families, when cards arrive, then both cards are kept`() = runTest {
+        viewModel.onSendMessage("Show order and product 123")
+        val order = givenOrderEntry(id = "123", number = "#123")
+        val product = givenProductEntry(id = "123", name = "Socks")
+
+        runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(order, product)))
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.messages.last().segments)
+            .contains(
+                AssistantUiSegment.Card(order.card),
+                AssistantUiSegment.Card(product.card),
+            )
+    }
+
+    @Test
     fun `when cancel is requested, then runtime is cancelled and turn is no longer active`() = runTest {
         viewModel.onSendMessage("Hello")
 
@@ -1136,6 +1172,19 @@ class AssistantViewModelTest {
             currency = "USD",
             customerName = "Jane Doe",
             date = "2026-05-01T10:00:00Z",
+        ),
+    )
+
+    private fun givenProductEntry(id: String, name: String) = AssistantCardEntry(
+        key = AssistantCardKey(family = "product", id = id),
+        card = AssistantCard.Product(
+            remoteProductId = id.toLong(),
+            name = name,
+            sku = "woo-socks",
+            price = "9.99",
+            stockStatus = "instock",
+            status = "publish",
+            imageUrl = "https://example.com/socks.png",
         ),
     )
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
@@ -70,6 +70,28 @@ class AssistantCardPayloadParserTest {
     }
 
     @Test
+    fun `given order payload, when parsed as entries, then raw family id key is preserved`() {
+        val entries = AssistantCardPayloadParser.parseEntries(
+            ShowCardsUiStructured(
+                cards = listOf(orderPayload(id = "00123", title = "#123"))
+            )
+        )
+
+        assertThat(entries.single().key).isEqualTo(AssistantCardKey(family = "order", id = "00123"))
+        assertThat(entries.single().card).isEqualTo(
+            AssistantCard.Order(
+                remoteOrderId = 123L,
+                number = "#123",
+                status = "processing",
+                total = "",
+                currency = "",
+                customerName = "",
+                date = "",
+            )
+        )
+    }
+
+    @Test
     fun `given product payload, when parsed, then product card contains displayed fields`() {
         val cards = AssistantCardPayloadParser.parse(
             ShowCardsUiStructured(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardUiStructuredParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardUiStructuredParserTest.kt
@@ -1,0 +1,78 @@
+package com.woocommerce.android.aiassistant.ui.cards
+
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardDetails
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AssistantCardUiStructuredParserTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+        explicitNulls = false
+    }
+    private val parser = AssistantCardUiStructuredParser(json)
+
+    @Test
+    fun `given missing uiStructured, when parsed, then no cards are returned`() {
+        assertThat(parser.parse(null)).isEmpty()
+    }
+
+    @Test
+    fun `given malformed cards field, when parsed, then no cards are returned`() {
+        val cards = parser.parse(
+            buildJsonObject {
+                put("cards", "not an array")
+            }
+        )
+
+        assertThat(cards).isEmpty()
+    }
+
+    @Test
+    fun `given malformed card details, when parsed, then no cards are returned`() {
+        val cards = parser.parse(
+            buildJsonObject {
+                putJsonArray("cards") {
+                    add(
+                        buildJsonObject {
+                            put("family", "order")
+                            put("id", "123")
+                            put("title", "#123")
+                            put("details", "not an object")
+                        }
+                    )
+                }
+            }
+        )
+
+        assertThat(cards).isEmpty()
+    }
+
+    @Test
+    fun `given valid uiStructured, when parsed, then card entries are returned`() {
+        val cards = parser.parse(
+            json.encodeToJsonElement(
+                ShowCardsUiStructured(
+                    cards = listOf(
+                        ShowCardPayload(
+                            family = "order",
+                            id = "123",
+                            title = "#123",
+                            details = ShowCardDetails.Order(status = "processing"),
+                        )
+                    )
+                )
+            )
+        )
+
+        assertThat(cards.map { it.key }).containsExactly(AssistantCardKey("order", "123"))
+    }
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-2967

This PR wires successful `show_cards` UI payloads into the visible Android AI Assistant transcript. It builds on the typed order/product card rendering work and the typing/tool-activity transcript model from #15819 so cards can be shown as first-class assistant message segments instead of remaining only in tool results.

#### What changes for users

When the assistant resolves order or product references through `show_cards`, the final assistant reply can now include native WooCommerce cards directly in the conversation. Those cards use the existing host-owned order/product row UI, support the existing open-order/open-product actions, and now render inside a rounded card surface with a visible background and subtle outline so the card content no longer floats on the chat background.

If the tool resolves only some requested references, the available cards are still shown. If no cards resolve, no empty card UI is displayed. Card duplicates are filtered by the first-seen `(family, id)` key for the active assistant turn.

#### Runtime and UI behavior

The assistant runtime now tracks tool names by tool-call ID while preserving the tool activity events from #15819. On `ToolCallFinished`, it emits `CardsResolved` only when the result is a successful `show_cards` call with parseable `uiStructured.cards`.

The ViewModel appends resolved cards as `AssistantUiSegment.Card` entries on the active assistant message. Cards that arrive between streamed text deltas stay attached to the same final visible assistant reply. Malformed, empty, non-success, non-`show_cards`, and arbitrary card-shaped JSON payloads do not create card segments.

The card parser uses `kotlinx-serialization-json` for AI payloads and keeps raw `(family, id)` keys alongside parsed render models so ViewModel-level dedupe follows the cross-platform first-seen rule.

#### Card rendering polish

Card chrome is owned by `AssistantCardSegment`, so all current and future assistant cards share the same transcript surface. The segment wraps renderer content in a Material 3 `Surface` with rounded corners, `surfaceContainerHighest`, and an `outlineVariant` border. Host renderers stay focused on card content and navigation rather than transcript container styling.

The host order card mapper also formats ISO order dates into the same short month/day style used by existing order rows, with a raw-string fallback for unparseable dates.

#### Boundaries and safety notes

This PR is stacked on #15819 (`issue/woomob-2970-typing-indicator-pill`). The PR should be reviewed as the `show_cards` delivery and card-surface slice on top of that base.

The assistant feature module remains host-agnostic. `:libs:ai-assistant:feature` owns runtime delivery, UI state, parsing, and segment chrome. `:WooCommerce` owns WooCommerce-specific row mapping and navigation. There are no new auth paths, Jetpack AI JWT changes, Gson usage for AI payloads, or dependency-direction reversals.

#### Tests added or updated

This PR adds focused coverage for:

- successful `show_cards` results emitting card events
- non-success `show_cards` results not emitting card events
- card-shaped `uiStructured` from non-`show_cards` tools being ignored
- malformed `uiStructured` producing no cards and no crash
- empty card payloads producing no card UI
- partial success preserving available cards
- arbitrary tool-result JSON not becoming fallback card UI
- appending resolved cards into assistant message state
- preserving cards on the final visible assistant message
- first-seen `(family, id)` dedupe, including same ID across different families
- parser raw key preservation and malformed payload handling
- host order-date formatting fallback behavior

### Test Steps
1. Build and install the Wasabi debug app from this branch.
2. Open the AI Assistant from the More menu on a store with recent orders or products.
3. Ask for a recent order or product in a card. **Note:** Given there is no system prompt, you need to explicitly ask for cards.
4. Verify the final assistant reply includes a native card attached to the assistant message, with a visible rounded background and subtle border.
5. Tap the card and verify it opens the corresponding order or product screen.
6. Ask for references that do not resolve to cards and verify no empty card UI is shown.
7. Ask a non-card question, such as revenue for today, and verify the response remains plain assistant text with no JSON or fallback card rendering.

### Images/gif
| Orders | Products |
| --- | --- |
| <img width="360" alt="Screenshot_20260504_212428" src="https://github.com/user-attachments/assets/5fdf9adb-c3cd-4ede-9c1f-d01c0e4036f4" /> |<img width="360" alt="Screenshot_20260504_212337" src="https://github.com/user-attachments/assets/9a72cc31-058a-48bb-a0cd-3b3ad8d9f321" /> |


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.