### PR TITLE
[WOOMOB-2973] Preserve deterministic AI write failures

### DIFF
--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/ToolResult.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/chat/ToolResult.kt
@@ -23,5 +23,11 @@ sealed interface ToolResult {
     data class TransportError(
         override val toolCallId: String,
         val retryable: Boolean,
+        val kind: ToolFailureKind = ToolFailureKind.OUTCOME_UNKNOWN,
     ) : ToolResult
+}
+
+enum class ToolFailureKind {
+    OUTCOME_UNKNOWN,
+    DETERMINISTIC_FAILURE,
 }

--- a/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
+++ b/libs/ai-assistant/core/src/main/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImpl.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.aiassistant.core.chat.FinishReason
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolDefinition
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolFailureKind
 import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
@@ -93,7 +94,7 @@ class AgenticLoopImpl(
             modelMessages = modelMessages + newAssistantMsg
             newTurnMessages.add(newAssistantMsg)
             modelMessages = appendCompletedToolMessages(modelMessages, newTurnMessages, completedTools)
-            completedTools.firstOutcomeUnknownError()?.let { error ->
+            completedTools.firstUnsafeTransportFailureError()?.let { error ->
                 emit(LoopEvent.Failed(error))
                 emit(failedFinish(history + newTurnMessages, retryAvailable = false, error))
                 return@flow
@@ -311,14 +312,21 @@ class AgenticLoopImpl(
         val safetyLevel: ToolSafetyLevel,
     )
 
-    private fun List<CompletedToolCall>.firstOutcomeUnknownError(): AssistantError.OutcomeUnknown? =
+    private fun List<CompletedToolCall>.firstUnsafeTransportFailureError(): AssistantError? =
         firstNotNullOfOrNull { completed ->
-            val isUnknownWriteOutcome = completed.safetyLevel == ToolSafetyLevel.UNSAFE &&
-                completed.result is ToolResult.TransportError
-            if (isUnknownWriteOutcome) {
-                AssistantError.OutcomeUnknown(toolName = completed.historyToolCall.name)
-            } else {
-                null
+            val result = completed.result as? ToolResult.TransportError
+                ?: return@firstNotNullOfOrNull null
+            if (completed.safetyLevel != ToolSafetyLevel.UNSAFE) {
+                return@firstNotNullOfOrNull null
+            }
+
+            when (result.kind) {
+                ToolFailureKind.OUTCOME_UNKNOWN -> AssistantError.OutcomeUnknown(
+                    toolName = completed.historyToolCall.name,
+                )
+                ToolFailureKind.DETERMINISTIC_FAILURE -> AssistantError.ToolFailed(
+                    toolName = completed.historyToolCall.name,
+                )
             }
         }
 

--- a/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
+++ b/libs/ai-assistant/core/src/test/kotlin/com/woocommerce/android/aiassistant/core/loop/AgenticLoopImplTest.kt
@@ -9,6 +9,7 @@ import com.woocommerce.android.aiassistant.core.chat.ChatStreamError
 import com.woocommerce.android.aiassistant.core.chat.FinishReason
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolFailureKind
 import com.woocommerce.android.aiassistant.core.chat.ToolRegistry
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
@@ -656,9 +657,68 @@ class AgenticLoopImplTest {
             assertThat(finished.retryAvailable).isFalse()
             assertThat(finished.error).isEqualTo(AssistantError.OutcomeUnknown(toolName = "orders_update"))
             assertThat(events.filterIsInstance<LoopEvent.ToolCallFinished>().single().result)
-                .isEqualTo(ToolResult.TransportError(toolCallId = "call_1", retryable = true))
+                .isEqualTo(
+                    ToolResult.TransportError(
+                        toolCallId = "call_1",
+                        retryable = true,
+                        kind = ToolFailureKind.OUTCOME_UNKNOWN,
+                    )
+                )
             assertThat(finished.updatedHistory.filterIsInstance<AssistantMessage.Tool>().single().toolCallId)
                 .isEqualTo("call_1")
+            job.cancel()
+        }
+
+    @Test
+    fun `given confirmed unsafe tool returns deterministic transport error, when running turn, then tool failed fails without retry`() =
+        runTest {
+            val unsafeDescriptor = ToolDescriptor(
+                name = "orders_update",
+                description = "Updates an order",
+                inputSchema = buildJsonObject { },
+                safetyLevel = ToolSafetyLevel.UNSAFE,
+            )
+            val registry = object : ToolRegistry {
+                override fun descriptors() = listOf(unsafeDescriptor)
+
+                override suspend fun execute(call: ToolCall): ToolResult =
+                    ToolResult.TransportError(
+                        toolCallId = call.id,
+                        retryable = true,
+                        kind = ToolFailureKind.DETERMINISTIC_FAILURE,
+                    )
+            }
+            val safetyOrchestrator = SafetyOrchestratorImpl()
+            val loop = loopWith(
+                flow {
+                    emit(
+                        AssistantEvent.ToolCallDelta(
+                            index = 0,
+                            id = "call_1",
+                            name = "orders_update",
+                            argumentsDelta = """{"id":42,"status":"processing"}""",
+                        )
+                    )
+                    emit(AssistantEvent.Finish(FinishReason.TOOL_CALLS))
+                },
+                registry = registry,
+                safetyOrchestrator = safetyOrchestrator,
+            )
+            val events = mutableListOf<LoopEvent>()
+
+            val job = launch {
+                loop.runTurn("conv", "update order", history, contextWithTools(unsafeDescriptor)).toList(events)
+            }
+
+            runCurrent()
+            val request = events.filterIsInstance<LoopEvent.ConfirmationRequested>().single().request
+            safetyOrchestrator.confirm(request.id)
+            advanceUntilIdle()
+
+            val finished = events.filterIsInstance<LoopEvent.Finished>().last()
+            assertThat(finished.outcome).isEqualTo(LoopOutcome.FAILED)
+            assertThat(finished.retryAvailable).isFalse()
+            assertThat(finished.error).isEqualTo(AssistantError.ToolFailed(toolName = "orders_update"))
             job.cancel()
         }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/OrdersUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/orders/OrdersUpdateToolHandler.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.aiassistant.tools.orders
 
+import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.aiassistant.core.chat.AssistantToolHandler
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolFailureKind
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import com.woocommerce.android.aiassistant.core.chat.inputSchema
@@ -13,6 +15,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.encodeToJsonElement
+import org.wordpress.android.fluxc.store.WCOrderStore
 import javax.inject.Inject
 
 internal class OrdersUpdateToolHandler @Inject constructor(
@@ -53,7 +56,13 @@ internal class OrdersUpdateToolHandler @Inject constructor(
                     ) as JsonObject,
                 )
             },
-            onFailure = { ToolResult.TransportError(toolCallId = call.id, retryable = true) },
+            onFailure = { error ->
+                ToolResult.TransportError(
+                    toolCallId = call.id,
+                    retryable = true,
+                    kind = error.toOrderUpdateFailureKind(),
+                )
+            },
         )
     }
 
@@ -80,3 +89,27 @@ internal class OrdersUpdateToolHandler @Inject constructor(
         )
     }
 }
+
+private fun Throwable.toOrderUpdateFailureKind(): ToolFailureKind {
+    val orderError = (this as? OnChangedException)?.error as? WCOrderStore.OrderError
+        ?: return ToolFailureKind.OUTCOME_UNKNOWN
+
+    return when (orderError.type) {
+        WCOrderStore.OrderErrorType.INVALID_ID,
+        WCOrderStore.OrderErrorType.INVALID_PARAM,
+        WCOrderStore.OrderErrorType.ORDER_STATUS_NOT_FOUND,
+        WCOrderStore.OrderErrorType.EMPTY_BILLING_EMAIL -> ToolFailureKind.DETERMINISTIC_FAILURE
+        WCOrderStore.OrderErrorType.GENERIC_ERROR -> if (orderError.isLocalMissingOrder()) {
+            ToolFailureKind.DETERMINISTIC_FAILURE
+        } else {
+            ToolFailureKind.OUTCOME_UNKNOWN
+        }
+        else -> ToolFailureKind.OUTCOME_UNKNOWN
+    }
+}
+
+private fun WCOrderStore.OrderError.isLocalMissingOrder(): Boolean =
+    message == "Order not found" ||
+        LOCAL_MISSING_ORDER_MESSAGE_REGEX.matches(message)
+
+private val LOCAL_MISSING_ORDER_MESSAGE_REGEX = Regex("""^Order with id \d+ not found$""")

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSource.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSource.kt
@@ -36,6 +36,8 @@ internal class AIProductsDataSource @Inject constructor(
             "For variable products, update individual variations instead."
     )
 
+    class ProductNotFoundException(productId: Long) : NoSuchElementException("Product $productId not found")
+
     suspend fun fetchProducts(
         search: String? = null,
         status: String? = null,
@@ -215,7 +217,7 @@ internal class AIProductsDataSource @Inject constructor(
         } else {
             val product = productStore.getProductByRemoteId(site, productId)
             product?.let { Result.success(it) }
-                ?: Result.failure(IllegalStateException("Product $productId not found after fetch"))
+                ?: Result.failure(ProductNotFoundException(productId))
         }
     }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsUpdateToolHandler.kt
@@ -1,8 +1,10 @@
 package com.woocommerce.android.aiassistant.tools.products
 
+import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.aiassistant.core.chat.AssistantToolHandler
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolDescriptor
+import com.woocommerce.android.aiassistant.core.chat.ToolFailureKind
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import com.woocommerce.android.aiassistant.core.chat.inputSchema
@@ -13,6 +15,10 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.encodeToJsonElement
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.store.Store.OnChangedError
+import org.wordpress.android.fluxc.store.WCProductStore
 import javax.inject.Inject
 
 internal class ProductsUpdateToolHandler @Inject constructor(
@@ -74,7 +80,11 @@ internal class ProductsUpdateToolHandler @Inject constructor(
                         toolCallId = call.id,
                         reason = requireNotNull(error.message),
                     )
-                    else -> ToolResult.TransportError(toolCallId = call.id, retryable = true)
+                    else -> ToolResult.TransportError(
+                        toolCallId = call.id,
+                        retryable = true,
+                        kind = error.toProductUpdateFailureKind(),
+                    )
                 }
             },
         )
@@ -100,4 +110,30 @@ internal class ProductsUpdateToolHandler @Inject constructor(
     private companion object {
         val ALLOWED_STATUSES = setOf("draft", "pending", "private", "publish")
     }
+}
+
+private fun Throwable.toProductUpdateFailureKind(): ToolFailureKind = when (this) {
+    is AIProductsDataSource.ProductNotFoundException -> ToolFailureKind.DETERMINISTIC_FAILURE
+    is OnChangedException -> error.toProductUpdateFailureKind()
+    else -> ToolFailureKind.OUTCOME_UNKNOWN
+}
+
+private fun OnChangedError.toProductUpdateFailureKind(): ToolFailureKind = when (this) {
+    is WCProductStore.ProductError -> toProductUpdateFailureKind()
+    is WooError -> toProductUpdateFailureKind()
+    else -> ToolFailureKind.OUTCOME_UNKNOWN
+}
+
+private fun WCProductStore.ProductError.toProductUpdateFailureKind(): ToolFailureKind = when (type) {
+    WCProductStore.ProductErrorType.INVALID_PRODUCT_ID,
+    WCProductStore.ProductErrorType.INVALID_PARAM,
+    WCProductStore.ProductErrorType.DUPLICATE_SKU,
+    WCProductStore.ProductErrorType.INVALID_MIN_MAX_QUANTITY -> ToolFailureKind.DETERMINISTIC_FAILURE
+    else -> ToolFailureKind.OUTCOME_UNKNOWN
+}
+
+private fun WooError.toProductUpdateFailureKind(): ToolFailureKind = when (type) {
+    WooErrorType.INVALID_ID,
+    WooErrorType.INVALID_PARAM -> ToolFailureKind.DETERMINISTIC_FAILURE
+    else -> ToolFailureKind.OUTCOME_UNKNOWN
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/OrdersUpdateToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/orders/OrdersUpdateToolHandlerTest.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.aiassistant.tools.orders
 
+import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolFailureKind
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -16,6 +18,7 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.store.WCOrderStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class OrdersUpdateToolHandlerTest {
@@ -83,12 +86,57 @@ class OrdersUpdateToolHandlerTest {
         }
 
     @Test
-    fun `given update fails, when execute is called, then retryable TransportError is returned`() = runTest {
-        whenever(dataSource.updateOrderStatus(123L, "processing")).thenReturn(
-            Result.failure(RuntimeException("network error"))
-        )
+    fun `given invalid order id failure, when execute is called, then invalid id TransportError is returned`() =
+        runTest {
+            whenever(dataSource.updateOrderStatus(123L, "processing")).thenReturn(
+                Result.failure(orderFailure(WCOrderStore.OrderErrorType.INVALID_ID))
+            )
 
-        val result = handler.execute(
+            val result = executeValidUpdate()
+
+            assertTransportErrorKind(result, ToolFailureKind.DETERMINISTIC_FAILURE)
+        }
+
+    @Test
+    fun `given local missing order failure, when execute is called, then not found TransportError is returned`() =
+        runTest {
+            whenever(dataSource.updateOrderStatus(123L, "processing")).thenReturn(
+                Result.failure(
+                    OnChangedException(WCOrderStore.OrderError(message = "Order with id 123 not found"))
+                )
+            )
+
+            val result = executeValidUpdate()
+
+            assertTransportErrorKind(result, ToolFailureKind.DETERMINISTIC_FAILURE)
+        }
+
+    @Test
+    fun `given validation order failure, when execute is called, then validation TransportError is returned`() =
+        runTest {
+            whenever(dataSource.updateOrderStatus(123L, "processing")).thenReturn(
+                Result.failure(orderFailure(WCOrderStore.OrderErrorType.ORDER_STATUS_NOT_FOUND))
+            )
+
+            val result = executeValidUpdate()
+
+            assertTransportErrorKind(result, ToolFailureKind.DETERMINISTIC_FAILURE)
+        }
+
+    @Test
+    fun `given generic update failure, when execute is called, then outcome unknown TransportError is returned`() =
+        runTest {
+            whenever(dataSource.updateOrderStatus(123L, "processing")).thenReturn(
+                Result.failure(RuntimeException("network error"))
+            )
+
+            val result = executeValidUpdate()
+
+            assertTransportErrorKind(result, ToolFailureKind.OUTCOME_UNKNOWN)
+        }
+
+    private suspend fun executeValidUpdate(): ToolResult =
+        handler.execute(
             toolCall(
                 buildJsonObject {
                     put("id", 123)
@@ -97,7 +145,13 @@ class OrdersUpdateToolHandlerTest {
             )
         )
 
+    private fun orderFailure(type: WCOrderStore.OrderErrorType): OnChangedException =
+        OnChangedException(WCOrderStore.OrderError(type = type))
+
+    private fun assertTransportErrorKind(result: ToolResult, kind: ToolFailureKind) {
         assertThat(result).isInstanceOf(ToolResult.TransportError::class.java)
-        assertThat((result as ToolResult.TransportError).retryable).isTrue
+        val error = result as ToolResult.TransportError
+        assertThat(error.retryable).isTrue
+        assertThat(error.kind).isEqualTo(kind)
     }
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSourceTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/AIProductsDataSourceTest.kt
@@ -215,6 +215,20 @@ class AIProductsDataSourceTest {
     }
 
     @Test
+    fun `given product remains absent after fetch, when getProduct is called, then product not found failure is returned`() =
+        runTest {
+            whenever(productStore.getProductByRemoteId(site, 10L)).thenReturn(null)
+            whenever(productStore.fetchSingleProduct(any())).thenReturn(
+                WCProductStore.OnProductChanged(remoteProductId = 10L)
+            )
+
+            val result = dataSource.getProduct(productId = 10L)
+
+            assertThat(result.exceptionOrNull())
+                .isInstanceOf(AIProductsDataSource.ProductNotFoundException::class.java)
+        }
+
+    @Test
     fun `given network fetch fails, when getProduct is called, then failure result is returned`() = runTest {
         whenever(productStore.getProductByRemoteId(site, 10L)).thenReturn(null)
         val errorEvent = WCProductStore.OnProductChanged().also {

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsUpdateToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsUpdateToolHandlerTest.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.aiassistant.tools.products
 
+import com.woocommerce.android.OnChangedException
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.core.chat.ToolFailureKind
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -22,6 +24,10 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.store.WCProductStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProductsUpdateToolHandlerTest {
@@ -178,15 +184,100 @@ class ProductsUpdateToolHandlerTest {
     }
 
     @Test
-    fun `given update fails, when execute is called, then retryable TransportError is returned`() = runTest {
+    fun `given invalid product id failure, when execute is called, then invalid id TransportError is returned`() =
+        runTest {
+            whenever(
+                dataSource.updateProduct(
+                    productId = 42L,
+                    update = AIProductsDataSource.ProductUpdate(regularPrice = "12.50")
+                )
+            ).thenReturn(
+                Result.failure(productFailure(WCProductStore.ProductErrorType.INVALID_PRODUCT_ID))
+            )
+
+            val result = executeValidUpdate()
+
+            assertTransportErrorKind(result, ToolFailureKind.DETERMINISTIC_FAILURE)
+        }
+
+    @Test
+    fun `given product not found failure, when execute is called, then not found TransportError is returned`() =
+        runTest {
+            whenever(
+                dataSource.updateProduct(
+                    productId = 42L,
+                    update = AIProductsDataSource.ProductUpdate(regularPrice = "12.50")
+                )
+            ).thenReturn(Result.failure(AIProductsDataSource.ProductNotFoundException(42L)))
+
+            val result = executeValidUpdate()
+
+            assertTransportErrorKind(result, ToolFailureKind.DETERMINISTIC_FAILURE)
+        }
+
+    @Test
+    fun `given validation product failure, when execute is called, then validation TransportError is returned`() =
+        runTest {
+            whenever(
+                dataSource.updateProduct(
+                    productId = 42L,
+                    update = AIProductsDataSource.ProductUpdate(regularPrice = "12.50")
+                )
+            ).thenReturn(
+                Result.failure(productFailure(WCProductStore.ProductErrorType.DUPLICATE_SKU))
+            )
+
+            val result = executeValidUpdate()
+
+            assertTransportErrorKind(result, ToolFailureKind.DETERMINISTIC_FAILURE)
+        }
+
+    @Test
+    fun `given invalid id Woo failure, when execute is called, then invalid id TransportError is returned`() =
+        runTest {
+            whenever(
+                dataSource.updateProduct(
+                    productId = 42L,
+                    update = AIProductsDataSource.ProductUpdate(regularPrice = "12.50")
+                )
+            ).thenReturn(Result.failure(wooFailure(WooErrorType.INVALID_ID)))
+
+            val result = executeValidUpdate()
+
+            assertTransportErrorKind(result, ToolFailureKind.DETERMINISTIC_FAILURE)
+        }
+
+    @Test
+    fun `given generic product update failure, when execute is called, then outcome unknown TransportError is returned`() =
+        runTest {
+            whenever(
+                dataSource.updateProduct(
+                    productId = 42L,
+                    update = AIProductsDataSource.ProductUpdate(regularPrice = "12.50")
+                )
+            ).thenReturn(Result.failure(RuntimeException("network error")))
+
+            val result = executeValidUpdate()
+
+            assertTransportErrorKind(result, ToolFailureKind.OUTCOME_UNKNOWN)
+        }
+
+    @Test
+    fun `given generic Woo failure, when execute is called, then outcome unknown TransportError is returned`() = runTest {
         whenever(
             dataSource.updateProduct(
                 productId = 42L,
                 update = AIProductsDataSource.ProductUpdate(regularPrice = "12.50")
             )
-        ).thenReturn(Result.failure(RuntimeException("network error")))
+        ).thenReturn(Result.failure(wooFailure(WooErrorType.API_ERROR)))
 
-        val result = handler.execute(
+        val result = executeValidUpdate()
+
+        assertTransportErrorKind(result, ToolFailureKind.OUTCOME_UNKNOWN)
+    }
+
+    private suspend fun executeValidUpdate(): ToolResult =
+        handler.execute(
             toolCall(
                 buildJsonObject {
                     put("id", 42)
@@ -195,7 +286,16 @@ class ProductsUpdateToolHandlerTest {
             )
         )
 
+    private fun productFailure(type: WCProductStore.ProductErrorType): OnChangedException =
+        OnChangedException(WCProductStore.ProductError(type = type))
+
+    private fun wooFailure(type: WooErrorType): OnChangedException =
+        OnChangedException(WooError(type = type, original = GenericErrorType.UNKNOWN))
+
+    private fun assertTransportErrorKind(result: ToolResult, kind: ToolFailureKind) {
         assertThat(result).isInstanceOf(ToolResult.TransportError::class.java)
-        assertThat((result as ToolResult.TransportError).retryable).isTrue
+        val error = result as ToolResult.TransportError
+        assertThat(error.retryable).isTrue
+        assertThat(error.kind).isEqualTo(kind)
     }
 }


### PR DESCRIPTION
### Description
Fixes WOOMOB-2973

The AI assistant previously treated every unsafe write tool transport error as an unknown outcome after the merchant confirmed the action. That was too broad: for some failures, the app can tell that the write did not happen, so the user should see the regular tool-failed state instead of being asked to verify whether the outcome happened.

This PR adds a small internal distinction to `ToolResult.TransportError` through a binary `ToolFailureKind`:

- `OUTCOME_UNKNOWN` remains the default, preserving existing behavior for ambiguous failures and for tools that do not classify their errors yet.
- `DETERMINISTIC_FAILURE` marks stable failure cases where the app can tell the write did not succeed.

`AgenticLoopImpl` now uses that distinction only for confirmed unsafe tool failures. Unknown outcomes still emit `AssistantError.OutcomeUnknown`; deterministic failures emit the existing `AssistantError.ToolFailed`. Model-facing tool JSON remains the generic `{"error":"Tool execution failed"}`, so raw FluxC/Woo exception details are not exposed to the model or UI.

The PR classifies deterministic failures for two single-write tools:

- `orders_update` maps stable order update failures such as invalid IDs, invalid parameters, missing order status, empty billing email, and the local "order not found" result to `DETERMINISTIC_FAILURE`. Generic/ambiguous failures keep `OUTCOME_UNKNOWN`.
- `products_update` maps product-not-found, invalid product ID, invalid parameters, duplicate SKU, invalid min/max quantity, and matching Woo API validation/ID failures to `DETERMINISTIC_FAILURE`. Generic/ambiguous failures keep `OUTCOME_UNKNOWN`.

`AIProductsDataSource` now throws a typed `ProductNotFoundException` when fetching a product succeeds but the product remains absent locally. That gives `products_update` a stable not-found signal without relying on raw error text.

The change intentionally keeps the scope narrow. Bulk/partial-write tools continue to use the default unknown-outcome behavior because their partial success semantics need separate handling. No UI, auth, telemetry, retry, diagnostics, or broad error-model changes are included.

### Test Steps
N/A - this is an internal AI assistant error-classification change covered by focused unit tests and module test suites.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.