### PR TITLE
[Woo POS][Phone POS] Bug: Refund-reason placeholder cut on phone

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosInputFields.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosInputFields.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextOverflow
 import com.woocommerce.android.ui.compose.component.NullableCurrencyTextFieldValueMapper
 import com.woocommerce.android.ui.payments.changeduecalculator.CurrencyVisualTransformation
 import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
@@ -183,6 +184,7 @@ fun WooPosInputField(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     contentAlignment: Alignment = Alignment.CenterStart,
+    labelMaxLines: Int = 1,
 ) {
     var labelWidth by remember { mutableIntStateOf(0) }
 
@@ -195,8 +197,9 @@ fun WooPosInputField(
                 text = label,
                 style = textStyle,
                 color = WooPosTheme.colors.onDisabledContainer,
-                maxLines = 1,
-                softWrap = false,
+                maxLines = labelMaxLines,
+                softWrap = labelMaxLines > 1,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.onGloballyPositioned { coordinates ->
                     labelWidth = coordinates.size.width
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundReasonScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundReasonScreen.kt
@@ -57,8 +57,9 @@ fun WooPosRefundReasonScreen(
                     onValueChange = { refundReason = it },
                     label = stringResource(R.string.woopos_orders_refund_reason_placeholder),
                     contentAlignment = Alignment.Center,
-                    textStyle = WooPosTypography.Heading,
+                    textStyle = WooPosTypography.BodyLarge,
                     textColor = MaterialTheme.colorScheme.onSurface,
+                    labelMaxLines = 2,
                     modifier = Modifier
                         .focusRequester(focusRequester)
                         .padding(horizontal = WooPosSpacing.Medium.value)


### PR DESCRIPTION
## Summary

On the *Motivo del reembolso* screen on a small phone in Spanish, the placeholder *"Motivo del pedido de reembolso"* gets hard-clipped on the right because `WooPosInputField` hardcodes `maxLines = 1, softWrap = false`.

This PR:

- Adds an opt-in `labelMaxLines: Int = 1` parameter to `WooPosInputField`. When `> 1`, the placeholder `WooPosText` renders with `maxLines = labelMaxLines`, `softWrap = true`, and `overflow = TextOverflow.Ellipsis`. Default behaviour is unchanged for all existing callers.
- Updates `WooPosRefundReasonScreen` to pass `labelMaxLines = 2` and lower `textStyle` from `Heading` (36sp → 30.6sp on phone) to `BodyLarge` (24sp → 20.4sp on phone) so the localised hint comfortably fits within two lines.

The cursor-positioning workaround inside `WooPosInputField` is untouched — only the visible label wraps; the field itself is still single-line.

## Test plan

- [ ] Build a Wasabi debug APK and install on a small phone in Spanish locale.
- [ ] Open POS → orders → open an order → tap *"Emitir reembolso"* → reach the reason input screen.
- [ ] Confirm the placeholder *"Motivo del pedido de reembolso"* fits across two lines with a trailing ellipsis if the line is still longer than the available width.
- [ ] Type a few characters and confirm the input cursor and entered text render correctly (no regression to the workaround logic).
- [ ] Switch to English; the placeholder fits on one line, no visual change.
- [ ] Sanity-check tablet: refund-reason screen renders unchanged (placeholder fits on a single line as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)