### PR TITLE
[Woo POS] Custom Amount, Part 8: in-pane form on tablet (iOS parity)

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeDialogs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeDialogs.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.woocommerce.android.ui.woopos.cardreader.connection.WooPosCardReaderConnectionDialog
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosExitConfirmationDialog
-import com.woocommerce.android.ui.woopos.home.items.customamount.WooPosCustomAmountDialog
 import com.woocommerce.android.ui.woopos.scanningsetup.WooPosScanningSetupDialog
 
 @Composable
@@ -34,10 +33,4 @@ fun WooPosHomeDialogs(
             onConnectionSuccess = { onHomeUIEvent(WooPosHomeUIEvent.DismissCardReaderConnectionDialog) }
         )
     }
-
-    WooPosCustomAmountDialog(
-        isVisible = dialogState is WooPosHomeState.DialogState.CustomAmountDialog,
-        editing = (dialogState as? WooPosHomeState.DialogState.CustomAmountDialog)?.editing,
-        onDismissRequest = { onHomeUIEvent(WooPosHomeUIEvent.DismissCustomAmountDialog) },
-    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home
 
 import com.woocommerce.android.ui.woopos.common.composeui.modifier.BarcodeInputDetector
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import dagger.hilt.android.scopes.ActivityRetainedScoped
@@ -60,6 +61,10 @@ sealed class ParentToChildrenEvent {
         val amount: BigDecimal,
         val isTaxable: Boolean,
         val editingItemNumber: Int? = null,
+    ) : ParentToChildrenEvent()
+
+    data class ShowCustomAmountForm(
+        val editing: WooPosCartItemViewState.CustomAmount? = null,
     ) : ParentToChildrenEvent()
 
     sealed class SearchEvent : ParentToChildrenEvent() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeScreen.kt
@@ -24,10 +24,13 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.isPreviewMode
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState
+import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.toolbar.PreviewWooPosFloatingToolbarStatusConnectedWithMenu
 import com.woocommerce.android.ui.woopos.home.toolbar.WooPosFloatingToolbar
 import org.wordpress.android.util.ToastUtils
@@ -142,11 +145,17 @@ private fun WooPosHomeScreen(
         }
 
         if (!isPreviewMode()) {
-            WooPosHomeScreenToolbar(
-                modifier = Modifier
-                    .padding(WooPosSpacing.Large.value)
-                    .align(Alignment.BottomStart),
-            )
+            val itemsViewModel: WooPosItemsViewModel = hiltViewModel()
+            val itemsState by itemsViewModel.viewState.collectAsState()
+            val isFloatingToolbarVisible = itemsState !is WooPosItemsToolbarViewState.CustomAmountForm
+
+            if (isFloatingToolbarVisible) {
+                WooPosHomeScreenToolbar(
+                    modifier = Modifier
+                        .padding(WooPosSpacing.Large.value)
+                        .align(Alignment.BottomStart),
+                )
+            }
 
             WooPosHomeDialogs(state.dialogState, onHomeUIEvent)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeState.kt
@@ -2,7 +2,6 @@ package com.woocommerce.android.ui.woopos.home
 
 import android.os.Parcelable
 import com.woocommerce.android.R
-import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -51,10 +50,5 @@ data class WooPosHomeState(
 
         @Parcelize
         data object CardReaderConnectionDialog : DialogState()
-
-        @Parcelize
-        data class CustomAmountDialog(
-            val editing: WooPosCartItemViewState.CustomAmount? = null,
-        ) : DialogState()
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeUIEvent.kt
@@ -7,7 +7,6 @@ sealed class WooPosHomeUIEvent {
     data object ExitConfirmationDialogDismissed : WooPosHomeUIEvent()
     data object DismissScanningSetupDialog : WooPosHomeUIEvent()
     data object DismissCardReaderConnectionDialog : WooPosHomeUIEvent()
-    data object DismissCustomAmountDialog : WooPosHomeUIEvent()
     data object OnPaymentCompletedViaCash : WooPosHomeUIEvent()
     data object ExitPosClicked : WooPosHomeUIEvent()
     data object PhoneOpenCartClicked : WooPosHomeUIEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -98,12 +98,6 @@ class WooPosHomeViewModel @Inject constructor(
                 )
             }
 
-            WooPosHomeUIEvent.DismissCustomAmountDialog -> {
-                _state.value = _state.value.copy(
-                    dialogState = DialogState.Hidden
-                )
-            }
-
             WooPosHomeUIEvent.OnPaymentCompletedViaCash -> onOrderSuccessfullyPaid(
                 PaymentMethod.CASH
             )
@@ -291,13 +285,12 @@ class WooPosHomeViewModel @Inject constructor(
                     }
 
                     is ChildToParentEvent.CustomAmountDialogRequested -> {
-                        _state.value = _state.value.copy(
-                            dialogState = DialogState.CustomAmountDialog(editing = event.editing)
+                        sendEventToChildren(
+                            ParentToChildrenEvent.ShowCustomAmountForm(editing = event.editing)
                         )
                     }
 
                     is ChildToParentEvent.CustomAmountSubmitted -> {
-                        _state.value = _state.value.copy(dialogState = DialogState.Hidden)
                         sendEventToChildren(
                             ParentToChildrenEvent.CustomAmountSubmitted(
                                 name = event.name,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -86,7 +86,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverfl
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerText
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
@@ -94,7 +93,6 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIco
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptiveIconSize
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState.Coupon.CouponValidationState
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartUIEvent.ItemRemovedFromCart
@@ -814,14 +812,7 @@ private fun CustomAmountItem(
             // Edit lives inside the overflow menu, so this also gates the edit path during checkout
             // — intentional: cart contents are locked once payment starts.
             if (canRemoveItems) {
-                when (currentWooPosBreakpoint()) {
-                    WooPosBreakpoint.Phone -> CustomAmountOverflowMenu(item = item, onUIEvent = onUIEvent)
-                    WooPosBreakpoint.SmallTablet,
-                    WooPosBreakpoint.Tablet -> {
-                        EditCustomAmountButton(item = item, onUIEvent = onUIEvent)
-                        RemoveItemFromCartButton(item = item, onUIEvent = onUIEvent)
-                    }
-                }
+                CustomAmountOverflowMenu(item = item, onUIEvent = onUIEvent)
             }
             Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
         }
@@ -846,26 +837,6 @@ private fun CustomAmountOverflowMenu(
             ),
         )
     )
-}
-
-@Composable
-private fun EditCustomAmountButton(
-    item: WooPosCartItemViewState.CustomAmount,
-    onUIEvent: (WooPosCartUIEvent) -> Unit,
-) {
-    IconButton(
-        onClick = { onUIEvent(WooPosCartUIEvent.EditCustomAmountClicked(item)) },
-        modifier = Modifier.size(WooPosIconSize.XLarge.value),
-    ) {
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_edit_filled_24dp),
-            tint = WooPosTheme.colors.onSurfaceVariantHighest,
-            contentDescription = stringResource(
-                id = R.string.woopos_cart_custom_amount_edit_content_description,
-                item.name,
-            ),
-        )
-    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartScreen.kt
@@ -86,6 +86,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOverfl
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerBox
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerText
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosElevation
@@ -93,6 +94,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIco
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptiveIconSize
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState.Coupon.CouponValidationState
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartUIEvent.ItemRemovedFromCart
@@ -812,7 +814,14 @@ private fun CustomAmountItem(
             // Edit lives inside the overflow menu, so this also gates the edit path during checkout
             // — intentional: cart contents are locked once payment starts.
             if (canRemoveItems) {
-                CustomAmountOverflowMenu(item = item, onUIEvent = onUIEvent)
+                when (currentWooPosBreakpoint()) {
+                    WooPosBreakpoint.Phone -> CustomAmountOverflowMenu(item = item, onUIEvent = onUIEvent)
+                    WooPosBreakpoint.SmallTablet,
+                    WooPosBreakpoint.Tablet -> {
+                        EditCustomAmountButton(item = item, onUIEvent = onUIEvent)
+                        RemoveItemFromCartButton(item = item, onUIEvent = onUIEvent)
+                    }
+                }
             }
             Spacer(modifier = Modifier.width(WooPosSpacing.Small.value))
         }
@@ -837,6 +846,26 @@ private fun CustomAmountOverflowMenu(
             ),
         )
     )
+}
+
+@Composable
+private fun EditCustomAmountButton(
+    item: WooPosCartItemViewState.CustomAmount,
+    onUIEvent: (WooPosCartUIEvent) -> Unit,
+) {
+    IconButton(
+        onClick = { onUIEvent(WooPosCartUIEvent.EditCustomAmountClicked(item)) },
+        modifier = Modifier.size(WooPosIconSize.XLarge.value),
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_edit_filled_24dp),
+            tint = WooPosTheme.colors.onSurfaceVariantHighest,
+            contentDescription = stringResource(
+                id = R.string.woopos_cart_custom_amount_edit_content_description,
+                item.name,
+            ),
+        )
+    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/cart/WooPosCartViewModel.kt
@@ -254,6 +254,8 @@ class WooPosCartViewModel @Inject constructor(
                     is ParentToChildrenEvent.ProductsRemoved -> Unit
 
                     is ParentToChildrenEvent.CustomAmountSubmitted -> handleCustomAmountSubmitted(event)
+
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> Unit
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsContent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.SearchState
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsNavigationData
 
@@ -17,6 +18,7 @@ fun WooPosItemsContent(
     productsSearchContent: @Composable () -> Unit,
     couponsSearchContent: @Composable () -> Unit,
     variationsContent: @Composable (WooPosVariationsNavigationData) -> Unit,
+    customAmountFormContent: @Composable (WooPosCartItemViewState.CustomAmount?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Crossfade(
@@ -30,6 +32,7 @@ fun WooPosItemsContent(
             ItemsScreenState.ProductsSearch -> productsSearchContent()
             ItemsScreenState.CouponsSearch -> couponsSearchContent()
             is ItemsScreenState.Variations -> variationsContent(screenState.variableProductData)
+            is ItemsScreenState.CustomAmountForm -> customAmountFormContent(screenState.editing)
         }
     }
 }
@@ -40,6 +43,7 @@ internal sealed class ItemsScreenState {
     data object ProductsSearch : ItemsScreenState()
     data object CouponsSearch : ItemsScreenState()
     data class Variations(val variableProductData: WooPosVariationsNavigationData) : ItemsScreenState()
+    data class CustomAmountForm(val editing: WooPosCartItemViewState.CustomAmount?) : ItemsScreenState()
 }
 
 internal fun WooPosItemsToolbarViewState.toScreenState(): ItemsScreenState = when (this) {
@@ -58,4 +62,5 @@ internal fun WooPosItemsToolbarViewState.toScreenState(): ItemsScreenState = whe
             is WooPosSearchInputState.Open -> ItemsScreenState.CouponsSearch
         }
     }
+    is WooPosItemsToolbarViewState.CustomAmountForm -> ItemsScreenState.CustomAmountForm(editing)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsScreen.kt
@@ -29,6 +29,7 @@ import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreen
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreenContentPreview
 import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchContentPreview
 import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchScreen
+import com.woocommerce.android.ui.woopos.home.items.customamount.WooPosCustomAmountFormScreen
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosItemsScreenPreview
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsScreen
 import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
@@ -181,6 +182,12 @@ private fun MainItemsList(
                         modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
                         variableProductData = data,
                         onBackClicked = onBackClicked,
+                    )
+                },
+                customAmountFormContent = { editing ->
+                    WooPosCustomAmountFormScreen(
+                        editing = editing,
+                        onBackClick = onBackClicked,
                     )
                 },
             )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsSearchHelper.kt
@@ -75,6 +75,7 @@ class WooPosItemsSearchHelper @Inject constructor(
                     is ParentToChildrenEvent.OrderSuccessfullyPaid -> Unit
                     is ParentToChildrenEvent.SettingsEvent -> Unit
                     is ParentToChildrenEvent.CustomAmountSubmitted -> Unit
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> Unit
                 }
             }
         }
@@ -129,6 +130,8 @@ class WooPosItemsSearchHelper @Inject constructor(
             is WooPosItemsToolbarViewState.ProductList -> R.string.woopos_search_products_and_variations
             is WooPosItemsToolbarViewState.CouponList -> R.string.woopos_search_coupons
             is WooPosItemsToolbarViewState.VariationList -> error("Search is not applicable for variations list")
+            is WooPosItemsToolbarViewState.CustomAmountForm ->
+                error("Search is not applicable for custom amount form")
         }
 
         viewStateFlow.value = viewStateFlow.value.copy(
@@ -183,6 +186,7 @@ class WooPosItemsSearchHelper @Inject constructor(
         is WooPosItemsToolbarViewState.CouponList -> false
         is WooPosItemsToolbarViewState.ProductList -> true
         is WooPosItemsToolbarViewState.VariationList -> false
+        is WooPosItemsToolbarViewState.CustomAmountForm -> false
     }
 
     private fun getCurrentSearchVisibleState(): SearchState.Visible? {
@@ -200,6 +204,7 @@ class WooPosItemsSearchHelper @Inject constructor(
             is WooPosItemsToolbarViewState.ProductList -> this.copy(search = search)
             is WooPosItemsToolbarViewState.CouponList -> this.copy(search = search)
             is WooPosItemsToolbarViewState.VariationList -> this
+            is WooPosItemsToolbarViewState.CustomAmountForm -> this
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbarViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsToolbarViewState.kt
@@ -1,6 +1,7 @@
 package com.woocommerce.android.ui.woopos.home.items
 
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsNavigationData
 
 sealed class WooPosItemsToolbarViewState(
@@ -27,6 +28,15 @@ sealed class WooPosItemsToolbarViewState(
     data class VariationList(
         override val tabs: List<Tab>,
         val variableProductData: WooPosVariationsNavigationData,
+    ) : WooPosItemsToolbarViewState(
+        tabs = tabs,
+        search = SearchState.Hidden,
+        backNavigation = true,
+    )
+
+    data class CustomAmountForm(
+        override val tabs: List<Tab>,
+        val editing: WooPosCartItemViewState.CustomAmount? = null,
     ) : WooPosItemsToolbarViewState(
         tabs = tabs,
         search = SearchState.Hidden,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -244,6 +244,8 @@ class WooPosItemsViewModel @Inject constructor(
     }
 
     private fun navigateBackFromSubScreen() {
+        // No-op if we're not actually on a sub-screen — guards against races where a back-event arrives
+        // after the items list has already been restored (e.g. submit + back fired in quick succession).
         when (_viewState.value) {
             is WooPosItemsToolbarViewState.VariationList,
             is WooPosItemsToolbarViewState.CustomAmountForm -> {
@@ -251,7 +253,7 @@ class WooPosItemsViewModel @Inject constructor(
                 preservedStateBeforeOpeningSubScreen = null
             }
 
-            else -> error("Unexpected state: ${_viewState.value}")
+            else -> Unit
         }
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -3,11 +3,13 @@ package com.woocommerce.android.ui.woopos.home.items
 import android.os.Parcelable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSearchInputState
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent
 import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
 import com.woocommerce.android.ui.woopos.home.WooPosChildrenToParentEventSender
 import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventReceiver
+import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.SearchState
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsToolbarViewState.Tab
 import com.woocommerce.android.ui.woopos.home.items.coupons.creation.WooPosCouponCreationFacade
@@ -21,6 +23,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Eve
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEventConstant
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.datastore.WooPosPreferencesRepository
+import com.woocommerce.android.viewmodel.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -44,8 +47,9 @@ class WooPosItemsViewModel @Inject constructor(
     private val syncStatusChecker: WooPosFullSyncStatusChecker,
     private val dateTimeProvider: DateTimeProvider,
     private val isWooCommerceVersionSunsetWarningRequired: WooPosIsWooCommerceVersionSunsetWarningRequired,
+    private val resourceProvider: ResourceProvider,
 ) : ViewModel() {
-    private var preservedStateBeforeOpeningVariations: WooPosItemsToolbarViewState? = null
+    private var preservedStateBeforeOpeningSubScreen: WooPosItemsToolbarViewState? = null
     private val _viewState = MutableStateFlow<WooPosItemsToolbarViewState>(initialState())
     val viewState: StateFlow<WooPosItemsToolbarViewState> = _viewState
         .stateIn(
@@ -107,7 +111,7 @@ class WooPosItemsViewModel @Inject constructor(
     fun onUIEvent(event: WooPosItemsUIEvent) {
         when (event) {
             WooPosItemsUIEvent.BackFromVariationsClicked -> {
-                navigateBackFromVariations()
+                navigateBackFromSubScreen()
             }
 
             WooPosItemsUIEvent.ClearSearchClicked -> searchHelper.onClearSearchClicked()
@@ -162,8 +166,15 @@ class WooPosItemsViewModel @Inject constructor(
                     is ParentToChildrenEvent.BarcodeEvent,
                     is ParentToChildrenEvent.MissingVariationEvent,
                     is ParentToChildrenEvent.RemoveProductsClicked,
-                    is ParentToChildrenEvent.ProductsRemoved,
-                    is ParentToChildrenEvent.CustomAmountSubmitted -> Unit
+                    is ParentToChildrenEvent.ProductsRemoved -> Unit
+
+                    is ParentToChildrenEvent.CustomAmountSubmitted -> {
+                        if (_viewState.value is WooPosItemsToolbarViewState.CustomAmountForm) {
+                            navigateBackFromSubScreen()
+                        }
+                    }
+
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> openCustomAmountForm(event.editing)
 
                     ParentToChildrenEvent.RefreshProductList,
                     is ParentToChildrenEvent.SettingsEvent.RetrySyncRequested -> refreshBannerState()
@@ -176,6 +187,27 @@ class WooPosItemsViewModel @Inject constructor(
         }
     }
 
+    private fun openCustomAmountForm(editing: WooPosCartItemViewState.CustomAmount?) {
+        searchHelper.updateLoadingState(isLoading = false)
+        if (_viewState.value !is WooPosItemsToolbarViewState.CustomAmountForm) {
+            preservedStateBeforeOpeningSubScreen = _viewState.value
+        }
+        val titleRes = if (editing != null) {
+            R.string.woopos_custom_amount_dialog_title_edit
+        } else {
+            R.string.woopos_custom_amount_dialog_title_add
+        }
+        _viewState.value = WooPosItemsToolbarViewState.CustomAmountForm(
+            tabs = listOf(
+                Tab.Variations(
+                    name = resourceProvider.getString(titleRes),
+                    highlightLevel = Tab.HighlightLevel.Full,
+                )
+            ),
+            editing = editing,
+        )
+    }
+
     private fun handleItemClicked(event: ParentToChildrenEvent.ItemClickedInItemsList) {
         when (event.itemData) {
             is ItemClickedData.Coupon,
@@ -185,7 +217,7 @@ class WooPosItemsViewModel @Inject constructor(
 
             is ItemClickedData.VariableProduct -> {
                 searchHelper.updateLoadingState(isLoading = false)
-                preservedStateBeforeOpeningVariations = _viewState.value
+                preservedStateBeforeOpeningSubScreen = _viewState.value
                 _viewState.value = WooPosItemsToolbarViewState.VariationList(
                     tabs = listOf(
                         Tab.Variations(
@@ -209,17 +241,19 @@ class WooPosItemsViewModel @Inject constructor(
                 is WooPosItemsToolbarViewState.ProductList -> WooPosAnalyticsEventConstant.ItemsListSource.PRODUCT
                 is WooPosItemsToolbarViewState.CouponList -> WooPosAnalyticsEventConstant.ItemsListSource.COUPON
                 is WooPosItemsToolbarViewState.VariationList -> WooPosAnalyticsEventConstant.ItemsListSource.PRODUCT
+                is WooPosItemsToolbarViewState.CustomAmountForm -> WooPosAnalyticsEventConstant.ItemsListSource.PRODUCT
             }
             val event = SearchButtonTapped(source = source)
             analyticsTracker.track(event)
         }
     }
 
-    private fun navigateBackFromVariations() {
+    private fun navigateBackFromSubScreen() {
         when (_viewState.value) {
-            is WooPosItemsToolbarViewState.VariationList -> {
-                _viewState.value = preservedStateBeforeOpeningVariations ?: initialState()
-                preservedStateBeforeOpeningVariations = null
+            is WooPosItemsToolbarViewState.VariationList,
+            is WooPosItemsToolbarViewState.CustomAmountForm -> {
+                _viewState.value = preservedStateBeforeOpeningSubScreen ?: initialState()
+                preservedStateBeforeOpeningSubScreen = null
             }
 
             else -> error("Unexpected state: ${_viewState.value}")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModel.kt
@@ -192,15 +192,10 @@ class WooPosItemsViewModel @Inject constructor(
         if (_viewState.value !is WooPosItemsToolbarViewState.CustomAmountForm) {
             preservedStateBeforeOpeningSubScreen = _viewState.value
         }
-        val titleRes = if (editing != null) {
-            R.string.woopos_custom_amount_dialog_title_edit
-        } else {
-            R.string.woopos_custom_amount_dialog_title_add
-        }
         _viewState.value = WooPosItemsToolbarViewState.CustomAmountForm(
             tabs = listOf(
                 Tab.Variations(
-                    name = resourceProvider.getString(titleRes),
+                    name = resourceProvider.getString(R.string.woopos_custom_amount_form_title),
                     highlightLevel = Tab.HighlightLevel.Full,
                 )
             ),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
@@ -81,17 +82,18 @@ fun WooPosCustomAmountFormScreen(
             NameSection(value = state.name, onNameChanged = viewModel::onNameChanged)
         }
 
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    top = WooPosSpacing.Medium.value,
-                    start = WooPosSpacing.Medium.value,
-                    end = WooPosSpacing.Medium.value,
-                )
-                .navigationBarsPadding(),
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceBright,
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            FormSubmitButton(state = state, onSubmit = viewModel::onSubmit)
+            FormSubmitButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = WooPosSpacing.Medium.value)
+                    .navigationBarsPadding(),
+                state = state,
+                onSubmit = viewModel::onSubmit,
+            )
         }
     }
 }
@@ -197,6 +199,7 @@ private fun TaxesToggle(
 private fun FormSubmitButton(
     state: WooPosCustomAmountDialogState,
     onSubmit: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val submitText = when (state.mode) {
         is WooPosCustomAmountDialogState.Mode.Edit -> R.string.woopos_custom_amount_dialog_submit_edit
@@ -205,7 +208,7 @@ private fun FormSubmitButton(
     val submitButtonState =
         if (state.isSubmitEnabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED
     WooPosButton(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier,
         text = stringResource(submitText),
         state = submitButtonState,
         onClick = onSubmit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -51,6 +52,13 @@ fun WooPosCustomAmountFormScreen(
 ) {
     LaunchedEffect(editing?.itemNumber) {
         viewModel.initializeFor(editing)
+    }
+
+    // Reset the VM init sentinel whenever the form leaves composition — covers back gestures, submit
+    // success, and any external navigation. Without this, opening the form again for the same item
+    // (or a fresh "add" after a cancel) would short-circuit `initializeFor` and reuse stale state.
+    DisposableEffect(Unit) {
+        onDispose { viewModel.onDismissed() }
     }
 
     BackHandler(enabled = true) { onBackClick() }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -84,8 +84,12 @@ fun WooPosCustomAmountFormScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .navigationBarsPadding()
-                .padding(WooPosSpacing.Medium.value),
+                .padding(
+                    top = WooPosSpacing.Medium.value,
+                    start = WooPosSpacing.Medium.value,
+                    end = WooPosSpacing.Medium.value,
+                )
+                .navigationBarsPadding(),
         ) {
             FormSubmitButton(state = state, onSubmit = viewModel::onSubmit)
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
@@ -75,6 +76,7 @@ fun WooPosCustomAmountFormScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .navigationBarsPadding()
                 .padding(WooPosSpacing.Medium.value),
         ) {
             FormSubmitButton(state = state, onSubmit = viewModel::onSubmit)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -9,18 +9,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
@@ -29,25 +23,19 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.woocommerce.android.R
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosDialogWrapper
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosInputField
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosMoneyInputField
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIconSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
@@ -56,184 +44,45 @@ import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import java.math.BigDecimal
 
 @Composable
-fun WooPosCustomAmountDialog(
-    isVisible: Boolean,
+fun WooPosCustomAmountFormScreen(
     editing: WooPosCartItemViewState.CustomAmount?,
-    onDismissRequest: () -> Unit,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
     viewModel: WooPosCustomAmountDialogViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(isVisible, editing?.itemNumber) {
-        if (isVisible) {
-            viewModel.initializeFor(editing)
-        } else {
-            viewModel.onDismissed()
-        }
+    LaunchedEffect(editing?.itemNumber) {
+        viewModel.initializeFor(editing)
     }
+
+    BackHandler(enabled = true) { onBackClick() }
 
     val state by viewModel.state.collectAsState()
 
-    val dialogTitleRes = when (state.mode) {
-        is WooPosCustomAmountDialogState.Mode.Edit -> R.string.woopos_custom_amount_dialog_title_edit
-        WooPosCustomAmountDialogState.Mode.Add -> R.string.woopos_custom_amount_dialog_title_add
-    }
-
-    when (currentWooPosBreakpoint()) {
-        WooPosBreakpoint.Phone -> PhoneFullScreenLayout(
-            isVisible = isVisible,
-            state = state,
-            dialogTitleRes = dialogTitleRes,
-            onAmountChanged = viewModel::onAmountChanged,
-            onNameChanged = viewModel::onNameChanged,
-            onTaxableToggled = viewModel::onTaxableToggled,
-            onSubmit = viewModel::onSubmit,
-            onDismissRequest = onDismissRequest,
-        )
-
-        WooPosBreakpoint.SmallTablet,
-        WooPosBreakpoint.Tablet -> TabletDialogLayout(
-            isVisible = isVisible,
-            state = state,
-            dialogTitleRes = dialogTitleRes,
-            onAmountChanged = viewModel::onAmountChanged,
-            onNameChanged = viewModel::onNameChanged,
-            onTaxableToggled = viewModel::onTaxableToggled,
-            onSubmit = viewModel::onSubmit,
-            onDismissRequest = onDismissRequest,
-        )
-    }
-}
-
-@Composable
-private fun TabletDialogLayout(
-    isVisible: Boolean,
-    state: WooPosCustomAmountDialogState,
-    dialogTitleRes: Int,
-    onAmountChanged: (BigDecimal?) -> Unit,
-    onNameChanged: (String) -> Unit,
-    onTaxableToggled: (Boolean) -> Unit,
-    onSubmit: () -> Unit,
-    onDismissRequest: () -> Unit,
-) {
-    WooPosDialogWrapper(
-        isVisible = isVisible,
-        dialogBackgroundContentDescription = stringResource(dialogTitleRes),
-        onCloseClick = onDismissRequest,
-        onDismissRequest = onDismissRequest,
-    ) {
+    Column(modifier = modifier.fillMaxSize()) {
         Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
-        ) {
-            WooPosText(
-                text = stringResource(dialogTitleRes),
-                style = WooPosTypography.Heading,
-                fontWeight = FontWeight.Bold,
-            )
-
-            AmountSection(state = state, onAmountChanged = onAmountChanged)
-            NameSection(value = state.name, onNameChanged = onNameChanged)
-            TaxesToggle(isTaxable = state.isTaxable, onToggled = onTaxableToggled)
-
-            Spacer(modifier = Modifier.height(WooPosSpacing.Small.value))
-
-            DialogActions(
-                state = state,
-                breakpoint = WooPosBreakpoint.Tablet,
-                onSubmit = onSubmit,
-                onCancel = onDismissRequest,
-            )
-        }
-    }
-}
-
-@Composable
-private fun PhoneFullScreenLayout(
-    isVisible: Boolean,
-    state: WooPosCustomAmountDialogState,
-    dialogTitleRes: Int,
-    onAmountChanged: (BigDecimal?) -> Unit,
-    onNameChanged: (String) -> Unit,
-    onTaxableToggled: (Boolean) -> Unit,
-    onSubmit: () -> Unit,
-    onDismissRequest: () -> Unit,
-) {
-    if (!isVisible) return
-
-    BackHandler(enabled = true) { onDismissRequest() }
-
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.surface,
-    ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            PhoneToolbar(
-                titleRes = dialogTitleRes,
-                onCloseClick = onDismissRequest,
-            )
-
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = WooPosSpacing.Medium.value),
-                verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
-            ) {
-                Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
-                AmountSection(state = state, onAmountChanged = onAmountChanged)
-                NameSection(value = state.name, onNameChanged = onNameChanged)
-                TaxesToggle(isTaxable = state.isTaxable, onToggled = onTaxableToggled)
-            }
-
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .navigationBarsPadding()
-                    .padding(WooPosSpacing.Medium.value),
-            ) {
-                DialogActions(
-                    state = state,
-                    breakpoint = WooPosBreakpoint.Phone,
-                    onSubmit = onSubmit,
-                    onCancel = onDismissRequest,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun PhoneToolbar(
-    titleRes: Int,
-    onCloseClick: () -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .statusBarsPadding()
-            .padding(
-                horizontal = WooPosSpacing.Small.value,
-                vertical = WooPosSpacing.Small.value,
-            ),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        IconButton(onClick = onCloseClick) {
-            Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.ic_close_24dp),
-                contentDescription = stringResource(R.string.close),
-                modifier = Modifier.size(WooPosIconSize.Large.value),
-                tint = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-        WooPosText(
-            text = stringResource(titleRes),
-            style = WooPosTypography.Heading,
-            fontWeight = FontWeight.Bold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
             modifier = Modifier
                 .weight(1f)
-                .padding(end = WooPosIconSize.Large.value + WooPosSpacing.Small.value),
-        )
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = WooPosSpacing.Medium.value),
+            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
+        ) {
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+            AmountSection(state = state, onAmountChanged = viewModel::onAmountChanged)
+            NameSection(value = state.name, onNameChanged = viewModel::onNameChanged)
+            TaxesToggle(isTaxable = state.isTaxable, onToggled = viewModel::onTaxableToggled)
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(WooPosSpacing.Medium.value),
+        ) {
+            FormActions(
+                state = state,
+                onSubmit = viewModel::onSubmit,
+                onCancel = onBackClick,
+            )
+        }
     }
 }
 
@@ -335,9 +184,8 @@ private fun TaxesToggle(
 }
 
 @Composable
-private fun DialogActions(
+private fun FormActions(
     state: WooPosCustomAmountDialogState,
-    breakpoint: WooPosBreakpoint,
     onSubmit: () -> Unit,
     onCancel: () -> Unit,
 ) {
@@ -348,7 +196,7 @@ private fun DialogActions(
     val submitButtonState =
         if (state.isSubmitEnabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED
 
-    when (breakpoint) {
+    when (currentWooPosBreakpoint()) {
         WooPosBreakpoint.Phone -> Column(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -33,13 +34,10 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButtonState
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosInputField
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosMoneyInputField
-import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
-import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
 import com.woocommerce.android.ui.woopos.home.cart.WooPosCartItemViewState
 import java.math.BigDecimal
 
@@ -68,8 +66,10 @@ fun WooPosCustomAmountFormScreen(
         ) {
             Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
             AmountSection(state = state, onAmountChanged = viewModel::onAmountChanged)
-            NameSection(value = state.name, onNameChanged = viewModel::onNameChanged)
+            HorizontalDivider(color = WooPosTheme.colors.outlineVariant)
             TaxesToggle(isTaxable = state.isTaxable, onToggled = viewModel::onTaxableToggled)
+            HorizontalDivider(color = WooPosTheme.colors.outlineVariant)
+            NameSection(value = state.name, onNameChanged = viewModel::onNameChanged)
         }
 
         Box(
@@ -77,11 +77,7 @@ fun WooPosCustomAmountFormScreen(
                 .fillMaxWidth()
                 .padding(WooPosSpacing.Medium.value),
         ) {
-            FormActions(
-                state = state,
-                onSubmit = viewModel::onSubmit,
-                onCancel = onBackClick,
-            )
+            FormSubmitButton(state = state, onSubmit = viewModel::onSubmit)
         }
     }
 }
@@ -184,10 +180,9 @@ private fun TaxesToggle(
 }
 
 @Composable
-private fun FormActions(
+private fun FormSubmitButton(
     state: WooPosCustomAmountDialogState,
     onSubmit: () -> Unit,
-    onCancel: () -> Unit,
 ) {
     val submitText = when (state.mode) {
         is WooPosCustomAmountDialogState.Mode.Edit -> R.string.woopos_custom_amount_dialog_submit_edit
@@ -195,41 +190,10 @@ private fun FormActions(
     }
     val submitButtonState =
         if (state.isSubmitEnabled) WooPosButtonState.ENABLED else WooPosButtonState.DISABLED
-
-    when (currentWooPosBreakpoint()) {
-        WooPosBreakpoint.Phone -> Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(WooPosSpacing.Small.value),
-        ) {
-            WooPosButton(
-                modifier = Modifier.fillMaxWidth(),
-                text = stringResource(submitText),
-                state = submitButtonState,
-                onClick = onSubmit,
-            )
-            WooPosOutlinedButton(
-                modifier = Modifier.fillMaxWidth(),
-                text = stringResource(R.string.woopos_custom_amount_dialog_cancel),
-                onClick = onCancel,
-            )
-        }
-
-        WooPosBreakpoint.SmallTablet,
-        WooPosBreakpoint.Tablet -> Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(WooPosSpacing.Medium.value),
-        ) {
-            WooPosOutlinedButton(
-                modifier = Modifier.weight(1f),
-                text = stringResource(R.string.woopos_custom_amount_dialog_cancel),
-                onClick = onCancel,
-            )
-            WooPosButton(
-                modifier = Modifier.weight(1f),
-                text = stringResource(submitText),
-                state = submitButtonState,
-                onClick = onSubmit,
-            )
-        }
-    }
+    WooPosButton(
+        modifier = Modifier.fillMaxWidth(),
+        text = stringResource(submitText),
+        state = submitButtonState,
+        onClick = onSubmit,
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/customamount/WooPosCustomAmountDialog.kt
@@ -83,7 +83,7 @@ fun WooPosCustomAmountFormScreen(
         }
 
         Surface(
-            color = MaterialTheme.colorScheme.surfaceBright,
+            color = MaterialTheme.colorScheme.surface,
             modifier = Modifier.fillMaxWidth(),
         ) {
             FormSubmitButton(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/products/WooPosProductsViewModel.kt
@@ -91,7 +91,8 @@ class WooPosProductsViewModel @Inject constructor(
                     is ParentToChildrenEvent.MissingVariationEvent,
                     is ParentToChildrenEvent.ProductsRemoved,
                     is ParentToChildrenEvent.SettingsEvent,
-                    is ParentToChildrenEvent.CustomAmountSubmitted -> Unit
+                    is ParentToChildrenEvent.CustomAmountSubmitted,
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> Unit
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/items/search/WooPosItemsSearchViewModel.kt
@@ -241,6 +241,7 @@ class WooPosItemsSearchViewModel @Inject constructor(
                     is ParentToChildrenEvent.MissingVariationEvent -> Unit
                     is ParentToChildrenEvent.SettingsEvent -> Unit
                     is ParentToChildrenEvent.CustomAmountSubmitted -> Unit
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> Unit
                     is ParentToChildrenEvent.ItemClickedInItemsList -> {
                         if (event.itemData is ItemClickedData.Product.Variation &&
                             searchHelper.isSearchOpen()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosPhoneProductsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/phone/WooPosPhoneProductsScreen.kt
@@ -38,6 +38,7 @@ import com.woocommerce.android.ui.woopos.home.items.WooPosItemsUIEvent
 import com.woocommerce.android.ui.woopos.home.items.WooPosItemsViewModel
 import com.woocommerce.android.ui.woopos.home.items.coupons.WooPosCouponsScreen
 import com.woocommerce.android.ui.woopos.home.items.coupons.search.WooPosCouponsSearchScreen
+import com.woocommerce.android.ui.woopos.home.items.customamount.WooPosCustomAmountFormScreen
 import com.woocommerce.android.ui.woopos.home.items.products.WooPosProductsScreen
 import com.woocommerce.android.ui.woopos.home.items.search.WooPosItemsSearchScreen
 import com.woocommerce.android.ui.woopos.home.items.variations.WooPosVariationsScreen
@@ -127,6 +128,14 @@ private fun WooPosPhoneProductsContent(
                         modifier = Modifier.padding(horizontal = WooPosSpacing.Medium.value),
                         variableProductData = data,
                         onBackClicked = {
+                            onItemsUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked)
+                        },
+                    )
+                },
+                customAmountFormContent = { editing ->
+                    WooPosCustomAmountFormScreen(
+                        editing = editing,
+                        onBackClick = {
                             onItemsUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked)
                         },
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -683,7 +683,8 @@ class WooPosTotalsViewModel @Inject constructor(
                     is ParentToChildrenEvent.RemoveProductsClicked,
                     is ParentToChildrenEvent.MissingVariationEvent,
                     is ParentToChildrenEvent.SettingsEvent,
-                    is ParentToChildrenEvent.CustomAmountSubmitted -> Unit
+                    is ParentToChildrenEvent.CustomAmountSubmitted,
+                    is ParentToChildrenEvent.ShowCustomAmountForm -> Unit
                 }
             }
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3714,6 +3714,7 @@
     <string name="woopos_custom_amount_entry_subtitle">Add a one-off charge</string>
     <string name="woopos_custom_amount_dialog_title_add">Add custom amount</string>
     <string name="woopos_custom_amount_dialog_title_edit">Edit custom amount</string>
+    <string name="woopos_custom_amount_form_title">Custom amount</string>
     <string name="woopos_custom_amount_dialog_amount_label">Amount</string>
     <string name="woopos_custom_amount_dialog_name_label">Name</string>
     <string name="woopos_custom_amount_dialog_name_placeholder">Custom amount</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3706,6 +3706,7 @@
     <string name="woopos_add_coupon_to_cart_accessibility_label">Add coupon to cart</string>
     <string name="woopos_cart_item_coupon_content_description">Coupon in cart %s</string>
     <string name="woopos_cart_item_custom_amount_content_description">Custom amount %1$s, %2$s</string>
+    <string name="woopos_cart_custom_amount_edit_content_description">Edit %s</string>
     <string name="woopos_cart_custom_amount_includes_tax">Tax included</string>
     <string name="woopos_cart_custom_amount_menu_edit">Edit</string>
     <string name="woopos_cart_custom_amount_menu_remove">Remove</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -375,6 +375,63 @@ class WooPosItemsViewModelTest {
     }
 
     @Test
+    fun `when ShowCustomAmountForm received, then state changes to CustomAmountForm`() = runTest {
+        // GIVEN
+        whenever(parentToChildrenEventReceiver.events).thenReturn(
+            flowOf(ParentToChildrenEvent.ShowCustomAmountForm())
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsToolbarViewState.CustomAmountForm::class.java)
+            assertThat((state as WooPosItemsToolbarViewState.CustomAmountForm).editing).isNull()
+        }
+    }
+
+    @Test
+    fun `when CustomAmountSubmitted received during form, then state restores preserved state`() = runTest {
+        // GIVEN
+        whenever(parentToChildrenEventReceiver.events).thenReturn(
+            flowOf(
+                ParentToChildrenEvent.ShowCustomAmountForm(),
+                ParentToChildrenEvent.CustomAmountSubmitted(
+                    name = "Tip",
+                    amount = java.math.BigDecimal("1.00"),
+                    isTaxable = false,
+                ),
+            )
+        )
+
+        // WHEN
+        val viewModel = createViewModel()
+
+        // THEN
+        viewModel.viewState.test {
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsToolbarViewState.ProductList::class.java)
+        }
+    }
+
+    @Test
+    fun `given on product list, when navigateBackFromSubScreen path triggers unexpectedly, then state is unchanged`() = runTest {
+        // GIVEN — no sub-screen open
+        val viewModel = createViewModel()
+
+        // WHEN — back-from-variations event fires while already on the product list
+        viewModel.onUIEvent(WooPosItemsUIEvent.BackFromVariationsClicked)
+
+        // THEN — state remains the product list (no crash, no transition)
+        viewModel.viewState.test {
+            val state = awaitItem()
+            assertThat(state).isInstanceOf(WooPosItemsToolbarViewState.ProductList::class.java)
+        }
+    }
+
+    @Test
     fun `when products tab clicked, then analytics event is tracked`() = runTest {
         // GIVEN
         val productsTab = WooPosItemsToolbarViewState.Tab.Products(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/items/WooPosItemsViewModelTest.kt
@@ -62,6 +62,9 @@ class WooPosItemsViewModelTest {
     private val syncStatusChecker: WooPosFullSyncStatusChecker = mock()
     private val dateTimeProvider: DateTimeProvider = mock()
     private val isWooVersionSunsetWarningRequired: WooPosIsWooCommerceVersionSunsetWarningRequired = mock()
+    private val resourceProvider: com.woocommerce.android.viewmodel.ResourceProvider = mock {
+        on { getString(any()) }.thenReturn("Custom amount")
+    }
 
     @Before
     fun setup() = runTest {
@@ -616,6 +619,7 @@ class WooPosItemsViewModelTest {
             syncStatusChecker = syncStatusChecker,
             dateTimeProvider = dateTimeProvider,
             isWooCommerceVersionSunsetWarningRequired = isWooVersionSunsetWarningRequired,
+            resourceProvider = resourceProvider,
         )
     }
 }


### PR DESCRIPTION
## Summary

Aligns the custom amount form with iOS: on tablet the form opens **inside the items pane** (left pane), drilling in/out like the existing variations flow — not as a centered modal. The Cart pane stays untouched. On phone, the form takes the whole screen (same as before, no behavioural change). Also matches iOS on the cart row: pencil + trash icons on tablet, 3-dots overflow on phone.

## What changed

- `WooPosItemsToolbarViewState.CustomAmountForm(editing)` — new sealed variant with `backNavigation = true` and a single tab carrying the localised title ("Add custom amount" / "Edit custom amount"). Mirrors `VariationList`.
- `WooPosItemsContent` — new `ItemsScreenState.CustomAmountForm` and a `customAmountFormContent` slot threaded through `WooPosItemsScreen` and `WooPosPhoneProductsScreen`.
- `WooPosItemsViewModel`:
  - Listens for new `ParentToChildrenEvent.ShowCustomAmountForm`: preserves the previous state into `preservedStateBeforeOpeningSubScreen` (renamed from `preservedStateBeforeOpeningVariations`) and switches to `CustomAmountForm`.
  - Listens for `ParentToChildrenEvent.CustomAmountSubmitted`: if currently in `CustomAmountForm`, restores the previous state.
  - `navigateBackFromSubScreen()` handles both `VariationList` and `CustomAmountForm`. `BackFromVariationsClicked` UI event is the shared back trigger (semantic shift; can be renamed later).
- `WooPosCustomAmountFormScreen` — extracted from the previous dialog body. No `WooPosDialogWrapper` anymore. Renders title via the items toolbar (back arrow + tab), then form sections, then sticky action bar.
- `WooPosHomeViewModel`: on `ChildToParentEvent.CustomAmountDialogRequested`, broadcasts `ParentToChildrenEvent.ShowCustomAmountForm` instead of mutating dialog state.
- `WooPosHomeState`: removed `DialogState.CustomAmountDialog`. `WooPosHomeUIEvent.DismissCustomAmountDialog` and the `WooPosCustomAmountDialog` rendering in `WooPosHomeDialogs` are removed.
- `WooPosCartScreen.CustomAmountItem`: switch on `currentWooPosBreakpoint()` — phone keeps the 3-dot overflow, tablet shows separate pencil + trash icons (matches iOS image #10).
- `ResourceProvider` injected into `WooPosItemsViewModel` for the localised tab title.

## Tests

- `WooPosItemsViewModelTest` — adapted constructor for `ResourceProvider`.
- Existing `WooPosCustomAmount*`, `WooPosCartViewModel*`, `WooPosHomeViewModel*` tests still pass.

## Verification

- `./gradlew :WooCommerce:compileWasabiDebugKotlin`
- `./gradlew detektAll`
- `./gradlew :WooCommerce:testWasabiDebugUnitTest --tests "*WooPosCustomAmount*" --tests "*WooPosItemsViewModel*" --tests "*WooPosCartViewModel*" --tests "*WooPosHomeViewModel*"`

## Test plan

- [ ] Tablet: tap "Custom amount" entry row → items pane swaps to form (cart pane stays). Back arrow returns. Submit → cart row appears, items pane returns to products list.
- [ ] Tablet: tap pencil on cart row → form opens prefilled. Update → row updates in place.
- [ ] Tablet: cart row shows pencil + trash icons (no 3-dots overflow).
- [ ] Phone: full-screen form (unchanged), cart row shows 3-dots overflow.
- [ ] System back from form returns to products list (no dialog state to dismiss).
- [ ] Variations flow still works (back from variations + state preservation unchanged).

## Stack

This feature ships as 8 stacked PRs (≤300 prod LOC each):

- [Part 1 — foundation (data + events + cart handler)](https://github.com/woocommerce/woocommerce-android/pull/15868)
- [Part 2 — cart rendering](https://github.com/woocommerce/woocommerce-android/pull/15869)
- [Part 3 — dialog ViewModel + state + currency helper](https://github.com/woocommerce/woocommerce-android/pull/15870)
- [Part 4 — dialog Compose UI + render hookup](https://github.com/woocommerce/woocommerce-android/pull/15871)
- [Part 5 — entry row + products screen integration](https://github.com/woocommerce/woocommerce-android/pull/15872)
- [Part 6 — refund support](https://github.com/woocommerce/woocommerce-android/pull/15874)
- [Part 7 — order details rendering](https://github.com/woocommerce/woocommerce-android/pull/15882)
- **Part 8 — in-pane form on tablet (iOS parity)** (this PR)