### PR TITLE
[Woo POS][Phone POS] Bug: Issue-refund toolbar title and selected-count overflow

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -64,15 +63,16 @@ import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimme
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosShimmerText
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosSuccessCheckmark
 import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosComponentSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosCornerRadius
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosIconSize
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.currentWooPosBreakpoint
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptiveIconSize
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
-import com.woocommerce.android.ui.woopos.util.ext.isWooPosPhoneLayout
 import java.math.BigDecimal
 
 private fun <S> AnimatedContentTransitionScope<S>.refundFadeTransition(): ContentTransform =
@@ -228,7 +228,7 @@ private fun RefundScreenHeader(
     closeButtonEnabled: Boolean = true,
 ) {
     val closeContentDescription = stringResource(R.string.close)
-    val isPhoneLayout = LocalContext.current.isWooPosPhoneLayout()
+    val isPhone = currentWooPosBreakpoint() == WooPosBreakpoint.Phone
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -250,10 +250,10 @@ private fun RefundScreenHeader(
 
         WooPosText(
             text = title,
-            style = if (isPhoneLayout) WooPosTypography.BodyLarge else WooPosTypography.Heading,
+            style = if (isPhone) WooPosTypography.BodyLarge else WooPosTypography.Heading,
             color = MaterialTheme.colorScheme.onSurface,
             fontWeight = FontWeight.Bold,
-            maxLines = if (isPhoneLayout) 2 else 1,
+            maxLines = if (isPhone) 2 else 1,
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.Center,
             modifier = Modifier
@@ -718,7 +718,7 @@ private fun ItemsHeaderRow(
                 color = WooPosTheme.colors.onSurfaceVariantLowest
             )
         }
-        if (LocalContext.current.isWooPosPhoneLayout()) {
+        if (currentWooPosBreakpoint() == WooPosBreakpoint.Phone) {
             Column {
                 selectAllLabel()
                 selectedCountLabel()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -71,6 +72,7 @@ import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosThe
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
 import com.woocommerce.android.ui.woopos.common.composeui.designsystem.toAdaptiveIconSize
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.util.ext.isWooPosPhoneLayout
 import java.math.BigDecimal
 
 private fun <S> AnimatedContentTransitionScope<S>.refundFadeTransition(): ContentTransform =
@@ -226,6 +228,7 @@ private fun RefundScreenHeader(
     closeButtonEnabled: Boolean = true,
 ) {
     val closeContentDescription = stringResource(R.string.close)
+    val isPhoneLayout = LocalContext.current.isWooPosPhoneLayout()
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -247,10 +250,10 @@ private fun RefundScreenHeader(
 
         WooPosText(
             text = title,
-            style = WooPosTypography.BodyLarge,
+            style = if (isPhoneLayout) WooPosTypography.BodyLarge else WooPosTypography.Heading,
             color = MaterialTheme.colorScheme.onSurface,
             fontWeight = FontWeight.Bold,
-            maxLines = 2,
+            maxLines = if (isPhoneLayout) 2 else 1,
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.Center,
             modifier = Modifier
@@ -699,19 +702,33 @@ private fun ItemsHeaderRow(
             )
         )
         Spacer(modifier = Modifier.width(WooPosSpacing.Large.value))
-        Column {
+        val selectAllLabel = @Composable {
             WooPosText(
                 text = stringResource(R.string.woopos_orders_select_all_items),
                 style = WooPosTypography.Caption,
                 fontWeight = FontWeight.Bold,
                 color = WooPosTheme.colors.onSurfaceVariantHighest
             )
+        }
+        val selectedCountLabel = @Composable {
             WooPosText(
                 text = stringResource(R.string.woopos_orders_items_selected_count, selectedCount),
                 style = WooPosTypography.Caption,
                 fontWeight = FontWeight.Normal,
                 color = WooPosTheme.colors.onSurfaceVariantLowest
             )
+        }
+        if (LocalContext.current.isWooPosPhoneLayout()) {
+            Column {
+                selectAllLabel()
+                selectedCountLabel()
+            }
+        } else {
+            Row {
+                selectAllLabel()
+                Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
+                selectedCountLabel()
+            }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -247,10 +247,10 @@ private fun RefundScreenHeader(
 
         WooPosText(
             text = title,
-            style = WooPosTypography.Heading,
+            style = WooPosTypography.BodyLarge,
             color = MaterialTheme.colorScheme.onSurface,
             fontWeight = FontWeight.Bold,
-            maxLines = 1,
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.Center,
             modifier = Modifier
@@ -699,14 +699,13 @@ private fun ItemsHeaderRow(
             )
         )
         Spacer(modifier = Modifier.width(WooPosSpacing.Large.value))
-        Row {
+        Column {
             WooPosText(
                 text = stringResource(R.string.woopos_orders_select_all_items),
                 style = WooPosTypography.Caption,
                 fontWeight = FontWeight.Bold,
                 color = WooPosTheme.colors.onSurfaceVariantHighest
             )
-            Spacer(modifier = Modifier.width(WooPosSpacing.XSmall.value))
             WooPosText(
                 text = stringResource(R.string.woopos_orders_items_selected_count, selectedCount),
                 style = WooPosTypography.Caption,


### PR DESCRIPTION
## Summary

Two fixes on the *Choose items to refund* step of the POS refund flow on a narrow phone in Spanish:

- **Title overflow.** *"Elige los artículos que quieres reembolsar"* was being cut to *"Elige los artículos q…"*. Lower `RefundScreenHeader` title from `Heading` to `BodyLarge` and bump `maxLines` from 1 to 2 (keep `TextOverflow.Ellipsis`) so the title fits across two lines if needed.
- **"Select all items (N seleccionado)" layout.** The count was being wrapped onto a separate line *inside* the parenthesis (`(2`, `SELECCIONA`, `DO)`), because both texts were in a `Row` with no weight or fixed width. Stack the bold label and the count vertically in a `Column` instead so each renders on its own line cleanly.

No string changes. Tablet rendering is unaffected (the title still fits on one line at the smaller `BodyLarge` size; the count layout improvement is universal).

## Test plan

- [ ] Build a Wasabi debug APK and install on a small phone in Spanish locale.
- [ ] Open POS → orders → open a refundable order → tap *"Emitir reembolso"* → reach the "Choose items" step.
- [ ] Confirm the toolbar title shows the full localised text (may wrap to two lines centered).
- [ ] Confirm the *"Seleccionar todos los artículos"* row shows the count *"(N seleccionado)"* on its own line directly below the bold label.
- [ ] Repeat in English; confirm no visual regression.
- [ ] Sanity-check tablet emulator: title still fits, count still aligned next to/below the label, no broken layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)