### PR TITLE
Pin nokogiri >= 1.19.3 (GHSA-c4rq-3m3g-8wgx)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'danger-dangermattic', '~> 1.2'
 gem 'fastlane', '~> 2.216'
 gem 'fastlane-plugin-firebase_app_distribution', '~> 0.10'
-gem 'nokogiri'
+gem 'nokogiri', '>= 1.19.3' # GHSA-c4rq-3m3g-8wgx — drop floor once toolkit is on >= 14.4.1
 gem 'rubocop', '~> 1.65'
 
 # Security: https://github.com/lostisland/faraday/pull/1665

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
     nanaimo (0.4.0)
     nap (1.1.0)
     naturally (2.3.0)
-    nokogiri (1.19.1)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (6.1.1)
@@ -369,7 +369,7 @@ DEPENDENCIES
   fastlane (~> 2.216)
   fastlane-plugin-firebase_app_distribution (~> 0.10)
   fastlane-plugin-wpmreleasetoolkit (~> 13.8)
-  nokogiri
+  nokogiri (>= 1.19.3)
   openssl (~> 4.0)
   rmagick (~> 4.1)
   rubocop (~> 1.65)


### PR DESCRIPTION
## Summary

Tightens the existing `gem 'nokogiri'` line in `Gemfile` to `gem 'nokogiri', '>= 1.19.3'` to pull in the fix for [GHSA-c4rq-3m3g-8wgx](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-c4rq-3m3g-8wgx) — a high-severity ReDoS in Nokogiri's CSS selector tokenizer (vulnerable `< 1.19.3`).

This repo is on `fastlane-plugin-wpmreleasetoolkit ~> 13.8`, which predates the toolkit's own `nokogiri >= 1.19.3` floor (added in 14.4.1). The explicit pin closes the gap without requiring a release-toolkit major bump.

When this repo eventually moves to `fastlane-plugin-wpmreleasetoolkit ~> 14.x`, the `gem 'nokogiri'` line should be **dropped entirely** — the toolkit's floor will carry it transitively.

Generated as part of the [nokogiri 1.19.3 Orchard campaign](https://github.a8c.com/mokagio/swiftlint-adoption-orchard-campaign/tree/main/nokogiri-1.19.3-campaign) covering all release-toolkit consumers.

## Testing

`bundle install`. `Gemfile.lock` resolves `nokogiri` to `1.19.3`.

---

*Posted by Claude Code (Opus 4.7) on behalf of @mokagio with approval.*