### PR TITLE
Replace ActiveSupport String#parameterize with a pure-Ruby helper

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1580,17 +1580,24 @@ platform :android do
     obsolete_changelogs
   end
 
+  # Mimics the subset of ActiveSupport's `String#parameterize` we rely on.
+  # release-toolkit dropped its `activesupport` runtime dependency in v14.3.1,
+  # so `String#parameterize` is no longer available here.
+  def parameterize(string)
+    string.downcase.gsub(/[^a-z0-9\-_]+/, '-').squeeze('-').gsub(/\A-|-\z/, '')
+  end
+
   # This function is Buildkite-specific
   def generate_prototype_build_number
     if ENV['BUILDKITE']
       commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
-      branch = ENV['BUILDKITE_BRANCH'].parameterize
+      branch = parameterize(ENV['BUILDKITE_BRANCH'])
       pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
 
       pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}"
     else
       repo = Git.open(PROJECT_ROOT_FOLDER)
-      commit = repo.current_branch.parameterize
+      commit = parameterize(repo.current_branch)
       branch = repo.revparse('HEAD')[0, 7]
 
       "#{branch}-#{commit}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1591,7 +1591,7 @@ platform :android do
   def generate_prototype_build_number
     if ENV['BUILDKITE']
       commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
-      branch = parameterize(ENV['BUILDKITE_BRANCH'])
+      branch = parameterize(ENV.fetch('BUILDKITE_BRANCH', nil))
       pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
 
       pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}"


### PR DESCRIPTION
### Description

`release-toolkit` [v14.3.1](https://github.com/wordpress-mobile/release-toolkit/pull/709) dropped its `activesupport` runtime dependency. `generate_prototype_build_number` in our `Fastfile` still calls `String#parameterize`, which will raise `NoMethodError` as soon as this repo bumps `release-toolkit` to `>= 14.3.1` (we're currently pinned to `~> 13.8`). This is a proactive fix so the bump doesn't break Prototype Builds.

Adds a tiny pure-Ruby `parameterize` helper (downcase, replace runs of non-`[a-z0-9_-]` with `-`, squeeze, strip leading/trailing `-`) and routes the two call sites through it. Output matches ActiveSupport's `String#parameterize` for the branch/commit names involved (e.g. `release/24.7` → `release-24-7`).

### Testing information

- `ruby -c fastlane/Fastfile` passes.
- `generate_prototype_build_number` produces the same build numbers as before for typical branch names.

### Screenshots

n/a

### RELEASE-NOTES

Not needed (CI/tooling only).

### Reviewer (matching checklist)

- [ ] Helper output is equivalent to the previous `String#parameterize` usage for the inputs we pass.