### PR TITLE
Prepare WCPay terminal payments before confirmation

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
@@ -95,7 +95,10 @@ class MockCardReaderManagerModule {
         override suspend fun createPaymentIntent(paymentInfo: PaymentInfo): CreatePaymentIntentResult =
             CreatePaymentIntentResult.Failed(IllegalStateException("Not used in instrumented tests"))
 
-        override suspend fun retrieveAndCollectPayment(clientSecret: String): RetrieveAndCollectResult =
+        override suspend fun retrieveAndCollectPayment(
+            clientSecret: String,
+            paymentInfo: PaymentInfo
+        ): RetrieveAndCollectResult =
             RetrieveAndCollectResult.Failed(IllegalStateException("Not used in instrumented tests"))
 
         override suspend fun refundInteracPayment(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -68,7 +68,7 @@ interface CardReaderManager {
      * Tap-to-Pay flow. The returned status is the PaymentIntent's status after processing —
      * typically `requires_capture`.
      */
-    suspend fun retrieveAndCollectPayment(clientSecret: String): RetrieveAndCollectResult
+    suspend fun retrieveAndCollectPayment(clientSecret: String, paymentInfo: PaymentInfo): RetrieveAndCollectResult
 
     suspend fun refundInteracPayment(
         refundParams: RefundParams,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -131,10 +131,13 @@ internal class CardReaderManagerImpl(
         return paymentManager.createPaymentIntentOnly(paymentInfo)
     }
 
-    override suspend fun retrieveAndCollectPayment(clientSecret: String): RetrieveAndCollectResult {
+    override suspend fun retrieveAndCollectPayment(
+        clientSecret: String,
+        paymentInfo: PaymentInfo
+    ): RetrieveAndCollectResult {
         if (!terminal.isInitialized()) error("Terminal not initialized")
         resetBluetoothDisplayMessage()
-        return paymentManager.retrieveAndCollectPayment(clientSecret)
+        return paymentManager.retrieveAndCollectPayment(clientSecret, paymentInfo)
     }
 
     override suspend fun refundInteracPayment(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/PaymentManager.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.cardreader.internal.payments
 
+import com.stripe.stripeterminal.external.models.CardPresentDetails
 import com.stripe.stripeterminal.external.models.PaymentIntent
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.CANCELED
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
+import com.woocommerce.android.cardreader.CardReaderStore.PreparePaymentResponse
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.cardreader.internal.payments.actions.CancelPaymentAction
@@ -32,6 +34,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 
+private const val EFTPOS_AU_NETWORK = "eftpos_au"
+
 @Suppress("LongParameterList")
 internal class PaymentManager(
     private val terminalWrapper: TerminalWrapper,
@@ -50,7 +54,7 @@ internal class PaymentManager(
         if (paymentIntent?.status != PaymentIntentStatus.REQUIRES_PAYMENT_METHOD) {
             return@flow
         }
-        processPaymentIntent(paymentInfo.orderId, paymentIntent).collect { emit(it) }
+        processPaymentIntent(paymentInfo, paymentIntent).collect { emit(it) }
     }
 
     fun retryPayment(orderId: Long, paymentData: PaymentData) =
@@ -82,10 +86,10 @@ internal class PaymentManager(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    suspend fun retrieveAndCollectPayment(clientSecret: String): RetrieveAndCollectResult =
+    suspend fun retrieveAndCollectPayment(clientSecret: String, paymentInfo: PaymentInfo): RetrieveAndCollectResult =
         try {
             val retrieved = terminalWrapper.retrievePaymentIntent(clientSecret)
-            val processed = terminalWrapper.processPaymentIntent(retrieved)
+            val processed = processPaymentIntentForRemoteReader(paymentInfo, retrieved)
             val id = processed.id
             val status = processed.status?.name?.lowercase()
             if (id == null || status == null) {
@@ -135,36 +139,49 @@ internal class PaymentManager(
         if (paymentIntent.status == PaymentIntentStatus.REQUIRES_PAYMENT_METHOD ||
             paymentIntent.status == PaymentIntentStatus.REQUIRES_CONFIRMATION
         ) {
-            paymentIntent = processPayment(paymentIntent)
+            emit(ProcessingPayment)
+            paymentIntent = processPaymentWithoutPreparation(paymentIntent)
         }
 
         /*
-            At this point,
+            Single-step terminal payments, such as Interac and EFTPOS-routed card-present payments, may already be
+            successful after processing. In that case, the backend capture endpoint is still called to record the
+            completed payment on the order, rather than to capture funds.
 
-            if this was an Interac payment. The payment has already been captured successfully
-            in the previous step (Processing step). In the next capture step, we will inform the backend about
-            the successful Interac payment transaction that has already happened and it's not the success/failure
-            of the actual Interac payment itself.
-
-            If this was a non-Interac payment. We expect the payment intent's status to be REQUIRES_CAPTURE and in
-            the next step we capture the payment in the backend. Here, the success/failure of the capture step defines
-            the success/failure of the actual payment.
+            Other card-present payments are expected to reach REQUIRES_CAPTURE and are captured by the backend.
          */
 
-        if (paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE || isInteracPaymentSuccessful(paymentIntent)) {
+        if (
+            paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE ||
+            isSingleStepTerminalPaymentSuccessful(paymentIntent)
+        ) {
             retrieveReceiptUrl(paymentIntent)?.let { receiptUrl ->
                 capturePayment(receiptUrl, orderId, cardReaderStore, paymentIntent)
             }
         }
     }
 
-    private fun isInteracPayment(paymentIntent: PaymentIntent): Boolean {
-        return !paymentIntent.getCharges().isNullOrEmpty() &&
-            paymentIntent.getCharges().getOrNull(0)?.paymentMethodDetails?.interacPresentDetails != null
-    }
+    private fun processPaymentIntent(paymentInfo: PaymentInfo, data: PaymentIntent) = flow {
+        var paymentIntent = data
+        if (paymentIntent.status == null || paymentIntent.status == CANCELED) {
+            emit(errorMapper.mapError(errorMessage = "Cannot retry paymentIntent with status ${paymentIntent.status}"))
+            return@flow
+        }
 
-    private fun isInteracPaymentSuccessful(paymentIntent: PaymentIntent): Boolean {
-        return isInteracPayment(paymentIntent) && paymentIntent.status == PaymentIntentStatus.SUCCEEDED
+        if (paymentIntent.status == PaymentIntentStatus.REQUIRES_PAYMENT_METHOD ||
+            paymentIntent.status == PaymentIntentStatus.REQUIRES_CONFIRMATION
+        ) {
+            paymentIntent = processPayment(paymentInfo, paymentIntent)
+        }
+
+        if (
+            paymentIntent.status == PaymentIntentStatus.REQUIRES_CAPTURE ||
+            isSingleStepTerminalPaymentSuccessful(paymentIntent)
+        ) {
+            retrieveReceiptUrl(paymentIntent)?.let { receiptUrl ->
+                capturePayment(receiptUrl, paymentInfo.orderId, cardReaderStore, paymentIntent)
+            }
+        }
     }
 
     private suspend fun FlowCollector<CardPaymentStatus>.retrieveReceiptUrl(
@@ -188,16 +205,55 @@ internal class PaymentManager(
     }
 
     private suspend fun FlowCollector<CardPaymentStatus>.processPayment(
+        paymentInfo: PaymentInfo,
         paymentIntent: PaymentIntent
     ): PaymentIntent {
         emit(ProcessingPayment)
+        if (paymentInfo.terminalPaymentPreparation == PaymentInfo.TerminalPaymentPreparation.NONE) {
+            return processPaymentWithoutPreparation(paymentIntent)
+        }
+
+        val collectedPaymentIntent = when (
+            val result = processPaymentIntentAction.collectPaymentMethod(paymentIntent)
+        ) {
+            is ProcessPaymentIntentStatus.Failure -> {
+                emit(errorMapper.mapTerminalError(paymentIntent, result.exception))
+                return paymentIntent
+            }
+            is ProcessPaymentIntentStatus.Success -> result.paymentIntent
+        }
+
+        when (val result = prepareTerminalPaymentIfNeeded(paymentInfo, collectedPaymentIntent)) {
+            TerminalPaymentPreparationResult.Prepared -> Unit
+            is TerminalPaymentPreparationResult.Failed -> {
+                emit(errorMapper.mapError(collectedPaymentIntent, result.message))
+                return collectedPaymentIntent
+            }
+        }
+
+        return when (val result = processPaymentIntentAction.confirmPaymentIntent(collectedPaymentIntent)) {
+            is ProcessPaymentIntentStatus.Failure -> {
+                emit(errorMapper.mapTerminalError(collectedPaymentIntent, result.exception))
+                collectedPaymentIntent
+            }
+            is ProcessPaymentIntentStatus.Success -> {
+                val paymentMethodType = determinePaymentMethodType(result.paymentIntent)
+                emit(ProcessingPaymentCompleted(paymentMethodType))
+                result.paymentIntent
+            }
+        }
+    }
+
+    private suspend fun FlowCollector<CardPaymentStatus>.processPaymentWithoutPreparation(
+        paymentIntent: PaymentIntent
+    ): PaymentIntent {
         return when (val result = processPaymentIntentAction.processPaymentIntent(paymentIntent)) {
             is ProcessPaymentIntentStatus.Failure -> {
                 emit(errorMapper.mapTerminalError(paymentIntent, result.exception))
                 paymentIntent
             }
             is ProcessPaymentIntentStatus.Success -> {
-                val paymentMethodType = determinePaymentMethodType(result)
+                val paymentMethodType = determinePaymentMethodType(result.paymentIntent)
                 emit(ProcessingPaymentCompleted(paymentMethodType))
                 result.paymentIntent
             }
@@ -224,7 +280,7 @@ internal class PaymentManager(
         return when {
             cardReaderConfig !is CardReaderConfigForSupportedCountry ||
                 !paymentUtils.isSupportedCurrency(paymentInfo.currency, cardReaderConfig) -> {
-                emit(errorMapper.mapError(errorMessage = "Unsupported currency: $paymentInfo.currency"))
+                emit(errorMapper.mapError(errorMessage = "Unsupported currency: ${paymentInfo.currency}"))
                 true
             }
             !terminalWrapper.isInitialized() -> {
@@ -235,13 +291,80 @@ internal class PaymentManager(
         }
     }
 
-    private fun determinePaymentMethodType(status: ProcessPaymentIntentStatus.Success): PaymentMethodType {
-        val charge = status.paymentIntent.getCharges().firstOrNull()
+    private suspend fun processPaymentIntentForRemoteReader(
+        paymentInfo: PaymentInfo,
+        paymentIntent: PaymentIntent
+    ): PaymentIntent {
+        if (paymentInfo.terminalPaymentPreparation == PaymentInfo.TerminalPaymentPreparation.NONE) {
+            return terminalWrapper.processPaymentIntent(paymentIntent)
+        }
+
+        val collectedPaymentIntent = terminalWrapper.collectPaymentMethod(paymentIntent)
+        when (val result = prepareTerminalPaymentIfNeeded(paymentInfo, collectedPaymentIntent)) {
+            TerminalPaymentPreparationResult.Prepared -> Unit
+            is TerminalPaymentPreparationResult.Failed -> throw IllegalStateException(result.message)
+        }
+        return terminalWrapper.confirmPaymentIntent(collectedPaymentIntent)
+    }
+
+    private suspend fun prepareTerminalPaymentIfNeeded(
+        paymentInfo: PaymentInfo,
+        paymentIntent: PaymentIntent
+    ): TerminalPaymentPreparationResult {
+        val shouldPrepare = when (paymentInfo.terminalPaymentPreparation) {
+            PaymentInfo.TerminalPaymentPreparation.NONE -> false
+            PaymentInfo.TerminalPaymentPreparation.CANADA_INTERAC -> isInteracPayment(paymentIntent)
+            PaymentInfo.TerminalPaymentPreparation.AUSTRALIA_CARD_PRESENT -> isEftposAuPayment(paymentIntent)
+        }
+        if (!shouldPrepare) return TerminalPaymentPreparationResult.Prepared
+
+        val paymentIntentId = paymentIntent.id
+            ?: return TerminalPaymentPreparationResult.Failed("PaymentIntent id not available")
+
+        return when (val response = cardReaderStore.preparePaymentIntent(paymentInfo.orderId, paymentIntentId)) {
+            PreparePaymentResponse.Success -> TerminalPaymentPreparationResult.Prepared
+            is PreparePaymentResponse.Error -> TerminalPaymentPreparationResult.Failed(response.message)
+        }
+    }
+
+    private fun isInteracPayment(paymentIntent: PaymentIntent): Boolean {
+        return paymentIntent.paymentMethod?.interacPresentDetails != null ||
+            paymentIntent.getCharges().firstOrNull()?.paymentMethodDetails?.interacPresentDetails != null
+    }
+
+    private fun isEftposAuPayment(paymentIntent: PaymentIntent): Boolean {
+        return paymentIntent.paymentMethod?.cardPresentDetails?.canProcessAsEftposAu() == true ||
+            paymentIntent.getCharges().firstOrNull()
+                ?.paymentMethodDetails
+                ?.cardPresentDetails
+                ?.canProcessAsEftposAu() == true
+    }
+
+    private fun CardPresentDetails.canProcessAsEftposAu(): Boolean {
+        return brand?.equals(EFTPOS_AU_NETWORK, ignoreCase = true) == true ||
+            network?.equals(EFTPOS_AU_NETWORK, ignoreCase = true) == true ||
+            networks?.available?.any { it.equals(EFTPOS_AU_NETWORK, ignoreCase = true) } == true
+    }
+
+    private fun isSingleStepTerminalPaymentSuccessful(paymentIntent: PaymentIntent): Boolean {
+        return paymentIntent.status == PaymentIntentStatus.SUCCEEDED &&
+            (isInteracPayment(paymentIntent) || isEftposAuPayment(paymentIntent))
+    }
+
+    private fun determinePaymentMethodType(paymentIntent: PaymentIntent): PaymentMethodType {
+        val charge = paymentIntent.getCharges().firstOrNull()
         return when {
+            paymentIntent.paymentMethod?.interacPresentDetails != null -> PaymentMethodType.INTERAC_PRESENT
+            paymentIntent.paymentMethod?.cardPresentDetails != null -> PaymentMethodType.CARD_PRESENT
             charge?.paymentMethodDetails?.interacPresentDetails != null -> PaymentMethodType.INTERAC_PRESENT
             charge?.paymentMethodDetails?.cardPresentDetails != null -> PaymentMethodType.CARD_PRESENT
             else -> PaymentMethodType.UNKNOWN
         }
+    }
+
+    private sealed class TerminalPaymentPreparationResult {
+        data object Prepared : TerminalPaymentPreparationResult()
+        data class Failed(val message: String) : TerminalPaymentPreparationResult()
     }
 }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/ProcessPaymentIntentAction.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/payments/actions/ProcessPaymentIntentAction.kt
@@ -32,4 +32,36 @@ internal class ProcessPaymentIntentAction(
             Failure(e)
         }
     }
+
+    suspend fun collectPaymentMethod(paymentIntent: PaymentIntent): ProcessPaymentIntentStatus {
+        logWrapper.d(LOG_TAG, "Collecting payment method")
+        return try {
+            val collectedPaymentIntent = terminal.collectPaymentMethod(paymentIntent)
+            logWrapper.d(LOG_TAG, "Collecting payment method succeeded")
+            Success(collectedPaymentIntent)
+        } catch (e: TerminalException) {
+            logWrapper.e(
+                LOG_TAG,
+                "Collecting payment method failed. " +
+                    "Message: ${e.errorMessage}, DeclineCode: ${e.apiError?.declineCode}"
+            )
+            Failure(e)
+        }
+    }
+
+    suspend fun confirmPaymentIntent(paymentIntent: PaymentIntent): ProcessPaymentIntentStatus {
+        logWrapper.d(LOG_TAG, "Confirming payment intent")
+        return try {
+            val confirmedPaymentIntent = terminal.confirmPaymentIntent(paymentIntent)
+            logWrapper.d(LOG_TAG, "Confirming payment intent succeeded")
+            Success(confirmedPaymentIntent)
+        } catch (e: TerminalException) {
+            logWrapper.e(
+                LOG_TAG,
+                "Confirming payment intent failed. " +
+                    "Message: ${e.errorMessage}, DeclineCode: ${e.apiError?.declineCode}"
+            )
+            Failure(e)
+        }
+    }
 }

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
@@ -24,6 +24,8 @@ import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
 import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration.Color
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.stripe.stripeterminal.ktx.cancelPaymentIntent
+import com.stripe.stripeterminal.ktx.collectPaymentMethod
+import com.stripe.stripeterminal.ktx.confirmPaymentIntent
 import com.stripe.stripeterminal.ktx.connectReader
 import com.stripe.stripeterminal.ktx.createPaymentIntent
 import com.stripe.stripeterminal.ktx.disconnectReader
@@ -100,6 +102,20 @@ internal class TerminalWrapper {
         Terminal.getInstance().processPaymentIntent(
             paymentIntent,
             CollectPaymentIntentConfiguration.Builder().build(),
+            ConfirmPaymentIntentConfiguration.Builder().build()
+        )
+
+    suspend fun collectPaymentMethod(paymentIntent: PaymentIntent): PaymentIntent =
+        Terminal.getInstance().collectPaymentMethod(
+            paymentIntent,
+            CollectPaymentIntentConfiguration.Builder()
+                .updatePaymentIntent(true)
+                .build()
+        )
+
+    suspend fun confirmPaymentIntent(paymentIntent: PaymentIntent): PaymentIntent =
+        Terminal.getInstance().confirmPaymentIntent(
+            paymentIntent,
             ConfirmPaymentIntentConfiguration.Builder().build()
         )
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/remote/CardReaderRemoteSession.kt
@@ -264,7 +264,12 @@ class CardReaderRemoteSession internal constructor(
         val paymentInfo = request.toPaymentInfo()
         when (val createResult = cardReaderManager.createPaymentIntent(paymentInfo)) {
             is CreatePaymentIntentResult.Success -> {
-                when (val collectResult = cardReaderManager.retrieveAndCollectPayment(createResult.clientSecret)) {
+                when (
+                    val collectResult = cardReaderManager.retrieveAndCollectPayment(
+                        createResult.clientSecret,
+                        paymentInfo
+                    )
+                ) {
                     is RetrieveAndCollectResult.Success -> accepted.send(
                         PaymentIntentResult(
                             requestId = request.requestId,
@@ -312,6 +317,8 @@ class CardReaderRemoteSession internal constructor(
         orderKey = orderKey,
         feeAmount = feeAmount,
         channel = PaymentInfo.PaymentChannel.Pos,
+        cardPresentCaptureMethod = cardPresentCaptureMethod,
+        terminalPaymentPreparation = terminalPaymentPreparation ?: PaymentInfo.TerminalPaymentPreparation.NONE,
         countryCode = countryCode,
     )
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/payments/PaymentManagerTest.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.cardreader.internal.payments
 
+import com.stripe.stripeterminal.external.models.CardNetworks
 import com.stripe.stripeterminal.external.models.CardPresentDetails
 import com.stripe.stripeterminal.external.models.Charge
 import com.stripe.stripeterminal.external.models.PaymentIntent
@@ -9,9 +10,11 @@ import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_CA
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_CONFIRMATION
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.REQUIRES_PAYMENT_METHOD
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus.SUCCEEDED
+import com.stripe.stripeterminal.external.models.PaymentMethod
 import com.stripe.stripeterminal.external.models.PaymentMethodDetails
 import com.woocommerce.android.cardreader.CardReaderStore
 import com.woocommerce.android.cardreader.CardReaderStore.CapturePaymentResponse
+import com.woocommerce.android.cardreader.CardReaderStore.PreparePaymentResponse
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUSA
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
@@ -113,6 +116,8 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
 
         whenever(cardReaderStore.capturePaymentIntent(any(), anyString()))
             .thenReturn(CapturePaymentResponse.Successful.Success)
+        whenever(cardReaderStore.preparePaymentIntent(any(), anyString()))
+            .thenReturn(PreparePaymentResponse.Success)
         whenever(paymentErrorMapper.mapTerminalError(anyOrNull(), anyOrNull()))
             .thenReturn(PaymentFailed(CardPaymentStatusErrorType.Generic, null, ""))
         whenever(paymentErrorMapper.mapCapturePaymentError(anyOrNull(), anyOrNull()))
@@ -259,6 +264,42 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
         }
 
     @Test
+    fun `given succeeded eftpos card present payment, when processing payment finishes successfully, then capture payment is emitted`() =
+        testBlocking {
+            val succeededCardPresentIntent = createPaymentIntent(
+                SUCCEEDED,
+                cardPresentDetails = createCardPresentDetails(brand = "eftpos_au")
+            )
+            whenever(processPaymentIntentAction.processPaymentIntent(anyOrNull()))
+                .thenReturn(ProcessPaymentIntentStatus.Success(succeededCardPresentIntent))
+
+            val result = manager
+                .acceptPayment(createPaymentInfo()).takeUntil(CapturingPayment::class).toList()
+
+            assertThat(result.last()).isInstanceOf(CapturingPayment::class.java)
+        }
+
+    @Test
+    fun `given succeeded non-eftpos card present payment, when processing payment finishes, then flow terminates`() =
+        testBlocking {
+            val succeededCardPresentIntent = createPaymentIntent(
+                SUCCEEDED,
+                cardPresentDetails = createCardPresentDetails(brand = "visa")
+            )
+            whenever(processPaymentIntentAction.processPaymentIntent(anyOrNull()))
+                .thenReturn(ProcessPaymentIntentStatus.Success(succeededCardPresentIntent))
+
+            val result = withTimeoutOrNull(TIMEOUT) {
+                manager
+                    .acceptPayment(createPaymentInfo())
+                    .toList()
+            }
+
+            assertThat(result).isNotNull
+            verify(cardReaderStore, never()).capturePaymentIntent(any(), anyString())
+        }
+
+    @Test
     fun `given interac payment, when processing payment finishes with canceled status, then flow terminates`() =
         testBlocking {
             val canceledInteracIntent = createPaymentIntent(CANCELED, interacPresentDetails = mock())
@@ -327,6 +368,113 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
             val result = manager.acceptPayment(createPaymentInfo()).toList()
 
             assertThat(result).contains(ProcessingPaymentCompleted(PaymentMethodType.UNKNOWN))
+        }
+
+    @Test
+    fun `given no terminal payment preparation, when payment is processed, then combined process call is used`() =
+        testBlocking {
+            val captureIntent = createPaymentIntent(REQUIRES_CAPTURE)
+            whenever(processPaymentIntentAction.processPaymentIntent(anyOrNull()))
+                .thenReturn(ProcessPaymentIntentStatus.Success(captureIntent))
+
+            manager.acceptPayment(
+                createPaymentInfo(
+                    terminalPaymentPreparation = PaymentInfo.TerminalPaymentPreparation.NONE
+                )
+            ).toList()
+
+            verify(processPaymentIntentAction).processPaymentIntent(anyOrNull())
+            verify(processPaymentIntentAction, never()).collectPaymentMethod(anyOrNull())
+            verify(processPaymentIntentAction, never()).confirmPaymentIntent(anyOrNull())
+            verify(cardReaderStore, never()).preparePaymentIntent(any(), anyString())
+        }
+
+    @Test
+    fun `given AU terminal payment preparation, when payment method is collected, then payment is prepared before confirmation`() =
+        testBlocking {
+            val eftposDetails = createCardPresentDetails(availableNetworks = listOf("eftpos_au"))
+            val collectedIntent = createPaymentIntent(REQUIRES_CONFIRMATION, cardPresentDetails = eftposDetails)
+            val confirmedIntent = createPaymentIntent(REQUIRES_CAPTURE, cardPresentDetails = mock())
+            whenever(processPaymentIntentAction.collectPaymentMethod(anyOrNull()))
+                .thenReturn(ProcessPaymentIntentStatus.Success(collectedIntent))
+            whenever(processPaymentIntentAction.confirmPaymentIntent(anyOrNull()))
+                .thenReturn(ProcessPaymentIntentStatus.Success(confirmedIntent))
+
+            val result = manager.acceptPayment(
+                createPaymentInfo(
+                    terminalPaymentPreparation = PaymentInfo.TerminalPaymentPreparation.AUSTRALIA_CARD_PRESENT
+                )
+            ).toList()
+
+            verify(cardReaderStore).preparePaymentIntent(DUMMY_ORDER_ID, "dummyId")
+            verify(processPaymentIntentAction).confirmPaymentIntent(collectedIntent)
+            verify(processPaymentIntentAction, never()).processPaymentIntent(anyOrNull())
+            assertThat(result).contains(ProcessingPaymentCompleted(PaymentMethodType.CARD_PRESENT))
+        }
+
+    @Test
+    fun `given AU terminal payment preparation, when selected card network is eftpos, then payment is prepared`() =
+        testBlocking {
+            val eftposDetails = createCardPresentDetails(brand = "visa", network = "eftpos_au")
+            val collectedIntent = createPaymentIntent(REQUIRES_CONFIRMATION, cardPresentDetails = eftposDetails)
+            val confirmedIntent = createPaymentIntent(REQUIRES_CAPTURE, cardPresentDetails = eftposDetails)
+            whenever(processPaymentIntentAction.collectPaymentMethod(anyOrNull()))
+                .thenReturn(ProcessPaymentIntentStatus.Success(collectedIntent))
+            whenever(processPaymentIntentAction.confirmPaymentIntent(anyOrNull()))
+                .thenReturn(ProcessPaymentIntentStatus.Success(confirmedIntent))
+
+            manager.acceptPayment(
+                createPaymentInfo(
+                    terminalPaymentPreparation = PaymentInfo.TerminalPaymentPreparation.AUSTRALIA_CARD_PRESENT
+                )
+            ).toList()
+
+            verify(cardReaderStore).preparePaymentIntent(DUMMY_ORDER_ID, "dummyId")
+            verify(processPaymentIntentAction).confirmPaymentIntent(collectedIntent)
+        }
+
+    @Test
+    fun `given AU terminal payment preparation, when visa card present is collected, then prepare is skipped`() =
+        testBlocking {
+            val visaDetails = createCardPresentDetails(
+                brand = "visa",
+                availableNetworks = listOf("visa")
+            )
+            val collectedIntent = createPaymentIntent(REQUIRES_CONFIRMATION, cardPresentDetails = visaDetails)
+            val confirmedIntent = createPaymentIntent(REQUIRES_CAPTURE, cardPresentDetails = visaDetails)
+            whenever(processPaymentIntentAction.collectPaymentMethod(anyOrNull()))
+                .thenReturn(ProcessPaymentIntentStatus.Success(collectedIntent))
+            whenever(processPaymentIntentAction.confirmPaymentIntent(anyOrNull()))
+                .thenReturn(ProcessPaymentIntentStatus.Success(confirmedIntent))
+
+            manager.acceptPayment(
+                createPaymentInfo(
+                    terminalPaymentPreparation = PaymentInfo.TerminalPaymentPreparation.AUSTRALIA_CARD_PRESENT
+                )
+            ).toList()
+
+            verify(cardReaderStore, never()).preparePaymentIntent(any(), anyString())
+            verify(processPaymentIntentAction).confirmPaymentIntent(collectedIntent)
+        }
+
+    @Test
+    fun `given CA interac preparation, when card present is collected, then prepare is skipped`() =
+        testBlocking {
+            val collectedIntent = createPaymentIntent(REQUIRES_CONFIRMATION, cardPresentDetails = mock())
+            val confirmedIntent = createPaymentIntent(REQUIRES_CAPTURE, cardPresentDetails = mock())
+            whenever(processPaymentIntentAction.collectPaymentMethod(anyOrNull()))
+                .thenReturn(ProcessPaymentIntentStatus.Success(collectedIntent))
+            whenever(processPaymentIntentAction.confirmPaymentIntent(anyOrNull()))
+                .thenReturn(ProcessPaymentIntentStatus.Success(confirmedIntent))
+
+            manager.acceptPayment(
+                createPaymentInfo(
+                    terminalPaymentPreparation = PaymentInfo.TerminalPaymentPreparation.CANADA_INTERAC
+                )
+            ).toList()
+
+            verify(cardReaderStore, never()).preparePaymentIntent(any(), anyString())
+            verify(processPaymentIntentAction).confirmPaymentIntent(collectedIntent)
         }
 
     @Test
@@ -545,17 +693,38 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
     private fun createPaymentIntent(
         status: PaymentIntentStatus,
         receiptUrl: String? = "test url",
-        interacPresentDetails: CardPresentDetails? = null
+        interacPresentDetails: CardPresentDetails? = null,
+        cardPresentDetails: CardPresentDetails? = null,
     ): PaymentIntent =
         mock<PaymentIntent>().also {
             whenever(it.status).thenReturn(status)
             whenever(it.id).thenReturn("dummyId")
+            val paymentMethod = mock<PaymentMethod>()
+            whenever(paymentMethod.interacPresentDetails).thenReturn(interacPresentDetails)
+            whenever(paymentMethod.cardPresentDetails).thenReturn(cardPresentDetails)
+            whenever(it.paymentMethod).thenReturn(paymentMethod)
             val paymentMethodDetails = mock<PaymentMethodDetails>()
             whenever(paymentMethodDetails.interacPresentDetails).thenReturn(interacPresentDetails)
+            whenever(paymentMethodDetails.cardPresentDetails).thenReturn(cardPresentDetails)
             val charge = mock<Charge>()
             whenever(charge.receiptUrl).thenReturn(receiptUrl)
             whenever(charge.paymentMethodDetails).thenReturn(paymentMethodDetails)
             whenever(it.getCharges()).thenReturn(listOf(charge))
+        }
+
+    private fun createCardPresentDetails(
+        brand: String? = null,
+        network: String? = null,
+        availableNetworks: List<String>? = null,
+    ): CardPresentDetails =
+        mock<CardPresentDetails>().also {
+            brand?.let { brand -> whenever(it.brand).thenReturn(brand) }
+            network?.let { network -> whenever(it.network).thenReturn(network) }
+            availableNetworks?.let { networks ->
+                val cardNetworks = mock<CardNetworks>()
+                whenever(cardNetworks.available).thenReturn(networks)
+                whenever(it.networks).thenReturn(cardNetworks)
+            }
         }
 
     private fun <T> Flow<T>.takeUntil(untilStatus: KClass<*>): Flow<T> =
@@ -585,6 +754,8 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
         statementDescriptor: String? = null,
         countryCode: String = "US",
         feeAmount: Long? = null,
+        terminalPaymentPreparation: PaymentInfo.TerminalPaymentPreparation =
+            PaymentInfo.TerminalPaymentPreparation.NONE,
     ): PaymentInfo =
         PaymentInfo(
             paymentDescription = paymentDescription,
@@ -600,6 +771,7 @@ class PaymentManagerTest : CardReaderBaseUnitTest() {
             statementDescriptor = StatementDescriptor(statementDescriptor),
             countryCode = countryCode,
             feeAmount = feeAmount,
-            channel = PaymentInfo.PaymentChannel.StoreManager
+            channel = PaymentInfo.PaymentChannel.StoreManager,
+            terminalPaymentPreparation = terminalPaymentPreparation,
         )
 }


### PR DESCRIPTION
Part of: RSM-642

### Description

This is the third PR in the Android AU WooPayments card-present stack.

Stacked after #15910 and continues in #15912.

It updates the payment flow so WooPayments terminal payments can be prepared between card collection and confirmation. For AU WooPayments, this lets eftpos-capable payments be prepared before confirmation. For Canada, it keeps older WooPayments installs working by skipping preparation when the route is not available.

The PR also asks Stripe Terminal to collect the full PaymentIntent details during collection and sets `manual_preferred` for CA/AU WooPayments terminal PaymentIntents, matching the regional handling we need for Interac and eftpos-style single-step payments.

### Test Steps

Testing is possible here, but it's easier with the test tools in the final PR enabling the selection of a simulated eftpos card.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
