### PR TITLE
Add WCPay terminal payment preparation API

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/InPersonPaymentsModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/InPersonPaymentsModule.kt
@@ -45,6 +45,18 @@ class InPersonPaymentsModule {
             return result.model?.token.orEmpty()
         }
 
+        override suspend fun preparePaymentIntent(
+            orderId: Long,
+            paymentId: String
+        ): CardReaderStore.PreparePaymentResponse {
+            val response = inPersonPaymentsStore.preparePayment(
+                selectedSite.get(),
+                paymentId,
+                orderId
+            )
+            return responseMapper.mapResponse(response)
+        }
+
         override suspend fun capturePaymentIntent(orderId: Long, paymentId: String): CapturePaymentResponse {
             val response = inPersonPaymentsStore.capturePayment(
                 appPrefs.getCardReaderPreferredPlugin(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CapturePaymentResponseMapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/CapturePaymentResponseMapper.kt
@@ -7,6 +7,7 @@ import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Error.ServerError
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Successful.PaymentAlreadyCaptured
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse.Successful.Success
+import com.woocommerce.android.cardreader.CardReaderStore.PreparePaymentResponse
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentError
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.AMOUNT_TOO_SMALL
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.CAPTURE_ERROR
@@ -16,6 +17,8 @@ import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentError
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.PAYMENT_ALREADY_CAPTURED
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentErrorType.SERVER_ERROR
 import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentResponsePayload
+import org.wordpress.android.fluxc.model.payments.inperson.WCPrepareTerminalPaymentResponsePayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
 import javax.inject.Inject
 
 class CapturePaymentResponseMapper @Inject constructor() {
@@ -28,6 +31,11 @@ class CapturePaymentResponseMapper @Inject constructor() {
         SERVER_ERROR -> ServerError(response.error.messageOrDefault())
         NETWORK_ERROR -> NetworkError(response.error.messageOrDefault())
         AMOUNT_TOO_SMALL -> mapAmountTooSmallError(response)
+    }
+
+    fun mapResponse(response: WCPrepareTerminalPaymentResponsePayload) = when (response.error) {
+        null -> PreparePaymentResponse.Success
+        else -> PreparePaymentResponse.Error(response.error.messageOrDefault())
     }
 
     private fun mapAmountTooSmallError(response: WCCapturePaymentResponsePayload): CaptureError {
@@ -51,6 +59,8 @@ class CapturePaymentResponseMapper @Inject constructor() {
     }
 
     private fun WCCapturePaymentError?.messageOrDefault() = this?.message ?: "No error message provided"
+
+    private fun WooError?.messageOrDefault() = this?.message ?: "No error message provided"
 
     companion object {
         private const val MINIMUM_AMOUNT_CURRENCY_KEY = "minimum_amount_currency"

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderStore.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderStore.kt
@@ -3,7 +3,14 @@ package com.woocommerce.android.cardreader
 interface CardReaderStore {
     suspend fun fetchConnectionToken(): String
 
+    suspend fun preparePaymentIntent(orderId: Long, paymentId: String): PreparePaymentResponse
+
     suspend fun capturePaymentIntent(orderId: Long, paymentId: String): CapturePaymentResponse
+
+    sealed class PreparePaymentResponse {
+        data object Success : PreparePaymentResponse()
+        data class Error(val message: String) : PreparePaymentResponse()
+    }
 
     sealed class CapturePaymentResponse {
         sealed class Successful : CapturePaymentResponse() {

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCPrepareTerminalPaymentResponsePayload.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/model/payments/inperson/WCPrepareTerminalPaymentResponsePayload.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.fluxc.model.payments.inperson
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+
+data class WCPrepareTerminalPaymentResponsePayload(
+    val site: SiteModel,
+    val paymentId: String,
+    val orderId: Long,
+    val error: WooError? = null,
+)

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClient.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.model.payments.inperson.WCCapturePaymentRespo
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentChargeApiResult
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentTransactionsSummaryResult
+import org.wordpress.android.fluxc.model.payments.inperson.WCPrepareTerminalPaymentResponsePayload
 import org.wordpress.android.fluxc.model.payments.inperson.WCTerminalStoreLocationError
 import org.wordpress.android.fluxc.model.payments.inperson.WCTerminalStoreLocationErrorType
 import org.wordpress.android.fluxc.model.payments.inperson.WCTerminalStoreLocationResult
@@ -26,6 +27,7 @@ import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
 import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooPayload
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.toWooError
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.STRIPE
 import org.wordpress.android.fluxc.store.WCInPersonPaymentsStore.InPersonPaymentsPluginType.WOOCOMMERCE_PAYMENTS
@@ -99,6 +101,32 @@ class InPersonPaymentsRestClient @Inject constructor(
                     orderId
                 )
             }
+        }
+    }
+
+    suspend fun preparePayment(
+        site: SiteModel,
+        paymentId: String,
+        orderId: Long
+    ): WCPrepareTerminalPaymentResponsePayload {
+        val body = mapOf(
+            "payment_intent_id" to paymentId
+        )
+        val response = wooNetwork.executePostGsonRequest(
+            site = site,
+            path = WOOCOMMERCE.payments.orders.id(orderId).prepare_terminal_payment.pathV3,
+            body = body,
+            clazz = Any::class.java
+        )
+
+        return when (response) {
+            is WPAPIResponse.Success -> WCPrepareTerminalPaymentResponsePayload(site, paymentId, orderId)
+            is WPAPIResponse.Error -> WCPrepareTerminalPaymentResponsePayload(
+                site = site,
+                paymentId = paymentId,
+                orderId = orderId,
+                error = response.error.toWooError()
+            )
         }
     }
 

--- a/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
+++ b/libs/fluxc-plugin/src/main/kotlin/org/wordpress/android/fluxc/store/WCInPersonPaymentsStore.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.fluxc.model.payments.inperson.WCConnectionTokenResu
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentAccountResult
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentChargeApiResult
 import org.wordpress.android.fluxc.model.payments.inperson.WCPaymentTransactionsSummaryResult
+import org.wordpress.android.fluxc.model.payments.inperson.WCPrepareTerminalPaymentResponsePayload
 import org.wordpress.android.fluxc.model.payments.inperson.WCTerminalStoreLocationResult
 import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType.UNKNOWN
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -49,6 +50,16 @@ class WCInPersonPaymentsStore @Inject constructor(
     ): WCCapturePaymentResponsePayload {
         return coroutineEngine.withDefaultContext(AppLog.T.API, this, "capturePayment") {
             restClient.capturePayment(activePlugin, site, paymentId, orderId)
+        }
+    }
+
+    suspend fun preparePayment(
+        site: SiteModel,
+        paymentId: String,
+        orderId: Long
+    ): WCPrepareTerminalPaymentResponsePayload {
+        return coroutineEngine.withDefaultContext(AppLog.T.API, this, "preparePayment") {
+            restClient.preparePayment(site, paymentId, orderId)
         }
     }
 

--- a/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClientTest.kt
+++ b/libs/fluxc-plugin/src/test/java/org/wordpress/android/fluxc/network/rest/wpcom/wc/payments/inperson/InPersonPaymentsRestClientTest.kt
@@ -1,0 +1,89 @@
+package org.wordpress.android.fluxc.network.rest.wpcom.wc.payments.inperson
+
+import com.google.gson.Gson
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.generated.endpoint.WOOCOMMERCE
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.BaseRequest.BaseNetworkError
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPINetworkError
+import org.wordpress.android.fluxc.network.rest.wpapi.WPAPIResponse
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooNetwork
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InPersonPaymentsRestClientTest {
+    private val wooNetwork: WooNetwork = mock()
+    private val site = SiteModel()
+
+    private lateinit var sut: InPersonPaymentsRestClient
+
+    @Before
+    fun setUp() {
+        sut = InPersonPaymentsRestClient(wooNetwork, Gson())
+    }
+
+    @Test
+    fun `given success response, when preparePayment, then WCPay prepare endpoint is called`() = runTest {
+        val orderId = 123L
+        val paymentId = "pi_test"
+        val expectedPath = WOOCOMMERCE.payments.orders.id(orderId).prepare_terminal_payment.pathV3
+
+        whenever(
+            wooNetwork.executePostGsonRequest(
+                site = any(),
+                path = any(),
+                clazz = eq(Any::class.java),
+                body = any()
+            )
+        ).thenReturn(WPAPIResponse.Success(Any(), emptyList()))
+
+        val result = sut.preparePayment(site, paymentId, orderId)
+
+        val bodyCaptor = argumentCaptor<Map<String, Any>>()
+        verify(wooNetwork).executePostGsonRequest(
+            site = eq(site),
+            path = eq(expectedPath),
+            clazz = eq(Any::class.java),
+            body = bodyCaptor.capture()
+        )
+
+        assertThat(bodyCaptor.firstValue).containsExactlyEntriesOf(mapOf("payment_intent_id" to paymentId))
+        assertThat(result.site).isEqualTo(site)
+        assertThat(result.paymentId).isEqualTo(paymentId)
+        assertThat(result.orderId).isEqualTo(orderId)
+        assertThat(result.error).isNull()
+    }
+
+    @Test
+    fun `given error response, when preparePayment, then error is mapped`() = runTest {
+        val networkError = WPAPINetworkError(
+            BaseNetworkError(GenericErrorType.NOT_FOUND, "Missing route"),
+            errorCode = "rest_no_route"
+        )
+        whenever(
+            wooNetwork.executePostGsonRequest(
+                site = any(),
+                path = any(),
+                clazz = eq(Any::class.java),
+                body = any()
+            )
+        ).thenReturn(WPAPIResponse.Error(networkError))
+
+        val result = sut.preparePayment(site, paymentId = "pi_test", orderId = 123L)
+
+        assertThat(result.error?.type).isEqualTo(WooErrorType.API_NOT_FOUND)
+        assertThat(result.error?.apiErrorCode).isEqualTo("rest_no_route")
+        assertThat(result.error?.message).isEqualTo("Missing route")
+    }
+}

--- a/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
+++ b/libs/fluxc-processor/src/main/resources/wc-wp-api-endpoints.txt
@@ -72,6 +72,7 @@
 
 /payments/connection_tokens
 /payments/orders/<id>/capture_terminal_payment
+/payments/orders/<id>/prepare_terminal_payment
 /payments/accounts
 /payments/charges/<charge_id>#String/
 


### PR DESCRIPTION
Part of: RSM-642

### Description

This is the second PR in the Android AU WooPayments card-present stack.

Stacked after #15909 and continues in #15911.

It adds the FluxC/WooPayments API plumbing for WCPay’s new `prepare_terminal_payment` endpoint. The endpoint is used after collecting a card and before confirming the terminal PaymentIntent, giving WooPayments a chance to apply the server-side preparation needed for regional card-present payment methods such as eftpos and Interac.

### Test Steps

It's easiest to test with the final PR in the stack, unit tests passing for this one should be sufficient.


### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
