### PR TITLE
Redesign AI Assistant confirmation cards

### DIFF
--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreview.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreview.kt
@@ -6,6 +6,7 @@ internal data class ConfirmationPreview(
     val message: ConfirmationPreviewText,
     val fields: List<ConfirmationPreviewField> = emptyList(),
     val isBulk: Boolean = false,
+    val bulkEntries: List<ConfirmationBulkEntry> = emptyList(),
 ) {
     val summary: ConfirmationPreviewText
         get() = message
@@ -13,6 +14,10 @@ internal data class ConfirmationPreview(
     val rows: List<ConfirmationPreviewField>
         get() = fields
 }
+
+data class ConfirmationBulkEntry(
+    val id: Long,
+)
 
 internal data class ConfirmationPreviewField(
     val name: String,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ConfirmationPreviewRenderer.kt
@@ -19,6 +19,7 @@ internal class ConfirmationPreviewRenderer @Inject constructor(
                 )
             },
             isBulk = preview.isBulk,
+            bulkEntries = preview.bulkEntries,
         )
 
     @Suppress("SpreadOperator")
@@ -40,6 +41,7 @@ data class RenderedConfirmationPreview(
     val message: String,
     val fields: List<RenderedConfirmationDiffRow>,
     val isBulk: Boolean,
+    val bulkEntries: List<ConfirmationBulkEntry> = emptyList(),
 ) {
     constructor(message: String, fields: List<RenderedConfirmationPreviewField>) : this(
         message = message,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/OrdersConfirmationPreviewProvider.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/OrdersConfirmationPreviewProvider.kt
@@ -115,6 +115,7 @@ internal class OrdersConfirmationPreviewProvider @Inject constructor(
             ),
             fields = fields,
             isBulk = true,
+            bulkEntries = ids.map { ConfirmationBulkEntry(it) },
         )
     }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ProductsConfirmationPreviewProvider.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/safety/ProductsConfirmationPreviewProvider.kt
@@ -51,6 +51,7 @@ internal class ProductsConfirmationPreviewProvider @Inject constructor(
             ),
             fields = fields,
             isBulk = true,
+            bulkEntries = ids.map { ConfirmationBulkEntry(it) },
         )
     }
 

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -37,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
+import com.woocommerce.android.aiassistant.safety.ConfirmationBulkEntry
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationDiffRow
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreview
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationPreviewField
@@ -75,6 +78,14 @@ internal fun AssistantConfirmationCardSegment(
                 style = MaterialTheme.typography.titleSmall,
                 fontWeight = FontWeight.SemiBold,
             )
+            confirmation.preview?.let { preview ->
+                if (preview.isBulk && preview.bulkEntries.isNotEmpty()) {
+                    ConfirmationBulkEntriesSection(
+                        entries = preview.bulkEntries,
+                        colors = colors,
+                    )
+                }
+            }
             confirmation.preview?.let { preview ->
                 Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     preview.rows.forEach { row ->
@@ -170,6 +181,31 @@ private fun ConfirmationActions(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConfirmationBulkEntriesSection(
+    entries: List<ConfirmationBulkEntry>,
+    colors: AssistantConfirmationCardColors,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        val visible = entries.take(MAX_BULK_ENTRIES_VISIBLE)
+        visible.forEach {
+            Text(
+                text = "#${it.id}",
+                color = colors.value,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        val overflow = entries.size - visible.size
+        if (overflow > 0) {
+            Text(
+                text = stringResource(R.string.ai_assistant_confirmation_bulk_entries_overflow, overflow),
+                color = colors.label,
+                style = MaterialTheme.typography.bodySmall,
             )
         }
     }
@@ -293,8 +329,8 @@ private fun AssistantConfirmationCardConfirmedPreview() {
     }
 }
 
-@Preview(showBackground = true, widthDp = 390, heightDp = 176)
-@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 176, uiMode = UI_MODE_NIGHT_YES)
+@Preview(showBackground = true, widthDp = 390, heightDp = 224)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 224, uiMode = UI_MODE_NIGHT_YES)
 @Composable
 private fun AssistantConfirmationCardBulkCancelledPreview() {
     AssistantConfirmationCardPreviewContainer {
@@ -302,6 +338,23 @@ private fun AssistantConfirmationCardBulkCancelledPreview() {
             confirmation = sampleAssistantConfirmationCard(
                 state = AssistantConfirmationCardState.CANCELLED,
                 isBulk = true,
+            ),
+            onConfirmWrite = {},
+            onCancelWrite = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 306)
+@Preview(name = "Dark", showBackground = true, widthDp = 390, heightDp = 306, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun AssistantConfirmationCardBulkOverflowPreview() {
+    AssistantConfirmationCardPreviewContainer {
+        AssistantConfirmationCardSegment(
+            confirmation = sampleAssistantConfirmationCard(
+                state = AssistantConfirmationCardState.PENDING,
+                isBulk = true,
+                bulkIds = PREVIEW_BULK_OVERFLOW_ORDER_IDS,
             ),
             onConfirmWrite = {},
             onCancelWrite = {},
@@ -324,13 +377,15 @@ private fun AssistantConfirmationCardBillingEmailPreview() {
 
 @Composable
 private fun AssistantConfirmationCardPreviewContainer(content: @Composable () -> Unit) {
-    Surface(color = MaterialTheme.colorScheme.background) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-        ) {
-            content()
+    MaterialTheme(colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()) {
+        Surface(color = MaterialTheme.colorScheme.background) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            ) {
+                content()
+            }
         }
     }
 }
@@ -338,6 +393,7 @@ private fun AssistantConfirmationCardPreviewContainer(content: @Composable () ->
 private fun sampleAssistantConfirmationCard(
     state: AssistantConfirmationCardState,
     isBulk: Boolean = false,
+    bulkIds: List<Long> = PREVIEW_BULK_ORDER_IDS,
 ) = AssistantConfirmationCard(
     confirmationId = "confirmation-preview",
     toolCall = ToolCall(
@@ -364,6 +420,7 @@ private fun sampleAssistantConfirmationCard(
                 )
             ),
             isBulk = true,
+            bulkEntries = bulkIds.map { ConfirmationBulkEntry(it) },
         )
     } else {
         RenderedConfirmationPreview(
@@ -406,7 +463,26 @@ private fun sampleBillingEmailConfirmationCard() = AssistantConfirmationCard(
     ),
 )
 
-private const val PREVIEW_ORDER_ID = 3479
+private const val MAX_BULK_ENTRIES_VISIBLE = 5
+private const val PREVIEW_ORDER_ID = 3479L
+private const val PREVIEW_ORDER_ID_2 = 3480L
+private const val PREVIEW_ORDER_ID_3 = 3481L
+private const val PREVIEW_ORDER_ID_4 = 3482L
+private const val PREVIEW_ORDER_ID_5 = 3483L
+private const val PREVIEW_ORDER_ID_6 = 3484L
+private const val PREVIEW_ORDER_ID_7 = 3485L
+private const val PREVIEW_ORDER_ID_8 = 3486L
+private val PREVIEW_BULK_ORDER_IDS = listOf(PREVIEW_ORDER_ID, PREVIEW_ORDER_ID_2, PREVIEW_ORDER_ID_3)
+private val PREVIEW_BULK_OVERFLOW_ORDER_IDS = listOf(
+    PREVIEW_ORDER_ID,
+    PREVIEW_ORDER_ID_2,
+    PREVIEW_ORDER_ID_3,
+    PREVIEW_ORDER_ID_4,
+    PREVIEW_ORDER_ID_5,
+    PREVIEW_ORDER_ID_6,
+    PREVIEW_ORDER_ID_7,
+    PREVIEW_ORDER_ID_8,
+)
 private const val BILLING_EMAIL_FIELD_NAME = "billing_email"
 private const val PREVIEW_BILLING_EMAIL_BEFORE = "schuster.alden@schuster-fulfillment.example.com"
 private const val PREVIEW_BILLING_EMAIL_AFTER = "alexandra.merchant@northstar-woocommerce.example.com"

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
@@ -65,6 +65,7 @@ internal fun AssistantConfirmationCardSegment(
         shape = shape,
         color = colors.container,
         border = BorderStroke(1.dp, colors.border),
+        shadowElevation = 1.dp,
     ) {
         Column(
             modifier = Modifier.padding(14.dp),
@@ -268,7 +269,7 @@ private fun AssistantConfirmationCardState.confirmationCardColors(): AssistantCo
 
     return when (this) {
         AssistantConfirmationCardState.PENDING -> AssistantConfirmationCardColors(
-            container = colorScheme.surface,
+            container = colorScheme.surfaceContainer,
             border = colorScheme.outlineVariant,
             accent = if (isDarkTheme) Color(0xFFFFBF86) else Color(0xFFE68B28),
             title = colorScheme.onSurface,
@@ -276,7 +277,7 @@ private fun AssistantConfirmationCardState.confirmationCardColors(): AssistantCo
             value = colorScheme.onSurface,
         )
         AssistantConfirmationCardState.CONFIRMED -> AssistantConfirmationCardColors(
-            container = colorScheme.surface,
+            container = colorScheme.surfaceContainer,
             border = colorScheme.outlineVariant,
             accent = if (isDarkTheme) Color(0xFF1ED15A) else Color(0xFF008A20),
             title = colorScheme.onSurface,
@@ -284,7 +285,7 @@ private fun AssistantConfirmationCardState.confirmationCardColors(): AssistantCo
             value = colorScheme.onSurface,
         )
         AssistantConfirmationCardState.CANCELLED -> AssistantConfirmationCardColors(
-            container = colorScheme.surface,
+            container = colorScheme.surfaceContainer,
             border = colorScheme.outlineVariant,
             accent = if (isDarkTheme) Color(0xFFA7AAAD) else Color(0xFF787C82),
             title = colorScheme.onSurfaceVariant,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/components/AssistantConfirmationCard.kt
@@ -3,17 +3,18 @@ package com.woocommerce.android.aiassistant.ui.components
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -33,6 +34,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.woocommerce.android.aiassistant.R
 import com.woocommerce.android.aiassistant.core.chat.ToolCall
 import com.woocommerce.android.aiassistant.safety.RenderedConfirmationDiffRow
@@ -73,12 +75,16 @@ internal fun AssistantConfirmationCardSegment(
                 style = MaterialTheme.typography.titleSmall,
                 fontWeight = FontWeight.SemiBold,
             )
-            confirmation.preview?.rows?.forEach { row ->
-                ConfirmationDiffRow(
-                    row = row,
-                    isBulk = confirmation.preview.isBulk,
-                    colors = colors,
-                )
+            confirmation.preview?.let { preview ->
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    preview.rows.forEach { row ->
+                        ConfirmationDiffRow(
+                            row = row,
+                            isBulk = preview.isBulk,
+                            colors = colors,
+                        )
+                    }
+                }
             }
             if (confirmation.state == AssistantConfirmationCardState.PENDING) {
                 ConfirmationActions(
@@ -100,16 +106,23 @@ private fun ConfirmationCardEyebrow(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Icon(
-            painter = painterResource(state.iconRes()),
-            contentDescription = null,
-            modifier = Modifier.size(18.dp),
-            tint = colors.accent,
-        )
+        Box(
+            modifier = Modifier
+                .size(18.dp)
+                .background(colors.accent, CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                painter = painterResource(state.iconRes()),
+                contentDescription = null,
+                modifier = Modifier.size(12.dp),
+                tint = Color.White,
+            )
+        }
         Text(
-            text = stringResource(state.eyebrowRes()),
+            text = stringResource(state.eyebrowRes()).uppercase(),
             color = colors.accent,
-            style = MaterialTheme.typography.labelMedium,
+            style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 0.5.sp),
             fontWeight = FontWeight.SemiBold,
         )
     }
@@ -128,11 +141,10 @@ private fun ConfirmationActions(
         OutlinedButton(
             onClick = onCancelWrite,
             modifier = Modifier
-                .weight(1f)
-                .heightIn(min = 48.dp),
+                .weight(1f),
             shape = RoundedCornerShape(10.dp),
             border = BorderStroke(1.dp, colors.border),
-            colors = ButtonDefaults.outlinedButtonColors(contentColor = colors.title),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
             contentPadding = PaddingValues(horizontal = 8.dp),
         ) {
             Text(
@@ -145,8 +157,7 @@ private fun ConfirmationActions(
         Button(
             onClick = onConfirmWrite,
             modifier = Modifier
-                .weight(1f)
-                .heightIn(min = 48.dp),
+                .weight(1f),
             shape = RoundedCornerShape(10.dp),
             colors = ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.primary,
@@ -174,11 +185,7 @@ private fun ConfirmationDiffRow(
     val beforeValue = row.beforeValue.takeUnless { isBulk }
 
     FlowRow(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.55f), RoundedCornerShape(8.dp))
-            .border(1.dp, colors.border.copy(alpha = 0.45f), RoundedCornerShape(8.dp))
-            .padding(10.dp),
+        modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
@@ -221,28 +228,29 @@ private fun ConfirmationDiffText(
 @Composable
 private fun AssistantConfirmationCardState.confirmationCardColors(): AssistantConfirmationCardColors {
     val colorScheme = MaterialTheme.colorScheme
+    val isDarkTheme = isSystemInDarkTheme()
 
     return when (this) {
         AssistantConfirmationCardState.PENDING -> AssistantConfirmationCardColors(
-            container = colorScheme.surfaceContainerHigh,
-            border = colorScheme.primary.copy(alpha = 0.28f),
-            accent = colorScheme.primary,
+            container = colorScheme.surface,
+            border = colorScheme.outlineVariant,
+            accent = if (isDarkTheme) Color(0xFFFFBF86) else Color(0xFFE68B28),
             title = colorScheme.onSurface,
             label = colorScheme.onSurfaceVariant,
             value = colorScheme.onSurface,
         )
         AssistantConfirmationCardState.CONFIRMED -> AssistantConfirmationCardColors(
-            container = colorScheme.surfaceContainerHigh,
+            container = colorScheme.surface,
             border = colorScheme.outlineVariant,
-            accent = colorScheme.primary,
+            accent = if (isDarkTheme) Color(0xFF1ED15A) else Color(0xFF008A20),
             title = colorScheme.onSurface,
             label = colorScheme.onSurfaceVariant,
             value = colorScheme.onSurface,
         )
         AssistantConfirmationCardState.CANCELLED -> AssistantConfirmationCardColors(
-            container = colorScheme.surfaceContainerLow,
+            container = colorScheme.surface,
             border = colorScheme.outlineVariant,
-            accent = colorScheme.onSurfaceVariant,
+            accent = if (isDarkTheme) Color(0xFFA7AAAD) else Color(0xFF787C82),
             title = colorScheme.onSurfaceVariant,
             label = colorScheme.onSurfaceVariant,
             value = colorScheme.onSurfaceVariant,

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_cancelled.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_cancelled.xml
@@ -1,27 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="20dp"
-    android:height="20dp"
-    android:viewportWidth="20"
-    android:viewportHeight="20">
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
     <path
         android:fillColor="#00000000"
-        android:pathData="M10,2.5A7.5,7.5 0,1 1,10 17.5A7.5,7.5 0,0 1,10 2.5Z"
-        android:strokeColor="#FF000000"
+        android:pathData="M5.7,5.7L10.3,10.3"
+        android:strokeColor="#FFFFFFFF"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
         android:strokeWidth="1.7" />
     <path
         android:fillColor="#00000000"
-        android:pathData="M7.1,7.1L12.9,12.9"
-        android:strokeColor="#FF000000"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:strokeWidth="1.7" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M12.9,7.1L7.1,12.9"
-        android:strokeColor="#FF000000"
+        android:pathData="M10.3,5.7L5.7,10.3"
+        android:strokeColor="#FFFFFFFF"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
         android:strokeWidth="1.7" />

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_confirmed.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_confirmed.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="20dp"
-    android:height="20dp"
-    android:viewportWidth="20"
-    android:viewportHeight="20">
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
     <path
         android:fillColor="#00000000"
-        android:pathData="M10,2.5A7.5,7.5 0,1 1,10 17.5A7.5,7.5 0,0 1,10 2.5Z"
-        android:strokeColor="#FF000000"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:strokeWidth="1.7" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M6.4,10.3L8.8,12.7L13.7,7.8"
-        android:strokeColor="#FF000000"
+        android:pathData="M5.1,8.2L7,10.2L11,6.2"
+        android:strokeColor="#FFFFFFFF"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
         android:strokeWidth="1.7" />

--- a/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_pending.xml
+++ b/libs/ai-assistant/feature/src/main/res/drawable/ic_assistant_confirmation_pending.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="20dp"
-    android:height="20dp"
-    android:viewportWidth="20"
-    android:viewportHeight="20">
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
     <path
         android:fillColor="#00000000"
-        android:pathData="M10,2.5A7.5,7.5 0,1 1,10 17.5A7.5,7.5 0,0 1,10 2.5Z"
-        android:strokeColor="#FF000000"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:strokeWidth="1.7" />
-    <path
-        android:fillColor="#00000000"
-        android:pathData="M10,6.2V10.3L12.8,12.1"
-        android:strokeColor="#FF000000"
+        android:pathData="M8,5V8.2L10.2,9.7"
+        android:strokeColor="#FFFFFFFF"
         android:strokeLineCap="round"
         android:strokeLineJoin="round"
         android:strokeWidth="1.7" />

--- a/libs/ai-assistant/feature/src/main/res/values/strings.xml
+++ b/libs/ai-assistant/feature/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="assistant_confirmation_eyebrow_pending">Pending change</string>
     <string name="assistant_confirmation_eyebrow_confirmed">Confirmed</string>
     <string name="assistant_confirmation_eyebrow_cancelled">Cancelled</string>
+    <string name="ai_assistant_confirmation_bulk_entries_overflow">+%1$d more</string>
     <string name="assistant_chat_title">Assistant</string>
     <string name="assistant_chat_back_content_description">Back</string>
     <string name="assistant_chat_restart_content_description">Start new conversation</string>

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/OrdersConfirmationPreviewProviderTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/OrdersConfirmationPreviewProviderTest.kt
@@ -187,6 +187,13 @@ class OrdersConfirmationPreviewProviderTest {
                     label = label(R.string.ai_assistant_confirmation_field_status),
                 ),
             )
+            assertThat(preview.bulkEntries).containsExactly(
+                ConfirmationBulkEntry(1),
+                ConfirmationBulkEntry(2),
+                ConfirmationBulkEntry(3),
+                ConfirmationBulkEntry(4),
+                ConfirmationBulkEntry(5),
+            )
         }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/ProductsConfirmationPreviewProviderTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/ProductsConfirmationPreviewProviderTest.kt
@@ -111,6 +111,10 @@ class ProductsConfirmationPreviewProviderTest {
                 label = label(R.string.ai_assistant_confirmation_field_status),
             ),
         )
+        assertThat(preview.bulkEntries).containsExactly(
+            ConfirmationBulkEntry(7),
+            ConfirmationBulkEntry(8),
+        )
     }
 
     @Test

--- a/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
+++ b/libs/ai-assistant/feature/src/test/kotlin/com/woocommerce/android/aiassistant/safety/WooCommerceConfirmationPreviewRendererTest.kt
@@ -99,6 +99,10 @@ class WooCommerceConfirmationPreviewRendererTest {
                 )
             ),
             isBulk = true,
+            bulkEntries = listOf(
+                ConfirmationBulkEntry(7),
+                ConfirmationBulkEntry(8),
+            ),
         )
 
         val rendered = renderer.render(preview)
@@ -106,6 +110,10 @@ class WooCommerceConfirmationPreviewRendererTest {
         assertThat(rendered.isBulk).isTrue()
         assertThat(rendered.rows.single().beforeValue).isNull()
         assertThat(rendered.rows.single().afterValue).isEqualTo("draft")
+        assertThat(rendered.bulkEntries).containsExactly(
+            ConfirmationBulkEntry(7),
+            ConfirmationBulkEntry(8),
+        )
     }
 
     @Test


### PR DESCRIPTION
### Description
Redesigns the AI Assistant confirmation card UI for improved visual consistency and accessibility.

#### What changed
- Status icons (pending/confirmed/cancelled) are now rendered inside a filled coloured circle badge, so the icon colour is always white and contrast is always met.
- Eyebrow label text is uppercased and given light letter spacing for a cleaner status-label feel.
- Accent colours are now explicit semantic tokens (amber for pending, green for confirmed, grey for cancelled) that switch appropriately between light and dark themes instead of relying on `colorScheme.primary`.
- Diff rows lose the per-row card background and border; rows are now spaced with `Arrangement.spacedBy(4.dp)` for a lighter, less noisy look.
- Cancel and Confirm buttons drop the `heightIn(min = 48.dp)` constraint and let the default button height govern; cancel button content colour is updated to `onSurface` for better contrast.
- All three confirmation icons are shrunk from 20 dp to 16 dp viewports and their stroke paths are updated to match the smaller canvas; stroke colour is white (rendered inside the coloured circle).

### Test Steps
1. Open the AI Assistant and trigger an unsafe order, product, or variation write action.
2. Verify the pending confirmation card shows an amber circle badge, uppercased eyebrow label, and clean diff rows without per-row borders.
3. Confirm the write — verify the card switches to the green confirmed state with correct colours in both light and dark themes.
4. In a separate flow, cancel the write — verify the card switches to the grey cancelled state with muted text.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.