### PR TITLE
[WOOMOB-2916] Restore assistant write tool descriptor scope

### DIFF
--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/OrdersUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/OrdersUpdateToolHandler.kt
@@ -41,10 +41,6 @@ internal class OrdersUpdateToolHandler @Inject constructor(
         val args = call.parseArgs<Args>(json).getOrElse {
             return ToolResult.ValidationError(call.id, "Invalid arguments: ${it.message}")
         }
-        return execute(call, args)
-    }
-
-    private suspend fun execute(call: ToolCall, args: Args): ToolResult {
         if (args.status !in ALLOWED_STATUSES) {
             return ToolResult.ValidationError(call.id, "'${args.status}' is not an allowed status.")
         }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/OrdersUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/OrdersUpdateToolHandler.kt
@@ -22,16 +22,14 @@ internal class OrdersUpdateToolHandler @Inject constructor(
 
     override val descriptor = ToolDescriptor(
         name = "orders_update",
-        description = "Update a single order. Accepts only the `status` field. " +
-            "Allowed transitions: on-hold -> processing, processing -> completed. " +
-            "Cancellation and refund flows are not supported by this tool; never use it to issue refunds. " +
-            "Writes require Android confirmation UI; do not ask for confirmation in prose. " +
-            "Use at most one write per assistant turn; this is one single-entity write outside explicit bulk tools.",
+        description = "Update an order's status. Status changes such as completed/cancelled/refunded fire " +
+            "customer emails — the merchant confirms before this dispatches. Do NOT use this to issue a " +
+            "refund — moving an order to 'refunded' only changes the status, it does not return funds.",
         inputSchema = inputSchema {
             integer("id", description = "The order ID. Required.", required = true)
             enum(
                 "status",
-                values = ALLOWED_STATUSES.toList(),
+                values = listOf("pending", "processing", "on-hold", "completed", "cancelled", "refunded", "failed"),
                 description = "New order status.",
                 required = true,
             )
@@ -49,15 +47,6 @@ internal class OrdersUpdateToolHandler @Inject constructor(
     private suspend fun execute(call: ToolCall, args: Args): ToolResult {
         if (args.status !in ALLOWED_STATUSES) {
             return ToolResult.ValidationError(call.id, "'${args.status}' is not an allowed status.")
-        }
-        val currentStatus = dataSource.getOrder(args.id).getOrElse {
-            return ToolResult.TransportError(call.id, retryable = true)
-        }.status.normalizedOrderStatus()
-        if (args.status !in ALLOWED_TRANSITIONS[currentStatus].orEmpty()) {
-            return ToolResult.ValidationError(
-                call.id,
-                "Cannot transition order from '$currentStatus' to '${args.status}'.",
-            )
         }
         return dataSource.updateOrderStatus(args.id, args.status).fold(
             onSuccess = {
@@ -81,16 +70,17 @@ internal class OrdersUpdateToolHandler @Inject constructor(
         val status: String,
     )
 
-    private fun String.normalizedOrderStatus(): String = removePrefix("wc-")
-
-    private companion object {
+    companion object {
+        // Allowed `status` values for `orders_update`
+        // Intentionally excludes "trash" to prevent accidental deletion of orders
         private val ALLOWED_STATUSES = setOf(
+            "pending",
             "processing",
+            "on-hold",
             "completed",
-        )
-        private val ALLOWED_TRANSITIONS = mapOf(
-            "on-hold" to setOf("processing"),
-            "processing" to setOf("completed"),
+            "cancelled",
+            "refunded",
+            "failed"
         )
     }
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsUpdateToolHandler.kt
@@ -22,11 +22,10 @@ internal class ProductsUpdateToolHandler @Inject constructor(
 
     override val descriptor = ToolDescriptor(
         name = "products_update",
-        description = "Update a single simple product. Accepts only these fields: `name`, `regular_price`, " +
-            "`sale_price`, `stock_quantity`, and `status`. Setting `stock_quantity` also enables stock " +
-            "management. Variable products and variations are not updated by this tool; use variation-specific " +
-            "tools when available. Writes require Android confirmation UI; do not ask for confirmation in prose. " +
-            "Use at most one write per assistant turn; this is one single-entity write outside explicit bulk tools.",
+        description = "Update a single simple product. Accepts only name, regular_price, sale_price, " +
+            "stock_quantity, and status. Setting stock_quantity also enables stock management. " +
+            "Variable products should be updated through individual variations, not the parent product. " +
+            "At most one write is executed per turn.",
         inputSchema = inputSchema {
             integer("id", description = "The product ID. Required.", required = true)
             string("name", description = "New product name.")

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolCatalogTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/WooCommerceToolCatalogTest.kt
@@ -112,24 +112,16 @@ class WooCommerceToolCatalogTest {
         val byName = allHandlers.associateBy { it.descriptor.name }
 
         val ordersUpdate = byName.getValue("orders_update").descriptor.description
-        assertThat(ordersUpdate).contains("Accepts only the `status` field")
-        assertThat(ordersUpdate).contains("on-hold -> processing")
-        assertThat(ordersUpdate).contains("processing -> completed")
-        assertThat(ordersUpdate).contains("refund")
-        assertThat(ordersUpdate).contains("confirmation")
-        assertThat(ordersUpdate).contains("one single-entity write")
+        assertThat(ordersUpdate).contains("status")
+        assertThat(ordersUpdate).contains("customer emails")
 
         val ordersBulkUpdate = byName.getValue("orders_bulk_update").descriptor.description
         assertThat(ordersBulkUpdate).contains("status")
         assertThat(ordersBulkUpdate).contains("Bulk writes require confirmation")
 
         val productsUpdate = byName.getValue("products_update").descriptor.description
-        assertThat(productsUpdate).contains("Accepts only these fields")
         assertThat(productsUpdate).contains("regular_price")
         assertThat(productsUpdate).contains("stock_quantity")
-        assertThat(productsUpdate).contains("Variable products and variations are not updated")
-        assertThat(productsUpdate).contains("confirmation")
-        assertThat(productsUpdate).contains("one single-entity write")
 
         val productsBulkUpdate = byName.getValue("products_bulk_update").descriptor.description
         assertThat(productsBulkUpdate).contains("regular_price")

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/OrdersUpdateToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/OrdersUpdateToolHandlerTest.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
@@ -17,8 +16,6 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
-import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class OrdersUpdateToolHandlerTest {
@@ -35,26 +32,6 @@ class OrdersUpdateToolHandlerTest {
 
     private fun toolCall(arguments: JsonObject): ToolCall =
         ToolCall(id = "call-1", name = "orders_update", arguments = arguments)
-
-    @Test
-    fun `given descriptor, when inspected, then schema exposes only supported order update contract`() {
-        val schema = handler.descriptor.inputSchema
-        val properties = requireNotNull(schema["properties"]).jsonObject
-        val statusEnum = requireNotNull(properties["status"]).jsonObject
-            .getValue("enum").jsonArray.map { it.jsonPrimitive.content }
-        val required = requireNotNull(schema["required"]).jsonArray.map { it.jsonPrimitive.content }
-
-        assertThat(handler.descriptor.name).isEqualTo("orders_update")
-        assertThat(properties.keys).containsExactlyInAnyOrder("id", "status")
-        assertThat(required).containsExactly("id", "status")
-        assertThat(statusEnum).containsExactlyInAnyOrder("processing", "completed")
-        assertThat(handler.descriptor.description).contains("Accepts only the `status` field")
-        assertThat(handler.descriptor.description).contains("on-hold -> processing")
-        assertThat(handler.descriptor.description).contains("processing -> completed")
-        assertThat(handler.descriptor.description).contains("refund")
-        assertThat(handler.descriptor.description).contains("confirmation")
-        assertThat(handler.descriptor.description).contains("one write")
-    }
 
     @Test
     fun `given missing id, when execute is called, then ValidationError is returned`() = runTest {
@@ -85,23 +62,8 @@ class OrdersUpdateToolHandlerTest {
     }
 
     @Test
-    fun `given unsupported target status, when execute is called, then ValidationError is returned`() = runTest {
-        val result = handler.execute(
-            toolCall(
-                buildJsonObject {
-                    put("id", 123)
-                    put("status", "refunded")
-                }
-            )
-        )
-
-        assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
-    }
-
-    @Test
     fun `given valid status, when execute is called, then updateOrderStatus is called and success is returned`() =
         runTest {
-            whenever(dataSource.getOrder(123L)).thenReturn(Result.success(order(status = "wc-on-hold")))
             whenever(dataSource.updateOrderStatus(123L, "processing")).thenReturn(Result.success(Unit))
 
             val result = handler.execute(
@@ -122,7 +84,6 @@ class OrdersUpdateToolHandlerTest {
 
     @Test
     fun `given update fails, when execute is called, then retryable TransportError is returned`() = runTest {
-        whenever(dataSource.getOrder(123L)).thenReturn(Result.success(order(status = "wc-on-hold")))
         whenever(dataSource.updateOrderStatus(123L, "processing")).thenReturn(
             Result.failure(RuntimeException("network error"))
         )
@@ -139,23 +100,4 @@ class OrdersUpdateToolHandlerTest {
         assertThat(result).isInstanceOf(ToolResult.TransportError::class.java)
         assertThat((result as ToolResult.TransportError).retryable).isTrue
     }
-
-    @Test
-    fun `given unsupported transition, when execute is called, then ValidationError is returned`() = runTest {
-        whenever(dataSource.getOrder(123L)).thenReturn(Result.success(order(status = "wc-completed")))
-
-        val result = handler.execute(
-            toolCall(
-                buildJsonObject {
-                    put("id", 123)
-                    put("status", "processing")
-                }
-            )
-        )
-
-        assertThat(result).isInstanceOf(ToolResult.ValidationError::class.java)
-    }
-
-    private fun order(status: String): OrderEntity =
-        OrderEntity(localSiteId = LocalId(1), orderId = 123L, status = status)
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsUpdateToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsUpdateToolHandlerTest.kt
@@ -70,16 +70,7 @@ class ProductsUpdateToolHandlerTest {
         assertThat(handler.descriptor.name).isEqualTo("products_update")
         assertThat(handler.descriptor.safetyLevel).isEqualTo(ToolSafetyLevel.UNSAFE)
         assertThat(handler.descriptor.description).contains("simple product")
-        assertThat(handler.descriptor.description).contains("Accepts only these fields")
-        assertThat(handler.descriptor.description).contains("name")
-        assertThat(handler.descriptor.description).contains("regular_price")
-        assertThat(handler.descriptor.description).contains("sale_price")
-        assertThat(handler.descriptor.description).contains("stock_quantity")
-        assertThat(handler.descriptor.description).contains("status")
         assertThat(handler.descriptor.description).contains("Variable products")
-        assertThat(handler.descriptor.description).contains("variations")
-        assertThat(handler.descriptor.description).contains("confirmation")
-        assertThat(handler.descriptor.description).contains("one write")
         assertThat(properties.keys).containsExactlyInAnyOrder(
             "id",
             "name",


### PR DESCRIPTION
### Description
Fixes WOOMOB-2916

This PR reverts accidental `orders_update` and `products_update` tool-handler changes that leaked in during review of #15823. The prompt PR should have been limited to prompt/configuration work, so this follow-up restores those tool handlers to their pre-#15823 versions and removes the related test assertions.

This branch intentionally uses revert commits for cleaner history:
- `Revert "Surface assistant write constraints in tool schemas"`
- `Revert "Refactor order update validation for detekt"`

What this reverts:
- Restores `OrdersUpdateToolHandler` to the pre-#15823 descriptor, status enum, and validation behavior.
- Restores `ProductsUpdateToolHandler` to the pre-#15823 descriptor wording.
- Removes the related descriptor/transition assertions that were added with those accidental tool-handler changes.

### Test Steps
Green CI is enough.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.