### PR TITLE
[RSM-3160] Persist Woo push notification type switches

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepository.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.datastore.DataStoreQualifier
 import com.woocommerce.android.datastore.DataStoreType.WOO_CORE_PUSH_NOTIFICATIONS_TOKENS
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.extensions.orNullIfEmpty
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.locale.LocaleProvider
@@ -47,13 +48,14 @@ class PushNotificationRepository @Inject constructor(
     private val notificationAnalyticsTracker: NotificationAnalyticsTracker,
     private val localeProvider: LocaleProvider,
     private val checkWooPluginPushNotificationsSupport: CheckWooPluginPushNotificationsSupport,
-    private val coroutineDispatchers: CoroutineDispatchers
+    private val coroutineDispatchers: CoroutineDispatchers,
+    private val selectedSite: SelectedSite
 ) {
-    fun observeWooNotificationPreferences(site: SiteModel): Flow<WooPushNotificationPreferences?> =
-        wooPushNotificationsStore.observeNotificationPreferences(site)
+    fun observeWooNotificationPreferences(): Flow<WooPushNotificationPreferences?> =
+        wooPushNotificationsStore.observeNotificationPreferences(selectedSite.get())
 
-    suspend fun fetchWooNotificationPreferences(site: SiteModel): Result<WooPushNotificationPreferences> {
-        val result = wooPushNotificationsStore.fetchNotificationPreferences(site)
+    suspend fun fetchWooNotificationPreferences(): Result<WooPushNotificationPreferences> {
+        val result = wooPushNotificationsStore.fetchNotificationPreferences(selectedSite.get())
         return if (!result.isError) {
             result.model?.let {
                 Result.success(it)
@@ -64,10 +66,9 @@ class PushNotificationRepository @Inject constructor(
     }
 
     suspend fun updateWooNotificationPreferences(
-        site: SiteModel,
         preferences: WooPushNotificationPreferences
     ): Result<WooPushNotificationPreferences> {
-        val result = wooPushNotificationsStore.updateNotificationPreferences(site, preferences)
+        val result = wooPushNotificationsStore.updateNotificationPreferences(selectedSite.get(), preferences)
         return if (!result.isError) {
             result.model?.let {
                 Result.success(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModel.kt
@@ -11,7 +11,6 @@ import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
 import com.woocommerce.android.notifications.ShowTestNotification
 import com.woocommerce.android.notifications.push.PushNotificationRepository
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -30,7 +29,6 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreOrderPreferences
 import java.math.BigDecimal
@@ -46,12 +44,9 @@ class NewOrderNotificationSettingsViewModel @Inject constructor(
     private val notificationChannelsHandler: NotificationChannelsHandler,
     private val showTestNotification: ShowTestNotification,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    selectedSite: SelectedSite,
     private val pushNotificationRepository: PushNotificationRepository,
     private val coroutineDispatchers: CoroutineDispatchers
 ) : ScopedViewModel(savedStateHandle) {
-    private val site: SiteModel = selectedSite.get()
-
     private val _viewState = MutableStateFlow(
         ViewState(
             currencySymbol = parameterRepository.getParameters().currencySymbol.orEmpty(),
@@ -122,7 +117,7 @@ class NewOrderNotificationSettingsViewModel @Inject constructor(
 
     private fun observeCachedNotificationPreferences() {
         launch {
-            pushNotificationRepository.observeWooNotificationPreferences(site)
+            pushNotificationRepository.observeWooNotificationPreferences()
                 .mapNotNull { it?.storeOrder }
                 .distinctUntilChanged()
                 .collect { orderPreferences ->
@@ -157,7 +152,6 @@ class NewOrderNotificationSettingsViewModel @Inject constructor(
         // Once started, let the save request finish even if the screen is closed.
         val result = withContext(NonCancellable + coroutineDispatchers.main) {
             pushNotificationRepository.updateWooNotificationPreferences(
-                site = site,
                 preferences = WooPushNotificationPreferences(storeOrder = orderPreferences)
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
@@ -55,6 +55,13 @@ class NotificationSettingsFragment : BaseFragment() {
         AnalyticsTracker.trackViewShown(this)
     }
 
+    override fun onStop() {
+        super.onStop()
+        if (navArgs.showSmarterNotifications) {
+            sharedViewModel.savePendingNotificationPreferences()
+        }
+    }
+
     private fun observeEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -100,6 +100,10 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         saveNotificationPreferencesTrigger.tryEmit(NOTIFICATION_PREFERENCES_SAVE_DEBOUNCE_MS)
     }
 
+    fun savePendingNotificationPreferences() {
+        saveNotificationPreferencesTrigger.tryEmit(0L)
+    }
+
     fun onNotificationTypeClicked(type: NotificationType) {
         when (type) {
             NotificationType.NEW_ORDERS -> triggerEvent(OpenNewOrderNotificationSettings)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -6,13 +6,21 @@ import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.notifications.push.PushNotificationRepository
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreOrderPreferences
@@ -20,14 +28,23 @@ import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPr
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreStockPreferences
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class NotificationSettingsSharedViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     selectedSite: SelectedSite,
     private val pushNotificationRepository: PushNotificationRepository,
-    private val resourceProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider,
+    private val coroutineDispatchers: CoroutineDispatchers
 ) : ScopedViewModel(savedStateHandle) {
+    private val site: SiteModel = selectedSite.get()
     private val wooPushNotificationPreferences = MutableStateFlow<WooPushNotificationPreferences?>(null)
+    private var savedWooPushNotificationPreferences: WooPushNotificationPreferences? = null
+    private var saveInProgressWooPushNotificationPreferences: WooPushNotificationPreferences? = null
+    private val saveNotificationPreferencesTrigger = MutableSharedFlow<Long>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     private val _isNotificationSettingsLoading = MutableStateFlow(true)
     val isNotificationSettingsLoading = _isNotificationSettingsLoading.asLiveData()
     private val _isNotificationTypeSelectionEnabled = MutableStateFlow(false)
@@ -58,9 +75,9 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     val notificationTypeItems = _notificationTypeItems.asLiveData()
 
     init {
-        val site = selectedSite.get()
         observeWooPushNotificationPreferences(site)
         fetchWooPushNotificationPreferences(site)
+        observeNotificationPreferencesChanges()
     }
 
     fun onNotificationTypeEnabledChanged(type: NotificationType, isEnabled: Boolean) {
@@ -69,15 +86,18 @@ class NotificationSettingsSharedViewModel @Inject constructor(
             NotificationType.NEW_ORDERS -> preferences.copy(
                 storeOrder = (preferences.storeOrder ?: StoreOrderPreferences()).copy(enabled = isEnabled)
             )
+
             NotificationType.NEW_REVIEWS -> preferences.copy(
                 storeReview = (preferences.storeReview ?: StoreReviewPreferences()).copy(enabled = isEnabled)
             )
+
             NotificationType.STOCK -> preferences.copy(
                 storeStock = (preferences.storeStock ?: StoreStockPreferences()).copy(enabled = isEnabled)
             )
         }
 
-        applyWooPushNotificationPreferences(updatedPreferences)
+        applyDisplayedWooPushNotificationPreferences(updatedPreferences)
+        saveNotificationPreferencesTrigger.tryEmit(NOTIFICATION_PREFERENCES_SAVE_DEBOUNCE_MS)
     }
 
     fun onNotificationTypeClicked(type: NotificationType) {
@@ -93,7 +113,7 @@ class NotificationSettingsSharedViewModel @Inject constructor(
             pushNotificationRepository.observeWooNotificationPreferences(site)
                 .collect { preferences ->
                     preferences?.let {
-                        applyWooPushNotificationPreferences(it)
+                        applyStoredWooPushNotificationPreferences(it)
                         _isNotificationSettingsLoading.value = false
                     }
                 }
@@ -104,7 +124,7 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         launch {
             try {
                 pushNotificationRepository.fetchWooNotificationPreferences(site)
-                    .onSuccess { applyWooPushNotificationPreferences(it) }
+                    .onSuccess { applyStoredWooPushNotificationPreferences(it) }
                     .onFailure { showFetchError(site) }
             } finally {
                 _isNotificationSettingsLoading.value = false
@@ -123,7 +143,76 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         )
     }
 
-    private fun applyWooPushNotificationPreferences(preferences: WooPushNotificationPreferences) {
+    private fun observeNotificationPreferencesChanges() {
+        launch {
+            saveNotificationPreferencesTrigger
+                .debounce { it }
+                .conflate()
+                .collect {
+                    wooPushNotificationPreferences.value?.let { preferences ->
+                        saveNotificationPreferences(preferences)
+                    }
+                }
+        }
+    }
+
+    private suspend fun saveNotificationPreferences(preferencesToSave: WooPushNotificationPreferences) {
+        val savedPreferences = savedWooPushNotificationPreferences ?: return
+        val updateRequest = preferencesToSave.diffFrom(savedPreferences)
+        if (updateRequest.isEmpty()) {
+            return
+        }
+
+        saveInProgressWooPushNotificationPreferences = preferencesToSave
+        // Once started, let the save request finish even if the screen is closed.
+        val result = withContext(NonCancellable + coroutineDispatchers.main) {
+            pushNotificationRepository.updateWooNotificationPreferences(
+                site = site,
+                preferences = updateRequest
+            )
+        }
+
+        result.onSuccess {
+            savedWooPushNotificationPreferences = preferencesToSave
+        }.onFailure {
+            if (wooPushNotificationPreferences.value != preferencesToSave) {
+                // User changed preferences after this save started, so don't rollback over the newer state.
+                return@onFailure
+            }
+            rollbackNotificationPreferences()
+            showUpdateError(preferencesToSave)
+        }
+        if (saveInProgressWooPushNotificationPreferences == preferencesToSave) {
+            // Clear only if another save hasn't started.
+            saveInProgressWooPushNotificationPreferences = null
+        }
+    }
+
+    private fun showUpdateError(preferencesToSave: WooPushNotificationPreferences) {
+        triggerEvent(
+            MultiLiveEvent.Event.ShowActionStringSnackbar(
+                message = resourceProvider.getString(R.string.settings_notifs_error_update),
+                actionText = resourceProvider.getString(R.string.retry),
+            ) {
+                applyDisplayedWooPushNotificationPreferences(preferencesToSave)
+                saveNotificationPreferencesTrigger.tryEmit(0L)
+            }
+        )
+    }
+
+    private fun applyStoredWooPushNotificationPreferences(preferences: WooPushNotificationPreferences) {
+        if (hasUnsavedNotificationPreferences()) {
+            return
+        }
+        if (saveInProgressWooPushNotificationPreferences != null) {
+            return
+        }
+
+        savedWooPushNotificationPreferences = preferences
+        applyDisplayedWooPushNotificationPreferences(preferences)
+    }
+
+    private fun applyDisplayedWooPushNotificationPreferences(preferences: WooPushNotificationPreferences) {
         wooPushNotificationPreferences.value = preferences
         _isNotificationTypeSelectionEnabled.value = true
         _notificationTypeItems.update { items ->
@@ -132,6 +221,29 @@ class NotificationSettingsSharedViewModel @Inject constructor(
             }
         }
     }
+
+    private fun rollbackNotificationPreferences() {
+        savedWooPushNotificationPreferences?.let { applyDisplayedWooPushNotificationPreferences(it) }
+    }
+
+    private fun hasUnsavedNotificationPreferences(): Boolean {
+        return wooPushNotificationPreferences.value?.let { displayedPreferences ->
+            savedWooPushNotificationPreferences?.let { savedPreferences ->
+                displayedPreferences != savedPreferences
+            }
+        } ?: false
+    }
+
+    private fun WooPushNotificationPreferences.diffFrom(
+        savedPreferences: WooPushNotificationPreferences
+    ): WooPushNotificationPreferences = WooPushNotificationPreferences(
+        storeOrder = storeOrder.takeIf { storeOrder != savedPreferences.storeOrder },
+        storeReview = storeReview.takeIf { storeReview != savedPreferences.storeReview },
+        storeStock = storeStock.takeIf { storeStock != savedPreferences.storeStock }
+    )
+
+    private fun WooPushNotificationPreferences.isEmpty(): Boolean =
+        storeOrder == null && storeReview == null && storeStock == null
 
     private fun WooPushNotificationPreferences.isEnabled(type: NotificationType): Boolean? =
         when (type) {
@@ -155,5 +267,9 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         NEW_ORDERS,
         STOCK,
         NEW_REVIEWS
+    }
+
+    companion object {
+        private const val NOTIFICATION_PREFERENCES_SAVE_DEBOUNCE_MS = 1000L
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -179,10 +179,7 @@ class NotificationSettingsSharedViewModel @Inject constructor(
             rollbackNotificationPreferences()
             showUpdateError(preferencesToSave)
         }
-        if (saveInProgressWooPushNotificationPreferences == preferencesToSave) {
-            // Clear only if another save hasn't started.
-            saveInProgressWooPushNotificationPreferences = null
-        }
+        saveInProgressWooPushNotificationPreferences = null
     }
 
     private fun showUpdateError(preferencesToSave: WooPushNotificationPreferences) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
 import com.woocommerce.android.notifications.push.PushNotificationRepository
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -21,7 +20,6 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreOrderPreferences
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreReviewPreferences
@@ -32,12 +30,10 @@ import javax.inject.Inject
 @HiltViewModel
 class NotificationSettingsSharedViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    selectedSite: SelectedSite,
     private val pushNotificationRepository: PushNotificationRepository,
     private val resourceProvider: ResourceProvider,
     private val coroutineDispatchers: CoroutineDispatchers
 ) : ScopedViewModel(savedStateHandle) {
-    private val site: SiteModel = selectedSite.get()
     private val wooPushNotificationPreferences = MutableStateFlow<WooPushNotificationPreferences?>(null)
     private var savedWooPushNotificationPreferences: WooPushNotificationPreferences? = null
     private var saveInProgressWooPushNotificationPreferences: WooPushNotificationPreferences? = null
@@ -75,8 +71,8 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     val notificationTypeItems = _notificationTypeItems.asLiveData()
 
     init {
-        observeWooPushNotificationPreferences(site)
-        fetchWooPushNotificationPreferences(site)
+        observeWooPushNotificationPreferences()
+        fetchWooPushNotificationPreferences()
         observeNotificationPreferencesChanges()
     }
 
@@ -112,9 +108,9 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         }
     }
 
-    private fun observeWooPushNotificationPreferences(site: SiteModel) {
+    private fun observeWooPushNotificationPreferences() {
         launch {
-            pushNotificationRepository.observeWooNotificationPreferences(site)
+            pushNotificationRepository.observeWooNotificationPreferences()
                 .collect { preferences ->
                     preferences?.let {
                         applyStoredWooPushNotificationPreferences(it)
@@ -124,25 +120,25 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         }
     }
 
-    private fun fetchWooPushNotificationPreferences(site: SiteModel) {
+    private fun fetchWooPushNotificationPreferences() {
         launch {
             try {
-                pushNotificationRepository.fetchWooNotificationPreferences(site)
+                pushNotificationRepository.fetchWooNotificationPreferences()
                     .onSuccess { applyStoredWooPushNotificationPreferences(it) }
-                    .onFailure { showFetchError(site) }
+                    .onFailure { showFetchError() }
             } finally {
                 _isNotificationSettingsLoading.value = false
             }
         }
     }
 
-    private fun showFetchError(site: SiteModel) {
+    private fun showFetchError() {
         triggerEvent(
             MultiLiveEvent.Event.ShowActionStringSnackbar(
                 message = resourceProvider.getString(R.string.settings_notifs_error_fetch),
                 actionText = resourceProvider.getString(R.string.retry),
             ) {
-                fetchWooPushNotificationPreferences(site)
+                fetchWooPushNotificationPreferences()
             }
         )
     }
@@ -171,7 +167,6 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         // Once started, let the save request finish even if the screen is closed.
         val result = withContext(NonCancellable + coroutineDispatchers.main) {
             pushNotificationRepository.updateWooNotificationPreferences(
-                site = site,
                 preferences = updateRequest
             )
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -165,13 +165,11 @@ class NotificationSettingsSharedViewModel @Inject constructor(
 
         saveInProgressWooPushNotificationPreferences = preferencesToSave
         // Once started, let the save request finish even if the screen is closed.
-        val result = withContext(NonCancellable + coroutineDispatchers.main) {
+        withContext(NonCancellable + coroutineDispatchers.main) {
             pushNotificationRepository.updateWooNotificationPreferences(
                 preferences = updateRequest
             )
-        }
-
-        result.onSuccess {
+        }.onSuccess {
             savedWooPushNotificationPreferences = preferencesToSave
         }.onFailure {
             if (wooPushNotificationPreferences.value != preferencesToSave) {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/PushNotificationRepositoryTest.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.analytics.AnalyticsEvent
+import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.util.locale.LocaleProvider
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.CompletableDeferred
@@ -57,6 +58,7 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
     private val localeProvider: LocaleProvider = mock {
         on { provideLocale() } doReturn Locale.US
     }
+    private val selectedSite: SelectedSite = mock()
     private val siteModel: SiteModel = mock()
     private val preferences: Preferences = mock()
     private val pushNotificationsDataStore: DataStore<Preferences> = mock {
@@ -82,7 +84,8 @@ class PushNotificationRepositoryTest : BaseUnitTest() {
             notificationAnalyticsTracker,
             localeProvider,
             checkWooPluginPushNotificationsSupport,
-            coroutinesTestRule.testDispatchers
+            coroutinesTestRule.testDispatchers,
+            selectedSite
         )
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.ShowTestNotification
 import com.woocommerce.android.notifications.push.PushNotificationRepository
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.notifications.NewOrderNotificationSettingsViewModel.NotificationPreference
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
@@ -30,13 +29,11 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doSuspendableAnswer
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreOrderPreferences
 import java.math.BigDecimal
@@ -50,9 +47,7 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
     private val notificationChannelsHandler: NotificationChannelsHandler = mock()
     private val showTestNotification: ShowTestNotification = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
-    private val selectedSite: SelectedSite = mock()
     private val pushNotificationRepository: PushNotificationRepository = mock()
-    private val site = SiteModel().apply { id = 123 }
     private lateinit var viewModel: NewOrderNotificationSettingsViewModel
 
     private suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
@@ -68,12 +63,11 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
         )
         whenever(notificationChannelsHandler.checkNewOrderNotificationSound())
             .thenReturn(NotificationChannelsHandler.NewOrderNotificationSoundStatus.DEFAULT)
-        whenever(selectedSite.get()).thenReturn(site)
-        whenever(pushNotificationRepository.observeWooNotificationPreferences(site))
+        whenever(pushNotificationRepository.observeWooNotificationPreferences())
             .thenReturn(flowOf(null))
-        whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any()))
+        whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
             .doSuspendableAnswer { invocation ->
-                val preferences = invocation.getArgument<WooPushNotificationPreferences>(1)
+                val preferences = invocation.getArgument<WooPushNotificationPreferences>(0)
                 Result.success(preferences)
             }
         prepareMocks()
@@ -84,7 +78,6 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
             notificationChannelsHandler = notificationChannelsHandler,
             showTestNotification = showTestNotification,
             analyticsTracker = analyticsTracker,
-            selectedSite = selectedSite,
             pushNotificationRepository = pushNotificationRepository,
             coroutineDispatchers = coroutinesTestRule.testDispatchers
         )
@@ -101,7 +94,7 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
     @Test
     fun `given cached order preferences, when view is loaded, then apply cached preferences`() = testBlocking {
         setup {
-            whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(
+            whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
                 flowOf(
                     WooPushNotificationPreferences(
                         storeOrder = StoreOrderPreferences(enabled = false, minAmount = BigDecimal(50))
@@ -146,7 +139,7 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
             viewModel.onNotificationsEnabledChanged(true)
             advanceUntilIdle()
 
-            verify(pushNotificationRepository, never()).updateWooNotificationPreferences(eq(site), any())
+            verify(pushNotificationRepository, never()).updateWooNotificationPreferences(any())
         }
 
     @Test
@@ -162,7 +155,7 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
     @Test
     fun `when all orders preference is selected, then save order preferences without amount`() = testBlocking {
         setup {
-            whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(
+            whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
                 flowOf(
                     WooPushNotificationPreferences(
                         storeOrder = StoreOrderPreferences(enabled = true, minAmount = BigDecimal(50))
@@ -216,7 +209,7 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
     fun `given threshold amount save is pending, when flushing pending preferences, then save immediately`() =
         testBlocking {
             setup {
-                whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(
+                whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
                     flowOf(
                         WooPushNotificationPreferences(
                             storeOrder = StoreOrderPreferences(enabled = true, minAmount = BigDecimal(50))
@@ -242,7 +235,7 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
 
             viewModel.savePendingOrderPreferences()
 
-            verify(pushNotificationRepository, never()).updateWooNotificationPreferences(eq(site), any())
+            verify(pushNotificationRepository, never()).updateWooNotificationPreferences(any())
         }
 
     @Test
@@ -250,16 +243,16 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
         testBlocking {
             val updateGate = CompletableDeferred<Result<WooPushNotificationPreferences>>()
             setup {
-                whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(
+                whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
                     flowOf(
                         WooPushNotificationPreferences(
                             storeOrder = StoreOrderPreferences(enabled = true, minAmount = BigDecimal(50))
                         )
                     )
                 )
-                whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any()))
+                whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
                     .doSuspendableAnswer { invocation ->
-                        val preferences = invocation.getArgument<WooPushNotificationPreferences>(1)
+                        val preferences = invocation.getArgument<WooPushNotificationPreferences>(0)
                         updateGate.await().map { preferences }
                     }
             }
@@ -272,7 +265,7 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
             updateGate.complete(Result.success(WooPushNotificationPreferences()))
             advanceUntilIdle()
 
-            verify(pushNotificationRepository, times(1)).updateWooNotificationPreferences(eq(site), any())
+            verify(pushNotificationRepository, times(1)).updateWooNotificationPreferences(any())
         }
 
     @Test
@@ -280,9 +273,9 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
         val firstUpdateGate = CompletableDeferred<Result<WooPushNotificationPreferences>>()
 
         setup {
-            whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any()))
+            whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
                 .doSuspendableAnswer { invocation ->
-                    val preferences = invocation.getArgument<WooPushNotificationPreferences>(1)
+                    val preferences = invocation.getArgument<WooPushNotificationPreferences>(0)
                     val result = if (preferences.storeOrder?.enabled == false) {
                         firstUpdateGate.await()
                     } else {
@@ -312,9 +305,9 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
     fun `given update fails, when retry is clicked, then save requested preferences again`() = testBlocking {
         var updateFails = true
         setup {
-            whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any()))
+            whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
                 .doSuspendableAnswer { invocation ->
-                    val preferences = invocation.getArgument<WooPushNotificationPreferences>(1)
+                    val preferences = invocation.getArgument<WooPushNotificationPreferences>(0)
                     if (updateFails) {
                         updateFails = false
                         Result.failure(Exception())
@@ -334,7 +327,7 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
 
         val preferencesCaptor = argumentCaptor<WooPushNotificationPreferences>()
         verify(pushNotificationRepository, times(2))
-            .updateWooNotificationPreferences(eq(site), preferencesCaptor.capture())
+            .updateWooNotificationPreferences(preferencesCaptor.capture())
         assertThat(preferencesCaptor.allValues.map { it.storeOrder }).containsOnly(
             StoreOrderPreferences(enabled = false, minAmount = null)
         )
@@ -344,14 +337,14 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
     fun `given saved order preferences, when update fails, then rollback to latest saved state`() =
         testBlocking {
             setup {
-                whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(
+                whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
                     flowOf(
                         WooPushNotificationPreferences(
                             storeOrder = StoreOrderPreferences(enabled = true, minAmount = BigDecimal(50))
                         )
                     )
                 )
-                whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any()))
+                whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
                     .thenReturn(Result.failure(Exception()))
             }
 
@@ -442,14 +435,14 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
 
     private suspend fun captureUpdatePreferences(): WooPushNotificationPreferences {
         val preferencesCaptor = argumentCaptor<WooPushNotificationPreferences>()
-        verify(pushNotificationRepository).updateWooNotificationPreferences(eq(site), preferencesCaptor.capture())
+        verify(pushNotificationRepository).updateWooNotificationPreferences(preferencesCaptor.capture())
         return preferencesCaptor.firstValue
     }
 
     private suspend fun captureLastUpdatePreferences(): WooPushNotificationPreferences {
         val preferencesCaptor = argumentCaptor<WooPushNotificationPreferences>()
         verify(pushNotificationRepository, atLeastOnce())
-            .updateWooNotificationPreferences(eq(site), preferencesCaptor.capture())
+            .updateWooNotificationPreferences(preferencesCaptor.capture())
         return preferencesCaptor.lastValue
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -19,9 +19,12 @@ import kotlinx.coroutines.test.runCurrent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -30,6 +33,7 @@ import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPr
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreOrderPreferences
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreReviewPreferences
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreStockPreferences
+import java.math.BigDecimal
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
@@ -39,6 +43,11 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }
     }
     private val site = SiteModel().apply { id = 123 }
+    private val defaultNotificationPreferences = WooPushNotificationPreferences(
+        storeOrder = StoreOrderPreferences(enabled = true),
+        storeReview = StoreReviewPreferences(enabled = true),
+        storeStock = StoreStockPreferences(enabled = true)
+    )
     private lateinit var notificationPreferencesFlow: MutableStateFlow<WooPushNotificationPreferences?>
     private lateinit var viewModel: NotificationSettingsSharedViewModel
 
@@ -48,13 +57,15 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(
             notificationPreferencesFlow
         )
-        mockSuccessfulFetch(WooPushNotificationPreferences())
+        mockSuccessfulFetch(defaultNotificationPreferences)
+        mockSuccessfulUpdate()
         prepareMocks()
         viewModel = NotificationSettingsSharedViewModel(
             savedStateHandle = SavedStateHandle(),
             selectedSite = selectedSite,
             pushNotificationRepository = pushNotificationRepository,
-            resourceProvider = resourceProvider
+            resourceProvider = resourceProvider,
+            coroutineDispatchers = coroutinesTestRule.testDispatchers
         )
     }
 
@@ -62,6 +73,12 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         whenever(pushNotificationRepository.fetchWooNotificationPreferences(site)).doSuspendableAnswer {
             notificationPreferencesFlow.value = preferences
             Result.success(preferences)
+        }
+    }
+
+    private suspend fun mockSuccessfulUpdate() {
+        whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any())).doSuspendableAnswer {
+            Result.success(it.getArgument<WooPushNotificationPreferences>(1))
         }
     }
 
@@ -105,7 +122,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             assertThat(loadingValues).contains(true)
             assertThat(viewModel.isNotificationTypeSelectionEnabled.captureValues().last()).isFalse()
 
-            fetchResult.complete(Result.success(WooPushNotificationPreferences()))
+            fetchResult.complete(Result.success(defaultNotificationPreferences))
             advanceUntilIdle()
 
             assertThat(viewModel.isNotificationSettingsLoading.captureValues().last()).isFalse()
@@ -123,7 +140,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
                         fetchFails = false
                         Result.failure(Exception())
                     } else {
-                        Result.success(WooPushNotificationPreferences())
+                        Result.success(defaultNotificationPreferences)
                     }
                 }
             }
@@ -149,7 +166,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             val fetchResult = CompletableDeferred<Result<WooPushNotificationPreferences>>()
             setup {
                 whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(
-                    flowOf(WooPushNotificationPreferences(storeOrder = StoreOrderPreferences(enabled = false)))
+                    flowOf(defaultNotificationPreferences.copy(storeOrder = StoreOrderPreferences(enabled = false)))
                 )
                 whenever(pushNotificationRepository.fetchWooNotificationPreferences(site)).doSuspendableAnswer {
                     fetchResult.await()
@@ -166,7 +183,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
                     .isEnabled
             ).isFalse()
 
-            fetchResult.complete(Result.success(WooPushNotificationPreferences()))
+            fetchResult.complete(Result.success(defaultNotificationPreferences))
             advanceUntilIdle()
         }
 
@@ -189,6 +206,160 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             assertThat(notificationTypeItems.first { it.type == NotificationType.NEW_ORDERS }.isEnabled).isFalse()
             assertThat(notificationTypeItems.first { it.type == NotificationType.NEW_REVIEWS }.isEnabled).isTrue()
             assertThat(notificationTypeItems.first { it.type == NotificationType.STOCK }.isEnabled).isFalse()
+        }
+
+    @Test
+    fun `when notification type switch is changed, then save changed notification preferences`() = testBlocking {
+        setup()
+        advanceUntilIdle()
+
+        viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, false)
+        advanceUntilIdle()
+
+        val preferences = captureUpdatePreferences()
+        assertThat(preferences.storeOrder).isNull()
+        assertThat(preferences.storeReview).isNull()
+        assertThat(preferences.storeStock).isEqualTo(StoreStockPreferences(enabled = false))
+    }
+
+    @Test
+    fun `given order preferences have threshold, when order switch is changed, then preserve threshold`() =
+        testBlocking {
+            val orderPreferences = WooPushNotificationPreferences(
+                storeOrder = StoreOrderPreferences(enabled = true, minAmount = BigDecimal(50))
+            )
+            setup {
+                notificationPreferencesFlow.value = orderPreferences
+                mockSuccessfulFetch(orderPreferences)
+            }
+            advanceUntilIdle()
+
+            viewModel.onNotificationTypeEnabledChanged(NotificationType.NEW_ORDERS, false)
+            advanceUntilIdle()
+
+            val preferences = captureUpdatePreferences()
+            assertThat(preferences.storeOrder)
+                .isEqualTo(StoreOrderPreferences(enabled = false, minAmount = BigDecimal(50)))
+        }
+
+    @Test
+    fun `given user reverts notification type before debounce, when debounce completes, then skip update request`() =
+        testBlocking {
+            setup()
+            advanceUntilIdle()
+
+            viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, false)
+            viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, true)
+            advanceUntilIdle()
+
+            verify(pushNotificationRepository, never()).updateWooNotificationPreferences(eq(site), any())
+        }
+
+    @Test
+    fun `given update request is pending, when cache emits stale value, then ignore stale cache value`() =
+        testBlocking {
+            val cachedPreferences = WooPushNotificationPreferences(
+                storeStock = StoreStockPreferences(enabled = true)
+            )
+            setup {
+                notificationPreferencesFlow.value = cachedPreferences
+                mockSuccessfulFetch(cachedPreferences)
+            }
+            advanceUntilIdle()
+
+            viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, false)
+            notificationPreferencesFlow.value = WooPushNotificationPreferences(
+                storeStock = StoreStockPreferences(enabled = true)
+            )
+            runCurrent()
+
+            val notificationTypeItems = viewModel.notificationTypeItems.captureValues().last()
+            assertThat(notificationTypeItems.first { it.type == NotificationType.STOCK }.isEnabled).isFalse()
+        }
+
+    @Test
+    fun `given update fails, when notification type switch is changed, then rollback and show error`() =
+        testBlocking {
+            val cachedPreferences = WooPushNotificationPreferences(
+                storeStock = StoreStockPreferences(enabled = true)
+            )
+            setup {
+                notificationPreferencesFlow.value = cachedPreferences
+                mockSuccessfulFetch(cachedPreferences)
+                whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any()))
+                    .thenReturn(Result.failure(Exception()))
+            }
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, false)
+                advanceUntilIdle()
+            }.last()
+
+            val notificationTypeItems = viewModel.notificationTypeItems.captureValues().last()
+            assertThat(notificationTypeItems.first { it.type == NotificationType.STOCK }.isEnabled).isTrue()
+            val snackbar = event as Event.ShowActionStringSnackbar
+            assertThat(snackbar.message).isEqualTo(resourceProvider.getString(R.string.settings_notifs_error_update))
+            assertThat(snackbar.actionText).isEqualTo(resourceProvider.getString(R.string.retry))
+        }
+
+    @Test
+    fun `given update fails, when retry is clicked, then save notification preferences again`() =
+        testBlocking {
+            var updateFails = true
+            setup {
+                whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any()))
+                    .doSuspendableAnswer { invocation ->
+                        val preferences = invocation.getArgument<WooPushNotificationPreferences>(1)
+                        if (updateFails) {
+                            updateFails = false
+                            Result.failure(Exception())
+                        } else {
+                            Result.success(preferences)
+                        }
+                    }
+            }
+            advanceUntilIdle()
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, false)
+                advanceUntilIdle()
+            }.last()
+
+            (event as Event.ShowActionStringSnackbar).action.onClick(null)
+            advanceUntilIdle()
+
+            val preferences = captureLastUpdatePreferences()
+            assertThat(preferences.storeStock).isEqualTo(StoreStockPreferences(enabled = false))
+        }
+
+    @Test
+    fun `given update is in progress, when notification type changes again, then save latest state`() =
+        testBlocking {
+            val firstUpdateGate = CompletableDeferred<Result<WooPushNotificationPreferences>>()
+            setup {
+                whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any()))
+                    .doSuspendableAnswer { invocation ->
+                        val preferences = invocation.getArgument<WooPushNotificationPreferences>(1)
+                        if (preferences.storeStock?.enabled == false) {
+                            firstUpdateGate.await()
+                        } else {
+                            Result.success(preferences)
+                        }
+                    }
+            }
+            advanceUntilIdle()
+
+            viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, false)
+            advanceUntilIdle()
+            viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, true)
+            firstUpdateGate.complete(
+                Result.success(WooPushNotificationPreferences(storeStock = StoreStockPreferences(enabled = false)))
+            )
+            advanceUntilIdle()
+
+            val preferences = captureLastUpdatePreferences()
+            assertThat(preferences.storeStock).isEqualTo(StoreStockPreferences(enabled = true))
+            verify(pushNotificationRepository, times(2)).updateWooNotificationPreferences(eq(site), any())
         }
 
     @Test
@@ -227,5 +398,18 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         }.last()
 
         assertThat(event).isInstanceOf(NotificationSettingsSharedViewModel.OpenStockNotificationSettings::class.java)
+    }
+
+    private suspend fun captureUpdatePreferences(): WooPushNotificationPreferences {
+        val preferencesCaptor = argumentCaptor<WooPushNotificationPreferences>()
+        verify(pushNotificationRepository).updateWooNotificationPreferences(eq(site), preferencesCaptor.capture())
+        return preferencesCaptor.firstValue
+    }
+
+    private suspend fun captureLastUpdatePreferences(): WooPushNotificationPreferences {
+        val preferencesCaptor = argumentCaptor<WooPushNotificationPreferences>()
+        verify(pushNotificationRepository, times(2))
+            .updateWooNotificationPreferences(eq(site), preferencesCaptor.capture())
+        return preferencesCaptor.lastValue
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -3,7 +3,6 @@ package com.woocommerce.android.ui.prefs.notifications
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.notifications.push.PushNotificationRepository
-import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NotificationType
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
@@ -22,13 +21,11 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doSuspendableAnswer
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreOrderPreferences
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreReviewPreferences
@@ -37,12 +34,10 @@ import java.math.BigDecimal
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
-    private val selectedSite: SelectedSite = mock()
     private val pushNotificationRepository: PushNotificationRepository = mock()
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }
     }
-    private val site = SiteModel().apply { id = 123 }
     private val defaultNotificationPreferences = WooPushNotificationPreferences(
         storeOrder = StoreOrderPreferences(enabled = true),
         storeReview = StoreReviewPreferences(enabled = true),
@@ -52,9 +47,8 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: NotificationSettingsSharedViewModel
 
     private suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
-        whenever(selectedSite.get()).thenReturn(site)
         notificationPreferencesFlow = MutableStateFlow(null)
-        whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(
+        whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
             notificationPreferencesFlow
         )
         mockSuccessfulFetch(defaultNotificationPreferences)
@@ -62,7 +56,6 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         prepareMocks()
         viewModel = NotificationSettingsSharedViewModel(
             savedStateHandle = SavedStateHandle(),
-            selectedSite = selectedSite,
             pushNotificationRepository = pushNotificationRepository,
             resourceProvider = resourceProvider,
             coroutineDispatchers = coroutinesTestRule.testDispatchers
@@ -70,15 +63,15 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
     }
 
     private suspend fun mockSuccessfulFetch(preferences: WooPushNotificationPreferences) {
-        whenever(pushNotificationRepository.fetchWooNotificationPreferences(site)).doSuspendableAnswer {
+        whenever(pushNotificationRepository.fetchWooNotificationPreferences()).doSuspendableAnswer {
             notificationPreferencesFlow.value = preferences
             Result.success(preferences)
         }
     }
 
     private suspend fun mockSuccessfulUpdate() {
-        whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any())).doSuspendableAnswer {
-            Result.success(it.getArgument<WooPushNotificationPreferences>(1))
+        whenever(pushNotificationRepository.updateWooNotificationPreferences(any())).doSuspendableAnswer {
+            Result.success(it.getArgument<WooPushNotificationPreferences>(0))
         }
     }
 
@@ -101,7 +94,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
 
         advanceUntilIdle()
 
-        verify(pushNotificationRepository).fetchWooNotificationPreferences(site)
+        verify(pushNotificationRepository).fetchWooNotificationPreferences()
     }
 
     @Test
@@ -109,8 +102,8 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         testBlocking {
             val fetchResult = CompletableDeferred<Result<WooPushNotificationPreferences>>()
             setup {
-                whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(flowOf(null))
-                whenever(pushNotificationRepository.fetchWooNotificationPreferences(site)).doSuspendableAnswer {
+                whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(flowOf(null))
+                whenever(pushNotificationRepository.fetchWooNotificationPreferences()).doSuspendableAnswer {
                     fetchResult.await()
                 }
             }
@@ -134,8 +127,8 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         testBlocking {
             var fetchFails = true
             setup {
-                whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(flowOf(null))
-                whenever(pushNotificationRepository.fetchWooNotificationPreferences(site)).doSuspendableAnswer {
+                whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(flowOf(null))
+                whenever(pushNotificationRepository.fetchWooNotificationPreferences()).doSuspendableAnswer {
                     if (fetchFails) {
                         fetchFails = false
                         Result.failure(Exception())
@@ -156,7 +149,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             snackbar.action.onClick(null)
             advanceUntilIdle()
 
-            verify(pushNotificationRepository, times(2)).fetchWooNotificationPreferences(site)
+            verify(pushNotificationRepository, times(2)).fetchWooNotificationPreferences()
             assertThat(viewModel.isNotificationTypeSelectionEnabled.captureValues().last()).isTrue()
         }
 
@@ -165,10 +158,10 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         testBlocking {
             val fetchResult = CompletableDeferred<Result<WooPushNotificationPreferences>>()
             setup {
-                whenever(pushNotificationRepository.observeWooNotificationPreferences(site)).thenReturn(
+                whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
                     flowOf(defaultNotificationPreferences.copy(storeOrder = StoreOrderPreferences(enabled = false)))
                 )
-                whenever(pushNotificationRepository.fetchWooNotificationPreferences(site)).doSuspendableAnswer {
+                whenever(pushNotificationRepository.fetchWooNotificationPreferences()).doSuspendableAnswer {
                     fetchResult.await()
                 }
             }
@@ -266,7 +259,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, true)
             advanceUntilIdle()
 
-            verify(pushNotificationRepository, never()).updateWooNotificationPreferences(eq(site), any())
+            verify(pushNotificationRepository, never()).updateWooNotificationPreferences(any())
         }
 
     @Test
@@ -300,7 +293,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             setup {
                 notificationPreferencesFlow.value = cachedPreferences
                 mockSuccessfulFetch(cachedPreferences)
-                whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any()))
+                whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
                     .thenReturn(Result.failure(Exception()))
             }
 
@@ -321,9 +314,9 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         testBlocking {
             var updateFails = true
             setup {
-                whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any()))
+                whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
                     .doSuspendableAnswer { invocation ->
-                        val preferences = invocation.getArgument<WooPushNotificationPreferences>(1)
+                        val preferences = invocation.getArgument<WooPushNotificationPreferences>(0)
                         if (updateFails) {
                             updateFails = false
                             Result.failure(Exception())
@@ -351,9 +344,9 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         testBlocking {
             val firstUpdateGate = CompletableDeferred<Result<WooPushNotificationPreferences>>()
             setup {
-                whenever(pushNotificationRepository.updateWooNotificationPreferences(eq(site), any()))
+                whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
                     .doSuspendableAnswer { invocation ->
-                        val preferences = invocation.getArgument<WooPushNotificationPreferences>(1)
+                        val preferences = invocation.getArgument<WooPushNotificationPreferences>(0)
                         if (preferences.storeStock?.enabled == false) {
                             firstUpdateGate.await()
                         } else {
@@ -373,7 +366,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
 
             val preferences = captureLastUpdatePreferences()
             assertThat(preferences.storeStock).isEqualTo(StoreStockPreferences(enabled = true))
-            verify(pushNotificationRepository, times(2)).updateWooNotificationPreferences(eq(site), any())
+            verify(pushNotificationRepository, times(2)).updateWooNotificationPreferences(any())
         }
 
     @Test
@@ -416,14 +409,14 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
 
     private suspend fun captureUpdatePreferences(): WooPushNotificationPreferences {
         val preferencesCaptor = argumentCaptor<WooPushNotificationPreferences>()
-        verify(pushNotificationRepository).updateWooNotificationPreferences(eq(site), preferencesCaptor.capture())
+        verify(pushNotificationRepository).updateWooNotificationPreferences(preferencesCaptor.capture())
         return preferencesCaptor.firstValue
     }
 
     private suspend fun captureLastUpdatePreferences(): WooPushNotificationPreferences {
         val preferencesCaptor = argumentCaptor<WooPushNotificationPreferences>()
         verify(pushNotificationRepository, times(2))
-            .updateWooNotificationPreferences(eq(site), preferencesCaptor.capture())
+            .updateWooNotificationPreferences(preferencesCaptor.capture())
         return preferencesCaptor.lastValue
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -243,6 +243,20 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given notification type change is pending, when screen stops, then save immediately`() =
+        testBlocking {
+            setup()
+            advanceUntilIdle()
+
+            viewModel.onNotificationTypeEnabledChanged(NotificationType.STOCK, false)
+            viewModel.savePendingNotificationPreferences()
+            runCurrent()
+
+            val preferences = captureUpdatePreferences()
+            assertThat(preferences.storeStock).isEqualTo(StoreStockPreferences(enabled = false))
+        }
+
+    @Test
     fun `given user reverts notification type before debounce, when debounce completes, then skip update request`() =
         testBlocking {
             setup()


### PR DESCRIPTION
### Description

Fixes RSM-3160

This builds on the Woo push notification settings shared state foundation by persisting changes from the notification type switches on the parent screen.

The parent screen now:
- applies switch changes immediately in the shared ViewModel
- saves changed notification preferences through `PushNotificationRepository`
- sends only changed preference sections in the update request
- preserves existing detail values, such as the new-order threshold, when toggling a parent switch
- ignores stale cache emissions while a save is pending
- rolls back and shows a retry action when an update fails
- flushes pending changes when leaving the screen

### Test Steps

1. Open the smarter notification settings screen.
2. Toggle each notification type switch: New orders, New reviews, and Stock.
3. Verify the switch state updates immediately.
4. Leave the screen and return to the smarter notification settings screen.
5. Verify the changed switch state is still shown.
6. Toggle a switch and immediately leave the screen.
7. Return to the smarter notification settings screen and verify the latest switch state was saved.
8. For new orders, set a threshold in the detail screen, return to the parent screen, toggle New orders, and verify the threshold is still preserved when opening the detail screen again.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.