### PR TITLE
[WOOMOB-3068] Add early access feedback CTA to AI Assistant

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/AppPrefsTest.kt
@@ -46,6 +46,15 @@ class AppPrefsTest {
     }
 
     @Test
+    fun whenAiAssistantEarlyAccessNoticeIsDismissedThenSitePreferencesResetClearsDismissal() {
+        AppPrefs.isAiAssistantEarlyAccessNoticeDismissed = true
+
+        AppPrefs.resetSitePreferences()
+
+        assertThat(AppPrefs.isAiAssistantEarlyAccessNoticeDismissed).isFalse()
+    }
+
+    @Test
     fun whenCardReaderOnboardingCompletedWithStripeExtThenCorrectOnboardingStatusIsStored() {
         AppPrefs.setCardReaderOnboardingData(
             localSiteId = 0,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -230,7 +230,9 @@ object AppPrefs {
 
         WOO_POS_SURVEY_NOTIFICATION_POTENTIAL_USER_SHOWN,
 
-        IS_USER_AGE_ELIGIBLE_FOR_APP_USE
+        IS_USER_AGE_ELIGIBLE_FOR_APP_USE,
+
+        AI_ASSISTANT_EARLY_ACCESS_NOTICE_DISMISSED
     }
 
     fun init(context: Context) {
@@ -342,6 +344,19 @@ object AppPrefs {
     var isUserAgeEligibleForAppUse: Boolean
         get() = getBoolean(key = UndeletablePrefKey.IS_USER_AGE_ELIGIBLE_FOR_APP_USE, default = true)
         set(value) = setBoolean(key = UndeletablePrefKey.IS_USER_AGE_ELIGIBLE_FOR_APP_USE, value = value)
+
+    var isAiAssistantEarlyAccessNoticeDismissed: Boolean
+        get() = getBoolean(
+            key = UndeletablePrefKey.AI_ASSISTANT_EARLY_ACCESS_NOTICE_DISMISSED,
+            default = false,
+        )
+        set(value) {
+            val committed = getPreferences()
+                .edit()
+                .putBoolean(UndeletablePrefKey.AI_ASSISTANT_EARLY_ACCESS_NOTICE_DISMISSED.toString(), value)
+                .commit()
+            check(committed) { "Failed to persist AI Assistant early access notice dismissal" }
+        }
 
     private const val FEATURE_FLAG_OVERRIDE_PREFIX = "feature_flag_override"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -150,6 +150,7 @@ object AppPrefs {
         TRACKING_EXTENSION_AVAILABLE,
         JETPACK_BENEFITS_BANNER_DISMISSAL_DATE,
         AI_PRODUCT_DESCRIPTION_CELEBRATION_SHOWN,
+        AI_ASSISTANT_EARLY_ACCESS_NOTICE_DISMISSED,
         AUTO_TAX_RATE_ID,
     }
 
@@ -230,9 +231,7 @@ object AppPrefs {
 
         WOO_POS_SURVEY_NOTIFICATION_POTENTIAL_USER_SHOWN,
 
-        IS_USER_AGE_ELIGIBLE_FOR_APP_USE,
-
-        AI_ASSISTANT_EARLY_ACCESS_NOTICE_DISMISSED
+        IS_USER_AGE_ELIGIBLE_FOR_APP_USE
     }
 
     fun init(context: Context) {
@@ -347,13 +346,13 @@ object AppPrefs {
 
     var isAiAssistantEarlyAccessNoticeDismissed: Boolean
         get() = getBoolean(
-            key = UndeletablePrefKey.AI_ASSISTANT_EARLY_ACCESS_NOTICE_DISMISSED,
+            key = DeletableSitePrefKey.AI_ASSISTANT_EARLY_ACCESS_NOTICE_DISMISSED,
             default = false,
         )
         set(value) {
             val committed = getPreferences()
                 .edit()
-                .putBoolean(UndeletablePrefKey.AI_ASSISTANT_EARLY_ACCESS_NOTICE_DISMISSED.toString(), value)
+                .putBoolean(DeletableSitePrefKey.AI_ASSISTANT_EARLY_ACCESS_NOTICE_DISMISSED.toString(), value)
                 .commit()
             check(committed) { "Failed to persist AI Assistant early access notice dismissal" }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -44,6 +44,8 @@ open class AppPrefsWrapper @Inject constructor() {
 
     var isUserAgeEligibleForAppUse by AppPrefs::isUserAgeEligibleForAppUse
 
+    var isAiAssistantEarlyAccessNoticeDismissed by AppPrefs::isAiAssistantEarlyAccessNoticeDismissed
+
     open var orderSummaryMigrated by AppPrefs::orderSummaryMigrated
     open var gatewayMigrated by AppPrefs::gatewayMigrated
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppUrls.kt
@@ -41,6 +41,8 @@ object AppUrls {
 
     const val CROWDSIGNAL_ANALYTICS_HUB_SURVEY = "https://automattic.survey.fm/woo-app-analytics-hub-production"
 
+    const val CROWDSIGNAL_AI_ASSISTANT_SURVEY = "https://automattic.survey.fm/woo-mobile-ai-assistant"
+
     const val ADDONS_SURVEY = "https://automattic.survey.fm/woo-app-addons-production"
 
     const val CROWDSIGNAL_STORE_SETUP_SURVEY =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/analytics/AnalyticsTracker.kt
@@ -377,6 +377,7 @@ class AnalyticsTracker private constructor(
         const val VALUE_ORDER_SHIPPING_LINES_FEEDBACK = "order_shipping_lines"
         const val VALUE_WOO_POS_POTENTIAL_USER_FEEDBACK = "woo_pos_potential_user"
         const val VALUE_WOO_POS_CURRENT_USER_FEEDBACK = "woo_pos_current_user"
+        const val VALUE_AI_ASSISTANT_FEEDBACK = "ai_assistant"
         const val VALUE_STATE_ON = "on"
         const val VALUE_STATE_OFF = "off"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aiassistant/AiAssistantHostFragment.kt
@@ -4,18 +4,25 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
+import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.NavGraphMainDirections
 import com.woocommerce.android.R
 import com.woocommerce.android.aiassistant.ui.AssistantRoute
 import com.woocommerce.android.aiassistant.ui.cards.AssistantCardAction
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.ui.base.BaseFragment
 import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.ui.feedback.SurveyType
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.util.CurrencyFormatter
 import dagger.hilt.android.AndroidEntryPoint
@@ -30,6 +37,9 @@ class AiAssistantHostFragment : BaseFragment() {
     @Inject
     internal lateinit var cardActionNavigator: WooAssistantCardActionNavigator
 
+    @Inject
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+
     override val activityAppBarStatus: AppBarStatus = AppBarStatus.Hidden
 
     override fun onCreateView(
@@ -38,13 +48,29 @@ class AiAssistantHostFragment : BaseFragment() {
         savedInstanceState: Bundle?
     ): View {
         return composeView {
+            var showEarlyAccessNotice by remember {
+                mutableStateOf(!appPrefsWrapper.isAiAssistantEarlyAccessNoticeDismissed)
+            }
+
             AssistantRoute(
                 conversationId = ASSISTANT_CONVERSATION_ID,
                 onBack = { findNavController().navigateUp() },
+                showEarlyAccessNotice = showEarlyAccessNotice,
+                onDismissEarlyAccessNotice = {
+                    appPrefsWrapper.isAiAssistantEarlyAccessNoticeDismissed = true
+                    showEarlyAccessNotice = false
+                },
+                onEarlyAccessFeedbackClick = ::openAiAssistantFeedbackSurvey,
                 assistantCardRenderer = WooAssistantCardRenderer(currencyFormatter),
                 onCardAction = ::onCardAction,
             )
         }
+    }
+
+    private fun openAiAssistantFeedbackSurvey() {
+        NavGraphMainDirections
+            .actionGlobalFeedbackSurveyFragment(SurveyType.AI_ASSISTANT)
+            .apply { findNavController().navigateSafely(this) }
     }
 
     private fun onCardAction(action: AssistantCardAction) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackCompletedFragment.kt
@@ -12,14 +12,11 @@ import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_ACTION
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_COMPLETED
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_GENERAL_CONTEXT
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
 import com.woocommerce.android.databinding.FragmentFeedbackCompletedBinding
 import com.woocommerce.android.extensions.setClickableText
 import com.woocommerce.android.extensions.startHelpActivity
 import com.woocommerce.android.support.help.HelpOrigin.FEEDBACK_SURVEY
 import com.woocommerce.android.ui.base.BaseFragment
-import com.woocommerce.android.ui.feedback.SurveyType.MAIN
 import com.woocommerce.android.ui.main.AppBarStatus
 import com.woocommerce.android.widgets.WooClickableSpan
 
@@ -31,14 +28,12 @@ class FeedbackCompletedFragment : BaseFragment(R.layout.fragment_feedback_comple
     override val activityAppBarStatus: AppBarStatus
         get() = AppBarStatus.Hidden
 
+    private val surveyType by lazy {
+        navArgs<FeedbackCompletedFragmentArgs>().value.surveyType
+    }
+
     private val feedbackContext by lazy {
-        (navArgs<FeedbackCompletedFragmentArgs>().value).let {
-            if (it.surveyType == MAIN) {
-                VALUE_FEEDBACK_GENERAL_CONTEXT
-            } else {
-                VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
-            }
-        }
+        surveyType.feedbackContext
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/FeedbackSurveyFragment.kt
@@ -18,16 +18,8 @@ import com.woocommerce.android.analytics.AnalyticsEvent.SURVEY_SCREEN
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_ACTION
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_FEEDBACK_CONTEXT
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ANALYTICS_HUB_FEEDBACK
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_CANCELED
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_GENERAL_CONTEXT
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_OPENED
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_FEEDBACK_STORE_SETUP_CONTEXT
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_ORDER_SHIPPING_LINES_FEEDBACK
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_PRODUCT_ADDONS_FEEDBACK
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_WOO_POS_CURRENT_USER_FEEDBACK
-import com.woocommerce.android.analytics.AnalyticsTracker.Companion.VALUE_WOO_POS_POTENTIAL_USER_FEEDBACK
 import com.woocommerce.android.databinding.FragmentFeedbackSurveyBinding
 import com.woocommerce.android.extensions.navigateSafely
 import com.woocommerce.android.tools.SelectedSite
@@ -60,16 +52,7 @@ class FeedbackSurveyFragment : BaseFragment(R.layout.fragment_feedback_survey) {
     private var backPressedCallback: OnBackPressedCallback? = null
     private val arguments: FeedbackSurveyFragmentArgs by navArgs()
     private val feedbackContext by lazy {
-        when (arguments.surveyType) {
-            SurveyType.MAIN -> VALUE_FEEDBACK_GENERAL_CONTEXT
-            SurveyType.PRODUCT -> VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
-            SurveyType.STORE_ONBOARDING -> VALUE_FEEDBACK_STORE_SETUP_CONTEXT
-            SurveyType.ADDONS -> VALUE_PRODUCT_ADDONS_FEEDBACK
-            SurveyType.ANALYTICS_HUB -> VALUE_ANALYTICS_HUB_FEEDBACK
-            SurveyType.ORDER_SHIPPING_LINES -> VALUE_ORDER_SHIPPING_LINES_FEEDBACK
-            SurveyType.WOO_POS_POTENTIAL_USER -> VALUE_WOO_POS_POTENTIAL_USER_FEEDBACK
-            SurveyType.WOO_POS_CURRENT_USER -> VALUE_WOO_POS_CURRENT_USER_FEEDBACK
-        }
+        arguments.surveyType.feedbackContext
     }
 
     private var _binding: FragmentFeedbackSurveyBinding? = null

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/feedback/SurveyType.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.feedback
 
 import com.woocommerce.android.AppUrls
 import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.analytics.AnalyticsTracker
 
 @Suppress("MagicNumber")
 enum class SurveyType(private val untaggedUrl: String, private val milestone: Int? = null) {
@@ -12,10 +13,24 @@ enum class SurveyType(private val untaggedUrl: String, private val milestone: In
     ANALYTICS_HUB(AppUrls.CROWDSIGNAL_ANALYTICS_HUB_SURVEY),
     ORDER_SHIPPING_LINES(AppUrls.CROWDSIGNAL_ORDER_SHIPPING_LINES_SURVEY),
     WOO_POS_POTENTIAL_USER(AppUrls.CROWDSIGNAL_WOO_POS_SURVEY_POTENTIAL_USER),
-    WOO_POS_CURRENT_USER(AppUrls.CROWDSIGNAL_WOO_POS_SURVEY_CURRENT_USER);
+    WOO_POS_CURRENT_USER(AppUrls.CROWDSIGNAL_WOO_POS_SURVEY_CURRENT_USER),
+    AI_ASSISTANT(AppUrls.CROWDSIGNAL_AI_ASSISTANT_SURVEY);
 
     val url
         get() = "$untaggedUrl?$platformTag$appVersionTag$milestoneTag"
+
+    val feedbackContext: String
+        get() = when (this) {
+            MAIN -> AnalyticsTracker.VALUE_FEEDBACK_GENERAL_CONTEXT
+            PRODUCT -> AnalyticsTracker.VALUE_FEEDBACK_PRODUCT_M3_CONTEXT
+            STORE_ONBOARDING -> AnalyticsTracker.VALUE_FEEDBACK_STORE_SETUP_CONTEXT
+            ADDONS -> AnalyticsTracker.VALUE_PRODUCT_ADDONS_FEEDBACK
+            ANALYTICS_HUB -> AnalyticsTracker.VALUE_ANALYTICS_HUB_FEEDBACK
+            ORDER_SHIPPING_LINES -> AnalyticsTracker.VALUE_ORDER_SHIPPING_LINES_FEEDBACK
+            WOO_POS_POTENTIAL_USER -> AnalyticsTracker.VALUE_WOO_POS_POTENTIAL_USER_FEEDBACK
+            WOO_POS_CURRENT_USER -> AnalyticsTracker.VALUE_WOO_POS_CURRENT_USER_FEEDBACK
+            AI_ASSISTANT -> AnalyticsTracker.VALUE_AI_ASSISTANT_FEEDBACK
+        }
 
     private val milestoneTag
         get() = when (this) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/feedback/SurveyTypeTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/feedback/SurveyTypeTest.kt
@@ -35,18 +35,18 @@ class SurveyTypeTest {
     }
 
     @Test
-    fun `AI Assistant SurveyType url should use AI Assistant Crowdsignal URL`() {
+    fun `when AI Assistant SurveyType url is requested, then it uses AI Assistant Crowdsignal URL`() {
         assertThat(SurveyType.AI_ASSISTANT.url).startsWith(AppUrls.CROWDSIGNAL_AI_ASSISTANT_SURVEY)
     }
 
     @Test
-    fun `AI Assistant SurveyType feedback context should use AI Assistant context`() {
+    fun `when AI Assistant SurveyType feedback context is requested, then it uses AI Assistant context`() {
         assertThat(SurveyType.AI_ASSISTANT.feedbackContext)
             .isEqualTo(AnalyticsTracker.VALUE_AI_ASSISTANT_FEEDBACK)
     }
 
     @Test
-    fun `SurveyType feedback context should preserve existing contexts`() {
+    fun `when SurveyType feedback context is requested, then it preserves existing contexts`() {
         assertThat(SurveyType.entries.associateWith { it.feedbackContext })
             .contains(
                 entry(SurveyType.MAIN, AnalyticsTracker.VALUE_FEEDBACK_GENERAL_CONTEXT),

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/feedback/SurveyTypeTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/feedback/SurveyTypeTest.kt
@@ -1,9 +1,12 @@
 package com.woocommerce.android.ui.feedback
 
+import com.woocommerce.android.AppUrls
 import com.woocommerce.android.BuildConfig
+import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.ui.feedback.SurveyType.MAIN
 import com.woocommerce.android.ui.feedback.SurveyType.PRODUCT
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.entry
 import org.junit.Test
 
 class SurveyTypeTest {
@@ -29,6 +32,32 @@ class SurveyTypeTest {
         assertThat(SurveyType.entries.toTypedArray()).allSatisfy {
             assertThat(it.url.contains("app-version=${BuildConfig.VERSION_NAME}")).isTrue()
         }
+    }
+
+    @Test
+    fun `AI Assistant SurveyType url should use AI Assistant Crowdsignal URL`() {
+        assertThat(SurveyType.AI_ASSISTANT.url).startsWith(AppUrls.CROWDSIGNAL_AI_ASSISTANT_SURVEY)
+    }
+
+    @Test
+    fun `AI Assistant SurveyType feedback context should use AI Assistant context`() {
+        assertThat(SurveyType.AI_ASSISTANT.feedbackContext)
+            .isEqualTo(AnalyticsTracker.VALUE_AI_ASSISTANT_FEEDBACK)
+    }
+
+    @Test
+    fun `SurveyType feedback context should preserve existing contexts`() {
+        assertThat(SurveyType.entries.associateWith { it.feedbackContext })
+            .contains(
+                entry(SurveyType.MAIN, AnalyticsTracker.VALUE_FEEDBACK_GENERAL_CONTEXT),
+                entry(SurveyType.PRODUCT, AnalyticsTracker.VALUE_FEEDBACK_PRODUCT_M3_CONTEXT),
+                entry(SurveyType.STORE_ONBOARDING, AnalyticsTracker.VALUE_FEEDBACK_STORE_SETUP_CONTEXT),
+                entry(SurveyType.ADDONS, AnalyticsTracker.VALUE_PRODUCT_ADDONS_FEEDBACK),
+                entry(SurveyType.ANALYTICS_HUB, AnalyticsTracker.VALUE_ANALYTICS_HUB_FEEDBACK),
+                entry(SurveyType.ORDER_SHIPPING_LINES, AnalyticsTracker.VALUE_ORDER_SHIPPING_LINES_FEEDBACK),
+                entry(SurveyType.WOO_POS_POTENTIAL_USER, AnalyticsTracker.VALUE_WOO_POS_POTENTIAL_USER_FEEDBACK),
+                entry(SurveyType.WOO_POS_CURRENT_USER, AnalyticsTracker.VALUE_WOO_POS_CURRENT_USER_FEEDBACK),
+            )
     }
 
     companion object {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -235,13 +235,13 @@ fun AssistantChatScreen(
             if (state.shouldShowEmptyState) {
                 AssistantEmptyState(
                     showEarlyAccessNotice = showEarlyAccessNotice,
+                    bottomContentPadding = bottomContentPadding,
                     onFeedbackClick = onEarlyAccessFeedbackClick,
                     onDismissEarlyAccessNotice = onDismissEarlyAccessNotice,
                     onSuggestionClick = submitSuggestion,
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(contentPadding)
-                        .padding(bottom = bottomContentPadding),
                 )
             } else {
                 AssistantMessageThread(
@@ -257,14 +257,12 @@ fun AssistantChatScreen(
                         .padding(contentPadding),
                 )
             }
-            if (!state.shouldShowEmptyState) {
-                AssistantContentBottomFade(
-                    bottomBarHeight = bottomBarContentHeight,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .fillMaxWidth(),
-                )
-            }
+            AssistantContentBottomFade(
+                bottomBarHeight = bottomBarContentHeight,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth(),
+            )
         }
     }
 }

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -191,7 +191,9 @@ fun AssistantChatScreen(
     val density = LocalDensity.current
     var bottomBarContentHeightPx by remember { mutableIntStateOf(0) }
     val bottomBarContentHeight = with(density) { bottomBarContentHeightPx.toDp() }
-    val bottomContentPadding = bottomBarContentHeight + FLOATING_COMPOSER_CONTENT_SPACING
+    val estimatedBottomBarHeight = FLOATING_COMPOSER_ESTIMATED_HEIGHT * density.fontScale
+    val bottomContentPadding = bottomBarContentHeight
+        .coerceAtLeast(estimatedBottomBarHeight) + FLOATING_COMPOSER_CONTENT_SPACING
     val submitMessage = {
         focusManager.clearFocus()
         onSendMessage()
@@ -255,12 +257,14 @@ fun AssistantChatScreen(
                         .padding(contentPadding),
                 )
             }
-            AssistantContentBottomFade(
-                bottomBarHeight = bottomBarContentHeight,
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .fillMaxWidth(),
-            )
+            if (!state.shouldShowEmptyState) {
+                AssistantContentBottomFade(
+                    bottomBarHeight = bottomBarContentHeight,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth(),
+                )
+            }
         }
     }
 }
@@ -488,6 +492,7 @@ private const val FLOATING_COMPOSER_FADE_MIDPOINT_ALPHA = 0.55f
 private const val FLOATING_COMPOSER_FADE_MIDPOINT_FRACTION = 0.35f
 private val FLOATING_COMPOSER_FADE_EXTRA_HEIGHT = 48.dp
 private val FLOATING_COMPOSER_BOTTOM_PADDING = 16.dp
+private val FLOATING_COMPOSER_ESTIMATED_HEIGHT = 84.dp
 private val FLOATING_COMPOSER_CONTENT_SPACING = 16.dp
 private val BOTTOM_PIN_THRESHOLD_DP = 48.dp
 private val USER_BUBBLE_MAX_WIDTH = 280.dp

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -91,6 +91,9 @@ import kotlinx.serialization.json.put
 fun AssistantRoute(
     conversationId: String,
     onBack: () -> Unit,
+    showEarlyAccessNotice: Boolean,
+    onDismissEarlyAccessNotice: () -> Unit,
+    onEarlyAccessFeedbackClick: () -> Unit,
     modifier: Modifier = Modifier,
     assistantCardRenderer: AssistantCardRenderer? = null,
     onCardAction: (AssistantCardAction) -> Unit = {},
@@ -102,6 +105,9 @@ fun AssistantRoute(
     AssistantChatScreen(
         viewModel = viewModel,
         onBack = onBack,
+        showEarlyAccessNotice = showEarlyAccessNotice,
+        onDismissEarlyAccessNotice = onDismissEarlyAccessNotice,
+        onEarlyAccessFeedbackClick = onEarlyAccessFeedbackClick,
         modifier = modifier,
         assistantCardRenderer = assistantCardRenderer,
         onCardAction = onCardAction,
@@ -112,6 +118,9 @@ fun AssistantRoute(
 fun AssistantChatScreen(
     viewModel: AssistantViewModel,
     onBack: () -> Unit,
+    showEarlyAccessNotice: Boolean,
+    onDismissEarlyAccessNotice: () -> Unit,
+    onEarlyAccessFeedbackClick: () -> Unit,
     modifier: Modifier = Modifier,
     assistantCardRenderer: AssistantCardRenderer? = null,
     onCardAction: (AssistantCardAction) -> Unit = {},
@@ -149,6 +158,9 @@ fun AssistantChatScreen(
             viewModel.onRestartConversation()
         },
         onBack = onBack,
+        showEarlyAccessNotice = showEarlyAccessNotice,
+        onDismissEarlyAccessNotice = onDismissEarlyAccessNotice,
+        onEarlyAccessFeedbackClick = onEarlyAccessFeedbackClick,
         modifier = modifier,
         assistantCardRenderer = assistantCardRenderer,
         onCardAction = onCardAction,
@@ -168,6 +180,9 @@ fun AssistantChatScreen(
     onCancelWrite: () -> Unit,
     onRestartConversation: () -> Unit,
     onBack: () -> Unit,
+    showEarlyAccessNotice: Boolean,
+    onDismissEarlyAccessNotice: () -> Unit,
+    onEarlyAccessFeedbackClick: () -> Unit,
     modifier: Modifier = Modifier,
     assistantCardRenderer: AssistantCardRenderer? = null,
     onCardAction: (AssistantCardAction) -> Unit = {},
@@ -217,6 +232,9 @@ fun AssistantChatScreen(
         Box(modifier = Modifier.fillMaxSize()) {
             if (state.shouldShowEmptyState) {
                 AssistantEmptyState(
+                    showEarlyAccessNotice = showEarlyAccessNotice,
+                    onFeedbackClick = onEarlyAccessFeedbackClick,
+                    onDismissEarlyAccessNotice = onDismissEarlyAccessNotice,
                     onSuggestionClick = submitSuggestion,
                     modifier = Modifier
                         .fillMaxSize()
@@ -864,6 +882,9 @@ private fun AssistantChatScreenEmptyStatePreview() {
         onCancelWrite = {},
         onRestartConversation = {},
         onBack = {},
+        showEarlyAccessNotice = true,
+        onDismissEarlyAccessNotice = {},
+        onEarlyAccessFeedbackClick = {},
     )
 }
 
@@ -917,6 +938,9 @@ private fun AssistantChatScreenStreamingMultipleToolActivityPreview() {
         onCancelWrite = {},
         onRestartConversation = {},
         onBack = {},
+        showEarlyAccessNotice = false,
+        onDismissEarlyAccessNotice = {},
+        onEarlyAccessFeedbackClick = {},
     )
 }
 
@@ -962,6 +986,9 @@ private fun AssistantChatScreenFinishedMultipleToolActivityPreview() {
         onCancelWrite = {},
         onRestartConversation = {},
         onBack = {},
+        showEarlyAccessNotice = false,
+        onDismissEarlyAccessNotice = {},
+        onEarlyAccessFeedbackClick = {},
     )
 }
 
@@ -988,6 +1015,9 @@ private fun AssistantChatScreenTypingPreview() {
         onCancelWrite = {},
         onRestartConversation = {},
         onBack = {},
+        showEarlyAccessNotice = false,
+        onDismissEarlyAccessNotice = {},
+        onEarlyAccessFeedbackClick = {},
     )
 }
 
@@ -1025,6 +1055,9 @@ private fun AssistantChatScreenPreview() {
         onCancelWrite = {},
         onRestartConversation = {},
         onBack = {},
+        showEarlyAccessNotice = false,
+        onDismissEarlyAccessNotice = {},
+        onEarlyAccessFeedbackClick = {},
         assistantCardRenderer = PreviewAssistantCardRenderer,
     )
 }
@@ -1071,6 +1104,9 @@ private fun AssistantChatScreenConfirmationPreview() {
         onCancelWrite = {},
         onRestartConversation = {},
         onBack = {},
+        showEarlyAccessNotice = false,
+        onDismissEarlyAccessNotice = {},
+        onEarlyAccessFeedbackClick = {},
     )
 }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEarlyAccessNoticeCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEarlyAccessNoticeCard.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -37,9 +36,11 @@ internal fun AssistantEarlyAccessNoticeCard(
     Surface(
         modifier = modifier,
         shape = RoundedCornerShape(EARLY_ACCESS_CARD_CORNER_RADIUS),
-        color = earlyAccessContainerColor(),
-        contentColor = earlyAccessContentColor(),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurface,
         border = BorderStroke(1.dp, earlyAccessBorderColor()),
+        tonalElevation = 2.dp,
+        shadowElevation = if (isSystemInDarkTheme()) 0.dp else 2.dp,
     ) {
         Box(modifier = Modifier.fillMaxWidth()) {
             Column(
@@ -52,7 +53,7 @@ internal fun AssistantEarlyAccessNoticeCard(
                 Text(
                     text = stringResource(R.string.assistant_early_access_notice_body),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = earlyAccessContentColor(),
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
                 AssistantEarlyAccessFeedbackButton(onClick = onFeedbackClick)
             }
@@ -79,7 +80,7 @@ private fun AssistantEarlyAccessBadge() {
     Surface(
         shape = RoundedCornerShape(EARLY_ACCESS_BADGE_CORNER_RADIUS),
         color = earlyAccessAccentColor(),
-        contentColor = Color.White,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
     ) {
         Text(
             text = stringResource(R.string.assistant_early_access_notice_badge),
@@ -121,45 +122,19 @@ private fun AssistantEarlyAccessFeedbackButton(onClick: () -> Unit) {
 }
 
 @Composable
-private fun earlyAccessContainerColor(): Color = if (isSystemInDarkTheme()) {
-    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f)
-} else {
-    Color(0xFFF3E9FF)
-}
+private fun earlyAccessButtonColor() = MaterialTheme.colorScheme.surface
 
 @Composable
-private fun earlyAccessButtonColor(): Color = if (isSystemInDarkTheme()) {
-    MaterialTheme.colorScheme.surface
-} else {
-    Color.White
-}
+private fun earlyAccessMutedContentColor() = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f)
 
 @Composable
-private fun earlyAccessContentColor(): Color = if (isSystemInDarkTheme()) {
-    MaterialTheme.colorScheme.onSurface
-} else {
-    Color(0xFF2F213B)
-}
+private fun earlyAccessBorderColor() = assistantOutlineColor()
 
 @Composable
-private fun earlyAccessMutedContentColor(): Color = earlyAccessContentColor().copy(alpha = 0.72f)
+private fun earlyAccessAccentColor() = MaterialTheme.colorScheme.primary
 
 @Composable
-private fun earlyAccessBorderColor(): Color = if (isSystemInDarkTheme()) {
-    assistantOutlineColor()
-} else {
-    Color(0xFFE0C7FF)
-}
-
-@Composable
-private fun earlyAccessAccentColor(): Color = Color(0xFF7F54B3)
-
-@Composable
-private fun earlyAccessActionContentColor(): Color = if (isSystemInDarkTheme()) {
-    Color(0xFFE0C7FF)
-} else {
-    earlyAccessAccentColor()
-}
+private fun earlyAccessActionContentColor() = MaterialTheme.colorScheme.primary
 
 private val EARLY_ACCESS_CARD_CORNER_RADIUS = 16.dp
 private val EARLY_ACCESS_BADGE_CORNER_RADIUS = 6.dp

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEarlyAccessNoticeCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEarlyAccessNoticeCard.kt
@@ -1,0 +1,173 @@
+package com.woocommerce.android.aiassistant.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.aiassistant.R
+import com.woocommerce.android.aiassistant.ui.assistantCanvasColor
+import com.woocommerce.android.aiassistant.ui.assistantOutlineColor
+
+@Composable
+internal fun AssistantEarlyAccessNoticeCard(
+    onFeedbackClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(EARLY_ACCESS_CARD_CORNER_RADIUS),
+        color = earlyAccessContainerColor(),
+        contentColor = earlyAccessContentColor(),
+        border = BorderStroke(1.dp, earlyAccessBorderColor()),
+    ) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(EARLY_ACCESS_CARD_PADDING),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                AssistantEarlyAccessBadge()
+                Text(
+                    text = stringResource(R.string.assistant_early_access_notice_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = earlyAccessContentColor(),
+                )
+                AssistantEarlyAccessFeedbackButton(onClick = onFeedbackClick)
+            }
+            IconButton(
+                onClick = onDismissClick,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 4.dp, end = 4.dp),
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_assistant_notice_dismiss),
+                    contentDescription = stringResource(
+                        R.string.assistant_early_access_notice_dismiss_content_description
+                    ),
+                    tint = earlyAccessMutedContentColor(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AssistantEarlyAccessBadge() {
+    Surface(
+        shape = RoundedCornerShape(EARLY_ACCESS_BADGE_CORNER_RADIUS),
+        color = earlyAccessAccentColor(),
+        contentColor = Color.White,
+    ) {
+        Text(
+            text = stringResource(R.string.assistant_early_access_notice_badge),
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun AssistantEarlyAccessFeedbackButton(onClick: () -> Unit) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(EARLY_ACCESS_BUTTON_CORNER_RADIUS),
+        color = earlyAccessButtonColor(),
+        contentColor = earlyAccessAccentColor(),
+        border = BorderStroke(1.dp, earlyAccessBorderColor()),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_assistant_feedback),
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = earlyAccessAccentColor(),
+            )
+            Text(
+                text = stringResource(R.string.assistant_early_access_notice_feedback),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = earlyAccessAccentColor(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun earlyAccessContainerColor(): Color = if (isSystemInDarkTheme()) {
+    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f)
+} else {
+    Color(0xFFF3E9FF)
+}
+
+@Composable
+private fun earlyAccessButtonColor(): Color = if (isSystemInDarkTheme()) {
+    MaterialTheme.colorScheme.surface
+} else {
+    Color.White
+}
+
+@Composable
+private fun earlyAccessContentColor(): Color = if (isSystemInDarkTheme()) {
+    MaterialTheme.colorScheme.onSurface
+} else {
+    Color(0xFF2F213B)
+}
+
+@Composable
+private fun earlyAccessMutedContentColor(): Color = earlyAccessContentColor().copy(alpha = 0.72f)
+
+@Composable
+private fun earlyAccessBorderColor(): Color = if (isSystemInDarkTheme()) {
+    assistantOutlineColor()
+} else {
+    Color(0xFFE0C7FF)
+}
+
+@Composable
+private fun earlyAccessAccentColor(): Color = Color(0xFF7F54B3)
+
+private val EARLY_ACCESS_CARD_CORNER_RADIUS = 16.dp
+private val EARLY_ACCESS_BADGE_CORNER_RADIUS = 6.dp
+private val EARLY_ACCESS_BUTTON_CORNER_RADIUS = 8.dp
+private val EARLY_ACCESS_CARD_PADDING = 16.dp
+
+@Preview(showBackground = true, widthDp = 390)
+@Composable
+private fun AssistantEarlyAccessNoticeCardPreview() {
+    Surface(color = assistantCanvasColor()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            AssistantEarlyAccessNoticeCard(
+                onFeedbackClick = {},
+                onDismissClick = {},
+            )
+        }
+    }
+}

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEarlyAccessNoticeCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEarlyAccessNoticeCard.kt
@@ -96,7 +96,7 @@ private fun AssistantEarlyAccessFeedbackButton(onClick: () -> Unit) {
         onClick = onClick,
         shape = RoundedCornerShape(EARLY_ACCESS_BUTTON_CORNER_RADIUS),
         color = earlyAccessButtonColor(),
-        contentColor = earlyAccessAccentColor(),
+        contentColor = earlyAccessActionContentColor(),
         border = BorderStroke(1.dp, earlyAccessBorderColor()),
     ) {
         Row(
@@ -108,13 +108,13 @@ private fun AssistantEarlyAccessFeedbackButton(onClick: () -> Unit) {
                 painter = painterResource(R.drawable.ic_assistant_feedback),
                 contentDescription = null,
                 modifier = Modifier.size(18.dp),
-                tint = earlyAccessAccentColor(),
+                tint = earlyAccessActionContentColor(),
             )
             Text(
                 text = stringResource(R.string.assistant_early_access_notice_feedback),
                 style = MaterialTheme.typography.labelLarge,
                 fontWeight = FontWeight.SemiBold,
-                color = earlyAccessAccentColor(),
+                color = earlyAccessActionContentColor(),
             )
         }
     }
@@ -153,6 +153,13 @@ private fun earlyAccessBorderColor(): Color = if (isSystemInDarkTheme()) {
 
 @Composable
 private fun earlyAccessAccentColor(): Color = Color(0xFF7F54B3)
+
+@Composable
+private fun earlyAccessActionContentColor(): Color = if (isSystemInDarkTheme()) {
+    Color(0xFFE0C7FF)
+} else {
+    earlyAccessAccentColor()
+}
 
 private val EARLY_ACCESS_CARD_CORNER_RADIUS = 16.dp
 private val EARLY_ACCESS_BADGE_CORNER_RADIUS = 6.dp

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEmptyState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEmptyState.kt
@@ -7,8 +7,10 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -29,6 +31,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.ui.assistantCanvasColor
@@ -37,6 +40,7 @@ import com.woocommerce.android.aiassistant.ui.assistantOutlineColor
 @Composable
 internal fun AssistantEmptyState(
     showEarlyAccessNotice: Boolean,
+    bottomContentPadding: Dp,
     onFeedbackClick: () -> Unit,
     onDismissEarlyAccessNotice: () -> Unit,
     onSuggestionClick: (String) -> Unit,
@@ -86,6 +90,7 @@ internal fun AssistantEmptyState(
                 }
             }
         }
+        Spacer(modifier = Modifier.height(bottomContentPadding))
     }
 }
 
@@ -171,6 +176,7 @@ private fun AssistantEmptyStatePreview() {
     Surface(color = assistantCanvasColor()) {
         AssistantEmptyState(
             showEarlyAccessNotice = true,
+            bottomContentPadding = 16.dp,
             onFeedbackClick = {},
             onDismissEarlyAccessNotice = {},
             onSuggestionClick = {},

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEmptyState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEmptyState.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -45,6 +47,7 @@ internal fun AssistantEmptyState(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .padding(horizontal = 16.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEmptyState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantEmptyState.kt
@@ -34,6 +34,9 @@ import com.woocommerce.android.aiassistant.ui.assistantOutlineColor
 
 @Composable
 internal fun AssistantEmptyState(
+    showEarlyAccessNotice: Boolean,
+    onFeedbackClick: () -> Unit,
+    onDismissEarlyAccessNotice: () -> Unit,
     onSuggestionClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -45,6 +48,13 @@ internal fun AssistantEmptyState(
             .padding(horizontal = 16.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
+        if (showEarlyAccessNotice) {
+            AssistantEarlyAccessNoticeCard(
+                onFeedbackClick = onFeedbackClick,
+                onDismissClick = onDismissEarlyAccessNotice,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
         Text(
             text = stringResource(R.string.assistant_chat_empty_state_title),
             color = MaterialTheme.colorScheme.onSurface,
@@ -156,6 +166,11 @@ private val EMPTY_STATE_DIVIDER_INDENT = 56.dp
 @Composable
 private fun AssistantEmptyStatePreview() {
     Surface(color = assistantCanvasColor()) {
-        AssistantEmptyState(onSuggestionClick = {})
+        AssistantEmptyState(
+            showEarlyAccessNotice = true,
+            onFeedbackClick = {},
+            onDismissEarlyAccessNotice = {},
+            onSuggestionClick = {},
+        )
     }
 }

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_feedback.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_feedback.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4,4H20C21.1,4 22,4.9 22,6V16C22,17.1 21.1,18 20,18H8L4,22V18C2.9,18 2,17.1 2,16V6C2,4.9 2.9,4 4,4ZM4,6V16H6V17.17L7.17,16H20V6H4Z" />
+</vector>

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_notice_dismiss.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_notice_dismiss.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6.4,5L12,10.6L17.6,5L19,6.4L13.4,12L19,17.6L17.6,19L12,13.4L6.4,19L5,17.6L10.6,12L5,6.4L6.4,5Z" />
+</vector>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -59,7 +59,7 @@
     <string name="assistant_chat_empty_state_suggestion_content_description">Send suggestion: %1$s</string>
     <string name="assistant_early_access_notice_badge">EARLY ACCESS</string>
     <string name="assistant_early_access_notice_body">Hi! We\'re just getting started, with more on the way. Let us know what\'s missing and what you\'d love help with!</string>
-    <string name="assistant_early_access_notice_feedback">Feedback &amp; requests</string>
+    <string name="assistant_early_access_notice_feedback">Give Feedback</string>
     <string name="assistant_early_access_notice_dismiss_content_description">Dismiss early access notice</string>
     <string name="assistant_stats_card_total_sales_label">Total Sales</string>
     <string name="assistant_stats_card_net_sales_label">Net Sales</string>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -57,6 +57,10 @@
     <string name="assistant_chat_empty_state_suggestion_orders">Recent orders</string>
     <string name="assistant_chat_empty_state_suggestion_customers">New customers</string>
     <string name="assistant_chat_empty_state_suggestion_content_description">Send suggestion: %1$s</string>
+    <string name="assistant_early_access_notice_badge">EARLY ACCESS</string>
+    <string name="assistant_early_access_notice_body">Hi! We\'re just getting started, with more on the way. Let us know what\'s missing and what you\'d love help with!</string>
+    <string name="assistant_early_access_notice_feedback">Feedback &amp; requests</string>
+    <string name="assistant_early_access_notice_dismiss_content_description">Dismiss early access notice</string>
     <string name="assistant_stats_card_total_sales_label">Total Sales</string>
     <string name="assistant_stats_card_net_sales_label">Net Sales</string>
     <string name="assistant_stats_card_total_orders_label">Total Orders</string>

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantViewModelTest.kt
@@ -103,6 +103,13 @@ class AssistantViewModelTest {
     }
 
     @Test
+    fun `given empty conversation, when message is sent, then empty state is hidden`() = runTest {
+        viewModel.onSendMessage("Show revenue this week")
+
+        assertThat(viewModel.uiState.value.shouldShowEmptyState).isFalse()
+    }
+
+    @Test
     fun `given active assistant bubble, when text delta arrives, then typing indicator is hidden`() = runTest {
         viewModel.onSendMessage("Summarize sales")
         runtime.emit(AssistantRuntimeEvent.AssistantTextDelta("Sales are up today."))
@@ -565,6 +572,16 @@ class AssistantViewModelTest {
                 )
             )
         }
+
+    @Test
+    fun `given active conversation, when conversation restarts, then empty state is visible`() = runTest {
+        viewModel.onSendMessage("Previous question")
+
+        viewModel.onRestartConversation()
+
+        assertThat(viewModel.uiState.value.messages).isEmpty()
+        assertThat(viewModel.uiState.value.shouldShowEmptyState).isTrue()
+    }
 
     @Test
     fun `given active turn, when restarted, then state is cleared and runtime turn is cancelled`() = runTest {


### PR DESCRIPTION
### Description
Fixes WOOMOB-3068

Adds an early access notice to the AI Assistant empty chat state so merchants understand the experience is still early and can send feedback directly from the assistant surface.

The notice is rendered by the assistant UI but controlled by the WooCommerce host:
- `AiAssistantHostFragment` decides if the notice is visible, persists dismissal in `AppPrefs`, and opens the AI Assistant Crowdsignal survey when `Give Feedback` is tapped.
- The dismissal preference uses `DeletableSitePrefKey`, so it is scoped to the selected site and cleared with site preferences. This supersedes the earlier global-key approach and matches the updated iOS behavior.
- The assistant feature receives explicit notice state and callbacks, keeping persistence and navigation outside `libs/ai-assistant`.
- Feedback survey metadata now includes `SurveyType.AI_ASSISTANT`, and completed/failed survey analytics use a centralized per-survey feedback context.
- The `SurveyType` feedback-context refactor also fixes an existing analytics bug where completed/failed feedback survey events treated every non-main survey as `products_m3` instead of using the same per-survey context mapping as the survey screen.
- The empty-state layout was adjusted so the notice and composer behave in large-font scenarios, and the CTA keeps sufficient contrast in light and dark modes.

### Test Steps
1. Build and install the Wasabi debug app with AI Assistant available.
2. Open AI Assistant with no active chat messages.
3. Verify the early access notice appears above the composer, the CTA reads `Give Feedback`, and the dismiss button is visible.
4. Tap `Give Feedback` and verify the feedback survey opens.
5. Return to AI Assistant, dismiss the notice, leave and reopen the screen, and verify the notice remains dismissed for the selected site.
6. If another store is available, switch stores and verify the notice can be shown independently for that selected site.
7. Repeat the empty-state view in dark mode or with large font enabled and verify the notice/composer remain readable and non-overlapping.

### Images/gif
<img width="360" alt="Screenshot_20260513_000224" src="https://github.com/user-attachments/assets/2e3febc5-35b1-4345-87d2-58d7c1e342fa" />
<img width="360" alt="Screenshot_20260513_000200" src="https://github.com/user-attachments/assets/6778dd4f-3a50-45e6-872e-4aa5f77b30e4" />
<img width="360" alt="Screenshot_20260513_000232" src="https://github.com/user-attachments/assets/d3919408-15f9-4e72-903a-1fc30c67c62d" />


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.