### PR TITLE
Refresh QR login prologue: 'Scan to log in' + computer icon in URL badge

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginPrologueScreen.kt
@@ -246,7 +246,7 @@ private fun UrlBadge() {
     val url = stringResource(id = R.string.login_qr_prologue_url)
     val clipboardLabel = stringResource(id = R.string.login_qr_prologue_url_clipboard_label)
     val copiedMessage = stringResource(id = R.string.login_qr_prologue_url_copied)
-    Box(
+    Row(
         modifier = Modifier
             .clip(RoundedCornerShape(dimensionResource(id = R.dimen.major_75)))
             .background(colorResource(id = R.color.prologue_login_url_badge_background))
@@ -257,8 +257,16 @@ private fun UrlBadge() {
             .padding(
                 horizontal = dimensionResource(id = R.dimen.major_125),
                 vertical = dimensionResource(id = R.dimen.major_85)
-            )
+            ),
+        horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.major_75)),
+        verticalAlignment = Alignment.CenterVertically
     ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_baseline_computer),
+            contentDescription = null,
+            tint = colorResource(id = R.color.prologue_login_on_background),
+            modifier = Modifier.size(dimensionResource(id = R.dimen.image_minor_80))
+        )
         Text(
             text = url,
             style = MaterialTheme.typography.titleLarge,

--- a/WooCommerce/src/main/res/drawable/ic_baseline_computer.xml
+++ b/WooCommerce/src/main/res/drawable/ic_baseline_computer.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/color_on_surface"
+        android:pathData="M20,18c1.1,0 1.99,-0.9 1.99,-2L22,6c0,-1.1 -0.9,-2 -2,-2H4c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2H0v2h24v-2H20zM4,6h16v10H4V6z" />
+</vector>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -213,14 +213,14 @@
     <string name="login_prologue_start_new_store">Starting a new store?</string>
 
     <!-- QR login prologue -->
-    <string name="login_qr_prologue_title">Scan to sign in</string>
+    <string name="login_qr_prologue_title">Scan to log in</string>
     <string name="login_qr_prologue_subtitle">On your computer, visit:</string>
     <string name="login_qr_prologue_url" translatable="false">woo.com/mobilelogin</string>
     <string name="login_qr_prologue_url_clipboard_label">WooCommerce login URL</string>
     <string name="login_qr_prologue_url_copied">Link copied to clipboard</string>
     <string name="login_qr_prologue_step_hint">Then scan the QR code that appears.</string>
     <string name="login_qr_prologue_scan_button">Scan QR code</string>
-    <string name="login_qr_prologue_fallback_link">Sign in with site address instead</string>
+    <string name="login_qr_prologue_fallback_link">No computer? Log in with site address</string>
     <string name="login_qr_prologue_camera_denied_title">Camera access needed</string>
     <string name="login_qr_prologue_camera_denied_body">Without camera access, you can still log in by entering your store address.</string>
     <string name="login_qr_prologue_camera_denied_allow_button">Allow camera access</string>


### PR DESCRIPTION
## Summary
- Rename the prologue title to `Scan to log in` (previously `Scan to sign in`).
- Drop a computer icon into the `woo.com/mobilelogin` URL badge, in front of the URL — reinforces "go to your computer" without an extra row of UI.
- Reword the fallback link to `No computer? Log in with site address`.
- Hero icon (QR scanner), subtitle copy, step hint, and the primary CTA are unchanged.

Branched on top of `issue/woomob-2936-verify-tracking-events`.

## Before / After

| Before | After |
|---|---|
| <img height="300" alt="Screenshot_20260514_144640" src="https://github.com/user-attachments/assets/f2638700-0ac3-42a3-822e-69647166be76" /> | <img height="300" alt="Screenshot 2026-05-14 at 15 17 00" src="https://github.com/user-attachments/assets/8efce1f4-da31-4994-af32-39f3cd0f12e6" /> |

## Test plan
- [ ] Open the QR login flow from the prologue and confirm the new title, URL badge layout, and fallback link copy.
- [ ] Tap the URL badge → still copies `woo.com/mobilelogin` to the clipboard and shows the "Link copied" toast.
- [ ] Light + dark mode.
- [ ] Portrait + landscape on a phone (compact-height) — confirm the URL badge with the icon still fits next to the subtitle in landscape.
- [ ] Tablet (portrait stack in landscape too).