### PR TITLE
Add Stripe smart-reader support (S700/S710/T600/T610) via internet discovery

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
@@ -20,7 +20,12 @@ import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover.S
 import com.woocommerce.android.cardreader.connection.ReaderType.BuildInReader.TapToPayDevice
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.Chipper2X
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeM2
+import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeS700
+import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeS710
+import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeT600
+import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeT610
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.WisePade3
+import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.WisePadeE
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateInProgress
 import com.woocommerce.android.di.StoreManagementMode
 import com.woocommerce.android.model.UiString
@@ -579,7 +584,12 @@ class CardReaderConnectViewModel @Inject constructor(
                 listOf(
                     Chipper2X,
                     StripeM2,
-                    WisePade3
+                    WisePade3,
+                    WisePadeE,
+                    StripeS700,
+                    StripeS710,
+                    StripeT600,
+                    StripeT610
                 )
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -11,7 +11,12 @@ import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.cardreader.connection.CardReaderTypesToDiscover.SpecificReaders.ExternalReaders
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.Chipper2X
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeM2
+import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeS700
+import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeS710
+import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeT600
+import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.StripeT610
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.WisePade3
+import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader.WisePadeE
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatus
 import com.woocommerce.android.cardreader.connection.event.SoftwareUpdateStatusErrorType
 import com.woocommerce.android.cardreader.remote.CardReaderRemoteFingerprint
@@ -332,7 +337,10 @@ class WooPosCardReaderConnectionController(
                 .discover(
                     isSimulated = developerOptionsRepository.isSimulatedCardReaderEnabled(),
                     cardReaderTypesToDiscover = ExternalReaders(
-                        listOf(Chipper2X, StripeM2, WisePade3)
+                        listOf(
+                            Chipper2X, StripeM2, WisePade3, WisePadeE,
+                            StripeS700, StripeS710, StripeT600, StripeT610,
+                        )
                     )
                 )
                 .flowOn(dispatchers.io)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderType.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/connection/CardReaderType.kt
@@ -4,12 +4,19 @@ import com.woocommerce.android.cardreader.connection.ReaderType.BuildInReader
 import com.woocommerce.android.cardreader.connection.ReaderType.ExternalReader
 
 sealed class ReaderType(val name: String) {
-    sealed class ExternalReader(extReaderName: String) : ReaderType(extReaderName) {
+    sealed class ExternalReader(
+        extReaderName: String,
+        val isInternetReader: Boolean = false,
+    ) : ReaderType(extReaderName) {
         object Chipper2X : ExternalReader("CHIPPER_2X")
         object StripeM2 : ExternalReader("STRIPE_M2")
-        object VerifoneP400 : ExternalReader("VERIFONE_P400")
+        object VerifoneP400 : ExternalReader("VERIFONE_P400", isInternetReader = true)
         object WisePade3 : ExternalReader("WISEPAD_3")
-        object WisePadeE : ExternalReader("WISEPOS_E")
+        object WisePadeE : ExternalReader("WISEPOS_E", isInternetReader = true)
+        object StripeS700 : ExternalReader("STRIPE_S700", isInternetReader = true)
+        object StripeS710 : ExternalReader("STRIPE_S710", isInternetReader = true)
+        object StripeT600 : ExternalReader("STRIPE_T600", isInternetReader = true)
+        object StripeT610 : ExternalReader("STRIPE_T610", isInternetReader = true)
     }
 
     sealed class BuildInReader(buildInReaderName: String) : ReaderType(buildInReaderName) {
@@ -26,6 +33,10 @@ sealed class ReaderType(val name: String) {
                 "VERIFONE_P400" -> ExternalReader.VerifoneP400
                 "WISEPAD_3" -> ExternalReader.WisePade3
                 "WISEPOS_E" -> ExternalReader.WisePadeE
+                "STRIPE_S700" -> ExternalReader.StripeS700
+                "STRIPE_S710" -> ExternalReader.StripeS710
+                "STRIPE_T600" -> ExternalReader.StripeT600
+                "STRIPE_T610" -> ExternalReader.StripeT610
                 "TAP_TO_PAY_DEVICE" -> BuildInReader.TapToPayDevice
                 else -> Unknown
             }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManager.kt
@@ -5,7 +5,9 @@ import android.app.Application
 import android.content.pm.PackageManager
 import android.os.Build
 import com.stripe.stripeterminal.external.callable.Callback
+import com.stripe.stripeterminal.external.callable.InternetReaderListener
 import com.stripe.stripeterminal.external.models.ConnectionConfiguration.BluetoothConnectionConfiguration
+import com.stripe.stripeterminal.external.models.ConnectionConfiguration.InternetConnectionConfiguration
 import com.stripe.stripeterminal.external.models.ConnectionConfiguration.TapToPayConnectionConfiguration
 import com.stripe.stripeterminal.external.models.DeviceType
 import com.stripe.stripeterminal.external.models.Reader
@@ -29,6 +31,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
@@ -65,17 +69,42 @@ internal class ConnectionManager(
 
                     is ExternalReaders -> {
                         checkIfNecessaryPermissionsAreGranted()
-                        discoverReadersAction.discoverExternalReaders(isSimulated)
+                        // Stripe SDK allows only one discoverReaders operation at a time. Run
+                        // internet discovery first (short-running). Skip the long-running
+                        // bluetooth scan if internet already returned a reader, so a BT timeout
+                        // doesn't overwrite a successful result in the UI.
+                        if (cardReaderTypesToDiscover.externalReaders.any { it.isInternetReader }) {
+                            flow {
+                                var foundInternetReader = false
+                                discoverReadersAction.discoverInternetReaders(isSimulated = isSimulated)
+                                    .collect { event ->
+                                        if (event is DiscoverReadersStatus.FoundReaders &&
+                                            event.readers.isNotEmpty()
+                                        ) {
+                                            foundInternetReader = true
+                                        }
+                                        emit(event)
+                                    }
+                                if (!foundInternetReader) {
+                                    emitAll(discoverReadersAction.discoverExternalReaders(isSimulated))
+                                }
+                            }
+                        } else {
+                            discoverReadersAction.discoverExternalReaders(isSimulated)
+                        }
                     }
                 }
             }
 
             UnspecifiedReaders -> {
                 checkIfNecessaryPermissionsAreGranted()
-                merge(
-                    discoverReadersAction.discoverBuildInReaders(isSimulated),
-                    discoverReadersAction.discoverExternalReaders(isSimulated)
-                )
+                // Stripe SDK serializes discoverReaders calls. Internet and Tap to Pay are
+                // short-running, so chain them before the long-running bluetooth discovery.
+                flow {
+                    emitAll(discoverReadersAction.discoverInternetReaders(isSimulated = isSimulated))
+                    emitAll(discoverReadersAction.discoverBuildInReaders(isSimulated))
+                    emitAll(discoverReadersAction.discoverExternalReaders(isSimulated))
+                }
             }
         }.map { state ->
             when (state) {
@@ -131,6 +160,11 @@ internal class ConnectionManager(
             try {
                 val reader = when (it.cardReader.deviceType) {
                     DeviceType.TAP_TO_PAY_DEVICE -> connectToBuiltInReader(cardReader, locationId)
+                    DeviceType.WISEPOS_E,
+                    DeviceType.STRIPE_S700,
+                    DeviceType.STRIPE_S710,
+                    DeviceType.STRIPE_T600,
+                    DeviceType.STRIPE_T610 -> connectToInternetReader(cardReader)
                     else -> connectToExternalReader(cardReader, locationId)
                 }
                 updateReaderStatus(CardReaderStatus.Connected(CardReaderImpl(reader)))
@@ -227,6 +261,16 @@ internal class ConnectionManager(
                 locationId,
                 autoReconnectOnUnexpectedDisconnect = true,
                 tapToPayReaderListener
+            )
+        )
+    }
+
+    private suspend fun connectToInternetReader(cardReader: CardReaderImpl): Reader {
+        return terminal.connectToInternet(
+            cardReader.cardReader,
+            InternetConnectionConfiguration(
+                internetReaderListener = object : InternetReaderListener {},
+                failIfInUse = false
             )
         )
     }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/connection/actions/DiscoverReadersAction.kt
@@ -51,6 +51,17 @@ internal class DiscoverReadersAction(
             DiscoveryConfiguration.BluetoothDiscoveryConfiguration(DISCOVERY_TIMEOUT_IN_SECONDS, isSimulated)
         )
 
+    fun discoverInternetReaders(
+        locationId: String? = null,
+        isSimulated: Boolean
+    ): Flow<DiscoverReadersStatus> =
+        discoverReaders(
+            DiscoveryConfiguration.InternetDiscoveryConfiguration(
+                location = locationId,
+                isSimulated = isSimulated
+            )
+        )
+
     @RequiresPermission(
         anyOf = [
             "android.permission.ACCESS_FINE_LOCATION",

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
@@ -71,6 +71,11 @@ internal class TerminalWrapper {
         configuration: ConnectionConfiguration.TapToPayConnectionConfiguration
     ): Reader = Terminal.getInstance().connectReader(reader, configuration)
 
+    suspend fun connectToInternet(
+        reader: Reader,
+        configuration: ConnectionConfiguration.InternetConnectionConfiguration
+    ): Reader = Terminal.getInstance().connectReader(reader, configuration)
+
     suspend fun disconnectReader() = Terminal.getInstance().disconnectReader()
 
     fun clearCachedCredentials() {

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/connection/ConnectionManagerTest.kt
@@ -21,6 +21,7 @@ import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.toList
@@ -29,6 +30,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -59,6 +61,8 @@ class ConnectionManagerTest : CardReaderBaseUnitTest() {
     fun setUp() {
         val defaultReaderStatus: StateFlow<CardReaderStatus> = MutableStateFlow(CardReaderStatus.NotConnected())
         whenever(terminalListenerImpl.readerStatus).thenReturn(defaultReaderStatus)
+        whenever(discoverReadersAction.discoverInternetReaders(anyOrNull(), anyBoolean()))
+            .thenReturn(emptyFlow())
 
         connectionManager = ConnectionManager(
             terminalWrapper,


### PR DESCRIPTION
## Summary
- Adds support for Stripe internet-discovered smart readers (S700, S710, T600, T610) to the WooPos connect flow and the main Payments connect flow.
- Wires `InternetDiscoveryConfiguration` + `InternetConnectionConfiguration` through `libs/cardreader` (new `discoverInternetReaders`, `connectToInternet`, `connectToInternetReader` routing).
- Sequential discovery: internet first (short-running); bluetooth only runs if internet returned zero readers. Avoids the SDK's "operation in progress" error from concurrent calls and prevents a BT timeout from overwriting a successful internet result in the UI.

## Test plan
- [ ] End-to-end on a physical tablet on the same Wi-Fi as the reader: discovery finds the smart reader, tap to connect succeeds, payment intent runs, card tap completes, charge processes (validated locally on Pixel Tablet + S710, livemode).
- [ ] Existing Bluetooth-only allowlists (no internet readers in the list) still trigger only BT discovery — no regression for Chipper/M2/WisePad3.
- [ ] Tap to Pay (built-in) discovery path unchanged.
- [ ] All `:libs:cardreader:testDebugUnitTest` pass (329/329 locally).
- [ ] Manual smoke test: scan with no readers on the account behaves cleanly (falls through to BT scan).

## Out of scope (follow-ups)
- Reconnect-on-foreground for internet readers — TLS session drops when app backgrounds; next `createPaymentIntent` fails with "No active Reader". Mirror the existing BT auto-reconnect.
- Analytics transport label: `PaymentsFlowTracker` emits `transport=bluetooth` for connection events on internet-discovered readers; needs an `internet` value.
- Manuals/icons/strings for the new reader types in `CardReaderManualsSupportedReadersMapper`.
- iOS port (`woocommerce-ios`) — equivalent changes in `CardReaderType.swift`, `StripeCardReaderService.swift`.
- Reader-location pairing UX — currently relies on merchants registering readers via the Stripe Dashboard. Could expose a registration-code flow in WC admin.
- Custom splash/logo on smart readers — Stripe Terminal Configurations API supports per-merchant branding (1080x1920 PNG/JPG, `stripe_s710[splashscreen]=file_xxx`). Demoable feature beyond plumbing.

## Notes
- No SDK bump needed — `stripeterminal-android@5.1.1` already exposes `STRIPE_S700`, `STRIPE_S710`, `STRIPE_T600`, `STRIPE_T610`, `InternetDiscoveryConfiguration`, and `InternetReaderListener`.
- Diff: 7 files, +103/-10.