### PR TITLE
[Woo POS][Phone POS] Bug: TTP buttons cut and reader-status subtitles cut on phone

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -377,8 +377,10 @@ private fun PreparingReader(title: String, subtitle: String) {
     Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
     WooPosText(
         text = subtitle,
-        style = WooPosTypography.Heading,
-        fontWeight = FontWeight.Bold
+        style = WooPosTypography.BodyLarge,
+        fontWeight = FontWeight.Bold,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
     )
 }
 
@@ -400,7 +402,7 @@ private fun ReaderReadyForPayment(readerStatus: WooPosTotalsViewState.ReaderStat
     Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
     WooPosText(
         text = readerStatus.subtitle,
-        style = WooPosTypography.Heading,
+        style = WooPosTypography.BodyLarge,
         fontWeight = FontWeight.Bold,
         textAlign = TextAlign.Center,
         modifier = Modifier.padding(horizontal = WooPosSpacing.XLarge.value)
@@ -440,7 +442,6 @@ private fun ReaderDisconnected(
             onClick = { onUIEvent(WooPosTotalsUIEvent.ConnectReaderClicked) },
             modifier = Modifier
                 .adaptiveContentWidth()
-                .height(WooPosComponentSize.Small.value)
                 .testTag(WooPosTestTags.CARD_READER_PAYMENT_BUTTON)
         )
     }
@@ -480,7 +481,6 @@ private fun TapToPayPromoted(
             onClick = { onUIEvent(WooPosTotalsUIEvent.OnTapToPayClicked) },
             modifier = Modifier
                 .adaptiveContentWidth()
-                .height(WooPosComponentSize.Small.value)
                 .testTag(WooPosTestTags.TAP_TO_PAY_PROMOTED_BUTTON)
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -225,6 +225,7 @@ private fun TotalsLoaded(
                 )
             }
         }
+        val isPhone = currentWooPosBreakpoint() == WooPosBreakpoint.Phone
         Column(
             modifier = Modifier.weight(1f),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -232,7 +233,7 @@ private fun TotalsLoaded(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .weight(1f),
+                    .weight(if (isPhone) 2f else 1f),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {


### PR DESCRIPTION
## Summary

Fixes four phone-only layout regressions on the Woo POS card-reader status screens (Spanish locale on a small phone):

1. **Pay with Tap to Pay** (and *Connect reader*) primary buttons were rendered as a row of dashes because the caller-side `.height(WooPosComponentSize.Small.value)` modifier collides with the inner `heightIn(min = height, max = height * 3)` in `WooPosButtons.kt::Button`, preventing the button from growing when the bold text wraps. Drop the redundant fixed `.height(...)` so the button grows vertically up to 3× when needed. Minimum height is unchanged (still enforced by the inner `heightIn`).
2. **"Tocar, deslizar o insertar tarjeta"** subtitle on the *Ready for payment* screen was clipped because it used `WooPosTypography.Heading` (36sp → 30.6sp scaled on phone). Lower to `BodyLarge` so the wrapped second line fits.
3. **"Preparando el lector para el pago"** subtitle had no horizontal padding and used the same too-large `Heading` style. Add `padding(horizontal = XLarge)` + `textAlign = Center`, and lower to `BodyLarge` for parity with the ready-for-payment subtitle.

No string changes. Tablet layout is unaffected: tablet uses the same `BodyLarge` style which renders at full 24sp; the dropped `.height(Small)` was always shadowed by the inner `Button` height clamping anyway.

## Test plan

- [ ] Build a Wasabi debug APK and install on a small phone emulator in Spanish locale.
- [ ] Open POS → start a transaction → reach the totals screen with no reader connected (TTP available): confirm the "Pay with Tap to Pay" / "Pagar con Toca para pagar" button shows full text.
- [ ] Same screen with no TTP available: confirm the "Connect reader" / "Conectar lector" button shows full text.
- [ ] Connect a reader: confirm the "Tocar, deslizar o insertar tarjeta" subtitle fully fits on screen.
- [ ] During the *Preparando el lector* transitional state: confirm the subtitle has horizontal padding and is centered.
- [ ] Sanity-check tablet emulator: no visual regression on the same screens.

## Screenshots
|Before|After|
|--|--|
|<img width="300" alt="Untitled" src="https://github.com/user-attachments/assets/a48d2504-18a9-4ead-93a8-706d61f37606" />|<img width="300" alt="Untitled2" src="https://github.com/user-attachments/assets/ff99b713-88af-4e10-9aea-7700dd24cdb5" />|
