### PR TITLE
Add EFTPOS simulator card developer option

### DIFF
--- a/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
+++ b/WooCommerce/src/androidTest/kotlin/com/woocommerce/android/di/MockCardReaderManagerModule.kt
@@ -70,10 +70,17 @@ class MockCardReaderManagerModule {
         override val connectionTokenProvider: CompositeConnectionTokenProvider
             get() = error("connectionTokenProvider is not used in instrumented tests")
 
-        override fun initialize(updateFrequency: SimulatorUpdateFrequency, useInterac: Boolean, isDebug: Boolean) {}
+        override fun initialize(
+            updateFrequency: SimulatorUpdateFrequency,
+            useInterac: Boolean,
+            useEftpos: Boolean,
+            isDebug: Boolean
+        ) {}
+
         override fun reinitializeSimulatedTerminal(
             updateFrequency: SimulatorUpdateFrequency,
-            useInterac: Boolean
+            useInterac: Boolean,
+            useEftpos: Boolean,
         ) {}
 
         override fun discoverReaders(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -117,6 +117,7 @@ object AppPrefs {
         USE_SIMULATED_READER,
         UPDATE_SIMULATED_READER_OPTION,
         ENABLE_SIMULATED_INTERAC,
+        ENABLE_SIMULATED_EFTPOS,
         NOTIFICATIONS_PERMISSION_BAR,
         IS_EU_SHIPPING_NOTICE_DISMISSED,
         HAS_SAVED_PRIVACY_SETTINGS,
@@ -283,6 +284,10 @@ object AppPrefs {
     var isInteracEnabled: Boolean
         get() = getBoolean(DeletablePrefKey.ENABLE_SIMULATED_INTERAC, false)
         set(value) = setBoolean(DeletablePrefKey.ENABLE_SIMULATED_INTERAC, value)
+
+    var isEftposEnabled: Boolean
+        get() = getBoolean(DeletablePrefKey.ENABLE_SIMULATED_EFTPOS, false)
+        set(value) = setBoolean(DeletablePrefKey.ENABLE_SIMULATED_EFTPOS, value)
 
     var updateReaderOptionSelected: String
         get() = getString(UPDATE_SIMULATED_READER_OPTION, UpdateFrequencyUiModel.RANDOM.toString())

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModel.kt
@@ -243,7 +243,8 @@ class CardReaderConnectViewModel @Inject constructor(
             cardReaderManager.initialize(
                 updateFrequency = developerOptionsRepository.getUpdateSimulatedReaderOption(),
                 useInterac = developerOptionsRepository.isInteracPaymentEnabled(),
-                BuildConfig.DEBUG,
+                useEftpos = developerOptionsRepository.isEftposPaymentEnabled(),
+                isDebug = BuildConfig.DEBUG,
             )
         }
         cardReaderManager.setupTapToPayUx(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/payments/cardreader/readermode/CardReaderModeViewModel.kt
@@ -79,6 +79,7 @@ class CardReaderModeViewModel @Inject constructor(
             cardReaderManager.initialize(
                 updateFrequency = developerOptionsRepository.getUpdateSimulatedReaderOption(),
                 useInterac = developerOptionsRepository.isInteracPaymentEnabled(),
+                useEftpos = developerOptionsRepository.isEftposPaymentEnabled(),
                 isDebug = BuildConfig.DEBUG,
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsRepository.kt
@@ -59,6 +59,23 @@ class DeveloperOptionsRepository @Inject constructor(
 
     fun changeEnableInteracPaymentState(isChecked: Boolean) {
         appPrefs.isInteracEnabled = isChecked
+        if (isChecked) {
+            appPrefs.isEftposEnabled = false
+        }
+        reinitializeSimulatedReaderIfNeeded()
+    }
+
+    fun isEftposPaymentEnabled(): Boolean = appPrefs.isEftposEnabled
+
+    fun observeEftposPaymentEnabled() = appPrefsTrigger
+        .map { appPrefs.isEftposEnabled }
+        .distinctUntilChanged()
+
+    fun changeEnableEftposPaymentState(isChecked: Boolean) {
+        appPrefs.isEftposEnabled = isChecked
+        if (isChecked) {
+            appPrefs.isInteracEnabled = false
+        }
         reinitializeSimulatedReaderIfNeeded()
     }
 
@@ -74,7 +91,8 @@ class DeveloperOptionsRepository @Inject constructor(
         if (cardReaderManager.initialized) {
             cardReaderManager.reinitializeSimulatedTerminal(
                 updateFrequency = getUpdateSimulatedReaderOption(),
-                useInterac = appPrefs.isInteracEnabled
+                useInterac = appPrefs.isInteracEnabled,
+                useEftpos = appPrefs.isEftposEnabled,
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/developer/DeveloperOptionsViewModel.kt
@@ -67,6 +67,21 @@ class DeveloperOptionsViewModel @Inject constructor(
         )
     }
 
+    private val eftposPaymentEnabledFlow = combine(
+        isSimulatedReaderEnabled,
+        developerOptionsRepository.observeEftposPaymentEnabled()
+    ) { simulatedReader, useEftpos ->
+        if (!simulatedReader) return@combine null
+
+        ToggleableListItem(
+            icon = R.drawable.ic_credit_card_give,
+            label = UiStringRes(R.string.enable_eftpos_payment),
+            isEnabled = true,
+            isChecked = useEftpos,
+            onToggled = developerOptionsRepository::changeEnableEftposPaymentState
+        )
+    }
+
     private val savedPrivacySettingsOnDialogFlow = developerOptionsRepository
         .observeSavedPrivacyBannerSettings()
         .map { isChecked ->
@@ -126,6 +141,7 @@ class DeveloperOptionsViewModel @Inject constructor(
         simulatedCardReaderFlow,
         readerUpdateFrequencyFlow,
         interacPaymentEnabledFlow,
+        eftposPaymentEnabledFlow,
         savedPrivacySettingsOnDialogFlow,
         apiFakerFlow,
         sendSentryReportFlow,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosBuiltInReaderConnector.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/WooPosBuiltInReaderConnector.kt
@@ -122,6 +122,7 @@ class WooPosBuiltInReaderConnector @Inject constructor(
             cardReaderManager.initialize(
                 updateFrequency = developerOptionsRepository.getUpdateSimulatedReaderOption(),
                 useInterac = developerOptionsRepository.isInteracPaymentEnabled(),
+                useEftpos = developerOptionsRepository.isEftposPaymentEnabled(),
                 isDebug = BuildConfig.DEBUG,
             )
             cardReaderManager.setupTapToPayUx(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/cardreader/connection/WooPosCardReaderConnectionController.kt
@@ -310,6 +310,7 @@ class WooPosCardReaderConnectionController(
             cardReaderManager.initialize(
                 updateFrequency = developerOptionsRepository.getUpdateSimulatedReaderOption(),
                 useInterac = developerOptionsRepository.isInteracPaymentEnabled(),
+                useEftpos = developerOptionsRepository.isEftposPaymentEnabled(),
                 isDebug = BuildConfig.DEBUG,
             )
         }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2378,6 +2378,7 @@
     <string name="optional_update_available_reader" translatable="false">Optional Update Available</string>
     <string name="randomly_update_reader">Randomly</string>
     <string name="enable_interac_payment" translatable="false">Enable Interac Payment</string>
+    <string name="enable_eftpos_payment" translatable="false">Enable EFTPOS Payment</string>
 
     <!--
         WCToggleSingleOptionView

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/payments/cardreader/connect/CardReaderConnectViewModelTest.kt
@@ -112,6 +112,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
     private val locationId = "location_id"
     private val updateFrequency = CardReaderManager.SimulatorUpdateFrequency.RANDOM
     private val useInterac = false
+    private val useEftpos = false
 
     @Before
     fun setUp() = testBlocking {
@@ -340,7 +341,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             (viewModel.event.value as CheckBluetoothEnabled).onBluetoothCheckResult(false)
             (viewModel.event.value as RequestEnableBluetooth).onEnableBluetoothRequestResult(true)
 
-            verify(cardReaderManager).initialize(updateFrequency, useInterac, BuildConfig.DEBUG)
+            verify(cardReaderManager).initialize(updateFrequency, useInterac, useEftpos, BuildConfig.DEBUG)
         }
 
     @Test
@@ -353,7 +354,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
                 .onBluetoothRuntimePermissionsRequestResult(true)
             (viewModel.event.value as CheckBluetoothEnabled).onBluetoothCheckResult(true)
 
-            verify(cardReaderManager).initialize(updateFrequency, useInterac, BuildConfig.DEBUG)
+            verify(cardReaderManager).initialize(updateFrequency, useInterac, useEftpos, BuildConfig.DEBUG)
         }
 
     @Test
@@ -365,7 +366,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
             (viewModel.event.value as RequestBluetoothRuntimePermissions)
                 .onBluetoothRuntimePermissionsRequestResult(false)
 
-            verify(cardReaderManager, never()).initialize(updateFrequency, useInterac, BuildConfig.DEBUG)
+            verify(cardReaderManager, never()).initialize(updateFrequency, useInterac, useEftpos, BuildConfig.DEBUG)
         }
 
     @Test
@@ -379,7 +380,7 @@ class CardReaderConnectViewModelTest : BaseUnitTest() {
 
             (viewModel.event.value as RequestEnableBluetooth).onEnableBluetoothRequestResult(true)
 
-            verify(cardReaderManager, never()).initialize(updateFrequency, useInterac, BuildConfig.DEBUG)
+            verify(cardReaderManager, never()).initialize(updateFrequency, useInterac, useEftpos, BuildConfig.DEBUG)
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/DeveloperOptionsViewModelTest.kt
@@ -23,6 +23,7 @@ class DeveloperOptionsViewModelTest : BaseUnitTest() {
     private val developerOptionsRepository: DeveloperOptionsRepository = mock {
         on { observeSimulatedCardReaderEnabled() }.thenReturn(flowOf(false))
         on { observeInteracPaymentEnabled() }.thenReturn(flowOf(false))
+        on { observeEftposPaymentEnabled() }.thenReturn(flowOf(false))
         on { observeSavedPrivacyBannerSettings() }.thenReturn(flowOf(false))
     }
 
@@ -100,6 +101,18 @@ class DeveloperOptionsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when simulated card reader btn toggled, then eftpos row displayed`() {
+        whenever(developerOptionsRepository.observeSimulatedCardReaderEnabled()).thenReturn(flowOf(true))
+
+        initViewModel()
+
+        assertThat(captureViewState()?.rows)
+            .anyMatch {
+                it.label == UiString.UiStringRes(R.string.enable_eftpos_payment)
+            }
+    }
+
+    @Test
     fun `given reader disabled, when dev options screen accessed, then update reader row not displayed`() {
         whenever(developerOptionsRepository.observeSimulatedCardReaderEnabled()).thenReturn(flowOf(false))
 
@@ -120,6 +133,18 @@ class DeveloperOptionsViewModelTest : BaseUnitTest() {
         assertThat(captureViewState()?.rows)
             .noneMatch {
                 it.label == UiString.UiStringRes(R.string.enable_interac_payment)
+            }
+    }
+
+    @Test
+    fun `given reader disabled, when dev options screen accessed, then eftpos row not displayed`() {
+        whenever(developerOptionsRepository.observeSimulatedCardReaderEnabled()).thenReturn(flowOf(false))
+
+        initViewModel()
+
+        assertThat(captureViewState()?.rows)
+            .noneMatch {
+                it.label == UiString.UiStringRes(R.string.enable_eftpos_payment)
             }
     }
 

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/CardReaderManager.kt
@@ -37,10 +37,15 @@ interface CardReaderManager {
     fun initialize(
         updateFrequency: SimulatorUpdateFrequency,
         useInterac: Boolean,
+        useEftpos: Boolean,
         isDebug: Boolean,
     )
 
-    fun reinitializeSimulatedTerminal(updateFrequency: SimulatorUpdateFrequency, useInterac: Boolean)
+    fun reinitializeSimulatedTerminal(
+        updateFrequency: SimulatorUpdateFrequency,
+        useInterac: Boolean,
+        useEftpos: Boolean,
+    )
 
     fun discoverReaders(
         isSimulated: Boolean,

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImpl.kt
@@ -64,6 +64,7 @@ internal class CardReaderManagerImpl(
     override fun initialize(
         updateFrequency: CardReaderManager.SimulatorUpdateFrequency,
         useInterac: Boolean,
+        useEftpos: Boolean,
         isDebug: Boolean
     ) {
         if (!terminal.isInitialized()) {
@@ -73,7 +74,7 @@ internal class CardReaderManagerImpl(
 
             initStripeTerminal(logLevel)
 
-            terminal.setupSimulator(updateFrequency, useInterac)
+            terminal.setupSimulator(updateFrequency, useInterac, useEftpos)
         } else {
             logWrapper.w(TAG, "CardReaderManager is already initialized")
         }
@@ -81,9 +82,10 @@ internal class CardReaderManagerImpl(
 
     override fun reinitializeSimulatedTerminal(
         updateFrequency: CardReaderManager.SimulatorUpdateFrequency,
-        useInterac: Boolean
+        useInterac: Boolean,
+        useEftpos: Boolean,
     ) {
-        terminal.setupSimulator(updateFrequency, useInterac)
+        terminal.setupSimulator(updateFrequency, useInterac, useEftpos)
     }
 
     override fun discoverReaders(

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/internal/wrappers/TerminalWrapper.kt
@@ -131,10 +131,20 @@ internal class TerminalWrapper {
 
     fun getConnectedReader(): CardReader? = Terminal.getInstance().connectedReader?.let { CardReaderImpl(it) }
 
-    fun setupSimulator(updateFrequency: CardReaderManager.SimulatorUpdateFrequency, useInterac: Boolean) {
+    fun setupSimulator(
+        updateFrequency: CardReaderManager.SimulatorUpdateFrequency,
+        useInterac: Boolean,
+        useEftpos: Boolean,
+    ) {
         Terminal.getInstance().simulatorConfiguration = SimulatorConfiguration(
             update = mapFrequencyOptions(updateFrequency),
-            simulatedCard = SimulatedCard(if (useInterac) SimulatedCardType.INTERAC else SimulatedCardType.VISA)
+            simulatedCard = SimulatedCard(
+                when {
+                    useEftpos -> SimulatedCardType.EFTPOS_AU_DEBIT
+                    useInterac -> SimulatedCardType.INTERAC
+                    else -> SimulatedCardType.VISA
+                }
+            )
         )
     }
 

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/CardReaderManagerImplTest.kt
@@ -59,6 +59,7 @@ class CardReaderManagerImplTest : CardReaderBaseUnitTest() {
     private val locationId = "locationId"
 
     private val useInterac = false
+    private val useEftpos = false
 
     @Before
     fun setUp() {
@@ -77,7 +78,7 @@ class CardReaderManagerImplTest : CardReaderBaseUnitTest() {
 
     @Test
     fun `given application delegate, when manager gets initialized, then delegate calls on create`() {
-        cardReaderManager.initialize(updateFrequency, useInterac, false)
+        cardReaderManager.initialize(updateFrequency, useInterac, useEftpos, false)
 
         verify(terminalApplicationDelegateWrapper).onCreate(application)
     }
@@ -100,7 +101,7 @@ class CardReaderManagerImplTest : CardReaderBaseUnitTest() {
     fun `given terminal not initialized, when init() invoked, then Terminal init() invoked`() {
         whenever(terminalWrapper.isInitialized()).thenReturn(false)
 
-        cardReaderManager.initialize(updateFrequency, useInterac, false)
+        cardReaderManager.initialize(updateFrequency, useInterac, useEftpos, false)
 
         verify(terminalWrapper).initTerminal(any(), any(), any(), any())
     }
@@ -109,7 +110,7 @@ class CardReaderManagerImplTest : CardReaderBaseUnitTest() {
     fun `given terminal initialized, when init() invoked, then Terminal init() not invoked`() {
         whenever(terminalWrapper.isInitialized()).thenReturn(true)
 
-        cardReaderManager.initialize(updateFrequency, useInterac, false)
+        cardReaderManager.initialize(updateFrequency, useInterac, useEftpos, false)
 
         verify(terminalWrapper, never()).initTerminal(any(), any(), any(), any())
     }


### PR DESCRIPTION
Closes: RSM-642

### Description

This is the final PR in the Android AU WooPayments card-present stack.

Stacked after #15911.

It adds a developer option for using Stripe Terminal’s eftpos simulator card, mirroring the existing Interac simulator toggle. This makes it easier to exercise the AU flow locally without needing a physical eftpos card for every smoke test.

### Test Steps

Simulated card payment:

1. Open developer options in a debug build.
2. Enable the eftpos simulator card option.
3. Take a simulated reader payment on an AU WooPayments test store 
4. Check the receipt to confirm the simulator used the eftpos test card.

Correct use of new endpoint:

1. Use a WooPayments store with WooPayments `10.8.0-test-1` or newer, in AU or CA
2. Start an in-person payment using an eftpos or interac card and confirm the app calls the endpoint with the order ID and PaymentIntent ID.
3. Confirm the endpoint is not called for other cards.
4. On a CA WooPayments store without the new route, confirm an Interac payment continues through the existing fallback flow.

eftpos branding:

1. Use an AU WooPayments test store with WooPayments `10.8.0-test-1` or newer.
2. Confirm in-person payments are available when the AU remote feature flag is enabled.
3. Confirm disabling `woo_ipp_australia_woopayments` hides AU WooPayments in-person payment eligibility.
6. Confirm the refund confirmation screen for an eftpos payment displays `eftpos`

Other tests:

1. Confirm eftpos refunds work correctly

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
