### PR TITLE
[WOOMOB-3011] Add product variation cards to AI Assistant

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
@@ -7,7 +7,10 @@ import android.view.ViewGroup
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.navOptions
+import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.AssistantRoute
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
 import com.woocommerce.android.extensions.navigateSafely
@@ -53,7 +56,7 @@ class AiAssistantHostFragment : BaseFragment() {
                         findNavController().navigateSafely(target.directions)
                     }
                     is WooAssistantCardNavigationTarget.DeepLink -> {
-                        findNavController().navigate(target.uri.toUri())
+                        findNavController().navigate(target.uri.toUri(), assistantCardDeepLinkNavOptions())
                     }
                 }
             }
@@ -62,5 +65,14 @@ class AiAssistantHostFragment : BaseFragment() {
 
     companion object {
         private const val ASSISTANT_CONVERSATION_ID = "dashboard-assistant"
+    }
+}
+
+internal fun assistantCardDeepLinkNavOptions(): NavOptions = navOptions {
+    anim {
+        enter = R.anim.default_enter_anim
+        exit = R.anim.default_exit_anim
+        popEnter = R.anim.default_pop_enter_anim
+        popExit = R.anim.default_pop_exit_anim
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
@@ -45,9 +45,16 @@ class AiAssistantHostFragment : BaseFragment() {
 
     private fun onCardAction(action: AssistantCardAction) {
         viewLifecycleOwner.lifecycleScope.launch {
-            val direction = cardActionNavigator.directionFor(action) ?: return@launch
+            val target = cardActionNavigator.targetFor(action) ?: return@launch
             if (viewLifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-                findNavController().navigateSafely(direction)
+                when (target) {
+                    is WooAssistantCardNavigationTarget.Direction -> {
+                        findNavController().navigateSafely(target.directions)
+                    }
+                    is WooAssistantCardNavigationTarget.DeepLink -> {
+                        findNavController().navigate(android.net.Uri.parse(target.uri))
+                    }
+                }
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -52,7 +53,7 @@ class AiAssistantHostFragment : BaseFragment() {
                         findNavController().navigateSafely(target.directions)
                     }
                     is WooAssistantCardNavigationTarget.DeepLink -> {
-                        findNavController().navigate(android.net.Uri.parse(target.uri))
+                        findNavController().navigate(target.uri.toUri())
                     }
                 }
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRenderer.kt
@@ -1,24 +1,101 @@
 package com.woocommerce.android.ui.aiassistant
 
+import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
+import com.woocommerce.android.ui.products.ProductStatus
+import com.woocommerce.android.ui.products.ProductStockStatus
 import com.woocommerce.android.ui.products.compose.ProductSummaryRow
+import com.woocommerce.android.ui.products.compose.ProductSummaryRowInfo
+import java.math.BigDecimal
 
-internal class AiAssistantVariationCardRenderer {
+internal class AiAssistantVariationCardRenderer(
+    private val currencyFormatter: AiAssistantCurrencyFormatter,
+) {
     @Composable
     fun Card(
         card: AssistantCard.Variation,
         onAction: (AssistantCardAction) -> Unit,
         modifier: Modifier,
     ) {
+        val context = LocalContext.current
+        val rowModel = card.toVariationSummaryRowModel(context, currencyFormatter)
         ProductSummaryRow(
-            title = card.name,
-            imageUrl = card.imageUrl,
+            title = rowModel.title,
+            imageUrl = rowModel.imageUrl,
             onClick = {},
             modifier = modifier,
-            supportingContent = {},
-        )
+        ) {
+            rowModel.supportingTexts.forEach { text ->
+                ProductSummaryRowInfo(text)
+            }
+        }
     }
+}
+
+internal data class AssistantVariationSummaryRowModel(
+    val title: String,
+    val imageUrl: String,
+    val supportingTexts: List<String>,
+)
+
+internal fun AssistantCard.Variation.toVariationSummaryRowModel(
+    context: Context,
+    currencyFormatter: AiAssistantCurrencyFormatter,
+): AssistantVariationSummaryRowModel {
+    fun formatVariationPrice(): String =
+        price.toBigDecimalOrNull()
+            ?.let { amount: BigDecimal -> currencyFormatter.buildBigDecimalFormatter()(amount) }
+            ?: price
+
+    fun attributesText(): String? =
+        attributes
+            .mapNotNull { attribute ->
+                val name = attribute.name.takeIf { it.isNotBlank() }
+                val option = attribute.option.takeIf { it.isNotBlank() }
+                if (name != null && option != null) {
+                    "$name: $option"
+                } else {
+                    null
+                }
+            }
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString(separator = " \u2022 ")
+
+    fun statusStockPriceText(): String? {
+        val productStatus = ProductStatus.fromString(status)
+            ?.takeIf { it != ProductStatus.PUBLISH }
+            ?.toLocalizedString(context)
+        val stock = stockStatus
+            .takeIf { it.isNotBlank() }
+            ?.let {
+                ProductStockStatus.stockStatusToDisplayString(
+                    context,
+                    ProductStockStatus.fromString(it),
+                )
+            }
+
+        return listOfNotNull(productStatus, stock, formatVariationPrice())
+            .filter { it.isNotBlank() }
+            .joinToString(separator = " \u2022 ")
+            .takeIf { it.isNotBlank() }
+    }
+
+    val skuText = sku
+        .takeIf { it.isNotBlank() }
+        ?.let { context.getString(R.string.orderdetail_product_lineitem_sku_value, it) }
+
+    return AssistantVariationSummaryRowModel(
+        title = name,
+        imageUrl = imageUrl,
+        supportingTexts = listOfNotNull(
+            attributesText(),
+            statusStockPriceText(),
+            skuText,
+        ),
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRenderer.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.ui.aiassistant
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
+import com.woocommerce.android.ui.products.compose.ProductSummaryRow
+
+internal class AiAssistantVariationCardRenderer {
+    @Composable
+    fun Card(
+        card: AssistantCard.Variation,
+        onAction: (AssistantCardAction) -> Unit,
+        modifier: Modifier,
+    ) {
+        ProductSummaryRow(
+            title = card.name,
+            imageUrl = card.imageUrl,
+            onClick = {},
+            modifier = modifier,
+            supportingContent = {},
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRenderer.kt
@@ -27,7 +27,7 @@ internal class AiAssistantVariationCardRenderer(
         ProductSummaryRow(
             title = rowModel.title,
             imageUrl = rowModel.imageUrl,
-            onClick = {},
+            onClick = { onAction(card.toOpenProductVariationAction()) },
             modifier = modifier,
         ) {
             rowModel.supportingTexts.forEach { text ->
@@ -36,6 +36,12 @@ internal class AiAssistantVariationCardRenderer(
         }
     }
 }
+
+internal fun AssistantCard.Variation.toOpenProductVariationAction(): AssistantCardAction =
+    AssistantCardAction.OpenProductVariation(
+        parentProductId = parentProductId,
+        variationId = variationId,
+    )
 
 internal data class AssistantVariationSummaryRowModel(
     val title: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRenderer.kt
@@ -88,14 +88,18 @@ internal fun AssistantCard.Variation.toVariationSummaryRowModel(
     val skuText = sku
         .takeIf { it.isNotBlank() }
         ?.let { context.getString(R.string.orderdetail_product_lineitem_sku_value, it) }
+    val title = name
+        .takeIf { it.isNotBlank() }
+        ?: skuText
+        ?: context.getString(R.string.ai_assistant_variation_card_id_title, variationId)
 
     return AssistantVariationSummaryRowModel(
-        title = name,
+        title = title,
         imageUrl = imageUrl,
         supportingTexts = listOfNotNull(
             attributesText(),
             statusStockPriceText(),
-            skuText,
+            skuText.takeIf { name.isNotBlank() },
         ),
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardActionNavigator.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardActionNavigator.kt
@@ -13,6 +13,11 @@ import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 
+internal sealed interface WooAssistantCardNavigationTarget {
+    data class Direction(val directions: NavDirections) : WooAssistantCardNavigationTarget
+    data class DeepLink(val uri: String) : WooAssistantCardNavigationTarget
+}
+
 internal class WooAssistantCardActionNavigator @Inject constructor(
     private val getCustomerWithStats: GetCustomerWithStats,
 ) {
@@ -20,20 +25,36 @@ internal class WooAssistantCardActionNavigator @Inject constructor(
         action: AssistantCardAction,
         locale: Locale = Locale.getDefault(),
     ): NavDirections? =
+        (targetFor(action, locale) as? WooAssistantCardNavigationTarget.Direction)?.directions
+
+    internal suspend fun targetFor(
+        action: AssistantCardAction,
+        locale: Locale = Locale.getDefault(),
+    ): WooAssistantCardNavigationTarget? =
         when (action) {
-            is AssistantCardAction.OpenOrder -> NavGraphMainDirections.actionGlobalOrderDetailFragment(
-                orderId = action.remoteOrderId,
-                ignoreTwoPaneLayoutLogic = true,
+            is AssistantCardAction.OpenOrder -> WooAssistantCardNavigationTarget.Direction(
+                NavGraphMainDirections.actionGlobalOrderDetailFragment(
+                    orderId = action.remoteOrderId,
+                    ignoreTwoPaneLayoutLogic = true,
+                )
             )
-            is AssistantCardAction.OpenProduct -> NavGraphMainDirections.actionGlobalProductDetailFragment(
-                mode = ProductDetailFragment.Mode.ShowProduct(action.remoteProductId),
+            is AssistantCardAction.OpenProduct -> WooAssistantCardNavigationTarget.Direction(
+                NavGraphMainDirections.actionGlobalProductDetailFragment(
+                    mode = ProductDetailFragment.Mode.ShowProduct(action.remoteProductId),
+                )
+            )
+            is AssistantCardAction.OpenProductVariation -> WooAssistantCardNavigationTarget.DeepLink(
+                uri = "wcandroid://variationDetail?remoteProductId=${action.parentProductId}" +
+                    "&remoteVariationId=${action.variationId}",
             )
             is AssistantCardAction.OpenAnalytics -> analyticsDatesToStatsTimeRangeSelection(
                 after = action.after,
                 before = action.before,
                 locale = locale,
             )?.let { rangeSelection ->
-                NavGraphMainDirections.actionGlobalAnalytics(rangeSelection)
+                WooAssistantCardNavigationTarget.Direction(
+                    NavGraphMainDirections.actionGlobalAnalytics(rangeSelection)
+                )
             }
             is AssistantCardAction.OpenCustomer -> {
                 val customer = getCustomerWithStats(
@@ -41,7 +62,9 @@ internal class WooAssistantCardActionNavigator @Inject constructor(
                     analyticsCustomerId = null,
                 ).getOrNull() ?: return null
 
-                NavGraphMainDirections.actionGlobalCustomerDetailsFragment(customer)
+                WooAssistantCardNavigationTarget.Direction(
+                    NavGraphMainDirections.actionGlobalCustomerDetailsFragment(customer)
+                )
             }
         }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
@@ -12,6 +12,7 @@ class WooAssistantCardRenderer internal constructor(
 ) : AssistantCardRenderer {
     private val orderCardRenderer = AiAssistantOrderCardRenderer(currencyFormatter)
     private val productCardRenderer = AiAssistantProductCardRenderer(currencyFormatter)
+    private val variationCardRenderer = AiAssistantVariationCardRenderer()
     private val statsCardRenderer = AiAssistantStatsCardRenderer(currencyFormatter)
     private val customerCardRenderer = AiAssistantCustomerCardRenderer()
 
@@ -26,6 +27,7 @@ class WooAssistantCardRenderer internal constructor(
         when (card) {
             is AssistantCard.Order -> orderCardRenderer.Card(card, onAction, modifier)
             is AssistantCard.Product -> productCardRenderer.Card(card, onAction, modifier)
+            is AssistantCard.Variation -> variationCardRenderer.Card(card, onAction, modifier)
             is AssistantCard.Stats -> statsCardRenderer.Card(card, onAction, modifier)
             is AssistantCard.Customer -> customerCardRenderer.Card(card, onAction, modifier)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardRenderer.kt
@@ -12,7 +12,7 @@ class WooAssistantCardRenderer internal constructor(
 ) : AssistantCardRenderer {
     private val orderCardRenderer = AiAssistantOrderCardRenderer(currencyFormatter)
     private val productCardRenderer = AiAssistantProductCardRenderer(currencyFormatter)
-    private val variationCardRenderer = AiAssistantVariationCardRenderer()
+    private val variationCardRenderer = AiAssistantVariationCardRenderer(currencyFormatter)
     private val statsCardRenderer = AiAssistantStatsCardRenderer(currencyFormatter)
     private val customerCardRenderer = AiAssistantCustomerCardRenderer()
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3213,6 +3213,7 @@
 
     <string name="more_menu_button_ai_assistant">AI Assistant</string>
     <string name="more_menu_button_ai_assistant_description">Ask about your store</string>
+    <string name="ai_assistant_variation_card_id_title">Variation %1$d</string>
 
     <string name="more_menu_button_bookings_description">Manage your client appointments</string>
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRendererTest.kt
@@ -1,0 +1,75 @@
+package com.woocommerce.android.ui.aiassistant
+
+import android.content.Context
+import com.woocommerce.android.R
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+class AiAssistantVariationCardRendererTest {
+    private val currencyFormatter: AiAssistantCurrencyFormatter = mock()
+
+    @Test
+    fun `given variation card, when row model is built, then product summary row fields are formatted`() {
+        val context: Context = mock()
+        val decimalFormatter: (BigDecimal) -> String = { amount -> "\$${amount.toPlainString()}" }
+        whenever(context.getString(R.string.product_status_draft)).thenReturn("Draft")
+        whenever(context.getString(R.string.product_stock_status_instock)).thenReturn("In stock")
+        whenever(context.getString(R.string.orderdetail_product_lineitem_sku_value, "woo-socks-blue"))
+            .thenReturn("SKU: woo-socks-blue")
+        whenever(currencyFormatter.buildBigDecimalFormatter()).thenReturn(decimalFormatter)
+
+        val model = variationCard().toVariationSummaryRowModel(context, currencyFormatter)
+
+        assertThat(model).isEqualTo(
+            AssistantVariationSummaryRowModel(
+                title = "Blue socks",
+                imageUrl = "https://example.com/blue-socks.png",
+                supportingTexts = listOf(
+                    "Size: M \u2022 Color: Blue",
+                    "Draft \u2022 In stock \u2022 \$12.99",
+                    "SKU: woo-socks-blue",
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun `given variation card has blank supporting fields, when row model is built, then blank rows are omitted`() {
+        val context: Context = mock()
+
+        val model = variationCard(
+            sku = "",
+            price = "",
+            stockStatus = "",
+            status = "publish",
+            attributes = emptyList(),
+        ).toVariationSummaryRowModel(context, currencyFormatter)
+
+        assertThat(model.supportingTexts).isEmpty()
+    }
+
+    private fun variationCard(
+        sku: String = "woo-socks-blue",
+        price: String = "12.99",
+        stockStatus: String = "instock",
+        status: String = "draft",
+        attributes: List<AssistantCard.Variation.Attribute> = listOf(
+            AssistantCard.Variation.Attribute(name = "Size", option = "M"),
+            AssistantCard.Variation.Attribute(name = "Color", option = "Blue"),
+        ),
+    ) = AssistantCard.Variation(
+        parentProductId = 100L,
+        variationId = 10L,
+        name = "Blue socks",
+        sku = sku,
+        price = price,
+        stockStatus = stockStatus,
+        status = status,
+        imageUrl = "https://example.com/blue-socks.png",
+        attributes = attributes,
+    )
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRendererTest.kt
@@ -75,6 +75,18 @@ class AiAssistantVariationCardRendererTest {
         assertThat(model.title).isEqualTo("Variation 10")
     }
 
+    @Test
+    fun `given variation card, when open action is built, then both ids are emitted`() {
+        val action = variationCard().toOpenProductVariationAction()
+
+        assertThat(action).isEqualTo(
+            com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction.OpenProductVariation(
+                parentProductId = 100L,
+                variationId = 10L,
+            )
+        )
+    }
+
     private fun variationCard(
         name: String = "Blue socks",
         sku: String = "woo-socks-blue",

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRendererTest.kt
@@ -52,7 +52,31 @@ class AiAssistantVariationCardRendererTest {
         assertThat(model.supportingTexts).isEmpty()
     }
 
+    @Test
+    fun `given variation card has blank name and non blank sku, when row model is built, then title uses sku label`() {
+        val context: Context = mock()
+        whenever(context.getString(R.string.orderdetail_product_lineitem_sku_value, "woo-socks-blue"))
+            .thenReturn("SKU: woo-socks-blue")
+
+        val model = variationCard(name = "", price = "", stockStatus = "", status = "publish")
+            .toVariationSummaryRowModel(context, currencyFormatter)
+
+        assertThat(model.title).isEqualTo("SKU: woo-socks-blue")
+    }
+
+    @Test
+    fun `given variation card has blank name and no sku, when row model is built, then title uses variation id label`() {
+        val context: Context = mock()
+        whenever(context.getString(R.string.ai_assistant_variation_card_id_title, 10L)).thenReturn("Variation 10")
+
+        val model = variationCard(name = "", sku = "", price = "", stockStatus = "", status = "publish")
+            .toVariationSummaryRowModel(context, currencyFormatter)
+
+        assertThat(model.title).isEqualTo("Variation 10")
+    }
+
     private fun variationCard(
+        name: String = "Blue socks",
         sku: String = "woo-socks-blue",
         price: String = "12.99",
         stockStatus: String = "instock",
@@ -64,7 +88,7 @@ class AiAssistantVariationCardRendererTest {
     ) = AssistantCard.Variation(
         parentProductId = 100L,
         variationId = 10L,
-        name = "Blue socks",
+        name = name,
         sku = sku,
         price = price,
         stockStatus = stockStatus,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRendererTest.kt
@@ -13,6 +13,11 @@ class AiAssistantVariationCardRendererTest {
     private val currencyFormatter: AiAssistantCurrencyFormatter = mock()
 
     @Test
+    fun `when renderer is created, then class has direct unit test coverage`() {
+        assertThat(AiAssistantVariationCardRenderer(currencyFormatter)).isNotNull
+    }
+
+    @Test
     fun `given variation card, when row model is built, then product summary row fields are formatted`() {
         val context: Context = mock()
         val decimalFormatter: (BigDecimal) -> String = { amount -> "\$${amount.toPlainString()}" }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRendererTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantVariationCardRendererTest.kt
@@ -53,6 +53,21 @@ class AiAssistantVariationCardRendererTest {
     }
 
     @Test
+    fun `given variation card has non numeric price, when row model is built, then raw price is used`() {
+        val context: Context = mock()
+
+        val model = variationCard(
+            sku = "",
+            price = "From 12.99",
+            stockStatus = "",
+            status = "publish",
+            attributes = emptyList(),
+        ).toVariationSummaryRowModel(context, currencyFormatter)
+
+        assertThat(model.supportingTexts).containsExactly("From 12.99")
+    }
+
+    @Test
     fun `given variation card has blank name and non blank sku, when row model is built, then title uses sku label`() {
         val context: Context = mock()
         whenever(context.getString(R.string.orderdetail_product_lineitem_sku_value, "woo-socks-blue"))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardActionNavigatorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aiassistant/WooAssistantCardActionNavigatorTest.kt
@@ -52,6 +52,19 @@ class WooAssistantCardActionNavigatorTest {
     }
 
     @Test
+    fun `given open product variation action, when mapped, then variation detail deep link is returned`() = runTest {
+        val target = navigator.targetFor(
+            AssistantCardAction.OpenProductVariation(parentProductId = 100L, variationId = 10L)
+        )
+
+        assertThat(target).isEqualTo(
+            WooAssistantCardNavigationTarget.DeepLink(
+                uri = "wcandroid://variationDetail?remoteProductId=100&remoteVariationId=10"
+            )
+        )
+    }
+
+    @Test
     fun `given open analytics action, when mapped, then analytics direction is returned`() = runTest {
         val direction = requireNotNull(
             navigator.directionFor(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/config/AssistantSystemPromptProvider.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/config/AssistantSystemPromptProvider.kt
@@ -152,6 +152,17 @@ internal class WooCommerceAssistantSystemPromptProvider @Inject constructor() : 
             BAD: Retry with synonyms, casing variants, plural forms, or fall back to listing every product
             hoping one looks close.
 
+            Pattern 3b - Stock-focused product queries.
+            Merchant: "what's low in stock" / "out of stock items" / "show me low stock"
+            GOOD: One product list call using the relevant stock filter, then render with `show_cards`. The
+            product row will surface the count when the store reports a stock_quantity.
+            Broad stock questions are product-level answers. Do not inspect variations unless the merchant
+            explicitly asks about sizes, colors, options, or variation-level stock. Do not call a detail-get role
+            after the product list just to learn the product name; `show_cards` fetches and renders product
+            details from the returned ids.
+            BAD: Pull every product and try to filter by stock in your own reasoning, or call a detail-get role
+            per row to read the count when the list summary already returns stock_quantity.
+
             Pattern 4 - Write tool with confirmation.
             Merchant: "set order 1250 status to completed"
             GOOD: Call the order-update tool with the id and the requested change. The Android confirmation card
@@ -207,10 +218,11 @@ internal class WooCommerceAssistantSystemPromptProvider @Inject constructor() : 
 
             When the merchant does request a change, just call the write tool because the Android app handles
             confirmation automatically - don't ask "shall I proceed?" in prose, don't repeat the
-            confirmation, and don't dump the returned JSON. Keep the post-write reply to one short phrase. If a
-            write returns an ambiguous outcome, narrate the uncertainty briefly and suggest the merchant verify in
-            the app; don't silently retry. If the merchant declines a write, that decline is their answer -
-            acknowledge it and stop.
+            confirmation, and don't dump the returned JSON. After every successful write, call `show_cards` with
+            the updated entity id so the merchant sees the new state - never stop after a write with prose alone.
+            Keep the post-write reply to one short phrase. If a write returns an ambiguous outcome, narrate the
+            uncertainty briefly and suggest the merchant verify in the app; don't silently retry. If the merchant
+            declines a write, that decline is their answer - acknowledge it and stop.
 
             Prefer bulk write tools when the same patch covers more than one entity. Multiple orders to the same
             status: orders_bulk_update. Multiple products sharing one patch: products_bulk_update. Multiple
@@ -264,7 +276,7 @@ internal class WooCommerceAssistantSystemPromptProvider @Inject constructor() : 
             prose; the prose is your final merchant-facing text.
 
             Use `show_cards` in the same assistant response as prose whenever this turn should show orders,
-            products, customers, or analytics stats. Render cards whenever you fetched a list of entities or
+            products, variations, customers, or analytics stats. Render cards whenever you fetched a list of entities or
             analytics stats the merchant asked about, are answering about one or more specific entities or
             analytics breakdowns the merchant should see in the UI, just changed an entity and want the merchant
             to see the updated card, or the merchant said "show", "list", "display", "give me", "tell me about",

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -55,8 +55,8 @@ internal class ShowCardsToolHandler internal constructor(
 
     override val descriptor = ToolDescriptor(
         name = SHOW_CARDS_TOOL_NAME,
-        description = "Show rich cards in the Android UI for order/product/customer entity references or an " +
-            "analytics_stats ID produced after a successful analytics_orders result.",
+        description = "Show rich cards in the Android UI for order/product/variation/customer entity references " +
+            "or an analytics_stats ID produced after a successful analytics_orders result.",
         inputSchema = buildJsonObject {
             put("type", "object")
             put("additionalProperties", false)
@@ -73,6 +73,7 @@ internal class ShowCardsToolHandler internal constructor(
                                 putJsonArray("enum") {
                                     add("order")
                                     add("product")
+                                    add("variation")
                                     add("analytics_stats")
                                     add("customer")
                                 }
@@ -81,7 +82,8 @@ internal class ShowCardsToolHandler internal constructor(
                                 put("type", "string")
                                 put(
                                     "description",
-                                    "Entity id. For analytics_stats, pass the exact card_id returned by " +
+                                    "Entity id. For variation, use strict {parentProductId}/{variationId}. " +
+                                        "For analytics_stats, pass the exact card_id returned by " +
                                         "analytics_orders. Manual form: " +
                                         "analytics_orders:after:<YYYY-MM-DD>:before:<YYYY-MM-DD>:" +
                                         "interval:<hour|day|week|month|year> for analytics_stats.",
@@ -166,6 +168,7 @@ internal class ShowCardsToolHandler internal constructor(
         val allowedKeys = when (family) {
             ShowCardFamily.Order -> ORDER_SUMMARY_KEYS
             ShowCardFamily.Product -> PRODUCT_SUMMARY_KEYS
+            ShowCardFamily.Variation -> VARIATION_SUMMARY_KEYS
             ShowCardFamily.AnalyticsStats -> ANALYTICS_STATS_SUMMARY_KEYS
             ShowCardFamily.Customer -> CUSTOMER_SUMMARY_KEYS
         }
@@ -198,6 +201,17 @@ internal class ShowCardsToolHandler internal constructor(
             "stock_quantity",
         )
         val CUSTOMER_SUMMARY_KEYS = setOf("id", "name", "email")
+        val VARIATION_SUMMARY_KEYS = setOf(
+            "id",
+            "product_id",
+            "variation_id",
+            "name",
+            "sku",
+            "price",
+            "stock_status",
+            "status",
+            "attributes",
+        )
         val ANALYTICS_STATS_SUMMARY_KEYS = setOf(
             "id",
             "after",

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -56,7 +56,10 @@ internal class ShowCardsToolHandler internal constructor(
     override val descriptor = ToolDescriptor(
         name = SHOW_CARDS_TOOL_NAME,
         description = "Show rich cards in the Android UI for order/product/variation/customer entity references " +
-            "or an analytics_stats ID produced after a successful analytics_orders result.",
+            "or an analytics_stats ID produced after a successful analytics_orders result. Variation references " +
+            "use strict {parentProductId}/{variationId} ids and should be used only for explicit " +
+            "variation-level questions about sizes, colors, options, or known variation IDs. For broad product " +
+            "inventory lists, render product references.",
         inputSchema = buildJsonObject {
             put("type", "object")
             put("additionalProperties", false)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.aiassistant.tools.handlers.cards
 
 import com.woocommerce.android.aiassistant.tools.orders.CompactOrderLineItem
+import com.woocommerce.android.aiassistant.tools.products.CompactVariationAttribute
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
@@ -172,6 +173,20 @@ internal sealed interface ShowCardDetails {
         @SerialName("stock_status") val stockStatus: String? = null,
         val status: String? = null,
         @SerialName("image_url") val imageUrl: String? = null,
+    ) : ShowCardDetails
+
+    @Serializable
+    @SerialName("variation")
+    data class Variation(
+        @SerialName("product_id") val productId: Long,
+        @SerialName("variation_id") val variationId: Long,
+        val name: String? = null,
+        val sku: String? = null,
+        val price: String? = null,
+        @SerialName("stock_status") val stockStatus: String? = null,
+        val status: String? = null,
+        @SerialName("image_url") val imageUrl: String? = null,
+        val attributes: List<CompactVariationAttribute> = emptyList(),
     ) : ShowCardDetails
 
     @Serializable

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsModels.kt
@@ -18,6 +18,7 @@ internal data class ShowCardsArguments(
 internal enum class ShowCardFamily(val serializedName: String) {
     Order("order"),
     Product("product"),
+    Variation("variation"),
     AnalyticsStats("analytics_stats"),
     Customer("customer");
 
@@ -76,6 +77,19 @@ internal data class ProductSummary(
     @SerialName("manage_stock") val manageStock: Boolean? = null,
     @SerialName("on_sale") val onSale: Boolean? = null,
     @SerialName("stock_quantity") val stockQuantity: Double? = null,
+)
+
+@Serializable
+internal data class VariationSummary(
+    val id: String,
+    @SerialName("product_id") val productId: Long,
+    @SerialName("variation_id") val variationId: Long,
+    val name: String? = null,
+    val sku: String? = null,
+    val price: String? = null,
+    @SerialName("stock_status") val stockStatus: String? = null,
+    val status: String? = null,
+    val attributes: List<CompactVariationAttribute> = emptyList(),
 )
 
 @Serializable

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsReferenceValidator.kt
@@ -69,6 +69,7 @@ internal class ShowCardsReferenceValidator {
             ShowCardFamily.Order,
             ShowCardFamily.Product,
             ShowCardFamily.Customer -> toLongOrNull()?.let { it > 0L } == true
+            ShowCardFamily.Variation -> VariationCardId.parse(this) != null
             ShowCardFamily.AnalyticsStats -> AnalyticsStatsCardId.parse(this) != null
         }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
@@ -11,6 +11,8 @@ import com.woocommerce.android.aiassistant.tools.customers.AICustomersDataSource
 import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
 import com.woocommerce.android.aiassistant.tools.orders.CompactOrderLineItem
 import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
+import com.woocommerce.android.aiassistant.tools.products.AIProductVariationsDataSource
+import com.woocommerce.android.aiassistant.tools.products.toProductVariationDetailResponse
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -20,6 +22,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.model.customer.WCCustomerModel
 import org.wordpress.android.fluxc.model.order.LineItem
 import org.wordpress.android.fluxc.persistence.entity.OrderEntity
@@ -47,6 +50,7 @@ internal sealed interface ShowCardsResolution {
 internal class DefaultShowCardsResolver @Inject constructor(
     private val ordersDataSource: AIOrdersDataSource,
     private val productsDataSource: AIProductsDataSource,
+    private val variationsDataSource: AIProductVariationsDataSource,
     private val analyticsDataSource: AIAnalyticsDataSource,
     private val customersDataSource: AICustomersDataSource,
     @AiAssistantJson private val json: Json,
@@ -54,12 +58,14 @@ internal class DefaultShowCardsResolver @Inject constructor(
     override suspend fun resolve(refs: List<ValidatedRef>): List<ShowCardsResolution> {
         val orderResults = resolveOrders(refs.filter { it.family == ShowCardFamily.Order })
         val productResults = resolveProducts(refs.filter { it.family == ShowCardFamily.Product })
+        val variationResults = resolveVariations(refs.filter { it.family == ShowCardFamily.Variation })
         val analyticsResults = resolveAnalyticsStats(refs.filter { it.family == ShowCardFamily.AnalyticsStats })
         val customerResults = resolveCustomers(refs.filter { it.family == ShowCardFamily.Customer })
 
         return refs.map { ref ->
             orderResults[ref]
                 ?: productResults[ref]
+                ?: variationResults[ref]
                 ?: analyticsResults[ref]
                 ?: customerResults[ref]
                 ?: ShowCardsResolution.Missing(
@@ -170,6 +176,61 @@ internal class DefaultShowCardsResolver @Inject constructor(
             ),
         ),
     )
+
+    private suspend fun resolveVariations(refs: List<ValidatedRef>): Map<ValidatedRef, ShowCardsResolution> {
+        if (refs.isEmpty()) return emptyMap()
+
+        return coroutineScope {
+            refs.map { ref -> async { ref to resolveVariation(ref) } }.awaitAll().toMap()
+        }
+    }
+
+    private suspend fun resolveVariation(ref: ValidatedRef): ShowCardsResolution {
+        val id = VariationCardId.parse(ref.id)
+            ?: return ShowCardsResolution.Missing(ref, ShowCardsRejectionReason.InvalidId)
+
+        return variationsDataSource.getVariation(
+            productId = id.productId,
+            variationId = id.variationId,
+        ).fold(
+            onSuccess = { variation -> variation.toResolved(ref) },
+            onFailure = { ShowCardsResolution.Missing(ref, ShowCardsRejectionReason.FetchFailed) },
+        )
+    }
+
+    private fun WCProductVariationModel.toResolved(ref: ValidatedRef): ShowCardsResolution.Resolved {
+        val detail = toProductVariationDetailResponse()
+        return ShowCardsResolution.Resolved(
+            ref = ref,
+            summary = jsonObject(
+                VariationSummary(
+                    id = ref.id,
+                    productId = detail.productId,
+                    variationId = detail.id,
+                    sku = detail.sku.takeIf { it.isNotBlank() },
+                    price = detail.price.takeIf { it.isNotBlank() },
+                    stockStatus = detail.stockStatus.takeIf { it.isNotBlank() },
+                    status = detail.status.takeIf { it.isNotBlank() },
+                    attributes = detail.attributes,
+                )
+            ),
+            card = ShowCardPayload(
+                family = ShowCardFamily.Variation.serializedName,
+                id = ref.id,
+                title = "Variation ${detail.id}",
+                details = ShowCardDetails.Variation(
+                    productId = detail.productId,
+                    variationId = detail.id,
+                    sku = detail.sku.takeIf { it.isNotBlank() },
+                    price = detail.price.takeIf { it.isNotBlank() },
+                    stockStatus = detail.stockStatus.takeIf { it.isNotBlank() },
+                    status = detail.status.takeIf { it.isNotBlank() },
+                    imageUrl = detail.image?.src?.takeIf { it.isNotBlank() },
+                    attributes = detail.attributes,
+                ),
+            ),
+        )
+    }
 
     private suspend fun resolveAnalyticsStats(refs: List<ValidatedRef>): Map<ValidatedRef, ShowCardsResolution> {
         if (refs.isEmpty()) return emptyMap()

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
@@ -10,7 +10,6 @@ import com.woocommerce.android.aiassistant.tools.analytics.analyticsStatsSummary
 import com.woocommerce.android.aiassistant.tools.customers.AICustomersDataSource
 import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
 import com.woocommerce.android.aiassistant.tools.orders.CompactOrderLineItem
-import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
 import com.woocommerce.android.aiassistant.tools.products.AIProductVariationsDataSource
 import com.woocommerce.android.aiassistant.tools.products.toProductVariationDetailResponse
 import kotlinx.coroutines.async
@@ -49,7 +48,7 @@ internal sealed interface ShowCardsResolution {
 
 internal class DefaultShowCardsResolver @Inject constructor(
     private val ordersDataSource: AIOrdersDataSource,
-    private val productsDataSource: AIProductsDataSource,
+    private val productsDataSource: com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource,
     private val variationsDataSource: AIProductVariationsDataSource,
     private val analyticsDataSource: AIAnalyticsDataSource,
     private val customersDataSource: AICustomersDataSource,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/VariationCardId.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/VariationCardId.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.aiassistant.tools.handlers.cards
+
+internal data class VariationCardId(
+    val productId: Long,
+    val variationId: Long,
+) {
+    fun asShowCardsId(): String = "$productId/$variationId"
+
+    companion object {
+        private val SHAPE = Regex("[1-9]\\d*/[1-9]\\d*")
+
+        fun parse(raw: String): VariationCardId? {
+            if (!SHAPE.matches(raw)) return null
+            val parts = raw.split("/")
+            val productId = parts[0].toLongOrNull() ?: return null
+            val variationId = parts[1].toLongOrNull() ?: return null
+            return VariationCardId(productId = productId, variationId = variationId)
+        }
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsToolHandler.kt
@@ -28,7 +28,10 @@ internal class ProductVariationsToolHandler @Inject constructor(
 
     override val descriptor = ToolDescriptor(
         name = "product_variations_list",
-        description = "List variations for a variable product, or fetch one variation by variation_id.",
+        description = "List variations for one variable product when the merchant explicitly asks about " +
+            "variations, sizes, colors, options, or a known variation ID. Required: product_id (the parent). " +
+            "Do not use this for broad product-level inventory questions such as out-of-stock products; " +
+            "product stock and variation stock are separate WooCommerce concepts.",
         inputSchema = inputSchema {
             integer("product_id", description = "The parent product ID. Required.", required = true)
             integer("variation_id", description = "Variation ID; omit to list variations or provide to fetch one.")

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsUpdateToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsUpdateToolHandler.kt
@@ -25,7 +25,9 @@ internal class ProductVariationsUpdateToolHandler @Inject constructor(
         name = "product_variations_update",
         description = "Update one product variation. Requires parent product_id and variation id. " +
             "Accepts only regular_price, sale_price, stock_quantity, stock_status, sku, and status. " +
-            "Setting stock_quantity also enables stock management. At most one write is executed per turn.",
+            "Setting stock_quantity also enables stock management. At most one write is executed per turn. " +
+            "After a successful update, call show_cards with family variation and the strict " +
+            "{parentProductId}/{variationId} id so the merchant sees the new state.",
         inputSchema = inputSchema {
             integer("product_id", description = "The parent product ID. Required.", required = true)
             integer("id", description = "The variation ID. Required.", required = true)

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsGetToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsGetToolHandler.kt
@@ -24,7 +24,9 @@ internal class ProductsGetToolHandler @Inject constructor(
         name = "products_get",
         description = "Fetch a single product with full detail (price, stock, categories, type). " +
             "Use when the merchant references a specific product by ID. " +
-            "For variable products use product_variations_list to inspect all variants or fetch one by variation_id.",
+            "For variable products, use product_variations_list only when the merchant explicitly asks about " +
+            "variations, sizes, colors, options, or variation-level stock. Do NOT call this tool to render a " +
+            "card after products_list - `show_cards` re-fetches product detail itself when given a reference.",
         inputSchema = inputSchema {
             integer("id", description = "The product ID. Required.", required = true)
         },

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -957,6 +957,7 @@ private object PreviewAssistantCardRenderer : AssistantCardRenderer {
         when (card) {
             is AssistantCard.Order -> PreviewOrderCard(card, modifier)
             is AssistantCard.Product -> PreviewProductCard(card, modifier)
+            is AssistantCard.Variation -> PreviewVariationCard(card, modifier)
             is AssistantCard.Customer -> PreviewCustomerCard(card, modifier)
             is AssistantCard.Stats -> PreviewStatsCard(card, modifier)
         }
@@ -1012,6 +1013,31 @@ private object PreviewAssistantCardRenderer : AssistantCardRenderer {
     @Composable
     private fun PreviewProductCard(
         card: AssistantCard.Product,
+        modifier: Modifier,
+    ) {
+        Column(
+            modifier = modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = card.name,
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = listOf(card.stockStatus, card.price)
+                    .filter { it.isNotBlank() }
+                    .joinToString(" - "),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+    }
+
+    @Composable
+    private fun PreviewVariationCard(
+        card: AssistantCard.Variation,
         modifier: Modifier,
     ) {
         Column(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModel.kt
@@ -352,6 +352,10 @@ class AssistantViewModel @AssistedInject constructor(
         when (this) {
             is AssistantCard.Order -> AssistantCardKey(family = "order", id = remoteOrderId.toString())
             is AssistantCard.Product -> AssistantCardKey(family = "product", id = remoteProductId.toString())
+            is AssistantCard.Variation -> AssistantCardKey(
+                family = "variation",
+                id = "$parentProductId/$variationId",
+            )
             is AssistantCard.Customer -> AssistantCardKey(family = "customer", id = remoteCustomerId.toString())
             is AssistantCard.Stats -> AssistantCardKey(family = "analytics_stats", id = id)
         }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCard.kt
@@ -21,6 +21,23 @@ sealed interface AssistantCard {
         val imageUrl: String,
     ) : AssistantCard
 
+    data class Variation(
+        val parentProductId: Long,
+        val variationId: Long,
+        val name: String,
+        val sku: String,
+        val price: String,
+        val stockStatus: String,
+        val status: String,
+        val imageUrl: String,
+        val attributes: List<Attribute>,
+    ) : AssistantCard {
+        data class Attribute(
+            val name: String,
+            val option: String,
+        )
+    }
+
     data class Customer(
         val remoteCustomerId: Long,
         val name: String,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardAction.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardAction.kt
@@ -3,6 +3,10 @@ package com.woocommerce.android.aiassistant.ui.cards
 sealed interface AssistantCardAction {
     data class OpenOrder(val remoteOrderId: Long) : AssistantCardAction
     data class OpenProduct(val remoteProductId: Long) : AssistantCardAction
+    data class OpenProductVariation(
+        val parentProductId: Long,
+        val variationId: Long,
+    ) : AssistantCardAction
     data class OpenCustomer(val remoteCustomerId: Long) : AssistantCardAction
     data class OpenAnalytics(
         val after: String,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardGroupMetadata.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardGroupMetadata.kt
@@ -19,6 +19,7 @@ internal fun List<AssistantCard>.toAssistantCardGroupMetadata(): AssistantCardGr
 private enum class AssistantCardGroupKind {
     Order,
     Product,
+    Variation,
     Stats,
     Customer,
 }
@@ -27,7 +28,7 @@ private val AssistantCard.groupKind: AssistantCardGroupKind
     get() = when (this) {
         is AssistantCard.Order -> AssistantCardGroupKind.Order
         is AssistantCard.Product -> AssistantCardGroupKind.Product
-        is AssistantCard.Variation -> AssistantCardGroupKind.Product
+        is AssistantCard.Variation -> AssistantCardGroupKind.Variation
         is AssistantCard.Stats -> AssistantCardGroupKind.Stats
         is AssistantCard.Customer -> AssistantCardGroupKind.Customer
     }
@@ -40,6 +41,10 @@ private val AssistantCardGroupKind.metadata: AssistantCardGroupMetadata
         )
         AssistantCardGroupKind.Product -> AssistantCardGroupMetadata(
             titleRes = R.string.assistant_chat_card_group_products,
+            iconRes = R.drawable.ic_assistant_card_group_products,
+        )
+        AssistantCardGroupKind.Variation -> AssistantCardGroupMetadata(
+            titleRes = R.string.assistant_chat_card_group_variations,
             iconRes = R.drawable.ic_assistant_card_group_products,
         )
         AssistantCardGroupKind.Stats -> AssistantCardGroupMetadata(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardGroupMetadata.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardGroupMetadata.kt
@@ -27,6 +27,7 @@ private val AssistantCard.groupKind: AssistantCardGroupKind
     get() = when (this) {
         is AssistantCard.Order -> AssistantCardGroupKind.Order
         is AssistantCard.Product -> AssistantCardGroupKind.Product
+        is AssistantCard.Variation -> AssistantCardGroupKind.Product
         is AssistantCard.Stats -> AssistantCardGroupKind.Stats
         is AssistantCard.Customer -> AssistantCardGroupKind.Customer
     }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.aiassistant.ui.cards
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardDetails
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+import com.woocommerce.android.aiassistant.tools.handlers.cards.VariationCardId
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
@@ -74,7 +75,7 @@ internal object AssistantCardPayloadParser {
         return AssistantCard.Variation(
             parentProductId = parentProductId,
             variationId = variationId,
-            name = details.name ?: card.title,
+            name = details.name.orEmpty(),
             sku = details.sku.orEmpty(),
             price = details.price.orEmpty(),
             stockStatus = details.stockStatus.orEmpty(),
@@ -175,11 +176,8 @@ internal object AssistantCardPayloadParser {
             runCatching { LocalDate.parse(this, DateTimeFormatter.ISO_LOCAL_DATE) }.isSuccess
 
     private fun String.toVariationIdParts(): Pair<Long, Long>? {
-        val parts = split("/")
-        if (parts.size != 2) return null
-        val parentProductId = parts[0].toLongOrNull()?.takeIf { it > 0L } ?: return null
-        val variationId = parts[1].toLongOrNull()?.takeIf { it > 0L } ?: return null
-        return parentProductId to variationId
+        val id = VariationCardId.parse(this) ?: return null
+        return id.productId to id.variationId
     }
 
     private const val ORDER_FAMILY = "order"

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParser.kt
@@ -30,6 +30,7 @@ internal object AssistantCardPayloadParser {
         when (card.family) {
             ORDER_FAMILY -> parseOrderCard(card)
             PRODUCT_FAMILY -> parseProductCard(card)
+            VARIATION_FAMILY -> parseVariationCard(card)
             CUSTOMER_FAMILY -> parseCustomerCard(card)
             ANALYTICS_STATS_FAMILY -> parseStatsCard(card)
             else -> null
@@ -62,6 +63,32 @@ internal object AssistantCardPayloadParser {
             stockStatus = details.stockStatus.orEmpty(),
             status = details.status.orEmpty(),
             imageUrl = details.imageUrl.orEmpty(),
+        )
+    }
+
+    private fun parseVariationCard(card: ShowCardPayload): AssistantCard? {
+        val details = card.details as? ShowCardDetails.Variation ?: return null
+        val (parentProductId, variationId) = card.id.toVariationIdParts() ?: return null
+        if (parentProductId != details.productId || variationId != details.variationId) return null
+
+        return AssistantCard.Variation(
+            parentProductId = parentProductId,
+            variationId = variationId,
+            name = details.name ?: card.title,
+            sku = details.sku.orEmpty(),
+            price = details.price.orEmpty(),
+            stockStatus = details.stockStatus.orEmpty(),
+            status = details.status.orEmpty(),
+            imageUrl = details.imageUrl.orEmpty(),
+            attributes = details.attributes.mapNotNull { attribute ->
+                val name = attribute.name?.takeIf { it.isNotBlank() }
+                val option = attribute.option?.takeIf { it.isNotBlank() }
+                if (name != null && option != null) {
+                    AssistantCard.Variation.Attribute(name = name, option = option)
+                } else {
+                    null
+                }
+            },
         )
     }
 
@@ -147,8 +174,17 @@ internal object AssistantCardPayloadParser {
         ISO_LOCAL_DATE_SHAPE.matches(this) &&
             runCatching { LocalDate.parse(this, DateTimeFormatter.ISO_LOCAL_DATE) }.isSuccess
 
+    private fun String.toVariationIdParts(): Pair<Long, Long>? {
+        val parts = split("/")
+        if (parts.size != 2) return null
+        val parentProductId = parts[0].toLongOrNull()?.takeIf { it > 0L } ?: return null
+        val variationId = parts[1].toLongOrNull()?.takeIf { it > 0L } ?: return null
+        return parentProductId to variationId
+    }
+
     private const val ORDER_FAMILY = "order"
     private const val PRODUCT_FAMILY = "product"
+    private const val VARIATION_FAMILY = "variation"
     private const val CUSTOMER_FAMILY = "customer"
     private const val ANALYTICS_STATS_FAMILY = "analytics_stats"
     private const val ISO_LOCAL_DATE_LENGTH = 10

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="assistant_chat_tool_activity_content_description">Assistant is working: %1$s</string>
     <string name="assistant_chat_card_group_orders">Orders</string>
     <string name="assistant_chat_card_group_products">Products</string>
+    <string name="assistant_chat_card_group_variations">Variations</string>
     <string name="assistant_chat_card_group_stats">Analytics</string>
     <string name="assistant_chat_card_group_customers">Customers</string>
     <string name="assistant_chat_card_group_generic">Cards</string>

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/config/AssistantSystemPromptProviderTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/config/AssistantSystemPromptProviderTest.kt
@@ -89,6 +89,18 @@ class AssistantSystemPromptProviderTest {
     }
 
     @Test
+    fun `when prompt is built, then broad stock questions stay product level unless variation level is explicit`() {
+        val prompt = promptFor(todayIsoDate = "2026-05-04")
+
+        assertThat(prompt).contains("Stock-focused product queries")
+        assertThat(prompt).contains("Broad stock questions are product-level answers")
+        assertThat(prompt).contains("Do not inspect variations unless the merchant")
+        assertThat(prompt).contains("explicitly asks about sizes, colors, options")
+        assertThat(prompt).contains("sizes, colors, options, or variation-level stock")
+        assertThat(prompt).contains("`show_cards` fetches and renders product")
+    }
+
+    @Test
     fun `when prompt is built, then show cards is the only card producer including customers and analytics stats`() {
         val prompt = promptFor(todayIsoDate = "2026-05-04")
 
@@ -97,7 +109,7 @@ class AssistantSystemPromptProviderTest {
         assertThat(prompt).contains("don't call the card-rendering tool")
         assertThat(prompt).contains("no cards appear")
         assertThat(prompt).contains("this turn should show orders")
-        assertThat(prompt).contains("products, customers, or analytics stats")
+        assertThat(prompt).contains("products, variations, customers, or analytics stats")
         assertThat(prompt).contains("Customer lists and cards")
         assertThat(prompt).contains("customer list call -> `show_cards`")
         assertThat(prompt).contains("One analytics read call with the appropriate window and a daily-grain parameter")

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -14,7 +14,9 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolut
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
+import com.woocommerce.android.aiassistant.tools.handlers.cards.VariationSummary
 import com.woocommerce.android.aiassistant.tools.orders.CompactOrderLineItem
+import com.woocommerce.android.aiassistant.tools.products.CompactVariationAttribute
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -40,12 +42,13 @@ class ShowCardsToolHandlerTest {
     private val handler = handlerWith(FakeResolver.empty())
 
     @Test
-    fun `when descriptor is inspected, then show cards accepts order product analytics stats and customer references`() {
+    fun `when descriptor is inspected, then show cards accepts order product variation analytics stats and customer refs`() {
         val descriptor = handler.descriptor
 
         assertThat(descriptor.name).isEqualTo("show_cards")
         assertThat(descriptor.description).contains("order")
         assertThat(descriptor.description).contains("product")
+        assertThat(descriptor.description).contains("variation")
         assertThat(descriptor.description).contains("analytics_stats")
         assertThat(descriptor.description).contains("customer")
         assertThat(descriptor.inputSchema.toString()).contains("references")
@@ -53,6 +56,7 @@ class ShowCardsToolHandlerTest {
         assertThat(descriptor.inputSchema.toString()).contains("id")
         assertThat(descriptor.inputSchema.toString()).contains("order")
         assertThat(descriptor.inputSchema.toString()).contains("product")
+        assertThat(descriptor.inputSchema.toString()).contains("variation")
         assertThat(descriptor.inputSchema.toString()).contains("analytics_stats")
         assertThat(descriptor.inputSchema.toString()).contains("customer")
         assertThat(descriptor.inputSchema.toString())
@@ -182,6 +186,42 @@ class ShowCardsToolHandlerTest {
         assertThat(validated(result)).isEqualTo(1)
         assertThat(rejectedReasons(result)).isEmpty()
         assertThat(resolvedIds(result)).containsExactly(ANALYTICS_STATS_ID)
+    }
+
+    @Test
+    fun `given variation composite id, when executed, then ref validates and resolved id is preserved`() = runTest {
+        val result = callShowCards(
+            resolver = FakeResolver.resolving(variationCard(id = "100/10")),
+            referencesJson = """[{ "family": "variation", "id": "100/10" }]"""
+        )
+
+        assertThat(validated(result)).isEqualTo(1)
+        assertThat(rejectedReasons(result)).isEmpty()
+        assertThat(resolvedFamilies(result)).containsExactly("variation")
+        assertThat(resolvedIds(result)).containsExactly("100/10")
+    }
+
+    @Test
+    fun `given invalid variation composite ids, when executed, then refs are rejected as invalid id`() = runTest {
+        val refs = listOf("100", "100/", "/10", "0/10", "100/0", "abc/10", "100/abc", "100:10")
+            .joinToString(separator = ",") { id -> """{ "family": "variation", "id": "$id" }""" }
+
+        val result = callShowCards(
+            resolver = FakeResolver.empty(),
+            referencesJson = "[$refs]"
+        )
+
+        assertThat(validated(result)).isEqualTo(0)
+        assertThat(rejectedReasons(result)).containsExactly(
+            "invalid_id",
+            "invalid_id",
+            "invalid_id",
+            "invalid_id",
+            "invalid_id",
+            "invalid_id",
+            "invalid_id",
+            "invalid_id",
+        )
     }
 
     @Test
@@ -605,6 +645,40 @@ class ShowCardsToolHandlerTest {
                     stockStatus = "instock",
                     status = "publish",
                     imageUrl = PRODUCT_IMAGE_URL,
+                ),
+            )
+        )
+    }
+
+    private fun variationCard(id: String): ShowCardsResolution.Resolved {
+        val ref = ValidatedRef(index = 0, family = ShowCardFamily.Variation, id = id)
+
+        return ShowCardsResolution.Resolved(
+            ref = ref,
+            summary = json.encodeToJsonElement(
+                VariationSummary(
+                    id = id,
+                    productId = 100L,
+                    variationId = 10L,
+                    sku = "woo-socks-blue",
+                    price = "12.99",
+                    stockStatus = "instock",
+                    status = "publish",
+                    attributes = listOf(CompactVariationAttribute(name = "Size", option = "M")),
+                )
+            ).jsonObject,
+            card = ShowCardPayload(
+                family = "variation",
+                id = id,
+                title = "Variation 10",
+                details = ShowCardDetails.Variation(
+                    productId = 100L,
+                    variationId = 10L,
+                    sku = "woo-socks-blue",
+                    price = "12.99",
+                    stockStatus = "instock",
+                    status = "publish",
+                    attributes = listOf(CompactVariationAttribute(name = "Size", option = "M")),
                 ),
             )
         )

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -51,6 +51,8 @@ class ShowCardsToolHandlerTest {
         assertThat(descriptor.description).contains("variation")
         assertThat(descriptor.description).contains("analytics_stats")
         assertThat(descriptor.description).contains("customer")
+        assertThat(descriptor.description).contains("explicit variation-level questions")
+        assertThat(descriptor.description).contains("broad product inventory lists")
         assertThat(descriptor.inputSchema.toString()).contains("references")
         assertThat(descriptor.inputSchema.toString()).contains("family")
         assertThat(descriptor.inputSchema.toString()).contains("id")

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -42,7 +42,7 @@ class ShowCardsToolHandlerTest {
     private val handler = handlerWith(FakeResolver.empty())
 
     @Test
-    fun `when descriptor is inspected, then show cards accepts order product variation analytics stats and customer refs`() {
+    fun `when descriptor is inspected, then show cards accepts order product variation analytics stats and customer references`() {
         val descriptor = handler.descriptor
 
         assertThat(descriptor.name).isEqualTo("show_cards")
@@ -59,6 +59,7 @@ class ShowCardsToolHandlerTest {
         assertThat(descriptor.inputSchema.toString()).contains("variation")
         assertThat(descriptor.inputSchema.toString()).contains("analytics_stats")
         assertThat(descriptor.inputSchema.toString()).contains("customer")
+        assertThat(descriptor.inputSchema.toString()).contains("{parentProductId}/{variationId}")
         assertThat(descriptor.inputSchema.toString())
             .contains("analytics_orders:after:<YYYY-MM-DD>:before:<YYYY-MM-DD>")
         assertThat(descriptor.description).doesNotContain("analytics_revenue")
@@ -168,6 +169,29 @@ class ShowCardsToolHandlerTest {
         val summary = firstResolvedSummary(result)
 
         assertThat(summary.keys).containsExactly("id", "name", "email")
+    }
+
+    @Test
+    fun `given resolved variation, when executed, then summary contains only allowlisted fields`() = runTest {
+        val result = callShowCards(
+            resolver = FakeResolver.resolving(variationCard(id = "100/10")),
+            referencesJson = """[{ "family": "variation", "id": "100/10" }]"""
+        )
+
+        val summary = firstResolvedSummary(result)
+
+        assertThat(summary.keys).containsExactly(
+            "id",
+            "product_id",
+            "variation_id",
+            "name",
+            "sku",
+            "price",
+            "stock_status",
+            "status",
+            "attributes",
+        )
+        assertThat(assertSuccess(result).structured.toString()).doesNotContain("image_url")
     }
 
     @Test
@@ -660,6 +684,7 @@ class ShowCardsToolHandlerTest {
                     id = id,
                     productId = 100L,
                     variationId = 10L,
+                    name = "Blue socks",
                     sku = "woo-socks-blue",
                     price = "12.99",
                     stockStatus = "instock",

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.aiassistant.tools.analytics.AnalyticsStats
 import com.woocommerce.android.aiassistant.tools.customers.AICustomersDataSource
 import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
 import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
+import com.woocommerce.android.aiassistant.tools.products.AIProductVariationsDataSource
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.boolean
@@ -26,12 +27,14 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.WCProductModel
+import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.model.customer.WCCustomerModel
 import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 
 class ShowCardsResolverTest {
     private val ordersDataSource: AIOrdersDataSource = mock()
     private val productsDataSource: AIProductsDataSource = mock()
+    private val variationsDataSource: AIProductVariationsDataSource = mock()
     private val analyticsDataSource: AIAnalyticsDataSource = mock()
     private val customersDataSource: AICustomersDataSource = mock()
     private val json = Json {
@@ -43,6 +46,7 @@ class ShowCardsResolverTest {
     private val resolver = DefaultShowCardsResolver(
         ordersDataSource = ordersDataSource,
         productsDataSource = productsDataSource,
+        variationsDataSource = variationsDataSource,
         analyticsDataSource = analyticsDataSource,
         customersDataSource = customersDataSource,
         json = json,
@@ -111,7 +115,7 @@ class ShowCardsResolverTest {
             before = "2026-05-07T23:59:59",
             interval = AnalyticsInterval.DAY,
         )
-        verifyNoInteractions(ordersDataSource, productsDataSource)
+        verifyNoInteractions(ordersDataSource, productsDataSource, variationsDataSource)
         val resolved = result.single() as ShowCardsResolution.Resolved
         assertThat(resolved.summary.getValue("id").jsonPrimitive.content).isEqualTo(ANALYTICS_STATS_ID)
         assertThat(resolved.summary.getValue("after").jsonPrimitive.content).isEqualTo("2026-05-01")
@@ -128,6 +132,32 @@ class ShowCardsResolverTest {
         assertThat(details.totals.getValue("orders_count").jsonPrimitive.content).isEqualTo("42")
         assertThat(details.intervalSubtotals).hasSize(2)
     }
+
+    @Test
+    fun `given variation ref, when resolved, then resolver fetches variation with parent and variation ids`() =
+        runTest {
+            whenever(variationsDataSource.getVariation(productId = 100L, variationId = 10L))
+                .thenReturn(Result.success(variation(productId = 100L, variationId = 10L)))
+
+            val result = resolver.resolve(listOf(ref(ShowCardFamily.Variation, "100/10")))
+
+            verify(variationsDataSource).getVariation(productId = 100L, variationId = 10L)
+            val resolved = result.single() as ShowCardsResolution.Resolved
+            assertThat(resolved.card.id).isEqualTo("100/10")
+            assertThat(resolved.summary.getValue("id").jsonPrimitive.content).isEqualTo("100/10")
+            assertThat(resolved.summary.getValue("product_id").jsonPrimitive.content).isEqualTo("100")
+            assertThat(resolved.summary.getValue("variation_id").jsonPrimitive.content).isEqualTo("10")
+            val details = resolved.card.details as ShowCardDetails.Variation
+            assertThat(details.productId).isEqualTo(100L)
+            assertThat(details.variationId).isEqualTo(10L)
+            assertThat(details.sku).isEqualTo("woo-socks-blue")
+            assertThat(details.price).isEqualTo("12.99")
+            assertThat(details.stockStatus).isEqualTo("instock")
+            assertThat(details.status).isEqualTo("publish")
+            assertThat(details.imageUrl).isEqualTo(PRODUCT_IMAGE_URL)
+            assertThat(details.attributes.map { it.name }).containsExactly("Size", "Color")
+            assertThat(details.attributes.map { it.option }).containsExactly("M", "Blue")
+        }
 
     @Test
     fun `given analytics stats ref, when resolved, then site currency is used for display`() = runTest {
@@ -552,6 +582,20 @@ class ShowCardsResolverTest {
         stockQuantity = stockQuantity,
         status = "publish",
         images = """[{"id":7,"src":"$PRODUCT_IMAGE_URL"}]""",
+    )
+
+    private fun variation(
+        productId: Long,
+        variationId: Long,
+    ) = WCProductVariationModel(
+        remoteProductId = RemoteId(productId),
+        remoteVariationId = RemoteId(variationId),
+        sku = "woo-socks-blue",
+        price = "12.99",
+        stockStatus = "instock",
+        status = "publish",
+        image = """{"id":7,"src":"$PRODUCT_IMAGE_URL"}""",
+        attributes = """[{"id":1,"name":"Size","option":"M"},{"id":2,"name":"Color","option":"Blue"}]""",
     )
 
     private fun customer(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
@@ -6,7 +6,6 @@ import com.woocommerce.android.aiassistant.tools.analytics.AnalyticsInterval
 import com.woocommerce.android.aiassistant.tools.analytics.AnalyticsStats
 import com.woocommerce.android.aiassistant.tools.customers.AICustomersDataSource
 import com.woocommerce.android.aiassistant.tools.orders.AIOrdersDataSource
-import com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource
 import com.woocommerce.android.aiassistant.tools.products.AIProductVariationsDataSource
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -33,7 +32,7 @@ import org.wordpress.android.fluxc.persistence.entity.OrderEntity
 
 class ShowCardsResolverTest {
     private val ordersDataSource: AIOrdersDataSource = mock()
-    private val productsDataSource: AIProductsDataSource = mock()
+    private val productsDataSource: com.woocommerce.android.aiassistant.tools.products.AIProductsDataSource = mock()
     private val variationsDataSource: AIProductVariationsDataSource = mock()
     private val analyticsDataSource: AIAnalyticsDataSource = mock()
     private val customersDataSource: AICustomersDataSource = mock()

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
@@ -57,12 +57,15 @@ class ShowCardsResolverTest {
         val orderOne = order(id = 1L, number = "1001")
         val orderTwo = order(id = 2L, number = "1002")
         val product = product(id = 3L, name = "Socks")
+        val variation = variation(productId = 3L, variationId = 10L)
         val customer = customer(id = 4L, firstName = "Ada", lastName = "Lovelace", email = "ada@example.com")
         val stats = analyticsStats()
         whenever(ordersDataSource.getOrders(listOf(1L, 2L))).thenReturn(
             Result.success(orderLookup(orderTwo, orderOne))
         )
         whenever(productsDataSource.getProducts(listOf(3L))).thenReturn(Result.success(productLookup(product)))
+        whenever(variationsDataSource.getVariation(productId = 3L, variationId = 10L))
+            .thenReturn(Result.success(variation))
         givenCustomersFetch(ids = listOf(4L), customer)
         whenever(
             analyticsDataSource.fetchOrdersStats(
@@ -77,6 +80,7 @@ class ShowCardsResolverTest {
                 ref(ShowCardFamily.Order, "1"),
                 ref(ShowCardFamily.AnalyticsStats, ANALYTICS_STATS_ID),
                 ref(ShowCardFamily.Product, "3"),
+                ref(ShowCardFamily.Variation, "3/10"),
                 ref(ShowCardFamily.Customer, "4"),
                 ref(ShowCardFamily.Order, "2"),
             )
@@ -84,11 +88,13 @@ class ShowCardsResolverTest {
 
         verify(ordersDataSource).getOrders(listOf(1L, 2L))
         verify(productsDataSource).getProducts(listOf(3L))
+        verify(variationsDataSource).getVariation(productId = 3L, variationId = 10L)
         verifyCustomersFetch(ids = listOf(4L))
         assertThat(result.map { it.ref.family.serializedName to it.ref.id }).containsExactly(
             "order" to "1",
             "analytics_stats" to ANALYTICS_STATS_ID,
             "product" to "3",
+            "variation" to "3/10",
             "customer" to "4",
             "order" to "2",
         )
@@ -158,6 +164,17 @@ class ShowCardsResolverTest {
             assertThat(details.attributes.map { it.name }).containsExactly("Size", "Color")
             assertThat(details.attributes.map { it.option }).containsExactly("M", "Blue")
         }
+
+    @Test
+    fun `given variation fetch fails, when resolved, then ref is fetch failed`() = runTest {
+        whenever(variationsDataSource.getVariation(productId = 100L, variationId = 10L))
+            .thenReturn(Result.failure(IllegalStateException("network")))
+
+        val result = resolver.resolve(listOf(ref(ShowCardFamily.Variation, "100/10")))
+
+        val missing = result.single() as ShowCardsResolution.Missing
+        assertThat(missing.reason).isEqualTo(ShowCardsRejectionReason.FetchFailed)
+    }
 
     @Test
     fun `given analytics stats ref, when resolved, then site currency is used for display`() = runTest {

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsToolHandlerTest.kt
@@ -85,6 +85,15 @@ class ProductVariationsToolHandlerTest {
         ToolCall(id = "call-1", name = "product_variations_list", arguments = arguments)
 
     @Test
+    fun `given descriptor, when inspected, then broad inventory questions are excluded`() {
+        val description = handler.descriptor.description
+
+        assertThat(description).contains("explicitly asks")
+        assertThat(description).contains("variations, sizes, colors, options")
+        assertThat(description).contains("broad product-level inventory questions")
+    }
+
+    @Test
     fun `given list mode, when execute is called, then data source is called with product id and paging`() = runTest {
         whenever(dataSource.fetchVariations(productId = 100L, page = 2, perPage = 25))
             .thenReturn(Result.success(emptyList()))

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsUpdateToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductVariationsUpdateToolHandlerTest.kt
@@ -75,6 +75,9 @@ class ProductVariationsUpdateToolHandlerTest {
         assertThat(handler.descriptor.safetyLevel).isEqualTo(ToolSafetyLevel.UNSAFE)
         assertThat(handler.descriptor.description).contains("product_id")
         assertThat(handler.descriptor.description).contains("stock_quantity")
+        assertThat(handler.descriptor.description).contains("After a successful update")
+        assertThat(handler.descriptor.description).contains("show_cards")
+        assertThat(handler.descriptor.description).contains("strict {parentProductId}/{variationId}")
         assertThat(requireNotNull(schema["additionalProperties"]).jsonPrimitive.boolean).isFalse
         assertThat(properties.keys).containsExactlyInAnyOrder(
             "product_id",

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsGetToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/products/ProductsGetToolHandlerTest.kt
@@ -49,6 +49,16 @@ class ProductsGetToolHandlerTest {
     )
 
     @Test
+    fun `given descriptor, when inspected, then variation and card-rendering guidance is aligned`() {
+        val description = handler.descriptor.description
+
+        assertThat(description).contains("use product_variations_list only when")
+        assertThat(description).contains("explicitly asks about variations, sizes, colors, options")
+        assertThat(description).contains("Do NOT call this tool to render a card after products_list")
+        assertThat(description).contains("`show_cards` re-fetches product detail")
+    }
+
+    @Test
     fun `given a valid id, when execute is called, then structured JSON contains expected fields`() = runTest {
         val product = makeProduct()
         whenever(dataSource.getProduct(42L)).thenReturn(Result.success(product))

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -825,6 +825,44 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given grouped variation cards have distinct parent product ids, when cards arrive, then both remain visible`() =
+        runTest {
+            viewModel.onSendMessage("Show matching variations")
+            val firstVariation = givenVariationCard(parentProductId = 100L, variationId = 10L, name = "Blue socks")
+            val secondVariation = givenVariationCard(parentProductId = 101L, variationId = 10L, name = "Green socks")
+
+            runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(firstVariation, secondVariation)))
+            advanceUntilIdle()
+
+            val cardGroups = viewModel.uiState.value.messages.last().segments
+                .filterIsInstance<AssistantUiSegment.CardGroup>()
+
+            assertThat(cardGroups).containsExactly(
+                AssistantUiSegment.CardGroup(listOf(firstVariation, secondVariation)),
+            )
+        }
+
+    @Test
+    fun `given grouped variation cards have same composite id, when cards arrive, then duplicate is filtered`() =
+        runTest {
+            viewModel.onSendMessage("Show matching variations")
+            val firstVariation = givenVariationCard(parentProductId = 100L, variationId = 10L, name = "Blue socks")
+            val duplicateVariation = givenVariationCard(parentProductId = 100L, variationId = 10L, name = "Red socks")
+            val secondVariation = givenVariationCard(parentProductId = 100L, variationId = 11L, name = "Green socks")
+
+            runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(firstVariation)))
+            runtime.emit(AssistantRuntimeEvent.CardsResolved(listOf(duplicateVariation, secondVariation)))
+            advanceUntilIdle()
+
+            val cardGroups = viewModel.uiState.value.messages.last().segments
+                .filterIsInstance<AssistantUiSegment.CardGroup>()
+
+            assertThat(cardGroups).containsExactly(
+                AssistantUiSegment.CardGroup(listOf(firstVariation, secondVariation)),
+            )
+        }
+
+    @Test
     fun `given repeated show cards calls, when cards arrive, then batches merge`() = runTest {
         viewModel.onSendMessage("Show matching cards")
         val firstOrder = givenOrderCard(id = "123", number = "#123")
@@ -1362,6 +1400,22 @@ class AssistantViewModelTest {
         stockStatus = "instock",
         status = "publish",
         imageUrl = "https://example.com/socks.png",
+    )
+
+    private fun givenVariationCard(
+        parentProductId: Long,
+        variationId: Long,
+        name: String = "Blue socks",
+    ) = AssistantCard.Variation(
+        parentProductId = parentProductId,
+        variationId = variationId,
+        name = name,
+        sku = "woo-socks-blue",
+        price = "12.99",
+        stockStatus = "instock",
+        status = "publish",
+        imageUrl = "https://example.com/blue-socks.png",
+        attributes = listOf(AssistantCard.Variation.Attribute(name = "Size", option = "M")),
     )
 
     private fun givenStatsCard(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardActionTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardActionTest.kt
@@ -19,6 +19,21 @@ class AssistantCardActionTest {
     }
 
     @Test
+    fun `given open product variation action, when created, then parent product and variation ids are preserved`() {
+        val action: AssistantCardAction = AssistantCardAction.OpenProductVariation(
+            parentProductId = 100L,
+            variationId = 10L,
+        )
+
+        assertThat(action).isEqualTo(
+            AssistantCardAction.OpenProductVariation(
+                parentProductId = 100L,
+                variationId = 10L,
+            )
+        )
+    }
+
+    @Test
     fun `given open customer action, when created, then remote customer id is preserved`() {
         val action: AssistantCardAction = AssistantCardAction.OpenCustomer(remoteCustomerId = 789L)
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardGroupKindTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardGroupKindTest.kt
@@ -22,10 +22,10 @@ class AssistantCardGroupKindTest {
     }
 
     @Test
-    fun `given only variation cards, when resolving group kind, then products metadata is returned`() {
+    fun `given only variation cards, when resolving group kind, then variations metadata is returned`() {
         val metadata = listOf(variationCard()).toAssistantCardGroupMetadata()
 
-        assertThat(metadata.titleRes).isEqualTo(R.string.assistant_chat_card_group_products)
+        assertThat(metadata.titleRes).isEqualTo(R.string.assistant_chat_card_group_variations)
         assertThat(metadata.iconRes).isEqualTo(R.drawable.ic_assistant_card_group_products)
     }
 
@@ -54,11 +54,11 @@ class AssistantCardGroupKindTest {
     }
 
     @Test
-    fun `given mixed product and variation cards, when resolving group kind, then products metadata is returned`() {
+    fun `given mixed product and variation cards, when resolving group kind, then generic metadata is returned`() {
         val metadata = listOf(productCard(), variationCard()).toAssistantCardGroupMetadata()
 
-        assertThat(metadata.titleRes).isEqualTo(R.string.assistant_chat_card_group_products)
-        assertThat(metadata.iconRes).isEqualTo(R.drawable.ic_assistant_card_group_products)
+        assertThat(metadata.titleRes).isEqualTo(R.string.assistant_chat_card_group_generic)
+        assertThat(metadata.iconRes).isEqualTo(R.drawable.ic_assistant_card_group_generic)
     }
 
     private fun orderCard() = AssistantCard.Order(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardGroupKindTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardGroupKindTest.kt
@@ -22,6 +22,14 @@ class AssistantCardGroupKindTest {
     }
 
     @Test
+    fun `given only variation cards, when resolving group kind, then products metadata is returned`() {
+        val metadata = listOf(variationCard()).toAssistantCardGroupMetadata()
+
+        assertThat(metadata.titleRes).isEqualTo(R.string.assistant_chat_card_group_products)
+        assertThat(metadata.iconRes).isEqualTo(R.drawable.ic_assistant_card_group_products)
+    }
+
+    @Test
     fun `given only stats cards, when resolving group kind, then stats metadata is returned`() {
         val metadata = listOf(statsCard()).toAssistantCardGroupMetadata()
 
@@ -45,6 +53,14 @@ class AssistantCardGroupKindTest {
         assertThat(metadata.iconRes).isEqualTo(R.drawable.ic_assistant_card_group_generic)
     }
 
+    @Test
+    fun `given mixed product and variation cards, when resolving group kind, then products metadata is returned`() {
+        val metadata = listOf(productCard(), variationCard()).toAssistantCardGroupMetadata()
+
+        assertThat(metadata.titleRes).isEqualTo(R.string.assistant_chat_card_group_products)
+        assertThat(metadata.iconRes).isEqualTo(R.drawable.ic_assistant_card_group_products)
+    }
+
     private fun orderCard() = AssistantCard.Order(
         remoteOrderId = 123L,
         number = "#1001",
@@ -63,6 +79,18 @@ class AssistantCardGroupKindTest {
         stockStatus = "instock",
         status = "publish",
         imageUrl = "https://example.com/socks.png",
+    )
+
+    private fun variationCard() = AssistantCard.Variation(
+        parentProductId = 456L,
+        variationId = 10L,
+        name = "Woo socks - Blue",
+        sku = "woo-socks-blue",
+        price = "12.99",
+        stockStatus = "instock",
+        status = "publish",
+        imageUrl = "https://example.com/blue-socks.png",
+        attributes = listOf(AssistantCard.Variation.Attribute(name = "Color", option = "Blue")),
     )
 
     private fun statsCard() = AssistantCard.Stats(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.aiassistant.ui.cards
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardDetails
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+import com.woocommerce.android.aiassistant.tools.products.CompactVariationAttribute
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
@@ -128,6 +129,52 @@ class AssistantCardPayloadParserTest {
                 stockStatus = "instock",
                 status = "publish",
                 imageUrl = "https://example.com/socks.png",
+            )
+        )
+    }
+
+    @Test
+    fun `given variation payload, when parsed, then variation card contains parent product and variation fields`() {
+        val cards = AssistantCardPayloadParser.parse(
+            ShowCardsUiStructured(
+                cards = listOf(
+                    ShowCardPayload(
+                        family = "variation",
+                        id = "100/10",
+                        title = "Blue socks",
+                        details = ShowCardDetails.Variation(
+                            productId = 100L,
+                            variationId = 10L,
+                            name = "Blue socks",
+                            sku = "woo-socks-blue",
+                            price = "12.99",
+                            stockStatus = "instock",
+                            status = "publish",
+                            imageUrl = "https://example.com/blue-socks.png",
+                            attributes = listOf(
+                                CompactVariationAttribute(name = "Size", option = "M"),
+                                CompactVariationAttribute(name = "Color", option = "Blue"),
+                            ),
+                        ),
+                    )
+                )
+            )
+        )
+
+        assertThat(cards).containsExactly(
+            AssistantCard.Variation(
+                parentProductId = 100L,
+                variationId = 10L,
+                name = "Blue socks",
+                sku = "woo-socks-blue",
+                price = "12.99",
+                stockStatus = "instock",
+                status = "publish",
+                imageUrl = "https://example.com/blue-socks.png",
+                attributes = listOf(
+                    AssistantCard.Variation.Attribute(name = "Size", option = "M"),
+                    AssistantCard.Variation.Attribute(name = "Color", option = "Blue"),
+                ),
             )
         )
     }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
@@ -206,6 +206,72 @@ class AssistantCardPayloadParserTest {
     }
 
     @Test
+    fun `given invalid variation payloads, when parsed, then variation cards are ignored`() {
+        val cards = AssistantCardPayloadParser.parse(
+            ShowCardsUiStructured(
+                cards = listOf(
+                    variationPayload(id = "100", productId = 100L, variationId = 10L),
+                    variationPayload(id = "100/11", productId = 100L, variationId = 10L),
+                    ShowCardPayload(
+                        family = "variation",
+                        id = "100/10",
+                        title = "Wrong details",
+                        details = ShowCardDetails.Product(sku = "woo-socks"),
+                    ),
+                )
+            )
+        )
+
+        assertThat(cards).isEmpty()
+    }
+
+    @Test
+    fun `given variation payload with blank optional fields, when parsed, then blank values are normalized`() {
+        val cards = AssistantCardPayloadParser.parse(
+            ShowCardsUiStructured(
+                cards = listOf(
+                    ShowCardPayload(
+                        family = "variation",
+                        id = "100/10",
+                        title = "Variation 10",
+                        details = ShowCardDetails.Variation(
+                            productId = 100L,
+                            variationId = 10L,
+                            name = null,
+                            sku = null,
+                            price = null,
+                            stockStatus = null,
+                            status = null,
+                            imageUrl = null,
+                            attributes = listOf(
+                                CompactVariationAttribute(name = "Size", option = ""),
+                                CompactVariationAttribute(name = "", option = "Blue"),
+                                CompactVariationAttribute(name = "Color", option = "Blue"),
+                            ),
+                        ),
+                    )
+                )
+            )
+        )
+
+        assertThat(cards).containsExactly(
+            AssistantCard.Variation(
+                parentProductId = 100L,
+                variationId = 10L,
+                name = "",
+                sku = "",
+                price = "",
+                stockStatus = "",
+                status = "",
+                imageUrl = "",
+                attributes = listOf(
+                    AssistantCard.Variation.Attribute(name = "Color", option = "Blue"),
+                ),
+            )
+        )
+    }
+
+    @Test
     fun `given customer payload, when parsed, then customer card contains displayed fields`() {
         val cards = AssistantCardPayloadParser.parse(
             ShowCardsUiStructured(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardPayloadParserTest.kt
@@ -180,6 +180,32 @@ class AssistantCardPayloadParserTest {
     }
 
     @Test
+    fun `given single variation payload, when parsed, then one variation card is returned`() {
+        val cards = AssistantCardPayloadParser.parse(
+            ShowCardsUiStructured(
+                cards = listOf(variationPayload(id = "100/10", productId = 100L, variationId = 10L))
+            )
+        )
+
+        assertThat(cards).containsExactly(
+            AssistantCard.Variation(
+                parentProductId = 100L,
+                variationId = 10L,
+                name = "Blue socks",
+                sku = "woo-socks-blue",
+                price = "12.99",
+                stockStatus = "instock",
+                status = "publish",
+                imageUrl = "https://example.com/blue-socks.png",
+                attributes = listOf(
+                    AssistantCard.Variation.Attribute(name = "Size", option = "M"),
+                    AssistantCard.Variation.Attribute(name = "Color", option = "Blue"),
+                ),
+            )
+        )
+    }
+
+    @Test
     fun `given customer payload, when parsed, then customer card contains displayed fields`() {
         val cards = AssistantCardPayloadParser.parse(
             ShowCardsUiStructured(
@@ -565,6 +591,30 @@ class AssistantCardPayloadParserTest {
         id = id,
         title = title,
         details = ShowCardDetails.Order(status = "processing"),
+    )
+
+    private fun variationPayload(
+        id: String,
+        productId: Long,
+        variationId: Long,
+    ) = ShowCardPayload(
+        family = "variation",
+        id = id,
+        title = "Blue socks",
+        details = ShowCardDetails.Variation(
+            productId = productId,
+            variationId = variationId,
+            name = "Blue socks",
+            sku = "woo-socks-blue",
+            price = "12.99",
+            stockStatus = "instock",
+            status = "publish",
+            imageUrl = "https://example.com/blue-socks.png",
+            attributes = listOf(
+                CompactVariationAttribute(name = "Size", option = "M"),
+                CompactVariationAttribute(name = "Color", option = "Blue"),
+            ),
+        ),
     )
 
     private fun analyticsStatsPayload(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
@@ -147,6 +147,25 @@ class AssistantCardSegmentMapperTest {
         )
     }
 
+    @Test
+    fun `given multiple variation payloads, when mapped, then grouped segment preserves variation order`() {
+        val segments = AssistantCardSegmentMapper.toSegments(
+            ShowCardsUiStructured(
+                cards = listOf(
+                    variationPayload(id = "100/10", productId = 100L, variationId = 10L, name = "Blue socks"),
+                    variationPayload(id = "100/11", productId = 100L, variationId = 11L, name = "Red socks"),
+                    variationPayload(id = "101/10", productId = 101L, variationId = 10L, name = "Green socks"),
+                )
+            )
+        )
+
+        val cardGroup = segments.single() as AssistantUiSegment.CardGroup
+        val variations = cardGroup.cards.filterIsInstance<AssistantCard.Variation>()
+        assertThat(variations.map { "${it.parentProductId}/${it.variationId}" })
+            .containsExactly("100/10", "100/11", "101/10")
+        assertThat(variations.map { it.name }).containsExactly("Blue socks", "Red socks", "Green socks")
+    }
+
     private fun orderPayload(id: String, title: String) = ShowCardPayload(
         family = "order",
         id = id,
@@ -173,14 +192,19 @@ class AssistantCardSegmentMapperTest {
         ),
     )
 
-    private fun variationPayload() = ShowCardPayload(
+    private fun variationPayload(
+        id: String = "100/10",
+        productId: Long = 100L,
+        variationId: Long = 10L,
+        name: String = "Blue socks",
+    ) = ShowCardPayload(
         family = "variation",
-        id = "100/10",
-        title = "Blue socks",
+        id = id,
+        title = name,
         details = ShowCardDetails.Variation(
-            productId = 100L,
-            variationId = 10L,
-            name = "Blue socks",
+            productId = productId,
+            variationId = variationId,
+            name = name,
             sku = "woo-socks-blue",
             price = "12.99",
             stockStatus = "instock",

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/cards/AssistantCardSegmentMapperTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.aiassistant.ui.cards
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardDetails
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
+import com.woocommerce.android.aiassistant.tools.products.CompactVariationAttribute
 import com.woocommerce.android.aiassistant.ui.AssistantUiSegment
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -116,6 +117,36 @@ class AssistantCardSegmentMapperTest {
         )
     }
 
+    @Test
+    fun `given variation payload, when mapped, then grouped segment contains typed variation card`() {
+        val segments = AssistantCardSegmentMapper.toSegments(
+            ShowCardsUiStructured(
+                cards = listOf(variationPayload())
+            )
+        )
+
+        assertThat(segments).containsExactly(
+            AssistantUiSegment.CardGroup(
+                listOf(
+                    AssistantCard.Variation(
+                        parentProductId = 100L,
+                        variationId = 10L,
+                        name = "Blue socks",
+                        sku = "woo-socks-blue",
+                        price = "12.99",
+                        stockStatus = "instock",
+                        status = "publish",
+                        imageUrl = "https://example.com/blue-socks.png",
+                        attributes = listOf(
+                            AssistantCard.Variation.Attribute(name = "Size", option = "M"),
+                            AssistantCard.Variation.Attribute(name = "Color", option = "Blue"),
+                        ),
+                    )
+                )
+            )
+        )
+    }
+
     private fun orderPayload(id: String, title: String) = ShowCardPayload(
         family = "order",
         id = id,
@@ -139,6 +170,26 @@ class AssistantCardSegmentMapperTest {
             stockStatus = "instock",
             status = "publish",
             imageUrl = "https://example.com/socks.png",
+        ),
+    )
+
+    private fun variationPayload() = ShowCardPayload(
+        family = "variation",
+        id = "100/10",
+        title = "Blue socks",
+        details = ShowCardDetails.Variation(
+            productId = 100L,
+            variationId = 10L,
+            name = "Blue socks",
+            sku = "woo-socks-blue",
+            price = "12.99",
+            stockStatus = "instock",
+            status = "publish",
+            imageUrl = "https://example.com/blue-socks.png",
+            attributes = listOf(
+                CompactVariationAttribute(name = "Size", option = "M"),
+                CompactVariationAttribute(name = "Color", option = "Blue"),
+            ),
         ),
     )
 


### PR DESCRIPTION
### Description
Fixes WOOMOB-3011

This PR adds product variation support to the AI Assistant `show_cards` flow so variation tool results can render as native assistant cards instead of falling back to raw structured JSON.

The implementation builds on the existing assistant card pipeline and keeps the model-facing summary compact while sending the Android-owned rendering details through `uiStructured`. Variation cards use the same host row infrastructure as product cards, preserve their parent product relationship, navigate through the existing assistant external-navigation seam, and use a dedicated `Variations` card-group header for parity with iOS.

Change list:
- **Tool support**
  - Adds `variation` as a supported `show_cards` family.
  - Validates variation refs with a strict composite ID shape: `{parentProductId}/{variationId}`.
  - Resolves variations through the existing product-variations data source with both parent product ID and variation ID.
  - Keeps the model-facing variation summary allowlisted to compact fields: IDs, SKU, price, stock/status, and attributes.
  - Rejects malformed variation IDs before resolution so invalid refs do not trigger broken fetches.
  - Aligns Android prompt and tool descriptions with iOS so broad stock/product inventory asks stay product-level, while variation tools/cards are reserved for explicit variation-level asks about sizes, colors, options, variation stock, or known variation IDs.

- **Card payloads and parsing**
  - Adds typed `ShowCardDetails.Variation` and `AssistantCard.Variation` models.
  - Round-trips the composite card ID plus explicit `product_id` and `variation_id` through the resolver, payload, parser, and renderer model.
  - Filters invalid or mismatched variation payloads rather than rendering ambiguous cards.
  - Preserves single variation cards and grouped multi-variation results in the assistant chat pipeline.

- **Shared AI Assistant UI**
  - Teaches assistant card grouping to recognize variation cards as their own group kind.
  - Uses the `Variations` header for variation-only groups, matching the current iOS AI Assistant presentation.
  - Updates active-card de-duplication to use the composite variation key so distinct variations with the same variation ID under different products can render together.
  - Keeps variation cards on the existing product-style visual treatment and leading icon.

- **WooCommerce host UI**
  - Adds a host-side variation card renderer backed by `ProductSummaryRow`, matching the existing product-card row surface instead of adding a bespoke row.
  - Maps variation attributes, stock/status, price, SKU, and image URL into the shared summary row model.
  - Adds title fallback behavior when no variation name is available: SKU first, then a localized variation ID label.

- **Navigation**
  - Adds `OpenProductVariation(parentProductId, variationId)` as an assistant card action.
  - Routes variation row taps through `WooAssistantCardActionNavigator`.
  - Opens the existing variation detail deep link with both `remoteProductId` and `remoteVariationId`.

- **Tests**
  - Covers variation descriptor support, validation, compact summary filtering, resolver success/failure paths, parser behavior, grouped card mapping, runtime de-duplication, row-model mapping, title fallback, card actions, group-header metadata, prompt/descriptor parity guidance, and host navigation.
  - Keeps analytics card behavior aligned with current `trunk`: only the `analytics_orders` card ID path is accepted for live analytics stats cards.

### Test Steps
1. Open the AI Assistant in a store that has a variable product with at least two variations.
2. Ask the assistant for product variations so it calls `show_cards` with `variation` references.
3. Verify a variation result renders as a native card row instead of raw JSON.
4. Verify the variation card group header says `Variations`.
5. Verify the row uses the same product-style summary layout as product cards, including attributes, stock/status, price, and SKU when available.
6. Repeat with multiple variations and verify they appear in the variation card group with all expected rows visible.
7. Tap a variation row and verify the app opens that variation’s detail screen for the correct parent product.
8. Try a variation with no display name and verify the row title falls back to SKU, or to a variation ID label when SKU is unavailable.

### Images/gif
<img width="360" alt="Screenshot_20260511_184003" src="https://github.com/user-attachments/assets/0e0bd6dd-7db2-4953-9e8a-b6e97cd0cd17" />


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
