### PR TITLE
[RSM-3059] Add Woo push notification shared state foundation

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.woocommerce.android.R
@@ -21,6 +22,9 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class NotificationSettingsFragment : BaseFragment() {
     private val viewModel: NotificationSettingsViewModel by viewModels()
+    private val sharedViewModel: NotificationSettingsSharedViewModel by hiltNavGraphViewModels(
+        R.id.nav_graph_notification_settings
+    )
     private val navArgs: NotificationSettingsFragmentArgs by navArgs()
 
     @Inject
@@ -30,10 +34,14 @@ class NotificationSettingsFragment : BaseFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
-            NotificationSettingsScreen(
-                viewModel = viewModel,
-                showSmarterNotifications = navArgs.showSmarterNotifications
-            )
+            if (navArgs.showSmarterNotifications) {
+                WooPushNotificationSettingsScreen(
+                    viewModel = viewModel,
+                    sharedViewModel = sharedViewModel
+                )
+            } else {
+                NotificationSettingsScreen(viewModel = viewModel)
+            }
         }
     }
 
@@ -51,10 +59,22 @@ class NotificationSettingsFragment : BaseFragment() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is NotificationSettingsViewModel.OpenDeviceNotificationSettings -> openDeviceNotificationSettings()
-                is NotificationSettingsViewModel.OpenNewOrderNotificationSettings -> openNewOrderNotificationSettings()
-                is NotificationSettingsViewModel.OpenNewReviewNotificationSettings ->
+                is MultiLiveEvent.Event.ShowActionStringSnackbar -> uiMessageResolver.showActionSnack(
+                    event.message,
+                    event.actionText,
+                    event.action
+                )
+            }
+        }
+        if (!navArgs.showSmarterNotifications) return
+
+        sharedViewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is NotificationSettingsSharedViewModel.OpenNewOrderNotificationSettings ->
+                    openNewOrderNotificationSettings()
+                is NotificationSettingsSharedViewModel.OpenNewReviewNotificationSettings ->
                     openNewReviewNotificationSettings()
-                is NotificationSettingsViewModel.OpenStockNotificationSettings -> openStockNotificationSettings()
+                is NotificationSettingsSharedViewModel.OpenStockNotificationSettings -> openStockNotificationSettings()
                 is MultiLiveEvent.Event.ShowActionStringSnackbar -> uiMessageResolver.showActionSnack(
                     event.message,
                     event.actionText,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsScreen.kt
@@ -4,142 +4,29 @@ import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.LinkAnnotation
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.woocommerce.android.R
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
-import com.woocommerce.android.ui.compose.component.WCSwitch
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsViewModel.NotificationType
-import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsViewModel.NotificationTypeItem
 
 @Composable
-fun NotificationSettingsScreen(
-    viewModel: NotificationSettingsViewModel,
-    showSmarterNotifications: Boolean
-) {
-    if (showSmarterNotifications) {
-        viewModel.notificationTypeItems.observeAsState().value?.let {
-            val isAppNotificationsEnabled = viewModel.isAppNotificationsEnabled.observeAsState(initial = true).value
-
-            SmarterNotificationSettingsScreen(
-                items = it,
-                isAppNotificationsEnabled = isAppNotificationsEnabled,
-                onNotificationTypeEnabledChanged = viewModel::onNotificationTypeEnabledChanged,
-                onNotificationTypeClicked = viewModel::onNotificationTypeClicked,
-                onDeviceNotificationSettingsClicked = viewModel::onDeviceNotificationSettingsClicked
-            )
-        }
-    } else {
-        viewModel.newOrderNotificationSoundStatus.observeAsState().value?.let {
-            NotificationSettingsScreen(
-                orderNotificationSoundStatus = it,
-                onDeviceNotificationSettingsClicked = viewModel::onDeviceNotificationSettingsClicked,
-                onEnableChaChingSoundClicked = viewModel::onEnableChaChingSoundClicked
-            )
-        }
-    }
-}
-
-@Composable
-private fun SmarterNotificationSettingsScreen(
-    items: List<NotificationTypeItem>,
-    isAppNotificationsEnabled: Boolean,
-    onNotificationTypeEnabledChanged: (NotificationType, Boolean) -> Unit,
-    onNotificationTypeClicked: (NotificationType) -> Unit,
-    onDeviceNotificationSettingsClicked: () -> Unit
-) {
-    Scaffold(containerColor = MaterialTheme.colorScheme.surface) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(paddingValues)
-                .verticalScroll(rememberScrollState())
-        ) {
-            items.forEach { item ->
-                NotificationTypeRow(
-                    item = item,
-                    onEnabledChanged = onNotificationTypeEnabledChanged,
-                    onClick = onNotificationTypeClicked,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-            AnimatedVisibility(visible = !isAppNotificationsEnabled) {
-                SystemNotificationsDisabledWarning(
-                    onClick = onDeviceNotificationSettingsClicked,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun SystemNotificationsDisabledWarning(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier
-            .clickable(onClick = onClick)
-            .padding(16.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_warning_filled_24dp),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(24.dp)
-        )
-
-        val textValue = stringResource(id = R.string.settings_notifs_app_notifications_disabled_warning)
-        val textColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.87f)
-        val highlightedTextStyle = SpanStyle(
-            color = MaterialTheme.colorScheme.primary
-        )
-        val warningText = remember(textValue, highlightedTextStyle) {
-            AnnotatedString.fromHtml(textValue).flatMapAnnotations { range ->
-                if (range.item is LinkAnnotation) {
-                    listOf(AnnotatedString.Range(highlightedTextStyle, range.start, range.end))
-                } else {
-                    listOf(range)
-                }
-            }
-        }
-        Text(
-            text = warningText,
-            style = MaterialTheme.typography.bodySmall,
-            color = textColor,
-            modifier = Modifier.weight(1f)
+fun NotificationSettingsScreen(viewModel: NotificationSettingsViewModel) {
+    viewModel.newOrderNotificationSoundStatus.observeAsState().value?.let {
+        NotificationSettingsScreen(
+            orderNotificationSoundStatus = it,
+            onDeviceNotificationSettingsClicked = viewModel::onDeviceNotificationSettingsClicked,
+            onEnableChaChingSoundClicked = viewModel::onEnableChaChingSoundClicked
         )
     }
 }
@@ -181,54 +68,6 @@ private fun NotificationSettingsScreen(
 }
 
 @Composable
-private fun NotificationTypeRow(
-    item: NotificationTypeItem,
-    onEnabledChanged: (NotificationType, Boolean) -> Unit,
-    onClick: (NotificationType) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier
-            .height(IntrinsicSize.Min)
-            .padding(top = 8.dp)
-            .fillMaxWidth()
-            .clickable { onClick(item.type) },
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                .padding(horizontal = 16.dp, vertical = 8.dp)
-        ) {
-            Text(
-                text = stringResource(id = item.title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            Text(
-                text = stringResource(id = item.subtitle),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 2.dp)
-            )
-        }
-        Spacer(modifier = Modifier.width(16.dp))
-        WCSwitch(
-            checked = item.isEnabled,
-            onCheckedChange = { onEnabledChanged(item.type, it) }
-        )
-        Spacer(modifier = Modifier.width(16.dp))
-        Icon(
-            painter = painterResource(id = R.drawable.ic_chevron_right_24dp),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(24.dp)
-        )
-        Spacer(modifier = Modifier.width(16.dp))
-    }
-}
-
-@Composable
 private fun NotificationSettingsItem(
     title: String,
     subtitle: String,
@@ -253,40 +92,6 @@ private fun NotificationSettingsItem(
 
 private val NewOrderNotificationSoundStatus.requiresAttention: Boolean
     get() = this != NewOrderNotificationSoundStatus.DEFAULT
-
-@Composable
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
-private fun SmarterNotificationSettingsScreenPreview() {
-    WooThemeWithBackground {
-        SmarterNotificationSettingsScreen(
-            items = listOf(
-                NotificationTypeItem(
-                    type = NotificationType.NEW_ORDERS,
-                    title = R.string.settings_notifs_new_orders,
-                    subtitle = R.string.settings_notifs_new_orders_subtitle,
-                    isEnabled = true
-                ),
-                NotificationTypeItem(
-                    type = NotificationType.NEW_REVIEWS,
-                    title = R.string.settings_notifs_new_reviews,
-                    subtitle = R.string.settings_notifs_new_reviews_subtitle,
-                    isEnabled = true
-                ),
-                NotificationTypeItem(
-                    type = NotificationType.STOCK,
-                    title = R.string.settings_notifs_stock,
-                    subtitle = R.string.settings_notifs_stock_subtitle,
-                    isEnabled = true
-                )
-            ),
-            isAppNotificationsEnabled = false,
-            onNotificationTypeEnabledChanged = { _, _ -> },
-            onNotificationTypeClicked = {},
-            onDeviceNotificationSettingsClicked = {}
-        )
-    }
-}
 
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -1,0 +1,159 @@
+package com.woocommerce.android.ui.prefs.notifications
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import com.woocommerce.android.R
+import com.woocommerce.android.notifications.push.PushNotificationRepository
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.viewmodel.MultiLiveEvent
+import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.android.viewmodel.ScopedViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences
+import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreOrderPreferences
+import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreReviewPreferences
+import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreStockPreferences
+import javax.inject.Inject
+
+@HiltViewModel
+class NotificationSettingsSharedViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    selectedSite: SelectedSite,
+    private val pushNotificationRepository: PushNotificationRepository,
+    private val resourceProvider: ResourceProvider
+) : ScopedViewModel(savedStateHandle) {
+    private val wooPushNotificationPreferences = MutableStateFlow<WooPushNotificationPreferences?>(null)
+    private val _isNotificationSettingsLoading = MutableStateFlow(true)
+    val isNotificationSettingsLoading = _isNotificationSettingsLoading.asLiveData()
+    private val _isNotificationTypeSelectionEnabled = MutableStateFlow(false)
+    val isNotificationTypeSelectionEnabled = _isNotificationTypeSelectionEnabled.asLiveData()
+
+    private val _notificationTypeItems = MutableStateFlow(
+        listOf(
+            NotificationTypeItem(
+                type = NotificationType.NEW_ORDERS,
+                title = R.string.settings_notifs_new_orders,
+                subtitle = R.string.settings_notifs_new_orders_subtitle,
+                isEnabled = true
+            ),
+            NotificationTypeItem(
+                type = NotificationType.NEW_REVIEWS,
+                title = R.string.settings_notifs_new_reviews,
+                subtitle = R.string.settings_notifs_new_reviews_subtitle,
+                isEnabled = true
+            ),
+            NotificationTypeItem(
+                type = NotificationType.STOCK,
+                title = R.string.settings_notifs_stock,
+                subtitle = R.string.settings_notifs_stock_subtitle,
+                isEnabled = true
+            )
+        )
+    )
+    val notificationTypeItems = _notificationTypeItems.asLiveData()
+
+    init {
+        val site = selectedSite.get()
+        observeWooPushNotificationPreferences(site)
+        fetchWooPushNotificationPreferences(site)
+    }
+
+    fun onNotificationTypeEnabledChanged(type: NotificationType, isEnabled: Boolean) {
+        val preferences = wooPushNotificationPreferences.value ?: return
+        val updatedPreferences = when (type) {
+            NotificationType.NEW_ORDERS -> preferences.copy(
+                storeOrder = (preferences.storeOrder ?: StoreOrderPreferences()).copy(enabled = isEnabled)
+            )
+            NotificationType.NEW_REVIEWS -> preferences.copy(
+                storeReview = (preferences.storeReview ?: StoreReviewPreferences()).copy(enabled = isEnabled)
+            )
+            NotificationType.STOCK -> preferences.copy(
+                storeStock = (preferences.storeStock ?: StoreStockPreferences()).copy(enabled = isEnabled)
+            )
+        }
+
+        applyWooPushNotificationPreferences(updatedPreferences)
+    }
+
+    fun onNotificationTypeClicked(type: NotificationType) {
+        when (type) {
+            NotificationType.NEW_ORDERS -> triggerEvent(OpenNewOrderNotificationSettings)
+            NotificationType.NEW_REVIEWS -> triggerEvent(OpenNewReviewNotificationSettings)
+            NotificationType.STOCK -> triggerEvent(OpenStockNotificationSettings)
+        }
+    }
+
+    private fun observeWooPushNotificationPreferences(site: SiteModel) {
+        launch {
+            pushNotificationRepository.observeWooNotificationPreferences(site)
+                .collect { preferences ->
+                    preferences?.let {
+                        applyWooPushNotificationPreferences(it)
+                        _isNotificationSettingsLoading.value = false
+                    }
+                }
+        }
+    }
+
+    private fun fetchWooPushNotificationPreferences(site: SiteModel) {
+        launch {
+            try {
+                pushNotificationRepository.fetchWooNotificationPreferences(site)
+                    .onSuccess { applyWooPushNotificationPreferences(it) }
+                    .onFailure { showFetchError(site) }
+            } finally {
+                _isNotificationSettingsLoading.value = false
+            }
+        }
+    }
+
+    private fun showFetchError(site: SiteModel) {
+        triggerEvent(
+            MultiLiveEvent.Event.ShowActionStringSnackbar(
+                message = resourceProvider.getString(R.string.settings_notifs_error_fetch),
+                actionText = resourceProvider.getString(R.string.retry),
+            ) {
+                fetchWooPushNotificationPreferences(site)
+            }
+        )
+    }
+
+    private fun applyWooPushNotificationPreferences(preferences: WooPushNotificationPreferences) {
+        wooPushNotificationPreferences.value = preferences
+        _isNotificationTypeSelectionEnabled.value = true
+        _notificationTypeItems.update { items ->
+            items.map { item ->
+                item.copy(isEnabled = preferences.isEnabled(item.type) ?: item.isEnabled)
+            }
+        }
+    }
+
+    private fun WooPushNotificationPreferences.isEnabled(type: NotificationType): Boolean? =
+        when (type) {
+            NotificationType.NEW_ORDERS -> storeOrder?.enabled
+            NotificationType.NEW_REVIEWS -> storeReview?.enabled
+            NotificationType.STOCK -> storeStock?.enabled
+        }
+
+    object OpenNewOrderNotificationSettings : MultiLiveEvent.Event()
+    object OpenNewReviewNotificationSettings : MultiLiveEvent.Event()
+    object OpenStockNotificationSettings : MultiLiveEvent.Event()
+
+    data class NotificationTypeItem(
+        val type: NotificationType,
+        @StringRes val title: Int,
+        @StringRes val subtitle: Int,
+        val isEnabled: Boolean
+    )
+
+    enum class NotificationType {
+        NEW_ORDERS,
+        STOCK,
+        NEW_REVIEWS
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsViewModel.kt
@@ -1,6 +1,5 @@
 package com.woocommerce.android.ui.prefs.notifications
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
@@ -16,7 +15,6 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
@@ -37,46 +35,6 @@ class NotificationSettingsViewModel @Inject constructor(
 
     private val _isAppNotificationsEnabled = MutableStateFlow(wooNotificationBuilder.isNotificationsEnabled())
     val isAppNotificationsEnabled = _isAppNotificationsEnabled.asLiveData()
-
-    private val _notificationTypeItems = MutableStateFlow(
-        listOf(
-            NotificationTypeItem(
-                type = NotificationType.NEW_ORDERS,
-                title = R.string.settings_notifs_new_orders,
-                subtitle = R.string.settings_notifs_new_orders_subtitle,
-                isEnabled = true
-            ),
-            NotificationTypeItem(
-                type = NotificationType.NEW_REVIEWS,
-                title = R.string.settings_notifs_new_reviews,
-                subtitle = R.string.settings_notifs_new_reviews_subtitle,
-                isEnabled = true
-            ),
-            NotificationTypeItem(
-                type = NotificationType.STOCK,
-                title = R.string.settings_notifs_stock,
-                subtitle = R.string.settings_notifs_stock_subtitle,
-                isEnabled = true
-            )
-        )
-    )
-    val notificationTypeItems = _notificationTypeItems.asLiveData()
-
-    fun onNotificationTypeEnabledChanged(type: NotificationType, isEnabled: Boolean) {
-        _notificationTypeItems.update { items ->
-            items.map {
-                if (it.type == type) it.copy(isEnabled = isEnabled) else it
-            }
-        }
-    }
-
-    fun onNotificationTypeClicked(type: NotificationType) {
-        when (type) {
-            NotificationType.NEW_ORDERS -> triggerEvent(OpenNewOrderNotificationSettings)
-            NotificationType.NEW_REVIEWS -> triggerEvent(OpenNewReviewNotificationSettings)
-            NotificationType.STOCK -> triggerEvent(OpenStockNotificationSettings)
-        }
-    }
 
     fun onDeviceNotificationSettingsClicked() {
         triggerEvent(OpenDeviceNotificationSettings)
@@ -114,20 +72,4 @@ class NotificationSettingsViewModel @Inject constructor(
     }
 
     object OpenDeviceNotificationSettings : MultiLiveEvent.Event()
-    object OpenNewOrderNotificationSettings : MultiLiveEvent.Event()
-    object OpenNewReviewNotificationSettings : MultiLiveEvent.Event()
-    object OpenStockNotificationSettings : MultiLiveEvent.Event()
-
-    data class NotificationTypeItem(
-        val type: NotificationType,
-        @StringRes val title: Int,
-        @StringRes val subtitle: Int,
-        val isEnabled: Boolean
-    )
-
-    enum class NotificationType {
-        NEW_ORDERS,
-        STOCK,
-        NEW_REVIEWS
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/WooPushNotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/WooPushNotificationSettingsScreen.kt
@@ -1,0 +1,238 @@
+package com.woocommerce.android.ui.prefs.notifications
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.unit.dp
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.compose.component.WCSwitch
+import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
+import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NotificationType
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NotificationTypeItem
+
+@Composable
+fun WooPushNotificationSettingsScreen(
+    viewModel: NotificationSettingsViewModel,
+    sharedViewModel: NotificationSettingsSharedViewModel
+) {
+    sharedViewModel.notificationTypeItems.observeAsState().value?.let {
+        val isAppNotificationsEnabled = viewModel.isAppNotificationsEnabled.observeAsState(initial = true).value
+        val isNotificationSettingsLoading =
+            sharedViewModel.isNotificationSettingsLoading.observeAsState(initial = false).value
+        val isNotificationTypeSelectionEnabled =
+            sharedViewModel.isNotificationTypeSelectionEnabled.observeAsState(initial = false).value
+
+        WooPushNotificationSettingsScreen(
+            items = it,
+            isAppNotificationsEnabled = isAppNotificationsEnabled,
+            isNotificationSettingsLoading = isNotificationSettingsLoading,
+            isNotificationTypeSelectionEnabled = isNotificationTypeSelectionEnabled,
+            onNotificationTypeEnabledChanged = sharedViewModel::onNotificationTypeEnabledChanged,
+            onNotificationTypeClicked = sharedViewModel::onNotificationTypeClicked,
+            onDeviceNotificationSettingsClicked = viewModel::onDeviceNotificationSettingsClicked
+        )
+    }
+}
+
+@Composable
+private fun WooPushNotificationSettingsScreen(
+    items: List<NotificationTypeItem>,
+    isAppNotificationsEnabled: Boolean,
+    isNotificationSettingsLoading: Boolean,
+    isNotificationTypeSelectionEnabled: Boolean,
+    onNotificationTypeEnabledChanged: (NotificationType, Boolean) -> Unit,
+    onNotificationTypeClicked: (NotificationType) -> Unit,
+    onDeviceNotificationSettingsClicked: () -> Unit
+) {
+    Scaffold(containerColor = MaterialTheme.colorScheme.surface) { paddingValues ->
+        AnimatedVisibility(
+            visible = isNotificationSettingsLoading,
+            enter = slideInVertically(),
+            exit = slideOutVertically()
+        ) {
+            LinearProgressIndicator(
+                modifier = Modifier.fillMaxWidth(),
+                trackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.24f)
+            )
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+        ) {
+            items.forEach { item ->
+                NotificationTypeRow(
+                    item = item,
+                    onEnabledChanged = onNotificationTypeEnabledChanged,
+                    onClick = onNotificationTypeClicked,
+                    enabled = isNotificationTypeSelectionEnabled,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            AnimatedVisibility(visible = !isAppNotificationsEnabled) {
+                SystemNotificationsDisabledWarning(
+                    onClick = onDeviceNotificationSettingsClicked,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SystemNotificationsDisabledWarning(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .clickable(onClick = onClick)
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_warning_filled_24dp),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(24.dp)
+        )
+
+        val textValue = stringResource(id = R.string.settings_notifs_app_notifications_disabled_warning)
+        val textColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.87f)
+        val highlightedTextStyle = SpanStyle(
+            color = MaterialTheme.colorScheme.primary
+        )
+        val warningText = remember(textValue, highlightedTextStyle) {
+            AnnotatedString.fromHtml(textValue).flatMapAnnotations { range ->
+                if (range.item is LinkAnnotation) {
+                    listOf(AnnotatedString.Range(highlightedTextStyle, range.start, range.end))
+                } else {
+                    listOf(range)
+                }
+            }
+        }
+        Text(
+            text = warningText,
+            style = MaterialTheme.typography.bodySmall,
+            color = textColor,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun NotificationTypeRow(
+    item: NotificationTypeItem,
+    onEnabledChanged: (NotificationType, Boolean) -> Unit,
+    onClick: (NotificationType) -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .height(IntrinsicSize.Min)
+            .padding(top = 8.dp)
+            .fillMaxWidth()
+            .clickable(enabled = enabled) { onClick(item.type) },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            Text(
+                text = stringResource(id = item.title),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = stringResource(id = item.subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 2.dp)
+            )
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        WCSwitch(
+            checked = item.isEnabled,
+            onCheckedChange = { onEnabledChanged(item.type, it) },
+            enabled = enabled
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Icon(
+            painter = painterResource(id = R.drawable.ic_chevron_right_24dp),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(24.dp)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+    }
+}
+
+@Composable
+@LightDarkThemePreviews
+private fun WooPushNotificationSettingsScreenPreview() {
+    WooThemeWithBackground {
+        WooPushNotificationSettingsScreen(
+            items = listOf(
+                NotificationTypeItem(
+                    type = NotificationType.NEW_ORDERS,
+                    title = R.string.settings_notifs_new_orders,
+                    subtitle = R.string.settings_notifs_new_orders_subtitle,
+                    isEnabled = true
+                ),
+                NotificationTypeItem(
+                    type = NotificationType.NEW_REVIEWS,
+                    title = R.string.settings_notifs_new_reviews,
+                    subtitle = R.string.settings_notifs_new_reviews_subtitle,
+                    isEnabled = true
+                ),
+                NotificationTypeItem(
+                    type = NotificationType.STOCK,
+                    title = R.string.settings_notifs_stock,
+                    subtitle = R.string.settings_notifs_stock_subtitle,
+                    isEnabled = true
+                )
+            ),
+            isAppNotificationsEnabled = false,
+            isNotificationSettingsLoading = false,
+            isNotificationTypeSelectionEnabled = true,
+            onNotificationTypeEnabledChanged = { _, _ -> },
+            onNotificationTypeClicked = {},
+            onDeviceNotificationSettingsClicked = {}
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/WooPushNotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/WooPushNotificationSettingsScreen.kt
@@ -45,23 +45,21 @@ fun WooPushNotificationSettingsScreen(
     viewModel: NotificationSettingsViewModel,
     sharedViewModel: NotificationSettingsSharedViewModel
 ) {
-    sharedViewModel.notificationTypeItems.observeAsState().value?.let {
-        val isAppNotificationsEnabled = viewModel.isAppNotificationsEnabled.observeAsState(initial = true).value
-        val isNotificationSettingsLoading =
-            sharedViewModel.isNotificationSettingsLoading.observeAsState(initial = false).value
-        val isNotificationTypeSelectionEnabled =
-            sharedViewModel.isNotificationTypeSelectionEnabled.observeAsState(initial = false).value
+    val notificationTypeItems = sharedViewModel.notificationTypeItems.observeAsState().value ?: return
+    val isAppNotificationsEnabled = viewModel.isAppNotificationsEnabled.observeAsState().value ?: return
+    val isNotificationSettingsLoading = sharedViewModel.isNotificationSettingsLoading.observeAsState().value ?: return
+    val isNotificationTypeSelectionEnabled =
+        sharedViewModel.isNotificationTypeSelectionEnabled.observeAsState().value ?: return
 
-        WooPushNotificationSettingsScreen(
-            items = it,
-            isAppNotificationsEnabled = isAppNotificationsEnabled,
-            isNotificationSettingsLoading = isNotificationSettingsLoading,
-            isNotificationTypeSelectionEnabled = isNotificationTypeSelectionEnabled,
-            onNotificationTypeEnabledChanged = sharedViewModel::onNotificationTypeEnabledChanged,
-            onNotificationTypeClicked = sharedViewModel::onNotificationTypeClicked,
-            onDeviceNotificationSettingsClicked = viewModel::onDeviceNotificationSettingsClicked
-        )
-    }
+    WooPushNotificationSettingsScreen(
+        items = notificationTypeItems,
+        isAppNotificationsEnabled = isAppNotificationsEnabled,
+        isNotificationSettingsLoading = isNotificationSettingsLoading,
+        isNotificationTypeSelectionEnabled = isNotificationTypeSelectionEnabled,
+        onNotificationTypeEnabledChanged = sharedViewModel::onNotificationTypeEnabledChanged,
+        onNotificationTypeClicked = sharedViewModel::onNotificationTypeClicked,
+        onDeviceNotificationSettingsClicked = viewModel::onDeviceNotificationSettingsClicked
+    )
 }
 
 @Composable

--- a/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
+++ b/WooCommerce/src/main/res/navigation/nav_graph_settings.xml
@@ -50,7 +50,7 @@
         </action>
         <action
             android:id="@+id/action_mainSettingsFragment_to_notificationSettingsFragment"
-            app:destination="@id/notificationSettingsFragment" />
+            app:destination="@id/nav_graph_notification_settings" />
         <action
             android:id="@+id/action_mainSettingsFragment_to_pluginsFragment"
             app:destination="@id/pluginsFragment" />
@@ -203,36 +203,44 @@
             android:defaultValue="false"
             app:argType="boolean" />
     </dialog>
-    <fragment
-        android:id="@+id/notificationSettingsFragment"
-        android:name="com.woocommerce.android.ui.prefs.notifications.NotificationSettingsFragment"
-        android:label="NotificationSettingsFragment">
+    <navigation
+        android:id="@+id/nav_graph_notification_settings"
+        app:startDestination="@id/notificationSettingsFragment">
         <argument
             android:name="showSmarterNotifications"
             android:defaultValue="false"
             app:argType="boolean" />
-        <action
-            android:id="@+id/action_notificationSettingsFragment_to_newOrderNotificationSettingsFragment"
-            app:destination="@id/newOrderNotificationSettingsFragment" />
-        <action
-            android:id="@+id/action_notificationSettingsFragment_to_newReviewNotificationSettingsFragment"
-            app:destination="@id/newReviewNotificationSettingsFragment" />
-        <action
-            android:id="@+id/action_notificationSettingsFragment_to_newStockNotificationSettingsFragment"
-            app:destination="@id/newStockNotificationSettingsFragment" />
-    </fragment>
-    <fragment
-        android:id="@+id/newOrderNotificationSettingsFragment"
-        android:name="com.woocommerce.android.ui.prefs.notifications.NewOrderNotificationSettingsFragment"
-        android:label="NewOrderNotificationSettingsFragment" />
-    <fragment
-        android:id="@+id/newReviewNotificationSettingsFragment"
-        android:name="com.woocommerce.android.ui.prefs.notifications.NewReviewNotificationSettingsFragment"
-        android:label="NewReviewNotificationSettingsFragment" />
-    <fragment
-        android:id="@+id/newStockNotificationSettingsFragment"
-        android:name="com.woocommerce.android.ui.prefs.notifications.NewStockNotificationSettingsFragment"
-        android:label="NewStockNotificationSettingsFragment" />
+        <fragment
+            android:id="@+id/notificationSettingsFragment"
+            android:name="com.woocommerce.android.ui.prefs.notifications.NotificationSettingsFragment"
+            android:label="NotificationSettingsFragment">
+            <argument
+                android:name="showSmarterNotifications"
+                android:defaultValue="false"
+                app:argType="boolean" />
+            <action
+                android:id="@+id/action_notificationSettingsFragment_to_newOrderNotificationSettingsFragment"
+                app:destination="@id/newOrderNotificationSettingsFragment" />
+            <action
+                android:id="@+id/action_notificationSettingsFragment_to_newReviewNotificationSettingsFragment"
+                app:destination="@id/newReviewNotificationSettingsFragment" />
+            <action
+                android:id="@+id/action_notificationSettingsFragment_to_newStockNotificationSettingsFragment"
+                app:destination="@id/newStockNotificationSettingsFragment" />
+        </fragment>
+        <fragment
+            android:id="@+id/newOrderNotificationSettingsFragment"
+            android:name="com.woocommerce.android.ui.prefs.notifications.NewOrderNotificationSettingsFragment"
+            android:label="NewOrderNotificationSettingsFragment" />
+        <fragment
+            android:id="@+id/newReviewNotificationSettingsFragment"
+            android:name="com.woocommerce.android.ui.prefs.notifications.NewReviewNotificationSettingsFragment"
+            android:label="NewReviewNotificationSettingsFragment" />
+        <fragment
+            android:id="@+id/newStockNotificationSettingsFragment"
+            android:name="com.woocommerce.android.ui.prefs.notifications.NewStockNotificationSettingsFragment"
+            android:label="NewStockNotificationSettingsFragment" />
+    </navigation>
     <fragment
         android:id="@+id/pluginsFragment"
         android:name="com.woocommerce.android.ui.prefs.plugins.PluginsFragment"

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -1,0 +1,231 @@
+package com.woocommerce.android.ui.prefs.notifications
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.notifications.push.PushNotificationRepository
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NotificationType
+import com.woocommerce.android.util.captureValues
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences
+import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreOrderPreferences
+import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreReviewPreferences
+import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreStockPreferences
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
+    private val selectedSite: SelectedSite = mock()
+    private val pushNotificationRepository: PushNotificationRepository = mock()
+    private val resourceProvider: ResourceProvider = mock {
+        on { getString(any()) } doAnswer { it.arguments[0].toString() }
+    }
+    private val site = SiteModel().apply { id = 123 }
+    private lateinit var notificationPreferencesFlow: MutableStateFlow<WooPushNotificationPreferences?>
+    private lateinit var viewModel: NotificationSettingsSharedViewModel
+
+    private suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
+        whenever(selectedSite.get()).thenReturn(site)
+        notificationPreferencesFlow = MutableStateFlow(null)
+        whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(
+            notificationPreferencesFlow
+        )
+        mockSuccessfulFetch(WooPushNotificationPreferences())
+        prepareMocks()
+        viewModel = NotificationSettingsSharedViewModel(
+            savedStateHandle = SavedStateHandle(),
+            selectedSite = selectedSite,
+            pushNotificationRepository = pushNotificationRepository,
+            resourceProvider = resourceProvider
+        )
+    }
+
+    private suspend fun mockSuccessfulFetch(preferences: WooPushNotificationPreferences) {
+        whenever(pushNotificationRepository.fetchWooNotificationPreferences(site)).doSuspendableAnswer {
+            notificationPreferencesFlow.value = preferences
+            Result.success(preferences)
+        }
+    }
+
+    @Test
+    fun `when view model is loaded, then expose notification type rows`() = testBlocking {
+        setup()
+
+        val notificationTypeItems = viewModel.notificationTypeItems.captureValues().last()
+
+        assertThat(notificationTypeItems.map { it.type }).containsExactly(
+            NotificationType.NEW_ORDERS,
+            NotificationType.NEW_REVIEWS,
+            NotificationType.STOCK
+        )
+    }
+
+    @Test
+    fun `when view model is loaded, then fetch notification preferences`() = testBlocking {
+        setup()
+
+        advanceUntilIdle()
+
+        verify(pushNotificationRepository).fetchWooNotificationPreferences(site)
+    }
+
+    @Test
+    fun `given no cached notification preferences, when fetch is in progress, then show loading`() =
+        testBlocking {
+            val fetchResult = CompletableDeferred<Result<WooPushNotificationPreferences>>()
+            setup {
+                whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(flowOf(null))
+                whenever(pushNotificationRepository.fetchWooNotificationPreferences(site)).doSuspendableAnswer {
+                    fetchResult.await()
+                }
+            }
+
+            val loadingValues = viewModel.isNotificationSettingsLoading.runAndCaptureValues {
+                advanceUntilIdle()
+            }
+
+            assertThat(loadingValues).contains(true)
+            assertThat(viewModel.isNotificationTypeSelectionEnabled.captureValues().last()).isFalse()
+
+            fetchResult.complete(Result.success(WooPushNotificationPreferences()))
+            advanceUntilIdle()
+
+            assertThat(viewModel.isNotificationSettingsLoading.captureValues().last()).isFalse()
+            assertThat(viewModel.isNotificationTypeSelectionEnabled.captureValues().last()).isTrue()
+        }
+
+    @Test
+    fun `given fetch fails, when retry is clicked, then fetch notification preferences again`() =
+        testBlocking {
+            var fetchFails = true
+            setup {
+                whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(flowOf(null))
+                whenever(pushNotificationRepository.fetchWooNotificationPreferences(site)).doSuspendableAnswer {
+                    if (fetchFails) {
+                        fetchFails = false
+                        Result.failure(Exception())
+                    } else {
+                        Result.success(WooPushNotificationPreferences())
+                    }
+                }
+            }
+
+            val event = viewModel.event.runAndCaptureValues {
+                advanceUntilIdle()
+            }.last()
+
+            val snackbar = event as Event.ShowActionStringSnackbar
+            assertThat(snackbar.message).isEqualTo(resourceProvider.getString(R.string.settings_notifs_error_fetch))
+            assertThat(snackbar.actionText).isEqualTo(resourceProvider.getString(R.string.retry))
+
+            snackbar.action.onClick(null)
+            advanceUntilIdle()
+
+            verify(pushNotificationRepository, times(2)).fetchWooNotificationPreferences(site)
+            assertThat(viewModel.isNotificationTypeSelectionEnabled.captureValues().last()).isTrue()
+        }
+
+    @Test
+    fun `given cached notification preferences, when fetch is in progress, then do not show loading`() =
+        testBlocking {
+            val fetchResult = CompletableDeferred<Result<WooPushNotificationPreferences>>()
+            setup {
+                whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(
+                    flowOf(WooPushNotificationPreferences(storeOrder = StoreOrderPreferences(enabled = false)))
+                )
+                whenever(pushNotificationRepository.fetchWooNotificationPreferences(site)).doSuspendableAnswer {
+                    fetchResult.await()
+                }
+            }
+
+            runCurrent()
+
+            assertThat(viewModel.isNotificationSettingsLoading.captureValues().last()).isFalse()
+            assertThat(viewModel.isNotificationTypeSelectionEnabled.captureValues().last()).isTrue()
+            assertThat(
+                viewModel.notificationTypeItems.captureValues().last()
+                    .first { it.type == NotificationType.NEW_ORDERS }
+                    .isEnabled
+            ).isFalse()
+
+            fetchResult.complete(Result.success(WooPushNotificationPreferences()))
+            advanceUntilIdle()
+        }
+
+    @Test
+    fun `given fetched notification preferences, when view is loaded, then expose notification type states`() =
+        testBlocking {
+            val fetchedPreferences = WooPushNotificationPreferences(
+                storeOrder = StoreOrderPreferences(enabled = false),
+                storeReview = StoreReviewPreferences(enabled = true),
+                storeStock = StoreStockPreferences(enabled = false)
+            )
+            setup {
+                mockSuccessfulFetch(fetchedPreferences)
+            }
+
+            advanceUntilIdle()
+
+            val notificationTypeItems = viewModel.notificationTypeItems.captureValues().last()
+
+            assertThat(notificationTypeItems.first { it.type == NotificationType.NEW_ORDERS }.isEnabled).isFalse()
+            assertThat(notificationTypeItems.first { it.type == NotificationType.NEW_REVIEWS }.isEnabled).isTrue()
+            assertThat(notificationTypeItems.first { it.type == NotificationType.STOCK }.isEnabled).isFalse()
+        }
+
+    @Test
+    fun `when new orders notification type is clicked, then open new orders settings`() = testBlocking {
+        setup()
+        advanceUntilIdle()
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onNotificationTypeClicked(NotificationType.NEW_ORDERS)
+        }.last()
+
+        assertThat(event).isInstanceOf(NotificationSettingsSharedViewModel.OpenNewOrderNotificationSettings::class.java)
+    }
+
+    @Test
+    fun `when new reviews notification type is clicked, then open new reviews settings`() = testBlocking {
+        setup()
+        advanceUntilIdle()
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onNotificationTypeClicked(NotificationType.NEW_REVIEWS)
+        }.last()
+
+        assertThat(event).isInstanceOf(
+            NotificationSettingsSharedViewModel.OpenNewReviewNotificationSettings::class.java
+        )
+    }
+
+    @Test
+    fun `when stock notification type is clicked, then open stock settings`() = testBlocking {
+        setup()
+        advanceUntilIdle()
+
+        val event = viewModel.event.runAndCaptureValues {
+            viewModel.onNotificationTypeClicked(NotificationType.STOCK)
+        }.last()
+
+        assertThat(event).isInstanceOf(NotificationSettingsSharedViewModel.OpenStockNotificationSettings::class.java)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsViewModelTest.kt
@@ -7,7 +7,6 @@ import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.ShowTestNotification
 import com.woocommerce.android.notifications.WooNotificationBuilder
-import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsViewModel.NotificationType
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -34,7 +33,7 @@ class NotificationSettingsViewModelTest : BaseUnitTest() {
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private lateinit var viewModel: NotificationSettingsViewModel
 
-    suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
+    fun setup(prepareMocks: () -> Unit = {}) {
         whenever(wooNotificationBuilder.isNotificationsEnabled()).thenReturn(true)
         prepareMocks()
         viewModel = NotificationSettingsViewModel(
@@ -170,73 +169,5 @@ class NotificationSettingsViewModelTest : BaseUnitTest() {
             channelType = NotificationChannelType.NEW_ORDER,
             dismissDelay = 10.seconds
         )
-    }
-
-    @Test
-    fun `when view is loaded, then expose notification type rows`() = testBlocking {
-        setup()
-
-        val notificationTypeItems = viewModel.notificationTypeItems.captureValues().last()
-
-        assertThat(notificationTypeItems.map { it.type }).containsExactly(
-            NotificationType.NEW_ORDERS,
-            NotificationType.NEW_REVIEWS,
-            NotificationType.STOCK
-        )
-    }
-
-    @Test
-    fun `when view is loaded, then all notification type switches are enabled`() = testBlocking {
-        setup()
-
-        val notificationTypeItems = viewModel.notificationTypeItems.captureValues().last()
-
-        assertThat(notificationTypeItems.map { it.isEnabled }).containsOnly(true)
-    }
-
-    @Test
-    fun `when notification type switch is changed, then update row state`() = testBlocking {
-        setup()
-
-        viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, false)
-
-        val notificationTypeItems = viewModel.notificationTypeItems.captureValues().last()
-
-        assertThat(
-            notificationTypeItems.first { it.type == NotificationType.STOCK }.isEnabled
-        ).isFalse()
-    }
-
-    @Test
-    fun `when new orders notification type is clicked, then open new orders settings`() = testBlocking {
-        setup()
-
-        val event = viewModel.event.runAndCaptureValues {
-            viewModel.onNotificationTypeClicked(NotificationType.NEW_ORDERS)
-        }.last()
-
-        assertThat(event).isInstanceOf(NotificationSettingsViewModel.OpenNewOrderNotificationSettings::class.java)
-    }
-
-    @Test
-    fun `when new reviews notification type is clicked, then open new reviews settings`() = testBlocking {
-        setup()
-
-        val event = viewModel.event.runAndCaptureValues {
-            viewModel.onNotificationTypeClicked(NotificationType.NEW_REVIEWS)
-        }.last()
-
-        assertThat(event).isInstanceOf(NotificationSettingsViewModel.OpenNewReviewNotificationSettings::class.java)
-    }
-
-    @Test
-    fun `when stock notification type is clicked, then open stock settings`() = testBlocking {
-        setup()
-
-        val event = viewModel.event.runAndCaptureValues {
-            viewModel.onNotificationTypeClicked(NotificationType.STOCK)
-        }.last()
-
-        assertThat(event).isInstanceOf(NotificationSettingsViewModel.OpenStockNotificationSettings::class.java)
     }
 }


### PR DESCRIPTION
### Description

Fixes RSM-3059

This PR adds the shared state foundation for Woo push notification settings.

It introduces a navigation graph scoped `NotificationSettingsSharedViewModel` that observes and fetches Woo push notification preferences, derives the parent notification row state from those preferences, and exposes loading and row enabled state for the parent screen.

It also moves the Woo push notification settings list into a dedicated `WooPushNotificationSettingsScreen`, keeps the notification sound screen separate, and places the notification settings destinations inside a nested nav graph so the shared ViewModel can be used by the parent and detail screens.

Parent row toggle persistence is not added in this PR. The next PR will add the update flow for those switches.

### Test Steps

1. Enable the `smarter_notifications` feature flag.
2. Open a Woo-driven site and go to Settings.
3. Tap `Notifications`.
4. Confirm the Woo push notification settings screen opens with `New orders`, `New reviews`, and `Stock` rows.
5. On a fresh install or after clearing app data, open the same screen and confirm the rows are disabled while preferences are loading.
6. Tap `New orders`, `New reviews`, and `Stock`, and confirm each row opens its detail screen.
7. Open a non-Woo-driven site, then go to Settings > Notifications.
8. Confirm the existing notification sound settings screen still opens and works as before.

### Images/gif

<img width="350" alt="Screenshot_20260514_000626" src="https://github.com/user-attachments/assets/5cd516fe-60a9-4bc2-b525-41f568651cc3" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.