### PR TITLE
[WOOMOB-3006] Type show cards resolved summaries

### DIFF
--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -20,6 +20,7 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolve
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsStructured
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
+import com.woocommerce.android.aiassistant.tools.handlers.cards.toJsonObject
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -157,7 +158,7 @@ internal class ShowCardsToolHandler internal constructor(
         ResolvedRef(
             family = ref.family.serializedName,
             id = ref.id,
-            summary = summary.filterAllowedKeysFor(ref.family),
+            summary = summary.toJsonObject(json).filterAllowedKeysFor(ref.family),
         )
 
     private fun ShowCardsResolution.Missing.toMissingRef(): MissingRef =

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -165,5 +165,4 @@ internal class ShowCardsToolHandler internal constructor(
             id = ref.id,
             reason = reason,
         )
-
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandler.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.MAX_SHOW_CARDS_R
 import com.woocommerce.android.aiassistant.tools.handlers.cards.MissingRef
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ResolvedRef
 import com.woocommerce.android.aiassistant.tools.handlers.cards.SHOW_CARDS_TOOL_NAME
-import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsArguments
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsReferenceValidator
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsRejectionReason
@@ -24,7 +23,6 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.toJsonObject
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -158,7 +156,7 @@ internal class ShowCardsToolHandler internal constructor(
         ResolvedRef(
             family = ref.family.serializedName,
             id = ref.id,
-            summary = summary.toJsonObject(json).filterAllowedKeysFor(ref.family),
+            summary = summary.toJsonObject(json),
         )
 
     private fun ShowCardsResolution.Missing.toMissingRef(): MissingRef =
@@ -168,61 +166,4 @@ internal class ShowCardsToolHandler internal constructor(
             reason = reason,
         )
 
-    private fun JsonObject.filterAllowedKeysFor(family: ShowCardFamily): JsonObject {
-        val allowedKeys = when (family) {
-            ShowCardFamily.Order -> ORDER_SUMMARY_KEYS
-            ShowCardFamily.Product -> PRODUCT_SUMMARY_KEYS
-            ShowCardFamily.Variation -> VARIATION_SUMMARY_KEYS
-            ShowCardFamily.AnalyticsStats -> ANALYTICS_STATS_SUMMARY_KEYS
-            ShowCardFamily.Customer -> CUSTOMER_SUMMARY_KEYS
-        }
-        return JsonObject(filterKeys { it in allowedKeys })
-    }
-
-    private companion object {
-        val ORDER_SUMMARY_KEYS = setOf(
-            "id",
-            "number",
-            "status",
-            "total",
-            "currency",
-            "date_created",
-            "customer_name",
-            "payment_method_title",
-            "customer_id",
-            "line_items_count",
-            "line_items",
-        )
-        val PRODUCT_SUMMARY_KEYS = setOf(
-            "id",
-            "name",
-            "sku",
-            "price",
-            "type",
-            "stock_status",
-            "manage_stock",
-            "on_sale",
-            "stock_quantity",
-        )
-        val CUSTOMER_SUMMARY_KEYS = setOf("id", "name", "email")
-        val VARIATION_SUMMARY_KEYS = setOf(
-            "id",
-            "product_id",
-            "variation_id",
-            "name",
-            "sku",
-            "price",
-            "stock_status",
-            "status",
-            "attributes",
-        )
-        val ANALYTICS_STATS_SUMMARY_KEYS = setOf(
-            "id",
-            "after",
-            "before",
-            "currency",
-            "totals",
-            "interval_subtotals",
-        )
-    }
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolvedSummary.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolvedSummary.kt
@@ -1,0 +1,23 @@
+package com.woocommerce.android.aiassistant.tools.handlers.cards
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+
+internal sealed interface ShowCardsResolvedSummary {
+    data class Order(val value: OrderSummary) : ShowCardsResolvedSummary
+    data class Product(val value: ProductSummary) : ShowCardsResolvedSummary
+    data class Variation(val value: VariationSummary) : ShowCardsResolvedSummary
+    data class AnalyticsStats(val value: AnalyticsStatsSummary) : ShowCardsResolvedSummary
+    data class Customer(val value: CustomerSummary) : ShowCardsResolvedSummary
+}
+
+internal fun ShowCardsResolvedSummary.toJsonObject(json: Json): JsonObject =
+    when (this) {
+        is ShowCardsResolvedSummary.Order -> json.encodeToJsonElement(value).jsonObject
+        is ShowCardsResolvedSummary.Product -> json.encodeToJsonElement(value).jsonObject
+        is ShowCardsResolvedSummary.Variation -> json.encodeToJsonElement(value).jsonObject
+        is ShowCardsResolvedSummary.AnalyticsStats -> json.encodeToJsonElement(value).jsonObject
+        is ShowCardsResolvedSummary.Customer -> json.encodeToJsonElement(value).jsonObject
+    }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolver.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.aiassistant.tools.handlers.cards
 
-import com.woocommerce.android.aiassistant.di.AiAssistantJson
 import com.woocommerce.android.aiassistant.tools.CachedLookupResult
 import com.woocommerce.android.aiassistant.tools.analytics.AIAnalyticsDataSource
 import com.woocommerce.android.aiassistant.tools.analytics.AnalyticsStats
@@ -15,11 +14,8 @@ import com.woocommerce.android.aiassistant.tools.products.toProductVariationDeta
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonObject
 import org.wordpress.android.fluxc.model.WCProductModel
 import org.wordpress.android.fluxc.model.WCProductVariationModel
 import org.wordpress.android.fluxc.model.customer.WCCustomerModel
@@ -36,7 +32,7 @@ internal sealed interface ShowCardsResolution {
 
     data class Resolved(
         override val ref: ValidatedRef,
-        val summary: JsonObject,
+        val summary: ShowCardsResolvedSummary,
         val card: ShowCardPayload,
     ) : ShowCardsResolution
 
@@ -52,7 +48,6 @@ internal class DefaultShowCardsResolver @Inject constructor(
     private val variationsDataSource: AIProductVariationsDataSource,
     private val analyticsDataSource: AIAnalyticsDataSource,
     private val customersDataSource: AICustomersDataSource,
-    @AiAssistantJson private val json: Json,
 ) : ShowCardsResolver {
     override suspend fun resolve(refs: List<ValidatedRef>): List<ShowCardsResolution> {
         val orderResults = resolveOrders(refs.filter { it.family == ShowCardFamily.Order })
@@ -117,7 +112,7 @@ internal class DefaultShowCardsResolver @Inject constructor(
         val lineItems = getLineItemList()
         return ShowCardsResolution.Resolved(
             ref = ref,
-            summary = jsonObject(
+            summary = ShowCardsResolvedSummary.Order(
                 OrderSummary(
                     id = ref.id,
                     number = number,
@@ -149,7 +144,7 @@ internal class DefaultShowCardsResolver @Inject constructor(
 
     private fun WCProductModel.toResolved(ref: ValidatedRef) = ShowCardsResolution.Resolved(
         ref = ref,
-        summary = jsonObject(
+        summary = ShowCardsResolvedSummary.Product(
             ProductSummary(
                 id = ref.id,
                 name = name,
@@ -201,7 +196,7 @@ internal class DefaultShowCardsResolver @Inject constructor(
         val detail = toProductVariationDetailResponse()
         return ShowCardsResolution.Resolved(
             ref = ref,
-            summary = jsonObject(
+            summary = ShowCardsResolvedSummary.Variation(
                 VariationSummary(
                     id = ref.id,
                     productId = detail.productId,
@@ -281,7 +276,7 @@ internal class DefaultShowCardsResolver @Inject constructor(
 
         return ShowCardsResolution.Resolved(
             ref = ref,
-            summary = jsonObject(
+            summary = ShowCardsResolvedSummary.AnalyticsStats(
                 AnalyticsStatsSummary(
                     id = ref.id,
                     after = query.after,
@@ -332,15 +327,12 @@ internal class DefaultShowCardsResolver @Inject constructor(
         )
     }
 
-    private inline fun <reified T> jsonObject(value: T): JsonObject =
-        json.encodeToJsonElement(value).jsonObject
-
     private fun WCCustomerModel.toResolved(ref: ValidatedRef): ShowCardsResolution.Resolved {
         val displayName = displayName(ref.id)
 
         return ShowCardsResolution.Resolved(
             ref = ref,
-            summary = jsonObject(
+            summary = ShowCardsResolvedSummary.Customer(
                 CustomerSummary(
                     id = ref.id,
                     name = displayName,

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -102,7 +102,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `given resolved order, when executed, then summary contains only allowlisted fields`() = runTest {
+    fun `given resolved order, when executed, then summary contains typed order fields`() = runTest {
         val result = callShowCards(FakeResolver.resolving(orderCard(id = "123")))
 
         val summary = firstResolvedSummary(result)
@@ -123,7 +123,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `given resolved product, when executed, then summary contains only allowlisted fields`() = runTest {
+    fun `given resolved product, when executed, then summary contains typed product fields`() = runTest {
         val result = callShowCards(
             resolver = FakeResolver.resolving(productCard(id = "456")),
             referencesJson = """[{ "family": "product", "id": "456" }]"""
@@ -145,7 +145,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `given resolved analytics stats, when executed, then summary contains only allowlisted fields`() = runTest {
+    fun `given resolved analytics stats, when executed, then summary contains typed analytics fields`() = runTest {
         val result = callShowCards(
             resolver = FakeResolver.resolving(analyticsStatsCard(id = ANALYTICS_STATS_ID)),
             referencesJson = """[{ "family": "analytics_stats", "id": "$ANALYTICS_STATS_ID" }]"""
@@ -164,7 +164,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `given resolved customer, when executed, then summary contains only allowlisted fields`() = runTest {
+    fun `given resolved customer, when executed, then summary contains typed customer fields`() = runTest {
         val result = callShowCards(
             resolver = FakeResolver.resolving(customerCard(id = "123")),
             referencesJson = """[{ "family": "customer", "id": "123" }]"""
@@ -176,7 +176,7 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `given resolved variation, when executed, then summary contains only allowlisted fields`() = runTest {
+    fun `given resolved variation, when executed, then summary contains typed variation fields`() = runTest {
         val result = callShowCards(
             resolver = FakeResolver.resolving(variationCard(id = "100/10")),
             referencesJson = """[{ "family": "variation", "id": "100/10" }]"""

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -120,6 +120,15 @@ class ShowCardsToolHandlerTest {
             "line_items_count",
             "line_items",
         )
+        assertThat(summary.getValue("id").jsonPrimitive.content).isEqualTo("123")
+        assertThat(summary.getValue("number").jsonPrimitive.content).isEqualTo("#123")
+        assertThat(summary.getValue("status").jsonPrimitive.content).isEqualTo("processing")
+        assertThat(summary.getValue("total").jsonPrimitive.content).isEqualTo("12.34")
+        assertThat(summary.getValue("currency").jsonPrimitive.content).isEqualTo("USD")
+        assertThat(summary.getValue("payment_method_title").jsonPrimitive.content).isEqualTo("Credit Card")
+        assertThat(summary.getValue("customer_id").jsonPrimitive.content).isEqualTo("55")
+        assertThat(summary.getValue("line_items_count").jsonPrimitive.content).isEqualTo("1")
+        assertThat(summary.getValue("line_items").jsonArray).hasSize(1)
     }
 
     @Test
@@ -142,6 +151,15 @@ class ShowCardsToolHandlerTest {
             "on_sale",
             "stock_quantity",
         )
+        assertThat(summary.getValue("id").jsonPrimitive.content).isEqualTo("456")
+        assertThat(summary.getValue("name").jsonPrimitive.content).isEqualTo("Socks")
+        assertThat(summary.getValue("sku").jsonPrimitive.content).isEqualTo("woo-socks")
+        assertThat(summary.getValue("price").jsonPrimitive.content).isEqualTo("9.99")
+        assertThat(summary.getValue("type").jsonPrimitive.content).isEqualTo("simple")
+        assertThat(summary.getValue("stock_status").jsonPrimitive.content).isEqualTo("instock")
+        assertThat(summary.getValue("manage_stock").jsonPrimitive.boolean).isTrue
+        assertThat(summary.getValue("on_sale").jsonPrimitive.boolean).isFalse
+        assertThat(summary.getValue("stock_quantity").jsonPrimitive.double).isEqualTo(12.0)
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -3,12 +3,14 @@ package com.woocommerce.android.aiassistant.tools.handlers
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.core.chat.ToolResult
 import com.woocommerce.android.aiassistant.core.chat.ToolSafetyLevel
+import com.woocommerce.android.aiassistant.tools.handlers.cards.AnalyticsStatsSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.CustomerSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.OrderSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ProductSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardDetails
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolvedSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsRejectionReason
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolution
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
@@ -19,11 +21,11 @@ import com.woocommerce.android.aiassistant.tools.orders.CompactOrderLineItem
 import com.woocommerce.android.aiassistant.tools.products.CompactVariationAttribute
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.double
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -251,34 +253,38 @@ class ShowCardsToolHandlerTest {
     }
 
     @Test
-    fun `given resolver returns summary extras, when executed, then structured excludes private fields`() = runTest {
-        val result = callShowCards(
-            resolver = FakeResolver.resolving(leakyProductCard(id = "456")),
-            referencesJson = """[{ "family": "product", "id": "456" }]"""
-        )
+    fun `given typed product summary with ui only card details, when executed, then structured excludes private fields`() =
+        runTest {
+            val result = callShowCards(
+                resolver = FakeResolver.resolving(productCard(id = "456")),
+                referencesJson = """[{ "family": "product", "id": "456" }]"""
+            )
 
-        val structuredText = assertSuccess(result).structured.toString()
+            val structuredText = assertSuccess(result).structured.toString()
+            val uiText = requireNotNull(assertSuccess(result).uiStructured).toString()
 
-        assertThat(structuredText).doesNotContain("Long description")
-        assertThat(structuredText).doesNotContain("<p>Private</p>")
-        assertThat(structuredText).doesNotContain("image.png")
-        assertThat(structuredText).doesNotContain("metadata")
-        assertThat(structuredText).doesNotContain("raw")
-    }
+            assertThat(uiText).contains(PRODUCT_IMAGE_URL)
+            assertThat(structuredText).doesNotContain("details")
+            assertThat(structuredText).doesNotContain("image_url")
+            assertThat(structuredText).doesNotContain(PRODUCT_IMAGE_URL)
+        }
 
     @Test
-    fun `given resolved analytics stats extras, when executed, then structured excludes private fields`() = runTest {
-        val result = callShowCards(
-            resolver = FakeResolver.resolving(leakyAnalyticsStatsCard(id = ANALYTICS_STATS_ID)),
-            referencesJson = """[{ "family": "analytics_stats", "id": "$ANALYTICS_STATS_ID" }]"""
-        )
+    fun `given typed variation summary with ui only card details, when executed, then structured excludes private fields`() =
+        runTest {
+            val result = callShowCards(
+                resolver = FakeResolver.resolving(variationCard(id = "100/10")),
+                referencesJson = """[{ "family": "variation", "id": "100/10" }]"""
+            )
 
-        val structuredText = assertSuccess(result).structured.toString()
+            val structuredText = assertSuccess(result).structured.toString()
+            val uiText = requireNotNull(assertSuccess(result).uiStructured).toString()
 
-        assertThat(structuredText).contains("interval_subtotals")
-        assertThat(structuredText).doesNotContain("private_total")
-        assertThat(structuredText).doesNotContain("debug")
-    }
+            assertThat(uiText).contains(PRODUCT_IMAGE_URL)
+            assertThat(structuredText).doesNotContain("details")
+            assertThat(structuredText).doesNotContain("image_url")
+            assertThat(structuredText).doesNotContain(PRODUCT_IMAGE_URL)
+        }
 
     @Test
     fun `given resolved ref, when executed, then uiStructured contains cards`() = runTest {
@@ -613,7 +619,7 @@ class ShowCardsToolHandlerTest {
 
         return ShowCardsResolution.Resolved(
             ref = ref,
-            summary = json.encodeToJsonElement(
+            summary = ShowCardsResolvedSummary.Order(
                 OrderSummary(
                     id = id,
                     number = "#$id",
@@ -627,7 +633,7 @@ class ShowCardsToolHandlerTest {
                     lineItemsCount = 1,
                     lineItems = listOf(CompactOrderLineItem(id = 10L, name = "Socks", quantity = 1f)),
                 )
-            ).jsonObject,
+            ),
             card = ShowCardPayload(
                 family = "order",
                 id = id,
@@ -648,7 +654,7 @@ class ShowCardsToolHandlerTest {
 
         return ShowCardsResolution.Resolved(
             ref = ref,
-            summary = json.encodeToJsonElement(
+            summary = ShowCardsResolvedSummary.Product(
                 ProductSummary(
                     id = id,
                     name = "Socks",
@@ -660,7 +666,7 @@ class ShowCardsToolHandlerTest {
                     onSale = false,
                     stockQuantity = 12.0,
                 )
-            ).jsonObject,
+            ),
             card = ShowCardPayload(
                 family = "product",
                 id = id,
@@ -678,10 +684,11 @@ class ShowCardsToolHandlerTest {
 
     private fun variationCard(id: String): ShowCardsResolution.Resolved {
         val ref = ValidatedRef(index = 0, family = ShowCardFamily.Variation, id = id)
+        val attributes = listOf(CompactVariationAttribute(name = "Size", option = "M"))
 
         return ShowCardsResolution.Resolved(
             ref = ref,
-            summary = json.encodeToJsonElement(
+            summary = ShowCardsResolvedSummary.Variation(
                 VariationSummary(
                     id = id,
                     productId = 100L,
@@ -691,9 +698,9 @@ class ShowCardsToolHandlerTest {
                     price = "12.99",
                     stockStatus = "instock",
                     status = "publish",
-                    attributes = listOf(CompactVariationAttribute(name = "Size", option = "M")),
+                    attributes = attributes,
                 )
-            ).jsonObject,
+            ),
             card = ShowCardPayload(
                 family = "variation",
                 id = id,
@@ -705,42 +712,8 @@ class ShowCardsToolHandlerTest {
                     price = "12.99",
                     stockStatus = "instock",
                     status = "publish",
-                    attributes = listOf(CompactVariationAttribute(name = "Size", option = "M")),
-                ),
-            )
-        )
-    }
-
-    private fun leakyProductCard(id: String): ShowCardsResolution.Resolved {
-        val ref = ValidatedRef(index = 0, family = ShowCardFamily.Product, id = id)
-
-        return ShowCardsResolution.Resolved(
-            ref = ref,
-            summary = buildJsonObject {
-                put("id", id)
-                put("name", "Socks")
-                put("sku", "woo-socks")
-                put("price", "9.99")
-                put("stock_status", "instock")
-                put("description", "Long description")
-                put("html", "<p>Private</p>")
-                put("images", buildJsonArray { add(JsonPrimitive("https://example.com/image.png")) })
-                putJsonObject("metadata") {
-                    put("private", "value")
-                }
-                putJsonObject("raw") {
-                    put("entity", "json")
-                }
-            },
-            card = ShowCardPayload(
-                family = "product",
-                id = id,
-                title = "Socks",
-                details = ShowCardDetails.Product(
-                    sku = "woo-socks",
-                    price = "9.99",
-                    stockStatus = "instock",
-                    status = "publish",
+                    imageUrl = PRODUCT_IMAGE_URL,
+                    attributes = attributes,
                 ),
             )
         )
@@ -765,14 +738,16 @@ class ShowCardsToolHandlerTest {
 
         return ShowCardsResolution.Resolved(
             ref = ref,
-            summary = buildJsonObject {
-                put("id", id)
-                put("after", "2026-05-01")
-                put("before", "2026-05-07")
-                put("currency", "USD")
-                put("totals", totals)
-                put("interval_subtotals", buildJsonArray { intervals.forEach { add(it) } })
-            },
+            summary = ShowCardsResolvedSummary.AnalyticsStats(
+                AnalyticsStatsSummary(
+                    id = id,
+                    after = "2026-05-01",
+                    before = "2026-05-07",
+                    currency = "USD",
+                    totals = totals,
+                    intervalSubtotals = intervals,
+                )
+            ),
             card = ShowCardPayload(
                 family = "analytics_stats",
                 id = id,
@@ -793,32 +768,19 @@ class ShowCardsToolHandlerTest {
 
         return ShowCardsResolution.Resolved(
             ref = ref,
-            summary = json.encodeToJsonElement(
+            summary = ShowCardsResolvedSummary.Customer(
                 CustomerSummary(
                     id = id,
                     name = "Ada Lovelace",
                     email = "ada@example.com",
                 )
-            ).jsonObject,
+            ),
             card = ShowCardPayload(
                 family = "customer",
                 id = id,
                 title = "Ada Lovelace",
                 details = ShowCardDetails.Customer(email = "ada@example.com"),
             )
-        )
-    }
-
-    private fun leakyAnalyticsStatsCard(id: String): ShowCardsResolution.Resolved {
-        val resolved = analyticsStatsCard(id)
-        return resolved.copy(
-            summary = buildJsonObject {
-                resolved.summary.forEach { (key, value) -> put(key, value) }
-                put("private_total", "should not leak")
-                putJsonObject("debug") {
-                    put("request", "raw")
-                }
-            }
         )
     }
 

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/ShowCardsToolHandlerTest.kt
@@ -10,9 +10,9 @@ import com.woocommerce.android.aiassistant.tools.handlers.cards.ProductSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardDetails
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardFamily
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardPayload
-import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolvedSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsRejectionReason
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolution
+import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolvedSummary
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsResolver
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ShowCardsUiStructured
 import com.woocommerce.android.aiassistant.tools.handlers.cards.ValidatedRef
@@ -21,9 +21,8 @@ import com.woocommerce.android.aiassistant.tools.orders.CompactOrderLineItem
 import com.woocommerce.android.aiassistant.tools.products.CompactVariationAttribute
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.double
 import kotlinx.serialization.json.int

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolvedSummaryTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolvedSummaryTest.kt
@@ -20,107 +20,12 @@ class ShowCardsResolvedSummaryTest {
 
     @Test
     fun `given typed summaries, when serialized, then each family keeps its expected summary keys`() {
-        val totals = buildJsonObject { put("total_sales", "170.35") }
-        val interval = buildJsonObject { put("interval", "2026-05-01") }
-
         val summaries = listOf(
-            ShowCardsResolvedSummary.Order(
-                OrderSummary(
-                    id = "123",
-                    number = "#123",
-                    status = "processing",
-                    total = "12.34",
-                    currency = "USD",
-                    dateCreated = "2026-05-01T10:00:00Z",
-                    customerName = "Jane Doe",
-                    paymentMethodTitle = "Credit Card",
-                    customerId = 55L,
-                    lineItemsCount = 1,
-                    lineItems = listOf(CompactOrderLineItem(id = 10L, name = "Socks", quantity = 1f)),
-                )
-            ) to listOf(
-                "id",
-                "number",
-                "status",
-                "total",
-                "currency",
-                "date_created",
-                "customer_name",
-                "payment_method_title",
-                "customer_id",
-                "line_items_count",
-                "line_items",
-            ),
-            ShowCardsResolvedSummary.Product(
-                ProductSummary(
-                    id = "456",
-                    name = "Socks",
-                    sku = "woo-socks",
-                    price = "9.99",
-                    type = "simple",
-                    stockStatus = "instock",
-                    manageStock = true,
-                    onSale = false,
-                    stockQuantity = 12.0,
-                )
-            ) to listOf(
-                "id",
-                "name",
-                "sku",
-                "price",
-                "type",
-                "stock_status",
-                "manage_stock",
-                "on_sale",
-                "stock_quantity",
-            ),
-            ShowCardsResolvedSummary.Variation(
-                VariationSummary(
-                    id = "100/10",
-                    productId = 100L,
-                    variationId = 10L,
-                    name = "Blue socks",
-                    sku = "woo-socks-blue",
-                    price = "12.99",
-                    stockStatus = "instock",
-                    status = "publish",
-                    attributes = listOf(CompactVariationAttribute(name = "Size", option = "M")),
-                )
-            ) to listOf(
-                "id",
-                "product_id",
-                "variation_id",
-                "name",
-                "sku",
-                "price",
-                "stock_status",
-                "status",
-                "attributes",
-            ),
-            ShowCardsResolvedSummary.AnalyticsStats(
-                AnalyticsStatsSummary(
-                    id = "analytics_orders:after:2026-05-01:before:2026-05-07:interval:day",
-                    after = "2026-05-01",
-                    before = "2026-05-07",
-                    currency = "USD",
-                    totals = totals,
-                    intervalSubtotals = listOf(interval),
-                )
-            ) to listOf(
-                "id",
-                "after",
-                "before",
-                "currency",
-                "totals",
-                "interval_subtotals",
-            ),
-            ShowCardsResolvedSummary.Customer(
-                CustomerSummary(
-                    id = "789",
-                    name = "Ada Lovelace",
-                    email = "ada@example.com",
-                )
-            ) to listOf("id", "name", "email"),
+            orderSummaryWithKeys(),
+            productSummaryWithKeys(),
+            variationSummaryWithKeys(),
+            analyticsStatsSummaryWithKeys(),
+            customerSummaryWithKeys(),
         )
 
         summaries.forEach { (summary, expectedKeys) ->
@@ -154,4 +59,106 @@ class ShowCardsResolvedSummaryTest {
             .isEqualTo("120.15")
         assertThat(summary.getValue("interval_subtotals").jsonArray).hasSize(1)
     }
+
+    private fun orderSummaryWithKeys() = ShowCardsResolvedSummary.Order(
+        OrderSummary(
+            id = "123",
+            number = "#123",
+            status = "processing",
+            total = "12.34",
+            currency = "USD",
+            dateCreated = "2026-05-01T10:00:00Z",
+            customerName = "Jane Doe",
+            paymentMethodTitle = "Credit Card",
+            customerId = 55L,
+            lineItemsCount = 1,
+            lineItems = listOf(CompactOrderLineItem(id = 10L, name = "Socks", quantity = 1f)),
+        )
+    ) to listOf(
+        "id",
+        "number",
+        "status",
+        "total",
+        "currency",
+        "date_created",
+        "customer_name",
+        "payment_method_title",
+        "customer_id",
+        "line_items_count",
+        "line_items",
+    )
+
+    private fun productSummaryWithKeys() = ShowCardsResolvedSummary.Product(
+        ProductSummary(
+            id = "456",
+            name = "Socks",
+            sku = "woo-socks",
+            price = "9.99",
+            type = "simple",
+            stockStatus = "instock",
+            manageStock = true,
+            onSale = false,
+            stockQuantity = 12.0,
+        )
+    ) to listOf(
+        "id",
+        "name",
+        "sku",
+        "price",
+        "type",
+        "stock_status",
+        "manage_stock",
+        "on_sale",
+        "stock_quantity",
+    )
+
+    private fun variationSummaryWithKeys() = ShowCardsResolvedSummary.Variation(
+        VariationSummary(
+            id = "100/10",
+            productId = 100L,
+            variationId = 10L,
+            name = "Blue socks",
+            sku = "woo-socks-blue",
+            price = "12.99",
+            stockStatus = "instock",
+            status = "publish",
+            attributes = listOf(CompactVariationAttribute(name = "Size", option = "M")),
+        )
+    ) to listOf(
+        "id",
+        "product_id",
+        "variation_id",
+        "name",
+        "sku",
+        "price",
+        "stock_status",
+        "status",
+        "attributes",
+    )
+
+    private fun analyticsStatsSummaryWithKeys() = ShowCardsResolvedSummary.AnalyticsStats(
+        AnalyticsStatsSummary(
+            id = "analytics_orders:after:2026-05-01:before:2026-05-07:interval:day",
+            after = "2026-05-01",
+            before = "2026-05-07",
+            currency = "USD",
+            totals = buildJsonObject { put("total_sales", "170.35") },
+            intervalSubtotals = listOf(buildJsonObject { put("interval", "2026-05-01") }),
+        )
+    ) to listOf(
+        "id",
+        "after",
+        "before",
+        "currency",
+        "totals",
+        "interval_subtotals",
+    )
+
+    private fun customerSummaryWithKeys() = ShowCardsResolvedSummary.Customer(
+        CustomerSummary(
+            id = "789",
+            name = "Ada Lovelace",
+            email = "ada@example.com",
+        )
+    ) to listOf("id", "name", "email")
 }

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolvedSummaryTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolvedSummaryTest.kt
@@ -1,0 +1,157 @@
+package com.woocommerce.android.aiassistant.tools.handlers.cards
+
+import com.woocommerce.android.aiassistant.tools.orders.CompactOrderLineItem
+import com.woocommerce.android.aiassistant.tools.products.CompactVariationAttribute
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ShowCardsResolvedSummaryTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+        explicitNulls = false
+    }
+
+    @Test
+    fun `given typed summaries, when serialized, then each family keeps its expected summary keys`() {
+        val totals = buildJsonObject { put("total_sales", "170.35") }
+        val interval = buildJsonObject { put("interval", "2026-05-01") }
+
+        val summaries = listOf(
+            ShowCardsResolvedSummary.Order(
+                OrderSummary(
+                    id = "123",
+                    number = "#123",
+                    status = "processing",
+                    total = "12.34",
+                    currency = "USD",
+                    dateCreated = "2026-05-01T10:00:00Z",
+                    customerName = "Jane Doe",
+                    paymentMethodTitle = "Credit Card",
+                    customerId = 55L,
+                    lineItemsCount = 1,
+                    lineItems = listOf(CompactOrderLineItem(id = 10L, name = "Socks", quantity = 1f)),
+                )
+            ) to listOf(
+                "id",
+                "number",
+                "status",
+                "total",
+                "currency",
+                "date_created",
+                "customer_name",
+                "payment_method_title",
+                "customer_id",
+                "line_items_count",
+                "line_items",
+            ),
+            ShowCardsResolvedSummary.Product(
+                ProductSummary(
+                    id = "456",
+                    name = "Socks",
+                    sku = "woo-socks",
+                    price = "9.99",
+                    type = "simple",
+                    stockStatus = "instock",
+                    manageStock = true,
+                    onSale = false,
+                    stockQuantity = 12.0,
+                )
+            ) to listOf(
+                "id",
+                "name",
+                "sku",
+                "price",
+                "type",
+                "stock_status",
+                "manage_stock",
+                "on_sale",
+                "stock_quantity",
+            ),
+            ShowCardsResolvedSummary.Variation(
+                VariationSummary(
+                    id = "100/10",
+                    productId = 100L,
+                    variationId = 10L,
+                    name = "Blue socks",
+                    sku = "woo-socks-blue",
+                    price = "12.99",
+                    stockStatus = "instock",
+                    status = "publish",
+                    attributes = listOf(CompactVariationAttribute(name = "Size", option = "M")),
+                )
+            ) to listOf(
+                "id",
+                "product_id",
+                "variation_id",
+                "name",
+                "sku",
+                "price",
+                "stock_status",
+                "status",
+                "attributes",
+            ),
+            ShowCardsResolvedSummary.AnalyticsStats(
+                AnalyticsStatsSummary(
+                    id = "analytics_orders:after:2026-05-01:before:2026-05-07:interval:day",
+                    after = "2026-05-01",
+                    before = "2026-05-07",
+                    currency = "USD",
+                    totals = totals,
+                    intervalSubtotals = listOf(interval),
+                )
+            ) to listOf(
+                "id",
+                "after",
+                "before",
+                "currency",
+                "totals",
+                "interval_subtotals",
+            ),
+            ShowCardsResolvedSummary.Customer(
+                CustomerSummary(
+                    id = "789",
+                    name = "Ada Lovelace",
+                    email = "ada@example.com",
+                )
+            ) to listOf("id", "name", "email"),
+        )
+
+        summaries.forEach { (summary, expectedKeys) ->
+            assertThat(summary.toJsonObject(json).keys).containsExactlyElementsOf(expectedKeys)
+        }
+    }
+
+    @Test
+    fun `given analytics stats summary, when serialized, then nested metric objects are preserved`() {
+        val totals = buildJsonObject {
+            put("total_sales", "170.35")
+            put("net_revenue", "120.15")
+        }
+        val interval = buildJsonObject {
+            put("interval", "2026-05-01")
+            put("date_start", "2026-05-01 00:00:00")
+        }
+
+        val summary = ShowCardsResolvedSummary.AnalyticsStats(
+            AnalyticsStatsSummary(
+                id = "analytics_orders:after:2026-05-01:before:2026-05-07:interval:day",
+                after = "2026-05-01",
+                before = "2026-05-07",
+                currency = "USD",
+                totals = totals,
+                intervalSubtotals = listOf(interval),
+            )
+        ).toJsonObject(json)
+
+        assertThat(summary.getValue("totals").jsonObject.getValue("net_revenue").jsonPrimitive.content)
+            .isEqualTo("120.15")
+        assertThat(summary.getValue("interval_subtotals").jsonArray).hasSize(1)
+    }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
@@ -48,7 +48,6 @@ class ShowCardsResolverTest {
         variationsDataSource = variationsDataSource,
         analyticsDataSource = analyticsDataSource,
         customersDataSource = customersDataSource,
-        json = json,
     )
 
     @Test
@@ -122,13 +121,13 @@ class ShowCardsResolverTest {
         )
         verifyNoInteractions(ordersDataSource, productsDataSource, variationsDataSource)
         val resolved = result.single() as ShowCardsResolution.Resolved
-        assertThat(resolved.summary.getValue("id").jsonPrimitive.content).isEqualTo(ANALYTICS_STATS_ID)
-        assertThat(resolved.summary.getValue("after").jsonPrimitive.content).isEqualTo("2026-05-01")
-        assertThat(resolved.summary.getValue("before").jsonPrimitive.content).isEqualTo("2026-05-07")
-        assertThat(resolved.summary.getValue("currency").jsonPrimitive.content).isEqualTo("USD")
-        assertThat(resolved.summary.getValue("totals").jsonObject.getValue("total_sales").jsonPrimitive.content)
+        assertThat(resolved.summaryJson().getValue("id").jsonPrimitive.content).isEqualTo(ANALYTICS_STATS_ID)
+        assertThat(resolved.summaryJson().getValue("after").jsonPrimitive.content).isEqualTo("2026-05-01")
+        assertThat(resolved.summaryJson().getValue("before").jsonPrimitive.content).isEqualTo("2026-05-07")
+        assertThat(resolved.summaryJson().getValue("currency").jsonPrimitive.content).isEqualTo("USD")
+        assertThat(resolved.summaryJson().getValue("totals").jsonObject.getValue("total_sales").jsonPrimitive.content)
             .isEqualTo("170.35")
-        assertThat(resolved.summary.getValue("interval_subtotals").jsonArray).hasSize(2)
+        assertThat(resolved.summaryJson().getValue("interval_subtotals").jsonArray).hasSize(2)
         assertThat(resolved.card.family).isEqualTo("analytics_stats")
         assertThat(resolved.card.id).isEqualTo(ANALYTICS_STATS_ID)
         assertThat(resolved.card.title).isEqualTo("Analytics")
@@ -149,9 +148,9 @@ class ShowCardsResolverTest {
             verify(variationsDataSource).getVariation(productId = 100L, variationId = 10L)
             val resolved = result.single() as ShowCardsResolution.Resolved
             assertThat(resolved.card.id).isEqualTo("100/10")
-            assertThat(resolved.summary.getValue("id").jsonPrimitive.content).isEqualTo("100/10")
-            assertThat(resolved.summary.getValue("product_id").jsonPrimitive.content).isEqualTo("100")
-            assertThat(resolved.summary.getValue("variation_id").jsonPrimitive.content).isEqualTo("10")
+            assertThat(resolved.summaryJson().getValue("id").jsonPrimitive.content).isEqualTo("100/10")
+            assertThat(resolved.summaryJson().getValue("product_id").jsonPrimitive.content).isEqualTo("100")
+            assertThat(resolved.summaryJson().getValue("variation_id").jsonPrimitive.content).isEqualTo("10")
             val details = resolved.card.details as ShowCardDetails.Variation
             assertThat(details.productId).isEqualTo(100L)
             assertThat(details.variationId).isEqualTo(10L)
@@ -194,7 +193,7 @@ class ShowCardsResolverTest {
             interval = AnalyticsInterval.DAY,
         )
         val resolved = result.single() as ShowCardsResolution.Resolved
-        assertThat(resolved.summary.getValue("currency").jsonPrimitive.content).isEqualTo("USD")
+        assertThat(resolved.summaryJson().getValue("currency").jsonPrimitive.content).isEqualTo("USD")
         val details = resolved.card.details as ShowCardDetails.AnalyticsStats
         assertThat(details.currency).isEqualTo("USD")
     }
@@ -218,7 +217,7 @@ class ShowCardsResolverTest {
             interval = AnalyticsInterval.DAY,
         )
         val resolved = result.single() as ShowCardsResolution.Resolved
-        assertThat(resolved.summary.getValue("currency").jsonPrimitive.content).isEqualTo("USD")
+        assertThat(resolved.summaryJson().getValue("currency").jsonPrimitive.content).isEqualTo("USD")
     }
 
     @Test
@@ -273,7 +272,7 @@ class ShowCardsResolverTest {
         val orderResult = result[0] as ShowCardsResolution.Missing
         val productResult = result[1] as ShowCardsResolution.Resolved
         assertThat(orderResult.reason).isEqualTo(ShowCardsRejectionReason.FetchFailed)
-        assertThat(productResult.summary.getValue("id").jsonPrimitive.content).isEqualTo("2")
+        assertThat(productResult.summaryJson().getValue("id").jsonPrimitive.content).isEqualTo("2")
     }
 
     @Test
@@ -291,7 +290,7 @@ class ShowCardsResolverTest {
         ).filterIsInstance<ShowCardsResolution.Resolved>()
 
         assertThat(
-            result[0].summary.keys
+            result[0].summaryJson().keys
         ).containsExactly(
             "id",
             "number",
@@ -302,7 +301,7 @@ class ShowCardsResolverTest {
             "customer_name",
             "line_items_count",
         )
-        assertThat(result[0].summary.getValue("customer_name").jsonPrimitive.content).isEqualTo("Jane Doe")
+        assertThat(result[0].summaryJson().getValue("customer_name").jsonPrimitive.content).isEqualTo("Jane Doe")
         assertThat(result[0].card.family).isEqualTo("order")
         assertThat(result[0].card.id).isEqualTo("1")
         assertThat(result[0].card.title).isEqualTo("#1")
@@ -312,7 +311,7 @@ class ShowCardsResolverTest {
         assertThat(orderDetails.currency).isEqualTo("USD")
         assertThat(orderDetails.dateCreated).isEqualTo("2026-05-01T10:00:00Z")
         assertThat(orderDetails.customerName).isEqualTo("Jane Doe")
-        assertThat(result[1].summary.keys).containsExactly(
+        assertThat(result[1].summaryJson().keys).containsExactly(
             "id",
             "name",
             "sku",
@@ -369,22 +368,22 @@ class ShowCardsResolverTest {
             )
         ).filterIsInstance<ShowCardsResolution.Resolved>()
 
-        assertThat(result[0].summary.keys).contains(
+        assertThat(result[0].summaryJson().keys).contains(
             "payment_method_title",
             "customer_id",
             "line_items_count",
             "line_items",
         )
-        assertThat(result[0].summary.getValue("payment_method_title").jsonPrimitive.content)
+        assertThat(result[0].summaryJson().getValue("payment_method_title").jsonPrimitive.content)
             .isEqualTo("Credit Card")
-        assertThat(result[0].summary.getValue("customer_id").jsonPrimitive.content).isEqualTo("55")
-        assertThat(result[0].summary.getValue("line_items_count").jsonPrimitive.content).isEqualTo("2")
-        assertThat(result[0].summary.getValue("line_items").jsonArray).hasSize(2)
-        assertThat(result[1].summary.keys).contains("manage_stock", "on_sale", "type", "stock_quantity")
-        assertThat(result[1].summary.getValue("type").jsonPrimitive.content).isEqualTo("simple")
-        assertThat(result[1].summary.getValue("manage_stock").jsonPrimitive.boolean).isTrue
-        assertThat(result[1].summary.getValue("on_sale").jsonPrimitive.boolean).isFalse
-        assertThat(result[1].summary.getValue("stock_quantity").jsonPrimitive.double).isEqualTo(12.0)
+        assertThat(result[0].summaryJson().getValue("customer_id").jsonPrimitive.content).isEqualTo("55")
+        assertThat(result[0].summaryJson().getValue("line_items_count").jsonPrimitive.content).isEqualTo("2")
+        assertThat(result[0].summaryJson().getValue("line_items").jsonArray).hasSize(2)
+        assertThat(result[1].summaryJson().keys).contains("manage_stock", "on_sale", "type", "stock_quantity")
+        assertThat(result[1].summaryJson().getValue("type").jsonPrimitive.content).isEqualTo("simple")
+        assertThat(result[1].summaryJson().getValue("manage_stock").jsonPrimitive.boolean).isTrue
+        assertThat(result[1].summaryJson().getValue("on_sale").jsonPrimitive.boolean).isFalse
+        assertThat(result[1].summaryJson().getValue("stock_quantity").jsonPrimitive.double).isEqualTo(12.0)
     }
 
     @Test
@@ -457,11 +456,11 @@ class ShowCardsResolverTest {
             verifyCustomersFetch(ids = listOf(123L, 456L))
             val resolved = result.filterIsInstance<ShowCardsResolution.Resolved>()
             assertThat(resolved.map { it.ref.id }).containsExactly("123", "456")
-            assertThat(resolved[0].summary.keys).containsExactly("id", "name", "email")
-            assertThat(resolved[0].summary.getValue("id").jsonPrimitive.content).isEqualTo("123")
-            assertThat(resolved[0].summary.getValue("name").jsonPrimitive.content).isEqualTo("Ada Lovelace")
-            assertThat(resolved[0].summary.getValue("email").jsonPrimitive.content).isEqualTo("ada@example.com")
-            assertThat(resolved[0].summary).doesNotContainKeys("phone", "address")
+            assertThat(resolved[0].summaryJson().keys).containsExactly("id", "name", "email")
+            assertThat(resolved[0].summaryJson().getValue("id").jsonPrimitive.content).isEqualTo("123")
+            assertThat(resolved[0].summaryJson().getValue("name").jsonPrimitive.content).isEqualTo("Ada Lovelace")
+            assertThat(resolved[0].summaryJson().getValue("email").jsonPrimitive.content).isEqualTo("ada@example.com")
+            assertThat(resolved[0].summaryJson()).doesNotContainKeys("phone", "address")
             assertThat(resolved[0].card.family).isEqualTo("customer")
             assertThat(resolved[0].card.id).isEqualTo("123")
             assertThat(resolved[0].card.title).isEqualTo("Ada Lovelace")
@@ -496,6 +495,8 @@ class ShowCardsResolverTest {
     }
 
     private fun ref(family: ShowCardFamily, id: String) = ValidatedRef(index = 0, family = family, id = id)
+
+    private fun ShowCardsResolution.Resolved.summaryJson() = summary.toJsonObject(json)
 
     private fun orderLookup(vararg orders: OrderEntity): CachedLookupResult<OrderEntity> =
         CachedLookupResult(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
@@ -289,22 +289,8 @@ class ShowCardsResolverTest {
             )
         ).filterIsInstance<ShowCardsResolution.Resolved>()
 
-        val orderSummary = (result[0].summary as ShowCardsResolvedSummary.Order).value
-        assertThat(orderSummary.id).isEqualTo("1")
-        assertThat(orderSummary.number).isEqualTo("1")
-        assertThat(orderSummary.status).isEqualTo("processing")
-        assertThat(orderSummary.total).isEqualTo("12.34")
-        assertThat(orderSummary.currency).isEqualTo("USD")
-        assertThat(orderSummary.dateCreated).isEqualTo("2026-05-01T10:00:00Z")
-        assertThat(orderSummary.customerName).isEqualTo("Jane Doe")
-
-        val productSummary = (result[1].summary as ShowCardsResolvedSummary.Product).value
-        assertThat(productSummary.id).isEqualTo("2")
-        assertThat(productSummary.name).isEqualTo("Socks")
-        assertThat(productSummary.sku).isEqualTo("woo-socks")
-        assertThat(productSummary.price).isEqualTo("9.99")
-        assertThat(productSummary.type).isEqualTo("simple")
-        assertThat(productSummary.stockStatus).isEqualTo("instock")
+        assertCompactOrderSummary(result[0])
+        assertCompactProductSummary(result[1])
 
         assertThat(
             result[0].summaryJson().keys
@@ -526,6 +512,27 @@ class ShowCardsResolverTest {
     private fun ref(family: ShowCardFamily, id: String) = ValidatedRef(index = 0, family = family, id = id)
 
     private fun ShowCardsResolution.Resolved.summaryJson() = summary.toJsonObject(json)
+
+    private fun assertCompactOrderSummary(resolved: ShowCardsResolution.Resolved) {
+        val summary = (resolved.summary as ShowCardsResolvedSummary.Order).value
+        assertThat(summary.id).isEqualTo("1")
+        assertThat(summary.number).isEqualTo("1")
+        assertThat(summary.status).isEqualTo("processing")
+        assertThat(summary.total).isEqualTo("12.34")
+        assertThat(summary.currency).isEqualTo("USD")
+        assertThat(summary.dateCreated).isEqualTo("2026-05-01T10:00:00Z")
+        assertThat(summary.customerName).isEqualTo("Jane Doe")
+    }
+
+    private fun assertCompactProductSummary(resolved: ShowCardsResolution.Resolved) {
+        val summary = (resolved.summary as ShowCardsResolvedSummary.Product).value
+        assertThat(summary.id).isEqualTo("2")
+        assertThat(summary.name).isEqualTo("Socks")
+        assertThat(summary.sku).isEqualTo("woo-socks")
+        assertThat(summary.price).isEqualTo("9.99")
+        assertThat(summary.type).isEqualTo("simple")
+        assertThat(summary.stockStatus).isEqualTo("instock")
+    }
 
     private fun orderLookup(vararg orders: OrderEntity): CachedLookupResult<OrderEntity> =
         CachedLookupResult(

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/tools/handlers/cards/ShowCardsResolverTest.kt
@@ -289,6 +289,23 @@ class ShowCardsResolverTest {
             )
         ).filterIsInstance<ShowCardsResolution.Resolved>()
 
+        val orderSummary = (result[0].summary as ShowCardsResolvedSummary.Order).value
+        assertThat(orderSummary.id).isEqualTo("1")
+        assertThat(orderSummary.number).isEqualTo("1")
+        assertThat(orderSummary.status).isEqualTo("processing")
+        assertThat(orderSummary.total).isEqualTo("12.34")
+        assertThat(orderSummary.currency).isEqualTo("USD")
+        assertThat(orderSummary.dateCreated).isEqualTo("2026-05-01T10:00:00Z")
+        assertThat(orderSummary.customerName).isEqualTo("Jane Doe")
+
+        val productSummary = (result[1].summary as ShowCardsResolvedSummary.Product).value
+        assertThat(productSummary.id).isEqualTo("2")
+        assertThat(productSummary.name).isEqualTo("Socks")
+        assertThat(productSummary.sku).isEqualTo("woo-socks")
+        assertThat(productSummary.price).isEqualTo("9.99")
+        assertThat(productSummary.type).isEqualTo("simple")
+        assertThat(productSummary.stockStatus).isEqualTo("instock")
+
         assertThat(
             result[0].summaryJson().keys
         ).containsExactly(
@@ -367,6 +384,18 @@ class ShowCardsResolverTest {
                 ref(ShowCardFamily.Product, "2"),
             )
         ).filterIsInstance<ShowCardsResolution.Resolved>()
+
+        val orderSummary = (result[0].summary as ShowCardsResolvedSummary.Order).value
+        assertThat(orderSummary.paymentMethodTitle).isEqualTo("Credit Card")
+        assertThat(orderSummary.customerId).isEqualTo(55L)
+        assertThat(orderSummary.lineItemsCount).isEqualTo(2)
+        assertThat(orderSummary.lineItems).hasSize(2)
+
+        val productSummary = (result[1].summary as ShowCardsResolvedSummary.Product).value
+        assertThat(productSummary.type).isEqualTo("simple")
+        assertThat(productSummary.manageStock).isTrue
+        assertThat(productSummary.onSale).isFalse
+        assertThat(productSummary.stockQuantity).isEqualTo(12.0)
 
         assertThat(result[0].summaryJson().keys).contains(
             "payment_method_title",


### PR DESCRIPTION
### Description
Fixes WOOMOB-3006

Why:
Show card summaries were built as generic JSON and then trimmed with handler-level key allowlists. That made the resolver contract easy to drift from the app-owned summary models, and it required every widened summary field to be mirrored in a separate allowlist before it could safely reach the assistant's structured response.

How:
- Added a typed `ShowCardsResolvedSummary` model for order, product, variation, analytics stats, and customer summaries.
- Updated the resolver to return typed summaries while keeping UI card payloads separate from assistant structured summaries.
- Updated the handler to serialize typed summaries directly through the assistant JSON configuration instead of filtering raw JSON by family-specific allowlists.
- Removed the duplicated summary key allowlists from `ShowCardsToolHandler`.
- Preserved the existing structured response shape for rendered refs while adding coverage that verifies typed order, product, variation, analytics, and customer summary fields.
- Added regression coverage to confirm UI-only card details such as image URLs do not leak into assistant structured summaries.

### Test Steps
1. Open the assistant and ask for an order or product that can be shown as a rich card.
2. Confirm the assistant response renders the rich card and includes the expected compact summary details.
3. Ask for analytics over a date range and confirm the analytics stats card still renders.
4. Ask for a specific product variation and confirm the variation card still renders with variation details.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.