### PR TITLE
[WOOMOB-3049] Improve assistant conversation scroll behavior

### DIFF
--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -22,9 +23,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -44,9 +44,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -57,6 +57,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -83,7 +84,9 @@ import com.woocommerce.android.aiassistant.ui.components.AssistantConfirmationCa
 import com.woocommerce.android.aiassistant.ui.components.AssistantEmptyState
 import com.woocommerce.android.aiassistant.ui.components.AssistantToolActivityPill
 import com.woocommerce.android.aiassistant.ui.components.AssistantTypingIndicator
-import kotlinx.coroutines.flow.distinctUntilChanged
+import com.woocommerce.android.aiassistant.ui.scroll.AssistantScrollController
+import com.woocommerce.android.aiassistant.ui.scroll.rememberAssistantScrollController
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -197,14 +200,27 @@ fun AssistantChatScreen(
     val estimatedBottomBarHeight = FLOATING_COMPOSER_ESTIMATED_HEIGHT * density.fontScale
     val bottomContentPadding = bottomBarContentHeight
         .coerceAtLeast(estimatedBottomBarHeight) + FLOATING_COMPOSER_CONTENT_SPACING
+    val visibleMessages = state.messages.filter { message ->
+        message.hasVisibleContent(state)
+    }
+    val showTypingIndicator = state.shouldShowTypingIndicator
+    val scrollController = rememberAssistantScrollController(
+        state = state,
+        visibleMessages = visibleMessages,
+        showTypingIndicator = showTypingIndicator,
+        bottomContentPadding = bottomContentPadding,
+    )
     val submitMessage = {
+        scrollController.onUserMessageSubmitted()
         focusManager.clearFocus()
         onSendMessage()
     }
     val submitSuggestion = { prompt: String ->
+        scrollController.onUserMessageSubmitted()
         focusManager.clearFocus()
         onSendSuggestion(prompt)
     }
+    val coroutineScope = rememberCoroutineScope()
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -249,6 +265,9 @@ fun AssistantChatScreen(
             } else {
                 AssistantMessageThread(
                     state = state,
+                    visibleMessages = visibleMessages,
+                    showTypingIndicator = showTypingIndicator,
+                    scrollController = scrollController,
                     onRetry = onRetry,
                     onConfirmWrite = onConfirmWrite,
                     onCancelWrite = onCancelWrite,
@@ -266,6 +285,52 @@ fun AssistantChatScreen(
                     .align(Alignment.BottomCenter)
                     .fillMaxWidth(),
             )
+            AssistantJumpToLatestButton(
+                visible = scrollController.hasNewerContentBelow.value,
+                bottomBarHeight = bottomBarContentHeight,
+                onClick = {
+                    coroutineScope.launch {
+                        scrollController.onJumpToLatestClicked()
+                    }
+                },
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AssistantJumpToLatestButton(
+    visible: Boolean,
+    bottomBarHeight: Dp,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+        modifier = modifier.padding(bottom = bottomBarHeight + 24.dp),
+    ) {
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 4.dp,
+        ) {
+            IconButton(
+                onClick = onClick,
+                modifier = Modifier
+                    .size(40.dp)
+                    .testTag(ASSISTANT_JUMP_TO_LATEST_TEST_TAG),
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_assistant_jump_to_latest),
+                    contentDescription = stringResource(
+                        R.string.ai_assistant_chat_jump_to_latest_content_description
+                    ),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
         }
     }
 }
@@ -394,6 +459,9 @@ private fun AssistantTopAppBar(
 @Composable
 private fun AssistantMessageThread(
     state: AssistantUiState,
+    visibleMessages: List<AssistantUiMessage>,
+    showTypingIndicator: Boolean,
+    scrollController: AssistantScrollController,
     onRetry: () -> Unit,
     onConfirmWrite: () -> Unit,
     onCancelWrite: () -> Unit,
@@ -402,54 +470,8 @@ private fun AssistantMessageThread(
     bottomContentPadding: Dp,
     modifier: Modifier = Modifier,
 ) {
-    val visibleMessages = state.messages.filter { message ->
-        message.hasVisibleContent(state)
-    }
-    val showTypingIndicator = state.shouldShowTypingIndicator
-    val listState = rememberLazyListState()
-    val bottomPinThresholdPx = with(LocalDensity.current) { BOTTOM_PIN_THRESHOLD_DP.roundToPx() }
-    val scrollSignal = visibleMessages.toScrollSignal(showTypingIndicator)
-    var previousScrollSignal by remember { mutableStateOf<AssistantThreadScrollSignal?>(null) }
-    var wasPinnedBeforeLatestChange by rememberSaveable { mutableStateOf(true) }
-
-    LaunchedEffect(listState, bottomPinThresholdPx, scrollSignal.renderedItemCount) {
-        snapshotFlow {
-            listState.isPinnedToRenderedEnd(
-                renderedItemCount = scrollSignal.renderedItemCount,
-                bottomPinThresholdPx = bottomPinThresholdPx,
-            )
-        }
-            .distinctUntilChanged()
-            .collect { wasPinnedBeforeLatestChange = it }
-    }
-
-    LaunchedEffect(scrollSignal) {
-        val renderedItemCount = scrollSignal.renderedItemCount
-        if (renderedItemCount == 0) {
-            previousScrollSignal = scrollSignal
-            return@LaunchedEffect
-        }
-
-        val previous = previousScrollSignal
-        val forceScrollForUserSend = previous != null &&
-            previous.lastUserMessageId != scrollSignal.lastUserMessageId
-        val isNewAssistantMessage = previous != null &&
-            previous.lastMessageId != scrollSignal.lastMessageId &&
-            scrollSignal.lastMessageRole == AssistantUiMessage.Role.ASSISTANT
-
-        if (forceScrollForUserSend || wasPinnedBeforeLatestChange) {
-            val targetIndex = renderedItemCount - 1
-            if (forceScrollForUserSend || isNewAssistantMessage) {
-                listState.animateScrollToItem(targetIndex)
-            } else {
-                listState.scrollToItem(targetIndex)
-            }
-        }
-        previousScrollSignal = scrollSignal
-    }
-
     LazyColumn(
-        state = listState,
+        state = scrollController.listState,
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(24.dp, Alignment.Top),
         contentPadding = PaddingValues(
@@ -495,57 +517,8 @@ private val FLOATING_COMPOSER_FADE_EXTRA_HEIGHT = 48.dp
 private val FLOATING_COMPOSER_BOTTOM_PADDING = 16.dp
 private val FLOATING_COMPOSER_ESTIMATED_HEIGHT = 84.dp
 private val FLOATING_COMPOSER_CONTENT_SPACING = 16.dp
-private val BOTTOM_PIN_THRESHOLD_DP = 48.dp
 private val USER_BUBBLE_MAX_WIDTH = 280.dp
-
-private data class AssistantThreadScrollSignal(
-    val renderedItemCount: Int,
-    val messageCount: Int,
-    val lastMessageId: String?,
-    val lastMessageRole: AssistantUiMessage.Role?,
-    val lastUserMessageId: String?,
-    val lastMessageSegmentCount: Int,
-    val lastMessageTextLength: Int,
-    val showTypingIndicator: Boolean,
-)
-
-private fun List<AssistantUiMessage>.toScrollSignal(
-    showTypingIndicator: Boolean,
-): AssistantThreadScrollSignal {
-    val lastMessage = lastOrNull()
-    return AssistantThreadScrollSignal(
-        renderedItemCount = size + if (showTypingIndicator) 1 else 0,
-        messageCount = size,
-        lastMessageId = lastMessage?.id,
-        lastMessageRole = lastMessage?.role,
-        lastUserMessageId = lastOrNull { it.role == AssistantUiMessage.Role.USER }?.id,
-        lastMessageSegmentCount = lastMessage?.segments?.size ?: 0,
-        lastMessageTextLength = lastMessage?.text?.length ?: 0,
-        showTypingIndicator = showTypingIndicator,
-    )
-}
-
-private fun LazyListState.isPinnedToRenderedEnd(
-    renderedItemCount: Int,
-    bottomPinThresholdPx: Int,
-): Boolean {
-    if (renderedItemCount == 0) return true
-
-    val lastVisibleItem = layoutInfo.visibleItemsInfo.lastOrNull() ?: return true
-    val targetIndex = renderedItemCount - 1
-    if (lastVisibleItem.index != targetIndex) return false
-
-    val distanceFromViewportEnd = layoutInfo.viewportEndOffset - (lastVisibleItem.offset + lastVisibleItem.size)
-    return isRenderedTargetPinnedToViewportEnd(
-        distanceFromViewportEnd = distanceFromViewportEnd,
-        bottomPinThresholdPx = bottomPinThresholdPx,
-    )
-}
-
-internal fun isRenderedTargetPinnedToViewportEnd(
-    distanceFromViewportEnd: Int,
-    bottomPinThresholdPx: Int,
-): Boolean = distanceFromViewportEnd in 0..bottomPinThresholdPx
+private const val ASSISTANT_JUMP_TO_LATEST_TEST_TAG = "assistant_jump_to_latest"
 
 @Composable
 private fun AssistantMessageBubble(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantBottomPinGeometry.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantBottomPinGeometry.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.aiassistant.ui.scroll
+
+internal fun isRenderedTargetPinnedAboveBottomContent(
+    distanceFromViewportEnd: Int,
+    bottomContentPaddingPx: Int,
+    bottomPinThresholdPx: Int,
+): Boolean = distanceFromViewportEnd - bottomContentPaddingPx >= -bottomPinThresholdPx
+
+internal fun scrollDeltaToRevealTargetAboveBottomContent(
+    distanceFromViewportEnd: Int,
+    bottomContentPaddingPx: Int,
+): Float = (bottomContentPaddingPx - distanceFromViewportEnd)
+    .coerceAtLeast(0)
+    .toFloat()

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantScrollController.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantScrollController.kt
@@ -1,0 +1,252 @@
+package com.woocommerce.android.aiassistant.ui.scroll
+
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.aiassistant.ui.AssistantUiMessage
+import com.woocommerce.android.aiassistant.ui.AssistantUiState
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+@Composable
+internal fun rememberAssistantScrollController(
+    state: AssistantUiState,
+    visibleMessages: List<AssistantUiMessage>,
+    showTypingIndicator: Boolean,
+    bottomContentPadding: Dp,
+): AssistantScrollController {
+    val listState = rememberLazyListState()
+    val bottomPinThresholdPx = with(LocalDensity.current) { BOTTOM_PIN_THRESHOLD_DP.roundToPx() }
+    val bottomContentPaddingPx = with(LocalDensity.current) { bottomContentPadding.roundToPx() }
+    val scrollSignal = visibleMessages.toThreadScrollSignal(
+        state = state,
+        showTypingIndicator = showTypingIndicator,
+    )
+    val viewportState = rememberAssistantThreadViewport(
+        listState = listState,
+        renderedItemCount = scrollSignal.renderedItemCount,
+        bottomContentPaddingPx = bottomContentPaddingPx,
+        bottomPinThresholdPx = bottomPinThresholdPx,
+    )
+
+    var previousScrollSignal by remember { mutableStateOf<AssistantThreadScrollSignal?>(null) }
+    val autoFollowEnabled = rememberSaveable { mutableStateOf(true) }
+    val hasNewerContentBelow = remember { mutableStateOf(false) }
+    var isProgrammaticScrollInProgress by remember { mutableStateOf(false) }
+    var hasObservedNonEmptyViewport by remember { mutableStateOf(false) }
+
+    suspend fun scrollToLatest(animated: Boolean) {
+        val targetIndex = scrollSignal.renderedItemCount - 1
+        if (targetIndex < 0) return
+
+        isProgrammaticScrollInProgress = true
+        try {
+            if (animated) {
+                listState.animateScrollToItem(targetIndex)
+            } else {
+                listState.scrollToItem(targetIndex)
+            }
+            listState.revealRenderedTargetAboveBottomContent(
+                targetIndex = targetIndex,
+                bottomContentPaddingPx = bottomContentPaddingPx,
+                animated = animated,
+            )
+        } finally {
+            isProgrammaticScrollInProgress = false
+        }
+    }
+
+    LaunchedEffect(scrollSignal) {
+        val decision = decideAssistantThreadScroll(
+            previous = previousScrollSignal,
+            current = scrollSignal,
+            autoFollowEnabled = autoFollowEnabled.value,
+        )
+        previousScrollSignal = scrollSignal
+
+        when (decision) {
+            AssistantThreadScrollDecision.None -> Unit
+            AssistantThreadScrollDecision.AnimateToLatest -> scrollToLatest(animated = true)
+            AssistantThreadScrollDecision.SnapToLatest -> scrollToLatest(animated = false)
+        }
+    }
+
+    LaunchedEffect(
+        viewportState.value,
+        scrollSignal.renderedItemCount,
+    ) {
+        val viewport = viewportState.value
+        val currentFollowState = AssistantThreadFollowState(
+            autoFollowEnabled = autoFollowEnabled.value,
+            hasObservedNonEmptyViewport = hasObservedNonEmptyViewport,
+        )
+        val followState = resolveAssistantThreadFollowState(
+            viewport = viewport,
+            isProgrammaticScrollInProgress = isProgrammaticScrollInProgress,
+            current = currentFollowState,
+        )
+        autoFollowEnabled.value = followState.autoFollowEnabled
+        hasObservedNonEmptyViewport = followState.hasObservedNonEmptyViewport
+    }
+
+    LaunchedEffect(
+        viewportState.value,
+        scrollSignal.renderedItemCount,
+        autoFollowEnabled.value,
+    ) {
+        val viewport = viewportState.value
+        hasNewerContentBelow.value = viewport.hasVisibleItems &&
+            !autoFollowEnabled.value &&
+            scrollSignal.renderedItemCount > 0 &&
+            !viewport.isPinnedToEnd
+    }
+
+    LaunchedEffect(
+        viewportState.value,
+        autoFollowEnabled.value,
+        hasObservedNonEmptyViewport,
+        scrollSignal.renderedItemCount,
+    ) {
+        val viewport = viewportState.value
+        val followState = AssistantThreadFollowState(
+            autoFollowEnabled = autoFollowEnabled.value,
+            hasObservedNonEmptyViewport = hasObservedNonEmptyViewport,
+        )
+        if (
+            shouldSnapToLatestAfterViewportChange(
+                viewport = viewport,
+                followState = followState,
+            )
+        ) {
+            scrollToLatest(animated = false)
+        }
+    }
+
+    return AssistantScrollController(
+        listState = listState,
+        autoFollowEnabled = autoFollowEnabled,
+        hasNewerContentBelow = hasNewerContentBelow,
+        onUserMessageSubmitted = { autoFollowEnabled.value = true },
+        onJumpToLatestClicked = {
+            autoFollowEnabled.value = true
+            scrollToLatest(animated = true)
+        },
+    )
+}
+
+internal class AssistantScrollController(
+    val listState: LazyListState,
+    val autoFollowEnabled: State<Boolean>,
+    val hasNewerContentBelow: State<Boolean>,
+    val onUserMessageSubmitted: () -> Unit,
+    val onJumpToLatestClicked: suspend () -> Unit,
+)
+
+@Composable
+private fun rememberAssistantThreadViewport(
+    listState: LazyListState,
+    renderedItemCount: Int,
+    bottomContentPaddingPx: Int,
+    bottomPinThresholdPx: Int,
+): State<AssistantThreadViewportState> {
+    return produceState(
+        initialValue = listState.toAssistantThreadViewportState(
+            renderedItemCount = renderedItemCount,
+            bottomContentPaddingPx = bottomContentPaddingPx,
+            bottomPinThresholdPx = bottomPinThresholdPx,
+        ),
+        listState,
+        renderedItemCount,
+        bottomContentPaddingPx,
+        bottomPinThresholdPx,
+    ) {
+        snapshotFlow {
+            listState.toAssistantThreadViewportState(
+                renderedItemCount = renderedItemCount,
+                bottomContentPaddingPx = bottomContentPaddingPx,
+                bottomPinThresholdPx = bottomPinThresholdPx,
+            )
+        }
+            .distinctUntilChanged()
+            .collectLatest { value = it }
+    }
+}
+
+private fun LazyListState.toAssistantThreadViewportState(
+    renderedItemCount: Int,
+    bottomContentPaddingPx: Int,
+    bottomPinThresholdPx: Int,
+) = AssistantThreadViewportState(
+    renderedItemCount = renderedItemCount,
+    isScrollInProgress = isScrollInProgress,
+    hasVisibleItems = layoutInfo.visibleItemsInfo.isNotEmpty(),
+    isPinnedToEnd = isRenderedEndPinnedAboveBottomContent(
+        renderedItemCount = renderedItemCount,
+        bottomContentPaddingPx = bottomContentPaddingPx,
+        bottomPinThresholdPx = bottomPinThresholdPx,
+    ),
+)
+
+private fun LazyListState.isRenderedEndPinnedAboveBottomContent(
+    renderedItemCount: Int,
+    bottomContentPaddingPx: Int,
+    bottomPinThresholdPx: Int,
+): Boolean {
+    if (renderedItemCount == 0) return true
+
+    val lastVisibleItem = layoutInfo.visibleItemsInfo.lastOrNull() ?: return false
+    val targetIndex = renderedItemCount - 1
+    if (lastVisibleItem.index != targetIndex) return false
+
+    val distanceFromViewportEnd = layoutInfo.viewportEndOffset - (lastVisibleItem.offset + lastVisibleItem.size)
+    return isRenderedTargetPinnedAboveBottomContent(
+        distanceFromViewportEnd = distanceFromViewportEnd,
+        bottomContentPaddingPx = bottomContentPaddingPx,
+        bottomPinThresholdPx = bottomPinThresholdPx,
+    )
+}
+
+private suspend fun LazyListState.revealRenderedTargetAboveBottomContent(
+    targetIndex: Int,
+    bottomContentPaddingPx: Int,
+    animated: Boolean,
+) {
+    repeat(REVEAL_SCROLL_ADJUSTMENT_PASSES) {
+        withFrameNanos { }
+        val distanceFromViewportEnd = distanceFromRenderedTargetToViewportEnd(targetIndex) ?: return
+        val scrollDelta = scrollDeltaToRevealTargetAboveBottomContent(
+            distanceFromViewportEnd = distanceFromViewportEnd,
+            bottomContentPaddingPx = bottomContentPaddingPx,
+        )
+        if (scrollDelta <= 0f) return
+
+        if (animated) {
+            animateScrollBy(scrollDelta)
+        } else {
+            scrollBy(scrollDelta)
+        }
+    }
+}
+
+private fun LazyListState.distanceFromRenderedTargetToViewportEnd(targetIndex: Int): Int? {
+    val targetItem = layoutInfo.visibleItemsInfo.firstOrNull { it.index == targetIndex } ?: return null
+    return layoutInfo.viewportEndOffset - (targetItem.offset + targetItem.size)
+}
+
+private const val REVEAL_SCROLL_ADJUSTMENT_PASSES = 2
+private val BOTTOM_PIN_THRESHOLD_DP = 48.dp

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantThreadFollowState.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantThreadFollowState.kt
@@ -1,0 +1,52 @@
+package com.woocommerce.android.aiassistant.ui.scroll
+
+internal data class AssistantThreadFollowState(
+    val autoFollowEnabled: Boolean,
+    val hasObservedNonEmptyViewport: Boolean,
+)
+
+internal data class AssistantThreadViewportState(
+    val renderedItemCount: Int,
+    val hasVisibleItems: Boolean,
+    val isPinnedToEnd: Boolean,
+    val isScrollInProgress: Boolean,
+) {
+    val hasRenderedItems: Boolean
+        get() = renderedItemCount > 0
+}
+
+internal fun resolveAssistantThreadFollowState(
+    viewport: AssistantThreadViewportState,
+    isProgrammaticScrollInProgress: Boolean,
+    current: AssistantThreadFollowState,
+): AssistantThreadFollowState {
+    if (!viewport.hasRenderedItems || !viewport.hasVisibleItems) {
+        return current
+    }
+
+    if (!current.hasObservedNonEmptyViewport) {
+        return AssistantThreadFollowState(
+            autoFollowEnabled = viewport.isPinnedToEnd,
+            hasObservedNonEmptyViewport = true,
+        )
+    }
+
+    return AssistantThreadFollowState(
+        autoFollowEnabled = when {
+            viewport.isPinnedToEnd -> true
+            viewport.isScrollInProgress && !isProgrammaticScrollInProgress -> false
+            else -> current.autoFollowEnabled
+        },
+        hasObservedNonEmptyViewport = true,
+    )
+}
+
+internal fun shouldSnapToLatestAfterViewportChange(
+    viewport: AssistantThreadViewportState,
+    followState: AssistantThreadFollowState,
+): Boolean = viewport.hasRenderedItems &&
+    viewport.hasVisibleItems &&
+    followState.hasObservedNonEmptyViewport &&
+    followState.autoFollowEnabled &&
+    !viewport.isPinnedToEnd &&
+    !viewport.isScrollInProgress

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantThreadScrollPolicy.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantThreadScrollPolicy.kt
@@ -1,0 +1,102 @@
+package com.woocommerce.android.aiassistant.ui.scroll
+
+import com.woocommerce.android.aiassistant.ui.AssistantUiMessage
+import com.woocommerce.android.aiassistant.ui.AssistantUiSegment
+import com.woocommerce.android.aiassistant.ui.AssistantUiState
+import com.woocommerce.android.aiassistant.ui.AssistantUiStatus
+import com.woocommerce.android.aiassistant.ui.orderedSegments
+
+internal fun List<AssistantUiMessage>.toThreadScrollSignal(
+    state: AssistantUiState,
+    showTypingIndicator: Boolean,
+): AssistantThreadScrollSignal {
+    val lastMessage = lastOrNull()
+    val lastMessageSegments = lastMessage?.orderedSegments(state).orEmpty()
+
+    return AssistantThreadScrollSignal(
+        renderedItemCount = size + if (showTypingIndicator) 1 else 0,
+        messageCount = size,
+        lastMessageId = lastMessage?.id,
+        lastMessageRole = lastMessage?.role,
+        lastUserMessageId = lastOrNull { it.role == AssistantUiMessage.Role.USER }?.id,
+        lastMessageSegmentCount = lastMessageSegments.size,
+        lastMessageTextLength = lastMessageSegments
+            .filterIsInstance<AssistantUiSegment.Text>()
+            .sumOf { it.text.length },
+        activeAssistantMessageId = state.activeAssistantMessageId,
+        activeConfirmationId = state.activeConfirmationId,
+        status = state.status,
+        showTypingIndicator = showTypingIndicator,
+    )
+}
+
+internal data class AssistantThreadScrollSignal(
+    val renderedItemCount: Int,
+    val messageCount: Int,
+    val lastMessageId: String?,
+    val lastMessageRole: AssistantUiMessage.Role?,
+    val lastUserMessageId: String?,
+    val lastMessageSegmentCount: Int,
+    val lastMessageTextLength: Int,
+    val activeAssistantMessageId: String?,
+    val activeConfirmationId: String?,
+    val status: AssistantUiStatus,
+    val showTypingIndicator: Boolean,
+)
+
+internal sealed interface AssistantThreadScrollDecision {
+    data object None : AssistantThreadScrollDecision
+    data object AnimateToLatest : AssistantThreadScrollDecision
+    data object SnapToLatest : AssistantThreadScrollDecision
+}
+
+internal fun decideAssistantThreadScroll(
+    previous: AssistantThreadScrollSignal?,
+    current: AssistantThreadScrollSignal,
+    autoFollowEnabled: Boolean,
+): AssistantThreadScrollDecision {
+    val previousSignal = previous.takeUnless { current.renderedItemCount == 0 || it == current }
+    if (previousSignal == null) {
+        return AssistantThreadScrollDecision.None
+    }
+
+    return when {
+        previousSignal.hasNewUserMessage(current) -> AssistantThreadScrollDecision.AnimateToLatest
+        !autoFollowEnabled -> AssistantThreadScrollDecision.None
+        previousSignal.shouldAnimateToLatest(current) -> AssistantThreadScrollDecision.AnimateToLatest
+        previousSignal.hasRenderedContentChange(current) -> AssistantThreadScrollDecision.SnapToLatest
+        else -> AssistantThreadScrollDecision.None
+    }
+}
+
+private fun AssistantThreadScrollSignal.hasNewUserMessage(
+    current: AssistantThreadScrollSignal,
+): Boolean = lastUserMessageId != current.lastUserMessageId
+
+private fun AssistantThreadScrollSignal.shouldAnimateToLatest(
+    current: AssistantThreadScrollSignal,
+): Boolean = hasNewAssistantMessage(current) ||
+    didRevealCardsAfterStreaming(current) ||
+    activeConfirmationId != current.activeConfirmationId
+
+private fun AssistantThreadScrollSignal.hasNewAssistantMessage(
+    current: AssistantThreadScrollSignal,
+): Boolean = lastMessageId != current.lastMessageId &&
+    current.lastMessageRole == AssistantUiMessage.Role.ASSISTANT
+
+private fun AssistantThreadScrollSignal.didRevealCardsAfterStreaming(
+    current: AssistantThreadScrollSignal,
+): Boolean = status == AssistantUiStatus.STREAMING &&
+    current.status != AssistantUiStatus.STREAMING &&
+    lastMessageId == current.lastMessageId &&
+    current.lastMessageSegmentCount > lastMessageSegmentCount
+
+private fun AssistantThreadScrollSignal.hasRenderedContentChange(
+    current: AssistantThreadScrollSignal,
+): Boolean = renderedItemCount != current.renderedItemCount ||
+    messageCount != current.messageCount ||
+    lastMessageSegmentCount != current.lastMessageSegmentCount ||
+    lastMessageTextLength != current.lastMessageTextLength ||
+    showTypingIndicator != current.showTypingIndicator ||
+    activeAssistantMessageId != current.activeAssistantMessageId ||
+    status != current.status

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_jump_to_latest.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_jump_to_latest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7.41,8.59L12,13.17L16.59,8.59L18,10L12,16L6,10L7.41,8.59Z" />
+</vector>

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="ai_assistant_chat_title">Assistant</string>
     <string name="ai_assistant_chat_back_content_description">Back</string>
     <string name="ai_assistant_chat_restart_content_description">Start new conversation</string>
+    <string name="ai_assistant_chat_jump_to_latest_content_description">Jump to latest</string>
     <string name="ai_assistant_chat_message_user_content_description">You: %1$s</string>
     <string name="ai_assistant_chat_message_assistant_content_description">Assistant: %1$s</string>
     <string name="ai_assistant_chat_typing_content_description">Assistant is thinking</string>

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/AssistantUiStateTest.kt
@@ -97,36 +97,6 @@ class AssistantUiStateTest {
     }
 
     @Test
-    fun `given target bottom extends below viewport, when checking pin state, then target is not pinned`() {
-        assertThat(
-            isRenderedTargetPinnedToViewportEnd(
-                distanceFromViewportEnd = -1,
-                bottomPinThresholdPx = 48,
-            )
-        ).isFalse()
-    }
-
-    @Test
-    fun `given target bottom is near viewport end, when checking pin state, then target is pinned`() {
-        assertThat(
-            isRenderedTargetPinnedToViewportEnd(
-                distanceFromViewportEnd = 48,
-                bottomPinThresholdPx = 48,
-            )
-        ).isTrue()
-    }
-
-    @Test
-    fun `given target bottom is far above viewport end, when checking pin state, then target is not pinned`() {
-        assertThat(
-            isRenderedTargetPinnedToViewportEnd(
-                distanceFromViewportEnd = 49,
-                bottomPinThresholdPx = 48,
-            )
-        ).isFalse()
-    }
-
-    @Test
     fun `given error state with no inline message error, when checking fallback, then fallback is visible`() {
         val state = AssistantUiState(
             status = AssistantUiStatus.ERROR,

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantBottomPinGeometryTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantBottomPinGeometryTest.kt
@@ -1,0 +1,81 @@
+package com.woocommerce.android.aiassistant.ui.scroll
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AssistantBottomPinGeometryTest {
+    @Test
+    fun `given target bottom is near below viewport end, when checking pin state, then target is pinned`() {
+        assertThat(
+            isRenderedTargetPinnedAboveBottomContent(
+                distanceFromViewportEnd = -48,
+                bottomContentPaddingPx = 0,
+                bottomPinThresholdPx = 48,
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `given target bottom is far below viewport end, when checking pin state, then target is not pinned`() {
+        assertThat(
+            isRenderedTargetPinnedAboveBottomContent(
+                distanceFromViewportEnd = -49,
+                bottomContentPaddingPx = 0,
+                bottomPinThresholdPx = 48,
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `given target bottom is far above viewport end, when checking pin state, then target is pinned`() {
+        assertThat(
+            isRenderedTargetPinnedAboveBottomContent(
+                distanceFromViewportEnd = 49,
+                bottomContentPaddingPx = 0,
+                bottomPinThresholdPx = 48,
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `given target bottom is under composer, when checking pin state, then target is not pinned`() {
+        assertThat(
+            isRenderedTargetPinnedAboveBottomContent(
+                distanceFromViewportEnd = 0,
+                bottomContentPaddingPx = 160,
+                bottomPinThresholdPx = 48,
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `given target bottom reaches visible end above composer, when checking pin state, then target is pinned`() {
+        assertThat(
+            isRenderedTargetPinnedAboveBottomContent(
+                distanceFromViewportEnd = 160,
+                bottomContentPaddingPx = 160,
+                bottomPinThresholdPx = 48,
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `given target bottom is hidden by composer, when computing reveal delta, then reveal delta is returned`() {
+        assertThat(
+            scrollDeltaToRevealTargetAboveBottomContent(
+                distanceFromViewportEnd = 0,
+                bottomContentPaddingPx = 160,
+            )
+        ).isEqualTo(160f)
+    }
+
+    @Test
+    fun `given target bottom is already above composer, when computing reveal delta, then content does not scroll`() {
+        assertThat(
+            scrollDeltaToRevealTargetAboveBottomContent(
+                distanceFromViewportEnd = 180,
+                bottomContentPaddingPx = 160,
+            )
+        ).isEqualTo(0f)
+    }
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantThreadFollowStateTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantThreadFollowStateTest.kt
@@ -1,0 +1,116 @@
+package com.woocommerce.android.aiassistant.ui.scroll
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AssistantThreadFollowStateTest {
+    @Test
+    fun `given no visible lazy items, when resolving viewport follow state, then observation is not consumed`() {
+        val result = resolveAssistantThreadFollowState(
+            viewport = viewportState(hasVisibleItems = false),
+            isProgrammaticScrollInProgress = false,
+            current = followState(
+                autoFollowEnabled = true,
+                hasObservedNonEmptyViewport = false,
+            ),
+        )
+
+        assertThat(result.autoFollowEnabled).isTrue()
+        assertThat(result.hasObservedNonEmptyViewport).isFalse()
+    }
+
+    @Test
+    fun `given restored viewport is off bottom, when resolving follow state, then auto follow is disabled`() {
+        val result = resolveAssistantThreadFollowState(
+            viewport = viewportState(isPinnedToEnd = false),
+            isProgrammaticScrollInProgress = false,
+            current = followState(
+                autoFollowEnabled = true,
+                hasObservedNonEmptyViewport = false,
+            ),
+        )
+
+        assertThat(result.autoFollowEnabled).isFalse()
+        assertThat(result.hasObservedNonEmptyViewport).isTrue()
+    }
+
+    @Test
+    fun `given programmatic scroll is in progress, when viewport is not pinned, then auto follow stays enabled`() {
+        val result = resolveAssistantThreadFollowState(
+            viewport = viewportState(
+                isPinnedToEnd = false,
+                isScrollInProgress = true,
+            ),
+            isProgrammaticScrollInProgress = true,
+            current = followState(
+                autoFollowEnabled = true,
+                hasObservedNonEmptyViewport = true,
+            ),
+        )
+
+        assertThat(result.autoFollowEnabled).isTrue()
+        assertThat(result.hasObservedNonEmptyViewport).isTrue()
+    }
+
+    @Test
+    fun `given following and viewport shrinks off latest, when checking correction, then snap to latest`() {
+        val shouldSnap = shouldSnapToLatestAfterViewportChange(
+            viewport = viewportState(isPinnedToEnd = false),
+            followState = followState(
+                autoFollowEnabled = true,
+                hasObservedNonEmptyViewport = true,
+            ),
+        )
+
+        assertThat(shouldSnap).isTrue()
+    }
+
+    @Test
+    fun `given restored viewport has not been observed, when checking correction, then do not snap to latest`() {
+        val shouldSnap = shouldSnapToLatestAfterViewportChange(
+            viewport = viewportState(isPinnedToEnd = false),
+            followState = followState(
+                autoFollowEnabled = true,
+                hasObservedNonEmptyViewport = false,
+            ),
+        )
+
+        assertThat(shouldSnap).isFalse()
+    }
+
+    @Test
+    fun `given user scroll is active, when checking correction, then do not snap to latest`() {
+        val shouldSnap = shouldSnapToLatestAfterViewportChange(
+            viewport = viewportState(
+                isPinnedToEnd = false,
+                isScrollInProgress = true,
+            ),
+            followState = followState(
+                autoFollowEnabled = true,
+                hasObservedNonEmptyViewport = true,
+            ),
+        )
+
+        assertThat(shouldSnap).isFalse()
+    }
+
+    private fun viewportState(
+        renderedItemCount: Int = 4,
+        hasVisibleItems: Boolean = true,
+        isPinnedToEnd: Boolean = true,
+        isScrollInProgress: Boolean = false,
+    ) = AssistantThreadViewportState(
+        renderedItemCount = renderedItemCount,
+        hasVisibleItems = hasVisibleItems,
+        isPinnedToEnd = isPinnedToEnd,
+        isScrollInProgress = isScrollInProgress,
+    )
+
+    private fun followState(
+        autoFollowEnabled: Boolean,
+        hasObservedNonEmptyViewport: Boolean,
+    ) = AssistantThreadFollowState(
+        autoFollowEnabled = autoFollowEnabled,
+        hasObservedNonEmptyViewport = hasObservedNonEmptyViewport,
+    )
+}

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantThreadScrollPolicyTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/ui/scroll/AssistantThreadScrollPolicyTest.kt
@@ -1,0 +1,241 @@
+package com.woocommerce.android.aiassistant.ui.scroll
+
+import com.woocommerce.android.aiassistant.ui.AssistantUiMessage
+import com.woocommerce.android.aiassistant.ui.AssistantUiSegment
+import com.woocommerce.android.aiassistant.ui.AssistantUiState
+import com.woocommerce.android.aiassistant.ui.AssistantUiStatus
+import com.woocommerce.android.aiassistant.ui.cards.AssistantCard
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class AssistantThreadScrollPolicyTest {
+    @Test
+    fun `given no previous signal, when content is non-empty, then decision is none`() {
+        val current = assistantSignal(renderedItemCount = 2)
+
+        val decision = decideAssistantThreadScroll(
+            previous = null,
+            current = current,
+            autoFollowEnabled = true,
+        )
+
+        assertThat(decision).isEqualTo(AssistantThreadScrollDecision.None)
+    }
+
+    @Test
+    fun `given same signal, when comparing, then decision is none`() {
+        val current = assistantSignal(lastMessageTextLength = 12)
+
+        val decision = decideAssistantThreadScroll(
+            previous = current,
+            current = current,
+            autoFollowEnabled = true,
+        )
+
+        assertThat(decision).isEqualTo(AssistantThreadScrollDecision.None)
+    }
+
+    @Test
+    fun `given new user message, when auto follow is disabled, then decision animates to latest`() {
+        val previous = userSignal(lastMessageId = "user-1", lastUserMessageId = "user-1")
+        val current = userSignal(lastMessageId = "user-2", lastUserMessageId = "user-2")
+
+        val decision = decideAssistantThreadScroll(
+            previous = previous,
+            current = current,
+            autoFollowEnabled = false,
+        )
+
+        assertThat(decision).isEqualTo(AssistantThreadScrollDecision.AnimateToLatest)
+    }
+
+    @Test
+    fun `given new assistant message while following, when comparing, then decision animates to latest`() {
+        val previous = userSignal(lastMessageId = "user-1", lastUserMessageId = "user-1")
+        val current = assistantSignal(
+            lastMessageId = "assistant-1",
+            lastUserMessageId = "user-1",
+        )
+
+        val decision = decideAssistantThreadScroll(
+            previous = previous,
+            current = current,
+            autoFollowEnabled = true,
+        )
+
+        assertThat(decision).isEqualTo(AssistantThreadScrollDecision.AnimateToLatest)
+    }
+
+    @Test
+    fun `given auto follow disabled, when assistant text grows, then decision is none`() {
+        val previous = assistantSignal(lastMessageTextLength = 6)
+        val current = assistantSignal(lastMessageTextLength = 24)
+
+        val decision = decideAssistantThreadScroll(
+            previous = previous,
+            current = current,
+            autoFollowEnabled = false,
+        )
+
+        assertThat(decision).isEqualTo(AssistantThreadScrollDecision.None)
+    }
+
+    @Test
+    fun `given auto follow enabled, when assistant text grows, then decision snaps to latest`() {
+        val previous = assistantSignal(lastMessageTextLength = 6)
+        val current = assistantSignal(lastMessageTextLength = 24)
+
+        val decision = decideAssistantThreadScroll(
+            previous = previous,
+            current = current,
+            autoFollowEnabled = true,
+        )
+
+        assertThat(decision).isEqualTo(AssistantThreadScrollDecision.SnapToLatest)
+    }
+
+    @Test
+    fun `given streaming finishes and cards are revealed, when following, then decision animates to latest`() {
+        val previous = assistantSignal(
+            lastMessageSegmentCount = 1,
+            status = AssistantUiStatus.STREAMING,
+            activeAssistantMessageId = "assistant-1",
+        )
+        val current = assistantSignal(
+            lastMessageSegmentCount = 2,
+            status = AssistantUiStatus.IDLE,
+            activeAssistantMessageId = null,
+        )
+
+        val decision = decideAssistantThreadScroll(
+            previous = previous,
+            current = current,
+            autoFollowEnabled = true,
+        )
+
+        assertThat(decision).isEqualTo(AssistantThreadScrollDecision.AnimateToLatest)
+    }
+
+    @Test
+    fun `given confirmation becomes active, when following, then decision animates to latest`() {
+        val previous = assistantSignal(activeConfirmationId = null)
+        val current = assistantSignal(activeConfirmationId = "confirmation-1")
+
+        val decision = decideAssistantThreadScroll(
+            previous = previous,
+            current = current,
+            autoFollowEnabled = true,
+        )
+
+        assertThat(decision).isEqualTo(AssistantThreadScrollDecision.AnimateToLatest)
+    }
+
+    @Test
+    fun `given confirmation resolves while not following, when comparing, then decision is none`() {
+        val previous = assistantSignal(activeConfirmationId = "confirmation-1")
+        val current = assistantSignal(activeConfirmationId = null)
+
+        val decision = decideAssistantThreadScroll(
+            previous = previous,
+            current = current,
+            autoFollowEnabled = false,
+        )
+
+        assertThat(decision).isEqualTo(AssistantThreadScrollDecision.None)
+    }
+
+    @Test
+    fun `given cards are visible at idle, when computing signal, then ordered segment count includes cards`() {
+        val message = assistantMessage(
+            AssistantUiSegment.Text("Here are recent orders."),
+            AssistantUiSegment.CardGroup(listOf(orderCard())),
+        )
+        val state = AssistantUiState(
+            messages = listOf(message),
+            status = AssistantUiStatus.IDLE,
+        )
+
+        val signal = state.messages.toThreadScrollSignal(
+            state = state,
+            showTypingIndicator = false,
+        )
+
+        assertThat(signal.renderedItemCount).isEqualTo(1)
+        assertThat(signal.lastMessageSegmentCount).isEqualTo(2)
+        assertThat(signal.lastMessageTextLength).isEqualTo("Here are recent orders.".length)
+    }
+
+    @Test
+    fun `given cards are hidden during streaming, when computing signal, then active assistant fields are populated`() {
+        val message = assistantMessage(
+            AssistantUiSegment.Text("Loading"),
+            AssistantUiSegment.CardGroup(listOf(orderCard())),
+        )
+        val state = AssistantUiState(
+            messages = listOf(message),
+            status = AssistantUiStatus.STREAMING,
+            activeAssistantMessageId = message.id,
+        )
+
+        val signal = state.messages.toThreadScrollSignal(
+            state = state,
+            showTypingIndicator = true,
+        )
+
+        assertThat(signal.renderedItemCount).isEqualTo(2)
+        assertThat(signal.lastMessageSegmentCount).isEqualTo(1)
+        assertThat(signal.activeAssistantMessageId).isEqualTo(message.id)
+        assertThat(signal.showTypingIndicator).isTrue()
+    }
+
+    private fun userSignal(
+        lastMessageId: String = "user-1",
+        lastUserMessageId: String = "user-1",
+    ) = assistantSignal(
+        lastMessageId = lastMessageId,
+        lastMessageRole = AssistantUiMessage.Role.USER,
+        lastUserMessageId = lastUserMessageId,
+        lastMessageTextLength = 12,
+    )
+
+    private fun assistantSignal(
+        renderedItemCount: Int = 1,
+        lastMessageId: String = "assistant-1",
+        lastMessageRole: AssistantUiMessage.Role = AssistantUiMessage.Role.ASSISTANT,
+        lastUserMessageId: String? = "user-1",
+        lastMessageSegmentCount: Int = 1,
+        lastMessageTextLength: Int = 12,
+        status: AssistantUiStatus = AssistantUiStatus.IDLE,
+        activeAssistantMessageId: String? = null,
+        activeConfirmationId: String? = null,
+        showTypingIndicator: Boolean = false,
+    ) = AssistantThreadScrollSignal(
+        renderedItemCount = renderedItemCount,
+        messageCount = renderedItemCount,
+        lastMessageId = lastMessageId,
+        lastMessageRole = lastMessageRole,
+        lastUserMessageId = lastUserMessageId,
+        lastMessageSegmentCount = lastMessageSegmentCount,
+        lastMessageTextLength = lastMessageTextLength,
+        activeAssistantMessageId = activeAssistantMessageId,
+        activeConfirmationId = activeConfirmationId,
+        status = status,
+        showTypingIndicator = showTypingIndicator,
+    )
+
+    private fun assistantMessage(vararg segments: AssistantUiSegment) = AssistantUiMessage(
+        id = "assistant-1",
+        role = AssistantUiMessage.Role.ASSISTANT,
+        segments = segments.toList(),
+    )
+
+    private fun orderCard() = AssistantCard.Order(
+        remoteOrderId = 1L,
+        number = "#1",
+        status = "processing",
+        total = "12.34",
+        currency = "USD",
+        customerName = "Jane Doe",
+        date = "2026-05-01T10:00:00Z",
+    )
+}


### PR DESCRIPTION
### Description
Fixes WOOMOB-3049

The Assistant conversation could lose track of whether the latest rendered content was actually visible when the floating composer and keyboard added bottom padding. That made the jump-to-latest button appear when the thread was already effectively at the latest item, and disappear when the latest content was still hidden under the composer.

This updates the Assistant thread scroll behavior to account for the floating composer padding when detecting the bottom position and when scrolling to the latest item. It also extracts the scroll behavior into a dedicated `ui.scroll` package with separate policy, follow-state, and geometry helpers so the behavior is easier to reason about and test.

### Test Steps
1. Build and install the Wasabi debug app.
2. Sign in to a store where Assistant is available.
3. Open Assistant and ask for recent orders so the response includes enough content to scroll.
4. Focus the composer to show the keyboard and verify the latest content remains visible above the floating composer when already following the thread.
5. Scroll upward and verify the jump-to-latest button appears.
6. Tap the jump-to-latest button and verify the latest content scrolls above the floating composer and the button hides.
7. Dismiss and reopen the keyboard while at the latest content and verify the thread stays pinned without showing the jump-to-latest button unnecessarily.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.