### PR TITLE
[Woo POS] Custom Amount, Part 6: refund support

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosCustomAmountInitialsAvatar.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosCustomAmountInitialsAvatar.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
@@ -42,11 +42,11 @@ fun WooPosCustomAmountInitialsAvatar(
 
 @WooPosPreview
 @Composable
-private fun WooPosCustomAmountInitialsAvatarPreview() {
+fun WooPosCustomAmountInitialsAvatarPreview() {
     WooPosTheme {
         Box(
             modifier = Modifier
-                .size(96.dp)
+                .size(WooPosComponentSize.Medium.value)
                 .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value)),
         ) {
             WooPosCustomAmountInitialsAvatar(name = "Service fee")
@@ -56,11 +56,11 @@ private fun WooPosCustomAmountInitialsAvatarPreview() {
 
 @WooPosPreview
 @Composable
-private fun WooPosCustomAmountInitialsAvatarBlankNamePreview() {
+fun WooPosCustomAmountInitialsAvatarBlankNamePreview() {
     WooPosTheme {
         Box(
             modifier = Modifier
-                .size(96.dp)
+                .size(WooPosComponentSize.Medium.value)
                 .clip(RoundedCornerShape(WooPosCornerRadius.Medium.value)),
         ) {
             WooPosCustomAmountInitialsAvatar(name = "")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotal.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotal.kt
@@ -6,12 +6,20 @@ import javax.inject.Inject
 
 class WooPosCalculateRefundSubtotal @Inject constructor() {
     operator fun invoke(refundableItems: List<WooPosRefundableItem>, numberOfDecimals: Int,): BigDecimal {
-        return refundableItems
+        val (lumpSumItems, productRows) = refundableItems.partition { it.isLumpSum }
+
+        val productSubtotal = productRows
             .groupBy { it.orderItemId }
             .entries
             .sumOf { (_, items) ->
                 val quantity = items.size.toBigDecimal()
                 quantity.multiply(items.first().unitPrice).setScale(numberOfDecimals, RoundingMode.HALF_UP)
             }
+
+        val lumpSumSubtotal = lumpSumItems.sumOf {
+            it.unitPrice.setScale(numberOfDecimals, RoundingMode.HALF_UP)
+        }
+
+        return productSubtotal + lumpSumSubtotal
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTax.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTax.kt
@@ -17,14 +17,18 @@ class WooPosCalculateRefundTax @Inject constructor() {
             return BigDecimal.ZERO
         }
 
-        val totalTax = refundableItems
+        val (lumpSumItems, productRows) = refundableItems.partition { it.isLumpSum }
+
+        val productTax = productRows
             .groupBy { it.orderItemId }
             .entries
             .sumOf { (orderItemId, items) ->
                 calculateTotalTaxesForItem(orderItemId, items.size, order, numberOfDecimals, roundAtSubtotal)
             }
 
-        return totalTax.setScale(numberOfDecimals, RoundingMode.HALF_UP)
+        val lumpSumTax = lumpSumItems.sumOf { it.unitTax }
+
+        return (productTax + lumpSumTax).setScale(numberOfDecimals, RoundingMode.HALF_UP)
     }
 
     private fun calculateTotalTaxesForItem(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTax.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTax.kt
@@ -26,7 +26,7 @@ class WooPosCalculateRefundTax @Inject constructor() {
                 calculateTotalTaxesForItem(orderItemId, items.size, order, numberOfDecimals, roundAtSubtotal)
             }
 
-        val lumpSumTax = lumpSumItems.sumOf { it.unitTax }
+        val lumpSumTax = lumpSumItems.sumOf { it.unitTax.setScale(numberOfDecimals, RoundingMode.HALF_UP) }
 
         return (productTax + lumpSumTax).setScale(numberOfDecimals, RoundingMode.HALF_UP)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItems.kt
@@ -66,6 +66,9 @@ class WooPosGetRefundableItems @Inject constructor(
 
     private fun buildFeeRows(order: Order, refunds: List<Refund>): List<WooPosRefundableItem> {
         if (order.feesLines.isEmpty()) return emptyList()
+        // Fees are always refunded whole — POS does not split a single fee across refunds. Any past refund
+        // touching a fee removes it from the refundable list. If the back-end ever introduces partial-fee
+        // refunds, this needs to subtract the refunded amount instead.
         val refundedFeeIds = refunds.flatMap { it.feeLines }.map { it.id }.toSet()
         return order.feesLines
             .filter { it.id !in refundedFeeIds }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItems.kt
@@ -25,9 +25,13 @@ class WooPosGetRefundableItems @Inject constructor(
         order: Order,
         refunds: List<Refund>,
     ): List<WooPosRefundableItem> {
-        if (order.items.isEmpty()) {
-            return emptyList()
-        }
+        val productRows = buildProductRows(order, refunds)
+        val feeRows = buildFeeRows(order, refunds)
+        return productRows + feeRows
+    }
+
+    private fun buildProductRows(order: Order, refunds: List<Refund>): List<WooPosRefundableItem> {
+        if (order.items.isEmpty()) return emptyList()
 
         val maxQuantities: Map<Long, Float> = calculateMaxRefundQuantities(refunds, order.items)
 
@@ -53,11 +57,32 @@ class WooPosGetRefundableItems @Inject constructor(
                         unitTax = unitTax,
                         formattedUnitPrice = formattedUnitPrice,
                         formattedUnitTax = formattedUnitTax,
-                        rowIndex = index
+                        rowIndex = index,
                     )
                 }
             }
         }
+    }
+
+    private fun buildFeeRows(order: Order, refunds: List<Refund>): List<WooPosRefundableItem> {
+        if (order.feesLines.isEmpty()) return emptyList()
+        val refundedFeeIds = refunds.flatMap { it.feeLines }.map { it.id }.toSet()
+        return order.feesLines
+            .filter { it.id !in refundedFeeIds }
+            .map { feeLine ->
+                WooPosRefundableItem(
+                    orderItemId = feeLine.id,
+                    productId = 0L,
+                    variationId = 0L,
+                    name = feeLine.name.orEmpty(),
+                    unitPrice = feeLine.total,
+                    unitTax = feeLine.totalTax,
+                    formattedUnitPrice = PriceUtils.formatCurrency(feeLine.total, order.currency, currencyFormatter),
+                    formattedUnitTax = PriceUtils.formatCurrency(feeLine.totalTax, order.currency, currencyFormatter),
+                    rowIndex = 0,
+                    isLumpSum = true,
+                )
+            }
     }
 
     /**

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItems.kt
@@ -14,7 +14,9 @@ class WooPosGroupRefundItems @Inject constructor() {
         order: Order,
         numberOfDecimals: Int,
     ): List<RefundRequestItem> {
-        return refundableItems
+        val (lumpSumItems, productItems) = refundableItems.partition { it.isLumpSum }
+
+        val productRequests = productItems
             .groupBy { it.orderItemId }
             .map { (orderItemId, items) ->
                 val originalItem = requireNotNull(order.items.find { it.itemId == orderItemId }) {
@@ -29,6 +31,32 @@ class WooPosGroupRefundItems @Inject constructor() {
                     refundTax = calculateRefundTaxes(originalItem, refundQuantity, numberOfDecimals)
                 )
             }
+
+        val feeRequests = lumpSumItems.map { feeRow ->
+            val originalFee = requireNotNull(order.feesLines.find { it.id == feeRow.orderItemId }) {
+                "Fee line with ID ${feeRow.orderItemId} not found in order ${order.id}."
+            }
+            RefundRequestItem(
+                itemId = originalFee.id,
+                quantity = 0,
+                refundTotal = originalFee.total.setScale(numberOfDecimals, RoundingMode.HALF_UP),
+                refundTax = buildFeeRefundTaxes(originalFee, numberOfDecimals),
+            )
+        }
+
+        return productRequests + feeRequests
+    }
+
+    private fun buildFeeRefundTaxes(
+        feeLine: Order.FeeLine,
+        numberOfDecimals: Int,
+    ): List<RefundRequestTax> {
+        return feeLine.taxes.map { tax ->
+            RefundRequestTax(
+                taxRateId = tax.rateId,
+                refundTotal = tax.taxAmount.setScale(numberOfDecimals, RoundingMode.HALF_UP),
+            )
+        }
     }
 
     private fun calculateRefundTotal(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItems.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItems.kt
@@ -36,6 +36,8 @@ class WooPosGroupRefundItems @Inject constructor() {
             val originalFee = requireNotNull(order.feesLines.find { it.id == feeRow.orderItemId }) {
                 "Fee line with ID ${feeRow.orderItemId} not found in order ${order.id}."
             }
+            // WooCommerce REST refunds API uses `quantity` only for line items; fee refunds are
+            // identified by `id` + `refundTotal`, so quantity is always 0 for a fee row.
             RefundRequestItem(
                 itemId = originalFee.id,
                 quantity = 0,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -718,6 +718,24 @@ private fun ItemsHeaderRow(
 }
 
 @Composable
+private fun CustomAmountRefundAvatar() {
+    Box(
+        modifier = Modifier
+            .size(WooPosComponentSize.XSmall.value)
+            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
+            .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_gridicons_money_on_surface),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.size(WooPosIconSize.Small.value),
+        )
+    }
+}
+
+@Composable
 private fun RefundableItemRow(
     item: WooPosRefundableItem,
     isSelected: Boolean,
@@ -758,14 +776,18 @@ private fun RefundableItemRow(
         )
         Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
 
-        WooPosItemImage(
-            modifier = Modifier
-                .size(WooPosComponentSize.XSmall.value)
-                .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
-            imageUrl = null,
-            placeholderIcon = ImageVector.vectorResource(R.drawable.ic_inventory_2_24dp),
-            placeholderIconSize = WooPosIconSize.Small.value
-        )
+        if (item.isLumpSum) {
+            CustomAmountRefundAvatar()
+        } else {
+            WooPosItemImage(
+                modifier = Modifier
+                    .size(WooPosComponentSize.XSmall.value)
+                    .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
+                imageUrl = null,
+                placeholderIcon = ImageVector.vectorResource(R.drawable.ic_inventory_2_24dp),
+                placeholderIconSize = WooPosIconSize.Small.value
+            )
+        }
         Spacer(modifier = Modifier.size(WooPosSpacing.Medium.value))
 
         Column(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -57,6 +57,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCustomAmountInitialsAvatar
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosItemImage
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
@@ -718,21 +719,13 @@ private fun ItemsHeaderRow(
 }
 
 @Composable
-private fun CustomAmountRefundAvatar() {
-    Box(
+private fun CustomAmountRefundAvatar(name: String) {
+    WooPosCustomAmountInitialsAvatar(
+        name = name,
         modifier = Modifier
             .size(WooPosComponentSize.XSmall.value)
-            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value))
-            .background(MaterialTheme.colorScheme.primaryContainer),
-        contentAlignment = Alignment.Center,
-    ) {
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_gridicons_money_on_surface),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-            modifier = Modifier.size(WooPosIconSize.Small.value),
-        )
-    }
+            .clip(RoundedCornerShape(WooPosCornerRadius.Small.value)),
+    )
 }
 
 @Composable
@@ -777,7 +770,7 @@ private fun RefundableItemRow(
         Spacer(modifier = Modifier.size(WooPosSpacing.Large.value))
 
         if (item.isLumpSum) {
-            CustomAmountRefundAvatar()
+            CustomAmountRefundAvatar(name = item.name)
         } else {
             WooPosItemImage(
                 modifier = Modifier

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundableItem.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundableItem.kt
@@ -14,7 +14,8 @@ data class WooPosRefundableItem(
     val formattedUnitPrice: String,
     val formattedUnitTax: String,
     val rowIndex: Int,
+    val isLumpSum: Boolean = false,
 ) {
     val uniqueId: String
-        get() = "${orderItemId}_$rowIndex"
+        get() = if (isLumpSum) "fee_$orderItemId" else "${orderItemId}_$rowIndex"
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -19,7 +19,7 @@ enum class FeatureFlag(
     LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES("woo_notification_1d_before_free_trial_expires"),
     LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES("woo_notification_1d_after_free_trial_expires"),
     WOO_POS("woo_pos"),
-    WOO_POS_PHONE("woo_pos_phone", localValue = true),
+    WOO_POS_PHONE("woo_pos_phone", localValue = PackageUtils.isDebugBuild()),
     WOO_POS_TAP_TO_PAY("woo_pos_tap_to_pay", localValue = PackageUtils.isDebugBuild()),
     APP_PASSWORDS_FOR_JETPACK_SITES("woo_app_passwords_for_jetpack_sites"),
     WOO_POS_LOCAL_CATALOG_M1("woo_pos_local_catalog_m1"),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -19,7 +19,7 @@ enum class FeatureFlag(
     LOCAL_NOTIFICATION_1D_BEFORE_FREE_TRIAL_EXPIRES("woo_notification_1d_before_free_trial_expires"),
     LOCAL_NOTIFICATION_1D_AFTER_FREE_TRIAL_EXPIRES("woo_notification_1d_after_free_trial_expires"),
     WOO_POS("woo_pos"),
-    WOO_POS_PHONE("woo_pos_phone", localValue = PackageUtils.isDebugBuild()),
+    WOO_POS_PHONE("woo_pos_phone", localValue = true),
     WOO_POS_TAP_TO_PAY("woo_pos_tap_to_pay", localValue = PackageUtils.isDebugBuild()),
     APP_PASSWORDS_FOR_JETPACK_SITES("woo_app_passwords_for_jetpack_sites"),
     WOO_POS_LOCAL_CATALOG_M1("woo_pos_local_catalog_m1"),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotalTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotalTest.kt
@@ -32,7 +32,7 @@ class WooPosCalculateRefundSubtotalTest {
     @Test
     fun `given empty list, when invoke called, then returns zero`() {
         val result = sut(emptyList(), 2)
-        assertThat(result).isEqualTo(BigDecimal("0"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("0"))
     }
 
     @Test
@@ -43,7 +43,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 2)
 
-        assertThat(result).isEqualTo(BigDecimal("20.00"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("20.00"))
     }
 
     @Test
@@ -56,7 +56,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 2)
 
-        assertThat(result).isEqualTo(BigDecimal("60.00"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("60.00"))
     }
 
     @Test
@@ -69,7 +69,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 2)
 
-        assertThat(result).isEqualTo(BigDecimal("60.00"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("60.00"))
     }
 
     @Test
@@ -85,7 +85,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 2)
 
-        assertThat(result).isEqualTo(BigDecimal("85.00"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("85.00"))
     }
 
     @Test
@@ -98,7 +98,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 2)
 
-        assertThat(result).isEqualTo(BigDecimal("31.00"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("31.00"))
     }
 
     @Test
@@ -110,7 +110,7 @@ class WooPosCalculateRefundSubtotalTest {
 
         val result = sut(refundableItems, 3)
 
-        assertThat(result).isEqualTo(BigDecimal("20.667"))
+        assertThat(result).isEqualByComparingTo(BigDecimal("20.667"))
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotalTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundSubtotalTest.kt
@@ -112,4 +112,45 @@ class WooPosCalculateRefundSubtotalTest {
 
         assertThat(result).isEqualTo(BigDecimal("20.667"))
     }
+
+    @Test
+    fun `given lump-sum fee row, when invoke called, then total is the fee unit price, not multiplied by quantity`() {
+        val feeRow = WooPosRefundableItem(
+            orderItemId = 99L,
+            productId = 0L,
+            variationId = 0L,
+            name = "Tip",
+            unitPrice = BigDecimal("12.50"),
+            unitTax = BigDecimal.ZERO,
+            formattedUnitPrice = "$12.50",
+            formattedUnitTax = "$0.00",
+            rowIndex = 0,
+            isLumpSum = true,
+        )
+
+        val result = sut(listOf(feeRow), 2)
+
+        assertThat(result).isEqualByComparingTo(BigDecimal("12.50"))
+    }
+
+    @Test
+    fun `given product and lump-sum rows, when invoke called, then both are summed`() {
+        val product = createRefundableItem(orderItemId = 1L, unitPrice = BigDecimal("20.00"))
+        val fee = WooPosRefundableItem(
+            orderItemId = 99L,
+            productId = 0L,
+            variationId = 0L,
+            name = "Tip",
+            unitPrice = BigDecimal("5.00"),
+            unitTax = BigDecimal.ZERO,
+            formattedUnitPrice = "$5.00",
+            formattedUnitTax = "$0.00",
+            rowIndex = 0,
+            isLumpSum = true,
+        )
+
+        val result = sut(listOf(product, fee), 2)
+
+        assertThat(result).isEqualByComparingTo(BigDecimal("25.00"))
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTaxTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosCalculateRefundTaxTest.kt
@@ -242,4 +242,53 @@ class WooPosCalculateRefundTaxTest {
 
         assertThat(result).isEqualTo(BigDecimal("10.00"))
     }
+
+    @Test
+    fun `given lump-sum fee row, when invoke called, then tax is fee unit tax`() {
+        val feeRow = WooPosRefundableItem(
+            orderItemId = 99L,
+            productId = 0L,
+            variationId = 0L,
+            name = "Tip",
+            unitPrice = BigDecimal("12.50"),
+            unitTax = BigDecimal("1.25"),
+            formattedUnitPrice = "$12.50",
+            formattedUnitTax = "$1.25",
+            rowIndex = 0,
+            isLumpSum = true,
+        )
+        val order = createOrder(emptyList())
+
+        val result = sut(listOf(feeRow), order, numberOfDecimals = 2, roundAtSubtotal = false)
+
+        assertThat(result).isEqualByComparingTo(BigDecimal("1.25"))
+    }
+
+    @Test
+    fun `given product and lump-sum rows, when invoke called, then taxes are summed`() {
+        val product = createRefundableItem(orderItemId = 1L)
+        val orderItem = createOrderItem(
+            itemId = 1L,
+            quantity = 1f,
+            totalTax = BigDecimal("2.00"),
+            taxes = listOf(Order.LineTaxEntry(rateId = 1L, taxAmount = BigDecimal("2.00"))),
+        )
+        val fee = WooPosRefundableItem(
+            orderItemId = 99L,
+            productId = 0L,
+            variationId = 0L,
+            name = "Tip",
+            unitPrice = BigDecimal("5.00"),
+            unitTax = BigDecimal("0.50"),
+            formattedUnitPrice = "$5.00",
+            formattedUnitTax = "$0.50",
+            rowIndex = 0,
+            isLumpSum = true,
+        )
+        val order = createOrder(listOf(orderItem))
+
+        val result = sut(listOf(product, fee), order, numberOfDecimals = 2, roundAtSubtotal = false)
+
+        assertThat(result).isEqualByComparingTo(BigDecimal("2.50"))
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItemsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGetRefundableItemsTest.kt
@@ -1145,4 +1145,87 @@ class WooPosGetRefundableItemsTest {
         assertThat(result).hasSize(5)
         assertThat(result.map { it.rowIndex }).containsExactly(0, 1, 2, 3, 4)
     }
+
+    @Test
+    fun `given order with custom amount, when invoke called, then includes lump-sum refundable row`() {
+        // GIVEN
+        val feeLine = Order.FeeLine(
+            id = 42L,
+            name = "Service fee",
+            total = BigDecimal("12.50"),
+            totalTax = BigDecimal("1.25"),
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.TAXABLE,
+            taxes = emptyList(),
+        )
+        val order = OrderTestUtils.generateTestOrder().copy(items = emptyList(), feesLines = listOf(feeLine))
+
+        // WHEN
+        val result = sut.invoke(order, emptyList())
+
+        // THEN
+        assertThat(result).hasSize(1)
+        val row = result.first()
+        assertThat(row.isLumpSum).isTrue()
+        assertThat(row.orderItemId).isEqualTo(42L)
+        assertThat(row.name).isEqualTo("Service fee")
+        assertThat(row.unitPrice).isEqualByComparingTo(BigDecimal("12.50"))
+        assertThat(row.unitTax).isEqualByComparingTo(BigDecimal("1.25"))
+        assertThat(row.uniqueId).isEqualTo("fee_42")
+    }
+
+    @Test
+    fun `given custom amount already refunded, when invoke called, then it is excluded`() {
+        // GIVEN
+        val feeLine = Order.FeeLine(
+            id = 42L,
+            name = "Service fee",
+            total = BigDecimal("12.50"),
+            totalTax = BigDecimal.ZERO,
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.NONE,
+            taxes = emptyList(),
+        )
+        val order = OrderTestUtils.generateTestOrder().copy(items = emptyList(), feesLines = listOf(feeLine))
+        val previousRefund = Refund(
+            id = 1L,
+            dateCreated = Date(),
+            amount = BigDecimal("12.50"),
+            reason = null,
+            automaticGatewayRefund = false,
+            items = emptyList(),
+            shippingLines = emptyList(),
+            feeLines = listOf(
+                Refund.FeeLine(id = 42L, name = "Service fee", totalTax = BigDecimal.ZERO, total = BigDecimal("-12.50"))
+            ),
+        )
+
+        // WHEN
+        val result = sut.invoke(order, listOf(previousRefund))
+
+        // THEN
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `given order with product and custom amount, when invoke called, then both rows are returned`() {
+        // GIVEN
+        val orderItem = generateOrderItem(itemId = 1L, quantity = 1f, price = BigDecimal("10.00"))
+        val feeLine = Order.FeeLine(
+            id = 99L,
+            name = "Tip",
+            total = BigDecimal("5.00"),
+            totalTax = BigDecimal.ZERO,
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.NONE,
+            taxes = emptyList(),
+        )
+        val order = OrderTestUtils.generateTestOrder()
+            .copy(items = listOf(orderItem), feesLines = listOf(feeLine))
+
+        // WHEN
+        val result = sut.invoke(order, emptyList())
+
+        // THEN
+        assertThat(result).hasSize(2)
+        assertThat(result.count { it.isLumpSum }).isEqualTo(1)
+        assertThat(result.count { !it.isLumpSum }).isEqualTo(1)
+    }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItemsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosGroupRefundItemsTest.kt
@@ -315,4 +315,84 @@ class WooPosGroupRefundItemsTest {
         assertThat(result[0].itemId).isEqualTo(1L)
         assertThat(result[0].quantity).isEqualTo(100)
     }
+
+    @Test
+    fun `given lump-sum fee row, when invoke called, then emits quantity 0 with full total and taxes`() {
+        // GIVEN
+        val feeLine = Order.FeeLine(
+            id = 777L,
+            name = "Service",
+            total = BigDecimal("12.50"),
+            totalTax = BigDecimal("1.25"),
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.TAXABLE,
+            taxes = listOf(Order.LineTaxEntry(rateId = 5L, taxAmount = BigDecimal("1.25"))),
+        )
+        val order = OrderTestUtils.generateTestOrder().copy(items = emptyList(), feesLines = listOf(feeLine))
+        val feeRow = WooPosRefundableItem(
+            orderItemId = 777L,
+            productId = 0L,
+            variationId = 0L,
+            name = "Service",
+            unitPrice = BigDecimal("12.50"),
+            unitTax = BigDecimal("1.25"),
+            formattedUnitPrice = "$12.50",
+            formattedUnitTax = "$1.25",
+            rowIndex = 0,
+            isLumpSum = true,
+        )
+
+        // WHEN
+        val result = sut(listOf(feeRow), order, 2)
+
+        // THEN
+        assertThat(result).hasSize(1)
+        assertThat(result[0].itemId).isEqualTo(777L)
+        assertThat(result[0].quantity).isEqualTo(0)
+        assertThat(result[0].refundTotal).isEqualByComparingTo(BigDecimal("12.50"))
+        assertThat(result[0].refundTax).hasSize(1)
+        assertThat(result[0].refundTax[0].taxRateId).isEqualTo(5L)
+        assertThat(result[0].refundTax[0].refundTotal).isEqualByComparingTo(BigDecimal("1.25"))
+    }
+
+    @Test
+    fun `given product row and fee row, when invoke called, then both emit with correct quantities`() {
+        // GIVEN
+        val product = createOrderItem(itemId = 1L, quantity = 1f, price = BigDecimal("10.00"))
+        val feeLine = Order.FeeLine(
+            id = 99L,
+            name = "Tip",
+            total = BigDecimal("5.00"),
+            totalTax = BigDecimal.ZERO,
+            taxStatus = Order.FeeLine.FeeLineTaxStatus.NONE,
+            taxes = emptyList(),
+        )
+        val order = OrderTestUtils.generateTestOrder().copy(items = listOf(product), feesLines = listOf(feeLine))
+        val rows = listOf(
+            createRefundableItem(orderItemId = 1L, unitPrice = BigDecimal("10.00")),
+            WooPosRefundableItem(
+                orderItemId = 99L,
+                productId = 0L,
+                variationId = 0L,
+                name = "Tip",
+                unitPrice = BigDecimal("5.00"),
+                unitTax = BigDecimal.ZERO,
+                formattedUnitPrice = "$5.00",
+                formattedUnitTax = "$0.00",
+                rowIndex = 0,
+                isLumpSum = true,
+            ),
+        )
+
+        // WHEN
+        val result = sut(rows, order, 2)
+
+        // THEN
+        assertThat(result).hasSize(2)
+        val productRequest = result.first { it.itemId == 1L }
+        val feeRequest = result.first { it.itemId == 99L }
+        assertThat(productRequest.quantity).isEqualTo(1)
+        assertThat(feeRequest.quantity).isEqualTo(0)
+        assertThat(feeRequest.refundTotal).isEqualByComparingTo(BigDecimal("5.00"))
+        assertThat(feeRequest.refundTax).isEmpty()
+    }
 }


### PR DESCRIPTION
## Summary

Part 6 of the custom-amount stack. After Parts 1–5 let merchants add custom amounts to a POS order, Part 6 makes them refundable — fee lines now appear in the POS refund items list and are correctly carried into the refund POST.

Mirrors iOS, which sends fee refunds in the existing `line_items` array with `quantity = 0`; WooCommerce resolves the id against the order's fee_lines server-side. No FluxC changes are required — `RefundRestClient.createRefundByItems` and `Refund.feeLines` already accept and parse this shape.

## What's included

- `WooPosRefundableItem`: new `isLumpSum: Boolean = false` flag; defaults preserve product behaviour. `uniqueId` switches to `fee_{feeId}` for lump-sum rows.
- `WooPosGetRefundableItems`: appends one refundable row per `order.feesLines` entry, skipping any fee whose id already appears in a prior refund's `feeLines`.
- `WooPosGroupRefundItems`: partitions rows; emits one `RefundRequestItem(quantity = 0, refundTotal = feeTotal, refundTax = …)` per fee line, sourcing the tax breakdown from the order's `FeeLine.taxes`.
- `WooPosCalculateRefundSubtotal` / `WooPosCalculateRefundTax`: lump-sum rows are summed directly (no quantity multiplication).
- `WooPosIssueRefundScreen`: renders a money-icon avatar (`ic_gridicons_money_on_surface` on `primaryContainer`) in place of the product placeholder for lump-sum rows; reuses the existing checkbox + selection wiring.

## Tests

- `WooPosGroupRefundItemsTest` — lump-sum fee emits `quantity = 0` with full total and full tax; mixed product + fee runs.
- `WooPosGetRefundableItemsTest` — fees become refundable; already-refunded fees are excluded; product + fee combination.
- `WooPosCalculateRefundSubtotalTest` — lump-sum sums without quantity multiplication.
- `WooPosCalculateRefundTaxTest` — lump-sum tax uses `unitTax` directly; combined with product math.

## Stacking

Targets **`feature/woopos-custom-amount-5-entry-row`** as its base. After Parts 1–5 land on trunk, this rebases onto trunk.

## Verification

- `./gradlew :WooCommerce:compileWasabiDebugKotlin`
- `./gradlew detektAll`
- `./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "*WooPosRefund*" --tests "*WooPosGetRefundableItems*" --tests "*WooPosGroupRefundItems*" --tests "*WooPosCalculateRefund*"`

## Test plan

- [ ] On a tablet, place an order with a product + a custom amount; complete payment.
- [ ] Open the order's refund flow → both the product row and the custom-amount row appear; the fee row shows a money-icon avatar instead of a product image and has no quantity stepper.
- [ ] Select only the custom amount → confirm refund → the issued refund on the backend has a fee-line refund with the correct amount and tax.
- [ ] Open the same order again → the (now-refunded) custom amount no longer appears in the refundable list.
- [ ] Place an order with only a custom amount, refund it, verify success.

## Out of scope

- Partial refunds of a custom amount (iOS only supports full refunds — matched here).
- Refund of shipping lines (separate, pre-existing gap in POS).
- FluxC / data-layer changes (not required).


## Stack

This feature ships as 6 stacked PRs (≤300 prod LOC each):

- [Part 1 — foundation (data + events + cart handler)](https://github.com/woocommerce/woocommerce-android/pull/15868)
- [Part 2 — cart rendering](https://github.com/woocommerce/woocommerce-android/pull/15869)
- [Part 3 — dialog ViewModel + state + currency helper](https://github.com/woocommerce/woocommerce-android/pull/15870)
- [Part 4 — dialog Compose UI + render hookup](https://github.com/woocommerce/woocommerce-android/pull/15871)
- [Part 5 — entry row + products screen integration](https://github.com/woocommerce/woocommerce-android/pull/15872)
- **Part 6 — refund support** (this PR) — [#15874](https://github.com/woocommerce/woocommerce-android/pull/15874)
