### PR TITLE
[RSM-3044] Ignore unknown push notification types

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -87,6 +87,11 @@ class NotificationMessageHandler @Inject constructor(
             return
         }
 
+        if (notificationModel.type == NotificationModel.Kind.UNKNOWN) {
+            wooLog.d(NOTIFICATIONS, "Discarding push notification with unknown type")
+            return
+        }
+
         val notification = notificationModel.toAppModel(resourceProvider)
         val notificationSource = messageData.detectNotificationSource(notification.remoteNoteId)
         val pushUserId = messageData[PUSH_ARG_USER]

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -197,6 +197,28 @@ class NotificationMessageHandlerTest {
     }
 
     @Test
+    fun `given notification type is unknown, when message received, then silently discard`() = runTest {
+        val unknownNotificationModel = NotificationModel(
+            remoteNoteId = 0L,
+            remoteSiteId = orderNotification.remoteSiteId,
+            type = NotificationModel.Kind.UNKNOWN
+        )
+        val mockParser: NotificationsParser = mock {
+            on { buildNotificationModelFromPayloadMap(any()) } doReturn unknownNotificationModel
+        }
+        createNotificationMessageHandler(mockParser)
+
+        notificationMessageHandler.onNewMessageReceived(mapOf("type" to "unknown_future_type"))
+
+        verify(wooLog).d(
+            eq(WooLog.T.NOTIFICATIONS),
+            eq("Discarding push notification with unknown type")
+        )
+        verifyNoInteractions(dispatcher)
+        verifyNoInteractions(notificationBuilder)
+    }
+
+    @Test
     fun `when the user id does not match, then do not process the notification`() = runTest {
         val payload = NotificationTestUtils.generateTestNewOrderNotificationPayload(userId = 67890)
 


### PR DESCRIPTION
### Description

Fixes RSM-3044

When Woo Core ships a new push notification `type` (for example, `store_stock`), older app builds that don't recognize the type currently fall through `WooNotificationType.kt`'s `else -> LocalReminder` branch and render a malformed notification — wrong channel, wrong icon, generic content. Backend filtering by app version is brittle and slow to coordinate. The simpler approach is to let the client itself act as the version gate: any push whose `type` doesn't map to a known kind is silently discarded.

`NotificationModel.Kind.fromString` (in fluxc) already maps any unrecognized type string to `Kind.UNKNOWN`, so no parallel allowlist is needed in the app. This PR adds a single early-return in `NotificationMessageHandler.onNewMessageReceived` right after the model is built:

```kotlin
if (notificationModel.type == NotificationModel.Kind.UNKNOWN) {
    wooLog.d(NOTIFICATIONS, "Discarding push notification with unknown type")
    return
}
```

The guard runs **before** `dispatchBackgroundEvents` (no Room write, no fetch dispatch, no order-update worker) and **before** `handleWooNotification` (nothing displayed, no `PUSH_NOTIFICATION_RECEIVED` analytics).


### Test Steps

> Note: I can grant access to a testing site that can trigger a `store_stock` push — ping me on Slack and I'll add you.

1. Install this build on a device and sign in to the test site that can trigger `store_stock` pushes.
2. From the test site, trigger an out-of-stock event so a `store_stock` push is delivered to the device.
3. Confirm **no notification is shown** in the system tray.
4. Confirm `logcat` contains `Discarding push notification with unknown type` from tag `WooCommerce-NOTIFICATIONS`.
5. Place a real order on the same site — confirm the **new-order** notification displays normally (channel, sound, icon, tap target all correct).
6. Leave a product review on the same site — confirm the **review** notification displays normally.

### Images/gif

N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.