### PR TITLE
Send token_hash with every QR login session-status poll

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClient.kt
@@ -18,6 +18,7 @@ import java.net.HttpURLConnection.HTTP_FORBIDDEN
 import java.net.HttpURLConnection.HTTP_NOT_FOUND
 import java.net.HttpURLConnection.HTTP_PRECON_FAILED
 import java.net.HttpURLConnection.HTTP_UNAUTHORIZED
+import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -52,10 +53,25 @@ class QrLoginRestClient @Inject constructor(
             }
         }
 
-    suspend fun checkSessionStatus(siteUrl: String, sessionId: String): Result<QrLoginSessionStatus> =
+    /**
+     * Poll the merchant's site for the next session-status transition.
+     *
+     * [token] is the plaintext QR ticket the app scanned. The REST client hashes it with
+     * SHA-256 and passes the result as the `token_hash` query parameter so the server can
+     * prove the caller scanned the QR before delivering an `exchange_grant`. Without this
+     * binding, anyone who learned the [sessionId] alone (mobile logs, network capture,
+     * leaked debug output, support ticket attachments) could poll for state and walk away
+     * with the grant the moment the merchant approves on wc-admin. See WC Core
+     * `b54daa591e` for the security review finding that introduced this requirement.
+     */
+    suspend fun checkSessionStatus(
+        siteUrl: String,
+        sessionId: String,
+        token: String,
+    ): Result<QrLoginSessionStatus> =
         withContext(dispatchers.io) {
             try {
-                Result.success(performSessionStatus(siteUrl, sessionId))
+                Result.success(performSessionStatus(siteUrl, sessionId, token))
             } catch (ce: CancellationException) {
                 throw ce
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
@@ -149,8 +165,8 @@ class QrLoginRestClient @Inject constructor(
 
     // region session status
 
-    private fun performSessionStatus(siteUrl: String, sessionId: String): QrLoginSessionStatus {
-        val request = buildSessionStatusRequest(siteUrl, sessionId)
+    private fun performSessionStatus(siteUrl: String, sessionId: String, token: String): QrLoginSessionStatus {
+        val request = buildSessionStatusRequest(siteUrl, sessionId, token)
         okHttpClient.newCall(request).execute().use { response ->
             if (!response.isSuccessful) throw mapSessionStatusHttpStatus(response.code)
             val parsed = gson.fromJson(response.body.string(), SessionStatusResponse::class.java)
@@ -158,12 +174,13 @@ class QrLoginRestClient @Inject constructor(
         }
     }
 
-    private fun buildSessionStatusRequest(siteUrl: String, sessionId: String): Request {
+    private fun buildSessionStatusRequest(siteUrl: String, sessionId: String, token: String): Request {
         val baseUrl = siteUrl.toHttpUrlOrNull()
             ?: throw IllegalArgumentException("siteUrl could not be parsed by HttpUrl")
         val statusUrl = baseUrl.newBuilder()
             .addPathSegments(SESSION_STATUS_PATH_SEGMENTS)
             .addQueryParameter("session_id", sessionId)
+            .addQueryParameter("token_hash", sha256Hex(token))
             .build()
         return Request.Builder()
             .url(statusUrl)
@@ -380,6 +397,17 @@ class QrLoginRestClient @Inject constructor(
             .noStore()
             .build()
         val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+
+        /**
+         * Lowercase-hex SHA-256 of the input. Matches PHP's `hash('sha256', $token)` so the
+         * client and server hashes line up byte-for-byte under the server's `hash_equals`.
+         */
+        fun sha256Hex(input: String): String {
+            val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+            return buildString(digest.size * 2) {
+                digest.forEach { append("%02x".format(it)) }
+            }
+        }
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModel.kt
@@ -207,7 +207,7 @@ class QrLoginScannerViewModel @Inject constructor(
                 }
                 if (_uiState.value !is WaitingForApproval) return@launch
 
-                val callResult = restClient.checkSessionStatus(ticket.siteUrl, sessionId)
+                val callResult = restClient.checkSessionStatus(ticket.siteUrl, sessionId, ticket.token)
                 // Guard after the await: cancel/start-over may have flipped state away from
                 // WaitingForApproval while the call was in flight. If so, drop the response
                 // on the floor so the user doesn't get bounced into a "Signing in…" spinner

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/network/qrlogin/QrLoginRestClientTest.kt
@@ -350,25 +350,49 @@ class QrLoginRestClientTest : BaseUnitTest() {
     // region session status
 
     @Test
-    fun `given session-status call, when executed, then GET request includes session_id`() = testBlocking {
+    fun `given session-status call, when executed, then GET request includes session_id and token_hash`() =
+        testBlocking {
+            responder = { ok(it, """{"state":"scanned"}""") }
+
+            client.checkSessionStatus("https://store.example", "sess-99", "tok-99")
+
+            val request = requireNotNull(lastRequest)
+            assertThat(request.method).isEqualTo("GET")
+            assertThat(request.url.queryParameter("session_id")).isEqualTo("sess-99")
+            // SHA-256("tok-99") — must line up byte-for-byte with PHP's hash('sha256', $token).
+            assertThat(request.url.queryParameter("token_hash"))
+                .isEqualTo("2cbd7d7c8841c55cab932e2e92cb3f788210c3883bfdb3cc8749623175430ca0")
+            assertThat(request.url.encodedPath)
+                .isEqualTo("/wp-json/wc-admin/mobile-app/qr-login-session-status")
+            assertThat(request.header("Cache-Control"))
+                .contains("no-cache")
+                .contains("no-store")
+        }
+
+    @Test
+    fun `given a different plaintext token, when session-status, then the hash differs`() = testBlocking {
+        // Direct sanity check that the hash isn't accidentally a fixed string. The two values
+        // below are the known SHA-256 hex digests for the two inputs.
         responder = { ok(it, """{"state":"scanned"}""") }
 
-        client.checkSessionStatus("https://store.example", "sess-99")
+        client.checkSessionStatus("https://store.example", "sess-1", "tok")
+        val hashForTok = requireNotNull(lastRequest).url.queryParameter("token_hash")
 
-        val request = requireNotNull(lastRequest)
-        assertThat(request.method).isEqualTo("GET")
-        assertThat(request.url.toString())
-            .isEqualTo("https://store.example/wp-json/wc-admin/mobile-app/qr-login-session-status?session_id=sess-99")
-        assertThat(request.header("Cache-Control"))
-            .contains("no-cache")
-            .contains("no-store")
+        client.checkSessionStatus("https://store.example", "sess-1", "plaintext-token-from-qr")
+        val hashForOther = requireNotNull(lastRequest).url.queryParameter("token_hash")
+
+        assertThat(hashForTok)
+            .isEqualTo("1a7674eb4ee78df7e1ac439a93c3fa8e3c945784d4dec9fd8e3011738b2f1d62")
+        assertThat(hashForOther)
+            .isEqualTo("b126ded63b57b4cc3ca5742336b9e2aa522fb4d80be84b364bfe402cdde536ef")
+        assertThat(hashForTok).isNotEqualTo(hashForOther)
     }
 
     @Test
     fun `given state=scanned, when session-status, then Scanned`() = testBlocking {
         responder = { ok(it, """{"state":"scanned"}""") }
 
-        val result = client.checkSessionStatus("https://store.example", "sess-1")
+        val result = client.checkSessionStatus("https://store.example", "sess-1", "tok")
 
         assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Scanned)
     }
@@ -377,7 +401,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given state=approved with grant, when session-status, then Approved with grant`() = testBlocking {
         responder = { ok(it, """{"state":"approved","exchange_grant":"grant-99"}""") }
 
-        val result = client.checkSessionStatus("https://store.example", "sess-1")
+        val result = client.checkSessionStatus("https://store.example", "sess-1", "tok")
 
         assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Approved("grant-99"))
     }
@@ -386,7 +410,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given state=approved without grant, when session-status, then fails closed as Expired`() = testBlocking {
         responder = { ok(it, """{"state":"approved"}""") }
 
-        val result = client.checkSessionStatus("https://store.example", "sess-1")
+        val result = client.checkSessionStatus("https://store.example", "sess-1", "tok")
 
         assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Expired)
     }
@@ -395,7 +419,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given state=rejected, when session-status, then Rejected`() = testBlocking {
         responder = { ok(it, """{"state":"rejected"}""") }
 
-        val result = client.checkSessionStatus("https://store.example", "sess-1")
+        val result = client.checkSessionStatus("https://store.example", "sess-1", "tok")
 
         assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Rejected)
     }
@@ -404,7 +428,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given state=expired, when session-status, then Expired`() = testBlocking {
         responder = { ok(it, """{"state":"expired"}""") }
 
-        val result = client.checkSessionStatus("https://store.example", "sess-1")
+        val result = client.checkSessionStatus("https://store.example", "sess-1", "tok")
 
         assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Expired)
     }
@@ -413,7 +437,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given unknown state, when session-status, then fails closed as Expired`() = testBlocking {
         responder = { ok(it, """{"state":"some_future_state"}""") }
 
-        val result = client.checkSessionStatus("https://store.example", "sess-1")
+        val result = client.checkSessionStatus("https://store.example", "sess-1", "tok")
 
         assertThat(result.getOrNull()).isEqualTo(QrLoginSessionStatus.Expired)
     }
@@ -422,7 +446,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given 429, when session-status, then RateLimited`() = testBlocking {
         responder = { respond(it, code = 429) }
 
-        val result = client.checkSessionStatus("https://store.example", "sess-1")
+        val result = client.checkSessionStatus("https://store.example", "sess-1", "tok")
 
         assertThat(result.exceptionOrNull()).isEqualTo(QrLoginSessionStatusException.RateLimited)
     }
@@ -431,7 +455,7 @@ class QrLoginRestClientTest : BaseUnitTest() {
     fun `given network IOException, when session-status, then Network`() = testBlocking {
         responder = { throw IOException("disconnect") }
 
-        val result = client.checkSessionStatus("https://store.example", "sess-1")
+        val result = client.checkSessionStatus("https://store.example", "sess-1", "tok")
 
         assertThat(result.exceptionOrNull()).isEqualTo(QrLoginSessionStatusException.Network)
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerViewModelTest.kt
@@ -92,7 +92,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
      * default calls this helper instead.
      */
     private suspend fun stubPollingTerminates() {
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.success(QrLoginSessionStatus.Scanned))
             .thenReturn(Result.success(QrLoginSessionStatus.Expired))
     }
@@ -155,7 +155,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     @Test
     fun `given approved with grant on first poll, when polling fires, then exchange runs and emits LoggedIn`() =
         testBlocking {
-            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
                 .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
             val events = viewModel.event.captureValues()
 
@@ -170,7 +170,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given rejected on poll, when polling fires, then state is MatchRejected with no retry`() = testBlocking {
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.success(QrLoginSessionStatus.Rejected))
 
         viewModel.onScanResult(successScan())
@@ -184,7 +184,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given expired on poll, when polling fires, then state is MatchTimedOut`() = testBlocking {
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.success(QrLoginSessionStatus.Expired))
 
         viewModel.onScanResult(successScan())
@@ -197,7 +197,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given scanned on poll, when polling fires, then state stays WaitingForApproval`() = testBlocking {
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.success(QrLoginSessionStatus.Scanned))
 
         viewModel.onScanResult(successScan())
@@ -206,7 +206,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         advanceTimeBy(POLL_TICK_MS * 2 + 1)
 
         assertThat(viewModel.uiState.value).isInstanceOf(UiState.WaitingForApproval::class.java)
-        verify(restClient, atLeastOnce()).checkSessionStatus(ticket.siteUrl, scanResult.sessionId)
+        verify(restClient, atLeastOnce()).checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token)
         // Stop the loop so runTest's post-body advanceUntilIdle doesn't chase it forever.
         viewModel.onCancelNumberMatch()
     }
@@ -214,7 +214,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     @Test
     fun `given transient poll errors, when fewer than threshold occur, then polling continues`() = testBlocking {
         // Three transient failures, then a Scanned response: polling must still be active.
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
             .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
             .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
@@ -231,7 +231,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     @Test
     fun `given transient poll errors, when threshold reached, then state transitions to Network error with retry`() =
         testBlocking {
-            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
                 .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
 
             viewModel.onScanResult(successScan())
@@ -244,7 +244,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given rate-limited poll, when first error fires, then transitions immediately`() = testBlocking {
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.failure(QrLoginSessionStatusException.RateLimited))
 
         viewModel.onScanResult(successScan())
@@ -257,7 +257,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given endpoint-missing poll, when first error fires, then transitions without retry`() = testBlocking {
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.failure(QrLoginSessionStatusException.EndpointMissing))
 
         viewModel.onScanResult(successScan())
@@ -275,7 +275,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     @Test
     fun `given WaitingForApproval, when onCancelNumberMatch, then state returns to Idle and polling stops`() =
         testBlocking {
-            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
                 .thenReturn(Result.success(QrLoginSessionStatus.Scanned))
 
             viewModel.onScanResult(successScan())
@@ -285,12 +285,12 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
             assertThat(viewModel.uiState.value).isEqualTo(UiState.Idle)
             // Once cancel fires, no further polls should happen.
-            verify(restClient, atLeastOnce()).checkSessionStatus(any(), any())
+            verify(restClient, atLeastOnce()).checkSessionStatus(any(), any(), any())
         }
 
     @Test
     fun `given waiting for approval, when another scan arrives, then it is ignored`() = testBlocking {
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.success(QrLoginSessionStatus.Scanned))
 
         viewModel.onScanResult(successScan(RAW_SCAN))
@@ -321,7 +321,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
         whenever(restClient.scan(ticket.siteUrl, ticket.token))
             .thenReturn(Result.failure(QrLoginScanException.Network))
             .thenReturn(Result.success(scanResult))
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.success(QrLoginSessionStatus.Scanned))
 
         viewModel.onScanResult(successScan())
@@ -342,7 +342,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     @Test
     fun `given exchange returns InvalidExchangeGrant, when polling triggers exchange, then MatchInvalidGrant`() =
         testBlocking {
-            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
                 .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
             whenever(restClient.exchange(ticket.siteUrl, ticket.token, "grant-1"))
                 .thenReturn(Result.failure(QrLoginExchangeException.InvalidExchangeGrant))
@@ -358,7 +358,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     @Test
     fun `given exchange returns Network, when polling triggers exchange, then Network with retry ticket`() =
         testBlocking {
-            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
                 .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
             whenever(restClient.exchange(ticket.siteUrl, ticket.token, "grant-1"))
                 .thenReturn(Result.failure(QrLoginExchangeException.Network))
@@ -375,7 +375,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     @Test
     fun `given exchange network error, when retried, then exchange is re-run with same grant`() =
         testBlocking {
-            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
                 .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
             whenever(restClient.exchange(ticket.siteUrl, ticket.token, "grant-1"))
                 .thenReturn(Result.failure(QrLoginExchangeException.Network))
@@ -395,7 +395,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given authenticator returns NotAWooSite, when login completes, then NotAWooSite error`() = testBlocking {
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
         whenever(authenticator.completeLogin(ticket, credentials))
             .thenReturn(Result.failure(QrLoginAuthenticationException.NotAWooSite))
@@ -409,7 +409,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given authenticator returns IOException, when login completes, then Network error`() = testBlocking {
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
         whenever(authenticator.completeLogin(ticket, credentials))
             .thenReturn(Result.failure(IOException("offline")))
@@ -469,7 +469,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given successful login, when LoggedIn dispatched, then tracks LOGIN_QR_SUCCESS`() = testBlocking {
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
 
         viewModel.onScanResult(successScan())
@@ -495,7 +495,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given rejected match, when polling fires, then tracks scan failed with approve step`() = testBlocking {
-        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+        whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
             .thenReturn(Result.success(QrLoginSessionStatus.Rejected))
 
         viewModel.onScanResult(successScan())
@@ -857,7 +857,7 @@ class QrLoginScannerViewModelTest : BaseUnitTest() {
     fun `given logged in and ticket, when warning confirmed and site confirmed, then emits LoggedIn`() =
         testBlocking {
             whenever(accountRepository.isUserLoggedIn()).thenReturn(true)
-            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId))
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
                 .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
             val events = viewModel.event.captureValues()
 


### PR DESCRIPTION
### Description

Pairs with WC Core [#64503](https://github.com/woocommerce/woocommerce/pull/64503) ([commit `b54daa591e`](https://github.com/woocommerce/woocommerce/commit/b54daa591e)), which made `token_hash` a required query parameter on `/qr-login-session-status` as part of the security review hardening. The Android client at `rsm-qr-login-main` only sends `session_id`, so every poll currently returns `400 rest_missing_callback_param` and the flow stalls after scan. This PR sends the missing `token_hash` on every poll.

#### Why the server needs it

`session_id` is the one value the app **can't** avoid putting on the wire — it's printed in every 2-second poll URL, so it leaks readily through logs, packet captures, screen recordings, support-ticket attachments. Before the hardening, anyone holding a leaked `session_id` could poll the same endpoint themselves and harvest the `exchange_grant` the moment the merchant approved on wc-admin. Binding each poll to `SHA-256(token)` proves the caller actually scanned the QR — the plaintext token never leaves the device, so an attacker with only the leak can't derive the matching hash and is held at an opaque `state: expired`.

```mermaid
sequenceDiagram
  participant Phone
  participant Logs as 📋 logs / capture /<br/>support attachment
  participant Attacker as 🕵️ Attacker
  participant Server

  Phone->>Server: POST /qr-login-scan { token }
  Server-->>Phone: { session_id }
  Note right of Server: stores SHA-256(token)<br/>keyed by SHA-256(session_id)

  Phone->>Server: GET /qr-login-session-status<br/>{ session_id, token_hash }
  Phone-->>Logs: session_id leaks in URL / log lines
  Logs-->>Attacker: reads session_id

  rect rgba(214,54,56,0.10)
  Note over Attacker,Server: Old design — session_id alone was enough
  Attacker->>Server: poll { session_id }
  Server-->>Attacker: { state: approved, exchange_grant } ❌
  end

  rect rgba(26,175,93,0.10)
  Note over Attacker,Server: New design — token_hash required
  Attacker->>Server: poll { session_id, token_hash: ??? }
  Server-->>Attacker: { state: expired } (opaque) ✅
  end
```

#### What changed Android-side

- `QrLoginRestClient.checkSessionStatus(siteUrl, sessionId, token)` hashes the token and adds `&token_hash=<sha256_hex>` on every poll.
- New `sha256Hex()` helper on the companion object — lowercase-hex output matches PHP's `hash('sha256', $token)` byte-for-byte under server-side `hash_equals`.
- `QrLoginScannerViewModel` passes `ticket.token` (already in scope from `scan()`) through to each poll tick.
- Tests pin `SHA-256` for two known plaintexts so a future change to algorithm/encoding/case fails loudly.

### Test Steps

Requires the WC Core build from PR [#64591](https://github.com/woocommerce/woocommerce/pull/64591) at `7bb7a1e79d` or later (the build that contains the `token_hash` server-side check).

1. Install the debug APK from this branch on a device.
2. Generate a QR code from the test site (`wp-admin → Mobile app login`).
3. Scan the QR. The merchant browser should advance to the "match number" step within ~2 s, and the Android app should show the number-display screen with a 90 s countdown.
4. Tap the correct number on wc-admin. The app should advance through "Signing in…" and finish at the logged-in store.

Negative path:

5. Re-scan the same QR after expiry (or tap "Cancel" mid-flow). The app should land on "Sign-in timed out" rather than hanging on `state: scanned` indefinitely.

### Images/gif

N/A — wire-level change. Visible only in HTTP logs and in the fact that the flow no longer dead-ends at the polling step.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.

> No release-notes entry: the QR login feature has not shipped to merchants yet, so the user-visible behavior on a real install is "QR login works" rather than "a previously broken path now works." A `[Internal]` note would be appropriate if the team prefers to track every Core-pairing fix in the changelog.
