### PR TITLE
[RSM] Phone POS TTP - Part 1: Multi-method payment buttons row

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCheckoutPaymentButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCheckoutPaymentButtons.kt
@@ -1,0 +1,47 @@
+package com.woocommerce.android.ui.woopos.home.totals
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
+
+@Composable
+internal fun WooPosCheckoutPaymentButtons(
+    methods: List<WooPosPaymentMethod>,
+    onMethodClicked: (WooPosPaymentMethod) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isPhone = currentWooPosBreakpoint() == WooPosBreakpoint.Phone
+    val outerPaddingModifier = if (isPhone) {
+        Modifier.padding(WooPosSpacing.Large.value)
+    } else {
+        Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(outerPaddingModifier)
+            .navigationBarsPadding(),
+        horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
+    ) {
+        methods.forEach { method ->
+            WooPosOutlinedButton(
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag(method.testTag()),
+                text = stringResource(method.labelRes()),
+                onClick = { onMethodClicked(method) },
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCheckoutPaymentButtons.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCheckoutPaymentButtons.kt
@@ -1,7 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.totals
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
@@ -27,21 +28,24 @@ internal fun WooPosCheckoutPaymentButtons(
         Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
     }
 
-    Row(
+    Column(
         modifier = modifier
             .fillMaxWidth()
             .then(outerPaddingModifier)
             .navigationBarsPadding(),
-        horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
+        verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
     ) {
-        methods.forEach { method ->
-            WooPosOutlinedButton(
-                modifier = Modifier
-                    .weight(1f)
-                    .testTag(method.testTag()),
-                text = stringResource(method.labelRes()),
-                onClick = { onMethodClicked(method) },
-            )
+        methods.forEachIndexed { index, method ->
+            val buttonModifier = Modifier
+                .fillMaxWidth()
+                .testTag(method.testTag())
+            val text = stringResource(method.labelRes())
+            val onClick = { onMethodClicked(method) }
+            if (index == 0) {
+                WooPosButton(modifier = buttonModifier, text = text, onClick = onClick)
+            } else {
+                WooPosOutlinedButton(modifier = buttonModifier, text = text, onClick = onClick)
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosPaymentMethod.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosPaymentMethod.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.woopos.home.totals
+
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.util.WooPosTestTags
+
+internal enum class WooPosPaymentMethod {
+    CARD_READER,
+    CASH,
+}
+
+internal fun WooPosPaymentMethod.labelRes(): Int = when (this) {
+    WooPosPaymentMethod.CARD_READER -> R.string.woopos_payment_method_card_reader_label
+    WooPosPaymentMethod.CASH -> R.string.woopos_payment_take_cash_payment_label
+}
+
+internal fun WooPosPaymentMethod.testTag(): String = when (this) {
+    WooPosPaymentMethod.CARD_READER -> WooPosTestTags.CARD_READER_PAYMENT_BUTTON
+    WooPosPaymentMethod.CASH -> WooPosTestTags.CASH_PAYMENT_BUTTON
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,7 +29,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -44,17 +42,14 @@ import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCircularLoadingIndicator
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreen
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosErrorScreenButtonState
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIcons
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
@@ -65,7 +60,6 @@ import com.woocommerce.android.ui.woopos.home.totals.WooPosTotalsViewState.Total
 import com.woocommerce.android.ui.woopos.home.totals.payment.failed.WooPosPaymentFailedScreen
 import com.woocommerce.android.ui.woopos.home.totals.payment.inprogress.WooPosPaymentInProgressScreen
 import com.woocommerce.android.ui.woopos.home.totals.payment.success.WooPosPaymentSuccessScreen
-import com.woocommerce.android.ui.woopos.util.WooPosTestTags
 
 @Composable
 fun WooPosTotalsScreen(
@@ -197,9 +191,7 @@ private fun TotalsLoaded(
                 verticalArrangement = Arrangement.Center,
             ) {
                 when (val readerStatus = state.readerStatus) {
-                    is WooPosTotalsViewState.ReaderStatus.Disconnected -> {
-                        ReaderDisconnected(status = readerStatus, onUIEvent = onUIEvent)
-                    }
+                    is WooPosTotalsViewState.ReaderStatus.Disconnected -> Unit
                     is WooPosTotalsViewState.ReaderStatus.Preparing -> {
                         PreparingReader(
                             title = readerStatus.title,
@@ -241,21 +233,20 @@ private fun TotalsLoaded(
             Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
         }
 
-        val isPhone = currentWooPosBreakpoint() == WooPosBreakpoint.Phone
-        WooPosOutlinedButton(
-            text = stringResource(R.string.woopos_payment_take_cash_payment_label),
-            onClick = { onUIEvent(WooPosTotalsUIEvent.OnCashPaymentClicked) },
-            modifier = Modifier
-                .fillMaxWidth()
-                .then(
-                    if (isPhone) {
-                        Modifier.padding(WooPosSpacing.Large.value)
-                    } else {
-                        Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
-                    }
-                )
-                .navigationBarsPadding()
-                .testTag(WooPosTestTags.CASH_PAYMENT_BUTTON)
+        val isReaderDisconnected = state.readerStatus is WooPosTotalsViewState.ReaderStatus.Disconnected
+        val methods = if (isReaderDisconnected) {
+            listOf(WooPosPaymentMethod.CARD_READER, WooPosPaymentMethod.CASH)
+        } else {
+            listOf(WooPosPaymentMethod.CASH)
+        }
+        WooPosCheckoutPaymentButtons(
+            methods = methods,
+            onMethodClicked = { method ->
+                when (method) {
+                    WooPosPaymentMethod.CARD_READER -> onUIEvent(WooPosTotalsUIEvent.ConnectReaderClicked)
+                    WooPosPaymentMethod.CASH -> onUIEvent(WooPosTotalsUIEvent.OnCashPaymentClicked)
+                }
+            },
         )
     }
 }
@@ -300,48 +291,6 @@ private fun ReaderReadyForPayment(readerStatus: WooPosTotalsViewState.ReaderStat
         textAlign = TextAlign.Center,
         modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
     )
-}
-
-@Composable
-private fun ReaderDisconnected(
-    modifier: Modifier = Modifier,
-    status: WooPosTotalsViewState.ReaderStatus.Disconnected,
-    onUIEvent: (WooPosTotalsUIEvent) -> Unit,
-) {
-    Column(
-        modifier = modifier.padding(WooPosSpacing.XLarge.value),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.SpaceEvenly,
-    ) {
-        Image(
-            modifier = Modifier.size(140.dp.toAdaptiveComponentSize()),
-            imageVector = WooPosIcons.CardReaderNotConnected,
-            contentDescription = stringResource(id = R.string.woopos_reader_not_connected_description),
-        )
-
-        Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
-
-        WooPosText(
-            text = status.title,
-            style = WooPosTypography.Heading,
-            fontWeight = FontWeight.Bold,
-        )
-
-        Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
-
-        WooPosText(
-            text = status.subtitle,
-            style = WooPosTypography.BodyLarge,
-        )
-        Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
-        WooPosButton(
-            text = status.actionButtonLabel,
-            onClick = { onUIEvent(WooPosTotalsUIEvent.ConnectReaderClicked) },
-            modifier = Modifier
-                .adaptiveContentWidth()
-                .height(WooPosComponentSize.Small.value)
-        )
-    }
 }
 
 @Composable
@@ -619,19 +568,6 @@ fun WooPosTotalsScreenPreviewForFreeOrders() {
             ),
             onUIEvent = {},
         )
-    }
-}
-
-@Composable
-@WooPosPreview
-fun TotalsErrorPreview() {
-    val readerStatus = WooPosTotalsViewState.ReaderStatus.Disconnected(
-        title = "Reader not connected",
-        subtitle = "To process this payment, please connect your reader.",
-        actionButtonLabel = "Connect to a reader",
-    )
-    WooPosTheme {
-        ReaderDisconnected(modifier = Modifier, status = readerStatus) {}
     }
 }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3753,6 +3753,7 @@
     <string name="woopos_payment_tax_label">Taxes</string>
     <string name="woopos_payment_total_label">Total</string>
     <string name="woopos_payment_take_cash_payment_label">Cash payment</string>
+    <string name="woopos_payment_method_card_reader_label">Card reader</string>
     <string name="woopos_totals_main_error_label">Couldn\'t load totals</string>
     <string name="woopos_totals_coupons_validation_failed_edit_order">Edit order</string>
     <string name="woopos_totals_coupons_validation_failed_remove_coupons">Remove coupons</string>

--- a/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
+++ b/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
@@ -4,6 +4,7 @@ object WooPosTestTags {
     const val PRODUCT_ITEM = "woo_pos_product_item"
     const val CHECKOUT_BUTTON = "woo_pos_checkout_button"
     const val CASH_PAYMENT_BUTTON = "woo_pos_cash_payment_button"
+    const val CARD_READER_PAYMENT_BUTTON = "woo_pos_card_reader_payment_button"
     const val COMPLETE_PAYMENT_BUTTON = "woo_pos_complete_payment_button"
     const val NEW_ORDER_BUTTON = "woo_pos_new_order_button"
     const val SUCCESS_CHECKMARK_ICON = "woo_pos_success_checkmark_icon"


### PR DESCRIPTION
### Description

Refactors the bottom of the POS checkout: replaces the single Cash payment button (and the fullscreen "Reader disconnected" CTA) with `WooPosCheckoutPaymentButtons`, a form-factor-aware vertical stack driven by a list of `WooPosPaymentMethod` enum values. The first method renders as a primary button, the rest as outlined. When the reader is disconnected, both Card reader and Cash render; otherwise only Cash. The new component is structured to accept Tap to Pay and an overflow dialog in later parts without further refactoring.

### Note on disconnected-state UX

The fullscreen `ReaderDisconnected` info card (icon + title + subtitle + CTA) is removed in this PR; the upper area's `Disconnected` branch is intentionally rendered as `Unit`. Until later parts cascade, a disconnected reader shows nothing on top — only the Card reader + Cash buttons at the bottom. The full info card is restored by Part 4 (#15841) for the TTP-available path and Part 8b (#15834) for the TTP-unavailable path. During the merge window between this PR and Part 8b, the disconnected screen looks bare; that is intentional, not a regression.

### Stack

Part 1 of the [RSM] Phone POS TTP stack:
- **Part 1 — this PR**
- Part 2 — Phone back button on POS checkout (#15839)
- Part 3 — Feature flag and TTP availability tracking (#15840)
- Part 4 — Tap to Pay promoted state in checkout (#15841)
- Part 5 — Tap to Pay in payment row and overflow dialog (#15842)
- Part 6 — Cash + Other payment methods row (#15825)
- Part 7 — Payment-failed screen padding fix (#15833)
- Part 8a — TTP reader connector foundation (#15850)
- Part 8b — Wire payment collection (#15834)
- Part 9 — Polish state transitions (#15835)

### Test Steps

1. Open POS, add an item, tap **Checkout**.
2. With **no reader connected**: verify two stacked buttons appear — primary **Card reader** and outlined **Cash payment**. Tap **Card reader** and confirm the connect-reader flow opens.
3. Connect a reader and return to checkout: verify only **Cash payment** is shown and the cash flow runs on tap.
4. Repeat on phone and tablet to verify horizontal padding for each form factor.

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

