### PR TITLE
Add AU WooPayments card-present configuration

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/CardBrandDisplayName.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/CardBrandDisplayName.kt
@@ -1,0 +1,10 @@
+package com.woocommerce.android.ui.payments
+
+import java.util.Locale
+
+fun String?.toCardBrandDisplayName(): String =
+    when (this?.lowercase(Locale.ROOT)) {
+        "cartes_bancaires" -> "Cartes Bancaires"
+        "eftpos", "eftpos_au" -> "eftpos"
+        else -> orEmpty().replaceFirstChar { it.uppercase() }
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProvider.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProvider.kt
@@ -41,6 +41,7 @@ class CardReaderCountryConfigProvider @Inject constructor(
             "LU" to FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED,
             "PT" to FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED,
             "ES" to FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED,
+            "AU" to FeatureFlag.IPP_AUSTRALIA_WOOPAYMENTS,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/TerminalPaymentIntentConfig.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/TerminalPaymentIntentConfig.kt
@@ -1,0 +1,73 @@
+package com.woocommerce.android.ui.payments.cardreader.payment
+
+import com.woocommerce.android.cardreader.payments.PaymentInfo
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.util.Currency
+import java.util.Locale
+
+object TerminalPaymentIntentConfig {
+    fun calculateApplicationFeeInCents(
+        countryCode: String,
+        orderTotal: BigDecimal,
+        currencyCode: String,
+    ): Long? =
+        when (countryCode.uppercase(Locale.ROOT)) {
+            CANADA_COUNTRY_CODE -> CANADA_FEE_FLAT_IN_CENTS
+            AUSTRALIA_COUNTRY_CODE -> calculatePercentageFeeInCents(
+                orderTotal = orderTotal,
+                currencyCode = currencyCode,
+                percentage = AUSTRALIA_FEE_PERCENTAGE,
+            ) + AUSTRALIA_FEE_FLAT_IN_CENTS
+            else -> null
+        }
+
+    fun cardPresentCaptureMethod(countryCode: String): PaymentInfo.CardPresentCaptureMethod? =
+        when (countryCode.uppercase(Locale.ROOT)) {
+            CANADA_COUNTRY_CODE,
+            AUSTRALIA_COUNTRY_CODE -> PaymentInfo.CardPresentCaptureMethod.MANUAL_PREFERRED
+            else -> null
+        }
+
+    fun terminalPaymentPreparation(
+        countryCode: String,
+        isWooPaymentsPreferred: Boolean,
+        isTerminalPaymentPreparationRouteAvailableInCanada: Boolean,
+    ): PaymentInfo.TerminalPaymentPreparation =
+        when {
+            !isWooPaymentsPreferred -> PaymentInfo.TerminalPaymentPreparation.NONE
+            countryCode.equals(CANADA_COUNTRY_CODE, ignoreCase = true) &&
+                isTerminalPaymentPreparationRouteAvailableInCanada ->
+                PaymentInfo.TerminalPaymentPreparation.CANADA_INTERAC
+            countryCode.equals(AUSTRALIA_COUNTRY_CODE, ignoreCase = true) ->
+                PaymentInfo.TerminalPaymentPreparation.AUSTRALIA_CARD_PRESENT
+            else -> PaymentInfo.TerminalPaymentPreparation.NONE
+        }
+
+    fun hasTerminalPaymentPreparationRoute(routes: List<String>): Boolean =
+        routes.any {
+            it.startsWith(PREPARE_TERMINAL_PAYMENT_ROUTE_PREFIX) &&
+                it.endsWith(PREPARE_TERMINAL_PAYMENT_ROUTE_SUFFIX)
+        }
+
+    private fun calculatePercentageFeeInCents(
+        orderTotal: BigDecimal,
+        currencyCode: String,
+        percentage: BigDecimal,
+    ): Long {
+        val fractionDigits = Currency.getInstance(currencyCode).defaultFractionDigits
+        return orderTotal
+            .multiply(percentage)
+            .movePointRight(fractionDigits)
+            .setScale(0, RoundingMode.HALF_UP)
+            .toLong()
+    }
+
+    private const val CANADA_COUNTRY_CODE = "CA"
+    private const val AUSTRALIA_COUNTRY_CODE = "AU"
+    private const val PREPARE_TERMINAL_PAYMENT_ROUTE_PREFIX = "/wc/v3/payments/orders/"
+    private const val PREPARE_TERMINAL_PAYMENT_ROUTE_SUFFIX = "/prepare_terminal_payment"
+    private const val CANADA_FEE_FLAT_IN_CENTS = 15L
+    private const val AUSTRALIA_FEE_FLAT_IN_CENTS = 10L
+    private val AUSTRALIA_FEE_PERCENTAGE = BigDecimal("0.017")
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/TerminalPaymentPreparationResolver.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/TerminalPaymentPreparationResolver.kt
@@ -1,0 +1,48 @@
+package com.woocommerce.android.ui.payments.cardreader.payment
+
+import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.cardreader.payments.PaymentInfo
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.WooCommerceStore
+
+class TerminalPaymentPreparationResolver(
+    private val wooStore: WooCommerceStore,
+    private val appPrefs: AppPrefs = AppPrefs,
+) {
+    suspend fun resolve(
+        countryCode: String,
+        site: SiteModel,
+        onRouteCheckFailed: () -> Unit,
+    ): PaymentInfo.TerminalPaymentPreparation {
+        val isWooPaymentsPreferred = appPrefs.getCardReaderPreferredPlugin(
+            localSiteId = site.id,
+            remoteSiteId = site.siteId,
+            selfHostedSiteId = site.selfHostedSiteId,
+        ) == PluginType.WOOCOMMERCE_PAYMENTS
+        val isRouteAvailableInCanada = countryCode.equals(CANADA_COUNTRY_CODE, ignoreCase = true) &&
+            isWooPaymentsPreferred &&
+            isTerminalPaymentPreparationRouteAvailable(site, onRouteCheckFailed)
+        return TerminalPaymentIntentConfig.terminalPaymentPreparation(
+            countryCode = countryCode,
+            isWooPaymentsPreferred = isWooPaymentsPreferred,
+            isTerminalPaymentPreparationRouteAvailableInCanada = isRouteAvailableInCanada,
+        )
+    }
+
+    private suspend fun isTerminalPaymentPreparationRouteAvailable(
+        site: SiteModel,
+        onRouteCheckFailed: () -> Unit,
+    ): Boolean = wooStore.fetchSiteRootApiRoutes(site).let { result ->
+        if (result.isError) {
+            onRouteCheckFailed()
+            false
+        } else {
+            TerminalPaymentIntentConfig.hasTerminalPaymentPreparationRoute(result.model.orEmpty())
+        }
+    }
+
+    private companion object {
+        const val CANADA_COUNTRY_CODE = "CA"
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentController.kt
@@ -54,6 +54,8 @@ import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentE
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentOrderHelper
 import com.woocommerce.android.ui.payments.cardreader.payment.InteracRefundFlowError
 import com.woocommerce.android.ui.payments.cardreader.payment.PaymentFlowError
+import com.woocommerce.android.ui.payments.cardreader.payment.TerminalPaymentIntentConfig
+import com.woocommerce.android.ui.payments.cardreader.payment.TerminalPaymentPreparationResolver
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderInteracRefundState
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState.PaymentFailed.BuiltInReaderFailedPayment
@@ -84,7 +86,6 @@ import org.wordpress.android.fluxc.store.WooCommerceStore
 import kotlin.reflect.KMutableProperty0
 
 private const val ARTIFICIAL_RETRY_DELAY = 500L
-private const val CANADA_FEE_FLAT_IN_CENTS = 15L
 
 @Suppress("LongParameterList", "LargeClass")
 class CardReaderPaymentController(
@@ -113,6 +114,7 @@ class CardReaderPaymentController(
     private val allowCancelledStatus: Boolean = false,
 ) {
     private var scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val terminalPaymentPreparationResolver = TerminalPaymentPreparationResolver(wooStore, appPrefs)
 
     private val _paymentState: MutableStateFlow<CardReaderPaymentOrRefundState> =
         MutableStateFlow(CardReaderPaymentState.LoadingData(::onCancelPaymentFlow))
@@ -291,8 +293,18 @@ class CardReaderPaymentController(
                 storeName = selectedSite.get().name.ifEmpty { null },
                 siteUrl = selectedSite.get().url.ifEmpty { null },
                 countryCode = countryCode,
-                feeAmount = calculateFeeInCents(countryCode),
-                channel = determinePaymentChannel(paymentOrRefund)
+                feeAmount = TerminalPaymentIntentConfig.calculateApplicationFeeInCents(
+                    countryCode = countryCode,
+                    orderTotal = order.total,
+                    currencyCode = order.currency,
+                ),
+                channel = determinePaymentChannel(paymentOrRefund),
+                cardPresentCaptureMethod = TerminalPaymentIntentConfig.cardPresentCaptureMethod(countryCode),
+                terminalPaymentPreparation = terminalPaymentPreparationResolver.resolve(
+                    countryCode = countryCode,
+                    site = site,
+                    onRouteCheckFailed = ::logTerminalPaymentPreparationRouteCheckFailed,
+                ),
             )
         ).collect { paymentStatus ->
             onPaymentStatusChanged(
@@ -852,12 +864,12 @@ class CardReaderPaymentController(
         }
     }
 
-    private fun calculateFeeInCents(countryCode: String) =
-        if (countryCode == "CA") {
-            CANADA_FEE_FLAT_IN_CENTS
-        } else {
-            null
-        }
+    private fun logTerminalPaymentPreparationRouteCheckFailed() {
+        WooLog.i(
+            WooLog.T.CARD_READER,
+            "Skipping terminal payment preparation because the WCPay endpoint could not be verified."
+        )
+    }
 
     private fun determinePaymentChannel(flow: CardReaderFlowParam.PaymentOrRefund): PaymentInfo.PaymentChannel? =
         when (flow) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModel.kt
@@ -25,6 +25,7 @@ import com.woocommerce.android.ui.orders.details.OrderDetailRepository
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.IssueRefundEvent
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.IssueRefundEvent.ShowRefundConfirmation
 import com.woocommerce.android.ui.payments.refunds.IssueRefundViewModel.PaymentMethodType
+import com.woocommerce.android.ui.payments.toCardBrandDisplayName
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.LiveDataDelegate
@@ -219,7 +220,7 @@ class RefundSummaryViewModel @Inject constructor(
                 is PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success -> {
                     cardType = PaymentMethodType.fromValue(result.paymentMethodType ?: "card_present")
                     val refundMethodWithCard = result.run {
-                        val brand = result.cardBrand.orEmpty().replaceFirstChar { it.uppercase() }
+                        val brand = result.cardBrand.toCardBrandDisplayName()
                         val last4 = result.cardLast4.orEmpty()
                         val creditCardRefundDefaultText =
                             resourceProvider.getString(R.string.order_refunds_credit_card_refund)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/remote/WooPosRemoteReaderPaymentFlow.kt
@@ -11,6 +11,8 @@ import com.woocommerce.android.di.PointOfSaleMode
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentOrderHelper
+import com.woocommerce.android.ui.payments.cardreader.payment.TerminalPaymentIntentConfig
+import com.woocommerce.android.ui.payments.cardreader.payment.TerminalPaymentPreparationResolver
 import com.woocommerce.android.ui.payments.receipt.PaymentReceiptHelper
 import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.ui.woopos.common.util.WooPosLogWrapper
@@ -31,6 +33,8 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
     @PointOfSaleMode private val paymentsFlowTracker: PaymentsFlowTracker,
     private val appPrefs: AppPrefs = AppPrefs,
 ) {
+    private val terminalPaymentPreparationResolver = TerminalPaymentPreparationResolver(wooStore, appPrefs)
+
     suspend fun collect(order: Order, onCaptureStarting: suspend () -> Unit = {}): Result {
         val result = collectInternal(order, onCaptureStarting)
         when (result) {
@@ -41,10 +45,8 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
     }
 
     private suspend fun collectInternal(order: Order, onCaptureStarting: suspend () -> Unit): Result {
-        val connected = remoteReaderSession.state.value as? WooPosRemoteReaderSession.State.Connected
-        if (connected?.reader?.isSimulated == true) {
-            onCaptureStarting()
-            return simulatePayment()
+        if (isSimulatedReaderConnected()) {
+            return simulatePayment(onCaptureStarting)
         }
 
         val site = selectedSite.get()
@@ -74,14 +76,32 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
             storeName = site.name.ifEmpty { null },
             siteUrl = site.url.ifEmpty { null },
             countryCode = countryCode,
-            feeAmount = if (countryCode == CANADA_COUNTRY_CODE) CANADA_FEE_FLAT_IN_CENTS else null,
+            feeAmount = TerminalPaymentIntentConfig.calculateApplicationFeeInCents(
+                countryCode = countryCode,
+                orderTotal = order.total,
+                currencyCode = order.currency,
+            ),
             channel = PaymentInfo.PaymentChannel.Pos,
+            cardPresentCaptureMethod = TerminalPaymentIntentConfig.cardPresentCaptureMethod(countryCode),
+            terminalPaymentPreparation = terminalPaymentPreparationResolver.resolve(
+                countryCode = countryCode,
+                site = site,
+                onRouteCheckFailed = ::logTerminalPaymentPreparationRouteCheckFailed,
+            ),
         )
 
+        return collectRemotePayment(order.id, paymentInfo, onCaptureStarting)
+    }
+
+    private suspend fun collectRemotePayment(
+        orderId: Long,
+        paymentInfo: PaymentInfo,
+        onCaptureStarting: suspend () -> Unit,
+    ): Result {
         return when (val outcome = remoteReaderSession.sendCollectPayment(paymentInfo)) {
             is CollectPaymentOutcome.Success -> {
                 onCaptureStarting()
-                capture(order.id, outcome.paymentIntentId)
+                capture(orderId, outcome.paymentIntentId)
             }
             is CollectPaymentOutcome.Rejected -> {
                 logger.e("Remote payment rejected: ${outcome.code} - ${outcome.description}")
@@ -107,8 +127,15 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
         }
     }
 
+    private fun isSimulatedReaderConnected(): Boolean =
+        (remoteReaderSession.state.value as? WooPosRemoteReaderSession.State.Connected)?.reader?.isSimulated == true
+
     private fun genericFailureMessage(): String =
         resourceProvider.getString(R.string.woopos_remote_payment_failed_generic)
+
+    private fun logTerminalPaymentPreparationRouteCheckFailed() {
+        logger.d("Skipping terminal payment preparation because the WCPay endpoint could not be verified.")
+    }
 
     private suspend fun capture(orderId: Long, paymentIntentId: String): Result =
         when (val response = cardReaderStore.capturePaymentIntent(orderId, paymentIntentId)) {
@@ -116,7 +143,8 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
             is CapturePaymentResponse.Error -> Result.Failed(response.message)
         }
 
-    private suspend fun simulatePayment(): Result {
+    private suspend fun simulatePayment(onCaptureStarting: suspend () -> Unit): Result {
+        onCaptureStarting()
         delay(SIMULATED_PAYMENT_DELAY_MS)
         return Result.Completed
     }
@@ -127,8 +155,6 @@ class WooPosRemoteReaderPaymentFlow @Inject constructor(
     }
 
     private companion object {
-        const val CANADA_COUNTRY_CODE = "CA"
-        const val CANADA_FEE_FLAT_IN_CENTS = 15L
         const val SIMULATED_PAYMENT_DELAY_MS = 1_500L
         const val CONNECTION_LOST_MARKER = "Connection to phone reader was lost"
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosGetPaymentMethod.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosGetPaymentMethod.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.R
 import com.woocommerce.android.extensions.isCashPayment
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.ui.payments.refunds.PaymentChargeRepository
+import com.woocommerce.android.ui.payments.toCardBrandDisplayName
 import com.woocommerce.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
@@ -49,7 +50,7 @@ class WooPosGetPaymentMethod @Inject constructor(
     private suspend fun loadCardDetails(chargeId: String, refundMethod: String): String {
         return when (val result = paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)) {
             is PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success -> {
-                val brand = result.cardBrand.orEmpty().replaceFirstChar { it.uppercase() }
+                val brand = result.cardBrand.toCardBrandDisplayName()
                 val last4 = result.cardLast4.orEmpty()
                 val creditCardRefundDefaultText =
                     resourceProvider.getString(R.string.order_refunds_credit_card_refund)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountries.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountries.kt
@@ -19,6 +19,9 @@ class WooPosSupportedCountries @Inject constructor(
             if (featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)) {
                 addAll(EU_EXTENDED_PAIRS)
             }
+            if (featureFlagRepository.isEnabled(FeatureFlag.IPP_AUSTRALIA_WOOPAYMENTS)) {
+                add(AUSTRALIA_PAIR)
+            }
         }
     }
 
@@ -43,5 +46,6 @@ class WooPosSupportedCountries @Inject constructor(
             "pt" to "eur",
             "es" to "eur",
         )
+        val AUSTRALIA_PAIR = "au" to "aud"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -38,4 +38,5 @@ enum class FeatureFlag(
     SMARTER_NOTIFICATIONS("smarter_notifications", localValue = PackageUtils.isDebugBuild()),
     IPP_COUNTRY_EXPANSION("woo_ipp_country_expansion"),
     IPP_COUNTRY_EXPANSION_EU_EXTENDED("woo_ipp_country_expansion_eu_extended"),
+    IPP_AUSTRALIA_WOOPAYMENTS("woo_ipp_australia_woopayments"),
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProviderTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/CardReaderCountryConfigProviderTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.payments.cardreader
 
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.config.CardReaderConfigForAT
+import com.woocommerce.android.cardreader.config.CardReaderConfigForAustralia
 import com.woocommerce.android.cardreader.config.CardReaderConfigForBE
 import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
 import com.woocommerce.android.cardreader.config.CardReaderConfigForDE
@@ -30,6 +31,7 @@ class CardReaderCountryConfigProviderTest {
     private val featureFlagRepository: FeatureFlagRepository = mock {
         on { isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION) }.thenReturn(false)
         on { isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED) }.thenReturn(false)
+        on { isEnabled(FeatureFlag.IPP_AUSTRALIA_WOOPAYMENTS) }.thenReturn(false)
     }
 
     private val sut = CardReaderCountryConfigProvider(
@@ -63,15 +65,23 @@ class CardReaderCountryConfigProviderTest {
             .isInstanceOf(CardReaderConfigForUnsupportedCountry::class.java)
     }
 
-    // --- Australia stays unsupported with both flags on ---
+    // --- Australia: gated by its own WooPayments flag ---
 
     @Test
-    fun `given AU country code with both expansion flags enabled, when config provide, then unsupported returned`() {
+    fun `given AU country code with primary and EU extended flags enabled, when config provide, then unsupported returned`() {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(true)
         whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(true)
 
         assertThat(sut.provideCountryConfigFor("AU"))
             .isInstanceOf(CardReaderConfigForUnsupportedCountry::class.java)
+    }
+
+    @Test
+    fun `given AU country code and AU flag on, when config provide, then Australia returned`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_AUSTRALIA_WOOPAYMENTS)).thenReturn(true)
+
+        assertThat(sut.provideCountryConfigFor("AU"))
+            .isInstanceOf(CardReaderConfigForAustralia::class.java)
     }
 
     // --- Primary expansion group: gated by IPP_COUNTRY_EXPANSION ---

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/onboarding/CardReaderOnboardingCheckerTest.kt
@@ -4,6 +4,7 @@ import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_O
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_NOT_COMPLETED
 import com.woocommerce.android.AppPrefs.CardReaderOnboardingStatus.CARD_READER_ONBOARDING_PENDING
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.cardreader.config.CardReaderConfigForAustralia
 import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
 import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUSA
@@ -332,6 +333,55 @@ class CardReaderOnboardingCheckerTest : BaseUnitTest() {
                 WooResult(
                     listOf(
                         buildWCPayPluginInfo(version = wcPayPluginVersion)
+                    )
+                )
+            )
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isEqualTo(
+                CardReaderOnboardingState.PluginUnsupportedVersion(PluginType.WOOCOMMERCE_PAYMENTS)
+            )
+        }
+
+    @Test
+    fun `given store in Australia, when wcpay plugin is minimum supported test build, then onboarding complete`() =
+        testBlocking {
+            val countryCode = "AU"
+            val wcPayPluginVersion = "10.8.0-test-1"
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn(countryCode)
+            whenever(cardReaderCountryConfigProvider.provideCountryConfigFor(countryCode))
+                .thenReturn(CardReaderConfigForAustralia)
+            whenever(wooStore.fetchSitePlugins(site)).thenReturn(
+                WooResult(
+                    listOf(
+                        buildWCPayPluginInfo(version = wcPayPluginVersion)
+                    )
+                )
+            )
+
+            val result = checker.getOnboardingState()
+
+            assertThat(result).isEqualTo(
+                CardReaderOnboardingState.OnboardingCompleted(
+                    PluginType.WOOCOMMERCE_PAYMENTS,
+                    wcPayPluginVersion,
+                    countryCode
+                )
+            )
+        }
+
+    @Test
+    fun `given store in Australia, when wcpay plugin is below minimum supported version, then unsupported returned`() =
+        testBlocking {
+            val countryCode = "AU"
+            whenever(wooStore.getStoreCountryCode(site)).thenReturn(countryCode)
+            whenever(cardReaderCountryConfigProvider.provideCountryConfigFor(countryCode))
+                .thenReturn(CardReaderConfigForAustralia)
+            whenever(wooStore.fetchSitePlugins(site)).thenReturn(
+                WooResult(
+                    listOf(
+                        buildWCPayPluginInfo(version = "10.7.1")
                     )
                 )
             )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/TerminalPaymentIntentConfigTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/TerminalPaymentIntentConfigTest.kt
@@ -1,0 +1,120 @@
+package com.woocommerce.android.ui.payments.cardreader.payment
+
+import com.woocommerce.android.cardreader.payments.PaymentInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.math.BigDecimal
+
+class TerminalPaymentIntentConfigTest {
+    @Test
+    fun `given Canada, when calculating application fee, then flat 15 cents returned`() {
+        val fee = TerminalPaymentIntentConfig.calculateApplicationFeeInCents(
+            countryCode = "CA",
+            orderTotal = BigDecimal("18.00"),
+            currencyCode = "CAD",
+        )
+
+        assertThat(fee).isEqualTo(15L)
+    }
+
+    @Test
+    fun `given Australia, when calculating application fee, then percentage plus flat fee returned`() {
+        val fee = TerminalPaymentIntentConfig.calculateApplicationFeeInCents(
+            countryCode = "AU",
+            orderTotal = BigDecimal("18.00"),
+            currencyCode = "AUD",
+        )
+
+        assertThat(fee).isEqualTo(41L)
+    }
+
+    @Test
+    fun `given unsupported country, when calculating application fee, then null returned`() {
+        val fee = TerminalPaymentIntentConfig.calculateApplicationFeeInCents(
+            countryCode = "US",
+            orderTotal = BigDecimal("18.00"),
+            currencyCode = "USD",
+        )
+
+        assertThat(fee).isNull()
+    }
+
+    @Test
+    fun `given Canada or Australia, when resolving capture method, then manual preferred returned`() {
+        assertThat(TerminalPaymentIntentConfig.cardPresentCaptureMethod("CA"))
+            .isEqualTo(PaymentInfo.CardPresentCaptureMethod.MANUAL_PREFERRED)
+        assertThat(TerminalPaymentIntentConfig.cardPresentCaptureMethod("AU"))
+            .isEqualTo(PaymentInfo.CardPresentCaptureMethod.MANUAL_PREFERRED)
+    }
+
+    @Test
+    fun `given unsupported country, when resolving capture method, then null returned`() {
+        assertThat(TerminalPaymentIntentConfig.cardPresentCaptureMethod("US")).isNull()
+    }
+
+    @Test
+    fun `given Canada with WCPay and route available or Australia with WCPay, when resolving terminal preparation, then country-specific value returned`() {
+        assertThat(
+            TerminalPaymentIntentConfig.terminalPaymentPreparation(
+                countryCode = "CA",
+                isWooPaymentsPreferred = true,
+                isTerminalPaymentPreparationRouteAvailableInCanada = true,
+            )
+        )
+            .isEqualTo(PaymentInfo.TerminalPaymentPreparation.CANADA_INTERAC)
+        assertThat(
+            TerminalPaymentIntentConfig.terminalPaymentPreparation(
+                countryCode = "AU",
+                isWooPaymentsPreferred = true,
+                isTerminalPaymentPreparationRouteAvailableInCanada = false,
+            )
+        )
+            .isEqualTo(PaymentInfo.TerminalPaymentPreparation.AUSTRALIA_CARD_PRESENT)
+    }
+
+    @Test
+    fun `given unsupported country, when resolving terminal preparation, then none returned`() {
+        assertThat(
+            TerminalPaymentIntentConfig.terminalPaymentPreparation(
+                countryCode = "US",
+                isWooPaymentsPreferred = true,
+                isTerminalPaymentPreparationRouteAvailableInCanada = false,
+            )
+        )
+            .isEqualTo(PaymentInfo.TerminalPaymentPreparation.NONE)
+    }
+
+    @Test
+    fun `given non-WooPayments gateway, when resolving terminal preparation, then none returned`() {
+        assertThat(
+            TerminalPaymentIntentConfig.terminalPaymentPreparation(
+                countryCode = "AU",
+                isWooPaymentsPreferred = false,
+                isTerminalPaymentPreparationRouteAvailableInCanada = true,
+            )
+        )
+            .isEqualTo(PaymentInfo.TerminalPaymentPreparation.NONE)
+    }
+
+    @Test
+    fun `given Canada without route available, when resolving terminal preparation, then none returned`() {
+        assertThat(
+            TerminalPaymentIntentConfig.terminalPaymentPreparation(
+                countryCode = "CA",
+                isWooPaymentsPreferred = true,
+                isTerminalPaymentPreparationRouteAvailableInCanada = false,
+            )
+        )
+            .isEqualTo(PaymentInfo.TerminalPaymentPreparation.NONE)
+    }
+
+    @Test
+    fun `given route list contains terminal preparation route, when checking route support, then true returned`() {
+        val routes = listOf(
+            "/wc/v3/orders",
+            "/wc/v3/payments/orders/(?P<order_id>\\w+)/prepare_terminal_payment",
+        )
+
+        assertThat(TerminalPaymentIntentConfig.hasTerminalPaymentPreparationRoute(routes)).isTrue()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/TerminalPaymentPreparationResolverTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/TerminalPaymentPreparationResolverTest.kt
@@ -1,0 +1,131 @@
+package com.woocommerce.android.ui.payments.cardreader.payment
+
+import com.woocommerce.android.AppPrefs
+import com.woocommerce.android.cardreader.payments.PaymentInfo
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WooCommerceStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TerminalPaymentPreparationResolverTest {
+    private val wooStore: WooCommerceStore = mock()
+    private val appPrefs: AppPrefs = mock()
+    private val site = SiteModel().apply {
+        id = 1
+        siteId = 2L
+        selfHostedSiteId = 3L
+    }
+
+    private lateinit var sut: TerminalPaymentPreparationResolver
+
+    @Before
+    fun setUp() {
+        sut = TerminalPaymentPreparationResolver(wooStore, appPrefs)
+    }
+
+    @Test
+    fun `given AU WooPayments site, when resolving, then AU preparation is returned without checking routes`() =
+        runTest {
+            givenPreferredPlugin(PluginType.WOOCOMMERCE_PAYMENTS)
+
+            val result = sut.resolve(
+                countryCode = "AU",
+                site = site,
+                onRouteCheckFailed = {}
+            )
+
+            assertThat(result).isEqualTo(PaymentInfo.TerminalPaymentPreparation.AUSTRALIA_CARD_PRESENT)
+            verify(wooStore, never()).fetchSiteRootApiRoutes(any())
+        }
+
+    @Test
+    fun `given CA WooPayments site with prepare route, when resolving, then Canada preparation is returned`() =
+        runTest {
+            var routeCheckFailed = false
+            givenPreferredPlugin(PluginType.WOOCOMMERCE_PAYMENTS)
+            whenever(wooStore.fetchSiteRootApiRoutes(site)).thenReturn(WooResult(listOf(PREPARE_ROUTE)))
+
+            val result = sut.resolve(
+                countryCode = "CA",
+                site = site,
+                onRouteCheckFailed = { routeCheckFailed = true }
+            )
+
+            assertThat(result).isEqualTo(PaymentInfo.TerminalPaymentPreparation.CANADA_INTERAC)
+            assertThat(routeCheckFailed).isFalse()
+        }
+
+    @Test
+    fun `given CA WooPayments site without prepare route, when resolving, then preparation is not needed`() =
+        runTest {
+            var routeCheckFailed = false
+            givenPreferredPlugin(PluginType.WOOCOMMERCE_PAYMENTS)
+            whenever(wooStore.fetchSiteRootApiRoutes(site)).thenReturn(WooResult(emptyList()))
+
+            val result = sut.resolve(
+                countryCode = "CA",
+                site = site,
+                onRouteCheckFailed = { routeCheckFailed = true }
+            )
+
+            assertThat(result).isEqualTo(PaymentInfo.TerminalPaymentPreparation.NONE)
+            assertThat(routeCheckFailed).isFalse()
+        }
+
+    @Test
+    fun `given CA WooPayments site route check fails, when resolving, then preparation is not needed and failure is reported`() =
+        runTest {
+            var routeCheckFailed = false
+            givenPreferredPlugin(PluginType.WOOCOMMERCE_PAYMENTS)
+            whenever(wooStore.fetchSiteRootApiRoutes(site)).thenReturn(
+                WooResult(WooError(WooErrorType.API_ERROR, GenericErrorType.UNKNOWN))
+            )
+
+            val result = sut.resolve(
+                countryCode = "CA",
+                site = site,
+                onRouteCheckFailed = { routeCheckFailed = true }
+            )
+
+            assertThat(result).isEqualTo(PaymentInfo.TerminalPaymentPreparation.NONE)
+            assertThat(routeCheckFailed).isTrue()
+        }
+
+    @Test
+    fun `given non-WooPayments site, when resolving, then preparation is not needed and routes are not checked`() =
+        runTest {
+            givenPreferredPlugin(PluginType.STRIPE_EXTENSION_GATEWAY)
+
+            val result = sut.resolve(
+                countryCode = "CA",
+                site = site,
+                onRouteCheckFailed = {}
+            )
+
+            assertThat(result).isEqualTo(PaymentInfo.TerminalPaymentPreparation.NONE)
+            verify(wooStore, never()).fetchSiteRootApiRoutes(any())
+        }
+
+    private fun givenPreferredPlugin(pluginType: PluginType) {
+        whenever(appPrefs.getCardReaderPreferredPlugin(site.id, site.siteId, site.selfHostedSiteId))
+            .thenReturn(pluginType)
+    }
+
+    private companion object {
+        const val PREPARE_ROUTE = "/wc/v3/payments/orders/(?P<order_id>\\w+)/prepare_terminal_payment"
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/payment/controller/CardReaderPaymentControllerTest.kt
@@ -45,6 +45,7 @@ import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderFlowP
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderOnboardingChecker
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType.BUILT_IN
+import com.woocommerce.android.ui.payments.cardreader.onboarding.PluginType
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderInteracRefundErrorMapper
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderInteracRefundableChecker
 import com.woocommerce.android.ui.payments.cardreader.payment.CardReaderPaymentCollectibilityChecker
@@ -98,6 +99,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import kotlin.reflect.KMutableProperty0
@@ -162,6 +164,10 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         whenever(wooStore.getStoreCountryCode(any())).thenReturn("US")
         whenever(appPrefs.getCardReaderStatementDescriptor(anyOrNull(), anyOrNull(), anyOrNull()))
             .thenReturn("test statement descriptor")
+        whenever(appPrefs.getCardReaderPreferredPlugin(any(), any(), any()))
+            .thenReturn(PluginType.WOOCOMMERCE_PAYMENTS)
+        whenever(wooStore.fetchSiteRootApiRoutes(any()))
+            .thenReturn(WooResult(listOf(PREPARE_TERMINAL_PAYMENT_ROUTE)))
         whenever(paymentReceiptHelper.isPluginCanSendReceipt(siteModel)).thenReturn(true)
 
         whenever(cardReaderPaymentOrderHelper.getAmountLabel(mockedOrder))
@@ -2700,6 +2706,97 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given australia and total 18, when flow started, then fee set to percentage plus flat fee`() =
+        testBlocking {
+            // Given
+            whenever(wooStore.getStoreCountryCode(any())).thenReturn("AU")
+            whenever(mockedOrder.currency).thenReturn("AUD")
+            whenever(mockedOrder.total).thenReturn(BigDecimal("18.00"))
+            whenever(orderRepository.fetchOrderById(ORDER_ID)).thenReturn(mockedOrder)
+            val captor = argumentCaptor<PaymentInfo>()
+
+            // When
+            controller.start()
+
+            // Then
+            verify(cardReaderManager).collectPayment(captor.capture())
+            assertThat(captor.firstValue.feeAmount).isEqualTo(41)
+        }
+
+    @Test
+    fun `given canada, when flow started, then manual preferred and interac preparation passed`() =
+        testBlocking {
+            // Given
+            whenever(wooStore.getStoreCountryCode(any())).thenReturn("CA")
+            val captor = argumentCaptor<PaymentInfo>()
+
+            // When
+            controller.start()
+
+            // Then
+            verify(cardReaderManager).collectPayment(captor.capture())
+            assertThat(captor.firstValue.cardPresentCaptureMethod)
+                .isEqualTo(PaymentInfo.CardPresentCaptureMethod.MANUAL_PREFERRED)
+            assertThat(captor.firstValue.terminalPaymentPreparation)
+                .isEqualTo(PaymentInfo.TerminalPaymentPreparation.CANADA_INTERAC)
+        }
+
+    @Test
+    fun `given canada without terminal preparation route, when flow started, then preparation is skipped`() =
+        testBlocking {
+            // Given
+            whenever(wooStore.getStoreCountryCode(any())).thenReturn("CA")
+            whenever(wooStore.fetchSiteRootApiRoutes(any())).thenReturn(WooResult(emptyList()))
+            val captor = argumentCaptor<PaymentInfo>()
+
+            // When
+            controller.start()
+
+            // Then
+            verify(cardReaderManager).collectPayment(captor.capture())
+            assertThat(captor.firstValue.cardPresentCaptureMethod)
+                .isEqualTo(PaymentInfo.CardPresentCaptureMethod.MANUAL_PREFERRED)
+            assertThat(captor.firstValue.terminalPaymentPreparation)
+                .isEqualTo(PaymentInfo.TerminalPaymentPreparation.NONE)
+        }
+
+    @Test
+    fun `given stripe gateway in canada, when flow started, then terminal preparation is skipped`() =
+        testBlocking {
+            // Given
+            whenever(wooStore.getStoreCountryCode(any())).thenReturn("CA")
+            whenever(appPrefs.getCardReaderPreferredPlugin(any(), any(), any()))
+                .thenReturn(PluginType.STRIPE_EXTENSION_GATEWAY)
+            val captor = argumentCaptor<PaymentInfo>()
+
+            // When
+            controller.start()
+
+            // Then
+            verify(cardReaderManager).collectPayment(captor.capture())
+            assertThat(captor.firstValue.terminalPaymentPreparation)
+                .isEqualTo(PaymentInfo.TerminalPaymentPreparation.NONE)
+        }
+
+    @Test
+    fun `given australia, when flow started, then manual preferred and card present preparation passed`() =
+        testBlocking {
+            // Given
+            whenever(wooStore.getStoreCountryCode(any())).thenReturn("AU")
+            val captor = argumentCaptor<PaymentInfo>()
+
+            // When
+            controller.start()
+
+            // Then
+            verify(cardReaderManager).collectPayment(captor.capture())
+            assertThat(captor.firstValue.cardPresentCaptureMethod)
+                .isEqualTo(PaymentInfo.CardPresentCaptureMethod.MANUAL_PREFERRED)
+            assertThat(captor.firstValue.terminalPaymentPreparation)
+                .isEqualTo(PaymentInfo.TerminalPaymentPreparation.AUSTRALIA_CARD_PRESENT)
+        }
+
+    @Test
     fun `given us and total 1,49, when flow started, then fee is not set`() =
         testBlocking {
             // Given
@@ -2714,6 +2811,9 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
             // Then
             verify(cardReaderManager).collectPayment(captor.capture())
             assertThat(captor.firstValue.feeAmount).isNull()
+            assertThat(captor.firstValue.cardPresentCaptureMethod).isNull()
+            assertThat(captor.firstValue.terminalPaymentPreparation)
+                .isEqualTo(PaymentInfo.TerminalPaymentPreparation.NONE)
         }
 
     @Test
@@ -3728,5 +3828,7 @@ class CardReaderPaymentControllerTest : BaseUnitTest() {
         private val siteModel = SiteModel().apply { name = "testName" }.apply { url = "testUrl.com" }
         private val DUMMY_TOTAL = BigDecimal(10.72)
         private const val DUMMY_CURRENCY_SYMBOL = "£"
+        private const val PREPARE_TERMINAL_PAYMENT_ROUTE =
+            "/wc/v3/payments/orders/(?P<order_id>\\w+)/prepare_terminal_payment"
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/refunds/RefundSummaryViewModelTest.kt
@@ -25,6 +25,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.gateways.WCGatewayModel
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.network.BaseRequest
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -98,6 +99,43 @@ class RefundSummaryViewModelTest : BaseUnitTest() {
             val viewState = viewModel.refundSummaryStateLiveData.liveData.getOrAwaitValue()
 
             assertThat(viewState.refundMethod).isEqualTo("Credit/Debit card (Visa **** 1234)")
+        }
+    }
+
+    @Test
+    fun `given eftpos card brand, when charge data loaded, then refund method uses lower case eftpos`() {
+        testBlocking {
+            val chargeId = "charge_id"
+            val order = createTestOrder(
+                paymentMethod = "woocommerce_payments",
+                chargeId = chargeId
+            )
+            whenever(orderDetailRepository.getOrderById(ORDER_ID)).thenReturn(order)
+            whenever(gatewayStore.getGateway(any(), any())).thenReturn(
+                WCGatewayModel(
+                    id = "woocommerce_payments",
+                    title = "WooPayments (Card)",
+                    description = "",
+                    order = 0,
+                    isEnabled = true,
+                    methodTitle = "WooPayments",
+                    methodDescription = "",
+                    features = listOf("refunds")
+                )
+            )
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = "eftpos_au",
+                    cardLast4 = "0978",
+                    paymentMethodType = "card_present"
+                )
+            )
+
+            initViewModel()
+
+            val viewState = viewModel.refundSummaryStateLiveData.liveData.getOrAwaitValue()
+
+            assertThat(viewState.refundMethod).isEqualTo("WooPayments (Card) (eftpos **** 0978)")
         }
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosGetPaymentMethodTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/WooPosGetPaymentMethodTest.kt
@@ -73,6 +73,64 @@ class WooPosGetPaymentMethodTest {
         }
 
     @Test
+    fun `given eftpos card details, when invoke, then returns lower case eftpos`() =
+        runTest {
+            // GIVEN
+            val gateway = PaymentGateway(
+                title = "WooPayments",
+                description = "",
+                isEnabled = true,
+                methodTitle = "WooPayments",
+                methodDescription = "",
+                supportsRefunds = true
+            )
+            whenever(loadPaymentGateway.invoke(testOrder)).thenReturn(Result.success(gateway))
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_test123")).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = "eftpos_au",
+                    cardLast4 = "0978",
+                    paymentMethodType = "card_present"
+                )
+            )
+
+            // WHEN
+            val result = sut(testOrder)
+
+            // THEN
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrThrow()).isEqualTo("WooPayments (eftpos **** 0978)")
+        }
+
+    @Test
+    fun `given cartes bancaires card details, when invoke, then returns display name`() =
+        runTest {
+            // GIVEN
+            val gateway = PaymentGateway(
+                title = "WooPayments",
+                description = "",
+                isEnabled = true,
+                methodTitle = "WooPayments",
+                methodDescription = "",
+                supportsRefunds = true
+            )
+            whenever(loadPaymentGateway.invoke(testOrder)).thenReturn(Result.success(gateway))
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_test123")).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = "cartes_bancaires",
+                    cardLast4 = "1234",
+                    paymentMethodType = "card_present"
+                )
+            )
+
+            // WHEN
+            val result = sut(testOrder)
+
+            // THEN
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrThrow()).isEqualTo("WooPayments (Cartes Bancaires **** 1234)")
+        }
+
+    @Test
     fun `given disabled gateway, when invoke, then returns manual refund with gateway title`() = runTest {
         // GIVEN
         val gateway = PaymentGateway(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosCanBeLaunchedInTabTest.kt
@@ -312,22 +312,32 @@ class WooPosCanBeLaunchedInTabTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given AU country and AUD currency and both flags on, when invoked, then return UnsupportedCurrency`() = testBlocking {
+    fun `given AU country and AUD currency and AU flag on, when invoked, then return Launchable`() = testBlocking {
         whenever(supportedCountries.supportedCountryCurrencyPairs())
             .thenReturn(
                 listOf(
-                    "us" to "usd", "gb" to "gbp",
-                    "fr" to "eur", "de" to "eur", "ie" to "eur", "nl" to "eur",
-                    "sg" to "sgd", "nz" to "nzd",
-                    "at" to "eur", "be" to "eur", "fi" to "eur", "it" to "eur",
-                    "lu" to "eur", "pt" to "eur", "es" to "eur",
+                    "us" to "usd",
+                    "gb" to "gbp",
+                    "fr" to "eur",
+                    "de" to "eur",
+                    "ie" to "eur",
+                    "nl" to "eur",
+                    "sg" to "sgd",
+                    "nz" to "nzd",
+                    "at" to "eur",
+                    "be" to "eur",
+                    "fi" to "eur",
+                    "it" to "eur",
+                    "lu" to "eur",
+                    "pt" to "eur",
+                    "es" to "eur",
+                    "au" to "aud",
                 )
             )
         val siteSettings = buildSiteSettings(countryCode = "AU", currencyCode = "AUD")
         whenever(wooCommerceStore.getSiteSettings(any())).thenReturn(siteSettings)
 
-        val result = sut()
-        assertEquals(NotLaunchable(NonLaunchabilityReason.UnsupportedCurrency), result)
+        assertEquals(Launchable, sut())
     }
 
     // ---

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountriesTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosSupportedCountriesTest.kt
@@ -22,6 +22,7 @@ class WooPosSupportedCountriesTest : BaseUnitTest() {
         whenever(featureFlagRepository.awaitRemoteFlagsLoaded()).thenReturn(Unit)
         whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(false)
         whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(false)
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_AUSTRALIA_WOOPAYMENTS)).thenReturn(false)
         sut = WooPosSupportedCountries(featureFlagRepository)
     }
 
@@ -67,7 +68,7 @@ class WooPosSupportedCountriesTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given both flags on, when supportedCountryCurrencyPairs called, then all 16 pairs returned and AU absent`() = testBlocking {
+    fun `given primary and EU extended flags on, when supportedCountryCurrencyPairs called, then all 16 pairs returned and AU absent`() = testBlocking {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(true)
         whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(true)
 
@@ -77,15 +78,30 @@ class WooPosSupportedCountriesTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given both flags on, when supportedCountries called, then all country codes returned`() = testBlocking {
+    fun `given AU flag on, when supportedCountryCurrencyPairs called, then base plus AU returned`() = testBlocking {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_AUSTRALIA_WOOPAYMENTS)).thenReturn(true)
+
+        assertThat(sut.supportedCountryCurrencyPairs())
+            .containsExactlyInAnyOrder(
+                "us" to "usd",
+                "pr" to "usd",
+                "gb" to "gbp",
+                "au" to "aud",
+            )
+    }
+
+    @Test
+    fun `given all expansion flags on, when supportedCountries called, then all country codes returned`() = testBlocking {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION)).thenReturn(true)
         whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_COUNTRY_EXPANSION_EU_EXTENDED)).thenReturn(true)
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.IPP_AUSTRALIA_WOOPAYMENTS)).thenReturn(true)
 
         assertThat(sut.supportedCountries())
             .containsExactlyInAnyOrder(
                 "us", "pr", "gb",
                 "fr", "de", "ie", "nl", "sg", "nz",
                 "at", "be", "fi", "it", "lu", "pt", "es",
+                "au",
             )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosTabShouldBeVisibleTest.kt
@@ -217,17 +217,15 @@ class WooPosTabShouldBeVisibleTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given AU country with both flags on, when invoked, then return success false`() = testBlocking {
+    fun `given AU country with AU flag on, when invoked, then return success true`() = testBlocking {
         whenever(supportedCountries.supportedCountries())
-            .thenReturn(
-                listOf("us", "gb", "fr", "de", "ie", "nl", "sg", "nz", "at", "be", "fi", "it", "lu", "pt", "es")
-            )
+            .thenReturn(listOf("us", "gb", "au"))
         val siteSettings = buildSiteSettings(countryCode = "AU", currencyCode = "AUD")
         whenever(wooCommerceStore.fetchSiteGeneralSettings(siteModel)).thenReturn(WooResult(siteSettings))
 
         val r = sut(forceRefresh = true)
         assertTrue(r.isSuccess)
-        assertFalse(r.getOrThrow())
+        assertTrue(r.getOrThrow())
     }
 
     private fun buildSiteSettings(countryCode: String = "us", currencyCode: String = "USD") =

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigFactory.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigFactory.kt
@@ -24,6 +24,7 @@ class CardReaderConfigFactory {
             "LU" to CardReaderConfigForLU,
             "PT" to CardReaderConfigForPT,
             "ES" to CardReaderConfigForES,
+            "AU" to CardReaderConfigForAustralia,
         )
     }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForAustralia.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfigForAustralia.kt
@@ -1,0 +1,24 @@
+package com.woocommerce.android.cardreader.config
+
+import com.woocommerce.android.cardreader.connection.ReaderType
+import com.woocommerce.android.cardreader.payments.CardPaymentStatus.PaymentMethodType
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+object CardReaderConfigForAustralia : CardReaderConfigForSupportedCountry(
+    currency = "AUD",
+    countryCode = "AU",
+    supportedReaders = listOf(
+        ReaderType.ExternalReader.WisePade3,
+    ),
+    paymentMethodTypes = listOf(PaymentMethodType.CARD_PRESENT),
+    supportedExtensions = listOf(
+        SupportedExtension(
+            type = SupportedExtensionType.WC_PAY,
+            supportedSince = "10.8.0-test-1"
+        ),
+    ),
+    minimumAllowedChargeAmount = BigDecimal("0.50"),
+    maximumTTPAllowedChargeAmountWithoutPin = null,
+)

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentAction.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.cardreader.internal.payments.actions
 
+import com.stripe.stripeterminal.external.models.CardPresentParameters
 import com.stripe.stripeterminal.external.models.PaymentIntent
 import com.stripe.stripeterminal.external.models.PaymentIntentParameters
+import com.stripe.stripeterminal.external.models.PaymentMethodOptionsParameters
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.LogWrapper
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
@@ -14,6 +16,7 @@ import com.woocommerce.android.cardreader.internal.payments.actions.CreatePaymen
 import com.woocommerce.android.cardreader.internal.wrappers.PaymentIntentParametersFactory
 import com.woocommerce.android.cardreader.internal.wrappers.TerminalWrapper
 import com.woocommerce.android.cardreader.payments.PaymentInfo
+import com.stripe.stripeterminal.external.models.CardPresentCaptureMethod as StripeCardPresentCaptureMethod
 
 internal class CreatePaymentAction(
     private val paymentIntentParametersFactory: PaymentIntentParametersFactory,
@@ -56,9 +59,24 @@ internal class CreatePaymentAction(
                 if (!isPluginCanSendReceipt) builder.setReceiptEmail(it)
             }
             feeAmount?.let { builder.setApplicationFeeAmount(it) }
+            cardPresentCaptureMethod?.let { builder.setPaymentMethodOptionsParameters(createPaymentMethodOptions(it)) }
             statementDescriptor.value?.takeIf { it.isNotEmpty() }?.let { builder.setStatementDescriptor(it) }
         }
         return builder.build()
+    }
+
+    private fun createPaymentMethodOptions(
+        captureMethod: PaymentInfo.CardPresentCaptureMethod
+    ): PaymentMethodOptionsParameters {
+        val stripeCaptureMethod = when (captureMethod) {
+            PaymentInfo.CardPresentCaptureMethod.MANUAL_PREFERRED -> StripeCardPresentCaptureMethod.ManualPreferred
+        }
+        val cardPresentParameters = CardPresentParameters.Builder()
+            .setCaptureMethod(stripeCaptureMethod)
+            .build()
+        return PaymentMethodOptionsParameters.Builder()
+            .setCardPresentParameters(cardPresentParameters)
+            .build()
     }
 
     private fun createMetaData(paymentInfo: PaymentInfo): Map<String, String> {

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/payments/PaymentInfo.kt
@@ -16,10 +16,22 @@ data class PaymentInfo(
     val orderKey: String?,
     val feeAmount: Long?,
     val channel: PaymentChannel?,
+    val cardPresentCaptureMethod: CardPresentCaptureMethod? = null,
+    val terminalPaymentPreparation: TerminalPaymentPreparation = TerminalPaymentPreparation.NONE,
     internal val countryCode: String? = null,
 ) {
     sealed class PaymentChannel(val value: String) {
         data object StoreManager : PaymentChannel("mobile_store_management")
         data object Pos : PaymentChannel("mobile_pos")
+    }
+
+    enum class CardPresentCaptureMethod {
+        MANUAL_PREFERRED,
+    }
+
+    enum class TerminalPaymentPreparation {
+        NONE,
+        CANADA_INTERAC,
+        AUSTRALIA_CARD_PRESENT,
     }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteMessage.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteMessage.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.remote
 
+import com.woocommerce.android.cardreader.payments.PaymentInfo
 import java.math.BigDecimal
 
 internal sealed class CardReaderRemoteMessage {
@@ -31,6 +32,8 @@ internal sealed class CardReaderRemoteMessage {
         val orderKey: String?,
         val feeAmount: Long?,
         val countryCode: String?,
+        val cardPresentCaptureMethod: PaymentInfo.CardPresentCaptureMethod?,
+        val terminalPaymentPreparation: PaymentInfo.TerminalPaymentPreparation?,
     ) : CardReaderRemoteMessage()
 
     data class PaymentIntentResult(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteNsd.kt
@@ -232,7 +232,9 @@ internal class CardReaderRemoteNsd(
         const val TXT_KEY_DEVICE_NAME = "name"
         const val TXT_KEY_SITE_HASH = "siteHash"
         const val TXT_KEY_DEVICE_ID = "did"
-        const val PROTOCOL_VERSION = "1"
+
+        // Bump when collect-payment messages change in ways that affect payment correctness.
+        const val PROTOCOL_VERSION = "2"
         private const val SERVICE_NAME_PREFIX = "woopos-remote"
         private const val SUFFIX_RANGE_EXCLUSIVE = 0x10000
         private const val HEX_RADIX = 16

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteTabletClient.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteTabletClient.kt
@@ -223,4 +223,6 @@ private fun PaymentInfo.toCollectPaymentRequest(requestId: String): CollectPayme
         orderKey = orderKey,
         feeAmount = feeAmount,
         countryCode = countryCode,
+        cardPresentCaptureMethod = cardPresentCaptureMethod,
+        terminalPaymentPreparation = terminalPaymentPreparation,
     )

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigFactoryTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.cardreader.internal.config
 
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.config.CardReaderConfigForAT
+import com.woocommerce.android.cardreader.config.CardReaderConfigForAustralia
 import com.woocommerce.android.cardreader.config.CardReaderConfigForBE
 import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
 import com.woocommerce.android.cardreader.config.CardReaderConfigForDE
@@ -170,8 +171,8 @@ class CardReaderConfigFactoryTest : CardReaderBaseUnitTest() {
     }
 
     @Test
-    fun `given country code AU, when getCardReaderConfigFor is called, then unsupported config returned`() {
+    fun `given country code AU, when getCardReaderConfigFor is called, then Australia card reader config returned`() {
         assertThat(cardReaderConfigFactory.getCardReaderConfigFor("AU"))
-            .isInstanceOf(CardReaderConfigForUnsupportedCountry::class.java)
+            .isInstanceOf(CardReaderConfigForAustralia::class.java)
     }
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/actions/CreatePaymentActionTest.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.cardreader.internal.payments.actions
 
 import com.stripe.stripeterminal.external.models.PaymentIntent
 import com.stripe.stripeterminal.external.models.PaymentIntentParameters
+import com.stripe.stripeterminal.external.models.PaymentMethodOptionsParameters
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
@@ -28,6 +29,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
+import com.stripe.stripeterminal.external.models.CardPresentCaptureMethod as StripeCardPresentCaptureMethod
 
 @Suppress("DoNotMockDataClass")
 @ExperimentalCoroutinesApi
@@ -55,6 +57,7 @@ internal class CreatePaymentActionTest : CardReaderBaseUnitTest() {
         whenever(intentParametersBuilder.setMetadata(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.setReceiptEmail(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.setApplicationFeeAmount(any())).thenReturn(intentParametersBuilder)
+        whenever(intentParametersBuilder.setPaymentMethodOptionsParameters(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.setStatementDescriptor(any())).thenReturn(intentParametersBuilder)
         whenever(intentParametersBuilder.build()).thenReturn(mock())
         whenever(cardReaderConfigFactory.getCardReaderConfigFor(any())).thenReturn(
@@ -186,6 +189,30 @@ internal class CreatePaymentActionTest : CardReaderBaseUnitTest() {
 
         verify(intentParametersBuilder).setApplicationFeeAmount(expected)
     }
+
+    @Test
+    fun `when card present capture method is manual preferred, then PaymentIntent card present options are set`() =
+        testBlocking {
+            val captor = argumentCaptor<PaymentMethodOptionsParameters>()
+
+            action.createPaymentIntent(
+                createPaymentInfo(
+                    cardPresentCaptureMethod = PaymentInfo.CardPresentCaptureMethod.MANUAL_PREFERRED
+                )
+            )
+
+            verify(intentParametersBuilder).setPaymentMethodOptionsParameters(captor.capture())
+            assertThat(captor.firstValue.cardPresentParameters?.captureMethod)
+                .isEqualTo(StripeCardPresentCaptureMethod.ManualPreferred)
+        }
+
+    @Test
+    fun `when card present capture method is null, then PaymentIntent payment method options are not set`() =
+        testBlocking {
+            action.createPaymentIntent(createPaymentInfo())
+
+            verify(intentParametersBuilder, never()).setPaymentMethodOptionsParameters(any())
+        }
 
     @Test
     fun `when creating payment intent, then store name set`() = testBlocking {
@@ -407,6 +434,7 @@ internal class CreatePaymentActionTest : CardReaderBaseUnitTest() {
         statementDescriptor: String? = null,
         feeAmount: Long? = null,
         channel: PaymentInfo.PaymentChannel? = null,
+        cardPresentCaptureMethod: PaymentInfo.CardPresentCaptureMethod? = null,
     ): PaymentInfo =
         PaymentInfo(
             paymentDescription = paymentDescription,
@@ -423,5 +451,6 @@ internal class CreatePaymentActionTest : CardReaderBaseUnitTest() {
             statementDescriptor = StatementDescriptor(statementDescriptor),
             feeAmount = feeAmount,
             channel = channel,
+            cardPresentCaptureMethod = cardPresentCaptureMethod,
         )
 }

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteProtocolTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteProtocolTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.remote
 
+import com.woocommerce.android.cardreader.payments.PaymentInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.io.ByteArrayInputStream
@@ -59,6 +60,8 @@ class CardReaderRemoteProtocolTest {
             orderKey = "wc_order_key",
             feeAmount = 15L,
             countryCode = "US",
+            cardPresentCaptureMethod = PaymentInfo.CardPresentCaptureMethod.MANUAL_PREFERRED,
+            terminalPaymentPreparation = PaymentInfo.TerminalPaymentPreparation.AUSTRALIA_CARD_PRESENT,
         )
 
         // WHEN
@@ -66,6 +69,37 @@ class CardReaderRemoteProtocolTest {
 
         // THEN
         assertThat(decoded).isEqualTo(original)
+    }
+
+    @Test
+    fun `given legacy CollectPaymentRequest, when read back, then payment preparation is absent`() {
+        // GIVEN
+        val json = """
+            {
+              "requestId": "req-legacy",
+              "paymentDescription": "Order #123",
+              "statementDescriptorRaw": "STORE",
+              "orderId": 123,
+              "amount": 12.34,
+              "currency": "usd",
+              "customerEmail": "customer@example.com",
+              "isPluginCanSendReceipt": true,
+              "customerName": "Jane Doe",
+              "storeName": "Test Store",
+              "siteUrl": "https://example.com",
+              "orderKey": "wc_order_key",
+              "feeAmount": 15,
+              "countryCode": "US",
+              "type": "collect_payment"
+            }
+        """.trimIndent()
+
+        // WHEN
+        val decoded = readRaw(json)
+
+        // THEN
+        assertThat(decoded).isInstanceOf(CardReaderRemoteMessage.CollectPaymentRequest::class.java)
+        assertThat((decoded as CardReaderRemoteMessage.CollectPaymentRequest).terminalPaymentPreparation).isNull()
     }
 
     @Test
@@ -103,6 +137,16 @@ class CardReaderRemoteProtocolTest {
     private fun roundTrip(msg: CardReaderRemoteMessage): CardReaderRemoteMessage {
         val buffer = ByteArrayOutputStream()
         protocol.write(DataOutputStream(buffer), msg)
+        return protocol.read(DataInputStream(ByteArrayInputStream(buffer.toByteArray())))
+    }
+
+    private fun readRaw(json: String): CardReaderRemoteMessage {
+        val bytes = json.toByteArray(Charsets.UTF_8)
+        val buffer = ByteArrayOutputStream()
+        DataOutputStream(buffer).use { output ->
+            output.writeInt(bytes.size)
+            output.write(bytes)
+        }
         return protocol.read(DataInputStream(ByteArrayInputStream(buffer.toByteArray())))
     }
 }

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/WooCommerceRestClient.kt
@@ -48,6 +48,16 @@ class WooCommerceRestClient @Inject constructor(private val wooNetwork: WooNetwo
         return response.toWooPayload()
     }
 
+    suspend fun fetchSiteRootAPIRoutes(site: SiteModel): WooPayload<RootWPAPIRestResponse> {
+        val response = wooNetwork.executeGetGsonRequest(
+            site = site,
+            path = "/",
+            params = mapOf("_fields" to "routes"),
+            clazz = RootWPAPIRestResponse::class.java
+        )
+        return response.toWooPayload()
+    }
+
     /**
      * Makes a GET call to `/wc/v3/settings/general` via the Jetpack tunnel (see [JetpackTunnelGsonRequest]),
      * retrieving site settings for the given WooCommerce [SiteModel].

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WooCommerceStore.kt
@@ -308,6 +308,26 @@ open class WooCommerceStore @Inject internal constructor(
         }
     }
 
+    suspend fun fetchSiteRootApiRoutes(site: SiteModel): WooResult<List<String>> {
+        return coroutineEngine.withDefaultContext(T.API, this, "fetchSiteRootApiRoutes") {
+            val response = wcCoreRestClient.fetchSiteRootAPIRoutes(site)
+            return@withDefaultContext when {
+                response.isError -> {
+                    AppLog.w(T.API, "Fetching WP API routes failed for site ${site.siteId}")
+                    WooResult(response.error)
+                }
+
+                response.result != null -> {
+                    WooResult(response.result.routes?.keys?.toList().orEmpty())
+                }
+
+                else -> {
+                    WooResult(WooError(GENERIC_ERROR, UNKNOWN))
+                }
+            }
+        }
+    }
+
     suspend fun enableCoupons(site: SiteModel): Boolean {
         return coroutineEngine.withDefaultContext(T.API, this, "enableCoupons") {
             val response = wcCoreRestClient.enableCoupons(site)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponse.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/discovery/RootWPAPIRestResponse.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.fluxc.network.discovery
 
+import com.google.gson.JsonElement
 import com.google.gson.annotations.SerializedName
 import org.wordpress.android.fluxc.network.Response
 import org.wordpress.android.fluxc.network.rest.JsonObjectOrNull
@@ -10,7 +11,8 @@ class RootWPAPIRestResponse(
     val url: String? = null,
     @SerializedName("gmt_offset") val gmtOffset: String? = null,
     val namespaces: List<String>? = null,
-    val authentication: Authentication? = null
+    val authentication: Authentication? = null,
+    val routes: Map<String, JsonElement>? = null
 ) : Response {
     class Authentication(
         @SerializedName("application-passwords") val applicationPasswords: ApplicationPasswords? = null


### PR DESCRIPTION
Part of: RSM-642

### Description

This is the first PR in the Android AU WooPayments card-present stack.

Stack continues in #15910.

It adds the Android-side country configuration needed for WooPayments in-person payments in Australia, behind the `woo_ipp_australia_woopayments` remote feature flag. It also adds the AU backstop application fee configuration used when creating terminal PaymentIntents, while keeping Stripe gateway support out of scope for this launch.

The PR also normalizes eftpos card brand display strings so customer-facing Android and POS refund surfaces show `eftpos` rather than the raw Stripe value.

### Test Steps

Testing's best done on the final PR in the stack – unit tests are fine for this one.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
