### PR TITLE
[Woo POS] Custom Amount, Part 4: dialog Compose UI + render hookup

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosCustomAmountInitialsAvatar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosCustomAmountInitialsAvatar.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
@@ -42,11 +42,11 @@ fun WooPosCustomAmountInitialsAvatar(
 
 @WooPosPreview
 @Composable
-private fun WooPosCustomAmountInitialsAvatarPreview() {
+fun WooPosCustomAmountInitialsAvatarPreview() {
     WooPosTheme {
         Box(
             modifier = Modifier
-                .size(96.dp)
+                .size(WooPosComponentSize.Medium.value)
                 .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value)),
         ) {
             WooPosCustomAmountInitialsAvatar(name = "Service fee")
@@ -56,11 +56,11 @@ private fun WooPosCustomAmountInitialsAvatarPreview() {
 
 @WooPosPreview
 @Composable
-private fun WooPosCustomAmountInitialsAvatarBlankNamePreview() {
+fun WooPosCustomAmountInitialsAvatarBlankNamePreview() {
     WooPosTheme {
         Box(
             modifier = Modifier
-                .size(96.dp)
+                .size(WooPosComponentSize.Medium.value)
                 .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value)),
         ) {
             WooPosCustomAmountInitialsAvatar(name = "")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosCustomAmountInitialsAvatar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosCustomAmountInitialsAvatar.kt
@@ -10,8 +10,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
@@ -40,13 +41,33 @@ fun WooPosCustomAmountInitialsAvatar(
     }
 }
 
+/**
+ * Tile wrapper around [WooPosCustomAmountInitialsAvatar] that applies a fixed size and rounded
+ * corner clip. Used by order details and refund custom amount rows; the cart row sizes the avatar
+ * by filling its parent card height instead and does not use this helper.
+ */
+@Composable
+fun WooPosCustomAmountTileAvatar(
+    name: String,
+    modifier: Modifier = Modifier,
+    size: Dp = WooPosComponentSize.XSmall.value,
+    cornerRadius: Dp = WooPosCornerRadius.Small.value,
+) {
+    WooPosCustomAmountInitialsAvatar(
+        name = name,
+        modifier = modifier
+            .size(size)
+            .clip(RoundedCornerShape(cornerRadius)),
+    )
+}
+
 @WooPosPreview
 @Composable
-private fun WooPosCustomAmountInitialsAvatarPreview() {
+fun WooPosCustomAmountInitialsAvatarPreview() {
     WooPosTheme {
         Box(
             modifier = Modifier
-                .size(96.dp)
+                .size(WooPosComponentSize.Medium.value)
                 .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value)),
         ) {
             WooPosCustomAmountInitialsAvatar(name = "Service fee")
@@ -56,11 +77,11 @@ private fun WooPosCustomAmountInitialsAvatarPreview() {
 
 @WooPosPreview
 @Composable
-private fun WooPosCustomAmountInitialsAvatarBlankNamePreview() {
+fun WooPosCustomAmountInitialsAvatarBlankNamePreview() {
     WooPosTheme {
         Box(
             modifier = Modifier
-                .size(96.dp)
+                .size(WooPosComponentSize.Medium.value)
                 .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value)),
         ) {
             WooPosCustomAmountInitialsAvatar(name = "")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeDialogs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeDialogs.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionDialog
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosExitConfirmationDialog
+import com.woocommerce.android.ui.woopos.home.items.customamount.WooPosCustomAmountDialog
 import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 
 @Composable
@@ -33,4 +34,10 @@ fun WooPosHomeDialogs(
             onConnectionSuccess = { onHomeUIEvent(WooPosHomeUIEvent.DismissCardReaderConnectionDialog) }
         )
     }
+
+    WooPosCustomAmountDialog(
+        isVisible = dialogState is WooPosHomeState.DialogState.CustomAmountDialog,
+        editing = (dialogState as? WooPosHomeState.DialogState.CustomAmountDialog)?.editing,
+        onDismissRequest = { onHomeUIEvent(WooPosHomeUIEvent.DismissCustomAmountDialog) },
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeDialogs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeDialogs.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionDialog
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosExitConfirmationDialog
-import com.woocommerce.android.ui.woopos.home.items.customamount.WooPosCustomAmountDialog
 import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 
 @Composable
@@ -34,10 +33,4 @@ fun WooPosHomeDialogs(
             onConnectionSuccess = { onHomeUIEvent(WooPosHomeUIEvent.DismissCardReaderConnectionDialog) }
         )
     }
-
-    WooPosCustomAmountDialog(
-        isVisible = dialogState is WooPosHomeState.DialogState.CustomAmountDialog,
-        editing = (dialogState as? WooPosHomeState.DialogState.CustomAmountDialog)?.editing,
-        onDismissRequest = { onHomeUIEvent(WooPosHomeUIEvent.DismissCustomAmountDialog) },
-    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home
 
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.BarcodeInputDetector
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import dagger.hilt.android.scopes.ActivityRetainedScoped
@@ -60,6 +61,10 @@ sealed class ParentToChildrenEvent {
         val amount: BigDecimal,
         val isTaxable: Boolean,
         val editingItemNumber: Int? = null,
+    ) : ParentToChildrenEvent()
+
+    data class ShowCustomAmountForm(
+        val editing: WooPosCartItemViewState.CustomAmount? = null,
     ) : ParentToChildrenEvent()
 
     sealed class SearchEvent : ParentToChildrenEvent() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -24,10 +24,13 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.isPreviewMode
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.toolbar.PreviewWooPosFloatingToolbarStatusConnectedWithMenu
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosFloatingToolbar
 import org.wordpress.android.util.ToastUtils
@@ -142,11 +145,17 @@ private fun WooPosHomeScreen(
         }
 
         if (!isPreviewMode()) {
-            WooPosHomeScreenToolbar(
-                modifier = Modifier
-                    .padding(WooPosSpacing.Large.value)
-                    .align(Alignment.BottomStart),
-            )
+            val itemsViewModel: WooPosItemsViewModel = hiltViewModel()
+            val itemsState by itemsViewModel.viewState.collectAsState()
+            val isFloatingToolbarVisible = itemsState !is WooPosItemsToolbarViewState.CustomAmountForm
+
+            if (isFloatingToolbarVisible) {
+                WooPosHomeScreenToolbar(
+                    modifier = Modifier
+                        .padding(WooPosSpacing.Large.value)
+                        .align(Alignment.BottomStart),
+                )
+            }
 
             WooPosHomeDialogs(state.dialogState, onHomeUIEvent)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeState.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.woopos.home
 
 import android.os.Parcelable
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -51,10 +50,5 @@ data class WooPosHomeState(
 
         @Parcelize
         data object CardReaderConnectionDialog : DialogState()
-
-        @Parcelize
-        data class CustomAmountDialog(
-            val editing: WooPosCartItemViewState.CustomAmount? = null,
-        ) : DialogState()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeUIEvent.kt
@@ -7,7 +7,6 @@ sealed class WooPosHomeUIEvent {
     data object ExitConfirmationDialogDismissed : WooPosHomeUIEvent()
     data object DismissScanningSetupDialog : WooPosHomeUIEvent()
     data object DismissCardReaderConnectionDialog : WooPosHomeUIEvent()
-    data object DismissCustomAmountDialog : WooPosHomeUIEvent()
     data object OnPaymentCompletedViaCash : WooPosHomeUIEvent()
     data object ExitPosClicked : WooPosHomeUIEvent()
     data object PhoneOpenCartClicked : WooPosHomeUIEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -98,12 +98,6 @@ class WooPosHomeViewModel @Inject constructor(
                 )
             }
 
-            WooPosHomeUIEvent.DismissCustomAmountDialog -> {
-                _state.value = _state.value.copy(
-                    dialogState = DialogState.Hidden
-                )
-            }
-
             WooPosHomeUIEvent.OnPaymentCompletedViaCash -> onOrderSuccessfullyPaid(
                 PaymentMethod.CASH
             )
@@ -291,13 +285,12 @@ class WooPosHomeViewModel @Inject constructor(
                     }
 
                     is ChildToParentEvent.CustomAmountDialogRequested -> {
-                        _state.value = _state.value.copy(
-                            dialogState = DialogState.CustomAmountDialog(editing = event.editing)
+                        sendEventToChildren(
+                            ParentToChildrenEvent.ShowCustomAmountForm(editing = event.editing)
                         )
                     }
 
                     is ChildToParentEvent.CustomAmountSubmitted -> {
-                        _state.value = _state.value.copy(dialogState = DialogState.Hidden)
                         sendEventToChildren(
                             ParentToChildrenEvent.CustomAmountSubmitted(
                                 name = event.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -86,7 +86,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverfl
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerText
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
@@ -94,7 +93,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIco
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptiveIconSize
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState.Coupon.CouponValidationState
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartUIEvent.ItemRemovedFromCart
@@ -814,14 +812,7 @@ private fun CustomAmountItem(
             // Edit lives inside the overflow menu, so this also gates the edit path during checkout
             // — intentional: cart contents are locked once payment starts.
             if (canRemoveItems) {
-                when (currentWooPosBreakpoint()) {
-                    WooPosBreakpoint.Phone -> CustomAmountOverflowMenu(item = item, onUIEvent = onUIEvent)
-                    WooPosBreakpoint.SmallTablet,
-                    WooPosBreakpoint.Tablet -> {
-                        EditCustomAmountButton(item = item, onUIEvent = onUIEvent)
-                        RemoveItemFromCartButton(item = item, onUIEvent = onUIEvent)
-                    }
-                }
+                CustomAmountOverflowMenu(item = item, onUIEvent = onUIEvent)
             }
             Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
         }
@@ -846,26 +837,6 @@ private fun CustomAmountOverflowMenu(
             ),
         )
     )
-}
-
-@Composable
-private fun EditCustomAmountButton(
-    item: WooPosCartItemViewState.CustomAmount,
-    onUIEvent: (WooPosCartUIEvent) -> Unit,
-) {
-    IconButton(
-        onClick = { onUIEvent(WooPosCartUIEvent.EditCustomAmountClicked(item)) },
-        modifier = Modifier.size(WooPosIconSize.XLarge.value),
-    ) {
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_edit_filled_24dp),
-            tint = WooPosTheme.colors.onSurfaceVariantHighest,
-            contentDescription = stringResource(
-                id = R.string.woopos_cart_custom_amount_edit_content_description,
-                item.name,
-            ),
-        )
-    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -86,6 +86,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverfl
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerText
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
@@ -93,6 +94,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIco
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptiveIconSize
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState.Coupon.CouponValidationState
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartUIEvent.ItemRemovedFromCart
@@ -812,7 +814,14 @@ private fun CustomAmountItem(
             // Edit lives inside the overflow menu, so this also gates the edit path during checkout
             // — intentional: cart contents are locked once payment starts.
             if (canRemoveItems) {
-                CustomAmountOverflowMenu(item = item, onUIEvent = onUIEvent)
+                when (currentWooPosBreakpoint()) {
+                    WooPosBreakpoint.Phone -> CustomAmountOverflowMenu(item = item, onUIEvent = onUIEvent)
+                    WooPosBreakpoint.SmallTablet,
+                    WooPosBreakpoint.Tablet -> {
+                        EditCustomAmountButton(item = item, onUIEvent = onUIEvent)
+                        RemoveItemFromCartButton(item = item, onUIEvent = onUIEvent)
+                    }
+                }
             }
             Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
         }
@@ -837,6 +846,26 @@ private fun CustomAmountOverflowMenu(
             ),
         )
     )
+}
+
+@Composable
+private fun EditCustomAmountButton(
+    item: WooPosCartItemViewState.CustomAmount,
+    onUIEvent: (WooPosCartUIEvent) -> Unit,
+) {
+    IconButton(
+        onClick = { onUIEvent(WooPosCartUIEvent.EditCustomAmountClicked(item)) },
+        modifier = Modifier.size(WooPosIconSize.XLarge.value),
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_edit_filled_24dp),
+            tint = WooPosTheme.colors.onSurfaceVariantHighest,
+            contentDescription = stringResource(
+                id = R.string.woopos_cart_custom_amount_edit_content_description,
+                item.name,
+            ),
+        )
+    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -254,6 +254,8 @@ class WooPosCartViewModel @Inject constructor(
                     is ParentToChildrenEvent.ProductsRemoved -> Unit
 
                     is ParentToChildrenEvent.CustomAmountSubmitted -> handleCustomAmountSubmitted(event)
+
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> Unit
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsContent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.SearchState
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsNavigationData
 
@@ -17,6 +18,7 @@ fun WooPosItemsContent(
     productsSearchContent: @Composable () -> Unit,
     couponsSearchContent: @Composable () -> Unit,
     variationsContent: @Composable (WooPosVariationsNavigationData) -> Unit,
+    customAmountFormContent: @Composable (WooPosCartItemViewState.CustomAmount?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Crossfade(
@@ -30,6 +32,7 @@ fun WooPosItemsContent(
             ItemsScreenState.ProductsSearch -> productsSearchContent()
             ItemsScreenState.CouponsSearch -> couponsSearchContent()
             is ItemsScreenState.Variations -> variationsContent(screenState.variableProductData)
+            is ItemsScreenState.CustomAmountForm -> customAmountFormContent(screenState.editing)
         }
     }
 }
@@ -40,6 +43,7 @@ internal sealed class ItemsScreenState {
     data object ProductsSearch : ItemsScreenState()
     data object CouponsSearch : ItemsScreenState()
     data class Variations(val variableProductData: WooPosVariationsNavigationData) : ItemsScreenState()
+    data class CustomAmountForm(val editing: WooPosCartItemViewState.CustomAmount?) : ItemsScreenState()
 }
 
 internal fun WooPosItemsToolbarViewState.toScreenState(): ItemsScreenState = when (this) {
@@ -58,4 +62,5 @@ internal fun WooPosItemsToolbarViewState.toScreenState(): ItemsScreenState = whe
             is WooPosSearchInputState.Open -> ItemsScreenState.CouponsSearch
         }
     }
+    is WooPosItemsToolbarViewState.CustomAmountForm -> ItemsScreenState.CustomAmountForm(editing)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -66,6 +67,7 @@ fun WooPosItemList(
     state: WooPosContentViewState,
     listState: LazyListState,
     animateItems: Boolean = true,
+    headerContent: (@Composable LazyItemScope.() -> Unit)? = null,
     onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
     onEndOfProductsListReached: () -> Unit,
     onErrorWhilePaginating: @Composable () -> Unit,
@@ -77,6 +79,12 @@ fun WooPosItemList(
         state = listState,
         withBottomShadow = true,
     ) {
+        if (headerContent != null) {
+            item(key = "woopos_item_list_header") {
+                headerContent()
+            }
+        }
+
         items(
             state.items,
             key = { item -> item.id }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsList.kt
@@ -81,7 +81,9 @@ fun WooPosItemList(
     ) {
         if (headerContent != null) {
             item(key = "woopos_item_list_header") {
-                headerContent()
+                Box(modifier = if (animateItems) Modifier.animateItem() else Modifier) {
+                    headerContent()
+                }
             }
         }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreen
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreenContentPreview
 import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchContentPreview
 import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchScreen
+import com.woocommerce.android.ui.woopos.home.items.customamount.WooPosCustomAmountFormScreen
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosItemsScreenPreview
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsScreen
 import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
@@ -181,6 +182,12 @@ private fun MainItemsList(
                         modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
                         variableProductData = data,
                         onBackClicked = onBackClicked,
+                    )
+                },
+                customAmountFormContent = { editing ->
+                    WooPosCustomAmountFormScreen(
+                        editing = editing,
+                        onBackClick = onBackClicked,
                     )
                 },
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -75,6 +75,7 @@ class WooPosItemsSearchHelper @Inject constructor(
                     is ParentToChildrenEvent.OrderSuccessfullyPaid -> Unit
                     is ParentToChildrenEvent.SettingsEvent -> Unit
                     is ParentToChildrenEvent.CustomAmountSubmitted -> Unit
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> Unit
                 }
             }
         }
@@ -129,6 +130,8 @@ class WooPosItemsSearchHelper @Inject constructor(
             is WooPosItemsToolbarViewState.ProductList -> R.string.woopos_search_products_and_variations
             is WooPosItemsToolbarViewState.CouponList -> R.string.woopos_search_coupons
             is WooPosItemsToolbarViewState.VariationList -> error("Search is not applicable for variations list")
+            is WooPosItemsToolbarViewState.CustomAmountForm ->
+                error("Search is not applicable for custom amount form")
         }
 
         viewStateFlow.value = viewStateFlow.value.copy(
@@ -183,6 +186,7 @@ class WooPosItemsSearchHelper @Inject constructor(
         is WooPosItemsToolbarViewState.CouponList -> false
         is WooPosItemsToolbarViewState.ProductList -> true
         is WooPosItemsToolbarViewState.VariationList -> false
+        is WooPosItemsToolbarViewState.CustomAmountForm -> false
     }
 
     private fun getCurrentSearchVisibleState(): SearchState.Visible? {
@@ -200,6 +204,7 @@ class WooPosItemsSearchHelper @Inject constructor(
             is WooPosItemsToolbarViewState.ProductList -> this.copy(search = search)
             is WooPosItemsToolbarViewState.CouponList -> this.copy(search = search)
             is WooPosItemsToolbarViewState.VariationList -> this
+            is WooPosItemsToolbarViewState.CustomAmountForm -> this
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbarViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbarViewState.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsNavigationData
 
 sealed class WooPosItemsToolbarViewState(
@@ -27,6 +28,15 @@ sealed class WooPosItemsToolbarViewState(
     data class VariationList(
         override val tabs: List<Tab>,
         val variableProductData: WooPosVariationsNavigationData,
+    ) : WooPosItemsToolbarViewState(
+        tabs = tabs,
+        search = SearchState.Hidden,
+        backNavigation = true,
+    )
+
+    data class CustomAmountForm(
+        override val tabs: List<Tab>,
+        val editing: WooPosCartItemViewState.CustomAmount? = null,
     ) : WooPosItemsToolbarViewState(
         tabs = tabs,
         search = SearchState.Hidden,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -244,6 +244,8 @@ class WooPosItemsViewModel @Inject constructor(
     }
 
     private fun navigateBackFromSubScreen() {
+        // No-op if we're not actually on a sub-screen — guards against races where a back-event arrives
+        // after the items list has already been restored (e.g. submit + back fired in quick succession).
         when (_viewState.value) {
             is WooPosItemsToolbarViewState.VariationList,
             is WooPosItemsToolbarViewState.CustomAmountForm -> {
@@ -251,7 +253,7 @@ class WooPosItemsViewModel @Inject constructor(
                 preservedStateBeforeOpeningSubScreen = null
             }
 
-            else -> error("Unexpected state: ${_viewState.value}")
+            else -> Unit
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -3,11 +3,13 @@ package com.woocommerce.android.ui.woopos.home.items
 import android.os.Parcelable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.SearchState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab
 import com.woocommerce.android.ui.woopos.home.items.coupons.creation.WooPosCouponCreationFacade
@@ -21,6 +23,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
+import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -44,8 +47,9 @@ class WooPosItemsViewModel @Inject constructor(
     private val syncStatusChecker: WooPosFullSyncStatusChecker,
     private val dateTimeProvider: DateTimeProvider,
     private val isWooCommerceVersionSunsetWarningRequired: WooPosIsWooCommerceVersionSunsetWarningRequired,
+    private val resourceProvider: ResourceProvider,
 ) : ViewModel() {
-    private var preservedStateBeforeOpeningVariations: WooPosItemsToolbarViewState? = null
+    private var preservedStateBeforeOpeningSubScreen: WooPosItemsToolbarViewState? = null
     private val _viewState = MutableStateFlow<WooPosItemsToolbarViewState>(initialState())
     val viewState: StateFlow<WooPosItemsToolbarViewState> = _viewState
         .stateIn(
@@ -107,7 +111,7 @@ class WooPosItemsViewModel @Inject constructor(
     fun onUIEvent(event: WooPosItemsUIEvent) {
         when (event) {
             WooPosItemsUIEvent.BackFromVariationsClicked -> {
-                navigateBackFromVariations()
+                navigateBackFromSubScreen()
             }
 
             WooPosItemsUIEvent.ClearSearchClicked -> searchHelper.onClearSearchClicked()
@@ -162,8 +166,15 @@ class WooPosItemsViewModel @Inject constructor(
                     is ParentToChildrenEvent.BarcodeEvent,
                     is ParentToChildrenEvent.MissingVariationEvent,
                     is ParentToChildrenEvent.RemoveProductsClicked,
-                    is ParentToChildrenEvent.ProductsRemoved,
-                    is ParentToChildrenEvent.CustomAmountSubmitted -> Unit
+                    is ParentToChildrenEvent.ProductsRemoved -> Unit
+
+                    is ParentToChildrenEvent.CustomAmountSubmitted -> {
+                        if (_viewState.value is WooPosItemsToolbarViewState.CustomAmountForm) {
+                            navigateBackFromSubScreen()
+                        }
+                    }
+
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> openCustomAmountForm(event.editing)
 
                     ParentToChildrenEvent.RefreshProductList,
                     is ParentToChildrenEvent.SettingsEvent.RetrySyncRequested -> refreshBannerState()
@@ -176,6 +187,27 @@ class WooPosItemsViewModel @Inject constructor(
         }
     }
 
+    private fun openCustomAmountForm(editing: WooPosCartItemViewState.CustomAmount?) {
+        searchHelper.updateLoadingState(isLoading = false)
+        if (_viewState.value !is WooPosItemsToolbarViewState.CustomAmountForm) {
+            preservedStateBeforeOpeningSubScreen = _viewState.value
+        }
+        val titleRes = if (editing != null) {
+            R.string.woopos_custom_amount_dialog_title_edit
+        } else {
+            R.string.woopos_custom_amount_dialog_title_add
+        }
+        _viewState.value = WooPosItemsToolbarViewState.CustomAmountForm(
+            tabs = listOf(
+                Tab.Variations(
+                    name = resourceProvider.getString(titleRes),
+                    highlightLevel = Tab.HighlightLevel.Full,
+                )
+            ),
+            editing = editing,
+        )
+    }
+
     private fun handleItemClicked(event: ParentToChildrenEvent.ItemClickedInItemsList) {
         when (event.itemData) {
             is ItemClickedData.Coupon,
@@ -185,7 +217,7 @@ class WooPosItemsViewModel @Inject constructor(
 
             is ItemClickedData.VariableProduct -> {
                 searchHelper.updateLoadingState(isLoading = false)
-                preservedStateBeforeOpeningVariations = _viewState.value
+                preservedStateBeforeOpeningSubScreen = _viewState.value
                 _viewState.value = WooPosItemsToolbarViewState.VariationList(
                     tabs = listOf(
                         Tab.Variations(
@@ -209,17 +241,19 @@ class WooPosItemsViewModel @Inject constructor(
                 is WooPosItemsToolbarViewState.ProductList -> WooPosAnalyticsEventConstant.ItemsListSource.PRODUCT
                 is WooPosItemsToolbarViewState.CouponList -> WooPosAnalyticsEventConstant.ItemsListSource.COUPON
                 is WooPosItemsToolbarViewState.VariationList -> WooPosAnalyticsEventConstant.ItemsListSource.PRODUCT
+                is WooPosItemsToolbarViewState.CustomAmountForm -> WooPosAnalyticsEventConstant.ItemsListSource.PRODUCT
             }
             val event = SearchButtonTapped(source = source)
             analyticsTracker.track(event)
         }
     }
 
-    private fun navigateBackFromVariations() {
+    private fun navigateBackFromSubScreen() {
         when (_viewState.value) {
-            is WooPosItemsToolbarViewState.VariationList -> {
-                _viewState.value = preservedStateBeforeOpeningVariations ?: initialState()
-                preservedStateBeforeOpeningVariations = null
+            is WooPosItemsToolbarViewState.VariationList,
+            is WooPosItemsToolbarViewState.CustomAmountForm -> {
+                _viewState.value = preservedStateBeforeOpeningSubScreen ?: initialState()
+                preservedStateBeforeOpeningSubScreen = null
             }
 
             else -> error("Unexpected state: ${_viewState.value}")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -192,15 +192,10 @@ class WooPosItemsViewModel @Inject constructor(
         if (_viewState.value !is WooPosItemsToolbarViewState.CustomAmountForm) {
             preservedStateBeforeOpeningSubScreen = _viewState.value
         }
-        val titleRes = if (editing != null) {
-            R.string.woopos_custom_amount_dialog_title_edit
-        } else {
-            R.string.woopos_custom_amount_dialog_title_add
-        }
         _viewState.value = WooPosItemsToolbarViewState.CustomAmountForm(
             tabs = listOf(
                 Tab.Variations(
-                    name = resourceProvider.getString(titleRes),
+                    name = resourceProvider.getString(R.string.woopos_custom_amount_form_title),
                     highlightLevel = Tab.HighlightLevel.Full,
                 )
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
@@ -135,7 +136,12 @@ private fun TabletDialogLayout(
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
 
-            DialogActions(state = state, onSubmit = onSubmit, onCancel = onDismissRequest)
+            DialogActions(
+                state = state,
+                breakpoint = WooPosBreakpoint.Tablet,
+                onSubmit = onSubmit,
+                onCancel = onDismissRequest,
+            )
         }
     }
 }
@@ -184,7 +190,12 @@ private fun PhoneFullScreenLayout(
                     .navigationBarsPadding()
                     .padding(WooPosSpacing.Medium.value),
             ) {
-                DialogActions(state = state, onSubmit = onSubmit, onCancel = onDismissRequest)
+                DialogActions(
+                    state = state,
+                    breakpoint = WooPosBreakpoint.Phone,
+                    onSubmit = onSubmit,
+                    onCancel = onDismissRequest,
+                )
             }
         }
     }
@@ -195,7 +206,7 @@ private fun PhoneToolbar(
     titleRes: Int,
     onCloseClick: () -> Unit,
 ) {
-    Box(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .statusBarsPadding()
@@ -203,7 +214,7 @@ private fun PhoneToolbar(
                 horizontal = WooPosSpacing.Small.value,
                 vertical = WooPosSpacing.Small.value,
             ),
-        contentAlignment = Alignment.CenterStart,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         IconButton(onClick = onCloseClick) {
             Icon(
@@ -213,13 +224,16 @@ private fun PhoneToolbar(
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
-        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-            WooPosText(
-                text = stringResource(titleRes),
-                style = WooPosTypography.Heading,
-                fontWeight = FontWeight.Bold,
-            )
-        }
+        WooPosText(
+            text = stringResource(titleRes),
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = WooPosIconSize.Large.value + WooPosSpacing.Small.value),
+        )
     }
 }
 
@@ -323,6 +337,7 @@ private fun TaxesToggle(
 @Composable
 private fun DialogActions(
     state: WooPosCustomAmountDialogState,
+    breakpoint: WooPosBreakpoint,
     onSubmit: () -> Unit,
     onCancel: () -> Unit,
 ) {
@@ -333,7 +348,7 @@ private fun DialogActions(
     val submitButtonState =
         if (state.isSubmitEnabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED
 
-    when (currentWooPosBreakpoint()) {
+    when (breakpoint) {
         WooPosBreakpoint.Phone -> Column(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -1,0 +1,213 @@
+package com.woocommerce.android.ui.woopos.home.items.customamount
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosInputField
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosMoneyInputField
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
+import java.math.BigDecimal
+
+@Composable
+fun WooPosCustomAmountDialog(
+    isVisible: Boolean,
+    editing: WooPosCartItemViewState.CustomAmount?,
+    onDismissRequest: () -> Unit,
+    viewModel: WooPosCustomAmountDialogViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(isVisible, editing?.itemNumber) {
+        if (isVisible) {
+            viewModel.initializeFor(editing)
+        } else {
+            viewModel.onDismissed()
+        }
+    }
+
+    val state by viewModel.state.collectAsState()
+
+    val dialogTitleRes = when (state.mode) {
+        is WooPosCustomAmountDialogState.Mode.Edit -> R.string.woopos_custom_amount_dialog_title_edit
+        WooPosCustomAmountDialogState.Mode.Add -> R.string.woopos_custom_amount_dialog_title_add
+    }
+
+    WooPosDialogWrapper(
+        isVisible = isVisible,
+        dialogBackgroundContentDescription = stringResource(dialogTitleRes),
+        onCloseClick = onDismissRequest,
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
+        ) {
+            WooPosText(
+                text = stringResource(dialogTitleRes),
+                style = WooPosTypography.Heading,
+                fontWeight = FontWeight.Bold,
+            )
+
+            AmountSection(
+                state = state,
+                onAmountChanged = viewModel::onAmountChanged,
+            )
+
+            NameSection(
+                value = state.name,
+                onNameChanged = viewModel::onNameChanged,
+            )
+
+            TaxesToggle(
+                isTaxable = state.isTaxable,
+                onToggled = viewModel::onTaxableToggled,
+            )
+
+            Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
+
+            DialogActions(
+                state = state,
+                onSubmit = {
+                    viewModel.onSubmit()
+                },
+                onCancel = onDismissRequest,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AmountSection(
+    state: WooPosCustomAmountDialogState,
+    onAmountChanged: (BigDecimal?) -> Unit,
+) {
+    Column {
+        WooPosText(
+            text = stringResource(R.string.woopos_custom_amount_dialog_amount_label),
+            style = WooPosTypography.BodySmall,
+            color = WooPosTheme.colors.onSurfaceVariantHighest,
+        )
+        Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = WooPosSpacing.Small.value),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            WooPosMoneyInputField(
+                value = state.amount,
+                onValueChange = onAmountChanged,
+                currencySymbol = state.currencySymbol,
+                currencyPosition = state.currencyPosition,
+                decimalSeparator = state.decimalSeparator,
+                numberOfDecimals = state.numberOfDecimals,
+                textStyle = WooPosTypography.Heading,
+                textColor = MaterialTheme.colorScheme.onSurface,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                contentAlignment = Alignment.CenterStart,
+            )
+        }
+    }
+}
+
+@Composable
+private fun NameSection(
+    value: String,
+    onNameChanged: (String) -> Unit,
+) {
+    Column {
+        WooPosText(
+            text = stringResource(R.string.woopos_custom_amount_dialog_name_label),
+            style = WooPosTypography.BodySmall,
+            color = WooPosTheme.colors.onSurfaceVariantHighest,
+        )
+        Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = WooPosSpacing.Small.value),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            WooPosInputField(
+                value = value,
+                onValueChange = onNameChanged,
+                label = stringResource(R.string.woopos_custom_amount_dialog_name_placeholder),
+                textColor = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TaxesToggle(
+    isTaxable: Boolean,
+    onToggled: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        WooPosText(
+            text = stringResource(R.string.woopos_custom_amount_dialog_charge_taxes),
+            style = WooPosTypography.BodyMedium,
+        )
+        Switch(
+            checked = isTaxable,
+            onCheckedChange = onToggled,
+        )
+    }
+}
+
+@Composable
+private fun DialogActions(
+    state: WooPosCustomAmountDialogState,
+    onSubmit: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
+    ) {
+        WooPosOutlinedButton(
+            modifier = Modifier.weight(1f),
+            text = stringResource(R.string.woopos_custom_amount_dialog_cancel),
+            onClick = onCancel,
+        )
+        val submitText = when (state.mode) {
+            is WooPosCustomAmountDialogState.Mode.Edit -> R.string.woopos_custom_amount_dialog_submit_edit
+            WooPosCustomAmountDialogState.Mode.Add -> R.string.woopos_custom_amount_dialog_submit_add
+        }
+        WooPosButton(
+            modifier = Modifier.weight(1f),
+            text = stringResource(submitText),
+            state = if (state.isSubmitEnabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED,
+            onClick = onSubmit,
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -1,15 +1,25 @@
 package com.woocommerce.android.ui.woopos.home.items.customamount
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -17,7 +27,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -29,9 +41,12 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosInputF
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosMoneyInputField
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIconSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import java.math.BigDecimal
 
@@ -57,6 +72,43 @@ fun WooPosCustomAmountDialog(
         WooPosCustomAmountDialogState.Mode.Add -> R.string.woopos_custom_amount_dialog_title_add
     }
 
+    when (currentWooPosBreakpoint()) {
+        WooPosBreakpoint.Phone -> PhoneFullScreenLayout(
+            isVisible = isVisible,
+            state = state,
+            dialogTitleRes = dialogTitleRes,
+            onAmountChanged = viewModel::onAmountChanged,
+            onNameChanged = viewModel::onNameChanged,
+            onTaxableToggled = viewModel::onTaxableToggled,
+            onSubmit = viewModel::onSubmit,
+            onDismissRequest = onDismissRequest,
+        )
+
+        WooPosBreakpoint.SmallTablet,
+        WooPosBreakpoint.Tablet -> TabletDialogLayout(
+            isVisible = isVisible,
+            state = state,
+            dialogTitleRes = dialogTitleRes,
+            onAmountChanged = viewModel::onAmountChanged,
+            onNameChanged = viewModel::onNameChanged,
+            onTaxableToggled = viewModel::onTaxableToggled,
+            onSubmit = viewModel::onSubmit,
+            onDismissRequest = onDismissRequest,
+        )
+    }
+}
+
+@Composable
+private fun TabletDialogLayout(
+    isVisible: Boolean,
+    state: WooPosCustomAmountDialogState,
+    dialogTitleRes: Int,
+    onAmountChanged: (BigDecimal?) -> Unit,
+    onNameChanged: (String) -> Unit,
+    onTaxableToggled: (Boolean) -> Unit,
+    onSubmit: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
     WooPosDialogWrapper(
         isVisible = isVisible,
         dialogBackgroundContentDescription = stringResource(dialogTitleRes),
@@ -73,29 +125,95 @@ fun WooPosCustomAmountDialog(
                 fontWeight = FontWeight.Bold,
             )
 
-            AmountSection(
-                state = state,
-                onAmountChanged = viewModel::onAmountChanged,
-            )
-
-            NameSection(
-                value = state.name,
-                onNameChanged = viewModel::onNameChanged,
-            )
-
-            TaxesToggle(
-                isTaxable = state.isTaxable,
-                onToggled = viewModel::onTaxableToggled,
-            )
+            AmountSection(state = state, onAmountChanged = onAmountChanged)
+            NameSection(value = state.name, onNameChanged = onNameChanged)
+            TaxesToggle(isTaxable = state.isTaxable, onToggled = onTaxableToggled)
 
             Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
 
-            DialogActions(
-                state = state,
-                onSubmit = {
-                    viewModel.onSubmit()
-                },
-                onCancel = onDismissRequest,
+            DialogActions(state = state, onSubmit = onSubmit, onCancel = onDismissRequest)
+        }
+    }
+}
+
+@Composable
+private fun PhoneFullScreenLayout(
+    isVisible: Boolean,
+    state: WooPosCustomAmountDialogState,
+    dialogTitleRes: Int,
+    onAmountChanged: (BigDecimal?) -> Unit,
+    onNameChanged: (String) -> Unit,
+    onTaxableToggled: (Boolean) -> Unit,
+    onSubmit: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    if (!isVisible) return
+
+    BackHandler(enabled = true) { onDismissRequest() }
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            PhoneToolbar(
+                titleRes = dialogTitleRes,
+                onCloseClick = onDismissRequest,
+            )
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = WooPosSpacing.Medium.value),
+                verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
+            ) {
+                Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+                AmountSection(state = state, onAmountChanged = onAmountChanged)
+                NameSection(value = state.name, onNameChanged = onNameChanged)
+                TaxesToggle(isTaxable = state.isTaxable, onToggled = onTaxableToggled)
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .navigationBarsPadding()
+                    .padding(WooPosSpacing.Medium.value),
+            ) {
+                DialogActions(state = state, onSubmit = onSubmit, onCancel = onDismissRequest)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PhoneToolbar(
+    titleRes: Int,
+    onCloseClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(
+                horizontal = WooPosSpacing.Small.value,
+                vertical = WooPosSpacing.Small.value,
+            ),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        IconButton(onClick = onCloseClick) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_close_24dp),
+                contentDescription = stringResource(R.string.close),
+                modifier = Modifier.size(WooPosIconSize.Large.value),
+                tint = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+            WooPosText(
+                text = stringResource(titleRes),
+                style = WooPosTypography.Heading,
+                fontWeight = FontWeight.Bold,
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
@@ -81,17 +82,18 @@ fun WooPosCustomAmountFormScreen(
             NameSection(value = state.name, onNameChanged = viewModel::onNameChanged)
         }
 
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    top = WooPosSpacing.Medium.value,
-                    start = WooPosSpacing.Medium.value,
-                    end = WooPosSpacing.Medium.value,
-                )
-                .navigationBarsPadding(),
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceBright,
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            FormSubmitButton(state = state, onSubmit = viewModel::onSubmit)
+            FormSubmitButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = WooPosSpacing.Medium.value)
+                    .navigationBarsPadding(),
+                state = state,
+                onSubmit = viewModel::onSubmit,
+            )
         }
     }
 }
@@ -197,6 +199,7 @@ private fun TaxesToggle(
 private fun FormSubmitButton(
     state: WooPosCustomAmountDialogState,
     onSubmit: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val submitText = when (state.mode) {
         is WooPosCustomAmountDialogState.Mode.Edit -> R.string.woopos_custom_amount_dialog_submit_edit
@@ -205,7 +208,7 @@ private fun FormSubmitButton(
     val submitButtonState =
         if (state.isSubmitEnabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED
     WooPosButton(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier,
         text = stringResource(submitText),
         state = submitButtonState,
         onClick = onSubmit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -51,6 +52,13 @@ fun WooPosCustomAmountFormScreen(
 ) {
     LaunchedEffect(editing?.itemNumber) {
         viewModel.initializeFor(editing)
+    }
+
+    // Reset the VM init sentinel whenever the form leaves composition — covers back gestures, submit
+    // success, and any external navigation. Without this, opening the form again for the same item
+    // (or a fresh "add" after a cancel) would short-circuit `initializeFor` and reuse stale state.
+    DisposableEffect(Unit) {
+        onDispose { viewModel.onDismissed() }
     }
 
     BackHandler(enabled = true) { onBackClick() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -297,7 +297,8 @@ private fun TaxesToggle(
                 value = isTaxable,
                 role = Role.Switch,
                 onValueChange = onToggled,
-            ),
+            )
+            .padding(vertical = WooPosSpacing.Small.value),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -84,8 +84,12 @@ fun WooPosCustomAmountFormScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .navigationBarsPadding()
-                .padding(WooPosSpacing.Medium.value),
+                .padding(
+                    top = WooPosSpacing.Medium.value,
+                    start = WooPosSpacing.Medium.value,
+                    end = WooPosSpacing.Medium.value,
+                )
+                .navigationBarsPadding(),
         ) {
             FormSubmitButton(state = state, onSubmit = viewModel::onSubmit)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -308,24 +308,47 @@ private fun DialogActions(
     onSubmit: () -> Unit,
     onCancel: () -> Unit,
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
-    ) {
-        WooPosOutlinedButton(
-            modifier = Modifier.weight(1f),
-            text = stringResource(R.string.woopos_custom_amount_dialog_cancel),
-            onClick = onCancel,
-        )
-        val submitText = when (state.mode) {
-            is WooPosCustomAmountDialogState.Mode.Edit -> R.string.woopos_custom_amount_dialog_submit_edit
-            WooPosCustomAmountDialogState.Mode.Add -> R.string.woopos_custom_amount_dialog_submit_add
+    val submitText = when (state.mode) {
+        is WooPosCustomAmountDialogState.Mode.Edit -> R.string.woopos_custom_amount_dialog_submit_edit
+        WooPosCustomAmountDialogState.Mode.Add -> R.string.woopos_custom_amount_dialog_submit_add
+    }
+    val submitButtonState =
+        if (state.isSubmitEnabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED
+
+    when (currentWooPosBreakpoint()) {
+        WooPosBreakpoint.Phone -> Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),
+        ) {
+            WooPosButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(submitText),
+                state = submitButtonState,
+                onClick = onSubmit,
+            )
+            WooPosOutlinedButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(R.string.woopos_custom_amount_dialog_cancel),
+                onClick = onCancel,
+            )
         }
-        WooPosButton(
-            modifier = Modifier.weight(1f),
-            text = stringResource(submitText),
-            state = if (state.isSubmitEnabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED,
-            onClick = onSubmit,
-        )
+
+        WooPosBreakpoint.SmallTablet,
+        WooPosBreakpoint.Tablet -> Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
+        ) {
+            WooPosOutlinedButton(
+                modifier = Modifier.weight(1f),
+                text = stringResource(R.string.woopos_custom_amount_dialog_cancel),
+                onClick = onCancel,
+            )
+            WooPosButton(
+                modifier = Modifier.weight(1f),
+                text = stringResource(submitText),
+                state = submitButtonState,
+                onClick = onSubmit,
+            )
+        }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
@@ -75,6 +76,7 @@ fun WooPosCustomAmountFormScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .navigationBarsPadding()
                 .padding(WooPosSpacing.Medium.value),
         ) {
             FormSubmitButton(state = state, onSubmit = viewModel::onSubmit)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
@@ -30,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -287,7 +289,13 @@ private fun TaxesToggle(
     onToggled: (Boolean) -> Unit,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = isTaxable,
+                role = Role.Switch,
+                onValueChange = onToggled,
+            ),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -297,7 +305,7 @@ private fun TaxesToggle(
         )
         Switch(
             checked = isTaxable,
-            onCheckedChange = onToggled,
+            onCheckedChange = null,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -9,18 +9,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
@@ -29,25 +23,19 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosInputField
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosMoneyInputField
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIconSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
@@ -56,184 +44,45 @@ import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import java.math.BigDecimal
 
 @Composable
-fun WooPosCustomAmountDialog(
-    isVisible: Boolean,
+fun WooPosCustomAmountFormScreen(
     editing: WooPosCartItemViewState.CustomAmount?,
-    onDismissRequest: () -> Unit,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
     viewModel: WooPosCustomAmountDialogViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(isVisible, editing?.itemNumber) {
-        if (isVisible) {
-            viewModel.initializeFor(editing)
-        } else {
-            viewModel.onDismissed()
-        }
+    LaunchedEffect(editing?.itemNumber) {
+        viewModel.initializeFor(editing)
     }
+
+    BackHandler(enabled = true) { onBackClick() }
 
     val state by viewModel.state.collectAsState()
 
-    val dialogTitleRes = when (state.mode) {
-        is WooPosCustomAmountDialogState.Mode.Edit -> R.string.woopos_custom_amount_dialog_title_edit
-        WooPosCustomAmountDialogState.Mode.Add -> R.string.woopos_custom_amount_dialog_title_add
-    }
-
-    when (currentWooPosBreakpoint()) {
-        WooPosBreakpoint.Phone -> PhoneFullScreenLayout(
-            isVisible = isVisible,
-            state = state,
-            dialogTitleRes = dialogTitleRes,
-            onAmountChanged = viewModel::onAmountChanged,
-            onNameChanged = viewModel::onNameChanged,
-            onTaxableToggled = viewModel::onTaxableToggled,
-            onSubmit = viewModel::onSubmit,
-            onDismissRequest = onDismissRequest,
-        )
-
-        WooPosBreakpoint.SmallTablet,
-        WooPosBreakpoint.Tablet -> TabletDialogLayout(
-            isVisible = isVisible,
-            state = state,
-            dialogTitleRes = dialogTitleRes,
-            onAmountChanged = viewModel::onAmountChanged,
-            onNameChanged = viewModel::onNameChanged,
-            onTaxableToggled = viewModel::onTaxableToggled,
-            onSubmit = viewModel::onSubmit,
-            onDismissRequest = onDismissRequest,
-        )
-    }
-}
-
-@Composable
-private fun TabletDialogLayout(
-    isVisible: Boolean,
-    state: WooPosCustomAmountDialogState,
-    dialogTitleRes: Int,
-    onAmountChanged: (BigDecimal?) -> Unit,
-    onNameChanged: (String) -> Unit,
-    onTaxableToggled: (Boolean) -> Unit,
-    onSubmit: () -> Unit,
-    onDismissRequest: () -> Unit,
-) {
-    WooPosDialogWrapper(
-        isVisible = isVisible,
-        dialogBackgroundContentDescription = stringResource(dialogTitleRes),
-        onCloseClick = onDismissRequest,
-        onDismissRequest = onDismissRequest,
-    ) {
+    Column(modifier = modifier.fillMaxSize()) {
         Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
-        ) {
-            WooPosText(
-                text = stringResource(dialogTitleRes),
-                style = WooPosTypography.Heading,
-                fontWeight = FontWeight.Bold,
-            )
-
-            AmountSection(state = state, onAmountChanged = onAmountChanged)
-            NameSection(value = state.name, onNameChanged = onNameChanged)
-            TaxesToggle(isTaxable = state.isTaxable, onToggled = onTaxableToggled)
-
-            Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
-
-            DialogActions(
-                state = state,
-                breakpoint = WooPosBreakpoint.Tablet,
-                onSubmit = onSubmit,
-                onCancel = onDismissRequest,
-            )
-        }
-    }
-}
-
-@Composable
-private fun PhoneFullScreenLayout(
-    isVisible: Boolean,
-    state: WooPosCustomAmountDialogState,
-    dialogTitleRes: Int,
-    onAmountChanged: (BigDecimal?) -> Unit,
-    onNameChanged: (String) -> Unit,
-    onTaxableToggled: (Boolean) -> Unit,
-    onSubmit: () -> Unit,
-    onDismissRequest: () -> Unit,
-) {
-    if (!isVisible) return
-
-    BackHandler(enabled = true) { onDismissRequest() }
-
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.surface,
-    ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            PhoneToolbar(
-                titleRes = dialogTitleRes,
-                onCloseClick = onDismissRequest,
-            )
-
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = WooPosSpacing.Medium.value),
-                verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
-            ) {
-                Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
-                AmountSection(state = state, onAmountChanged = onAmountChanged)
-                NameSection(value = state.name, onNameChanged = onNameChanged)
-                TaxesToggle(isTaxable = state.isTaxable, onToggled = onTaxableToggled)
-            }
-
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .navigationBarsPadding()
-                    .padding(WooPosSpacing.Medium.value),
-            ) {
-                DialogActions(
-                    state = state,
-                    breakpoint = WooPosBreakpoint.Phone,
-                    onSubmit = onSubmit,
-                    onCancel = onDismissRequest,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun PhoneToolbar(
-    titleRes: Int,
-    onCloseClick: () -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .statusBarsPadding()
-            .padding(
-                horizontal = WooPosSpacing.Small.value,
-                vertical = WooPosSpacing.Small.value,
-            ),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        IconButton(onClick = onCloseClick) {
-            Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.ic_close_24dp),
-                contentDescription = stringResource(R.string.close),
-                modifier = Modifier.size(WooPosIconSize.Large.value),
-                tint = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-        WooPosText(
-            text = stringResource(titleRes),
-            style = WooPosTypography.Heading,
-            fontWeight = FontWeight.Bold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
             modifier = Modifier
                 .weight(1f)
-                .padding(end = WooPosIconSize.Large.value + WooPosSpacing.Small.value),
-        )
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = WooPosSpacing.Medium.value),
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
+        ) {
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+            AmountSection(state = state, onAmountChanged = viewModel::onAmountChanged)
+            NameSection(value = state.name, onNameChanged = viewModel::onNameChanged)
+            TaxesToggle(isTaxable = state.isTaxable, onToggled = viewModel::onTaxableToggled)
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(WooPosSpacing.Medium.value),
+        ) {
+            FormActions(
+                state = state,
+                onSubmit = viewModel::onSubmit,
+                onCancel = onBackClick,
+            )
+        }
     }
 }
 
@@ -335,9 +184,8 @@ private fun TaxesToggle(
 }
 
 @Composable
-private fun DialogActions(
+private fun FormActions(
     state: WooPosCustomAmountDialogState,
-    breakpoint: WooPosBreakpoint,
     onSubmit: () -> Unit,
     onCancel: () -> Unit,
 ) {
@@ -348,7 +196,7 @@ private fun DialogActions(
     val submitButtonState =
         if (state.isSubmitEnabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED
 
-    when (breakpoint) {
+    when (currentWooPosBreakpoint()) {
         WooPosBreakpoint.Phone -> Column(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -206,17 +206,16 @@ private fun PhoneToolbar(
     titleRes: Int,
     onCloseClick: () -> Unit,
 ) {
-    Row(
+    Box(
         modifier = Modifier
             .fillMaxWidth()
             .statusBarsPadding()
-            .padding(
-                horizontal = WooPosSpacing.Small.value,
-                vertical = WooPosSpacing.Small.value,
-            ),
-        verticalAlignment = Alignment.CenterVertically,
+            .padding(WooPosSpacing.Small.value),
     ) {
-        IconButton(onClick = onCloseClick) {
+        IconButton(
+            onClick = onCloseClick,
+            modifier = Modifier.align(Alignment.CenterStart),
+        ) {
             Icon(
                 imageVector = ImageVector.vectorResource(R.drawable.ic_close_24dp),
                 contentDescription = stringResource(R.string.close),
@@ -230,9 +229,7 @@ private fun PhoneToolbar(
             fontWeight = FontWeight.Bold,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier
-                .weight(1f)
-                .padding(end = WooPosIconSize.Large.value + WooPosSpacing.Small.value),
+            modifier = Modifier.align(Alignment.Center),
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -33,13 +34,10 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosInputField
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosMoneyInputField
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import java.math.BigDecimal
 
@@ -68,8 +66,10 @@ fun WooPosCustomAmountFormScreen(
         ) {
             Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
             AmountSection(state = state, onAmountChanged = viewModel::onAmountChanged)
-            NameSection(value = state.name, onNameChanged = viewModel::onNameChanged)
+            HorizontalDivider(color = WooPosTheme.colors.outlineVariant)
             TaxesToggle(isTaxable = state.isTaxable, onToggled = viewModel::onTaxableToggled)
+            HorizontalDivider(color = WooPosTheme.colors.outlineVariant)
+            NameSection(value = state.name, onNameChanged = viewModel::onNameChanged)
         }
 
         Box(
@@ -77,11 +77,7 @@ fun WooPosCustomAmountFormScreen(
                 .fillMaxWidth()
                 .padding(WooPosSpacing.Medium.value),
         ) {
-            FormActions(
-                state = state,
-                onSubmit = viewModel::onSubmit,
-                onCancel = onBackClick,
-            )
+            FormSubmitButton(state = state, onSubmit = viewModel::onSubmit)
         }
     }
 }
@@ -184,10 +180,9 @@ private fun TaxesToggle(
 }
 
 @Composable
-private fun FormActions(
+private fun FormSubmitButton(
     state: WooPosCustomAmountDialogState,
     onSubmit: () -> Unit,
-    onCancel: () -> Unit,
 ) {
     val submitText = when (state.mode) {
         is WooPosCustomAmountDialogState.Mode.Edit -> R.string.woopos_custom_amount_dialog_submit_edit
@@ -195,41 +190,10 @@ private fun FormActions(
     }
     val submitButtonState =
         if (state.isSubmitEnabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED
-
-    when (currentWooPosBreakpoint()) {
-        WooPosBreakpoint.Phone -> Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),
-        ) {
-            WooPosButton(
-                modifier = Modifier.fillMaxWidth(),
-                text = stringResource(submitText),
-                state = submitButtonState,
-                onClick = onSubmit,
-            )
-            WooPosOutlinedButton(
-                modifier = Modifier.fillMaxWidth(),
-                text = stringResource(R.string.woopos_custom_amount_dialog_cancel),
-                onClick = onCancel,
-            )
-        }
-
-        WooPosBreakpoint.SmallTablet,
-        WooPosBreakpoint.Tablet -> Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
-        ) {
-            WooPosOutlinedButton(
-                modifier = Modifier.weight(1f),
-                text = stringResource(R.string.woopos_custom_amount_dialog_cancel),
-                onClick = onCancel,
-            )
-            WooPosButton(
-                modifier = Modifier.weight(1f),
-                text = stringResource(submitText),
-                state = submitButtonState,
-                onClick = onSubmit,
-            )
-        }
-    }
+    WooPosButton(
+        modifier = Modifier.fillMaxWidth(),
+        text = stringResource(submitText),
+        state = submitButtonState,
+        onClick = onSubmit,
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -83,7 +83,7 @@ fun WooPosCustomAmountFormScreen(
         }
 
         Surface(
-            color = MaterialTheme.colorScheme.surfaceBright,
+            color = MaterialTheme.colorScheme.surface,
             modifier = Modifier.fillMaxWidth(),
         ) {
             FormSubmitButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -29,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
@@ -306,6 +308,13 @@ private fun TaxesToggle(
         Switch(
             checked = isTaxable,
             onCheckedChange = null,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = colorResource(R.color.color_on_primary),
+                checkedTrackColor = colorResource(R.color.color_primary),
+                uncheckedThumbColor = colorResource(R.color.divider_color),
+                uncheckedTrackColor = colorResource(R.color.color_surface_elevated),
+                uncheckedBorderColor = colorResource(R.color.divider_color),
+            ),
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountEntryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountEntryRow.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.items.customamount
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,10 +13,12 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -69,18 +72,13 @@ fun WooPosCustomAmountEntryRow(
         ) {
             Box(
                 modifier = Modifier
-                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .background(MaterialTheme.colorScheme.surfaceContainerLow)
                     .width(WooPosComponentSize.Large.value)
                     .fillMaxHeight()
                     .heightIn(min = WooPosComponentSize.Large.value),
                 contentAlignment = Alignment.Center,
             ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_gridicons_money_on_surface),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                    modifier = Modifier.size(44.dp.toAdaptiveIconSize()),
-                )
+                TagWithPlusBadge()
             }
 
             Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
@@ -108,6 +106,41 @@ fun WooPosCustomAmountEntryRow(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun TagWithPlusBadge() {
+    Box {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_gridicons_tag),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(44.dp.toAdaptiveIconSize()),
+        )
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .offset(x = 6.dp, y = 6.dp)
+                .size(18.dp)
+                .border(
+                    width = 2.dp,
+                    color = MaterialTheme.colorScheme.surfaceContainerLow,
+                    shape = CircleShape,
+                )
+                .background(
+                    color = MaterialTheme.colorScheme.onSurface,
+                    shape = CircleShape,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_add),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.surfaceContainerLow,
+                modifier = Modifier.size(12.dp),
+            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountEntryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountEntryRow.kt
@@ -25,8 +25,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -54,16 +54,18 @@ fun WooPosCustomAmountEntryRow(
     WooPosCard(
         modifier = modifier
             .fillMaxWidth()
-            .wrapContentHeight()
-            .clickable(onClick = onClick)
-            .semantics { contentDescription = title },
+            .wrapContentHeight(),
         backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
         elevation = WooPosElevation.Medium,
         shadowType = ShadowType.Soft,
         shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
     ) {
         Row(
-            modifier = Modifier.height(IntrinsicSize.Min),
+            modifier = Modifier
+                .clickable(onClick = onClick)
+                .clearAndSetSemantics { contentDescription = title }
+                .height(IntrinsicSize.Min)
+                .fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountEntryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountEntryRow.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.woopos.home.items.customamount
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,12 +12,10 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -78,7 +75,12 @@ fun WooPosCustomAmountEntryRow(
                     .heightIn(min = WooPosComponentSize.Large.value),
                 contentAlignment = Alignment.Center,
             ) {
-                TagWithPlusBadge()
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_shoppingmode_24dp),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.size(44.dp.toAdaptiveIconSize()),
+                )
             }
 
             Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
@@ -106,41 +108,6 @@ fun WooPosCustomAmountEntryRow(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-        }
-    }
-}
-
-@Composable
-private fun TagWithPlusBadge() {
-    Box {
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_gridicons_tag),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.size(44.dp.toAdaptiveIconSize()),
-        )
-        Box(
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .offset(x = 6.dp, y = 6.dp)
-                .size(18.dp)
-                .border(
-                    width = 2.dp,
-                    color = MaterialTheme.colorScheme.surfaceContainerLow,
-                    shape = CircleShape,
-                )
-                .background(
-                    color = MaterialTheme.colorScheme.onSurface,
-                    shape = CircleShape,
-                ),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.ic_add),
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.surfaceContainerLow,
-                modifier = Modifier.size(12.dp),
-            )
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountEntryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountEntryRow.kt
@@ -70,16 +70,16 @@ fun WooPosCustomAmountEntryRow(
             Box(
                 modifier = Modifier
                     .background(MaterialTheme.colorScheme.primaryContainer)
-                    .width(WooPosComponentSize.Medium.value)
+                    .width(WooPosComponentSize.Large.value)
                     .fillMaxHeight()
-                    .heightIn(min = WooPosComponentSize.Medium.value),
+                    .heightIn(min = WooPosComponentSize.Large.value),
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_gridicons_money_on_surface),
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                    modifier = Modifier.size(36.dp.toAdaptiveIconSize()),
+                    modifier = Modifier.size(44.dp.toAdaptiveIconSize()),
                 )
             }
 
@@ -94,7 +94,7 @@ fun WooPosCustomAmountEntryRow(
                 WooPosText(
                     text = title,
                     maxLines = 1,
-                    style = WooPosTypography.BodySmall,
+                    style = WooPosTypography.BodyLarge,
                     fontWeight = FontWeight.Bold,
                     overflow = TextOverflow.Ellipsis,
                     color = MaterialTheme.colorScheme.onSurface,
@@ -102,7 +102,7 @@ fun WooPosCustomAmountEntryRow(
                 Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value))
                 WooPosText(
                     text = subtitle,
-                    style = WooPosTypography.BodySmall,
+                    style = WooPosTypography.BodyLarge,
                     color = WooPosTheme.colors.onSurfaceVariantHighest,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountEntryRow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountEntryRow.kt
@@ -1,0 +1,121 @@
+package com.woocommerce.android.ui.woopos.home.items.customamount
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptiveIconSize
+
+@Composable
+fun WooPosCustomAmountEntryRow(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val title = stringResource(R.string.woopos_custom_amount_entry_title)
+    val subtitle = stringResource(R.string.woopos_custom_amount_entry_subtitle)
+
+    WooPosCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .clickable(onClick = onClick)
+            .semantics { contentDescription = title },
+        backgroundColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        elevation = WooPosElevation.Medium,
+        shadowType = ShadowType.Soft,
+        shape = RoundedCornerShape(WooPosCornerRadius.Medium.value),
+    ) {
+        Row(
+            modifier = Modifier.height(IntrinsicSize.Min),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .width(WooPosComponentSize.Medium.value)
+                    .fillMaxHeight()
+                    .heightIn(min = WooPosComponentSize.Medium.value),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_gridicons_money_on_surface),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(36.dp.toAdaptiveIconSize()),
+                )
+            }
+
+            Spacer(modifier = Modifier.width(WooPosSpacing.Medium.value))
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = WooPosSpacing.Medium.value)
+                    .padding(vertical = WooPosSpacing.Medium.value),
+            ) {
+                WooPosText(
+                    text = title,
+                    maxLines = 1,
+                    style = WooPosTypography.BodySmall,
+                    fontWeight = FontWeight.Bold,
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(modifier = Modifier.height(WooPosSpacing.XSmall.value))
+                WooPosText(
+                    text = subtitle,
+                    style = WooPosTypography.BodySmall,
+                    color = WooPosTheme.colors.onSurfaceVariantHighest,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@WooPosPreview
+@Composable
+fun WooPosCustomAmountEntryRowPreview() {
+    WooPosTheme {
+        WooPosCustomAmountEntryRow(onClick = {})
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsScreen.kt
@@ -111,14 +111,13 @@ private fun ProductsList(
         ) {
             when (val itemsState = state.value) {
                 is WooPosProductsViewState.Content -> {
-                    WooPosCustomAmountEntryRow(
-                        modifier = Modifier.padding(
-                            horizontal = WooPosSpacing.Medium.value,
-                            vertical = WooPosSpacing.XSmall.value,
-                        ),
-                        onClick = onCustomAmountEntryRowClicked,
+                    Content(
+                        itemsState = itemsState,
+                        listState = listState,
+                        onItemClicked = onItemClicked,
+                        onEndOfItemListReached = onEndOfItemListReached,
+                        onCustomAmountEntryRowClicked = onCustomAmountEntryRowClicked,
                     )
-                    Content(itemsState, listState, onItemClicked, onEndOfItemListReached)
                 }
 
                 is WooPosProductsViewState.Loading -> WooPosItemsLoadingIndicator(
@@ -148,12 +147,18 @@ private fun Content(
     itemsState: WooPosProductsViewState.Content,
     listState: LazyListState,
     onItemClicked: (item: WooPosItemSelectionViewState) -> Unit,
-    onEndOfItemListReached: () -> Unit
+    onEndOfItemListReached: () -> Unit,
+    onCustomAmountEntryRowClicked: () -> Unit,
 ) {
     WooPosItemList(
         modifier = Modifier.padding(top = WooPosSpacing.XSmall.value),
         state = itemsState,
         listState = listState,
+        headerContent = {
+            WooPosCustomAmountEntryRow(
+                onClick = onCustomAmountEntryRowClicked,
+            )
+        },
         onItemClicked = onItemClicked,
         onEndOfProductsListReached = onEndOfItemListReached,
     ) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsScreen.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsLoadingIndicator
 import com.woocommerce.android.ui.woopos.home.items.WooPosPaginationState
 import com.woocommerce.android.ui.woopos.home.items.WooPosProductsViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosPullToRefreshState
+import com.woocommerce.android.ui.woopos.home.items.customamount.WooPosCustomAmountEntryRow
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsUIEvent.EndOfItemsListReached
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsUIEvent.ProductsLoadingErrorRetryButtonClicked
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsUIEvent.PullToRefreshTriggered
@@ -74,6 +75,9 @@ private fun WooPosProductsScreen(
         onEndOfItemListReached = { onUIEvent(EndOfItemsListReached) },
         onRetryClicked = { onUIEvent(ProductsLoadingErrorRetryButtonClicked) },
         onPullToRefreshTriggered = { onUIEvent(PullToRefreshTriggered) },
+        onCustomAmountEntryRowClicked = {
+            onUIEvent(WooPosProductsUIEvent.CustomAmountEntryRowClicked)
+        },
     )
 }
 
@@ -87,6 +91,7 @@ private fun ProductsList(
     onEndOfItemListReached: () -> Unit,
     onRetryClicked: () -> Unit,
     onPullToRefreshTriggered: () -> Unit,
+    onCustomAmountEntryRowClicked: () -> Unit = {},
 ) {
     val pullToRefreshState = rememberPullRefreshState(
         refreshing = state.value.pullToRefreshState == WooPosPullToRefreshState.Refreshing,
@@ -106,6 +111,13 @@ private fun ProductsList(
         ) {
             when (val itemsState = state.value) {
                 is WooPosProductsViewState.Content -> {
+                    WooPosCustomAmountEntryRow(
+                        modifier = Modifier.padding(
+                            horizontal = WooPosSpacing.Medium.value,
+                            vertical = WooPosSpacing.XSmall.value,
+                        ),
+                        onClick = onCustomAmountEntryRowClicked,
+                    )
                     Content(itemsState, listState, onItemClicked, onEndOfItemListReached)
                 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsUIEvent.kt
@@ -7,4 +7,5 @@ sealed class WooPosProductsUIEvent {
     data object EndOfItemsListReached : WooPosProductsUIEvent()
     data object PullToRefreshTriggered : WooPosProductsUIEvent()
     data object ProductsLoadingErrorRetryButtonClicked : WooPosProductsUIEvent()
+    data object CustomAmountEntryRowClicked : WooPosProductsUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -107,6 +107,10 @@ class WooPosProductsViewModel @Inject constructor(
                 handleItemClick(event)
             }
 
+            WooPosProductsUIEvent.CustomAmountEntryRowClicked -> {
+                sendEventToParent(ChildToParentEvent.CustomAmountDialogRequested())
+            }
+
             WooPosProductsUIEvent.PullToRefreshTriggered -> {
                 handlePullToRefresh()
                 viewModelScope.launch {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -91,7 +91,8 @@ class WooPosProductsViewModel @Inject constructor(
                     is ParentToChildrenEvent.MissingVariationEvent,
                     is ParentToChildrenEvent.ProductsRemoved,
                     is ParentToChildrenEvent.SettingsEvent,
-                    is ParentToChildrenEvent.CustomAmountSubmitted -> Unit
+                    is ParentToChildrenEvent.CustomAmountSubmitted,
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> Unit
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -108,6 +108,9 @@ class WooPosProductsViewModel @Inject constructor(
             }
 
             WooPosProductsUIEvent.CustomAmountEntryRowClicked -> {
+                viewModelScope.launch {
+                    analyticsTracker.track(WooPosAnalyticsEvent.Event.CustomAmountEntryRowTapped)
+                }
                 sendEventToParent(ChildToParentEvent.CustomAmountDialogRequested())
             }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -241,6 +241,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
                     is ParentToChildrenEvent.MissingVariationEvent -> Unit
                     is ParentToChildrenEvent.SettingsEvent -> Unit
                     is ParentToChildrenEvent.CustomAmountSubmitted -> Unit
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> Unit
                     is ParentToChildrenEvent.ItemClickedInItemsList -> {
                         if (event.itemData is ItemClickedData.Product.Variation &&
                             searchHelper.isSearchOpen()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosPhoneProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosPhoneProductsScreen.kt
@@ -38,6 +38,7 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreen
 import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchScreen
+import com.woocommerce.android.ui.woopos.home.items.customamount.WooPosCustomAmountFormScreen
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsScreen
 import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsScreen
@@ -127,6 +128,14 @@ private fun WooPosPhoneProductsContent(
                         modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
                         variableProductData = data,
                         onBackClicked = {
+                            onItemsUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked)
+                        },
+                    )
+                },
+                customAmountFormContent = { editing ->
+                    WooPosCustomAmountFormScreen(
+                        editing = editing,
+                        onBackClick = {
                             onItemsUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked)
                         },
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -683,7 +683,8 @@ class WooPosTotalsViewModel @Inject constructor(
                     is ParentToChildrenEvent.RemoveProductsClicked,
                     is ParentToChildrenEvent.MissingVariationEvent,
                     is ParentToChildrenEvent.SettingsEvent,
-                    is ParentToChildrenEvent.CustomAmountSubmitted -> Unit
+                    is ParentToChildrenEvent.CustomAmountSubmitted,
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> Unit
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosOrdersState.kt
@@ -71,6 +71,8 @@ object WooPosOrdersState {
                     val lineTotal: String,
                     val imageUrl: String?,
                     val bookingInfo: BookingInfo? = null,
+                    val isLumpSum: Boolean = false,
+                    val includesTax: Boolean = false,
                 )
 
                 @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
@@ -1,6 +1,8 @@
 package com.woocommerce.android.ui.woopos.orders.details
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,6 +18,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -297,14 +300,16 @@ private fun OrderProductItem(row: WooPosOrdersState.OrderDetailsViewState.Comput
             }
         )
 
-        OrderLineItemImage(
-            imageUrl = row.imageUrl,
-            modifier = Modifier.constrainAs(image) {
-                start.linkTo(parent.start)
-                top.linkTo(parent.top)
-                bottom.linkTo(parent.bottom)
-            }
-        )
+        val imageModifier = Modifier.constrainAs(image) {
+            start.linkTo(parent.start)
+            top.linkTo(parent.top)
+            bottom.linkTo(parent.bottom)
+        }
+        if (row.isLumpSum) {
+            CustomAmountAvatar(modifier = imageModifier)
+        } else {
+            OrderLineItemImage(imageUrl = row.imageUrl, modifier = imageModifier)
+        }
 
         val hasAttributes = !row.attributesDescription.isNullOrEmpty()
         if (hasAttributes) {
@@ -330,10 +335,19 @@ private fun OrderProductItem(row: WooPosOrdersState.OrderDetailsViewState.Comput
         }
 
         val bookingInfo = row.bookingInfo
-        if (bookingInfo != null) {
-            BookingInfoContent(bookingInfo = bookingInfo, modifier = subtitleModifier)
-        } else {
-            WooPosText(
+        when {
+            bookingInfo != null -> BookingInfoContent(bookingInfo = bookingInfo, modifier = subtitleModifier)
+            row.isLumpSum -> {
+                if (row.includesTax) {
+                    WooPosText(
+                        text = stringResource(R.string.woopos_cart_custom_amount_includes_tax),
+                        style = WooPosTypography.BodyMedium,
+                        color = WooPosTheme.colors.onSurfaceVariantHighest,
+                        modifier = subtitleModifier,
+                    )
+                }
+            }
+            else -> WooPosText(
                 text = row.qtyAndUnitPrice,
                 style = WooPosTypography.BodyMedium,
                 color = WooPosTheme.colors.onSurfaceVariantHighest,
@@ -348,6 +362,24 @@ private fun OrderProductItem(row: WooPosOrdersState.OrderDetailsViewState.Comput
                 top.linkTo(nameText.top)
                 end.linkTo(parent.end)
             }
+        )
+    }
+}
+
+@Composable
+private fun CustomAmountAvatar(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .size(56.dp.toAdaptiveIconSize())
+            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
+            .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_gridicons_money_on_surface),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.size(WooPosIconSize.Small.value),
         )
     }
 }
@@ -706,6 +738,16 @@ fun WooPosOrderDetailsPreview() {
                     bookingInfo = WooPosOrdersState.OrderDetailsViewState.Computed.Details.BookingInfo.Loaded(
                         "Booking #33 \u00B7 Jul 5, 2025, 10:00 AM - 10:30 AM"
                     )
+                ),
+                WooPosOrdersState.OrderDetailsViewState.Computed.Details.LineItemRow(
+                    id = 901,
+                    name = "Gift wrap",
+                    attributesDescription = null,
+                    qtyAndUnitPrice = "",
+                    lineTotal = "$2.50",
+                    imageUrl = null,
+                    isLumpSum = true,
+                    includesTax = true,
                 )
             )
         ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
@@ -34,7 +34,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCustomAmountInitialsAvatar
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCustomAmountTileAvatar
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosItemImage
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverflowMenu
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverflowMenuItem
@@ -304,7 +304,7 @@ private fun OrderProductItem(row: WooPosOrdersState.OrderDetailsViewState.Comput
             bottom.linkTo(parent.bottom)
         }
         if (row.isLumpSum) {
-            CustomAmountAvatar(name = row.name, modifier = imageModifier)
+            WooPosCustomAmountTileAvatar(name = row.name, modifier = imageModifier)
         } else {
             OrderLineItemImage(imageUrl = row.imageUrl, modifier = imageModifier)
         }
@@ -362,16 +362,6 @@ private fun OrderProductItem(row: WooPosOrdersState.OrderDetailsViewState.Comput
             }
         )
     }
-}
-
-@Composable
-private fun CustomAmountAvatar(name: String, modifier: Modifier = Modifier) {
-    WooPosCustomAmountInitialsAvatar(
-        name = name,
-        modifier = modifier
-            .size(56.dp.toAdaptiveIconSize())
-            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
-    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetails.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.ui.woopos.orders.details
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -18,7 +16,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -37,6 +34,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.ShadowType
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCard
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCustomAmountInitialsAvatar
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosItemImage
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverflowMenu
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverflowMenuItem
@@ -306,7 +304,7 @@ private fun OrderProductItem(row: WooPosOrdersState.OrderDetailsViewState.Comput
             bottom.linkTo(parent.bottom)
         }
         if (row.isLumpSum) {
-            CustomAmountAvatar(modifier = imageModifier)
+            CustomAmountAvatar(name = row.name, modifier = imageModifier)
         } else {
             OrderLineItemImage(imageUrl = row.imageUrl, modifier = imageModifier)
         }
@@ -367,21 +365,13 @@ private fun OrderProductItem(row: WooPosOrdersState.OrderDetailsViewState.Comput
 }
 
 @Composable
-private fun CustomAmountAvatar(modifier: Modifier = Modifier) {
-    Box(
+private fun CustomAmountAvatar(name: String, modifier: Modifier = Modifier) {
+    WooPosCustomAmountInitialsAvatar(
+        name = name,
         modifier = modifier
             .size(56.dp.toAdaptiveIconSize())
-            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
-            .background(MaterialTheme.colorScheme.primaryContainer),
-        contentAlignment = Alignment.Center,
-    ) {
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_gridicons_money_on_surface),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-            modifier = Modifier.size(WooPosIconSize.Small.value),
-        )
-    }
+            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
+    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -194,7 +194,11 @@ class WooPosOrderDetailsMapper @Inject constructor(
                     lineTotal = formatPrice(feeLine.total, order.currency),
                     imageUrl = null,
                     isLumpSum = true,
-                    includesTax = feeLine.taxStatus == Order.FeeLine.FeeLineTaxStatus.TAXABLE,
+                    includesTax = when (feeLine.taxStatus) {
+                        Order.FeeLine.FeeLineTaxStatus.TAXABLE -> true
+                        Order.FeeLine.FeeLineTaxStatus.NONE,
+                        Order.FeeLine.FeeLineTaxStatus.UNKNOWN -> false
+                    },
                 )
             }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapper.kt
@@ -43,7 +43,8 @@ class WooPosOrderDetailsMapper @Inject constructor(
             is RefundsFetchResult.Error -> emptyList()
         }
         val nonRefundedItems = getNonRefundedItems(order, refunds)
-        val lineItems = buildLineItems(order, nonRefundedItems)
+        val lineItems = buildLineItems(order, nonRefundedItems) +
+            buildCustomAmountRows(order, refunds)
         val refundInfo = refundInfoBuilder.buildRefundInfo(order, historicalRefundsResult)
         val breakdown = refundInfoBuilder.buildTotalsBreakdown(order, refundInfo)
         val actions = orderActionsProvider.getAvailableActions(order)
@@ -80,7 +81,7 @@ class WooPosOrderDetailsMapper @Inject constructor(
         val lineItems = when {
             isFullyRefunded -> LineItemsState.Loaded(emptyList())
             hasPartialRefund -> LineItemsState.Loading
-            else -> LineItemsState.Loaded(buildLineItems(order))
+            else -> LineItemsState.Loaded(buildLineItems(order) + buildCustomAmountRows(order))
         }
         val refundedLineItems = when {
             isFullyRefunded || hasPartialRefund -> LineItemsState.Loading
@@ -134,7 +135,7 @@ class WooPosOrderDetailsMapper @Inject constructor(
             is RefundsFetchResult.Error -> emptyList()
         }
         val items = getNonRefundedItems(order, refunds)
-        return buildLineItems(order, items)
+        return buildLineItems(order, items) + buildCustomAmountRows(order, refunds)
     }
 
     suspend fun buildLineItemsForSingleRefund(
@@ -174,6 +175,28 @@ class WooPosOrderDetailsMapper @Inject constructor(
                 )
             }
         }.awaitAll()
+    }
+
+    private fun buildCustomAmountRows(
+        order: Order,
+        refunds: List<Refund> = emptyList()
+    ): List<LineItemRow> {
+        if (order.feesLines.isEmpty()) return emptyList()
+        val refundedFeeIds = refunds.flatMap { it.feeLines }.map { it.id }.toSet()
+        return order.feesLines
+            .filter { it.id !in refundedFeeIds }
+            .map { feeLine ->
+                LineItemRow(
+                    id = feeLine.id,
+                    name = feeLine.name.orEmpty(),
+                    attributesDescription = null,
+                    qtyAndUnitPrice = "",
+                    lineTotal = formatPrice(feeLine.total, order.currency),
+                    imageUrl = null,
+                    isLumpSum = true,
+                    includesTax = feeLine.taxStatus == Order.FeeLine.FeeLineTaxStatus.TAXABLE,
+                )
+            }
     }
 
     private suspend fun buildLineItems(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotal.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotal.kt
@@ -6,12 +6,20 @@ import javax.inject.Inject
 
 class WooPosCalculateRefundSubtotal @Inject constructor() {
     operator fun invoke(refundableItems: List<WooPosRefundableItem>, numberOfDecimals: Int,): BigDecimal {
-        return refundableItems
+        val (lumpSumItems, productRows) = refundableItems.partition { it.isLumpSum }
+
+        val productSubtotal = productRows
             .groupBy { it.orderItemId }
             .entries
             .sumOf { (_, items) ->
                 val quantity = items.size.toBigDecimal()
                 quantity.multiply(items.first().unitPrice).setScale(numberOfDecimals, RoundingMode.HALF_UP)
             }
+
+        val lumpSumSubtotal = lumpSumItems.sumOf {
+            it.unitPrice.setScale(numberOfDecimals, RoundingMode.HALF_UP)
+        }
+
+        return productSubtotal + lumpSumSubtotal
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTax.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTax.kt
@@ -17,14 +17,18 @@ class WooPosCalculateRefundTax @Inject constructor() {
             return BigDecimal.ZERO
         }
 
-        val totalTax = refundableItems
+        val (lumpSumItems, productRows) = refundableItems.partition { it.isLumpSum }
+
+        val productTax = productRows
             .groupBy { it.orderItemId }
             .entries
             .sumOf { (orderItemId, items) ->
                 calculateTotalTaxesForItem(orderItemId, items.size, order, numberOfDecimals, roundAtSubtotal)
             }
 
-        return totalTax.setScale(numberOfDecimals, RoundingMode.HALF_UP)
+        val lumpSumTax = lumpSumItems.sumOf { it.unitTax }
+
+        return (productTax + lumpSumTax).setScale(numberOfDecimals, RoundingMode.HALF_UP)
     }
 
     private fun calculateTotalTaxesForItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTax.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTax.kt
@@ -26,7 +26,7 @@ class WooPosCalculateRefundTax @Inject constructor() {
                 calculateTotalTaxesForItem(orderItemId, items.size, order, numberOfDecimals, roundAtSubtotal)
             }
 
-        val lumpSumTax = lumpSumItems.sumOf { it.unitTax }
+        val lumpSumTax = lumpSumItems.sumOf { it.unitTax.setScale(numberOfDecimals, RoundingMode.HALF_UP) }
 
         return (productTax + lumpSumTax).setScale(numberOfDecimals, RoundingMode.HALF_UP)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItems.kt
@@ -66,6 +66,9 @@ class WooPosGetRefundableItems @Inject constructor(
 
     private fun buildFeeRows(order: Order, refunds: List<Refund>): List<WooPosRefundableItem> {
         if (order.feesLines.isEmpty()) return emptyList()
+        // Fees are always refunded whole — POS does not split a single fee across refunds. Any past refund
+        // touching a fee removes it from the refundable list. If the back-end ever introduces partial-fee
+        // refunds, this needs to subtract the refunded amount instead.
         val refundedFeeIds = refunds.flatMap { it.feeLines }.map { it.id }.toSet()
         return order.feesLines
             .filter { it.id !in refundedFeeIds }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItems.kt
@@ -25,9 +25,13 @@ class WooPosGetRefundableItems @Inject constructor(
         order: Order,
         refunds: List<Refund>,
     ): List<WooPosRefundableItem> {
-        if (order.items.isEmpty()) {
-            return emptyList()
-        }
+        val productRows = buildProductRows(order, refunds)
+        val feeRows = buildFeeRows(order, refunds)
+        return productRows + feeRows
+    }
+
+    private fun buildProductRows(order: Order, refunds: List<Refund>): List<WooPosRefundableItem> {
+        if (order.items.isEmpty()) return emptyList()
 
         val maxQuantities: Map<Long, Float> = calculateMaxRefundQuantities(refunds, order.items)
 
@@ -53,11 +57,32 @@ class WooPosGetRefundableItems @Inject constructor(
                         unitTax = unitTax,
                         formattedUnitPrice = formattedUnitPrice,
                         formattedUnitTax = formattedUnitTax,
-                        rowIndex = index
+                        rowIndex = index,
                     )
                 }
             }
         }
+    }
+
+    private fun buildFeeRows(order: Order, refunds: List<Refund>): List<WooPosRefundableItem> {
+        if (order.feesLines.isEmpty()) return emptyList()
+        val refundedFeeIds = refunds.flatMap { it.feeLines }.map { it.id }.toSet()
+        return order.feesLines
+            .filter { it.id !in refundedFeeIds }
+            .map { feeLine ->
+                WooPosRefundableItem(
+                    orderItemId = feeLine.id,
+                    productId = 0L,
+                    variationId = 0L,
+                    name = feeLine.name.orEmpty(),
+                    unitPrice = feeLine.total,
+                    unitTax = feeLine.totalTax,
+                    formattedUnitPrice = PriceUtils.formatCurrency(feeLine.total, order.currency, currencyFormatter),
+                    formattedUnitTax = PriceUtils.formatCurrency(feeLine.totalTax, order.currency, currencyFormatter),
+                    rowIndex = 0,
+                    isLumpSum = true,
+                )
+            }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItems.kt
@@ -14,7 +14,9 @@ class WooPosGroupRefundItems @Inject constructor() {
         order: Order,
         numberOfDecimals: Int,
     ): List<RefundRequestItem> {
-        return refundableItems
+        val (lumpSumItems, productItems) = refundableItems.partition { it.isLumpSum }
+
+        val productRequests = productItems
             .groupBy { it.orderItemId }
             .map { (orderItemId, items) ->
                 val originalItem = requireNotNull(order.items.find { it.itemId == orderItemId }) {
@@ -29,6 +31,32 @@ class WooPosGroupRefundItems @Inject constructor() {
                     refundTax = calculateRefundTaxes(originalItem, refundQuantity, numberOfDecimals)
                 )
             }
+
+        val feeRequests = lumpSumItems.map { feeRow ->
+            val originalFee = requireNotNull(order.feesLines.find { it.id == feeRow.orderItemId }) {
+                "Fee line with ID ${feeRow.orderItemId} not found in order ${order.id}."
+            }
+            RefundRequestItem(
+                itemId = originalFee.id,
+                quantity = 0,
+                refundTotal = originalFee.total.setScale(numberOfDecimals, RoundingMode.HALF_UP),
+                refundTax = buildFeeRefundTaxes(originalFee, numberOfDecimals),
+            )
+        }
+
+        return productRequests + feeRequests
+    }
+
+    private fun buildFeeRefundTaxes(
+        feeLine: Order.FeeLine,
+        numberOfDecimals: Int,
+    ): List<RefundRequestTax> {
+        return feeLine.taxes.map { tax ->
+            RefundRequestTax(
+                taxRateId = tax.rateId,
+                refundTotal = tax.taxAmount.setScale(numberOfDecimals, RoundingMode.HALF_UP),
+            )
+        }
     }
 
     private fun calculateRefundTotal(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItems.kt
@@ -36,6 +36,8 @@ class WooPosGroupRefundItems @Inject constructor() {
             val originalFee = requireNotNull(order.feesLines.find { it.id == feeRow.orderItemId }) {
                 "Fee line with ID ${feeRow.orderItemId} not found in order ${order.id}."
             }
+            // WooCommerce REST refunds API uses `quantity` only for line items; fee refunds are
+            // identified by `id` + `refundTotal`, so quantity is always 0 for a fee row.
             RefundRequestItem(
                 itemId = originalFee.id,
                 quantity = 0,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -718,6 +718,24 @@ private fun ItemsHeaderRow(
 }
 
 @Composable
+private fun CustomAmountRefundAvatar() {
+    Box(
+        modifier = Modifier
+            .size(WooPosComponentSize.XSmall.value)
+            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
+            .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_gridicons_money_on_surface),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.size(WooPosIconSize.Small.value),
+        )
+    }
+}
+
+@Composable
 private fun RefundableItemRow(
     item: WooPosRefundableItem,
     isSelected: Boolean,
@@ -758,14 +776,18 @@ private fun RefundableItemRow(
         )
         Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
 
-        WooPosItemImage(
-            modifier = Modifier
-                .size(WooPosComponentSize.XSmall.value)
-                .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
-            imageUrl = null,
-            placeholderIcon = ImageVector.vectorResource(R.drawable.ic_inventory_2_24dp),
-            placeholderIconSize = WooPosIconSize.Small.value
-        )
+        if (item.isLumpSum) {
+            CustomAmountRefundAvatar()
+        } else {
+            WooPosItemImage(
+                modifier = Modifier
+                    .size(WooPosComponentSize.XSmall.value)
+                    .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
+                imageUrl = null,
+                placeholderIcon = ImageVector.vectorResource(R.drawable.ic_inventory_2_24dp),
+                placeholderIconSize = WooPosIconSize.Small.value
+            )
+        }
         Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
 
         Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -57,6 +57,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCustomAmountInitialsAvatar
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosItemImage
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
@@ -718,21 +719,13 @@ private fun ItemsHeaderRow(
 }
 
 @Composable
-private fun CustomAmountRefundAvatar() {
-    Box(
+private fun CustomAmountRefundAvatar(name: String) {
+    WooPosCustomAmountInitialsAvatar(
+        name = name,
         modifier = Modifier
             .size(WooPosComponentSize.XSmall.value)
-            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
-            .background(MaterialTheme.colorScheme.primaryContainer),
-        contentAlignment = Alignment.Center,
-    ) {
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_gridicons_money_on_surface),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-            modifier = Modifier.size(WooPosIconSize.Small.value),
-        )
-    }
+            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
+    )
 }
 
 @Composable
@@ -777,7 +770,7 @@ private fun RefundableItemRow(
         Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
 
         if (item.isLumpSum) {
-            CustomAmountRefundAvatar()
+            CustomAmountRefundAvatar(name = item.name)
         } else {
             WooPosItemImage(
                 modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -57,7 +57,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCustomAmountInitialsAvatar
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCustomAmountTileAvatar
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosItemImage
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
@@ -719,16 +719,6 @@ private fun ItemsHeaderRow(
 }
 
 @Composable
-private fun CustomAmountRefundAvatar(name: String) {
-    WooPosCustomAmountInitialsAvatar(
-        name = name,
-        modifier = Modifier
-            .size(WooPosComponentSize.XSmall.value)
-            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
-    )
-}
-
-@Composable
 private fun RefundableItemRow(
     item: WooPosRefundableItem,
     isSelected: Boolean,
@@ -770,7 +760,7 @@ private fun RefundableItemRow(
         Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
 
         if (item.isLumpSum) {
-            CustomAmountRefundAvatar(name = item.name)
+            WooPosCustomAmountTileAvatar(name = item.name)
         } else {
             WooPosItemImage(
                 modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundableItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundableItem.kt
@@ -14,7 +14,8 @@ data class WooPosRefundableItem(
     val formattedUnitPrice: String,
     val formattedUnitTax: String,
     val rowIndex: Int,
+    val isLumpSum: Boolean = false,
 ) {
     val uniqueId: String
-        get() = "${orderItemId}_$rowIndex"
+        get() = if (isLumpSum) "fee_$orderItemId" else "${orderItemId}_$rowIndex"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -120,6 +120,10 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "clear_cart_tapped"
         }
 
+        data object CustomAmountEntryRowTapped : Event() {
+            override val name: String = "custom_amount_entry_row_tapped"
+        }
+
         data class CustomAmountSubmitted(
             val mode: Mode,
             val isTaxable: Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -19,7 +19,7 @@ enum class FeatureFlag(
     LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES("woo_notification_1d_before_free_trial_expires"),
     LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES("woo_notification_1d_after_free_trial_expires"),
     WOO_POS("woo_pos"),
-    WOO_POS_PHONE("woo_pos_phone", localValue = true),
+    WOO_POS_PHONE("woo_pos_phone", localValue = PackageUtils.isDebugBuild()),
     WOO_POS_TAP_TO_PAY("woo_pos_tap_to_pay", localValue = PackageUtils.isDebugBuild()),
     APP_PASSWORDS_FOR_JETPACK_SITES("woo_app_passwords_for_jetpack_sites"),
     WOO_POS_LOCAL_CATALOG_M1("woo_pos_local_catalog_m1"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -19,7 +19,7 @@ enum class FeatureFlag(
     LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES("woo_notification_1d_before_free_trial_expires"),
     LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES("woo_notification_1d_after_free_trial_expires"),
     WOO_POS("woo_pos"),
-    WOO_POS_PHONE("woo_pos_phone", localValue = PackageUtils.isDebugBuild()),
+    WOO_POS_PHONE("woo_pos_phone", localValue = true),
     WOO_POS_TAP_TO_PAY("woo_pos_tap_to_pay", localValue = PackageUtils.isDebugBuild()),
     APP_PASSWORDS_FOR_JETPACK_SITES("woo_app_passwords_for_jetpack_sites"),
     WOO_POS_LOCAL_CATALOG_M1("woo_pos_local_catalog_m1"),

--- a/WooCommerce/src/main/res/drawable/ic_shoppingmode_24dp.xml
+++ b/WooCommerce/src/main/res/drawable/ic_shoppingmode_24dp.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@color/color_icon"
+            android:pathData="M446,-80q-15,0 -30,-6t-27,-18L103,-390q-12,-12 -17.5,-26.5T80,-446q0,-15 5.5,-30t17.5,-27l352,-353q11,-11 26,-17.5t31,-6.5h287q33,0 56.5,23.5T879,-800v287q0,16 -6,30.5T856,-457L503,-104q-12,12 -27,18t-30,6Zm0,-80 353,-354v-286H513L160,-446l286,286Zm253,-480q25,0 42.5,-17.5T759,-700q0,-25 -17.5,-42.5T699,-760q-25,0 -42.5,17.5T639,-700q0,25 17.5,42.5T699,-640ZM480,-480Z" />
+    </group>
+</vector>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3709,7 +3709,15 @@
     <string name="woopos_cart_custom_amount_includes_tax">Tax included</string>
     <string name="woopos_cart_custom_amount_menu_edit">Edit</string>
     <string name="woopos_cart_custom_amount_menu_remove">Remove</string>
+    <string name="woopos_custom_amount_dialog_title_add">Add custom amount</string>
+    <string name="woopos_custom_amount_dialog_title_edit">Edit custom amount</string>
+    <string name="woopos_custom_amount_dialog_amount_label">Amount</string>
+    <string name="woopos_custom_amount_dialog_name_label">Name</string>
     <string name="woopos_custom_amount_dialog_name_placeholder">Custom amount</string>
+    <string name="woopos_custom_amount_dialog_charge_taxes">Charge taxes</string>
+    <string name="woopos_custom_amount_dialog_submit_add">Add custom amount</string>
+    <string name="woopos_custom_amount_dialog_submit_edit">Update custom amount</string>
+    <string name="woopos_custom_amount_dialog_cancel">Cancel</string>
     <string name="woopos_cart_title">Cart</string>
     <string name="woopos_cart_changes_in_the_cart">There are changes in the cart</string>
     <string name="woopos_cart_barcode_scan_result_product_not_found">Unknown scanned item</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3709,6 +3709,8 @@
     <string name="woopos_cart_custom_amount_includes_tax">Tax included</string>
     <string name="woopos_cart_custom_amount_menu_edit">Edit</string>
     <string name="woopos_cart_custom_amount_menu_remove">Remove</string>
+    <string name="woopos_custom_amount_entry_title">Custom amount</string>
+    <string name="woopos_custom_amount_entry_subtitle">Add a one-off charge</string>
     <string name="woopos_custom_amount_dialog_title_add">Add custom amount</string>
     <string name="woopos_custom_amount_dialog_title_edit">Edit custom amount</string>
     <string name="woopos_custom_amount_dialog_amount_label">Amount</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3714,6 +3714,7 @@
     <string name="woopos_custom_amount_entry_subtitle">Add a one-off charge</string>
     <string name="woopos_custom_amount_dialog_title_add">Add custom amount</string>
     <string name="woopos_custom_amount_dialog_title_edit">Edit custom amount</string>
+    <string name="woopos_custom_amount_form_title">Custom amount</string>
     <string name="woopos_custom_amount_dialog_amount_label">Amount</string>
     <string name="woopos_custom_amount_dialog_name_label">Name</string>
     <string name="woopos_custom_amount_dialog_name_placeholder">Custom amount</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3706,6 +3706,7 @@
     <string name="woopos_add_coupon_to_cart_accessibility_label">Add coupon to cart</string>
     <string name="woopos_cart_item_coupon_content_description">Coupon in cart %s</string>
     <string name="woopos_cart_item_custom_amount_content_description">Custom amount %1$s, %2$s</string>
+    <string name="woopos_cart_custom_amount_edit_content_description">Edit %s</string>
     <string name="woopos_cart_custom_amount_includes_tax">Tax included</string>
     <string name="woopos_cart_custom_amount_menu_edit">Edit</string>
     <string name="woopos_cart_custom_amount_menu_remove">Remove</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -375,6 +375,63 @@ class WooPosItemsViewModelTest {
     }
 
     @Test
+    fun `when ShowCustomAmountForm received, then state changes to CustomAmountForm`() = runTest {
+        // GIVEN
+        whenever(parentToChildrenEventReceiver.events).thenReturn(
+            flowOf(ParentToChildrenEvent.ShowCustomAmountForm())
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsToolbarViewState.CustomAmountForm::class.java)
+            assertThat((state as WooPosItemsToolbarViewState.CustomAmountForm).editing).isNull()
+        }
+    }
+
+    @Test
+    fun `when CustomAmountSubmitted received during form, then state restores preserved state`() = runTest {
+        // GIVEN
+        whenever(parentToChildrenEventReceiver.events).thenReturn(
+            flowOf(
+                ParentToChildrenEvent.ShowCustomAmountForm(),
+                ParentToChildrenEvent.CustomAmountSubmitted(
+                    name = "Tip",
+                    amount = java.math.BigDecimal("1.00"),
+                    isTaxable = false,
+                ),
+            )
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsToolbarViewState.ProductList::class.java)
+        }
+    }
+
+    @Test
+    fun `given on product list, when navigateBackFromSubScreen path triggers unexpectedly, then state is unchanged`() = runTest {
+        // GIVEN — no sub-screen open
+        val viewModel = createViewModel()
+
+        // WHEN — back-from-variations event fires while already on the product list
+        viewModel.onUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked)
+
+        // THEN — state remains the product list (no crash, no transition)
+        viewModel.viewState.test {
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsToolbarViewState.ProductList::class.java)
+        }
+    }
+
+    @Test
     fun `when products tab clicked, then analytics event is tracked`() = runTest {
         // GIVEN
         val productsTab = WooPosItemsToolbarViewState.Tab.Products(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -62,6 +62,9 @@ class WooPosItemsViewModelTest {
     private val syncStatusChecker: WooPosFullSyncStatusChecker = mock()
     private val dateTimeProvider: DateTimeProvider = mock()
     private val isWooVersionSunsetWarningRequired: WooPosIsWooCommerceVersionSunsetWarningRequired = mock()
+    private val resourceProvider: com.woocommerce.android.viewmodel.ResourceProvider = mock {
+        on { getString(any()) }.thenReturn("Custom amount")
+    }
 
     @Before
     fun setup() = runTest {
@@ -616,6 +619,7 @@ class WooPosItemsViewModelTest {
             syncStatusChecker = syncStatusChecker,
             dateTimeProvider = dateTimeProvider,
             isWooCommerceVersionSunsetWarningRequired = isWooVersionSunsetWarningRequired,
+            resourceProvider = resourceProvider,
         )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModelTest.kt
@@ -338,6 +338,23 @@ class WooPosProductsViewModelTest {
     }
 
     @Test
+    fun `when custom amount entry row clicked, then dialog request event sent and tracked`() = runTest {
+        // GIVEN
+        val viewModel = createViewModel()
+
+        // WHEN
+        viewModel.onUIEvent(WooPosProductsUIEvent.CustomAmountEntryRowClicked)
+
+        // THEN
+        verify(fromChildToParentEventSender).sendToParent(
+            eq(ChildToParentEvent.CustomAmountDialogRequested())
+        )
+        verify(analyticsTracker).track(
+            eq(WooPosAnalyticsEvent.Event.CustomAmountEntryRowTapped)
+        )
+    }
+
+    @Test
     fun `when pull to refresh, then should track event`() = runTest {
         // GIVEN
         whenever(productsDataSource.refreshProducts()).thenReturn(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -13,13 +13,15 @@ import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsVi
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersState.OrderDetailsViewState.Computed.Details.TotalsBreakdown
 import com.woocommerce.android.ui.woopos.orders.details.refund.RefundInfo
 import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundInfoBuilder
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
-import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -30,7 +32,10 @@ import java.math.BigDecimal
 import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class WooPosOrderDetailsMapperTest : BaseUnitTest() {
+class WooPosOrderDetailsMapperTest {
+    @Rule
+    @JvmField
+    val coroutineTestRule = WooPosCoroutineTestRule()
 
     private val resourceProvider: ResourceProvider = mock()
     private val getProductById: WooPosGetProductById = mock()
@@ -153,7 +158,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         OrderTestUtils.generateTestOrder().copy(items = items)
 
     @Test
-    fun `given order is paid, when mapOrderDetails, then totalPaid equals formatted total`() = testBlocking {
+    fun `given order is paid, when mapOrderDetails, then totalPaid equals formatted total`() = runTest {
         whenever(formatPrice(paidOrder.total, paidOrder.currency)).thenReturn("$106.00")
 
         val result = sut.mapOrderDetails(paidOrder, RefundsFetchResult.Success(emptyList()))
@@ -162,7 +167,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given order is unpaid, when mapOrderDetails, then totalPaid equals formatted zero`() = testBlocking {
+    fun `given order is unpaid, when mapOrderDetails, then totalPaid equals formatted zero`() = runTest {
         val unpaidOrder = paidOrder.copy(datePaid = null)
         whenever(formatPrice(unpaidOrder.total, unpaidOrder.currency)).thenReturn("$106.00")
         whenever(formatPrice(BigDecimal.ZERO, unpaidOrder.currency)).thenReturn("$0.00")
@@ -174,7 +179,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given order is paid, when mapOrderDetailsWithoutRefunds, then totalPaid equals formatted total`() =
-        testBlocking {
+        runTest {
             whenever(formatPrice(paidOrder.total)).thenReturn("$106.00")
 
             val result = sut.mapOrderDetailsWithoutRefunds(paidOrder)
@@ -184,7 +189,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given order is unpaid, when mapOrderDetailsWithoutRefunds, then totalPaid equals formatted zero`() =
-        testBlocking {
+        runTest {
             val unpaidOrder = paidOrder.copy(datePaid = null)
             whenever(formatPrice(unpaidOrder.total)).thenReturn("$106.00")
             whenever(formatPrice(BigDecimal.ZERO)).thenReturn("$0.00")
@@ -195,7 +200,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given refunds with items, when mapOrderDetails, then refundedLineItems are populated`() = testBlocking {
+    fun `given refunds with items, when mapOrderDetails, then refundedLineItems are populated`() = runTest {
         // GIVEN
         setupDefaults()
         val orderItems = listOf(
@@ -229,7 +234,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given multiple refunds for same item, when mapOrderDetails, then quantities are aggregated`() = testBlocking {
+    fun `given multiple refunds for same item, when mapOrderDetails, then quantities are aggregated`() = runTest {
         // GIVEN
         setupDefaults()
         val orderItems = listOf(
@@ -264,7 +269,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given refunds with no items, when mapOrderDetails, then refundedLineItems is empty`() = testBlocking {
+    fun `given refunds with no items, when mapOrderDetails, then refundedLineItems is empty`() = runTest {
         // GIVEN
         setupDefaults()
         val orderItems = listOf(
@@ -284,7 +289,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given refund fetch error, when mapOrderDetails, then refundedLineItems is empty`() = testBlocking {
+    fun `given refund fetch error, when mapOrderDetails, then refundedLineItems is empty`() = runTest {
         // GIVEN
         setupDefaults()
         val orderItems = listOf(
@@ -302,7 +307,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given order without refunds, when mapOrderDetailsWithoutRefunds, then lineItems loaded and refunds empty`() =
-        testBlocking {
+        runTest {
             // GIVEN
             setupDefaults()
             val orderItems = listOf(
@@ -321,7 +326,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given order with partial refund, when mapOrderDetailsWithoutRefunds, then both lineItems are loading`() =
-        testBlocking {
+        runTest {
             // GIVEN
             setupDefaults()
             val orderItems = listOf(
@@ -339,7 +344,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given fully refunded order, when mapOrderDetailsWithoutRefunds, then lineItems loaded empty and refundedLineItems loading`() =
-        testBlocking {
+        runTest {
             // GIVEN
             setupDefaults()
             val orderItems = listOf(
@@ -359,7 +364,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given refunds for multiple items, when mapOrderDetails, then each item has separate entry`() = testBlocking {
+    fun `given refunds for multiple items, when mapOrderDetails, then each item has separate entry`() = runTest {
         // GIVEN
         setupDefaults()
         val orderItems = listOf(
@@ -393,7 +398,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given fully refunded item, when mapOrderDetails, then item is excluded from lineItems`() = testBlocking {
+    fun `given fully refunded item, when mapOrderDetails, then item is excluded from lineItems`() = runTest {
         // GIVEN
         setupDefaults()
         val orderItems = listOf(
@@ -423,7 +428,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given no refunds, when mapOrderDetails, then all items shown in lineItems`() = testBlocking {
+    fun `given no refunds, when mapOrderDetails, then all items shown in lineItems`() = runTest {
         // GIVEN
         setupDefaults()
         val orderItems = listOf(
@@ -445,7 +450,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given refunded item not found in order, when buildRefundedLineItems, then refund item name is used as fallback`() =
-        testBlocking {
+        runTest {
             // GIVEN
             setupDefaults()
             val orderItems = listOf(
@@ -477,7 +482,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given same product in different line items, when one is refunded, then only that line item is affected`() =
-        testBlocking {
+        runTest {
             // GIVEN
             setupDefaults()
             val orderItems = listOf(
@@ -520,7 +525,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given refund with tax, when buildRefundedLineItems, then prices exclude tax`() = testBlocking {
+    fun `given refund with tax, when buildRefundedLineItems, then prices exclude tax`() = runTest {
         // GIVEN
         setupDefaults()
         val orderItems = listOf(
@@ -553,7 +558,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given refund with negative quantity, when buildRefundedLineItems, then quantity is shown as positive`() =
-        testBlocking {
+        runTest {
             // GIVEN
             setupDefaults()
             val orderItems = listOf(
@@ -592,7 +597,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given order with partial refund, when mapOrderDetailsWithoutRefunds, then refundsState is Loading`() =
-        testBlocking {
+        runTest {
             // GIVEN
             setupDefaults()
             val orderItems = listOf(
@@ -609,7 +614,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given fully refunded order, when mapOrderDetailsWithoutRefunds, then refundsState is Loading`() =
-        testBlocking {
+        runTest {
             // GIVEN
             setupDefaults()
             val orderItems = listOf(
@@ -629,7 +634,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given order without refunds, when mapOrderDetailsWithoutRefunds, then refundsState is Loaded empty`() =
-        testBlocking {
+        runTest {
             // GIVEN
             setupDefaults()
             val orderItems = listOf(
@@ -646,7 +651,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given order with fee line, when mapOrderDetails, then custom amount row is appended after products`() =
-        testBlocking {
+        runTest {
             // GIVEN
             setupDefaults()
             val order = createOrder(
@@ -670,7 +675,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given taxable fee line, when mapOrderDetails, then row includesTax is true`() = testBlocking {
+    fun `given taxable fee line, when mapOrderDetails, then row includesTax is true`() = runTest {
         // GIVEN
         setupDefaults()
         val order = createOrder(items = emptyList()).copy(
@@ -694,7 +699,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given non-taxable fee line, when mapOrderDetails, then row includesTax is false`() = testBlocking {
+    fun `given non-taxable fee line, when mapOrderDetails, then row includesTax is false`() = runTest {
         // GIVEN
         setupDefaults()
         val order = createOrder(items = emptyList()).copy(
@@ -716,7 +721,29 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given fee line refunded by id, when mapOrderDetails, then fee row is excluded`() = testBlocking {
+    fun `given unknown tax status fee line, when mapOrderDetails, then row includesTax is false`() = runTest {
+        // GIVEN
+        setupDefaults()
+        val order = createOrder(items = emptyList()).copy(
+            feesLines = listOf(
+                createFeeLine(
+                    id = 1L,
+                    name = "Service charge",
+                    total = BigDecimal("3.50"),
+                    taxStatus = Order.FeeLine.FeeLineTaxStatus.UNKNOWN,
+                )
+            )
+        )
+
+        // WHEN
+        val result = sut.mapOrderDetails(order, RefundsFetchResult.Success(emptyList()))
+
+        // THEN
+        assertThat((result.lineItems as LineItemsState.Loaded).items.single().includesTax).isFalse()
+    }
+
+    @Test
+    fun `given fee line refunded by id, when mapOrderDetails, then fee row is excluded`() = runTest {
         // GIVEN
         setupDefaults()
         val order = createOrder(items = emptyList()).copy(
@@ -749,7 +776,7 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
 
     @Test
     fun `given order with fee line, when mapOrderDetailsWithoutRefunds, then custom amount row is appended`() =
-        testBlocking {
+        runTest {
             // GIVEN
             setupDefaults()
             val order = createOrder(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/WooPosOrderDetailsMapperTest.kt
@@ -643,4 +643,153 @@ class WooPosOrderDetailsMapperTest : BaseUnitTest() {
             // THEN
             assertThat(result.breakdown.refundsState).isEqualTo(RefundsState.Loaded(refunds = emptyList()))
         }
+
+    @Test
+    fun `given order with fee line, when mapOrderDetails, then custom amount row is appended after products`() =
+        testBlocking {
+            // GIVEN
+            setupDefaults()
+            val order = createOrder(
+                items = listOf(
+                    createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00")),
+                )
+            ).copy(
+                feesLines = listOf(createFeeLine(id = 99L, name = "Gift wrap", total = BigDecimal("2.50")))
+            )
+
+            // WHEN
+            val result = sut.mapOrderDetails(order, RefundsFetchResult.Success(emptyList()))
+
+            // THEN
+            val lineItems = (result.lineItems as LineItemsState.Loaded).items
+            assertThat(lineItems).hasSize(2)
+            assertThat(lineItems[0].isLumpSum).isFalse()
+            assertThat(lineItems[1].isLumpSum).isTrue()
+            assertThat(lineItems[1].name).isEqualTo("Gift wrap")
+            assertThat(lineItems[1].lineTotal).isEqualTo("$2.50")
+        }
+
+    @Test
+    fun `given taxable fee line, when mapOrderDetails, then row includesTax is true`() = testBlocking {
+        // GIVEN
+        setupDefaults()
+        val order = createOrder(items = emptyList()).copy(
+            feesLines = listOf(
+                createFeeLine(
+                    id = 1L,
+                    name = "Service charge",
+                    total = BigDecimal("5.00"),
+                    taxStatus = Order.FeeLine.FeeLineTaxStatus.TAXABLE,
+                )
+            )
+        )
+
+        // WHEN
+        val result = sut.mapOrderDetails(order, RefundsFetchResult.Success(emptyList()))
+
+        // THEN
+        val row = (result.lineItems as LineItemsState.Loaded).items.single()
+        assertThat(row.isLumpSum).isTrue()
+        assertThat(row.includesTax).isTrue()
+    }
+
+    @Test
+    fun `given non-taxable fee line, when mapOrderDetails, then row includesTax is false`() = testBlocking {
+        // GIVEN
+        setupDefaults()
+        val order = createOrder(items = emptyList()).copy(
+            feesLines = listOf(
+                createFeeLine(
+                    id = 1L,
+                    name = "Tip",
+                    total = BigDecimal("1.00"),
+                    taxStatus = Order.FeeLine.FeeLineTaxStatus.NONE,
+                )
+            )
+        )
+
+        // WHEN
+        val result = sut.mapOrderDetails(order, RefundsFetchResult.Success(emptyList()))
+
+        // THEN
+        assertThat((result.lineItems as LineItemsState.Loaded).items.single().includesTax).isFalse()
+    }
+
+    @Test
+    fun `given fee line refunded by id, when mapOrderDetails, then fee row is excluded`() = testBlocking {
+        // GIVEN
+        setupDefaults()
+        val order = createOrder(items = emptyList()).copy(
+            feesLines = listOf(
+                createFeeLine(id = 1L, name = "Gift wrap", total = BigDecimal("2.50")),
+                createFeeLine(id = 2L, name = "Tip", total = BigDecimal("1.00")),
+            )
+        )
+        val refund = Refund(
+            id = 1L,
+            dateCreated = Date(),
+            amount = BigDecimal("2.50"),
+            reason = null,
+            automaticGatewayRefund = false,
+            items = emptyList(),
+            shippingLines = emptyList(),
+            feeLines = listOf(
+                Refund.FeeLine(id = 1L, name = "Gift wrap", totalTax = BigDecimal.ZERO, total = BigDecimal("-2.50"))
+            ),
+        )
+
+        // WHEN
+        val result = sut.mapOrderDetails(order, RefundsFetchResult.Success(listOf(refund)))
+
+        // THEN
+        val rows = (result.lineItems as LineItemsState.Loaded).items
+        assertThat(rows).hasSize(1)
+        assertThat(rows.single().name).isEqualTo("Tip")
+    }
+
+    @Test
+    fun `given order with fee line, when mapOrderDetailsWithoutRefunds, then custom amount row is appended`() =
+        testBlocking {
+            // GIVEN
+            setupDefaults()
+            val order = createOrder(
+                items = listOf(
+                    createOrderItem(itemId = 1L, productId = 10L, name = "Cup", price = BigDecimal("4.00")),
+                )
+            ).copy(
+                feesLines = listOf(
+                    createFeeLine(
+                        id = 99L,
+                        name = "Service charge",
+                        total = BigDecimal("3.00"),
+                        taxStatus = Order.FeeLine.FeeLineTaxStatus.TAXABLE,
+                    )
+                )
+            )
+
+            // WHEN
+            val result = sut.mapOrderDetailsWithoutRefunds(order)
+
+            // THEN
+            val rows = (result.lineItems as LineItemsState.Loaded).items
+            assertThat(rows).hasSize(2)
+            assertThat(rows.last().isLumpSum).isTrue()
+            assertThat(rows.last().includesTax).isTrue()
+            assertThat(rows.last().name).isEqualTo("Service charge")
+        }
+
+    private fun createFeeLine(
+        id: Long,
+        name: String,
+        total: BigDecimal,
+        totalTax: BigDecimal = BigDecimal.ZERO,
+        taxStatus: Order.FeeLine.FeeLineTaxStatus = Order.FeeLine.FeeLineTaxStatus.NONE,
+    ) = Order.FeeLine(
+        id = id,
+        name = name,
+        total = total,
+        totalTax = totalTax,
+        taxStatus = taxStatus,
+        taxes = emptyList(),
+    )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotalTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotalTest.kt
@@ -32,7 +32,7 @@ class WooPosCalculateRefundSubtotalTest {
     @Test
     fun `given empty list, when invoke called, then returns zero`() {
         val result = sut(emptyList(), 2)
-        assertThat(result).isEqualTo(BigDecimal("0"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("0"))
     }
 
     @Test
@@ -43,7 +43,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 2)
 
-        assertThat(result).isEqualTo(BigDecimal("20.00"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("20.00"))
     }
 
     @Test
@@ -56,7 +56,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 2)
 
-        assertThat(result).isEqualTo(BigDecimal("60.00"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("60.00"))
     }
 
     @Test
@@ -69,7 +69,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 2)
 
-        assertThat(result).isEqualTo(BigDecimal("60.00"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("60.00"))
     }
 
     @Test
@@ -85,7 +85,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 2)
 
-        assertThat(result).isEqualTo(BigDecimal("85.00"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("85.00"))
     }
 
     @Test
@@ -98,7 +98,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 2)
 
-        assertThat(result).isEqualTo(BigDecimal("31.00"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("31.00"))
     }
 
     @Test
@@ -110,7 +110,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 3)
 
-        assertThat(result).isEqualTo(BigDecimal("20.667"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("20.667"))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotalTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotalTest.kt
@@ -112,4 +112,45 @@ class WooPosCalculateRefundSubtotalTest {
 
         assertThat(result).isEqualTo(BigDecimal("20.667"))
     }
+
+    @Test
+    fun `given lump-sum fee row, when invoke called, then total is the fee unit price, not multiplied by quantity`() {
+        val feeRow = WooPosRefundableItem(
+            orderItemId = 99L,
+            productId = 0L,
+            variationId = 0L,
+            name = "Tip",
+            unitPrice = BigDecimal("12.50"),
+            unitTax = BigDecimal.ZERO,
+            formattedUnitPrice = "$12.50",
+            formattedUnitTax = "$0.00",
+            rowIndex = 0,
+            isLumpSum = true,
+        )
+
+        val result = sut(listOf(feeRow), 2)
+
+        assertThat(result).isEqualByComparingTo(BigDecimal("12.50"))
+    }
+
+    @Test
+    fun `given product and lump-sum rows, when invoke called, then both are summed`() {
+        val product = createRefundableItem(orderItemId = 1L, unitPrice = BigDecimal("20.00"))
+        val fee = WooPosRefundableItem(
+            orderItemId = 99L,
+            productId = 0L,
+            variationId = 0L,
+            name = "Tip",
+            unitPrice = BigDecimal("5.00"),
+            unitTax = BigDecimal.ZERO,
+            formattedUnitPrice = "$5.00",
+            formattedUnitTax = "$0.00",
+            rowIndex = 0,
+            isLumpSum = true,
+        )
+
+        val result = sut(listOf(product, fee), 2)
+
+        assertThat(result).isEqualByComparingTo(BigDecimal("25.00"))
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTaxTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTaxTest.kt
@@ -242,4 +242,53 @@ class WooPosCalculateRefundTaxTest {
 
         assertThat(result).isEqualTo(BigDecimal("10.00"))
     }
+
+    @Test
+    fun `given lump-sum fee row, when invoke called, then tax is fee unit tax`() {
+        val feeRow = WooPosRefundableItem(
+            orderItemId = 99L,
+            productId = 0L,
+            variationId = 0L,
+            name = "Tip",
+            unitPrice = BigDecimal("12.50"),
+            unitTax = BigDecimal("1.25"),
+            formattedUnitPrice = "$12.50",
+            formattedUnitTax = "$1.25",
+            rowIndex = 0,
+            isLumpSum = true,
+        )
+        val order = createOrder(emptyList())
+
+        val result = sut(listOf(feeRow), order, numberOfDecimals = 2, roundAtSubtotal = false)
+
+        assertThat(result).isEqualByComparingTo(BigDecimal("1.25"))
+    }
+
+    @Test
+    fun `given product and lump-sum rows, when invoke called, then taxes are summed`() {
+        val product = createRefundableItem(orderItemId = 1L)
+        val orderItem = createOrderItem(
+            itemId = 1L,
+            quantity = 1f,
+            totalTax = BigDecimal("2.00"),
+            taxes = listOf(Order.LineTaxEntry(rateId = 1L, taxAmount = BigDecimal("2.00"))),
+        )
+        val fee = WooPosRefundableItem(
+            orderItemId = 99L,
+            productId = 0L,
+            variationId = 0L,
+            name = "Tip",
+            unitPrice = BigDecimal("5.00"),
+            unitTax = BigDecimal("0.50"),
+            formattedUnitPrice = "$5.00",
+            formattedUnitTax = "$0.50",
+            rowIndex = 0,
+            isLumpSum = true,
+        )
+        val order = createOrder(listOf(orderItem))
+
+        val result = sut(listOf(product, fee), order, numberOfDecimals = 2, roundAtSubtotal = false)
+
+        assertThat(result).isEqualByComparingTo(BigDecimal("2.50"))
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItemsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItemsTest.kt
@@ -1145,4 +1145,87 @@ class WooPosGetRefundableItemsTest {
         assertThat(result).hasSize(5)
         assertThat(result.map { it.rowIndex }).containsExactly(0, 1, 2, 3, 4)
     }
+
+    @Test
+    fun `given order with custom amount, when invoke called, then includes lump-sum refundable row`() {
+        // GIVEN
+        val feeLine = Order.FeeLine(
+            id = 42L,
+            name = "Service fee",
+            total = BigDecimal("12.50"),
+            totalTax = BigDecimal("1.25"),
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.TAXABLE,
+            taxes = emptyList(),
+        )
+        val order = OrderTestUtils.generateTestOrder().copy(items = emptyList(), feesLines = listOf(feeLine))
+
+        // WHEN
+        val result = sut.invoke(order, emptyList())
+
+        // THEN
+        assertThat(result).hasSize(1)
+        val row = result.first()
+        assertThat(row.isLumpSum).isTrue()
+        assertThat(row.orderItemId).isEqualTo(42L)
+        assertThat(row.name).isEqualTo("Service fee")
+        assertThat(row.unitPrice).isEqualByComparingTo(BigDecimal("12.50"))
+        assertThat(row.unitTax).isEqualByComparingTo(BigDecimal("1.25"))
+        assertThat(row.uniqueId).isEqualTo("fee_42")
+    }
+
+    @Test
+    fun `given custom amount already refunded, when invoke called, then it is excluded`() {
+        // GIVEN
+        val feeLine = Order.FeeLine(
+            id = 42L,
+            name = "Service fee",
+            total = BigDecimal("12.50"),
+            totalTax = BigDecimal.ZERO,
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.NONE,
+            taxes = emptyList(),
+        )
+        val order = OrderTestUtils.generateTestOrder().copy(items = emptyList(), feesLines = listOf(feeLine))
+        val previousRefund = Refund(
+            id = 1L,
+            dateCreated = Date(),
+            amount = BigDecimal("12.50"),
+            reason = null,
+            automaticGatewayRefund = false,
+            items = emptyList(),
+            shippingLines = emptyList(),
+            feeLines = listOf(
+                Refund.FeeLine(id = 42L, name = "Service fee", totalTax = BigDecimal.ZERO, total = BigDecimal("-12.50"))
+            ),
+        )
+
+        // WHEN
+        val result = sut.invoke(order, listOf(previousRefund))
+
+        // THEN
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `given order with product and custom amount, when invoke called, then both rows are returned`() {
+        // GIVEN
+        val orderItem = generateOrderItem(itemId = 1L, quantity = 1f, price = BigDecimal("10.00"))
+        val feeLine = Order.FeeLine(
+            id = 99L,
+            name = "Tip",
+            total = BigDecimal("5.00"),
+            totalTax = BigDecimal.ZERO,
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.NONE,
+            taxes = emptyList(),
+        )
+        val order = OrderTestUtils.generateTestOrder()
+            .copy(items = listOf(orderItem), feesLines = listOf(feeLine))
+
+        // WHEN
+        val result = sut.invoke(order, emptyList())
+
+        // THEN
+        assertThat(result).hasSize(2)
+        assertThat(result.count { it.isLumpSum }).isEqualTo(1)
+        assertThat(result.count { !it.isLumpSum }).isEqualTo(1)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItemsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItemsTest.kt
@@ -315,4 +315,84 @@ class WooPosGroupRefundItemsTest {
         assertThat(result[0].itemId).isEqualTo(1L)
         assertThat(result[0].quantity).isEqualTo(100)
     }
+
+    @Test
+    fun `given lump-sum fee row, when invoke called, then emits quantity 0 with full total and taxes`() {
+        // GIVEN
+        val feeLine = Order.FeeLine(
+            id = 777L,
+            name = "Service",
+            total = BigDecimal("12.50"),
+            totalTax = BigDecimal("1.25"),
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.TAXABLE,
+            taxes = listOf(Order.LineTaxEntry(rateId = 5L, taxAmount = BigDecimal("1.25"))),
+        )
+        val order = OrderTestUtils.generateTestOrder().copy(items = emptyList(), feesLines = listOf(feeLine))
+        val feeRow = WooPosRefundableItem(
+            orderItemId = 777L,
+            productId = 0L,
+            variationId = 0L,
+            name = "Service",
+            unitPrice = BigDecimal("12.50"),
+            unitTax = BigDecimal("1.25"),
+            formattedUnitPrice = "$12.50",
+            formattedUnitTax = "$1.25",
+            rowIndex = 0,
+            isLumpSum = true,
+        )
+
+        // WHEN
+        val result = sut(listOf(feeRow), order, 2)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        assertThat(result[0].itemId).isEqualTo(777L)
+        assertThat(result[0].quantity).isEqualTo(0)
+        assertThat(result[0].refundTotal).isEqualByComparingTo(BigDecimal("12.50"))
+        assertThat(result[0].refundTax).hasSize(1)
+        assertThat(result[0].refundTax[0].taxRateId).isEqualTo(5L)
+        assertThat(result[0].refundTax[0].refundTotal).isEqualByComparingTo(BigDecimal("1.25"))
+    }
+
+    @Test
+    fun `given product row and fee row, when invoke called, then both emit with correct quantities`() {
+        // GIVEN
+        val product = createOrderItem(itemId = 1L, quantity = 1f, price = BigDecimal("10.00"))
+        val feeLine = Order.FeeLine(
+            id = 99L,
+            name = "Tip",
+            total = BigDecimal("5.00"),
+            totalTax = BigDecimal.ZERO,
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.NONE,
+            taxes = emptyList(),
+        )
+        val order = OrderTestUtils.generateTestOrder().copy(items = listOf(product), feesLines = listOf(feeLine))
+        val rows = listOf(
+            createRefundableItem(orderItemId = 1L, unitPrice = BigDecimal("10.00")),
+            WooPosRefundableItem(
+                orderItemId = 99L,
+                productId = 0L,
+                variationId = 0L,
+                name = "Tip",
+                unitPrice = BigDecimal("5.00"),
+                unitTax = BigDecimal.ZERO,
+                formattedUnitPrice = "$5.00",
+                formattedUnitTax = "$0.00",
+                rowIndex = 0,
+                isLumpSum = true,
+            ),
+        )
+
+        // WHEN
+        val result = sut(rows, order, 2)
+
+        // THEN
+        assertThat(result).hasSize(2)
+        val productRequest = result.first { it.itemId == 1L }
+        val feeRequest = result.first { it.itemId == 99L }
+        assertThat(productRequest.quantity).isEqualTo(1)
+        assertThat(feeRequest.quantity).isEqualTo(0)
+        assertThat(feeRequest.refundTotal).isEqualByComparingTo(BigDecimal("5.00"))
+        assertThat(feeRequest.refundTax).isEmpty()
+    }
 }


### PR DESCRIPTION
## Summary

Part 4 of 5. The Compose UI for the custom-amount dialog, plus wiring into `WooPosHomeDialogs` so it shows whenever `DialogState.CustomAmountDialog` is active.

After this PR lands the dialog can be opened from the cart's edit pencil (added in Part 2). The entry point from the products list comes in Part 5.

## What's included

- `WooPosCustomAmountDialog.kt`: the Compose dialog with title (mode-dependent), amount input (`WooPosMoneyInputField`), name input (`WooPosInputField`), "Charge taxes" switch, Cancel / primary action buttons. On phone it renders as a full-screen `Surface` with a top close toolbar and a sticky bottom action bar; on tablet it uses `WooPosDialogWrapper` as a centered modal. `LaunchedEffect(isVisible, editing?.itemNumber)` drives initialise/reset.
- `WooPosHomeDialogs.kt`: render `WooPosCustomAmountDialog` when the home state's `dialogState` is `CustomAmountDialog`.
- Dialog strings: titles, labels, button captions, cancel.

## Stacking

Targets **`feature/woopos-custom-amount-3-dialog-vm`** as its base.

## Verification

- `./gradlew :WooCommerce:compileWasabiDebugKotlin`
- `./gradlew detektAll`

## Test plan

- [ ] Compile passes.
- [ ] Open the dialog by editing a custom amount in the cart (becomes possible end-to-end after Part 5 lets users add one).
- [ ] Dialog title flips between "Add custom amount" / "Edit custom amount" based on mode.
- [ ] Currency symbol / decimal separator follow site settings.
- [ ] Toggle Charge taxes — state preserved on submit.
- [ ] Cancel button dismisses without emitting; primary button disabled when amount is empty or zero.


## Stack

This feature ships as 6 stacked PRs (≤300 prod LOC each):

- [Part 1 — foundation (data + events + cart handler)](https://github.com/woocommerce/woocommerce-android/pull/15868)
- [Part 2 — cart rendering](https://github.com/woocommerce/woocommerce-android/pull/15869)
- [Part 3 — dialog ViewModel + state + currency helper](https://github.com/woocommerce/woocommerce-android/pull/15870)
- **Part 4 — dialog Compose UI + render hookup** (this PR) — [#15871](https://github.com/woocommerce/woocommerce-android/pull/15871)
- [Part 5 — entry row + products screen integration](https://github.com/woocommerce/woocommerce-android/pull/15872)
- [Part 6 — refund support](https://github.com/woocommerce/woocommerce-android/pull/15874)