### PR TITLE
Localize compact currency formatting via CompactDecimalFormat

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.util
 
+import android.icu.text.CompactDecimalFormat
 import com.woocommerce.android.di.AppCoroutineScope
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.locale.LocaleProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
@@ -14,6 +16,7 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import java.text.DecimalFormat
 import java.util.Currency
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.absoluteValue
@@ -24,12 +27,12 @@ class CurrencyFormatter @Inject constructor(
     private val wcStore: WooCommerceStore,
     private val selectedSite: SelectedSite,
     private val siteIndependentCurrencyFormatter: SiteIndependentCurrencyFormatter,
+    private val localeProvider: LocaleProvider,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatchers: CoroutineDispatchers
 ) {
     companion object {
         private const val ONE_THOUSAND = 1000
-        private const val ONE_MILLION = 1000000
 
         private const val BACKOFF_DELAY = 1_000L
         private const val BACKOFF_INTENTS = 3
@@ -38,21 +41,21 @@ class CurrencyFormatter @Inject constructor(
         private val currencyFormatter: DecimalFormat by lazy {
             DecimalFormat("0.00")
         }
+    }
 
-        // Formats the value to one decimal place
-        private val currencyFormatterRounded: DecimalFormat by lazy {
-            DecimalFormat("0.0")
-        }
-
-        private fun currencyStringRounded(rawValue: Double): String {
-            val roundedValue = rawValue.roundToInt().toDouble()
-            return if (roundedValue.absoluteValue >= ONE_MILLION) {
-                currencyFormatterRounded.format(roundedValue / ONE_MILLION) + "m"
-            } else if (roundedValue.absoluteValue >= ONE_THOUSAND) {
-                currencyFormatterRounded.format(roundedValue / ONE_THOUSAND) + "k"
-            } else {
-                currencyFormatter.format(roundedValue).toString().removeSuffix(".00")
-            }
+    private fun currencyStringRounded(rawValue: Double): String {
+        val roundedValue = rawValue.roundToInt().toDouble()
+        return if (roundedValue.absoluteValue >= ONE_THOUSAND) {
+            val locale = localeProvider.provideLocale() ?: Locale.getDefault()
+            CompactDecimalFormat
+                .getInstance(locale, CompactDecimalFormat.CompactStyle.SHORT)
+                .apply {
+                    minimumFractionDigits = 1
+                    maximumFractionDigits = 1
+                }
+                .format(roundedValue)
+        } else {
+            currencyFormatter.format(roundedValue).toString().removeSuffix(".00")
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt
@@ -78,6 +78,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
                 wcStore = wcStore,
                 selectedSite = selectedSite,
                 siteIndependentCurrencyFormatter = siteIndependentCurrencyFormatter,
+                localeProvider = localeProvider,
                 appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher),
                 dispatchers = coroutinesTestRule.testDispatchers
             )
@@ -150,6 +151,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
                 wcStore = wcStore,
                 selectedSite = selectedSite,
                 siteIndependentCurrencyFormatter = siteIndependentCurrencyFormatter,
+                localeProvider = localeProvider,
                 appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher),
                 dispatchers = coroutinesTestRule.testDispatchers
             )
@@ -193,6 +195,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
             wcStore = wcStore,
             selectedSite = selectedSite,
             siteIndependentCurrencyFormatter = siteIndependentCurrencyFormatter,
+            localeProvider = localeProvider,
             appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher),
             dispatchers = coroutinesTestRule.testDispatchers
         )
@@ -223,6 +226,7 @@ class DefaultCurrencyFormatterTest : BaseUnitTest() {
             wcStore = wcStore,
             selectedSite = selectedSite,
             siteIndependentCurrencyFormatter = siteIndependentCurrencyFormatter,
+            localeProvider = localeProvider,
             appCoroutineScope = TestScope(coroutinesTestRule.testDispatcher),
             dispatchers = coroutinesTestRule.testDispatchers
         )


### PR DESCRIPTION
## What changed

`WooCommerce/src/main/kotlin/com/woocommerce/android/util/CurrencyFormatter.kt`:

- Replaced the manual `+ "m"` / `+ "k"` suffixing in `currencyStringRounded` with `android.icu.text.CompactDecimalFormat.getInstance(locale, SHORT)`. The compact format is locale-aware: English -> "1.5K" / "1.5M", Turkish -> "1,5 B" / "1,5 Mn", Japanese -> "1.5万", etc.
- Added a `LocaleProvider` constructor parameter (the same interface `SiteIndependentCurrencyFormatter` already injects) so the rounded formatter can pick up the device locale.
- Moved `currencyStringRounded` out of the `companion object` (it now needs `localeProvider`) and removed the `ONE_MILLION` constant + `currencyFormatterRounded` `DecimalFormat` since `CompactDecimalFormat` covers both branches.

`WooCommerce/src/test/kotlin/com/woocommerce/android/util/DefaultCurrencyFormatterTest.kt`:

- Added `localeProvider = localeProvider` to the four `CurrencyFormatter(...)` constructions in this file (the field is already declared and mocked in the test class). No assertions changed.

Closes #12541

## Why

The reporter switched the app to Turkish on a store with TRY revenue and saw "1.0k" / "1.0m" -- the issue title is literally "Localize currency formatter", and the body asks for "1b" in Turkish (Turkish abbreviates `bin` as "B"). The hardcoded suffixes mean every locale gets the English short form regardless of the device's locale setting.

`CompactDecimalFormat` (API 24+, minSdk for this app is 26 -- see `settings.gradle`) is exactly the locale-aware compact-number formatter ICU ships for this purpose. It produces the correct short form for every locale CLDR ships data for, including the Turkish "B" / "Mn" pair the issue calls out, the Japanese "万", the Hindi "लाख", etc. Using it also collapses the manual million/thousand split into one call.

The existing call site (`formatCurrencyRounded`) is unchanged: it still passes the formatted string to `wcStore.formatCurrencyForDisplay(...)` which prepends/appends the currency symbol, so the surrounding behavior is preserved.

## Verification

- Java/Android SDK isn't available on this machine, so I couldn't run `./gradlew testWasabiDebugUnitTest` locally to exercise the change. CI will run the full test suite on this PR; if anything regresses I'll fix it on this branch.
- Read-only checks I did manually: imports resolve to the existing `LocaleProvider` interface (`WooCommerce/src/main/kotlin/com/woocommerce/android/util/locale/LocaleProvider.kt`), `android.icu.text.CompactDecimalFormat` is available from API 24 and the project's `minSdkVersion = 26` (per `settings.gradle`), and the four `CurrencyFormatter(...)` test constructions in `DefaultCurrencyFormatterTest` now all pass the new `localeProvider` argument.
- `formatCurrencyRounded` is the only caller of `currencyStringRounded` (verified via `grep -rn "currencyStringRounded"`); no behavior change for values < 1000.

Happy to follow up with a dedicated `currencyStringRounded` unit test if you'd like locale-by-locale coverage -- I left it out of this PR to keep the diff minimal and because the existing test surface lives one level higher (around `formatAmountWithCurrency`).
