### PR TITLE
[WOOMOB-3050] Float assistant composer with gradient bottom fade

### DIFF
--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -173,7 +174,7 @@ fun AssistantChatScreen(
 ) {
     val focusManager = LocalFocusManager.current
     val density = LocalDensity.current
-    var bottomBarContentHeightPx by remember { mutableStateOf(0) }
+    var bottomBarContentHeightPx by remember { mutableIntStateOf(0) }
     val bottomBarContentHeight = with(density) { bottomBarContentHeightPx.toDp() }
     val bottomContentPadding = bottomBarContentHeight + FLOATING_COMPOSER_CONTENT_SPACING
     val submitMessage = {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -6,14 +6,18 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -44,8 +48,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -54,6 +63,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.aiassistant.R
@@ -161,6 +171,20 @@ fun AssistantChatScreen(
     assistantCardRenderer: AssistantCardRenderer? = null,
     onCardAction: (AssistantCardAction) -> Unit = {},
 ) {
+    val focusManager = LocalFocusManager.current
+    val density = LocalDensity.current
+    var bottomBarContentHeightPx by remember { mutableStateOf(0) }
+    val bottomBarContentHeight = with(density) { bottomBarContentHeightPx.toDp() }
+    val bottomContentPadding = bottomBarContentHeight + FLOATING_COMPOSER_CONTENT_SPACING
+    val submitMessage = {
+        focusManager.clearFocus()
+        onSendMessage()
+    }
+    val submitSuggestion = { prompt: String ->
+        focusManager.clearFocus()
+        onSendSuggestion(prompt)
+    }
+
     Scaffold(
         modifier = modifier.fillMaxSize(),
         containerColor = assistantCanvasColor(),
@@ -170,17 +194,33 @@ fun AssistantChatScreen(
                 onRestartConversation = onRestartConversation,
                 onBack = onBack,
             )
-        }
+        },
+        bottomBar = {
+            AssistantFloatingComposerBar(
+                state = state,
+                inputText = inputText,
+                onInputTextChange = onInputTextChange,
+                onSendMessage = submitMessage,
+                onCancelTurn = onCancelTurn,
+                onContentHeightChanged = { bottomBarContentHeightPx = it },
+            )
+        },
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-        ) {
+        val layoutDirection = LocalLayoutDirection.current
+        val contentPadding = PaddingValues(
+            start = innerPadding.calculateStartPadding(layoutDirection),
+            top = innerPadding.calculateTopPadding(),
+            end = innerPadding.calculateEndPadding(layoutDirection),
+        )
+
+        Box(modifier = Modifier.fillMaxSize()) {
             if (state.shouldShowEmptyState) {
                 AssistantEmptyState(
-                    onSuggestionClick = onSendSuggestion,
-                    modifier = Modifier.weight(1f),
+                    onSuggestionClick = submitSuggestion,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(contentPadding)
+                        .padding(bottom = bottomContentPadding),
                 )
             } else {
                 AssistantMessageThread(
@@ -190,20 +230,77 @@ fun AssistantChatScreen(
                     onCancelWrite = onCancelWrite,
                     assistantCardRenderer = assistantCardRenderer,
                     onCardAction = onCardAction,
-                    modifier = Modifier.weight(1f),
+                    bottomContentPadding = bottomContentPadding,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(contentPadding),
                 )
             }
-            AssistantStatusPanel(state = state)
-            AssistantComposer(
-                inputText = inputText,
-                onInputTextChange = onInputTextChange,
-                isTurnActive = state.isTurnActive,
-                shouldShowStopControl = state.shouldShowStopControl,
-                onSendMessage = onSendMessage,
-                onCancelTurn = onCancelTurn,
+            AssistantContentBottomFade(
+                bottomBarHeight = bottomBarContentHeight,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth(),
             )
         }
     }
+}
+
+@Composable
+private fun AssistantFloatingComposerBar(
+    state: AssistantUiState,
+    inputText: String,
+    onInputTextChange: (String) -> Unit,
+    onSendMessage: () -> Unit,
+    onCancelTurn: () -> Unit,
+    onContentHeightChanged: (Int) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .onSizeChanged { onContentHeightChanged(it.height) }
+            .padding(bottom = FLOATING_COMPOSER_BOTTOM_PADDING),
+    ) {
+        AssistantStatusPanel(
+            state = state,
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 8.dp),
+        )
+        AssistantComposer(
+            inputText = inputText,
+            onInputTextChange = onInputTextChange,
+            isTurnActive = state.isTurnActive,
+            shouldShowStopControl = state.shouldShowStopControl,
+            onSendMessage = onSendMessage,
+            onCancelTurn = onCancelTurn,
+        )
+    }
+}
+
+@Composable
+private fun AssistantContentBottomFade(
+    bottomBarHeight: Dp,
+    modifier: Modifier = Modifier,
+) {
+    val canvasColor = assistantCanvasColor()
+    Box(
+        modifier = modifier
+            .height(bottomBarHeight + FLOATING_COMPOSER_FADE_EXTRA_HEIGHT)
+            .drawBehind {
+                drawRect(
+                    brush = Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0f to Color.Transparent,
+                            FLOATING_COMPOSER_FADE_MIDPOINT_FRACTION to canvasColor.copy(
+                                alpha = FLOATING_COMPOSER_FADE_MIDPOINT_ALPHA
+                            ),
+                            1f to canvasColor,
+                        ),
+                    )
+                )
+            },
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -278,6 +375,7 @@ private fun AssistantMessageThread(
     onCancelWrite: () -> Unit,
     assistantCardRenderer: AssistantCardRenderer?,
     onCardAction: (AssistantCardAction) -> Unit,
+    bottomContentPadding: Dp,
     modifier: Modifier = Modifier,
 ) {
     val visibleMessages = state.messages.filter { message ->
@@ -330,7 +428,12 @@ private fun AssistantMessageThread(
         state = listState,
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(24.dp, Alignment.Top),
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 18.dp),
+        contentPadding = PaddingValues(
+            start = 16.dp,
+            end = 16.dp,
+            top = 18.dp,
+            bottom = bottomContentPadding,
+        ),
     ) {
         items(
             items = visibleMessages,
@@ -362,6 +465,11 @@ private fun AssistantMessageThread(
 private const val TYPING_INDICATOR_ITEM_KEY = "assistant-typing-indicator"
 private const val REVEAL_ANIMATION_DURATION_MS = 180
 private const val REVEAL_SLIDE_OFFSET_DIVISOR = 3
+private const val FLOATING_COMPOSER_FADE_MIDPOINT_ALPHA = 0.55f
+private const val FLOATING_COMPOSER_FADE_MIDPOINT_FRACTION = 0.35f
+private val FLOATING_COMPOSER_FADE_EXTRA_HEIGHT = 48.dp
+private val FLOATING_COMPOSER_BOTTOM_PADDING = 16.dp
+private val FLOATING_COMPOSER_CONTENT_SPACING = 16.dp
 private val BOTTOM_PIN_THRESHOLD_DP = 48.dp
 private val USER_BUBBLE_MAX_WIDTH = 280.dp
 
@@ -611,12 +719,18 @@ private fun AssistantInlineError(
 }
 
 @Composable
-private fun AssistantStatusPanel(state: AssistantUiState) {
+private fun AssistantStatusPanel(
+    state: AssistantUiState,
+    modifier: Modifier = Modifier,
+) {
     when (state.status) {
         AssistantUiStatus.AWAITING_CONFIRMATION -> Unit
         AssistantUiStatus.ERROR -> {
             if (state.shouldShowFallbackError) {
-                AssistantFallbackErrorPanel(error = state.error)
+                AssistantFallbackErrorPanel(
+                    error = state.error,
+                    modifier = modifier,
+                )
             }
         }
         AssistantUiStatus.IDLE,
@@ -625,20 +739,32 @@ private fun AssistantStatusPanel(state: AssistantUiState) {
 }
 
 @Composable
-private fun AssistantFallbackErrorPanel(error: AssistantUiError?) {
+private fun AssistantFallbackErrorPanel(
+    error: AssistantUiError?,
+    modifier: Modifier = Modifier,
+) {
     if (error == null) return
 
-    Row(
-        modifier = Modifier
+    Surface(
+        modifier = modifier
             .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.errorContainer)
-            .padding(16.dp),
+            .padding(top = 4.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.errorContainer,
+        tonalElevation = 2.dp,
+        shadowElevation = if (isSystemInDarkTheme()) 0.dp else 2.dp,
     ) {
-        Text(
-            text = stringResource(error.toMessageRes()),
-            color = MaterialTheme.colorScheme.onErrorContainer,
-            style = MaterialTheme.typography.bodyMedium,
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Text(
+                text = stringResource(error.toMessageRes()),
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
     }
 }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantComposer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantComposer.kt
@@ -75,7 +75,7 @@ internal fun AssistantComposer(
                     .fillMaxWidth()
                     .heightIn(min = COMPOSER_MIN_HEIGHT),
                 shape = RoundedCornerShape(COMPOSER_CORNER_RADIUS),
-                color = MaterialTheme.colorScheme.surface,
+                color = MaterialTheme.colorScheme.surfaceContainer,
                 border = BorderStroke(1.dp, assistantOutlineColor()),
                 tonalElevation = 2.dp,
                 shadowElevation = if (isSystemInDarkTheme()) 0.dp else 2.dp,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantComposer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantComposer.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.aiassistant.ui.components
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -31,7 +33,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.aiassistant.R
-import com.woocommerce.android.aiassistant.ui.assistantCanvasColor
 import com.woocommerce.android.aiassistant.ui.assistantOutlineColor
 
 @Composable
@@ -48,7 +49,7 @@ internal fun AssistantComposer(
     val showPendingHint = isTurnActive && !shouldShowStopControl
     Surface(
         modifier = modifier,
-        color = assistantCanvasColor(),
+        color = Color.Transparent,
     ) {
         Column(
             modifier = Modifier
@@ -76,6 +77,8 @@ internal fun AssistantComposer(
                 shape = RoundedCornerShape(COMPOSER_CORNER_RADIUS),
                 color = MaterialTheme.colorScheme.surface,
                 border = BorderStroke(1.dp, assistantOutlineColor()),
+                tonalElevation = 2.dp,
+                shadowElevation = if (isSystemInDarkTheme()) 0.dp else 2.dp,
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
### Description
Fixes WOOMOB-3050

Floats the assistant chat composer above the chat content and adds a ChatGPT-style bottom fade so scrolled content recedes behind the input area instead of being abruptly blocked.

This moves the composer and fallback status panel into the `Scaffold` bottom bar, keeps that container transparent, measures the bottom bar content, and draws a bottom-aligned gradient from the main screen content. The chat thread and empty state use the measured composer height plus spacing for bottom padding, so the last visible message/card can still scroll fully above the composer. Sending a message or suggestion now also clears focus to hide the keyboard.

The composer pill keeps its existing internal controls, with elevation applied to the pill itself rather than the bottom bar container.

### Test Steps
1. Open the assistant chat screen and verify the composer appears as a floating pill over the chat surface.
2. Scroll a long assistant response with cards to the bottom and verify content fades behind the composer, including around the pill corners.
3. Verify the last visible card/message can scroll fully above the composer without clipping.
4. Open the empty assistant state and verify suggestions are not obscured by the floating composer.
5. Trigger the fallback error state and verify the error panel floats with the composer above the input.
6. Send a message from the focused composer and verify the keyboard is dismissed.
7. Repeat the visual checks in dark mode.

### Images/gif

https://github.com/user-attachments/assets/55ab9e22-640b-4b9b-8320-3607699adaf8

<img width="360" alt="Screenshot_20260511_180029" src="https://github.com/user-attachments/assets/888d2363-8061-4f17-9882-30972668816a" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.