### PR TITLE
[WOOMOB-3027] Reconcile login URL with canonical SiteModel URL after WP-API discovery

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 24.8
 -----
 - [Internal] Added REMOTE_TAP_TO_PAY feature flag (off in production) for the upcoming Woo POS Remote Tap-to-Pay feature [https://github.com/woocommerce/woocommerce-android/pull/15696]
+- [*] Fixed login getting stuck in a retry loop when an http URL was returned for an HTTPS-only site [https://github.com/woocommerce/woocommerce-android/pull/15846]
 
 24.7
 -----

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModel.kt
@@ -69,9 +69,24 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         private const val SUCCESS_PARAMETER = "success"
         private const val USERNAME_PARAMETER = "user_login"
         private const val PASSWORD_PARAMETER = "password"
+        private const val HAS_RECONCILED_SITE_URL_KEY = "has-reconciled-site-url"
     }
 
-    private val siteAddress: String = savedStateHandle[SITE_ADDRESS_KEY]!!
+    private var siteAddress: String
+        get() = savedStateHandle[SITE_ADDRESS_KEY]!!
+        set(value) {
+            savedStateHandle[SITE_ADDRESS_KEY] = value
+        }
+
+    // The URL the WP.com `connect/site-info` endpoint reports as the canonical site URL is
+    // sometimes wrong — its cache can return an http URL for a site that 301s to https. Once
+    // FluxC's WP-API discovery resolves the real scheme, we adopt it and re-attempt login
+    // (guarded so a misbehaving server can't trigger a ping-pong update).
+    private var hasReconciledSiteUrl: Boolean
+        get() = savedStateHandle[HAS_RECONCILED_SITE_URL_KEY] ?: false
+        set(value) {
+            savedStateHandle[HAS_RECONCILED_SITE_URL_KEY] = value
+        }
 
     private val authError = savedStateHandle.getNullableStateFlow(
         scope = viewModelScope,
@@ -253,6 +268,13 @@ class LoginSiteCredentialsViewModel @Inject constructor(
         loadingMessage.value = R.string.login_site_credentials_fetching_site
         wpApiSiteRepository.fetchSite(url = siteAddress).fold(
             onSuccess = { site ->
+                val canonicalUrl = site.url
+                if (!hasReconciledSiteUrl && !canonicalUrl.isNullOrEmpty() && canonicalUrl != siteAddress) {
+                    hasReconciledSiteUrl = true
+                    siteAddress = canonicalUrl
+                    login()
+                    return@fold
+                }
                 if (site.hasWooCommerce) {
                     fetchedSiteId.value = site.id
                     loadingMessage.value = 0

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/sitecredentials/LoginSiteCredentialsViewModelTest.kt
@@ -379,4 +379,40 @@ class LoginSiteCredentialsViewModelTest : BaseUnitTest() {
             assertThat((event as LoginSiteCredentialsViewModel.ShowApplicationPasswordTutorialScreen).url)
                 .isEqualTo(urlAuthFull)
         }
+
+    @Test
+    fun `given canonical site URL is https but siteAddress is http, when login fails with INVALID_NONCE, then ViewModel retries with the canonical https URL and succeeds`() =
+        testBlocking {
+            val canonicalHttpsAddress = "https://site.com"
+            val canonicalSite = SiteModel().apply {
+                hasWooCommerce = true
+                url = canonicalHttpsAddress
+            }
+            val invalidNonce = CookieNonceAuthenticationException(
+                errorMessage = UiStringText("INVALID_NONCE"),
+                errorType = Nonce.CookieNonceErrorType.INVALID_NONCE,
+                networkStatusCode = null
+            )
+
+            setup {
+                whenever(wpApiSiteRepository.login(siteAddress, testUsername, testPassword))
+                    .thenReturn(Result.failure(invalidNonce))
+                whenever(wpApiSiteRepository.fetchSite(siteAddress))
+                    .thenReturn(Result.success(canonicalSite))
+                whenever(wpApiSiteRepository.login(canonicalHttpsAddress, testUsername, testPassword))
+                    .thenReturn(Result.success(Unit))
+                whenever(wpApiSiteRepository.fetchSite(canonicalHttpsAddress, testUsername, testPassword))
+                    .thenReturn(Result.success(canonicalSite))
+            }
+
+            viewModel.viewState.observeForTesting {
+                viewModel.onUsernameChanged(testUsername)
+                viewModel.onPasswordChanged(testPassword)
+                viewModel.onContinueClick()
+            }
+
+            verify(wpApiSiteRepository).login(siteAddress, testUsername, testPassword)
+            verify(wpApiSiteRepository).login(canonicalHttpsAddress, testUsername, testPassword)
+            assertThat(viewModel.event.value).isEqualTo(LoggedIn(canonicalSite.id))
+        }
 }

--- a/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
+++ b/libs/fluxc-tests/src/test/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClientTest.kt
@@ -233,6 +233,50 @@ class NonceRestClientTest {
     }
 
     @Test
+    fun `given http site that 302s to https on wp-login, when requesting nonce, then retries POST against https`() =
+        test {
+            val httpSite = "http://example.com"
+            val httpsSite = "https://example.com"
+            val nonceUrl = "$httpsSite/wp-admin/admin-ajax.php?action=rest-nonce"
+            givenPostRedirect(siteUrl = httpSite, location = "$httpsSite/wp-login.php")
+            givenPostRedirect(siteUrl = httpsSite, location = nonceUrl)
+            whenever(wpApiEncodedRequestBuilder.syncGetRequest(subject, nonceUrl))
+                .thenReturn(WPAPIResponse.Success("expectedNONCE", emptyList()))
+
+            val actual = subject.requestNonce(httpSite, "user", "pwd")
+
+            assertIs<Nonce.Available>(actual)
+            assertEquals("expectedNONCE", actual.value)
+        }
+
+    @Test
+    fun `given redirect to a different host, when requesting nonce, then returns INVALID_NONCE without following`() =
+        test {
+            val httpSite = "http://example.com"
+            givenPostRedirect(siteUrl = httpSite, location = "https://attacker.example/wp-login.php")
+
+            val actual = subject.requestNonce(httpSite, "user", "pwd")
+
+            assertIs<Nonce.FailedRequest>(actual)
+            assertEquals(Nonce.CookieNonceErrorType.INVALID_NONCE, actual.type)
+        }
+
+    @Test
+    fun `given a second scheme upgrade redirect, when requesting nonce, then recursion guard returns INVALID_NONCE`() =
+        test {
+            val httpSite = "http://example.com"
+            val httpsSite = "https://example.com"
+            givenPostRedirect(siteUrl = httpSite, location = "$httpsSite/wp-login.php")
+            // After the upgrade retry, the upgraded host redirects back to itself again — pathological
+            // case that should NOT recurse a third time.
+            givenPostRedirect(siteUrl = httpsSite, location = "$httpsSite/wp-login.php")
+
+            val actual = subject.requestNonce(httpSite, "user", "pwd")
+
+            assertIs<Nonce.FailedRequest>(actual)
+        }
+
+    @Test
     fun `when basic auth required, then NetworkResponse returns correct error type`() = test {
         val error = WPAPINetworkError(
             BaseNetworkError(
@@ -273,6 +317,30 @@ class NonceRestClientTest {
 
     private suspend fun givenNonceRequestResponse(response: WPAPIResponse<String>) {
         whenever(wpApiEncodedRequestBuilder.syncGetRequest(subject, nonceRequestUrl))
+            .thenReturn(response)
+    }
+
+    private suspend fun givenPostRedirect(siteUrl: String, location: String, statusCode: Int = 302) {
+        val wpLoginUrl = "$siteUrl/wp-login.php"
+        val nonceRedirectUrl = "$siteUrl/wp-admin/admin-ajax.php?action=rest-nonce"
+        val body = mapOf("log" to "user", "pwd" to "pwd", "redirect_to" to nonceRedirectUrl)
+        val response = WPAPIResponse.Error<String>(
+            WPAPINetworkError(
+                BaseNetworkError(
+                    VolleyError(
+                        NetworkResponse(
+                            statusCode,
+                            byteArrayOf(),
+                            false,
+                            System.currentTimeMillis(),
+                            listOf(com.android.volley.Header("Location", location))
+                        )
+                    )
+                ),
+                null
+            )
+        )
+        whenever(wpApiEncodedRequestBuilder.syncPostRequest(subject, wpLoginUrl, body = body))
             .thenReturn(response)
     }
 }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt
@@ -47,7 +47,7 @@ class NonceRestClient @Inject constructor(
      *  [rest-nonce endpoint](https://developer.wordpress.org/reference/functions/wp_ajax_rest_nonce/)
      *  that became available in WordPress 5.3.
      */
-    @Suppress("NestedBlockDepth")
+    @Suppress("NestedBlockDepth", "LongMethod")
     suspend fun requestNonce(siteUrl: String, username: String, password: String): Nonce {
         @Suppress("MagicNumber")
         fun Int.isRedirect(): Boolean = this in 300..399
@@ -93,7 +93,24 @@ class NonceRestClient @Inject constructor(
                 } else {
                     val networkResponse = response.error.volleyError?.networkResponse
                     if (networkResponse?.statusCode?.isRedirect() == true) {
-                        requestNonce(networkResponse.headers?.get("Location") ?: redirectUrl, username)
+                        val location = networkResponse.headers?.get("Location") ?: redirectUrl
+                        if (location.contains("admin-ajax.php") && location.contains("rest-nonce")) {
+                            requestNonce(location, username)
+                        } else if (isSchemeUpgrade(wpLoginUrl, location)) {
+                            requestNonce(
+                                location.replace("wp-login.php", "").trimEnd('/'),
+                                username,
+                                password
+                            )
+                        } else {
+                            FailedRequest(
+                                timeOfResponse = currentTimeProvider.currentDate().time,
+                                username = username,
+                                type = Nonce.CookieNonceErrorType.INVALID_NONCE,
+                                networkError = response.error,
+                                errorMessage = response.error.message,
+                            )
+                        }
                     } else {
                         FailedRequest(
                             timeOfResponse = currentTimeProvider.currentDate().time,
@@ -109,6 +126,12 @@ class NonceRestClient @Inject constructor(
         return nonce.also {
             nonceMap[siteUrl] = it
         }
+    }
+
+    private fun isSchemeUpgrade(originalUrl: String, redirectUrl: String): Boolean {
+        return originalUrl.startsWith("http://") &&
+            redirectUrl.startsWith("https://") &&
+            redirectUrl.removePrefix("https://") == originalUrl.removePrefix("http://")
     }
 
     private fun getErrorType(networkResponse: NetworkResponse?): Nonce.CookieNonceErrorType = when {


### PR DESCRIPTION
Fixes WOOMOB-3027

### Description

When a user logged in to a self-hosted WooCommerce site that 301/302-redirects HTTP→HTTPS, every login attempt could fail in an unrecoverable loop with `INVALID_NONCE`. The attached Linear ticket captured a session with 30+ failed attempts in a row.

Root cause is two URL holders that disagreed and were never reconciled:

- **`LoginSiteCredentialsViewModel.siteAddress`** — captured once from `savedStateHandle` (sourced from `LoginActivity.gotConnectSiteInfo` → `result.urlAfterRedirects`). For the failing user, WP.com's `connect/site-info` endpoint returned `http://…` because of a stale cache entry on its side (most likely). 
- **`SiteStore.SiteModel.url`** — written by FluxC's local WP-API discovery (`SiteWPAPIRestClient.fetchWPAPISite`), which actually probes `/wp-json/`, follows redirects, and resolves the canonical scheme correctly. Every iteration of the failing log shows this returning `https://…` and persisting to Room.


The fix adds a one-shot reconciliation in `fetchSiteForTutorial.onSuccess`: if `SiteModel.url` differs from the current `siteAddress`, adopt it, persist via `SavedStateHandle`, and re-enter `login()`. A `hasReconciledSiteUrl` flag prevents ping-pong if a misbehaving server were to keep flipping. `siteAddress` itself is now a mutable property backed by `SavedStateHandle` so the reconciled value survives process death.

### Test Steps

**Setup — replace `<YOUR_TEST_SITE_URL>` with a hostname you have wp-admin credentials for** (e.g. a `*.jurassic.ninja` sandbox). Run the build on an emulator/device first.

```bash
# 1. Enable apifaker
adb shell am broadcast \
  -a com.woocommerce.android.apifaker.SET_STATUS \
  --ez enabled true \
  com.woocommerce.android.dev

# 2. Register the mock endpoint with an inline http response
adb shell "am broadcast \
  -a com.woocommerce.android.apifaker.ADD_ENDPOINT \
  --es api_type wp-com \
  --es path /rest/v1.1/connect/site-info \
  --es http_method GET \
  --ei response_status_code 200 \
  --es response_body '{\"exists\":true,\"isWordPress\":true,\"hasJetpack\":true,\"isJetpackActive\":false,\"isJetpackConnected\":false,\"isWordPressDotCom\":false,\"isCommerceGarden\":false,\"urlAfterRedirects\":\"http://<YOUR_TEST_SITE_URL>\",\"jetpackVersion\":\"15.7.1\",\"skipRemoteInstall\":false}' \
  com.woocommerce.android.dev"

# 3. Verify (look for 1 endpoint with http://… in the body)
adb shell am broadcast -a com.woocommerce.android.apifaker.LIST_ENDPOINTS com.woocommerce.android.dev
adb logcat -d -s WCApiFaker | tail -30
```


Then in the app:

1. Force-stop the app and re-launch it (so the apifaker DB is read fresh).
2. Tap **Log in**, type any domain, tap **Continue**. (apifaker intercepts `connect/site-info`; the typed value doesn't matter — `urlAfterRedirects` will always be the http URL above.)
3. On the username/password screen, enter valid wp-admin credentials for `<YOUR_TEST_SITE_URL>` and tap **Continue**.
4. Watch logcat:
   ```bash
   adb logcat -s WooCommerce-LOGIN:* WooCommerce-WP:* WordPress-MAIN:*
   ```
5. **Expected**: first attempt logs `Authenticating in to site http://<YOUR_TEST_SITE_URL>` and fails with `INVALID_NONCE`; immediately after, `DB Updating site: https://<YOUR_TEST_SITE_URL>`; then a second `Authenticating in to site https://<YOUR_TEST_SITE_URL>` that succeeds and proceeds to the eligibility/site-picker step. **Without this fix**: the http attempt loops indefinitely — every user retry starts from the http URL.

Negative-control sanity check (no fix needed for this case): use `EDIT_ENDPOINT` (or repeat step 2 with `https://` in the JSON), force-stop, log in again — should succeed first attempt with no retry visible.

**Tear down when done:**

```bash
adb shell am broadcast -a com.woocommerce.android.apifaker.CLEAR_ENDPOINTS com.woocommerce.android.dev
adb shell am broadcast -a com.woocommerce.android.apifaker.SET_STATUS --ez enabled false com.woocommerce.android.dev
```

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.