### PR TITLE
[WOOMOB-3084] Make AI assistant dashboard card removable and reorderable

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/DashboardWidget.kt
@@ -26,6 +26,10 @@ data class DashboardWidget(
         val trackingIdentifier: String,
         private val isSupported: Boolean = true,
     ) {
+        AI_ASSISTANT(
+            titleResource = R.string.more_menu_button_ai_assistant,
+            trackingIdentifier = "ai_assistant",
+        ),
         PUSH_NOTIFICATIONS(
             titleResource = R.string.my_store_widget_push_notifications_menu_title,
             trackingIdentifier = "push_notifications"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -231,7 +231,6 @@ private fun DashboardWidgetCard(
                 modifier = modifier
             )
         }
-
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardContainer.kt
@@ -45,7 +45,6 @@ import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardCardsState
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenRangePicker
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.AIAssistantEntry
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.ConfigurableWidget
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.FeedbackWidget
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.NewWidgetsCard
@@ -233,12 +232,6 @@ private fun DashboardWidgetCard(
             )
         }
 
-        is AIAssistantEntry -> {
-            DashboardAIAssistantCard(
-                onClick = it.onClick,
-                modifier = modifier
-            )
-        }
     }
 }
 
@@ -251,6 +244,11 @@ private fun ConfigurableWidgetCard(
     modifier: Modifier
 ) {
     when (widgetUiModel.widget.type) {
+        DashboardWidget.Type.AI_ASSISTANT -> DashboardAIAssistantCard(
+            onClick = dashboardViewModel::onAiAssistantCardClicked,
+            modifier = modifier
+        )
+
         DashboardWidget.Type.PUSH_NOTIFICATIONS -> DashboardPushNotificationsCard(
             onClick = {
                 dashboardViewModel.trackCardInteracted(DashboardWidget.Type.PUSH_NOTIFICATIONS.trackingIdentifier)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModel.kt
@@ -26,7 +26,6 @@ import com.woocommerce.android.notifications.push.ShouldShowEnablePushNotificati
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.tools.SiteConnectionType
 import com.woocommerce.android.tools.connectionType
-import com.woocommerce.android.ui.aiassistant.AIAssistantEligibilityChecker
 import com.woocommerce.android.ui.analytics.ranges.StatsTimeRangeSelection.SelectionType
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.OpenEditWidgets
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardEvent.RefreshJitm
@@ -68,15 +67,13 @@ class DashboardViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     dashboardTransactionLauncher: DashboardTransactionLauncher,
     shouldShowPrivacyBanner: ShouldShowPrivacyBanner,
-    dashboardRepository: DashboardRepository,
+    private val dashboardRepository: DashboardRepository,
     private val pushNotificationRegistrationStatus: PushNotificationRegistrationStatus,
     private val shouldShowEnablePushNotificationsUi: ShouldShowEnablePushNotificationsUi,
     private val feedbackPrefs: FeedbackPrefs,
-    private val aiAssistantEligibilityChecker: AIAssistantEligibilityChecker,
 ) : ScopedViewModel(savedState) {
     companion object {
         private const val DAYS_TO_REDISPLAY_JP_BENEFITS_BANNER = 5
-        private const val AI_ASSISTANT_TRACKING_TYPE = "ai_assistant"
         val SUPPORTED_RANGES_ON_MY_STORE_TAB = listOf(
             SelectionType.TODAY,
             SelectionType.WEEK_TO_DATE,
@@ -111,10 +108,9 @@ class DashboardViewModel @Inject constructor(
     private val dashboardWidgets = combine(
         dashboardRepository.widgets,
         dashboardRepository.hasNewWidgets,
-        feedbackPrefs.userFeedbackIsDueObservable,
-        aiAssistantEligibilityChecker.observeEligibility()
-    ) { configurableWidgets, hasNewWidgets, userFeedbackIsDue, isAiAssistantEligible ->
-        mapWidgetsToUiModels(configurableWidgets, hasNewWidgets, userFeedbackIsDue, isAiAssistantEligible)
+        feedbackPrefs.userFeedbackIsDueObservable
+    ) { configurableWidgets, hasNewWidgets, userFeedbackIsDue ->
+        mapWidgetsToUiModels(configurableWidgets, hasNewWidgets, userFeedbackIsDue)
     }
 
     val hasNewWidgets = dashboardRepository.hasNewWidgets.asLiveData()
@@ -152,6 +148,13 @@ class DashboardViewModel @Inject constructor(
         }
 
         updateShareStoreButtonVisibility()
+        insertAIAssistantWidgetByDefault()
+    }
+
+    private fun insertAIAssistantWidgetByDefault() {
+        launch {
+            dashboardRepository.insertAIAssistantWidgetAtTopIfMissing()
+        }
     }
 
     private fun updateShareStoreButtonVisibility() {
@@ -239,16 +242,8 @@ class DashboardViewModel @Inject constructor(
     private fun mapWidgetsToUiModels(
         widgets: List<DashboardWidget>,
         hasNewWidgets: Boolean,
-        userFeedbackIsDue: Boolean,
-        isAiAssistantEligible: Boolean
+        userFeedbackIsDue: Boolean
     ): List<DashboardWidgetUiModel> = buildList {
-        add(
-            DashboardWidgetUiModel.AIAssistantEntry(
-                isVisible = isAiAssistantEligible,
-                onClick = ::onAiAssistantCardClicked
-            )
-        )
-
         addAll(
             widgets.map { DashboardWidgetUiModel.ConfigurableWidget(it) }
         )
@@ -302,8 +297,8 @@ class DashboardViewModel @Inject constructor(
         )
     }
 
-    private fun onAiAssistantCardClicked() {
-        trackCardInteracted(AI_ASSISTANT_TRACKING_TYPE)
+    fun onAiAssistantCardClicked() {
+        trackCardInteracted(DashboardWidget.Type.AI_ASSISTANT.trackingIdentifier)
         triggerEvent(DashboardEvent.OpenAiAssistant)
     }
 
@@ -350,11 +345,6 @@ class DashboardViewModel @Inject constructor(
             override val isVisible: Boolean
                 get() = widget.isVisible
         }
-
-        data class AIAssistantEntry(
-            override val isVisible: Boolean,
-            val onClick: () -> Unit
-        ) : DashboardWidgetUiModel
 
         data class ShareStoreWidget(
             override val isVisible: Boolean,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStore.kt
@@ -72,7 +72,8 @@ class DashboardDataStore @Inject constructor(
     @VisibleForTesting
     internal fun getDefaultWidgets(): List<DashboardWidgetDataModel> {
         fun DashboardWidget.Type.shouldBeEnabledByDefault() =
-            this == DashboardWidget.Type.STATS ||
+            this == DashboardWidget.Type.AI_ASSISTANT ||
+                this == DashboardWidget.Type.STATS ||
                 this == DashboardWidget.Type.POPULAR_PRODUCTS ||
                 this == DashboardWidget.Type.ONBOARDING ||
                 this == DashboardWidget.Type.BLAZE ||

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt
@@ -32,7 +32,8 @@ class DashboardRepository @Inject constructor(
     observeOnboardingWidgetStatus: ObserveOnboardingWidgetStatus,
     observeStockWidgetStatus: ObserveStockWidgetStatus,
     observeGoogleAdsWidgetStatus: ObserveGoogleAdsWidgetStatus,
-    observeInboxWidgetStatus: ObserveInboxWidgetStatus
+    observeInboxWidgetStatus: ObserveInboxWidgetStatus,
+    observeAIAssistantWidgetStatus: ObserveAIAssistantWidgetStatus,
 ) {
     private val siteCoroutineScopeFlow = selectedSite.observe().map {
         selectedSite.siteComponent?.let { component ->
@@ -65,6 +66,8 @@ class DashboardRepository @Inject constructor(
 
     private val inboxWidgetStatus = widgetStatusFlow { observeInboxWidgetStatus() }
 
+    private val aiAssistantWidgetStatus = widgetStatusFlow { observeAIAssistantWidgetStatus() }
+
     val widgets = combine(
         dashboardDataStore.widgets,
         siteOrdersState,
@@ -73,9 +76,10 @@ class DashboardRepository @Inject constructor(
         onboardingWidgetStatus,
         stockWidgetStatus,
         googleAdsWidgetStatus,
-        inboxWidgetStatus
+        inboxWidgetStatus,
+        aiAssistantWidgetStatus
     ) { widgets, siteOrdersState, blazeWidgetStatus, pushNotificationsWidgetStatus, onboardingWidgetStatus,
-        stockWidgetStatus, googleAdsWidgetStatus, inboxWidgetStatus ->
+        stockWidgetStatus, googleAdsWidgetStatus, inboxWidgetStatus, aiAssistantWidgetStatus ->
         widgets.toDomainModel(
             siteOrdersState,
             blazeWidgetStatus,
@@ -83,7 +87,8 @@ class DashboardRepository @Inject constructor(
             onboardingWidgetStatus,
             stockWidgetStatus,
             googleAdsWidgetStatus,
-            inboxWidgetStatus
+            inboxWidgetStatus,
+            aiAssistantWidgetStatus
         )
     }
 
@@ -123,6 +128,26 @@ class DashboardRepository @Inject constructor(
         updateWidgets(widgets + newWidgets)
     }
 
+    suspend fun insertAIAssistantWidgetAtTopIfMissing() {
+        val storedWidgets = dashboardDataStore.widgets.first()
+        if (storedWidgets.any { it.type == DashboardWidget.Type.AI_ASSISTANT.name }) {
+            return
+        }
+
+        val aiAssistantWidget = DashboardWidget(
+            type = DashboardWidget.Type.AI_ASSISTANT,
+            isSelected = true,
+            status = DashboardWidget.Status.Available
+        ).toDataModel()
+
+        dashboardDataStore.updateDashboard(
+            DashboardDataModel.newBuilder()
+                .addWidgets(aiAssistantWidget)
+                .addAllWidgets(storedWidgets)
+                .build()
+        )
+    }
+
     private fun List<DashboardWidgetDataModel>.toDomainModel(
         siteOrdersState: DashboardWidget.Status,
         blazeWidgetStatus: DashboardWidget.Status,
@@ -130,7 +155,8 @@ class DashboardRepository @Inject constructor(
         onboardingWidgetStatus: DashboardWidget.Status,
         stockWidgetStatus: DashboardWidget.Status,
         googleAdsWidgetStatus: DashboardWidget.Status,
-        inboxWidgetStatus: DashboardWidget.Status
+        inboxWidgetStatus: DashboardWidget.Status,
+        aiAssistantWidgetStatus: DashboardWidget.Status
     ): List<DashboardWidget> {
         return map { widget ->
             val type = DashboardWidget.Type.valueOf(widget.type)
@@ -148,6 +174,7 @@ class DashboardRepository @Inject constructor(
                     DashboardWidget.Type.STOCK -> stockWidgetStatus
                     DashboardWidget.Type.GOOGLE_ADS -> googleAdsWidgetStatus
                     DashboardWidget.Type.INBOX -> inboxWidgetStatus
+                    DashboardWidget.Type.AI_ASSISTANT -> aiAssistantWidgetStatus
 
                     else -> DashboardWidget.Status.Available
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveAIAssistantWidgetStatus.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveAIAssistantWidgetStatus.kt
@@ -1,0 +1,16 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.ui.aiassistant.AIAssistantEligibilityChecker
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class ObserveAIAssistantWidgetStatus @Inject constructor(
+    private val aiAssistantEligibilityChecker: AIAssistantEligibilityChecker,
+) {
+    operator fun invoke(): Flow<DashboardWidget.Status> =
+        aiAssistantEligibilityChecker.observeEligibility().map { isEligible ->
+            if (isEligible) DashboardWidget.Status.Available else DashboardWidget.Status.Hidden
+        }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -11,9 +11,8 @@ import com.woocommerce.android.notifications.push.PushNotificationRegistrationSt
 import com.woocommerce.android.notifications.push.PushNotificationRegistrationStatus.Status
 import com.woocommerce.android.notifications.push.ShouldShowEnablePushNotificationsUi
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.aiassistant.AIAssistantEligibilityChecker
-import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.AIAssistantEntry
 import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.ConfigurableWidget
+import com.woocommerce.android.ui.dashboard.DashboardViewModel.DashboardWidgetUiModel.NewWidgetsCard
 import com.woocommerce.android.ui.dashboard.data.DashboardRepository
 import com.woocommerce.android.ui.prefs.privacy.banner.domain.ShouldShowPrivacyBanner
 import com.woocommerce.android.util.captureValues
@@ -73,10 +72,6 @@ class DashboardViewModelTest : BaseUnitTest() {
     private val shouldShowEnablePushNotificationsUi: ShouldShowEnablePushNotificationsUi = mock {
         on { invoke() } doReturn flowOf(false)
     }
-    private val aiAssistantEligibilityChecker: AIAssistantEligibilityChecker = mock {
-        on { observeEligibility() } doReturn flowOf(false)
-    }
-
     private lateinit var viewModel: DashboardViewModel
 
     suspend fun setup(prepareMocks: suspend () -> Unit) {
@@ -95,9 +90,48 @@ class DashboardViewModelTest : BaseUnitTest() {
             pushNotificationRegistrationStatus = pushNotificationRegistrationStatus,
             shouldShowEnablePushNotificationsUi = shouldShowEnablePushNotificationsUi,
             feedbackPrefs = feedbackPrefs,
-            aiAssistantEligibilityChecker = aiAssistantEligibilityChecker,
         )
     }
+
+    @Test
+    fun `given ai assistant is missing, when dashboard starts, then repository inserts ai assistant at top`() =
+        testBlocking {
+            // GIVEN
+            val widgetsFlow = MutableStateFlow(DEFAULT_WIDGETS_WITHOUT_AI)
+            setup {
+                whenever(dashboardRepository.widgets).thenReturn(widgetsFlow)
+            }
+
+            // WHEN
+            viewModel.dashboardCardsState.captureValues().last()
+
+            // THEN
+            verify(dashboardRepository).insertAIAssistantWidgetAtTopIfMissing()
+        }
+
+    @Test
+    fun `given upgraded config is only missing ai assistant, when insertion emission lands, then new widgets card is hidden`() =
+        testBlocking {
+            // GIVEN
+            val widgets = MutableStateFlow(DEFAULT_WIDGETS_WITHOUT_AI)
+            val hasNewWidgets = MutableStateFlow(true)
+            setup {
+                whenever(dashboardRepository.widgets).thenReturn(widgets)
+                whenever(dashboardRepository.hasNewWidgets).thenReturn(hasNewWidgets)
+            }
+
+            // WHEN
+            val states = viewModel.dashboardCardsState.captureValues()
+            widgets.value = listOf(dashboardWidget(DashboardWidget.Type.AI_ASSISTANT)) + DEFAULT_WIDGETS_WITHOUT_AI
+            hasNewWidgets.value = false
+
+            // THEN
+            verify(dashboardRepository).insertAIAssistantWidgetAtTopIfMissing()
+            val newWidgetsCard = states.last().widgets
+                .filterIsInstance<NewWidgetsCard>()
+                .single()
+            assertThat(newWidgetsCard.isVisible).isFalse()
+        }
 
     @Test
     fun `given a Jetpack site, when screen starts, then hide the Jetpack Benefits banner`() = testBlocking {
@@ -297,35 +331,44 @@ class DashboardViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given ai assistant is eligible, when screen starts, then dashboard state shows assistant entry`() =
+    fun `given ai assistant is available, when screen starts, then dashboard state shows assistant widget`() =
         testBlocking {
             // GIVEN
+            val aiAssistant = dashboardWidget(DashboardWidget.Type.AI_ASSISTANT)
             setup {
-                whenever(aiAssistantEligibilityChecker.observeEligibility()).thenReturn(flowOf(true))
+                whenever(dashboardRepository.widgets).thenReturn(flowOf(listOf(aiAssistant, dashboardWidget(DashboardWidget.Type.STATS))))
             }
 
             // WHEN
             val viewState = viewModel.dashboardCardsState.captureValues().last()
 
             // THEN
-            val assistantEntry = viewState.widgets.filterIsInstance<AIAssistantEntry>().single()
-            assertThat(assistantEntry.isVisible).isTrue()
+            val assistantWidget = viewState.widgets
+                .filterIsInstance<ConfigurableWidget>()
+                .single { it.widget.type == DashboardWidget.Type.AI_ASSISTANT }
+            assertThat(assistantWidget.isVisible).isTrue()
         }
 
     @Test
-    fun `given ai assistant is not eligible, when screen starts, then dashboard state hides assistant entry`() =
+    fun `given ai assistant is hidden, when screen starts, then dashboard state hides assistant widget`() =
         testBlocking {
             // GIVEN
+            val aiAssistant = dashboardWidget(
+                type = DashboardWidget.Type.AI_ASSISTANT,
+                status = DashboardWidget.Status.Hidden
+            )
             setup {
-                whenever(aiAssistantEligibilityChecker.observeEligibility()).thenReturn(flowOf(false))
+                whenever(dashboardRepository.widgets).thenReturn(flowOf(listOf(aiAssistant, dashboardWidget(DashboardWidget.Type.STATS))))
             }
 
             // WHEN
             val viewState = viewModel.dashboardCardsState.captureValues().last()
 
             // THEN
-            val assistantEntry = viewState.widgets.filterIsInstance<AIAssistantEntry>().single()
-            assertThat(assistantEntry.isVisible).isFalse()
+            val assistantWidget = viewState.widgets
+                .filterIsInstance<ConfigurableWidget>()
+                .single { it.widget.type == DashboardWidget.Type.AI_ASSISTANT }
+            assertThat(assistantWidget.isVisible).isFalse()
         }
 
     @Test
@@ -333,6 +376,11 @@ class DashboardViewModelTest : BaseUnitTest() {
         testBlocking {
             // GIVEN
             val orderedWidgets = listOf(
+                DashboardWidget(
+                    type = DashboardWidget.Type.AI_ASSISTANT,
+                    isSelected = true,
+                    status = DashboardWidget.Status.Available
+                ),
                 DashboardWidget(
                     type = DashboardWidget.Type.ORDERS,
                     isSelected = true,
@@ -345,7 +393,6 @@ class DashboardViewModelTest : BaseUnitTest() {
                 )
             )
             setup {
-                whenever(aiAssistantEligibilityChecker.observeEligibility()).thenReturn(flowOf(true))
                 whenever(feedbackPrefs.userFeedbackIsDueObservable).thenReturn(flowOf(true))
                 whenever(dashboardRepository.widgets).thenReturn(flowOf(orderedWidgets))
             }
@@ -356,28 +403,28 @@ class DashboardViewModelTest : BaseUnitTest() {
                 .filter { it.isVisible }
 
             // THEN
-            assertThat(visibleWidgets[0]).isInstanceOf(AIAssistantEntry::class.java)
+            assertThat(visibleWidgets[0]).isInstanceOf(ConfigurableWidget::class.java)
+            assertThat((visibleWidgets[0] as ConfigurableWidget).widget.type)
+                .isEqualTo(DashboardWidget.Type.AI_ASSISTANT)
             assertThat(visibleWidgets[1])
                 .isInstanceOf(DashboardViewModel.DashboardWidgetUiModel.FeedbackWidget::class.java)
             assertThat(visibleWidgets.filterIsInstance<ConfigurableWidget>().map { it.widget.type })
-                .containsExactly(DashboardWidget.Type.ORDERS, DashboardWidget.Type.STATS)
+                .containsExactly(
+                    DashboardWidget.Type.AI_ASSISTANT,
+                    DashboardWidget.Type.ORDERS,
+                    DashboardWidget.Type.STATS
+                )
         }
 
     @Test
     fun `given ai assistant card is visible, when card tapped, then open assistant event is emitted`() =
         testBlocking {
             // GIVEN
-            setup {
-                whenever(aiAssistantEligibilityChecker.observeEligibility()).thenReturn(flowOf(true))
-            }
-            val assistantEntry = viewModel.dashboardCardsState.captureValues().last()
-                .widgets
-                .filterIsInstance<AIAssistantEntry>()
-                .single()
+            setup {}
 
             // WHEN
             val event = viewModel.event.runAndCaptureValues {
-                assistantEntry.onClick()
+                viewModel.onAiAssistantCardClicked()
             }.last()
 
             // THEN
@@ -410,7 +457,6 @@ class DashboardViewModelTest : BaseUnitTest() {
                 )
             )
             setup {
-                whenever(aiAssistantEligibilityChecker.observeEligibility()).thenReturn(flowOf(false))
                 whenever(dashboardRepository.widgets).thenReturn(flowOf(orderedWidgets))
             }
 
@@ -601,5 +647,22 @@ class DashboardViewModelTest : BaseUnitTest() {
         statusFlow.value = Status.REGISTERED_WOO_ONLY
         jetpackBenefitsBanner = viewModel.jetpackBenefitsBannerState.getOrAwaitValue()
         assertThat(jetpackBenefitsBanner!!.show).isFalse()
+    }
+
+    private companion object {
+        fun dashboardWidget(
+            type: DashboardWidget.Type,
+            isSelected: Boolean = true,
+            status: DashboardWidget.Status = DashboardWidget.Status.Available
+        ) = DashboardWidget(type = type, isSelected = isSelected, status = status)
+
+        val DEFAULT_WIDGETS_WITHOUT_AI = listOf(
+            dashboardWidget(DashboardWidget.Type.STATS),
+            dashboardWidget(DashboardWidget.Type.POPULAR_PRODUCTS),
+            dashboardWidget(DashboardWidget.Type.ONBOARDING),
+            dashboardWidget(DashboardWidget.Type.BLAZE),
+            dashboardWidget(DashboardWidget.Type.GOOGLE_ADS),
+            dashboardWidget(DashboardWidget.Type.PUSH_NOTIFICATIONS)
+        )
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -476,6 +476,34 @@ class DashboardViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given stored ai assistant is below stats, when dashboard state is built, then visible order follows storage`() =
+        testBlocking {
+            // GIVEN
+            val orderedWidgets = listOf(
+                dashboardWidget(DashboardWidget.Type.STATS, isSelected = true),
+                dashboardWidget(DashboardWidget.Type.AI_ASSISTANT, isSelected = true),
+                dashboardWidget(DashboardWidget.Type.ORDERS, isSelected = true)
+            )
+            setup {
+                whenever(dashboardRepository.widgets).thenReturn(flowOf(orderedWidgets))
+            }
+
+            // WHEN
+            val visibleConfigurableTypes = viewModel.dashboardCardsState.captureValues().last()
+                .widgets
+                .filter { it.isVisible }
+                .filterIsInstance<ConfigurableWidget>()
+                .map { it.widget.type }
+
+            // THEN
+            assertThat(visibleConfigurableTypes).containsExactly(
+                DashboardWidget.Type.STATS,
+                DashboardWidget.Type.AI_ASSISTANT,
+                DashboardWidget.Type.ORDERS
+            )
+        }
+
+    @Test
     fun `given feedback card is shown, when positive button is tapped, then handle click`() = testBlocking {
         setup {
             whenever(feedbackPrefs.userFeedbackIsDueObservable).thenReturn(flowOf(true))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -504,6 +504,32 @@ class DashboardViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given stored ai assistant is unselected, when dashboard state is built, then ai assistant is not visible`() =
+        testBlocking {
+            // GIVEN
+            setup {
+                whenever(dashboardRepository.widgets).thenReturn(
+                    flowOf(
+                        listOf(
+                            dashboardWidget(DashboardWidget.Type.AI_ASSISTANT, isSelected = false),
+                            dashboardWidget(DashboardWidget.Type.STATS, isSelected = true)
+                        )
+                    )
+                )
+            }
+
+            // WHEN
+            val visibleTypes = viewModel.dashboardCardsState.captureValues().last()
+                .widgets
+                .filter { it.isVisible }
+                .filterIsInstance<ConfigurableWidget>()
+                .map { it.widget.type }
+
+            // THEN
+            assertThat(visibleTypes).doesNotContain(DashboardWidget.Type.AI_ASSISTANT)
+        }
+
+    @Test
     fun `given feedback card is shown, when positive button is tapped, then handle click`() = testBlocking {
         setup {
             whenever(feedbackPrefs.userFeedbackIsDueObservable).thenReturn(flowOf(true))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/DashboardViewModelTest.kt
@@ -336,7 +336,14 @@ class DashboardViewModelTest : BaseUnitTest() {
             // GIVEN
             val aiAssistant = dashboardWidget(DashboardWidget.Type.AI_ASSISTANT)
             setup {
-                whenever(dashboardRepository.widgets).thenReturn(flowOf(listOf(aiAssistant, dashboardWidget(DashboardWidget.Type.STATS))))
+                whenever(dashboardRepository.widgets).thenReturn(
+                    flowOf(
+                        listOf(
+                            aiAssistant,
+                            dashboardWidget(DashboardWidget.Type.STATS)
+                        )
+                    )
+                )
             }
 
             // WHEN
@@ -358,7 +365,14 @@ class DashboardViewModelTest : BaseUnitTest() {
                 status = DashboardWidget.Status.Hidden
             )
             setup {
-                whenever(dashboardRepository.widgets).thenReturn(flowOf(listOf(aiAssistant, dashboardWidget(DashboardWidget.Type.STATS))))
+                whenever(dashboardRepository.widgets).thenReturn(
+                    flowOf(
+                        listOf(
+                            aiAssistant,
+                            dashboardWidget(DashboardWidget.Type.STATS)
+                        )
+                    )
+                )
             }
 
             // WHEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStoreTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardDataStoreTest.kt
@@ -1,9 +1,11 @@
 package com.woocommerce.android.ui.dashboard.data
 
+import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.tools.SelectedSite
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -25,5 +27,23 @@ class DashboardDataStoreTest {
 
         // Then
         assertEquals(dashboardDataStore.getDefaultWidgets(), widgets)
+    }
+
+    @Test
+    fun `given default dashboard config, when widgets observed, then ai assistant is first and selected`() {
+        runBlocking {
+            // Given
+            whenever(selectedSite.siteComponent).thenReturn(null)
+            whenever(selectedSite.observe()).thenReturn(flowOf(null))
+
+            val dashboardDataStore = DashboardDataStore(selectedSite)
+
+            // When
+            val widgets = dashboardDataStore.widgets.first()
+
+            // Then
+            assertThat(widgets.first().type).isEqualTo(DashboardWidget.Type.AI_ASSISTANT.name)
+            assertThat(widgets.first().isAdded).isTrue()
+        }
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.dashboard.data
 import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.mystore.data.DashboardWidgetDataModel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -117,6 +118,24 @@ class DashboardRepositoryTest {
 
             // Then
             verify(dashboardDataStore, never()).updateDashboard(any())
+        }
+
+    @Test
+    fun `given ai assistant is stored and status is hidden, when observing widgets, then ai assistant is hidden`() =
+        runTest {
+            // Given
+            whenever(dashboardDataStore.widgets).thenReturn(flowOf(listOf(aiAssistantDataModel(isAdded = true))))
+            whenever(selectedSite.observe()).thenReturn(flowOf(null))
+            whenever(selectedSite.siteComponent).thenReturn(null)
+            val repository = createRepository()
+
+            // When
+            val widgets = repository.widgets.first()
+
+            // Then
+            assertThat(widgets.single().type).isEqualTo(DashboardWidget.Type.AI_ASSISTANT)
+            assertThat(widgets.single().status).isEqualTo(DashboardWidget.Status.Hidden)
+            assertThat(widgets.single().isVisible).isFalse()
         }
 
     private fun createRepository() = DashboardRepository(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepositoryTest.kt
@@ -1,11 +1,16 @@
 package com.woocommerce.android.ui.dashboard.data
 
+import com.woocommerce.android.model.DashboardWidget
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.mystore.data.DashboardWidgetDataModel
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertNotNull
 import org.junit.Test
+import org.mockito.kotlin.check
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class DashboardRepositoryTest {
@@ -18,6 +23,7 @@ class DashboardRepositoryTest {
     private val observeStockWidgetStatus: ObserveStockWidgetStatus = mock()
     private val observeGoogleAdsWidgetStatus: ObserveGoogleAdsWidgetStatus = mock()
     private val observeInboxWidgetStatus: ObserveInboxWidgetStatus = mock()
+    private val observeAIAssistantWidgetStatus: ObserveAIAssistantWidgetStatus = mock()
 
     @Test
     fun `given site component is null, when repository is initialized, then it completes without crash`() = runTest {
@@ -36,10 +42,58 @@ class DashboardRepositoryTest {
             observeOnboardingWidgetStatus,
             observeStockWidgetStatus,
             observeGoogleAdsWidgetStatus,
-            observeInboxWidgetStatus
+            observeInboxWidgetStatus,
+            observeAIAssistantWidgetStatus
         )
 
         // Then
         assertNotNull(repository)
     }
+
+    @Test
+    fun `given ai assistant is missing, when inserting ai assistant, then it is persisted as first selected widget`() =
+        runTest {
+            // Given
+            val storedWidgets = listOf(statsDataModel(isAdded = true), ordersDataModel(isAdded = true))
+            whenever(dashboardDataStore.widgets).thenReturn(flowOf(storedWidgets))
+            val repository = createRepository()
+
+            // When
+            repository.insertAIAssistantWidgetAtTopIfMissing()
+
+            // Then
+            verify(dashboardDataStore).updateDashboard(
+                check {
+                    assertThat(it.widgetsList.map { widget -> widget.type }).containsExactly(
+                        DashboardWidget.Type.AI_ASSISTANT.name,
+                        DashboardWidget.Type.STATS.name,
+                        DashboardWidget.Type.ORDERS.name
+                    )
+                    assertThat(it.widgetsList.first().isAdded).isTrue()
+                }
+            )
+        }
+
+    private fun createRepository() = DashboardRepository(
+        selectedSite,
+        dashboardDataStore,
+        observeSiteOrdersState,
+        observeBlazeWidgetStatus,
+        observePushNotificationsWidgetStatus,
+        observeOnboardingWidgetStatus,
+        observeStockWidgetStatus,
+        observeGoogleAdsWidgetStatus,
+        observeInboxWidgetStatus,
+        observeAIAssistantWidgetStatus
+    )
+
+    private fun widgetDataModel(type: DashboardWidget.Type, isAdded: Boolean = true): DashboardWidgetDataModel =
+        DashboardWidgetDataModel.newBuilder()
+            .setType(type.name)
+            .setIsAdded(isAdded)
+            .build()
+
+    private fun statsDataModel(isAdded: Boolean = true) = widgetDataModel(DashboardWidget.Type.STATS, isAdded)
+
+    private fun ordersDataModel(isAdded: Boolean = true) = widgetDataModel(DashboardWidget.Type.ORDERS, isAdded)
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepositoryTest.kt
@@ -8,8 +8,10 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertNotNull
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.check
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -74,6 +76,49 @@ class DashboardRepositoryTest {
             )
         }
 
+    @Test
+    fun `given ai assistant is already stored unselected, when inserting default ai widget, then repository does not update widgets`() =
+        runTest {
+            // Given
+            whenever(dashboardDataStore.widgets).thenReturn(
+                flowOf(
+                    listOf(
+                        aiAssistantDataModel(isAdded = false),
+                        statsDataModel(isAdded = true)
+                    )
+                )
+            )
+            val repository = createRepository()
+
+            // When
+            repository.insertAIAssistantWidgetAtTopIfMissing()
+
+            // Then
+            verify(dashboardDataStore, never()).updateDashboard(any())
+        }
+
+    @Test
+    fun `given ai assistant is already stored below stats, when inserting default ai widget, then repository does not update widgets`() =
+        runTest {
+            // Given
+            whenever(dashboardDataStore.widgets).thenReturn(
+                flowOf(
+                    listOf(
+                        statsDataModel(isAdded = true),
+                        aiAssistantDataModel(isAdded = true),
+                        ordersDataModel(isAdded = true)
+                    )
+                )
+            )
+            val repository = createRepository()
+
+            // When
+            repository.insertAIAssistantWidgetAtTopIfMissing()
+
+            // Then
+            verify(dashboardDataStore, never()).updateDashboard(any())
+        }
+
     private fun createRepository() = DashboardRepository(
         selectedSite,
         dashboardDataStore,
@@ -92,6 +137,9 @@ class DashboardRepositoryTest {
             .setType(type.name)
             .setIsAdded(isAdded)
             .build()
+
+    private fun aiAssistantDataModel(isAdded: Boolean = true) =
+        widgetDataModel(DashboardWidget.Type.AI_ASSISTANT, isAdded)
 
     private fun statsDataModel(isAdded: Boolean = true) = widgetDataModel(DashboardWidget.Type.STATS, isAdded)
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveAIAssistantWidgetStatusTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/data/ObserveAIAssistantWidgetStatusTest.kt
@@ -1,0 +1,39 @@
+package com.woocommerce.android.ui.dashboard.data
+
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.ui.aiassistant.AIAssistantEligibilityChecker
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ObserveAIAssistantWidgetStatusTest {
+    private val aiAssistantEligibilityChecker: AIAssistantEligibilityChecker = mock()
+
+    @Test
+    fun `given ai assistant is eligible, when observing status, then status is available`() = runTest {
+        // GIVEN
+        whenever(aiAssistantEligibilityChecker.observeEligibility()).thenReturn(flowOf(true))
+
+        // WHEN
+        val status = ObserveAIAssistantWidgetStatus(aiAssistantEligibilityChecker).invoke().first()
+
+        // THEN
+        assertThat(status).isEqualTo(DashboardWidget.Status.Available)
+    }
+
+    @Test
+    fun `given ai assistant is not eligible, when observing status, then status is hidden`() = runTest {
+        // GIVEN
+        whenever(aiAssistantEligibilityChecker.observeEligibility()).thenReturn(flowOf(false))
+
+        // WHEN
+        val status = ObserveAIAssistantWidgetStatus(aiAssistantEligibilityChecker).invoke().first()
+
+        // THEN
+        assertThat(status).isEqualTo(DashboardWidget.Status.Hidden)
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModelTest.kt
@@ -73,6 +73,30 @@ class DashboardWidgetEditorViewModelTest : BaseUnitTest() {
             )
         }
 
+    @Test
+    fun `given ai assistant is hidden, when editor state is built, then ai assistant is not exposed`() =
+        testBlocking {
+            // GIVEN
+            val widgets = MutableSharedFlow<List<DashboardWidget>>(replay = 1)
+            setup(widgets)
+            widgets.emit(
+                listOf(
+                    dashboardWidget(
+                        type = DashboardWidget.Type.AI_ASSISTANT,
+                        isSelected = true,
+                        status = DashboardWidget.Status.Hidden
+                    ),
+                    dashboardWidget(DashboardWidget.Type.STATS, isSelected = true)
+                )
+            )
+
+            // WHEN
+            val state = viewModel.viewState.getOrAwaitValue()
+
+            // THEN
+            assertThat(state.orderedWidgetList.map { it.type }).doesNotContain(DashboardWidget.Type.AI_ASSISTANT)
+        }
+
     private fun setup(widgets: MutableSharedFlow<List<DashboardWidget>>) {
         whenever(dashboardRepository.widgets).thenReturn(widgets)
         viewModel = DashboardWidgetEditorViewModel(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModelTest.kt
@@ -1,0 +1,62 @@
+package com.woocommerce.android.ui.dashboard.widgeteditor
+
+import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
+import com.woocommerce.android.model.DashboardWidget
+import com.woocommerce.android.ui.dashboard.data.DashboardRepository
+import com.woocommerce.android.util.getOrAwaitValue
+import com.woocommerce.android.viewmodel.BaseUnitTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.check
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class DashboardWidgetEditorViewModelTest : BaseUnitTest() {
+    private val dashboardRepository: DashboardRepository = mock()
+    private val analyticsTracker: AnalyticsTrackerWrapper = mock()
+    private lateinit var viewModel: DashboardWidgetEditorViewModel
+
+    @Test
+    fun `given ai assistant is selected, when user unselects it and saves, then ai assistant is persisted unselected`() =
+        testBlocking {
+            // GIVEN
+            val aiAssistant = dashboardWidget(DashboardWidget.Type.AI_ASSISTANT, isSelected = true)
+            val stats = dashboardWidget(DashboardWidget.Type.STATS, isSelected = true)
+            val widgets = MutableSharedFlow<List<DashboardWidget>>(replay = 1)
+            setup(widgets)
+            widgets.emit(listOf(aiAssistant, stats))
+            viewModel.viewState.getOrAwaitValue()
+
+            // WHEN
+            viewModel.onSelectionChange(aiAssistant, false)
+            viewModel.onSaveClicked()
+
+            // THEN
+            verify(dashboardRepository).updateWidgets(
+                check {
+                    assertThat(it.first { widget -> widget.type == DashboardWidget.Type.AI_ASSISTANT }.isSelected)
+                        .isFalse()
+                }
+            )
+        }
+
+    private fun setup(widgets: MutableSharedFlow<List<DashboardWidget>>) {
+        whenever(dashboardRepository.widgets).thenReturn(widgets)
+        viewModel = DashboardWidgetEditorViewModel(
+            savedState = SavedStateHandle(),
+            dashboardRepository = dashboardRepository,
+            analyticsTracker = analyticsTracker
+        )
+    }
+
+    private fun dashboardWidget(
+        type: DashboardWidget.Type,
+        isSelected: Boolean = true,
+        status: DashboardWidget.Status = DashboardWidget.Status.Available
+    ) = DashboardWidget(type = type, isSelected = isSelected, status = status)
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/dashboard/widgeteditor/DashboardWidgetEditorViewModelTest.kt
@@ -45,6 +45,34 @@ class DashboardWidgetEditorViewModelTest : BaseUnitTest() {
             )
         }
 
+    @Test
+    fun `given ai assistant is first, when user reorders it below stats and saves, then new order is persisted`() =
+        testBlocking {
+            // GIVEN
+            val aiAssistant = dashboardWidget(DashboardWidget.Type.AI_ASSISTANT, isSelected = true)
+            val stats = dashboardWidget(DashboardWidget.Type.STATS, isSelected = true)
+            val orders = dashboardWidget(DashboardWidget.Type.ORDERS, isSelected = true)
+            val widgets = MutableSharedFlow<List<DashboardWidget>>(replay = 1)
+            setup(widgets)
+            widgets.emit(listOf(aiAssistant, stats, orders))
+            viewModel.viewState.getOrAwaitValue()
+
+            // WHEN
+            viewModel.onOrderChange(fromIndex = 0, toIndex = 1)
+            viewModel.onSaveClicked()
+
+            // THEN
+            verify(dashboardRepository).updateWidgets(
+                check {
+                    assertThat(it.map { widget -> widget.type }).containsExactly(
+                        DashboardWidget.Type.STATS,
+                        DashboardWidget.Type.AI_ASSISTANT,
+                        DashboardWidget.Type.ORDERS
+                    )
+                }
+            )
+        }
+
     private fun setup(widgets: MutableSharedFlow<List<DashboardWidget>>) {
         whenever(dashboardRepository.widgets).thenReturn(widgets)
         viewModel = DashboardWidgetEditorViewModel(

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -498,9 +498,7 @@ private fun AssistantMessageThread(
         }
         if (showTypingIndicator) {
             item(key = TYPING_INDICATOR_ITEM_KEY) {
-                AssistantRevealOnFirstComposition(
-                    modifier = Modifier.animateItem(),
-                ) {
+                AssistantRevealOnFirstComposition {
                     AssistantTypingIndicator()
                 }
             }


### PR DESCRIPTION
### Description
Fixes WOOMOB-3084

This makes the AI Assistant dashboard card a persisted configurable dashboard widget. The card is inserted first and selected for default or upgraded dashboard configurations, then uses the existing dashboard customization flow for removal and reordering. Dashboard widget status now uses the existing AI Assistant eligibility checker so ineligible sites keep the widget hidden from both the dashboard and editor surfaces.

This also includes a small user-directed AI Assistant chat UI fix: the transient typing indicator no longer uses LazyColumn item placement/removal animation, while keeping its explicit first-composition reveal animation.

### Test Steps
1. On an AI Assistant eligible site with a fresh or pre-upgrade dashboard configuration, open My Store and confirm the AI Assistant card appears as the first dashboard card.
2. Open dashboard customization, unselect the AI Assistant card, save, and confirm it no longer appears on the dashboard.
3. Reopen customization, reselect/reorder the AI Assistant card below another widget, save, and confirm the dashboard follows the saved order.
4. On an ineligible site or with AI Assistant disabled, confirm the AI Assistant card is not visible on the dashboard and is not listed in customization.
5. In AI Assistant chat, trigger the assistant typing indicator and confirm it animates in without leaving frozen dots over the eventual assistant response.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.