### PR TITLE
[WOOMOB-3026] Step 16: QR login — support legacy app-login QR codes

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -301,6 +301,8 @@ class AnalyticsTracker private constructor(
         const val VALUE_WP_COM = "wp_com"
         const val VALUE_NO_WP_COM = "no_wp_com"
         const val VALUE_PREVIOUS_PERIOD = "previous_period"
+        const val VALUE_APP_LOGIN_SOURCE_DEEPLINK = "deeplink"
+        const val VALUE_APP_LOGIN_SOURCE_QR = "qr"
 
         const val KEY_FLOW = "flow"
         const val KEY_HAS_DIFFERENT_SHIPPING_DETAILS = "has_different_shipping_details"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FLOW
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_URL
+import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_APP_LOGIN_SOURCE_DEEPLINK
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_JETPACK_INSTALLATION_SOURCE_WEB
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_NO_WP_COM
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_WP_COM
@@ -320,14 +321,14 @@ class LoginActivity :
         loginViaSiteAddress(prefilledSiteUrl = siteUrl)
     }
 
-    override fun onQrLoginSiteCredentials(siteUrl: String, username: String) {
+    override fun onQrLoginAppLoginCredentials(siteUrl: String, username: String) {
         disableDynamicEdgeToEdge()
-        showUsernamePasswordScreen(
-            siteAddress = siteUrl,
-            inputUsername = username,
-            endpointAddress = null,
-            inputPassword = null
-        )
+        showAppLoginSiteCredentials(siteUrl = siteUrl, username = username)
+    }
+
+    override fun onQrLoginAppLoginWpComEmail(siteUrl: String, wpComEmail: String) {
+        disableDynamicEdgeToEdge()
+        showAppLoginWpComEmail(siteUrl = siteUrl, wpComEmail = wpComEmail)
     }
 
     private fun hasJetpackConnectedIntent(): Boolean {
@@ -1097,25 +1098,19 @@ class LoginActivity :
         val username = uri.getQueryParameter(USERNAME_PARAMETER) ?: ""
         when {
             siteUrl.isNotEmpty() && wpComEmail.isNotEmpty() -> {
-                gotWpcomSiteInfo(siteUrl)
-                AnalyticsTracker.track(
-                    stat = AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
-                    properties = mapOf(KEY_FLOW to VALUE_WP_COM)
+                trackAppLoginSuccess(
+                    flow = VALUE_WP_COM,
+                    source = VALUE_APP_LOGIN_SOURCE_DEEPLINK,
                 )
-                showEmailPasswordScreen(email = wpComEmail, verifyEmail = false)
+                showAppLoginWpComEmail(siteUrl = siteUrl, wpComEmail = wpComEmail)
             }
 
             siteUrl.isNotEmpty() && username.isNotEmpty() -> {
-                AnalyticsTracker.track(
-                    stat = AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
-                    properties = mapOf(KEY_FLOW to VALUE_NO_WP_COM)
+                trackAppLoginSuccess(
+                    flow = VALUE_NO_WP_COM,
+                    source = VALUE_APP_LOGIN_SOURCE_DEEPLINK,
                 )
-                showUsernamePasswordScreen(
-                    siteAddress = siteUrl,
-                    inputUsername = username,
-                    endpointAddress = null,
-                    inputPassword = null
-                )
+                showAppLoginSiteCredentials(siteUrl = siteUrl, username = username)
             }
 
             else -> {
@@ -1127,6 +1122,40 @@ class LoginActivity :
                 showPrologue()
             }
         }
+    }
+
+    private fun trackAppLoginSuccess(flow: String, source: String) {
+        AnalyticsTracker.track(
+            stat = AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
+            properties = mapOf(
+                KEY_FLOW to flow,
+                KEY_SOURCE to source,
+            )
+        )
+    }
+
+    /**
+     * Shared UI entry point for the self-hosted `app-login` flow — used by both the OS-deeplink
+     * handler ([handleAppLoginUri]) and the in-app QR scanner ([onQrLoginAppLoginCredentials]).
+     * Each caller owns its own analytics event with the correct `source` value, so we keep
+     * tracking out of this helper.
+     */
+    private fun showAppLoginSiteCredentials(siteUrl: String, username: String) {
+        showUsernamePasswordScreen(
+            siteAddress = siteUrl,
+            inputUsername = username,
+            endpointAddress = null,
+            inputPassword = null
+        )
+    }
+
+    /**
+     * Shared UI entry point for the WP.com `app-login` flow — symmetric to
+     * [showAppLoginSiteCredentials]. Each caller owns its own analytics event.
+     */
+    private fun showAppLoginWpComEmail(siteUrl: String, wpComEmail: String) {
+        gotWpcomSiteInfo(siteUrl)
+        showEmailPasswordScreen(email = wpComEmail, verifyEmail = false)
     }
 
     private fun keepTrackOfAgeEligibility() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -320,6 +320,16 @@ class LoginActivity :
         loginViaSiteAddress(prefilledSiteUrl = siteUrl)
     }
 
+    override fun onQrLoginSiteCredentials(siteUrl: String, username: String) {
+        disableDynamicEdgeToEdge()
+        showUsernamePasswordScreen(
+            siteAddress = siteUrl,
+            inputUsername = username,
+            endpointAddress = null,
+            inputPassword = null
+        )
+    }
+
     private fun hasJetpackConnectedIntent(): Boolean {
         val action = intent.action
         val uri = intent.data

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
@@ -9,10 +9,13 @@ package com.woocommerce.android.ui.login.qrlogin
  * woocommerce://qr-login?token=<64-byte hex>&siteUrl=<URL-encoded site URL>
  * ```
  *
- * The scanner also accepts the legacy wc-admin credentials QR:
+ * The scanner also accepts the legacy wc-admin app-login QR in two shapes — self-hosted
+ * credentials and WP.com email — mirroring what the OS-deeplink handler in
+ * `LoginActivity.handleAppLoginUri` already accepts:
  *
  * ```
  * woocommerce://app-login?siteUrl=<URL-encoded site URL>&username=<URL-encoded username>
+ * woocommerce://app-login?siteUrl=<URL-encoded site URL>&wpcomEmail=<URL-encoded email>
  * ```
  *
  * The [Ticket.token] is a single-use 5-minute bearer ticket — not a credential. The app exchanges
@@ -49,10 +52,29 @@ sealed interface QrLoginPayload {
      */
     data class SiteUrl(val siteUrl: String) : QrLoginPayload
 
-    data class AppLogin(
-        val siteUrl: String,
-        val username: String
-    ) : QrLoginPayload
+    /**
+     * Legacy wc-admin `app-login` QR. Two shapes are accepted, mirroring the OS-deeplink path:
+     *  - [Credentials] for self-hosted sites: site URL + `username`, hands off to the existing
+     *    site-credentials screen with both fields prefilled (password still required).
+     *  - [WpComEmail] for WP.com-connected sites: site URL + `wpcomEmail`, hands off to the
+     *    email/password screen via `gotWpcomSiteInfo`, matching the existing deeplink flow.
+     *
+     * Unlike [Ticket]/[SiteUrl], the site URL here may be http or https — these payloads do not
+     * hit the QR-exchange endpoint, so we leave the scheme decision to the downstream login flow.
+     */
+    sealed interface AppLogin : QrLoginPayload {
+        val siteUrl: String
+
+        data class Credentials(
+            override val siteUrl: String,
+            val username: String
+        ) : AppLogin
+
+        data class WpComEmail(
+            override val siteUrl: String,
+            val wpComEmail: String
+        ) : AppLogin
+    }
 
     data object Invalid : QrLoginPayload
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayload.kt
@@ -9,6 +9,12 @@ package com.woocommerce.android.ui.login.qrlogin
  * woocommerce://qr-login?token=<64-byte hex>&siteUrl=<URL-encoded site URL>
  * ```
  *
+ * The scanner also accepts the legacy wc-admin credentials QR:
+ *
+ * ```
+ * woocommerce://app-login?siteUrl=<URL-encoded site URL>&username=<URL-encoded username>
+ * ```
+ *
  * The [Ticket.token] is a single-use 5-minute bearer ticket — not a credential. The app exchanges
  * it for an Application Password by POSTing to
  * `{siteUrl}/wp-json/wc-admin/mobile-app/qr-login-exchange`.
@@ -42,6 +48,11 @@ sealed interface QrLoginPayload {
      * with no manual typing.
      */
     data class SiteUrl(val siteUrl: String) : QrLoginPayload
+
+    data class AppLogin(
+        val siteUrl: String,
+        val username: String
+    ) : QrLoginPayload
 
     data object Invalid : QrLoginPayload
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
@@ -13,9 +13,10 @@ import javax.inject.Inject
  * woocommerce://qr-login?token=<64-byte hex>&siteUrl=<URL-encoded site URL>
  * ```
  *
- * Also accepts the legacy wc-admin credentials QR
- * (`woocommerce://app-login?siteUrl=…&username=…`) and routes it to the existing site
- * credentials flow instead of treating it as an invalid QR.
+ * Also accepts the legacy wc-admin `app-login` QR in two shapes
+ * (`woocommerce://app-login?siteUrl=…&username=…` and
+ * `woocommerce://app-login?siteUrl=…&wpcomEmail=…`) and routes them to the existing login
+ * screens — mirroring the OS-deeplink handler in `LoginActivity.handleAppLoginUri`.
  *
  * The same deeplink shape is also used as a "site-URL only" QR — when `token` is missing or
  * blank, the payload becomes [QrLoginPayload.SiteUrl] and the scanner routes the merchant to
@@ -23,7 +24,7 @@ import javax.inject.Inject
  *
  * Anything malformed, missing parameters, or with the wrong scheme/host returns
  * [QrLoginPayload.Invalid]. New QR-login payloads require an https `siteUrl`; legacy app-login
- * payloads accept http or https because they hand off to the existing credentials flow instead of
+ * payloads accept http or https because they hand off to the existing login flows instead of
  * exchanging a bearer ticket. The parser does not validate the token format
  * beyond non-blank — that's the server's job during exchange. `siteUrl` is parsed via OkHttp's
  * [okhttp3.HttpUrl] and rejected if it carries userinfo, query, or fragment components — those
@@ -67,7 +68,7 @@ class QrLoginPayloadParser @Inject constructor() {
      */
     private fun parseQrLoginDeeplink(raw: String?): QrLoginPayload? {
         val uri = parseDeepLink(raw, QR_LOGIN_HOST) ?: return null
-        val siteUrl = uri.queryParam(PARAM_SITE_URL)?.let(::normalizeSiteUrl) ?: return null
+        val siteUrl = uri.queryParam(PARAM_SITE_URL)?.let { normalizeSiteUrl(it) } ?: return null
         val token = uri.queryParam(PARAM_TOKEN)?.takeIf { it.isNotBlank() }
         return if (token != null) {
             QrLoginPayload.Ticket(token = token, siteUrl = siteUrl)
@@ -76,11 +77,19 @@ class QrLoginPayloadParser @Inject constructor() {
         }
     }
 
+    /**
+     * Mirrors the precedence in [com.woocommerce.android.ui.login.LoginActivity.handleAppLoginUri]:
+     * `wpcomEmail` wins over `username` when both are present, so a QR that encodes both routes
+     * through the WP.com flow just like the OS deeplink would.
+     */
     private fun parseAppLoginDeeplink(raw: String?): QrLoginPayload.AppLogin? {
         val uri = parseDeepLink(raw, APP_LOGIN_HOST) ?: return null
-        val siteUrl = uri.queryParam(PARAM_SITE_URL)?.let(::normalizeLoginSiteUrl) ?: return null
+        val siteUrl = uri.queryParam(PARAM_SITE_URL)?.let { normalizeSiteUrl(it, allowHttp = true) } ?: return null
+        uri.queryParam(PARAM_WP_COM_EMAIL)?.takeIf { it.isNotBlank() }?.let { email ->
+            return QrLoginPayload.AppLogin.WpComEmail(siteUrl = siteUrl, wpComEmail = email)
+        }
         val username = uri.queryParam(PARAM_USERNAME)?.takeIf { it.isNotBlank() } ?: return null
-        return QrLoginPayload.AppLogin(siteUrl = siteUrl, username = username)
+        return QrLoginPayload.AppLogin.Credentials(siteUrl = siteUrl, username = username)
     }
 
     /**
@@ -124,23 +133,23 @@ class QrLoginPayloadParser @Inject constructor() {
         }
     }
 
-    private fun normalizeSiteUrl(raw: String): String? {
-        if (raw.isBlank() || !raw.lowercase().startsWith(HTTPS_PREFIX)) return null
-        val parsed = raw.toHttpUrlOrNull()?.takeIf { it.scheme == "https" } ?: return null
+    /**
+     * Single normalizer for every site-URL we accept. The userinfo/query/fragment rejection is
+     * security-load-bearing (those are classic spoofing surfaces in the confirmation prompt), so
+     * we keep it in one place. [allowHttp] is opt-in for legacy app-login QRs, which hand off to
+     * the existing login flows and don't hit the QR-exchange endpoint; everything else stays
+     * https-only.
+     */
+    private fun normalizeSiteUrl(raw: String, allowHttp: Boolean = false): String? {
+        if (raw.isBlank()) return null
+        val parsed = raw.toHttpUrlOrNull()
+            ?.takeIf { it.scheme == "https" || (allowHttp && it.scheme == "http") }
+            ?: return null
         val hasUserInfo = parsed.username.isNotEmpty() || parsed.password.isNotEmpty()
         val hasQueryOrFragment = parsed.querySize > 0 || parsed.fragment != null
         if (hasUserInfo || hasQueryOrFragment) return null
         // Rebuild from the parsed URL so any normalization OkHttp applies (e.g. lowercased host)
         // is reflected in the value we hand to the exchange client and the confirmation dialog.
-        return parsed.newBuilder().build().toString().trimEnd('/')
-    }
-
-    private fun normalizeLoginSiteUrl(raw: String): String? {
-        if (raw.isBlank()) return null
-        val parsed = raw.toHttpUrlOrNull()?.takeIf { it.scheme == "https" || it.scheme == "http" } ?: return null
-        val hasUserInfo = parsed.username.isNotEmpty() || parsed.password.isNotEmpty()
-        val hasQueryOrFragment = parsed.querySize > 0 || parsed.fragment != null
-        if (hasUserInfo || hasQueryOrFragment) return null
         return parsed.newBuilder().build().toString().trimEnd('/')
     }
 
@@ -151,9 +160,9 @@ class QrLoginPayloadParser @Inject constructor() {
         const val PARAM_TOKEN = "token"
         const val PARAM_SITE_URL = "siteUrl"
         const val PARAM_USERNAME = "username"
+        const val PARAM_WP_COM_EMAIL = "wpcomEmail"
         const val PARAM_ACTION = "action"
         const val PARAM_SCHEME = "scheme"
-        const val HTTPS_PREFIX = "https://"
         const val INSTALL_QR_HOST = "woocommerce.com"
         const val INSTALL_QR_PATH_FIRST_SEGMENT = "mobile"
         const val WP_COM_HOST = "wordpress.com"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
@@ -13,12 +13,18 @@ import javax.inject.Inject
  * woocommerce://qr-login?token=<64-byte hex>&siteUrl=<URL-encoded site URL>
  * ```
  *
+ * Also accepts the legacy wc-admin credentials QR
+ * (`woocommerce://app-login?siteUrl=…&username=…`) and routes it to the existing site
+ * credentials flow instead of treating it as an invalid QR.
+ *
  * The same deeplink shape is also used as a "site-URL only" QR — when `token` is missing or
  * blank, the payload becomes [QrLoginPayload.SiteUrl] and the scanner routes the merchant to
  * the site-address login screen with the URL prefilled instead of attempting an exchange.
  *
- * Anything malformed, missing parameters, with the wrong scheme/host, or with a non-https
- * `siteUrl` returns [QrLoginPayload.Invalid]. The parser does not validate the token format
+ * Anything malformed, missing parameters, or with the wrong scheme/host returns
+ * [QrLoginPayload.Invalid]. New QR-login payloads require an https `siteUrl`; legacy app-login
+ * payloads accept http or https because they hand off to the existing credentials flow instead of
+ * exchanging a bearer ticket. The parser does not validate the token format
  * beyond non-blank — that's the server's job during exchange. `siteUrl` is parsed via OkHttp's
  * [okhttp3.HttpUrl] and rejected if it carries userinfo, query, or fragment components — those
  * have no role in a Woo site root and are classic spoofing surfaces in the confirmation prompt.
@@ -32,6 +38,7 @@ class QrLoginPayloadParser @Inject constructor() {
     fun parse(raw: String?): QrLoginPayload {
         parseWpComMagicLinkUrl(raw)?.let { return it }
         if (looksLikeInstallQr(raw)) return QrLoginPayload.InstallQrCode
+        parseAppLoginDeeplink(raw)?.let { return it }
         return parseQrLoginDeeplink(raw) ?: QrLoginPayload.Invalid
     }
 
@@ -59,7 +66,7 @@ class QrLoginPayloadParser @Inject constructor() {
      * `siteUrl` validation is identical in both branches.
      */
     private fun parseQrLoginDeeplink(raw: String?): QrLoginPayload? {
-        val uri = parseDeepLink(raw) ?: return null
+        val uri = parseDeepLink(raw, QR_LOGIN_HOST) ?: return null
         val siteUrl = uri.queryParam(PARAM_SITE_URL)?.let(::normalizeSiteUrl) ?: return null
         val token = uri.queryParam(PARAM_TOKEN)?.takeIf { it.isNotBlank() }
         return if (token != null) {
@@ -67,6 +74,13 @@ class QrLoginPayloadParser @Inject constructor() {
         } else {
             QrLoginPayload.SiteUrl(siteUrl = siteUrl)
         }
+    }
+
+    private fun parseAppLoginDeeplink(raw: String?): QrLoginPayload.AppLogin? {
+        val uri = parseDeepLink(raw, APP_LOGIN_HOST) ?: return null
+        val siteUrl = uri.queryParam(PARAM_SITE_URL)?.let(::normalizeLoginSiteUrl) ?: return null
+        val username = uri.queryParam(PARAM_USERNAME)?.takeIf { it.isNotBlank() } ?: return null
+        return QrLoginPayload.AppLogin(siteUrl = siteUrl, username = username)
     }
 
     /**
@@ -84,7 +98,7 @@ class QrLoginPayloadParser @Inject constructor() {
         return pathSegments.firstOrNull()?.equals(INSTALL_QR_PATH_FIRST_SEGMENT, ignoreCase = true) == true
     }
 
-    private fun parseDeepLink(raw: String?): URI? {
+    private fun parseDeepLink(raw: String?, expectedHost: String): URI? {
         val trimmed = raw?.trim().orEmpty().takeIf { it.isNotEmpty() } ?: return null
         val uri = try {
             URI(trimmed)
@@ -92,7 +106,7 @@ class QrLoginPayloadParser @Inject constructor() {
             return null
         }
         val schemeMatches = uri.scheme.equals(SCHEME, ignoreCase = true)
-        val hostMatches = uri.host?.equals(HOST, ignoreCase = true) == true
+        val hostMatches = uri.host?.equals(expectedHost, ignoreCase = true) == true
         val pathAllowed = uri.rawPath.isNullOrEmpty() || uri.rawPath == "/"
         return uri.takeIf { schemeMatches && hostMatches && pathAllowed }
     }
@@ -121,11 +135,22 @@ class QrLoginPayloadParser @Inject constructor() {
         return parsed.newBuilder().build().toString().trimEnd('/')
     }
 
+    private fun normalizeLoginSiteUrl(raw: String): String? {
+        if (raw.isBlank()) return null
+        val parsed = raw.toHttpUrlOrNull()?.takeIf { it.scheme == "https" || it.scheme == "http" } ?: return null
+        val hasUserInfo = parsed.username.isNotEmpty() || parsed.password.isNotEmpty()
+        val hasQueryOrFragment = parsed.querySize > 0 || parsed.fragment != null
+        if (hasUserInfo || hasQueryOrFragment) return null
+        return parsed.newBuilder().build().toString().trimEnd('/')
+    }
+
     private companion object {
         const val SCHEME = "woocommerce"
-        const val HOST = "qr-login"
+        const val QR_LOGIN_HOST = "qr-login"
+        const val APP_LOGIN_HOST = "app-login"
         const val PARAM_TOKEN = "token"
         const val PARAM_SITE_URL = "siteUrl"
+        const val PARAM_USERNAME = "username"
         const val PARAM_ACTION = "action"
         const val PARAM_SCHEME = "scheme"
         const val HTTPS_PREFIX = "https://"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParser.kt
@@ -85,11 +85,13 @@ class QrLoginPayloadParser @Inject constructor() {
     private fun parseAppLoginDeeplink(raw: String?): QrLoginPayload.AppLogin? {
         val uri = parseDeepLink(raw, APP_LOGIN_HOST) ?: return null
         val siteUrl = uri.queryParam(PARAM_SITE_URL)?.let { normalizeSiteUrl(it, allowHttp = true) } ?: return null
-        uri.queryParam(PARAM_WP_COM_EMAIL)?.takeIf { it.isNotBlank() }?.let { email ->
-            return QrLoginPayload.AppLogin.WpComEmail(siteUrl = siteUrl, wpComEmail = email)
+        val email = uri.queryParam(PARAM_WP_COM_EMAIL)?.takeIf { it.isNotBlank() }
+        val username = uri.queryParam(PARAM_USERNAME)?.takeIf { it.isNotBlank() }
+        return when {
+            email != null -> QrLoginPayload.AppLogin.WpComEmail(siteUrl = siteUrl, wpComEmail = email)
+            username != null -> QrLoginPayload.AppLogin.Credentials(siteUrl = siteUrl, username = username)
+            else -> null
         }
-        val username = uri.queryParam(PARAM_USERNAME)?.takeIf { it.isNotBlank() } ?: return null
-        return QrLoginPayload.AppLogin.Credentials(siteUrl = siteUrl, username = username)
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -49,6 +49,7 @@ class QrLoginScannerFragment : Fragment() {
         fun onQrLoginCompleted(localSiteId: Int)
         fun onQrLoginFallbackClicked()
         fun onQrLoginSiteUrlPrefill(siteUrl: String)
+        fun onQrLoginSiteCredentials(siteUrl: String, username: String)
     }
 
     private val scannerViewModel: BarcodeScanningViewModel by viewModels()
@@ -174,6 +175,8 @@ class QrLoginScannerFragment : Fragment() {
                     openWpComMagicLinkUrl(event.url)
                 is QrLoginScannerViewModel.Dispatch.RouteToSiteAddressEntry ->
                     routeToSiteAddressEntry(event.siteUrl)
+                is QrLoginScannerViewModel.Dispatch.RouteToSiteCredentialsEntry ->
+                    routeToSiteCredentialsEntry(event.siteUrl, event.username)
             }
         }
     }
@@ -241,5 +244,12 @@ class QrLoginScannerFragment : Fragment() {
         requireNotNull(listener) {
             "${requireActivity().javaClass.simpleName} must implement QrLoginScannerFragment.Listener"
         }.onQrLoginSiteUrlPrefill(siteUrl)
+    }
+
+    private fun routeToSiteCredentialsEntry(siteUrl: String, username: String) {
+        scannerViewModel.stopCodesRecognition()
+        requireNotNull(listener) {
+            "${requireActivity().javaClass.simpleName} must implement QrLoginScannerFragment.Listener"
+        }.onQrLoginSiteCredentials(siteUrl, username)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -49,7 +49,8 @@ class QrLoginScannerFragment : Fragment() {
         fun onQrLoginCompleted(localSiteId: Int)
         fun onQrLoginFallbackClicked()
         fun onQrLoginSiteUrlPrefill(siteUrl: String)
-        fun onQrLoginSiteCredentials(siteUrl: String, username: String)
+        fun onQrLoginAppLoginCredentials(siteUrl: String, username: String)
+        fun onQrLoginAppLoginWpComEmail(siteUrl: String, wpComEmail: String)
     }
 
     private val scannerViewModel: BarcodeScanningViewModel by viewModels()
@@ -175,8 +176,10 @@ class QrLoginScannerFragment : Fragment() {
                     openWpComMagicLinkUrl(event.url)
                 is QrLoginScannerViewModel.Dispatch.RouteToSiteAddressEntry ->
                     routeToSiteAddressEntry(event.siteUrl)
-                is QrLoginScannerViewModel.Dispatch.RouteToSiteCredentialsEntry ->
-                    routeToSiteCredentialsEntry(event.siteUrl, event.username)
+                is QrLoginScannerViewModel.Dispatch.RouteToAppLoginCredentials ->
+                    routeToAppLoginCredentials(event.siteUrl, event.username)
+                is QrLoginScannerViewModel.Dispatch.RouteToAppLoginWpComEmail ->
+                    routeToAppLoginWpComEmail(event.siteUrl, event.wpComEmail)
             }
         }
     }
@@ -246,10 +249,17 @@ class QrLoginScannerFragment : Fragment() {
         }.onQrLoginSiteUrlPrefill(siteUrl)
     }
 
-    private fun routeToSiteCredentialsEntry(siteUrl: String, username: String) {
+    private fun routeToAppLoginCredentials(siteUrl: String, username: String) {
         scannerViewModel.stopCodesRecognition()
         requireNotNull(listener) {
             "${requireActivity().javaClass.simpleName} must implement QrLoginScannerFragment.Listener"
-        }.onQrLoginSiteCredentials(siteUrl, username)
+        }.onQrLoginAppLoginCredentials(siteUrl, username)
+    }
+
+    private fun routeToAppLoginWpComEmail(siteUrl: String, wpComEmail: String) {
+        scannerViewModel.stopCodesRecognition()
+        requireNotNull(listener) {
+            "${requireActivity().javaClass.simpleName} must implement QrLoginScannerFragment.Listener"
+        }.onQrLoginAppLoginWpComEmail(siteUrl, wpComEmail)
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -107,8 +107,11 @@ class QrLoginScannerViewModel @Inject constructor(
             is QrLoginPayload.SiteUrl -> handleHandoff(
                 PendingHandoff.SiteUrlPrefill(siteUrl = payload.siteUrl)
             )
-            is QrLoginPayload.AppLogin -> handleHandoff(
-                PendingHandoff.AppLogin(siteUrl = payload.siteUrl, username = payload.username)
+            is QrLoginPayload.AppLogin.Credentials -> handleHandoff(
+                PendingHandoff.AppLoginCredentials(siteUrl = payload.siteUrl, username = payload.username)
+            )
+            is QrLoginPayload.AppLogin.WpComEmail -> handleHandoff(
+                PendingHandoff.AppLoginWpComEmail(siteUrl = payload.siteUrl, wpComEmail = payload.wpComEmail)
             )
             QrLoginPayload.InstallQrCode -> {
                 trackScanFailure(
@@ -163,17 +166,42 @@ class QrLoginScannerViewModel @Inject constructor(
                 analyticsTracker.track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL)
                 triggerEvent(Dispatch.RouteToSiteAddressEntry(siteUrl = pending.siteUrl))
             }
-            is PendingHandoff.AppLogin -> {
+            is PendingHandoff.AppLoginCredentials -> {
                 loggedIn = true
-                analyticsTracker.track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL)
+                trackAppLoginHandoff(flowValue = AnalyticsTracker.VALUE_NO_WP_COM)
                 triggerEvent(
-                    Dispatch.RouteToSiteCredentialsEntry(
+                    Dispatch.RouteToAppLoginCredentials(
                         siteUrl = pending.siteUrl,
                         username = pending.username
                     )
                 )
             }
+            is PendingHandoff.AppLoginWpComEmail -> {
+                loggedIn = true
+                trackAppLoginHandoff(flowValue = AnalyticsTracker.VALUE_WP_COM)
+                triggerEvent(
+                    Dispatch.RouteToAppLoginWpComEmail(
+                        siteUrl = pending.siteUrl,
+                        wpComEmail = pending.wpComEmail
+                    )
+                )
+            }
         }
+    }
+
+    /**
+     * Mirror the analytics shape the OS-deeplink handler (`LoginActivity.handleAppLoginUri`) uses
+     * for the same URI so QR scans and deeplink clicks land in the same funnel. The `source`
+     * property lets dashboards still split the two when they need to.
+     */
+    private fun trackAppLoginHandoff(flowValue: String) {
+        analyticsTracker.track(
+            AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
+            mapOf(
+                AnalyticsTracker.KEY_FLOW to flowValue,
+                AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_APP_LOGIN_SOURCE_QR
+            )
+        )
     }
 
     private fun startScan(ticket: QrLoginPayload.Ticket) {
@@ -520,7 +548,19 @@ class QrLoginScannerViewModel @Inject constructor(
          */
         data class RouteToSiteAddressEntry(val siteUrl: String) : Dispatch()
 
-        data class RouteToSiteCredentialsEntry(val siteUrl: String, val username: String) : Dispatch()
+        /**
+         * The merchant scanned a legacy `woocommerce://app-login?siteUrl=…&username=…` QR
+         * (self-hosted variant). The fragment routes them straight to the site-credentials
+         * screen with both fields prefilled — same downstream as the OS-deeplink path.
+         */
+        data class RouteToAppLoginCredentials(val siteUrl: String, val username: String) : Dispatch()
+
+        /**
+         * The merchant scanned a legacy `woocommerce://app-login?siteUrl=…&wpcomEmail=…` QR
+         * (WP.com variant). The fragment routes them to the WP.com email/password screen via
+         * `gotWpcomSiteInfo`, mirroring the OS-deeplink path.
+         */
+        data class RouteToAppLoginWpComEmail(val siteUrl: String, val wpComEmail: String) : Dispatch()
     }
 
     sealed interface UiState {
@@ -550,7 +590,8 @@ class QrLoginScannerViewModel @Inject constructor(
         data class Ticket(val ticket: QrLoginPayload.Ticket, val host: String) : PendingHandoff
         data class WpComMagicLink(val url: String) : PendingHandoff
         data class SiteUrlPrefill(val siteUrl: String) : PendingHandoff
-        data class AppLogin(val siteUrl: String, val username: String) : PendingHandoff
+        data class AppLoginCredentials(val siteUrl: String, val username: String) : PendingHandoff
+        data class AppLoginWpComEmail(val siteUrl: String, val wpComEmail: String) : PendingHandoff
     }
 
     enum class AuthPhase {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -107,6 +107,9 @@ class QrLoginScannerViewModel @Inject constructor(
             is QrLoginPayload.SiteUrl -> handleHandoff(
                 PendingHandoff.SiteUrlPrefill(siteUrl = payload.siteUrl)
             )
+            is QrLoginPayload.AppLogin -> handleHandoff(
+                PendingHandoff.AppLogin(siteUrl = payload.siteUrl, username = payload.username)
+            )
             QrLoginPayload.InstallQrCode -> {
                 trackScanFailure(
                     step = Step.PAYLOAD,
@@ -127,10 +130,9 @@ class QrLoginScannerViewModel @Inject constructor(
     }
 
     /**
-     * Gate every QR hand-off (ticket / wp.com magic link / site-URL prefill) on the user being
-     * signed out. If a session is already active we surface a confirmation screen first; the
-     * user must opt in to replacing it before we run [AccountRepository.logout] and resume the
-     * original action.
+     * Gate every QR hand-off on the user being signed out. If a session is already active we
+     * surface a confirmation screen first; the user must opt in to replacing it before we run
+     * [AccountRepository.logout] and resume the original action.
      */
     private fun handleHandoff(pending: PendingHandoff) {
         if (accountRepository.isUserLoggedIn()) {
@@ -160,6 +162,16 @@ class QrLoginScannerViewModel @Inject constructor(
                 loggedIn = true
                 analyticsTracker.track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL)
                 triggerEvent(Dispatch.RouteToSiteAddressEntry(siteUrl = pending.siteUrl))
+            }
+            is PendingHandoff.AppLogin -> {
+                loggedIn = true
+                analyticsTracker.track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL)
+                triggerEvent(
+                    Dispatch.RouteToSiteCredentialsEntry(
+                        siteUrl = pending.siteUrl,
+                        username = pending.username
+                    )
+                )
             }
         }
     }
@@ -507,6 +519,8 @@ class QrLoginScannerViewModel @Inject constructor(
          * [siteUrl] prefilled and validation auto-started.
          */
         data class RouteToSiteAddressEntry(val siteUrl: String) : Dispatch()
+
+        data class RouteToSiteCredentialsEntry(val siteUrl: String, val username: String) : Dispatch()
     }
 
     sealed interface UiState {
@@ -536,6 +550,7 @@ class QrLoginScannerViewModel @Inject constructor(
         data class Ticket(val ticket: QrLoginPayload.Ticket, val host: String) : PendingHandoff
         data class WpComMagicLink(val url: String) : PendingHandoff
         data class SiteUrlPrefill(val siteUrl: String) : PendingHandoff
+        data class AppLogin(val siteUrl: String, val username: String) : PendingHandoff
     }
 
     enum class AuthPhase {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
@@ -41,6 +41,24 @@ class QrLoginPayloadParserTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given legacy app login deep link, when parsed, then returns AppLogin`() {
+        val raw = "woocommerce://app-login?siteUrl=https%3A%2F%2Fstore.example&username=admin"
+
+        val result = parser.parse(raw)
+
+        assertThat(result).isEqualTo(
+            QrLoginPayload.AppLogin(siteUrl = "https://store.example", username = "admin")
+        )
+    }
+
+    @Test
+    fun `given legacy app login deep link without username, when parsed, then returns Invalid`() {
+        val raw = "woocommerce://app-login?siteUrl=https%3A%2F%2Fstore.example"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
     fun `given prefix but no query, when parsed, then returns Invalid`() {
         assertThat(parser.parse("woocommerce://qr-login")).isEqualTo(QrLoginPayload.Invalid)
         assertThat(parser.parse("woocommerce://qr-login/")).isEqualTo(QrLoginPayload.Invalid)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPayloadParserTest.kt
@@ -41,21 +41,83 @@ class QrLoginPayloadParserTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given legacy app login deep link, when parsed, then returns AppLogin`() {
+    fun `given legacy app login deep link with username, when parsed, then returns AppLogin Credentials`() {
         val raw = "woocommerce://app-login?siteUrl=https%3A%2F%2Fstore.example&username=admin"
 
         val result = parser.parse(raw)
 
         assertThat(result).isEqualTo(
-            QrLoginPayload.AppLogin(siteUrl = "https://store.example", username = "admin")
+            QrLoginPayload.AppLogin.Credentials(siteUrl = "https://store.example", username = "admin")
         )
     }
 
     @Test
-    fun `given legacy app login deep link without username, when parsed, then returns Invalid`() {
+    fun `given legacy app login deep link with http siteUrl, when parsed, then returns AppLogin Credentials`() {
+        val raw = "woocommerce://app-login?siteUrl=http%3A%2F%2Fstore.example&username=admin"
+
+        val result = parser.parse(raw)
+
+        assertThat(result).isEqualTo(
+            QrLoginPayload.AppLogin.Credentials(siteUrl = "http://store.example", username = "admin")
+        )
+    }
+
+    @Test
+    fun `given legacy app login deep link with wpcomEmail, when parsed, then returns AppLogin WpComEmail`() {
+        val raw = "woocommerce://app-login?siteUrl=https%3A%2F%2Fstore.example&wpcomEmail=admin%40example.com"
+
+        val result = parser.parse(raw)
+
+        assertThat(result).isEqualTo(
+            QrLoginPayload.AppLogin.WpComEmail(siteUrl = "https://store.example", wpComEmail = "admin@example.com")
+        )
+    }
+
+    @Test
+    fun `given legacy app login with both wpcomEmail and username, when parsed, then wpcomEmail wins`() {
+        val raw = "woocommerce://app-login?siteUrl=https%3A%2F%2Fstore.example" +
+            "&wpcomEmail=admin%40example.com&username=admin"
+
+        val result = parser.parse(raw)
+
+        assertThat(result).isEqualTo(
+            QrLoginPayload.AppLogin.WpComEmail(siteUrl = "https://store.example", wpComEmail = "admin@example.com")
+        )
+    }
+
+    @Test
+    fun `given legacy app login deep link without username or wpcomEmail, when parsed, then returns Invalid`() {
         val raw = "woocommerce://app-login?siteUrl=https%3A%2F%2Fstore.example"
 
         assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given legacy app login deep link with blank username, when parsed, then returns Invalid`() {
+        val raw = "woocommerce://app-login?siteUrl=https%3A%2F%2Fstore.example&username="
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given legacy app login deep link without siteUrl, when parsed, then returns Invalid`() {
+        val raw = "woocommerce://app-login?username=admin"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given legacy app login deep link with userinfo in siteUrl, when parsed, then returns Invalid`() {
+        val raw = "woocommerce://app-login?siteUrl=https%3A%2F%2Fuser%3Apass%40store.example&username=admin"
+
+        assertThat(parser.parse(raw)).isEqualTo(QrLoginPayload.Invalid)
+    }
+
+    @Test
+    fun `given legacy app login deep link with uppercase host, when parsed, then returns AppLogin Credentials`() {
+        val raw = "WOOCOMMERCE://APP-LOGIN?siteUrl=https%3A%2F%2Fstore.example&username=admin"
+
+        assertThat(parser.parse(raw)).isInstanceOf(QrLoginPayload.AppLogin.Credentials::class.java)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -644,6 +644,23 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given legacy app login payload, when scan succeeds, then emits RouteToSiteCredentialsEntry`() =
+        testBlocking {
+            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.AppLogin(SITE_URL, USERNAME))
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+
+            assertThat(events.last()).isEqualTo(
+                QrLoginScannerViewModel.Dispatch.RouteToSiteCredentialsEntry(
+                    siteUrl = SITE_URL,
+                    username = USERNAME
+                )
+            )
+            verify(restClient, never()).scan(any(), any())
+        }
+
+    @Test
     fun `given site url payload, when scan succeeds, then does not track LOGIN_QR_SCAN_FAILED or LOGIN_QR_SUCCESS`() =
         testBlocking {
             whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.SiteUrl(SITE_URL))
@@ -701,6 +718,23 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             assertThat(viewModel.uiState.value).isEqualTo(
                 QrLoginScannerViewModel.UiState.WarningSessionReplace(
                     QrLoginScannerViewModel.PendingHandoff.SiteUrlPrefill(siteUrl = SITE_URL)
+                )
+            )
+            assertThat(events).isEmpty()
+        }
+
+    @Test
+    fun `given logged in and legacy app login payload, when scan succeeds, then ui state exposes WarningSessionReplace`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.AppLogin(SITE_URL, USERNAME))
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+
+            assertThat(viewModel.uiState.value).isEqualTo(
+                QrLoginScannerViewModel.UiState.WarningSessionReplace(
+                    QrLoginScannerViewModel.PendingHandoff.AppLogin(siteUrl = SITE_URL, username = USERNAME)
                 )
             )
             assertThat(events).isEmpty()
@@ -785,6 +819,26 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given warning for legacy app login, when confirmed, then logs out and emits RouteToSiteCredentialsEntry`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.AppLogin(SITE_URL, USERNAME))
+            val events = viewModel.event.captureValues()
+            viewModel.onScanResult(successScan())
+
+            viewModel.onConfirmSessionReplace()
+
+            verify(accountRepository).logout()
+            assertThat(events.last()).isEqualTo(
+                QrLoginScannerViewModel.Dispatch.RouteToSiteCredentialsEntry(
+                    siteUrl = SITE_URL,
+                    username = USERNAME
+                )
+            )
+            verify(analyticsTracker).track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL)
+        }
+
+    @Test
     fun `given warning, when confirmed, then tracks LOGIN_QR_SESSION_REPLACE_CONFIRMED`() = testBlocking {
         whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
         viewModel.onScanResult(successScan())
@@ -857,6 +911,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         const val WP_COM_URL =
             "https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=abc"
         const val SITE_URL = "https://store.example.com"
+        const val USERNAME = "admin"
         const val POLL_TICK_MS = 2_000L
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -644,20 +644,73 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given legacy app login payload, when scan succeeds, then emits RouteToSiteCredentialsEntry`() =
+    fun `given legacy app login credentials payload, when scan succeeds, then emits RouteToAppLoginCredentials`() =
         testBlocking {
-            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.AppLogin(SITE_URL, USERNAME))
+            whenever(parser.parse(RAW_SCAN))
+                .thenReturn(QrLoginPayload.AppLogin.Credentials(SITE_URL, USERNAME))
             val events = viewModel.event.captureValues()
 
             viewModel.onScanResult(successScan())
 
             assertThat(events.last()).isEqualTo(
-                QrLoginScannerViewModel.Dispatch.RouteToSiteCredentialsEntry(
+                QrLoginScannerViewModel.Dispatch.RouteToAppLoginCredentials(
                     siteUrl = SITE_URL,
                     username = USERNAME
                 )
             )
             verify(restClient, never()).scan(any(), any())
+        }
+
+    @Test
+    fun `given legacy app login wpcom payload, when scan succeeds, then emits RouteToAppLoginWpComEmail`() =
+        testBlocking {
+            whenever(parser.parse(RAW_SCAN))
+                .thenReturn(QrLoginPayload.AppLogin.WpComEmail(SITE_URL, WP_COM_EMAIL))
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+
+            assertThat(events.last()).isEqualTo(
+                QrLoginScannerViewModel.Dispatch.RouteToAppLoginWpComEmail(
+                    siteUrl = SITE_URL,
+                    wpComEmail = WP_COM_EMAIL
+                )
+            )
+            verify(restClient, never()).scan(any(), any())
+        }
+
+    @Test
+    fun `given legacy app login credentials payload, when handed off, then tracks app login success with qr source`() =
+        testBlocking {
+            whenever(parser.parse(RAW_SCAN))
+                .thenReturn(QrLoginPayload.AppLogin.Credentials(SITE_URL, USERNAME))
+
+            viewModel.onScanResult(successScan())
+
+            verify(analyticsTracker).track(
+                AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
+                mapOf(
+                    AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_NO_WP_COM,
+                    AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_APP_LOGIN_SOURCE_QR,
+                )
+            )
+        }
+
+    @Test
+    fun `given legacy app login wpcom payload, when handed off, then tracks app login success with qr source`() =
+        testBlocking {
+            whenever(parser.parse(RAW_SCAN))
+                .thenReturn(QrLoginPayload.AppLogin.WpComEmail(SITE_URL, WP_COM_EMAIL))
+
+            viewModel.onScanResult(successScan())
+
+            verify(analyticsTracker).track(
+                AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
+                mapOf(
+                    AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_WP_COM,
+                    AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_APP_LOGIN_SOURCE_QR,
+                )
+            )
         }
 
     @Test
@@ -724,17 +777,42 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given logged in and legacy app login payload, when scan succeeds, then ui state exposes WarningSessionReplace`() =
+    fun `given logged in and legacy app login credentials, when scan succeeds, then ui state exposes WarningSessionReplace`() =
         testBlocking {
             whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
-            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.AppLogin(SITE_URL, USERNAME))
+            whenever(parser.parse(RAW_SCAN))
+                .thenReturn(QrLoginPayload.AppLogin.Credentials(SITE_URL, USERNAME))
             val events = viewModel.event.captureValues()
 
             viewModel.onScanResult(successScan())
 
             assertThat(viewModel.uiState.value).isEqualTo(
                 QrLoginScannerViewModel.UiState.WarningSessionReplace(
-                    QrLoginScannerViewModel.PendingHandoff.AppLogin(siteUrl = SITE_URL, username = USERNAME)
+                    QrLoginScannerViewModel.PendingHandoff.AppLoginCredentials(
+                        siteUrl = SITE_URL,
+                        username = USERNAME
+                    )
+                )
+            )
+            assertThat(events).isEmpty()
+        }
+
+    @Test
+    fun `given logged in and legacy app login wpcom, when scan succeeds, then ui state exposes WarningSessionReplace`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(parser.parse(RAW_SCAN))
+                .thenReturn(QrLoginPayload.AppLogin.WpComEmail(SITE_URL, WP_COM_EMAIL))
+            val events = viewModel.event.captureValues()
+
+            viewModel.onScanResult(successScan())
+
+            assertThat(viewModel.uiState.value).isEqualTo(
+                QrLoginScannerViewModel.UiState.WarningSessionReplace(
+                    QrLoginScannerViewModel.PendingHandoff.AppLoginWpComEmail(
+                        siteUrl = SITE_URL,
+                        wpComEmail = WP_COM_EMAIL
+                    )
                 )
             )
             assertThat(events).isEmpty()
@@ -819,10 +897,11 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given warning for legacy app login, when confirmed, then logs out and emits RouteToSiteCredentialsEntry`() =
+    fun `given warning for legacy app login credentials, when confirmed, then logs out and emits RouteToAppLoginCredentials`() =
         testBlocking {
             whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
-            whenever(parser.parse(RAW_SCAN)).thenReturn(QrLoginPayload.AppLogin(SITE_URL, USERNAME))
+            whenever(parser.parse(RAW_SCAN))
+                .thenReturn(QrLoginPayload.AppLogin.Credentials(SITE_URL, USERNAME))
             val events = viewModel.event.captureValues()
             viewModel.onScanResult(successScan())
 
@@ -830,12 +909,45 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
             verify(accountRepository).logout()
             assertThat(events.last()).isEqualTo(
-                QrLoginScannerViewModel.Dispatch.RouteToSiteCredentialsEntry(
+                QrLoginScannerViewModel.Dispatch.RouteToAppLoginCredentials(
                     siteUrl = SITE_URL,
                     username = USERNAME
                 )
             )
-            verify(analyticsTracker).track(AnalyticsEvent.LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL)
+            verify(analyticsTracker).track(
+                AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
+                mapOf(
+                    AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_NO_WP_COM,
+                    AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_APP_LOGIN_SOURCE_QR,
+                )
+            )
+        }
+
+    @Test
+    fun `given warning for legacy app login wpcom, when confirmed, then logs out and emits RouteToAppLoginWpComEmail`() =
+        testBlocking {
+            whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
+            whenever(parser.parse(RAW_SCAN))
+                .thenReturn(QrLoginPayload.AppLogin.WpComEmail(SITE_URL, WP_COM_EMAIL))
+            val events = viewModel.event.captureValues()
+            viewModel.onScanResult(successScan())
+
+            viewModel.onConfirmSessionReplace()
+
+            verify(accountRepository).logout()
+            assertThat(events.last()).isEqualTo(
+                QrLoginScannerViewModel.Dispatch.RouteToAppLoginWpComEmail(
+                    siteUrl = SITE_URL,
+                    wpComEmail = WP_COM_EMAIL
+                )
+            )
+            verify(analyticsTracker).track(
+                AnalyticsEvent.LOGIN_APP_LOGIN_LINK_SUCCESS,
+                mapOf(
+                    AnalyticsTracker.KEY_FLOW to AnalyticsTracker.VALUE_WP_COM,
+                    AnalyticsTracker.KEY_SOURCE to AnalyticsTracker.VALUE_APP_LOGIN_SOURCE_QR,
+                )
+            )
         }
 
     @Test
@@ -912,6 +1024,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
             "https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=abc"
         const val SITE_URL = "https://store.example.com"
         const val USERNAME = "admin"
+        const val WP_COM_EMAIL = "admin@example.com"
         const val POLL_TICK_MS = 2_000L
     }
 }


### PR DESCRIPTION
Linear: WOOMOB-3026

## Summary
- The QR scanner now accepts the legacy wc-admin `app-login` QR in both shapes (self-hosted `username` and WP.com `wpcomEmail`), routing them to the same login screens the OS-deeplink handler already uses.
- The OS-deeplink handler (`LoginActivity.handleAppLoginUri`) and the new QR path share UI helpers, so the two entry points stay in sync.
- Both entry points now emit `LOGIN_APP_LOGIN_LINK_SUCCESS` with a `source` property (`qr` vs `deeplink`) — unified funnel, filterable by source.

## Root cause
The new scanner only recognised `woocommerce://qr-login?...` payloads, so the legacy wc-admin credentials QR (`woocommerce://app-login?...`) fell through to the invalid-code error even though the same URL — clicked as a deeplink — is handled by `handleAppLoginUri`.

## Approach
- `QrLoginPayload.AppLogin` is now a sealed interface with `Credentials` (siteUrl + username) and `WpComEmail` (siteUrl + wpcomEmail) variants, mirroring the two shapes accepted by `handleAppLoginUri`.
- `QrLoginPayloadParser`:
  - Merged the two near-identical site-URL normalisers into a single `normalizeSiteUrl(raw, allowHttp = false)`, with `allowHttp = true` for `app-login` only — keeps the userinfo/query/fragment rejection in one place.
  - Removed the dead `HTTPS_PREFIX.startsWith` pre-check.
- `QrLoginScannerViewModel`: two new `PendingHandoff` / `Dispatch` cases for the two app-login variants. Handoffs now track `LOGIN_APP_LOGIN_LINK_SUCCESS` with `flow=wp_com|no_wp_com` + `source=qr`, instead of the previously reused (and misleading) `LOGIN_QR_HANDED_OFF_SITE_URL_PREFILL`.
- `LoginActivity`: extracted `showAppLoginSiteCredentials` / `showAppLoginWpComEmail` / `trackAppLoginSuccess`. `handleAppLoginUri` now delegates to those helpers, and the new QR listener overrides do too — single source of truth for the post-handoff navigation. Deeplink call sites pass `source=deeplink` so the funnel remains comparable.

## Testing

1. Run the app with this PR changes
2. Open the login in woo-app modal flow and scan the login qr code

For convenience you can test against this screenshot: 

<img width="996" height="732" alt="Screenshot 2026-05-11 at 13 39 04" src="https://github.com/user-attachments/assets/2eea3a79-2a22-4969-8664-efde125606b5" />
