### PR TITLE
[WOOMOB-3009] QR login: make error screen scrollable with anchored buttons

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginConfirmSiteScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginConfirmSiteScreen.kt
@@ -48,7 +48,7 @@ fun QrLoginConfirmSiteScreen(
             .padding(horizontal = dimensionResource(id = R.dimen.major_150)),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        // Hero scrolls so the Connect / Cancel buttons stay visible in landscape on phones
+        // Content scrolls so the Connect / Cancel buttons stay visible in landscape on phones
         // where the static layout would otherwise push them off the bottom edge.
         Column(
             modifier = Modifier
@@ -58,14 +58,14 @@ fun QrLoginConfirmSiteScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
-            Hero(host = host)
+            Content(host = host)
         }
         Buttons(onConfirm = onConfirm, onCancel = onCancel)
     }
 }
 
 @Composable
-private fun Hero(host: String) {
+private fun Content(host: String) {
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -47,7 +49,39 @@ fun QrLoginErrorScreen(
             .systemBarsPadding()
             .padding(horizontal = dimensionResource(id = R.dimen.major_150)),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+    ) {
+        // Content scrolls so the primary / secondary buttons stay visible in landscape on phones,
+        // with large system fonts, or with longer translated copy where the static layout would
+        // otherwise push them off the bottom edge.
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Content(title = title, body = body, bodyArgs = bodyArgs)
+        }
+        Buttons(
+            primaryActionLabel = primaryActionLabel,
+            secondaryActionLabel = secondaryActionLabel,
+            onPrimaryClicked = onPrimaryClicked,
+            onSecondaryClicked = onSecondaryClicked,
+        )
+    }
+}
+
+@Composable
+private fun Content(
+    @StringRes title: Int,
+    @StringRes body: Int,
+    bodyArgs: List<Int>,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
     ) {
         Image(
             painter = painterResource(id = R.drawable.img_woo_generic_error),
@@ -73,7 +107,22 @@ fun QrLoginErrorScreen(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center
         )
-        Spacer(Modifier.height(dimensionResource(id = R.dimen.major_200)))
+    }
+}
+
+@Composable
+private fun Buttons(
+    @StringRes primaryActionLabel: Int,
+    @StringRes secondaryActionLabel: Int,
+    onPrimaryClicked: () -> Unit,
+    onSecondaryClicked: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = dimensionResource(id = R.dimen.major_100)),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         WCColoredButton(
             onClick = onPrimaryClicked,
             text = stringResource(id = primaryActionLabel),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginErrorScreen.kt
@@ -120,7 +120,10 @@ private fun Buttons(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(bottom = dimensionResource(id = R.dimen.major_100)),
+            .padding(
+                top = dimensionResource(id = R.dimen.major_150),
+                bottom = dimensionResource(id = R.dimen.major_100)
+            ),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         WCColoredButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
@@ -112,7 +112,7 @@ fun QrLoginPrologueScreen(
                 ),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // Hero scrolls so the fallback link below stays visible in landscape on phones
+            // Content scrolls so the fallback link below stays visible in landscape on phones
             // where the static layout would otherwise push it off the bottom edge.
             Column(
                 modifier = Modifier
@@ -121,7 +121,7 @@ fun QrLoginPrologueScreen(
                     .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Hero()
+                Content()
             }
             Buttons(onScanClicked = handleScanClicked, onFallbackClicked = onFallbackClicked)
         }
@@ -129,16 +129,16 @@ fun QrLoginPrologueScreen(
 }
 
 @Composable
-private fun Hero() {
+private fun Content() {
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     // Tablets have enough vertical room for the portrait stack in landscape too — only the
-    // compact height bucket (phones in landscape) needs the compacted hero.
+    // compact height bucket (phones in landscape) needs the compacted layout.
     val isCompactHeight = LocalContext.current.windowHeightSizeClass == WindowSizeClass.Compact
-    if (isLandscape && isCompactHeight) HeroLandscape() else HeroPortrait()
+    if (isLandscape && isCompactHeight) ContentLandscape() else ContentPortrait()
 }
 
 @Composable
-private fun HeroPortrait() {
+private fun ContentPortrait() {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -174,13 +174,13 @@ private fun HeroPortrait() {
 }
 
 /**
- * Landscape phones only have ~400dp of vertical space, so the portrait hero pushes the bottom
+ * Landscape phones only have ~400dp of vertical space, so the portrait layout pushes the bottom
  * CTAs off-screen. Pair the QR icon with the title on a single row and keep the URL line and
  * step hint horizontally centered below — everything fits without scrolling and reads as a
  * single centered block.
  */
 @Composable
-private fun HeroLandscape() {
+private fun ContentLandscape() {
     Column(
         modifier = Modifier
             .fillMaxWidth()


### PR DESCRIPTION
### Description

Fixes WOOMOB-3009.

Make `QrLoginErrorScreen` use the same scrollable-content + bottom-anchored-buttons pattern as the prologue and confirm screens, so the primary/secondary actions stay reachable in landscape, with large fonts, or with longer translations.

Also renames the private `Hero*` composables in the prologue and confirm screens to `Content*` for consistency.

### Test Steps

1. Trigger the error screen: `adb shell am start -a android.intent.action.VIEW -d "woocommerce://qr-login?token=invalid" com.woocommerce.android.dev`.
2. Rotate to landscape and bump `font_scale` to 1.3 — both buttons stay reachable; content scrolls if needed.

### Images/gif
<img width="2856" height="1280" alt="07-landscape-2 0x-scrolled-with-padding" src="https://github.com/user-attachments/assets/0b740c16-9c58-4d06-a2aa-efe56893304a" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
