### PR TITLE
[WOOMOB-2985] Polish assistant chat and rich cards

### DIFF
--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilder.kt
@@ -59,24 +59,15 @@ internal class WooCommerceConfirmationPreviewBuilder @Inject constructor() {
             }
         }
 
-        if (status != null) {
-            val message = if (status in CUSTOMER_NOTIFYING_STATUSES) {
-                string(
-                    R.string.ai_assistant_confirmation_order_set_status_emails_customer,
-                    raw(id.toString()),
-                    raw(status),
-                )
-            } else {
-                string(R.string.ai_assistant_confirmation_order_set_status, raw(id.toString()), raw(status))
-            }
-            return ConfirmationPreview(message = message, fields = fields)
-        }
-
         return ConfirmationPreview(
             message = string(
                 R.string.ai_assistant_confirmation_order_update_summary,
                 raw(id.toString()),
-                fields.toChangeSummary(),
+                fields.toChangeSummary(
+                    statusEmailImpact = status
+                        ?.takeIf { it in CUSTOMER_NOTIFYING_STATUSES }
+                        ?.let { R.string.ai_assistant_confirmation_change_summary_status_emails_customer },
+                ),
             ),
             fields = fields,
         )

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -352,8 +352,16 @@ private fun LazyListState.isPinnedToRenderedEnd(
     if (lastVisibleItem.index != targetIndex) return false
 
     val distanceFromViewportEnd = layoutInfo.viewportEndOffset - (lastVisibleItem.offset + lastVisibleItem.size)
-    return distanceFromViewportEnd <= bottomPinThresholdPx
+    return isRenderedTargetPinnedToViewportEnd(
+        distanceFromViewportEnd = distanceFromViewportEnd,
+        bottomPinThresholdPx = bottomPinThresholdPx,
+    )
 }
+
+internal fun isRenderedTargetPinnedToViewportEnd(
+    distanceFromViewportEnd: Int,
+    bottomPinThresholdPx: Int,
+): Boolean = distanceFromViewportEnd in 0..bottomPinThresholdPx
 
 private fun AssistantUiMessage.hasVisibleContent(): Boolean =
     role == AssistantUiMessage.Role.USER ||

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -241,7 +241,7 @@ private fun AssistantMessageThread(
     modifier: Modifier = Modifier,
 ) {
     val visibleMessages = state.messages.filter { message ->
-        message.hasVisibleContent(isStreaming = state.isStreamingMessage(message))
+        message.hasVisibleContent(state)
     }
     val showTypingIndicator = state.shouldShowTypingIndicator
     val listState = rememberLazyListState()
@@ -298,7 +298,7 @@ private fun AssistantMessageThread(
         ) { message ->
             AssistantMessageBubble(
                 message = message,
-                isStreaming = state.isStreamingMessage(message),
+                displaySegments = message.orderedSegments(state),
                 onRetry = onRetry,
                 onConfirmWrite = onConfirmWrite,
                 onCancelWrite = onCancelWrite,
@@ -366,42 +366,10 @@ internal fun isRenderedTargetPinnedToViewportEnd(
     bottomPinThresholdPx: Int,
 ): Boolean = distanceFromViewportEnd in 0..bottomPinThresholdPx
 
-private fun AssistantUiMessage.hasVisibleContent(isStreaming: Boolean): Boolean =
-    role == AssistantUiMessage.Role.USER ||
-        error != null ||
-        orderedSegments(isStreaming = isStreaming).any { segment ->
-            when (segment) {
-                is AssistantUiSegment.Text -> segment.text.isNotEmpty()
-                is AssistantUiSegment.CardGroup -> segment.cards.isNotEmpty()
-                is AssistantUiSegment.ConfirmationCard,
-                is AssistantUiSegment.ToolActivity -> true
-            }
-        }
-
-internal fun AssistantUiState.isStreamingMessage(message: AssistantUiMessage): Boolean =
-    status == AssistantUiStatus.STREAMING &&
-        message.role == AssistantUiMessage.Role.ASSISTANT &&
-        message.id == activeAssistantMessageId
-
-internal fun AssistantUiMessage.orderedSegments(isStreaming: Boolean): List<AssistantUiSegment> {
-    if (role != AssistantUiMessage.Role.ASSISTANT) return segments
-
-    val displaySegments = if (isStreaming) {
-        segments.filterNot { it is AssistantUiSegment.CardGroup }
-    } else {
-        segments
-    }
-    val hasAssistantText = displaySegments.any { it is AssistantUiSegment.Text && it.text.isNotEmpty() }
-    if (isStreaming || !hasAssistantText) return displaySegments
-
-    return displaySegments.filterNot { it is AssistantUiSegment.CardGroup } +
-        displaySegments.filterIsInstance<AssistantUiSegment.CardGroup>()
-}
-
 @Composable
 private fun AssistantMessageBubble(
     message: AssistantUiMessage,
-    isStreaming: Boolean,
+    displaySegments: List<AssistantUiSegment>,
     onRetry: () -> Unit,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
@@ -418,7 +386,7 @@ private fun AssistantMessageBubble(
             .semantics(mergeDescendants = true) { contentDescription = description },
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        message.orderedSegments(isStreaming = isStreaming).forEach { segment ->
+        displaySegments.forEach { segment ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = rowArrangement,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -32,10 +33,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -57,6 +61,7 @@ import com.woocommerce.android.aiassistant.ui.components.AssistantComposer
 import com.woocommerce.android.aiassistant.ui.components.AssistantConfirmationCardSegment
 import com.woocommerce.android.aiassistant.ui.components.AssistantToolActivityPill
 import com.woocommerce.android.aiassistant.ui.components.AssistantTypingIndicator
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -237,21 +242,51 @@ private fun AssistantMessageThread(
     val visibleMessages = state.messages.filter { it.hasVisibleContent() }
     val showTypingIndicator = state.shouldShowTypingIndicator
     val listState = rememberLazyListState()
-    LaunchedEffect(
-        visibleMessages.size,
-        visibleMessages.lastOrNull()?.segments,
-        showTypingIndicator,
-    ) {
-        val totalItems = visibleMessages.size + if (showTypingIndicator) 1 else 0
-        if (totalItems > 0) {
-            listState.animateScrollToItem(totalItems - 1)
+    val bottomPinThresholdPx = with(LocalDensity.current) { BOTTOM_PIN_THRESHOLD_DP.roundToPx() }
+    val scrollSignal = visibleMessages.toScrollSignal(showTypingIndicator)
+    var previousScrollSignal by remember { mutableStateOf<AssistantThreadScrollSignal?>(null) }
+    var wasPinnedBeforeLatestChange by rememberSaveable { mutableStateOf(true) }
+
+    LaunchedEffect(listState, bottomPinThresholdPx, scrollSignal.renderedItemCount) {
+        snapshotFlow {
+            listState.isPinnedToRenderedEnd(
+                renderedItemCount = scrollSignal.renderedItemCount,
+                bottomPinThresholdPx = bottomPinThresholdPx,
+            )
         }
+            .distinctUntilChanged()
+            .collect { wasPinnedBeforeLatestChange = it }
+    }
+
+    LaunchedEffect(scrollSignal) {
+        val renderedItemCount = scrollSignal.renderedItemCount
+        if (renderedItemCount == 0) {
+            previousScrollSignal = scrollSignal
+            return@LaunchedEffect
+        }
+
+        val previous = previousScrollSignal
+        val forceScrollForUserSend = previous != null &&
+            previous.lastUserMessageId != scrollSignal.lastUserMessageId
+        val isNewAssistantMessage = previous != null &&
+            previous.lastMessageId != scrollSignal.lastMessageId &&
+            scrollSignal.lastMessageRole == AssistantUiMessage.Role.ASSISTANT
+
+        if (forceScrollForUserSend || wasPinnedBeforeLatestChange) {
+            val targetIndex = renderedItemCount - 1
+            if (forceScrollForUserSend || isNewAssistantMessage) {
+                listState.animateScrollToItem(targetIndex)
+            } else {
+                listState.scrollToItem(targetIndex)
+            }
+        }
+        previousScrollSignal = scrollSignal
     }
 
     LazyColumn(
         state = listState,
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Bottom),
+        verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 18.dp),
     ) {
         items(
@@ -276,6 +311,48 @@ private fun AssistantMessageThread(
 }
 
 private const val TYPING_INDICATOR_ITEM_KEY = "assistant-typing-indicator"
+private val BOTTOM_PIN_THRESHOLD_DP = 48.dp
+
+private data class AssistantThreadScrollSignal(
+    val renderedItemCount: Int,
+    val messageCount: Int,
+    val lastMessageId: String?,
+    val lastMessageRole: AssistantUiMessage.Role?,
+    val lastUserMessageId: String?,
+    val lastMessageSegmentCount: Int,
+    val lastMessageTextLength: Int,
+    val showTypingIndicator: Boolean,
+)
+
+private fun List<AssistantUiMessage>.toScrollSignal(
+    showTypingIndicator: Boolean,
+): AssistantThreadScrollSignal {
+    val lastMessage = lastOrNull()
+    return AssistantThreadScrollSignal(
+        renderedItemCount = size + if (showTypingIndicator) 1 else 0,
+        messageCount = size,
+        lastMessageId = lastMessage?.id,
+        lastMessageRole = lastMessage?.role,
+        lastUserMessageId = lastOrNull { it.role == AssistantUiMessage.Role.USER }?.id,
+        lastMessageSegmentCount = lastMessage?.segments?.size ?: 0,
+        lastMessageTextLength = lastMessage?.text?.length ?: 0,
+        showTypingIndicator = showTypingIndicator,
+    )
+}
+
+private fun LazyListState.isPinnedToRenderedEnd(
+    renderedItemCount: Int,
+    bottomPinThresholdPx: Int,
+): Boolean {
+    if (renderedItemCount == 0) return true
+
+    val lastVisibleItem = layoutInfo.visibleItemsInfo.lastOrNull() ?: return true
+    val targetIndex = renderedItemCount - 1
+    if (lastVisibleItem.index != targetIndex) return false
+
+    val distanceFromViewportEnd = layoutInfo.viewportEndOffset - (lastVisibleItem.offset + lastVisibleItem.size)
+    return distanceFromViewportEnd <= bottomPinThresholdPx
+}
 
 private fun AssistantUiMessage.hasVisibleContent(): Boolean =
     role == AssistantUiMessage.Role.USER ||
@@ -408,7 +485,7 @@ private fun AssistantTextBubble(text: String, isUser: Boolean) {
 
     Box(
         modifier = Modifier
-            .widthIn(max = 360.dp)
+            .then(if (isUser) Modifier.widthIn(max = 360.dp) else Modifier.fillMaxWidth())
             .background(bubbleColor, shape)
             .then(
                 if (isUser) {
@@ -425,6 +502,7 @@ private fun AssistantTextBubble(text: String, isUser: Boolean) {
     ) {
         Text(
             text = text,
+            modifier = if (isUser) Modifier else Modifier.widthIn(max = 360.dp),
             color = textColor,
             style = MaterialTheme.typography.bodyMedium,
             textAlign = if (isUser) TextAlign.End else TextAlign.Start,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -240,7 +240,9 @@ private fun AssistantMessageThread(
     onCardAction: (AssistantCardAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val visibleMessages = state.messages.filter { it.hasVisibleContent() }
+    val visibleMessages = state.messages.filter { message ->
+        message.hasVisibleContent(isStreaming = state.isStreamingMessage(message))
+    }
     val showTypingIndicator = state.shouldShowTypingIndicator
     val listState = rememberLazyListState()
     val bottomPinThresholdPx = with(LocalDensity.current) { BOTTOM_PIN_THRESHOLD_DP.roundToPx() }
@@ -296,6 +298,7 @@ private fun AssistantMessageThread(
         ) { message ->
             AssistantMessageBubble(
                 message = message,
+                isStreaming = state.isStreamingMessage(message),
                 onRetry = onRetry,
                 onConfirmWrite = onConfirmWrite,
                 onCancelWrite = onCancelWrite,
@@ -363,14 +366,42 @@ internal fun isRenderedTargetPinnedToViewportEnd(
     bottomPinThresholdPx: Int,
 ): Boolean = distanceFromViewportEnd in 0..bottomPinThresholdPx
 
-private fun AssistantUiMessage.hasVisibleContent(): Boolean =
+private fun AssistantUiMessage.hasVisibleContent(isStreaming: Boolean): Boolean =
     role == AssistantUiMessage.Role.USER ||
         error != null ||
-        hasVisibleAssistantContent
+        orderedSegments(isStreaming = isStreaming).any { segment ->
+            when (segment) {
+                is AssistantUiSegment.Text -> segment.text.isNotEmpty()
+                is AssistantUiSegment.CardGroup -> segment.cards.isNotEmpty()
+                is AssistantUiSegment.ConfirmationCard,
+                is AssistantUiSegment.ToolActivity -> true
+            }
+        }
+
+internal fun AssistantUiState.isStreamingMessage(message: AssistantUiMessage): Boolean =
+    status == AssistantUiStatus.STREAMING &&
+        message.role == AssistantUiMessage.Role.ASSISTANT &&
+        message.id == activeAssistantMessageId
+
+internal fun AssistantUiMessage.orderedSegments(isStreaming: Boolean): List<AssistantUiSegment> {
+    if (role != AssistantUiMessage.Role.ASSISTANT) return segments
+
+    val displaySegments = if (isStreaming) {
+        segments.filterNot { it is AssistantUiSegment.CardGroup }
+    } else {
+        segments
+    }
+    val hasAssistantText = displaySegments.any { it is AssistantUiSegment.Text && it.text.isNotEmpty() }
+    if (isStreaming || !hasAssistantText) return displaySegments
+
+    return displaySegments.filterNot { it is AssistantUiSegment.CardGroup } +
+        displaySegments.filterIsInstance<AssistantUiSegment.CardGroup>()
+}
 
 @Composable
 private fun AssistantMessageBubble(
     message: AssistantUiMessage,
+    isStreaming: Boolean,
     onRetry: () -> Unit,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
@@ -387,7 +418,7 @@ private fun AssistantMessageBubble(
             .semantics(mergeDescendants = true) { contentDescription = description },
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        message.segments.forEach { segment ->
+        message.orderedSegments(isStreaming = isStreaming).forEach { segment ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = rowArrangement,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -629,6 +629,49 @@ private fun AssistantUiStatus.toHeaderText(): String = when (this) {
     AssistantUiStatus.ERROR -> stringResource(R.string.assistant_chat_status_error)
 }
 
+@Preview(showBackground = true, widthDp = 390, heightDp = 180)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 180, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantTextBubblePreview() {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                AssistantTextBubble(
+                    text = "Show orders that need attention",
+                    isUser = true,
+                )
+            }
+            Row(modifier = Modifier.fillMaxWidth()) {
+                AssistantTextBubble(
+                    text = "I found a few processing orders with recent customer notes.",
+                    isUser = false,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 260)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 260, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantCardGroupSegmentPreview() {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            AssistantCardGroupSegment(
+                cards = listOf(sampleOrderCard(), sampleProductCard()),
+                assistantCardRenderer = PreviewAssistantCardRenderer,
+                onCardAction = {},
+            )
+        }
+    }
+}
+
 @Preview(showBackground = true, widthDp = 390, heightDp = 720)
 @Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 720, uiMode = UI_MODE_NIGHT_YES)
 @Composable

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -419,8 +420,8 @@ private fun AssistantMessageSegment(
                 AssistantTextBubble(text = segment.text, isUser = isUser)
             }
         }
-        is AssistantUiSegment.Card -> AssistantCardSegment(
-            card = segment.card,
+        is AssistantUiSegment.CardGroup -> AssistantCardGroupSegment(
+            cards = segment.cards,
             assistantCardRenderer = assistantCardRenderer,
             onCardAction = onCardAction,
         )
@@ -434,12 +435,12 @@ private fun AssistantMessageSegment(
 }
 
 @Composable
-private fun AssistantCardSegment(
-    card: AssistantCard,
+private fun AssistantCardGroupSegment(
+    cards: List<AssistantCard>,
     assistantCardRenderer: AssistantCardRenderer?,
     onCardAction: (AssistantCardAction) -> Unit,
 ) {
-    if (assistantCardRenderer == null) return
+    if (assistantCardRenderer == null || cards.isEmpty()) return
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -447,22 +448,50 @@ private fun AssistantCardSegment(
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
-        when (card) {
-            is AssistantCard.Order -> assistantCardRenderer.OrderCard(
-                card = card,
-                onAction = onCardAction,
-                modifier = Modifier.fillMaxWidth(),
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = stringResource(cards.groupHeaderRes()),
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
             )
-            is AssistantCard.Product -> assistantCardRenderer.ProductCard(
-                card = card,
-                onAction = onCardAction,
-                modifier = Modifier.fillMaxWidth(),
-            )
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            cards.forEachIndexed { index, card ->
+                when (card) {
+                    is AssistantCard.Order -> assistantCardRenderer.OrderCard(
+                        card = card,
+                        onAction = onCardAction,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    is AssistantCard.Product -> assistantCardRenderer.ProductCard(
+                        card = card,
+                        onAction = onCardAction,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                if (index < cards.lastIndex) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 14.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                    )
+                }
+            }
         }
     }
 }
 
 private val ASSISTANT_CARD_CORNER_RADIUS = 12.dp
+
+private fun List<AssistantCard>.groupHeaderRes(): Int {
+    val containsOrders = any { it is AssistantCard.Order }
+    val containsProducts = any { it is AssistantCard.Product }
+    return when {
+        containsOrders && !containsProducts -> R.string.assistant_chat_card_group_orders
+        containsProducts && !containsOrders -> R.string.assistant_chat_card_group_products
+        else -> R.string.assistant_chat_card_group_generic
+    }
+}
 
 @Composable
 private fun AssistantTextBubble(text: String, isUser: Boolean) {
@@ -667,9 +696,9 @@ private fun AssistantChatScreenPreview() {
                     role = AssistantUiMessage.Role.ASSISTANT,
                     segments = listOf(
                         AssistantUiSegment.Text("Here is order #3479."),
-                        AssistantUiSegment.Card(sampleOrderCard()),
+                        AssistantUiSegment.CardGroup(listOf(sampleOrderCard())),
                         AssistantUiSegment.Text("Here is a matching product."),
-                        AssistantUiSegment.Card(sampleProductCard()),
+                        AssistantUiSegment.CardGroup(listOf(sampleProductCard())),
                     ),
                 ),
             )

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -9,9 +9,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -143,13 +143,12 @@ fun AssistantChatScreen(
                 status = state.status,
                 onBack = onBack,
             )
-        },
+        }
     ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .imePadding(),
         ) {
             AssistantMessageThread(
                 state = state,
@@ -200,6 +199,7 @@ private fun AssistantTopAppBar(
         actions = {
             AssistantStatusLabel(status = status)
         },
+        windowInsets = WindowInsets()
     )
 }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiMessageOrdering.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiMessageOrdering.kt
@@ -1,0 +1,34 @@
+package com.woocommerce.android.aiassistant.ui
+
+internal fun AssistantUiMessage.hasVisibleContent(state: AssistantUiState): Boolean =
+    role == AssistantUiMessage.Role.USER ||
+        error != null ||
+        orderedSegments(state).any { segment ->
+            when (segment) {
+                is AssistantUiSegment.Text -> segment.text.isNotEmpty()
+                is AssistantUiSegment.CardGroup -> segment.cards.isNotEmpty()
+                is AssistantUiSegment.ConfirmationCard,
+                is AssistantUiSegment.ToolActivity -> true
+            }
+        }
+
+internal fun AssistantUiMessage.orderedSegments(state: AssistantUiState): List<AssistantUiSegment> {
+    if (role != AssistantUiMessage.Role.ASSISTANT) return segments
+
+    val isStreaming = state.isStreamingMessage(this)
+    val displaySegments = if (isStreaming) {
+        segments.filterNot { it is AssistantUiSegment.CardGroup }
+    } else {
+        segments
+    }
+    val hasAssistantText = displaySegments.any { it is AssistantUiSegment.Text && it.text.isNotEmpty() }
+    if (isStreaming || !hasAssistantText) return displaySegments
+
+    return displaySegments.filterNot { it is AssistantUiSegment.CardGroup } +
+        displaySegments.filterIsInstance<AssistantUiSegment.CardGroup>()
+}
+
+private fun AssistantUiState.isStreamingMessage(message: AssistantUiMessage): Boolean =
+    status == AssistantUiStatus.STREAMING &&
+        message.role == AssistantUiMessage.Role.ASSISTANT &&
+        message.id == activeAssistantMessageId

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -104,16 +104,6 @@ sealed interface AssistantUiSegment {
     data class ToolActivity(val activity: AssistantToolActivity) : AssistantUiSegment
 }
 
-internal val AssistantUiMessage.hasVisibleAssistantContent: Boolean
-    get() = segments.any { segment ->
-        when (segment) {
-            is AssistantUiSegment.Text -> segment.text.isNotEmpty()
-            is AssistantUiSegment.ConfirmationCard -> true
-            is AssistantUiSegment.CardGroup -> segment.cards.isNotEmpty()
-            is AssistantUiSegment.ToolActivity -> true
-        }
-    }
-
 @StringRes
 internal fun AssistantToolActivity.labelRes(): Int = when (toolName) {
     "orders_list",

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -119,7 +119,6 @@ internal fun AssistantToolActivity.labelRes(): Int = when (toolName) {
     "analytics_orders",
     "analytics_revenue" -> R.string.assistant_chat_tool_activity_analytics
     "customers_list" -> R.string.assistant_chat_tool_activity_customers
-    "show_cards" -> R.string.assistant_chat_tool_activity_cards
     else -> R.string.assistant_chat_tool_activity_generic
 }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiState.kt
@@ -99,7 +99,7 @@ sealed interface AssistantUiSegment {
 
     data class ConfirmationCard(val model: AssistantConfirmationCard) : AssistantUiSegment
 
-    data class Card(val card: AssistantCard) : AssistantUiSegment
+    data class CardGroup(val cards: List<AssistantCard>) : AssistantUiSegment
 
     data class ToolActivity(val activity: AssistantToolActivity) : AssistantUiSegment
 }
@@ -109,7 +109,7 @@ internal val AssistantUiMessage.hasVisibleAssistantContent: Boolean
         when (segment) {
             is AssistantUiSegment.Text -> segment.text.isNotEmpty()
             is AssistantUiSegment.ConfirmationCard -> true
-            is AssistantUiSegment.Card -> true
+            is AssistantUiSegment.CardGroup -> segment.cards.isNotEmpty()
             is AssistantUiSegment.ToolActivity -> true
         }
     }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationDispatchResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
 import com.woocommerce.android.aiassistant.runtime.AssistantTurnRequest
+import com.woocommerce.android.aiassistant.tools.handlers.cards.SHOW_CARDS_TOOL_NAME
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardKey
 import com.woocommerce.android.tools.SelectedSite
@@ -231,6 +232,8 @@ class AssistantViewModel @AssistedInject constructor(
     }
 
     private fun showToolActivity(event: AssistantRuntimeEvent.ToolCallStarted) {
+        if (event.toolName == SHOW_CARDS_TOOL_NAME) return
+
         val messageId = activeAssistantMessageId ?: return
         _uiState.update { state ->
             state.copy(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -310,16 +310,15 @@ class AssistantViewModel @AssistedInject constructor(
 
     private fun appendAssistantCards(cards: List<AssistantCard>) {
         val messageId = activeAssistantMessageId ?: return
-        val newSegments = cards
+        val newCards = cards
             .filter { activeCardKeys.add(it.toCardKey()) }
-            .map { AssistantUiSegment.Card(it) }
-        if (newSegments.isEmpty()) return
+        if (newCards.isEmpty()) return
 
         _uiState.update { state ->
             state.copy(
                 messages = state.messages.map { message ->
                     if (message.id == messageId) {
-                        message.copy(segments = message.segments + newSegments)
+                        message.appendCardGroup(newCards)
                     } else {
                         message
                     }
@@ -460,6 +459,28 @@ class AssistantViewModel @AssistedInject constructor(
         val updatedSegments = segments.toMutableList()
         updatedSegments[updatedSegments.lastIndex] = lastSegment.copy(text = lastSegment.text + delta)
         return copy(segments = updatedSegments)
+    }
+
+    private fun AssistantUiMessage.appendCardGroup(cards: List<AssistantCard>): AssistantUiMessage {
+        val latestGroupIndex = segments.indexOfLast { it is AssistantUiSegment.CardGroup }
+        val shouldMergeWithLatestGroup = latestGroupIndex != -1 &&
+            segments.drop(latestGroupIndex + 1).none { it.breaksCardGrouping() }
+
+        if (!shouldMergeWithLatestGroup) {
+            return copy(segments = segments + AssistantUiSegment.CardGroup(cards))
+        }
+
+        val updatedSegments = segments.toMutableList()
+        val latestGroup = updatedSegments[latestGroupIndex] as AssistantUiSegment.CardGroup
+        updatedSegments[latestGroupIndex] = latestGroup.copy(cards = latestGroup.cards + cards)
+        return copy(segments = updatedSegments)
+    }
+
+    private fun AssistantUiSegment.breaksCardGrouping(): Boolean = when (this) {
+        is AssistantUiSegment.Text -> text.isNotEmpty()
+        is AssistantUiSegment.ConfirmationCard -> true
+        is AssistantUiSegment.CardGroup -> false
+        is AssistantUiSegment.ToolActivity -> false
     }
 
     private fun AssistantUiMessage.withToolActivity(activity: AssistantToolActivity): AssistantUiMessage =

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapper.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapper.kt
@@ -4,6 +4,12 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStruc
 import com.woocommerce.android.aiassistant.ui.AssistantUiSegment
 
 internal object AssistantCardSegmentMapper {
-    fun toSegments(payload: ShowCardsUiStructured): List<AssistantUiSegment.Card> =
-        AssistantCardPayloadParser.parse(payload).map(AssistantUiSegment::Card)
+    fun toSegments(payload: ShowCardsUiStructured): List<AssistantUiSegment.CardGroup> {
+        val cards = AssistantCardPayloadParser.parse(payload)
+        return if (cards.isEmpty()) {
+            emptyList()
+        } else {
+            listOf(AssistantUiSegment.CardGroup(cards))
+        }
+    }
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantComposer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantComposer.kt
@@ -1,25 +1,32 @@
 package com.woocommerce.android.aiassistant.ui.components
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -36,62 +43,165 @@ internal fun AssistantComposer(
     modifier: Modifier = Modifier,
 ) {
     val canSend = inputText.isNotBlank() && !isTurnActive
+    val showPendingHint = isTurnActive && !shouldShowStopControl
     Surface(
         modifier = modifier,
         color = MaterialTheme.colorScheme.surface,
         shadowElevation = 4.dp,
     ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Row(
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (showPendingHint) {
+                Text(
+                    text = stringResource(R.string.assistant_chat_pending_confirmation_hint),
+                    modifier = Modifier.padding(horizontal = 14.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            Surface(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                verticalAlignment = Alignment.Bottom,
+                    .heightIn(min = COMPOSER_MIN_HEIGHT),
+                shape = RoundedCornerShape(COMPOSER_CORNER_RADIUS),
+                color = MaterialTheme.colorScheme.surface,
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+                shadowElevation = 2.dp,
             ) {
-                OutlinedTextField(
-                    value = inputText,
-                    onValueChange = onInputTextChange,
-                    modifier = Modifier.weight(1f),
-                    minLines = 1,
-                    maxLines = 4,
-                    shape = RoundedCornerShape(12.dp),
-                    placeholder = { Text(stringResource(R.string.assistant_chat_placeholder)) },
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-                    keyboardActions = KeyboardActions(
-                        onSend = {
-                            if (canSend) {
-                                onSendMessage()
-                            }
-                        }
-                    ),
-                )
-                if (shouldShowStopControl) {
-                    Button(
-                        onClick = onCancelTurn,
-                        modifier = Modifier.heightIn(min = 56.dp),
-                        shape = RoundedCornerShape(12.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.error,
-                            contentColor = MaterialTheme.colorScheme.onError,
-                        ),
-                    ) {
-                        Text(stringResource(R.string.assistant_chat_stop))
-                    }
-                } else {
-                    Button(
-                        onClick = onSendMessage,
-                        enabled = canSend,
-                        modifier = Modifier.heightIn(min = 56.dp),
-                        shape = RoundedCornerShape(12.dp),
-                    ) {
-                        Text(stringResource(R.string.assistant_chat_send))
-                    }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    AssistantComposerInput(
+                        inputText = inputText,
+                        onInputTextChange = onInputTextChange,
+                        canSend = canSend,
+                        onSendMessage = onSendMessage,
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(start = 18.dp, top = 12.dp, bottom = 12.dp),
+                    )
+                    AssistantComposerActionButton(
+                        shouldShowStopControl = shouldShowStopControl,
+                        canSend = canSend,
+                        onSendMessage = onSendMessage,
+                        onCancelTurn = onCancelTurn,
+                        modifier = Modifier.padding(end = 6.dp),
+                    )
                 }
             }
         }
     }
 }
+
+@Composable
+private fun AssistantComposerInput(
+    inputText: String,
+    onInputTextChange: (String) -> Unit,
+    canSend: Boolean,
+    onSendMessage: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val textColor = MaterialTheme.colorScheme.onSurface
+    BasicTextField(
+        value = inputText,
+        onValueChange = onInputTextChange,
+        modifier = modifier,
+        minLines = 1,
+        maxLines = 6,
+        textStyle = MaterialTheme.typography.bodyMedium.merge(TextStyle(color = textColor)),
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+        keyboardActions = KeyboardActions(
+            onSend = {
+                if (canSend) {
+                    onSendMessage()
+                }
+            }
+        ),
+        decorationBox = { innerTextField ->
+            Box(contentAlignment = Alignment.CenterStart) {
+                if (inputText.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.assistant_chat_placeholder),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                innerTextField()
+            }
+        },
+    )
+}
+
+@Composable
+private fun AssistantComposerActionButton(
+    shouldShowStopControl: Boolean,
+    canSend: Boolean,
+    onSendMessage: () -> Unit,
+    onCancelTurn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val buttonEnabled = shouldShowStopControl || canSend
+    val buttonContainer = if (buttonEnabled) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerHighest
+    }
+    val buttonContent = if (buttonEnabled) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val contentDescription = if (shouldShowStopControl) {
+        stringResource(R.string.assistant_chat_stop_content_description)
+    } else {
+        stringResource(R.string.assistant_chat_send_content_description)
+    }
+    val iconRes = if (shouldShowStopControl) {
+        R.drawable.ic_assistant_composer_stop
+    } else {
+        R.drawable.ic_assistant_composer_send
+    }
+
+    IconButton(
+        onClick = {
+            if (shouldShowStopControl) {
+                onCancelTurn()
+            } else if (canSend) {
+                onSendMessage()
+            }
+        },
+        enabled = buttonEnabled,
+        modifier = modifier.size(COMPOSER_ACTION_HIT_TARGET_SIZE),
+    ) {
+        Surface(
+            shape = CircleShape,
+            color = buttonContainer,
+            modifier = Modifier.size(COMPOSER_ACTION_BUTTON_SIZE),
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    painter = painterResource(iconRes),
+                    contentDescription = contentDescription,
+                    tint = buttonContent,
+                    modifier = Modifier.size(COMPOSER_ACTION_ICON_SIZE),
+                )
+            }
+        }
+    }
+}
+
+private val COMPOSER_MIN_HEIGHT = 56.dp
+private val COMPOSER_CORNER_RADIUS = 28.dp
+private val COMPOSER_ACTION_BUTTON_SIZE = 36.dp
+private val COMPOSER_ACTION_HIT_TARGET_SIZE = 44.dp
+private val COMPOSER_ACTION_ICON_SIZE = 18.dp
 
 @Preview(showBackground = true, widthDp = 390, heightDp = 104)
 @Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 104, uiMode = UI_MODE_NIGHT_YES)
@@ -99,6 +209,20 @@ internal fun AssistantComposer(
 private fun AssistantComposerReadyPreview() {
     AssistantComposer(
         inputText = "Show orders from today",
+        onInputTextChange = {},
+        isTurnActive = false,
+        shouldShowStopControl = false,
+        onSendMessage = {},
+        onCancelTurn = {},
+    )
+}
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 128)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 128, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantComposerMultilinePreview() {
+    AssistantComposer(
+        inputText = "Find processing orders from this week and summarize the customer notes that mention shipping",
         onInputTextChange = {},
         isTurnActive = false,
         shouldShowStopControl = false,
@@ -116,6 +240,20 @@ private fun AssistantComposerStreamingPreview() {
         onInputTextChange = {},
         isTurnActive = true,
         shouldShowStopControl = true,
+        onSendMessage = {},
+        onCancelTurn = {},
+    )
+}
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 128)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 128, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantComposerPendingConfirmationPreview() {
+    AssistantComposer(
+        inputText = "",
+        onInputTextChange = {},
+        isTurnActive = true,
+        shouldShowStopControl = false,
         onSendMessage = {},
         onCancelTurn = {},
     )

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantComposer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantComposer.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.aiassistant.ui.components
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.aiassistant.R
 
@@ -89,4 +91,32 @@ internal fun AssistantComposer(
             }
         }
     }
+}
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 104)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 104, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantComposerReadyPreview() {
+    AssistantComposer(
+        inputText = "Show orders from today",
+        onInputTextChange = {},
+        isTurnActive = false,
+        shouldShowStopControl = false,
+        onSendMessage = {},
+        onCancelTurn = {},
+    )
+}
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 104)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 104, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantComposerStreamingPreview() {
+    AssistantComposer(
+        inputText = "",
+        onInputTextChange = {},
+        isTurnActive = true,
+        shouldShowStopControl = true,
+        onSendMessage = {},
+        onCancelTurn = {},
+    )
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
@@ -1,10 +1,13 @@
 package com.woocommerce.android.aiassistant.ui.components
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,13 +31,19 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.aiassistant.R
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.safety.RenderedConfirmationDiffRow
+import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreview
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreviewField
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCard
 import com.woocommerce.android.aiassistant.ui.AssistantConfirmationCardState
 import com.woocommerce.android.aiassistant.ui.eyebrowRes
 import com.woocommerce.android.aiassistant.ui.iconRes
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 @Composable
 internal fun AssistantConfirmationCardSegment(
@@ -155,64 +164,57 @@ private fun ConfirmationActions(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ConfirmationDiffRow(
     row: RenderedConfirmationPreviewField,
     isBulk: Boolean,
     colors: AssistantConfirmationCardColors,
 ) {
-    Row(
+    val beforeValue = row.beforeValue.takeUnless { isBulk }
+
+    FlowRow(
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.55f), RoundedCornerShape(8.dp))
             .border(1.dp, colors.border.copy(alpha = 0.45f), RoundedCornerShape(8.dp))
             .padding(10.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
-        Text(
-            text = row.label,
-            modifier = Modifier.weight(0.85f),
+        ConfirmationDiffText(
+            text = "${row.label}:",
             color = colors.label,
-            style = MaterialTheme.typography.labelMedium,
             fontWeight = FontWeight.SemiBold,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
         )
-        Row(
-            modifier = Modifier.weight(1.15f),
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            if (!isBulk) {
-                row.beforeValue?.let { beforeValue ->
-                    ConfirmationDiffValue(
-                        value = beforeValue,
-                        colors = colors,
-                        strikethrough = true,
-                    )
-                }
-            }
-            ConfirmationDiffValue(
-                value = row.afterValue,
-                colors = colors,
+        beforeValue?.let {
+            ConfirmationDiffText(
+                text = it,
+                color = colors.label,
+                textDecoration = TextDecoration.LineThrough,
             )
         }
+        ConfirmationDiffText(
+            text = row.afterValue,
+            color = colors.value,
+            fontWeight = FontWeight.SemiBold,
+        )
     }
 }
 
 @Composable
-private fun ConfirmationDiffValue(
-    value: String,
-    colors: AssistantConfirmationCardColors,
-    strikethrough: Boolean = false,
+private fun ConfirmationDiffText(
+    text: String,
+    color: Color,
+    fontWeight: FontWeight = FontWeight.Normal,
+    textDecoration: TextDecoration? = null,
 ) {
     Text(
-        text = value,
-        color = if (strikethrough) colors.label else colors.value,
+        text = text,
+        color = color,
         style = MaterialTheme.typography.bodySmall,
-        fontWeight = if (strikethrough) FontWeight.Normal else FontWeight.SemiBold,
-        textDecoration = if (strikethrough) TextDecoration.LineThrough else null,
+        fontWeight = fontWeight,
+        textDecoration = textDecoration,
     )
 }
 
@@ -378,7 +380,7 @@ private fun sampleBillingEmailConfirmationCard() = AssistantConfirmationCard(
         name = "orders_update",
         arguments = buildJsonObject {
             put("id", PREVIEW_ORDER_ID)
-            put("billing_email", "merchant@example.com")
+            put("billing_email", PREVIEW_BILLING_EMAIL_AFTER)
         },
     ),
     state = AssistantConfirmationCardState.PENDING,
@@ -388,8 +390,8 @@ private fun sampleBillingEmailConfirmationCard() = AssistantConfirmationCard(
             RenderedConfirmationDiffRow(
                 name = BILLING_EMAIL_FIELD_NAME,
                 label = "Billing email",
-                value = "merchant@example.com",
-                beforeValue = "schuster.alden@schuster.com",
+                value = PREVIEW_BILLING_EMAIL_AFTER,
+                beforeValue = PREVIEW_BILLING_EMAIL_BEFORE,
             )
         ),
         isBulk = false,
@@ -398,3 +400,5 @@ private fun sampleBillingEmailConfirmationCard() = AssistantConfirmationCard(
 
 private const val PREVIEW_ORDER_ID = 3479
 private const val BILLING_EMAIL_FIELD_NAME = "billing_email"
+private const val PREVIEW_BILLING_EMAIL_BEFORE = "schuster.alden@schuster-fulfillment.example.com"
+private const val PREVIEW_BILLING_EMAIL_AFTER = "alexandra.merchant@northstar-woocommerce.example.com"

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
@@ -256,3 +256,145 @@ private data class AssistantConfirmationCardColors(
     val label: Color,
     val value: Color,
 )
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 230)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 230, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantConfirmationCardPendingPreview() {
+    AssistantConfirmationCardPreviewContainer {
+        AssistantConfirmationCardSegment(
+            confirmation = sampleAssistantConfirmationCard(AssistantConfirmationCardState.PENDING),
+            onConfirmWrite = {},
+            onCancelWrite = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 176)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 176, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantConfirmationCardConfirmedPreview() {
+    AssistantConfirmationCardPreviewContainer {
+        AssistantConfirmationCardSegment(
+            confirmation = sampleAssistantConfirmationCard(AssistantConfirmationCardState.CONFIRMED),
+            onConfirmWrite = {},
+            onCancelWrite = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 176)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 176, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantConfirmationCardBulkCancelledPreview() {
+    AssistantConfirmationCardPreviewContainer {
+        AssistantConfirmationCardSegment(
+            confirmation = sampleAssistantConfirmationCard(
+                state = AssistantConfirmationCardState.CANCELLED,
+                isBulk = true,
+            ),
+            onConfirmWrite = {},
+            onCancelWrite = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 284)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 284, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantConfirmationCardBillingEmailPreview() {
+    AssistantConfirmationCardPreviewContainer {
+        AssistantConfirmationCardSegment(
+            confirmation = sampleBillingEmailConfirmationCard(),
+            onConfirmWrite = {},
+            onCancelWrite = {},
+        )
+    }
+}
+
+@Composable
+private fun AssistantConfirmationCardPreviewContainer(content: @Composable () -> Unit) {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            content()
+        }
+    }
+}
+
+private fun sampleAssistantConfirmationCard(
+    state: AssistantConfirmationCardState,
+    isBulk: Boolean = false,
+) = AssistantConfirmationCard(
+    confirmationId = "confirmation-preview",
+    toolCall = ToolCall(
+        id = "call-preview",
+        name = if (isBulk) "orders_bulk_update" else "orders_update",
+        arguments = buildJsonObject {
+            if (isBulk) {
+                put("status", "completed")
+            } else {
+                put("id", PREVIEW_ORDER_ID)
+                put("status", "completed")
+            }
+        },
+    ),
+    state = state,
+    preview = if (isBulk) {
+        RenderedConfirmationPreview(
+            message = "Update 3 orders",
+            fields = listOf(
+                RenderedConfirmationDiffRow(
+                    name = "status",
+                    label = "Status",
+                    value = "Completed",
+                )
+            ),
+            isBulk = true,
+        )
+    } else {
+        RenderedConfirmationPreview(
+            message = "Update order #3479",
+            fields = listOf(
+                RenderedConfirmationDiffRow(
+                    name = "status",
+                    label = "Status",
+                    value = "Completed",
+                    beforeValue = "Processing",
+                )
+            ),
+            isBulk = false,
+        )
+    },
+)
+
+private fun sampleBillingEmailConfirmationCard() = AssistantConfirmationCard(
+    confirmationId = "billing-email-confirmation-preview",
+    toolCall = ToolCall(
+        id = "call-billing-email-preview",
+        name = "orders_update",
+        arguments = buildJsonObject {
+            put("id", PREVIEW_ORDER_ID)
+            put("billing_email", "merchant@example.com")
+        },
+    ),
+    state = AssistantConfirmationCardState.PENDING,
+    preview = RenderedConfirmationPreview(
+        message = "Update order #3650",
+        fields = listOf(
+            RenderedConfirmationDiffRow(
+                name = BILLING_EMAIL_FIELD_NAME,
+                label = "Billing email",
+                value = "merchant@example.com",
+                beforeValue = "schuster.alden@schuster.com",
+            )
+        ),
+        isBulk = false,
+    ),
+)
+
+private const val PREVIEW_ORDER_ID = 3479
+private const val BILLING_EMAIL_FIELD_NAME = "billing_email"

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -66,7 +65,11 @@ internal fun AssistantConfirmationCardSegment(
                 fontWeight = FontWeight.SemiBold,
             )
             confirmation.preview?.rows?.forEach { row ->
-                ConfirmationDiffRow(row = row, colors = colors)
+                ConfirmationDiffRow(
+                    row = row,
+                    isBulk = confirmation.preview.isBulk,
+                    colors = colors,
+                )
             }
             if (confirmation.state == AssistantConfirmationCardState.PENDING) {
                 ConfirmationActions(
@@ -155,66 +158,62 @@ private fun ConfirmationActions(
 @Composable
 private fun ConfirmationDiffRow(
     row: RenderedConfirmationPreviewField,
+    isBulk: Boolean,
     colors: AssistantConfirmationCardColors,
 ) {
-    Column(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.55f), RoundedCornerShape(8.dp))
             .border(1.dp, colors.border.copy(alpha = 0.45f), RoundedCornerShape(8.dp))
             .padding(10.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = row.label,
+            modifier = Modifier.weight(0.85f),
             color = colors.label,
             style = MaterialTheme.typography.labelMedium,
             fontWeight = FontWeight.SemiBold,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
         )
-        row.beforeValue?.let { beforeValue ->
-            ConfirmationDiffLine(
-                prefix = stringResource(R.string.assistant_confirmation_now),
-                value = beforeValue,
+        Row(
+            modifier = Modifier.weight(1.15f),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (!isBulk) {
+                row.beforeValue?.let { beforeValue ->
+                    ConfirmationDiffValue(
+                        value = beforeValue,
+                        colors = colors,
+                        strikethrough = true,
+                    )
+                }
+            }
+            ConfirmationDiffValue(
+                value = row.afterValue,
                 colors = colors,
-                strikethrough = true,
             )
         }
-        ConfirmationDiffLine(
-            prefix = stringResource(R.string.assistant_confirmation_after),
-            value = row.afterValue,
-            colors = colors,
-        )
     }
 }
 
 @Composable
-private fun ConfirmationDiffLine(
-    prefix: String,
+private fun ConfirmationDiffValue(
     value: String,
     colors: AssistantConfirmationCardColors,
     strikethrough: Boolean = false,
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        verticalAlignment = Alignment.Top,
-    ) {
-        Text(
-            text = prefix,
-            modifier = Modifier.widthIn(min = 40.dp),
-            color = colors.label,
-            style = MaterialTheme.typography.bodySmall,
-            fontWeight = FontWeight.Medium,
-        )
-        Text(
-            text = value,
-            modifier = Modifier.weight(1f),
-            color = if (strikethrough) colors.label else colors.value,
-            style = MaterialTheme.typography.bodySmall,
-            fontWeight = if (strikethrough) FontWeight.Normal else FontWeight.SemiBold,
-            textDecoration = if (strikethrough) TextDecoration.LineThrough else null,
-        )
-    }
+    Text(
+        text = value,
+        color = if (strikethrough) colors.label else colors.value,
+        style = MaterialTheme.typography.bodySmall,
+        fontWeight = if (strikethrough) FontWeight.Normal else FontWeight.SemiBold,
+        textDecoration = if (strikethrough) TextDecoration.LineThrough else null,
+    )
 }
 
 @Composable

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantInFlightDots.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantInFlightDots.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.aiassistant.ui.components
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -9,15 +10,20 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -60,6 +66,21 @@ internal fun AssistantInFlightDots(
                     .alpha(alpha)
                     .size(dotSize)
                     .background(color = color, shape = CircleShape),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 160, heightDp = 72)
+@Preview(name = "Dark", showBackground = true, widthDp = 160, heightDp = 72, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantInFlightDotsPreview() {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        Column(modifier = Modifier.padding(24.dp)) {
+            AssistantInFlightDots(
+                color = MaterialTheme.colorScheme.primary,
+                dotSize = InFlightDotsTypingSize,
+                spacing = InFlightDotsTypingSpacing,
             )
         }
     }

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_composer_send.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_composer_send.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M4,12L5.41,13.41L11,7.83V20H13V7.83L18.59,13.42L20,12L12,4L4,12Z" />
+</vector>

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_composer_stop.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_composer_stop.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M6,6H18V18H6V6Z" />
+</vector>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -63,6 +63,9 @@
     <string name="assistant_chat_tool_activity_cards">Preparing cards</string>
     <string name="assistant_chat_tool_activity_generic">Checking your store</string>
     <string name="assistant_chat_tool_activity_content_description">Assistant is working: %1$s</string>
+    <string name="assistant_chat_card_group_orders">Orders</string>
+    <string name="assistant_chat_card_group_products">Products</string>
+    <string name="assistant_chat_card_group_generic">Cards</string>
     <string name="assistant_chat_placeholder">Ask about your store</string>
     <string name="assistant_chat_send">Send</string>
     <string name="assistant_chat_stop">Stop</string>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="ai_assistant_confirmation_order_update_generic">Update an order</string>
-    <string name="ai_assistant_confirmation_order_set_status">Set order #%1$s to %2$s</string>
-    <string name="ai_assistant_confirmation_order_set_status_emails_customer">Set order #%1$s to %2$s (emails the customer)</string>
     <string name="ai_assistant_confirmation_order_update_summary">Update order #%1$s: %2$s</string>
     <string name="ai_assistant_confirmation_orders_bulk_update_generic">Update many orders</string>
     <string name="ai_assistant_confirmation_orders_bulk_update_summary_single">Update %1$d order: %2$s</string>
@@ -42,8 +40,6 @@
     <string name="assistant_confirmation_eyebrow_pending">Pending change</string>
     <string name="assistant_confirmation_eyebrow_confirmed">Confirmed</string>
     <string name="assistant_confirmation_eyebrow_cancelled">Cancelled</string>
-    <string name="assistant_confirmation_now">Now</string>
-    <string name="assistant_confirmation_after">After</string>
     <string name="assistant_chat_title">AI Assistant</string>
     <string name="assistant_chat_status_idle">Ready</string>
     <string name="assistant_chat_status_streaming">Working</string>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -64,7 +64,10 @@
     <string name="assistant_chat_card_group_generic">Cards</string>
     <string name="assistant_chat_placeholder">Ask about your store</string>
     <string name="assistant_chat_send">Send</string>
+    <string name="assistant_chat_send_content_description">Send message</string>
     <string name="assistant_chat_stop">Stop</string>
+    <string name="assistant_chat_stop_content_description">Stop response</string>
+    <string name="assistant_chat_pending_confirmation_hint">Resolve the pending change above.</string>
     <string name="assistant_chat_retry">Retry</string>
     <string name="assistant_chat_confirm_tool">Confirm %1$s?</string>
     <string name="assistant_chat_confirm">Confirm</string>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -56,7 +56,6 @@
     <string name="assistant_chat_tool_activity_products_write">Updating products</string>
     <string name="assistant_chat_tool_activity_analytics">Checking analytics</string>
     <string name="assistant_chat_tool_activity_customers">Checking customers</string>
-    <string name="assistant_chat_tool_activity_cards">Preparing cards</string>
     <string name="assistant_chat_tool_activity_generic">Checking your store</string>
     <string name="assistant_chat_tool_activity_content_description">Assistant is working: %1$s</string>
     <string name="assistant_chat_card_group_orders">Orders</string>

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/runtime/AgenticLoopAssistantRuntimeTest.kt
@@ -186,7 +186,7 @@ class AgenticLoopAssistantRuntimeTest {
                     ),
                     state = AssistantConfirmationCardState.PENDING,
                     preview = RenderedConfirmationPreview(
-                        message = "Set order #123 to processing (emails the customer)",
+                        message = "Update order #123: status -> processing (emails the customer)",
                         fields = listOf(
                             RenderedConfirmationPreviewField(
                                 name = "status",

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilderTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewBuilderTest.kt
@@ -14,7 +14,7 @@ class WooCommerceConfirmationPreviewBuilderTest {
     private val builder = WooCommerceConfirmationPreviewBuilder()
 
     @Test
-    fun `given order status update emails customer, when preview is built, then resource message is included`() {
+    fun `given order status update emails customer, when preview is built, then typed summary is included`() {
         val call = toolCall(
             name = "orders_update",
             arguments = buildJsonObject {
@@ -27,16 +27,22 @@ class WooCommerceConfirmationPreviewBuilderTest {
 
         assertThat(preview.summary).isEqualTo(
             string(
-                R.string.ai_assistant_confirmation_order_set_status_emails_customer,
+                R.string.ai_assistant_confirmation_order_update_summary,
                 raw("42"),
-                raw("processing"),
+                string(
+                    R.string.ai_assistant_confirmation_change_summary_status_emails_customer,
+                    raw("processing"),
+                ),
             )
         )
         assertThat(preview.message).isEqualTo(
             string(
-                R.string.ai_assistant_confirmation_order_set_status_emails_customer,
+                R.string.ai_assistant_confirmation_order_update_summary,
                 raw("42"),
-                raw("processing"),
+                string(
+                    R.string.ai_assistant_confirmation_change_summary_status_emails_customer,
+                    raw("processing"),
+                ),
             )
         )
         assertThat(preview.fields).containsExactly(
@@ -61,7 +67,11 @@ class WooCommerceConfirmationPreviewBuilderTest {
         val preview = builder.build(call)
 
         assertThat(preview.message).isEqualTo(
-            string(R.string.ai_assistant_confirmation_order_set_status, raw("3000000000"), raw("pending"))
+            string(
+                R.string.ai_assistant_confirmation_order_update_summary,
+                raw("3000000000"),
+                string(R.string.ai_assistant_confirmation_change_summary_status, raw("pending")),
+            )
         )
     }
 
@@ -80,7 +90,11 @@ class WooCommerceConfirmationPreviewBuilderTest {
         val preview = builder.build(call)
 
         assertThat(preview.message).isEqualTo(
-            string(R.string.ai_assistant_confirmation_order_set_status, raw("42"), raw("pending"))
+            string(
+                R.string.ai_assistant_confirmation_order_update_summary,
+                raw("42"),
+                string(R.string.ai_assistant_confirmation_change_summary_status, raw("pending")),
+            )
         )
         assertThat(preview.fields).containsExactly(
             ConfirmationPreviewField(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
@@ -21,7 +21,7 @@ class WooCommerceConfirmationPreviewRendererTest {
     private val renderer = ConfirmationPreviewRenderer(context)
 
     @Test
-    fun `given order status update, when preview is rendered, then message uses string resource`() {
+    fun `given order status update, when preview is rendered, then message uses typed summary`() {
         val preview = builder.build(
             toolCall(
                 name = "orders_update",
@@ -36,16 +36,22 @@ class WooCommerceConfirmationPreviewRendererTest {
 
         assertThat(rendered.summary).isEqualTo(
             context.getString(
-                R.string.ai_assistant_confirmation_order_set_status_emails_customer,
+                R.string.ai_assistant_confirmation_order_update_summary,
                 "42",
-                "processing",
+                context.getString(
+                    R.string.ai_assistant_confirmation_change_summary_status_emails_customer,
+                    "processing",
+                ),
             )
         )
         assertThat(rendered.message).isEqualTo(
             context.getString(
-                R.string.ai_assistant_confirmation_order_set_status_emails_customer,
+                R.string.ai_assistant_confirmation_order_update_summary,
                 "42",
-                "processing",
+                context.getString(
+                    R.string.ai_assistant_confirmation_change_summary_status_emails_customer,
+                    "processing",
+                ),
             )
         )
         assertThat(rendered.fields).containsExactly(
@@ -76,7 +82,7 @@ class WooCommerceConfirmationPreviewRendererTest {
 
         val rendered = renderer.render(preview)
 
-        assertThat(rendered.summary).isEqualTo("Set order #42 to processing (emails the customer)")
+        assertThat(rendered.summary).isEqualTo("Update order #42: status -> processing (emails the customer)")
         assertThat(rendered.rows).containsExactly(
             RenderedConfirmationDiffRow(
                 name = "status",

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -228,7 +228,6 @@ class AssistantUiStateTest {
             "analytics_orders" to R.string.assistant_chat_tool_activity_analytics,
             "analytics_revenue" to R.string.assistant_chat_tool_activity_analytics,
             "customers_list" to R.string.assistant_chat_tool_activity_customers,
-            "show_cards" to R.string.assistant_chat_tool_activity_cards,
         )
 
         expectedLabels.forEach { (toolName, labelRes) ->

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -4,7 +4,9 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.AssistantError
+import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
+import kotlinx.serialization.json.buildJsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -338,6 +340,107 @@ class AssistantUiStateTest {
         )
     }
 
+    @Test
+    fun `given final card group before text, when ordering segments, then text renders before card group`() {
+        val cardGroup = AssistantUiSegment.CardGroup(listOf(orderCard()))
+        val text = AssistantUiSegment.Text("Here is the order.")
+        val message = AssistantUiMessage(
+            id = "message-1",
+            role = AssistantUiMessage.Role.ASSISTANT,
+            segments = listOf(cardGroup, text),
+        )
+
+        val orderedSegments = message.orderedSegments(isStreaming = false)
+
+        assertThat(orderedSegments).containsExactly(text, cardGroup)
+    }
+
+    @Test
+    fun `given final text card group text, when ordering segments, then text renders before card group`() {
+        val firstText = AssistantUiSegment.Text("Here are your matching orders.")
+        val cardGroup = AssistantUiSegment.CardGroup(listOf(orderCard()))
+        val secondText = AssistantUiSegment.Text("I found the most recent one first.")
+        val message = AssistantUiMessage(
+            id = "message-1",
+            role = AssistantUiMessage.Role.ASSISTANT,
+            segments = listOf(firstText, cardGroup, secondText),
+        )
+
+        val orderedSegments = message.orderedSegments(isStreaming = false)
+
+        assertThat(orderedSegments).containsExactly(firstText, secondText, cardGroup)
+    }
+
+    @Test
+    fun `given final card-only message, when ordering segments, then card group remains visible`() {
+        val cardGroup = AssistantUiSegment.CardGroup(listOf(orderCard()))
+        val message = AssistantUiMessage(
+            id = "message-1",
+            role = AssistantUiMessage.Role.ASSISTANT,
+            segments = listOf(cardGroup),
+        )
+
+        val orderedSegments = message.orderedSegments(isStreaming = false)
+
+        assertThat(orderedSegments).containsExactly(cardGroup)
+    }
+
+    @Test
+    fun `given final text card group and confirmation, when ordering segments, then confirmation is not moved after cards`() {
+        val text = AssistantUiSegment.Text("Review this change before applying it.")
+        val cardGroup = AssistantUiSegment.CardGroup(listOf(orderCard()))
+        val confirmationCard = AssistantUiSegment.ConfirmationCard(confirmationCard())
+        val message = AssistantUiMessage(
+            id = "message-1",
+            role = AssistantUiMessage.Role.ASSISTANT,
+            segments = listOf(text, cardGroup, confirmationCard),
+        )
+
+        val orderedSegments = message.orderedSegments(isStreaming = false)
+
+        assertThat(orderedSegments).containsExactly(text, confirmationCard, cardGroup)
+    }
+
+    @Test
+    fun `given streaming assistant message with card group, when ordering segments, then card group is hidden`() {
+        val text = AssistantUiSegment.Text("I found this order.")
+        val cardGroup = AssistantUiSegment.CardGroup(listOf(orderCard()))
+        val message = AssistantUiMessage(
+            id = "message-1",
+            role = AssistantUiMessage.Role.ASSISTANT,
+            segments = listOf(text, cardGroup),
+        )
+
+        val orderedSegments = message.orderedSegments(isStreaming = true)
+
+        assertThat(orderedSegments).containsExactly(text)
+    }
+
+    @Test
+    fun `given non-streaming error and finished states, when ordering segments, then card groups are visible`() {
+        val cardGroup = AssistantUiSegment.CardGroup(listOf(orderCard()))
+        val text = AssistantUiSegment.Text("Here is the order.")
+        val message = AssistantUiMessage(
+            id = "message-1",
+            role = AssistantUiMessage.Role.ASSISTANT,
+            segments = listOf(cardGroup, text),
+        )
+
+        listOf(
+            AssistantUiState(status = AssistantUiStatus.ERROR, activeAssistantMessageId = "message-1"),
+            AssistantUiState(
+                status = AssistantUiStatus.ERROR,
+                error = AssistantUiError.CANCELLED,
+                activeAssistantMessageId = "message-1",
+            ),
+            AssistantUiState(status = AssistantUiStatus.IDLE, activeAssistantMessageId = null),
+        ).forEach { state ->
+            assertThat(message.orderedSegments(isStreaming = state.isStreamingMessage(message)))
+                .describedAs(state.status.name)
+                .containsExactly(text, cardGroup)
+        }
+    }
+
     private fun orderCard() = AssistantCard.Order(
         remoteOrderId = 123L,
         number = "#1001",
@@ -346,5 +449,15 @@ class AssistantUiStateTest {
         currency = "USD",
         customerName = "Jane Doe",
         date = "2026-05-01T10:00:00Z",
+    )
+
+    private fun confirmationCard() = AssistantConfirmationCard(
+        confirmationId = "confirmation-1",
+        toolCall = ToolCall(
+            id = "tool-call-1",
+            name = "orders_update",
+            arguments = buildJsonObject { },
+        ),
+        state = AssistantConfirmationCardState.PENDING,
     )
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -350,7 +350,7 @@ class AssistantUiStateTest {
             segments = listOf(cardGroup, text),
         )
 
-        val orderedSegments = message.orderedSegments(isStreaming = false)
+        val orderedSegments = message.orderedSegments(AssistantUiState(status = AssistantUiStatus.IDLE))
 
         assertThat(orderedSegments).containsExactly(text, cardGroup)
     }
@@ -366,7 +366,7 @@ class AssistantUiStateTest {
             segments = listOf(firstText, cardGroup, secondText),
         )
 
-        val orderedSegments = message.orderedSegments(isStreaming = false)
+        val orderedSegments = message.orderedSegments(AssistantUiState(status = AssistantUiStatus.IDLE))
 
         assertThat(orderedSegments).containsExactly(firstText, secondText, cardGroup)
     }
@@ -380,7 +380,7 @@ class AssistantUiStateTest {
             segments = listOf(cardGroup),
         )
 
-        val orderedSegments = message.orderedSegments(isStreaming = false)
+        val orderedSegments = message.orderedSegments(AssistantUiState(status = AssistantUiStatus.IDLE))
 
         assertThat(orderedSegments).containsExactly(cardGroup)
     }
@@ -396,7 +396,7 @@ class AssistantUiStateTest {
             segments = listOf(text, cardGroup, confirmationCard),
         )
 
-        val orderedSegments = message.orderedSegments(isStreaming = false)
+        val orderedSegments = message.orderedSegments(AssistantUiState(status = AssistantUiStatus.IDLE))
 
         assertThat(orderedSegments).containsExactly(text, confirmationCard, cardGroup)
     }
@@ -411,7 +411,12 @@ class AssistantUiStateTest {
             segments = listOf(text, cardGroup),
         )
 
-        val orderedSegments = message.orderedSegments(isStreaming = true)
+        val orderedSegments = message.orderedSegments(
+            AssistantUiState(
+                status = AssistantUiStatus.STREAMING,
+                activeAssistantMessageId = "message-1",
+            )
+        )
 
         assertThat(orderedSegments).containsExactly(text)
     }
@@ -435,7 +440,7 @@ class AssistantUiStateTest {
             ),
             AssistantUiState(status = AssistantUiStatus.IDLE, activeAssistantMessageId = null),
         ).forEach { state ->
-            assertThat(message.orderedSegments(isStreaming = state.isStreamingMessage(message)))
+            assertThat(message.orderedSegments(state))
                 .describedAs(state.status.name)
                 .containsExactly(text, cardGroup)
         }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -63,6 +63,36 @@ class AssistantUiStateTest {
     }
 
     @Test
+    fun `given target bottom extends below viewport, when checking pin state, then target is not pinned`() {
+        assertThat(
+            isRenderedTargetPinnedToViewportEnd(
+                distanceFromViewportEnd = -1,
+                bottomPinThresholdPx = 48,
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `given target bottom is near viewport end, when checking pin state, then target is pinned`() {
+        assertThat(
+            isRenderedTargetPinnedToViewportEnd(
+                distanceFromViewportEnd = 48,
+                bottomPinThresholdPx = 48,
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `given target bottom is far above viewport end, when checking pin state, then target is not pinned`() {
+        assertThat(
+            isRenderedTargetPinnedToViewportEnd(
+                distanceFromViewportEnd = 49,
+                bottomPinThresholdPx = 48,
+            )
+        ).isFalse()
+    }
+
+    @Test
     fun `given error state with no inline message error, when checking fallback, then fallback is visible`() {
         val state = AssistantUiState(
             status = AssistantUiStatus.ERROR,

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -281,16 +281,16 @@ class AssistantUiStateTest {
     }
 
     @Test
-    fun `given assistant card, when card segment is created, then card is preserved`() {
+    fun `given assistant cards, when card group segment is created, then cards are preserved`() {
         val card = orderCard()
 
-        val segment: AssistantUiSegment = AssistantUiSegment.Card(card)
+        val segment: AssistantUiSegment = AssistantUiSegment.CardGroup(listOf(card))
 
-        assertThat(segment).isEqualTo(AssistantUiSegment.Card(card))
+        assertThat(segment).isEqualTo(AssistantUiSegment.CardGroup(listOf(card)))
     }
 
     @Test
-    fun `given assistant message, when text and card segments are used, then segment order is preserved`() {
+    fun `given assistant message, when text and card group segments are used, then segment order is preserved`() {
         val card = orderCard()
 
         val message = AssistantUiMessage(
@@ -298,13 +298,13 @@ class AssistantUiStateTest {
             role = AssistantUiMessage.Role.ASSISTANT,
             segments = listOf(
                 AssistantUiSegment.Text("Here is the order."),
-                AssistantUiSegment.Card(card),
+                AssistantUiSegment.CardGroup(listOf(card)),
             ),
         )
 
         assertThat(message.segments).containsExactly(
             AssistantUiSegment.Text("Here is the order."),
-            AssistantUiSegment.Card(card),
+            AssistantUiSegment.CardGroup(listOf(card)),
         )
     }
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -1196,6 +1196,40 @@ class AssistantViewModelTest {
             )
         }
 
+    @Test
+    fun `given cancelled confirmation is resolved, when next turn starts, then transcript card stays closed`() = runTest {
+        viewModel.onSendMessage("Cancel order 123")
+        runtime.emit(AssistantRuntimeEvent.AwaitingConfirmation(givenConfirmationCard()))
+        advanceUntilIdle()
+
+        viewModel.onCancelTurn()
+        runtime.emit(
+            AssistantRuntimeEvent.ConfirmationResolved(
+                ConfirmationResult("confirmation-1", ConfirmationDecision.CANCELLED)
+            )
+        )
+        runtime.emit(
+            AssistantRuntimeEvent.Finished(
+                outcome = LoopOutcome.STOPPED,
+                updatedHistory = listOf(AssistantMessage.User("Cancel order 123")),
+            )
+        )
+        advanceUntilIdle()
+        val resolvedMessageId = viewModel.uiState.value.messages.last().id
+
+        viewModel.onSendMessage("Show order 123")
+        advanceUntilIdle()
+
+        val resolvedMessage = viewModel.uiState.value.messages.first { it.id == resolvedMessageId }
+        assertThat(resolvedMessage.segments).contains(
+            AssistantUiSegment.ConfirmationCard(
+                givenConfirmationCard().copy(state = AssistantConfirmationCardState.CANCELLED)
+            )
+        )
+        assertThat(viewModel.uiState.value.activeConfirmationId).isNull()
+        assertThat(viewModel.uiState.value.status).isEqualTo(AssistantUiStatus.STREAMING)
+    }
+
     private fun givenConfirmationCard() = AssistantConfirmationCard(
         confirmationId = "confirmation-1",
         toolCall = ToolCall(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -646,7 +646,7 @@ class AssistantViewModelTest {
     }
 
     @Test
-    fun `given active assistant bubble, when cards arrive, then card segments are appended`() = runTest {
+    fun `given active assistant bubble, when cards arrive, then grouped card segment is appended`() = runTest {
         viewModel.onSendMessage("Show order 123")
         val activeBubbleId = viewModel.uiState.value.messages.last().id
         val orderCard = givenOrderCard(id = "123", number = "#123")
@@ -660,7 +660,7 @@ class AssistantViewModelTest {
                 role = AssistantUiMessage.Role.ASSISTANT,
                 segments = listOf(
                     AssistantUiSegment.Text(""),
-                    AssistantUiSegment.Card(orderCard),
+                    AssistantUiSegment.CardGroup(listOf(orderCard)),
                 ),
             )
         )
@@ -693,7 +693,7 @@ class AssistantViewModelTest {
                     role = AssistantUiMessage.Role.ASSISTANT,
                     segments = listOf(
                         AssistantUiSegment.Text("Here is the order."),
-                        AssistantUiSegment.Card(orderCard),
+                        AssistantUiSegment.CardGroup(listOf(orderCard)),
                         AssistantUiSegment.Text("Anything else?"),
                     ),
                 )
@@ -717,7 +717,7 @@ class AssistantViewModelTest {
         )
         advanceUntilIdle()
 
-        assertThat(viewModel.uiState.value.messages.last().segments.filterIsInstance<AssistantUiSegment.Card>())
+        assertThat(viewModel.uiState.value.messages.last().segments.filterIsInstance<AssistantUiSegment.CardGroup>())
             .isEmpty()
     }
 
@@ -732,12 +732,33 @@ class AssistantViewModelTest {
         runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(duplicateOrder, secondOrder)))
         advanceUntilIdle()
 
-        val cardSegments = viewModel.uiState.value.messages.last().segments
-            .filterIsInstance<AssistantUiSegment.Card>()
+        val cardGroups = viewModel.uiState.value.messages.last().segments
+            .filterIsInstance<AssistantUiSegment.CardGroup>()
 
-        assertThat(cardSegments).containsExactly(
-            AssistantUiSegment.Card(firstOrder),
-            AssistantUiSegment.Card(secondOrder),
+        assertThat(cardGroups).containsExactly(
+            AssistantUiSegment.CardGroup(listOf(firstOrder, secondOrder)),
+        )
+    }
+
+    @Test
+    fun `given completed tool activity separates card batches, when cards arrive, then batches merge`() = runTest {
+        viewModel.onSendMessage("Show matching cards")
+        val firstOrder = givenOrderCard(id = "123", number = "#123")
+        val secondOrder = givenOrderCard(id = "456", number = "#456")
+
+        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = "show_cards"))
+        runtime.emit(AssistantRuntimeEvent.ToolCallFinished(toolCallId = "call-1"))
+        runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(firstOrder)))
+        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-2", toolName = "show_cards"))
+        runtime.emit(AssistantRuntimeEvent.ToolCallFinished(toolCallId = "call-2"))
+        runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(secondOrder)))
+        advanceUntilIdle()
+
+        val cardGroups = viewModel.uiState.value.messages.last().segments
+            .filterIsInstance<AssistantUiSegment.CardGroup>()
+
+        assertThat(cardGroups).containsExactly(
+            AssistantUiSegment.CardGroup(listOf(firstOrder, secondOrder)),
         )
     }
 
@@ -752,8 +773,7 @@ class AssistantViewModelTest {
 
         assertThat(viewModel.uiState.value.messages.last().segments)
             .contains(
-                AssistantUiSegment.Card(order),
-                AssistantUiSegment.Card(product),
+                AssistantUiSegment.CardGroup(listOf(order, product)),
             )
     }
 
@@ -777,8 +797,10 @@ class AssistantViewModelTest {
             )
             advanceUntilIdle()
 
-            assertThat(viewModel.uiState.value.messages.last().segments.filterIsInstance<AssistantUiSegment.Card>())
-                .isEmpty()
+            val cardGroups = viewModel.uiState.value.messages.last().segments
+                .filterIsInstance<AssistantUiSegment.CardGroup>()
+
+            assertThat(cardGroups).isEmpty()
         }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -12,6 +12,7 @@ import com.woocommerce.android.aiassistant.runtime.AssistantRuntime
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeConfirmationDispatchResult
 import com.woocommerce.android.aiassistant.runtime.AssistantRuntimeEvent
 import com.woocommerce.android.aiassistant.runtime.AssistantTurnRequest
+import com.woocommerce.android.aiassistant.tools.handlers.cards.SHOW_CARDS_TOOL_NAME
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.Dispatchers
@@ -129,6 +130,24 @@ class AssistantViewModelTest {
                     toolName = "orders_get",
                 )
             ),
+        )
+        assertThat(viewModel.uiState.value.shouldShowTypingIndicator).isTrue()
+    }
+
+    @Test
+    fun `given active assistant bubble, when show cards tool starts, then tool activity is hidden`() = runTest {
+        viewModel.onSendMessage("Show matching orders")
+
+        runtime.emit(
+            AssistantRuntimeEvent.ToolCallStarted(
+                toolCallId = "call-1",
+                toolName = SHOW_CARDS_TOOL_NAME,
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.messages.last().segments).containsExactly(
+            AssistantUiSegment.Text(""),
         )
         assertThat(viewModel.uiState.value.shouldShowTypingIndicator).isTrue()
     }
@@ -667,6 +686,21 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given show cards tool activity is hidden, when cards resolve, then card group is still appended`() = runTest {
+        viewModel.onSendMessage("Show order 123")
+        val orderCard = givenOrderCard(id = "123", number = "#123")
+
+        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = SHOW_CARDS_TOOL_NAME))
+        runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(orderCard)))
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.messages.last().segments).containsExactly(
+            AssistantUiSegment.Text(""),
+            AssistantUiSegment.CardGroup(listOf(orderCard)),
+        )
+    }
+
+    @Test
     fun `given cards arrive between text deltas, when turn finishes, then cards stay on active assistant message`() =
         runTest {
             viewModel.onSendMessage("Show order 123")
@@ -741,15 +775,15 @@ class AssistantViewModelTest {
     }
 
     @Test
-    fun `given completed tool activity separates card batches, when cards arrive, then batches merge`() = runTest {
+    fun `given repeated show cards calls, when cards arrive, then batches merge`() = runTest {
         viewModel.onSendMessage("Show matching cards")
         val firstOrder = givenOrderCard(id = "123", number = "#123")
         val secondOrder = givenOrderCard(id = "456", number = "#456")
 
-        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = "show_cards"))
+        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-1", toolName = SHOW_CARDS_TOOL_NAME))
         runtime.emit(AssistantRuntimeEvent.ToolCallFinished(toolCallId = "call-1"))
         runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(firstOrder)))
-        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-2", toolName = "show_cards"))
+        runtime.emit(AssistantRuntimeEvent.ToolCallStarted(toolCallId = "call-2", toolName = SHOW_CARDS_TOOL_NAME))
         runtime.emit(AssistantRuntimeEvent.ToolCallFinished(toolCallId = "call-2"))
         runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(secondOrder)))
         advanceUntilIdle()

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 
 class AssistantCardSegmentMapperTest {
     @Test
-    fun `given order and product payloads, when mapped, then card segments preserve parsed card order`() {
+    fun `given order and product payloads, when mapped, then grouped segment preserves parsed card order`() {
         val segments = AssistantCardSegmentMapper.toSegments(
             ShowCardsUiStructured(
                 cards = listOf(
@@ -20,28 +20,28 @@ class AssistantCardSegmentMapperTest {
         )
 
         assertThat(segments).containsExactly(
-            AssistantUiSegment.Card(
-                AssistantCard.Order(
-                    remoteOrderId = 1L,
-                    number = "#1",
-                    status = "processing",
-                    total = "12.34",
-                    currency = "USD",
-                    customerName = "Jane Doe",
-                    date = "2026-05-01T10:00:00Z",
+            AssistantUiSegment.CardGroup(
+                listOf(
+                    AssistantCard.Order(
+                        remoteOrderId = 1L,
+                        number = "#1",
+                        status = "processing",
+                        total = "12.34",
+                        currency = "USD",
+                        customerName = "Jane Doe",
+                        date = "2026-05-01T10:00:00Z",
+                    ),
+                    AssistantCard.Product(
+                        remoteProductId = 2L,
+                        name = "Socks",
+                        sku = "woo-socks",
+                        price = "9.99",
+                        stockStatus = "instock",
+                        status = "publish",
+                        imageUrl = "https://example.com/socks.png",
+                    ),
                 )
-            ),
-            AssistantUiSegment.Card(
-                AssistantCard.Product(
-                    remoteProductId = 2L,
-                    name = "Socks",
-                    sku = "woo-socks",
-                    price = "9.99",
-                    stockStatus = "instock",
-                    status = "publish",
-                    imageUrl = "https://example.com/socks.png",
-                )
-            ),
+            )
         )
     }
 


### PR DESCRIPTION
### Description
Part of WOOMOB-2985

This PR is the first part of the Android AI Assistant UI polish work. It focuses on making streamed replies, rich cards, confirmation cards, and the composer behave more consistently with the iOS implementation. There are still additional polish pieces to add in follow-up work.

#### What changes for users

The assistant chat now feels more stable while a turn is streaming. Messages stay top-aligned instead of visually recentering as the transcript grows, assistant bubbles keep a steadier width while tokens stream in, and autoscroll only follows new output when the user is already pinned near the latest response. If the user scrolls up during a long streamed reply, the transcript no longer force-snaps back to the bottom.

Rich order and product cards now render as one grouped assistant card surface, with a localized group header and dividers between rows. The previous expansion-style footer controls are intentionally not shown, so the card group reads like a compact result set rather than a paginated list.

#### `show_cards` display ordering

The UI now owns rich-card display order instead of relying on prompt timing or raw tool-event arrival order:

- `show_cards` card groups are hidden while the active assistant message is still streaming.
- Once the assistant turn is no longer streaming, prose and non-card segments render before card groups when the message has text.
- Card-only assistant turns still show cards once the turn finishes.
- Confirmation cards are not treated as normal rich cards, because their placement carries user-action semantics.
- The `show_cards` tool activity pill is suppressed when rich cards are the visible output.

This avoids final transcripts like `cards → text` or `text → cards → text` when the model emits cards and prose in different event phases.

#### Confirmation card polish

Confirmation cards now better match the iOS confirmation-card treatment:

- Pending, confirmed, and cancelled states use the updated inline card styling.
- Resolved confirmation cards persist in the transcript after confirm/cancel.
- Diff rows show the label with a trailing colon, prior values with strikethrough, and new values with emphasized text.
- Long values, including billing emails, wrap naturally without field-specific email or length heuristics.
- Bulk confirmations omit prior values when there is no reliable per-item prior state.
- Confirmation flow behavior remains unchanged: confirm/cancel still dispatch `ConfirmationResult` and conversation cancel/reset paths resolve pending confirmations cleanly.

#### Composer polish

The assistant composer has been rebuilt as an iOS-style input bar while preserving the existing behavior contract:

- Pill-shaped input container using Material/Woo theme tokens.
- Circular icon send and stop controls with accessibility labels.
- Send remains enabled only for non-blank input while no turn is active.
- IME send still goes through the same guarded send path.
- Stop appears only while a turn can be cancelled.
- Multiline input growth is bounded.
- Awaiting-confirmation state can show a short pending-change hint.

#### Compose previews

This PR adds or expands previews for the assistant components touched by the polish work, including chat text/card states, composer states, in-flight dots, and confirmation-card variants. The previews use realistic assistant sample states so future UI changes have a more useful local visual target.

#### Boundaries and safety notes

All production changes stay in `:libs:ai-assistant:feature`. There are no `:WooCommerce` host changes in this PR, no `:libs:ai-assistant:core` dependency-direction changes, no new auth path, no Jetpack AI JWT changes, and no Gson usage for AI payloads.

### Test Steps
1. Open the AI Assistant entry point in the app.
2. Ask for recent orders or products and verify the assistant reply remains top-aligned while streaming.
3. Verify rich cards render in one grouped card container below the assistant prose, without Show all / View all / +N footer controls.
4. Scroll up while a response is streaming and verify the thread does not force-scroll back to the latest token.
5. Ask for a write action that requires confirmation, then confirm and cancel separate attempts; verify confirmation cards keep their resolved state in the transcript.
6. Type in the composer and verify send, stop, multiline, and pending-confirmation states behave correctly.

### Images/gif

https://github.com/user-attachments/assets/b28fcbf3-b3c6-4180-afe6-1b0e059b2214



- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.