### PR TITLE
[RSM-3275] Connect new order detail screen to shared notification state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.ui.base.BaseFragment
@@ -17,6 +18,9 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class NewOrderNotificationSettingsFragment : BaseFragment() {
     private val viewModel: NewOrderNotificationSettingsViewModel by viewModels()
+    private val sharedViewModel: NotificationSettingsSharedViewModel by hiltNavGraphViewModels(
+        R.id.nav_graph_notification_settings
+    )
 
     @Inject
     lateinit var uiMessageResolver: UIMessageResolver
@@ -25,7 +29,10 @@ class NewOrderNotificationSettingsFragment : BaseFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
-            NewOrderNotificationSettingsScreen(viewModel = viewModel)
+            NewOrderNotificationSettingsScreen(
+                viewModel = viewModel,
+                sharedViewModel = sharedViewModel
+            )
         }
     }
 
@@ -41,11 +48,20 @@ class NewOrderNotificationSettingsFragment : BaseFragment() {
 
     override fun onStop() {
         super.onStop()
-        viewModel.savePendingOrderPreferences()
+        sharedViewModel.savePendingNotificationPreferences()
     }
 
     private fun observeEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.ShowActionStringSnackbar -> uiMessageResolver.showActionSnack(
+                    event.message,
+                    event.actionText,
+                    event.action
+                )
+            }
+        }
+        sharedViewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
                 is MultiLiveEvent.Event.ShowActionStringSnackbar -> uiMessageResolver.showActionSnack(
                     event.message,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsScreen.kt
@@ -29,30 +29,36 @@ import com.woocommerce.android.ui.compose.component.BigDecimalTextFieldValueMapp
 import com.woocommerce.android.ui.compose.component.WCOutlinedTypedTextField
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
 import com.woocommerce.android.ui.prefs.compose.SettingsSectionHeader
-import com.woocommerce.android.ui.prefs.notifications.NewOrderNotificationSettingsViewModel.NotificationPreference
 import com.woocommerce.android.ui.prefs.notifications.NewOrderNotificationSettingsViewModel.ViewState
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NewOrderNotificationPreference
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NewOrderNotificationSettingsViewState
 import com.woocommerce.android.ui.prefs.notifications.compose.EnableNotificationsCard
 import com.woocommerce.android.ui.prefs.notifications.compose.NotificationPreferenceOption
 import java.math.BigDecimal
 
 @Composable
-fun NewOrderNotificationSettingsScreen(viewModel: NewOrderNotificationSettingsViewModel) {
-    viewModel.viewState.observeAsState().value?.let { viewState ->
-        NewOrderNotificationSettingsScreen(
-            viewState = viewState,
-            onNotificationsEnabledChanged = viewModel::onNotificationsEnabledChanged,
-            onNotificationPreferenceChanged = viewModel::onNotificationPreferenceChanged,
-            onThresholdAmountChanged = viewModel::onThresholdAmountChanged,
-            onEnableChaChingSoundClicked = viewModel::onEnableChaChingSoundClicked
-        )
-    }
+fun NewOrderNotificationSettingsScreen(
+    viewModel: NewOrderNotificationSettingsViewModel,
+    sharedViewModel: NotificationSettingsSharedViewModel
+) {
+    val viewState = viewModel.viewState.observeAsState().value ?: return
+    val sharedViewState = sharedViewModel.newOrderNotificationSettingsViewState.observeAsState().value ?: return
+    NewOrderNotificationSettingsScreen(
+        viewState = viewState,
+        sharedViewState = sharedViewState,
+        onNotificationsEnabledChanged = sharedViewModel::onNewOrderNotificationsEnabledChanged,
+        onNotificationPreferenceChanged = sharedViewModel::onNewOrderNotificationPreferenceChanged,
+        onThresholdAmountChanged = sharedViewModel::onNewOrderThresholdAmountChanged,
+        onEnableChaChingSoundClicked = viewModel::onEnableChaChingSoundClicked
+    )
 }
 
 @Composable
 private fun NewOrderNotificationSettingsScreen(
     viewState: ViewState,
+    sharedViewState: NewOrderNotificationSettingsViewState,
     onNotificationsEnabledChanged: (Boolean) -> Unit,
-    onNotificationPreferenceChanged: (NotificationPreference) -> Unit,
+    onNotificationPreferenceChanged: (NewOrderNotificationPreference) -> Unit,
     onThresholdAmountChanged: (BigDecimal) -> Unit,
     onEnableChaChingSoundClicked: () -> Unit
 ) {
@@ -69,7 +75,7 @@ private fun NewOrderNotificationSettingsScreen(
             EnableNotificationsCard(
                 title = stringResource(R.string.settings_notifs_enable_title),
                 description = stringResource(R.string.settings_notifs_new_orders_enable_description),
-                isEnabled = viewState.notificationsEnabled,
+                isEnabled = sharedViewState.notificationsEnabled,
                 onEnabledChanged = onNotificationsEnabledChanged
             )
             AnimatedVisibility(
@@ -95,24 +101,25 @@ private fun NewOrderNotificationSettingsScreen(
             NotificationPreferenceOption(
                 title = stringResource(R.string.settings_notifs_new_orders_all_title),
                 description = stringResource(R.string.settings_notifs_new_orders_all_description),
-                selected = viewState.notificationPreference == NotificationPreference.AllOrders,
-                enabled = viewState.notificationsEnabled,
-                onClick = { onNotificationPreferenceChanged(NotificationPreference.AllOrders) }
+                selected = sharedViewState.notificationPreference ==
+                    NewOrderNotificationPreference.AllOrders,
+                enabled = sharedViewState.notificationsEnabled,
+                onClick = { onNotificationPreferenceChanged(NewOrderNotificationPreference.AllOrders) }
             )
             val isHighValuePreferenceSelected =
-                viewState.notificationPreference == NotificationPreference.HighValueOrders
+                sharedViewState.notificationPreference == NewOrderNotificationPreference.HighValueOrders
             NotificationPreferenceOption(
                 title = stringResource(R.string.settings_notifs_new_orders_high_value_title),
                 description = stringResource(R.string.settings_notifs_new_orders_high_value_description),
                 selected = isHighValuePreferenceSelected,
-                enabled = viewState.notificationsEnabled,
-                onClick = { onNotificationPreferenceChanged(NotificationPreference.HighValueOrders) }
+                enabled = sharedViewState.notificationsEnabled,
+                onClick = { onNotificationPreferenceChanged(NewOrderNotificationPreference.HighValueOrders) }
             )
             AnimatedVisibility(visible = isHighValuePreferenceSelected) {
                 ThresholdAmountField(
-                    amount = viewState.thresholdAmount,
+                    amount = sharedViewState.thresholdAmount,
                     currencySymbol = viewState.currencySymbol,
-                    enabled = viewState.notificationsEnabled,
+                    enabled = sharedViewState.notificationsEnabled,
                     onAmountChanged = onThresholdAmountChanged
                 )
             }
@@ -181,9 +188,11 @@ private fun NewOrderNotificationSettingsScreenPreview() {
     WooThemeWithBackground {
         NewOrderNotificationSettingsScreen(
             viewState = ViewState(
-                notificationPreference = NotificationPreference.HighValueOrders,
                 currencySymbol = "$",
                 newOrderNotificationSoundStatus = NewOrderNotificationSoundStatus.SOUND_MODIFIED
+            ),
+            sharedViewState = NewOrderNotificationSettingsViewState(
+                notificationPreference = NewOrderNotificationPreference.HighValueOrders
             ),
             onNotificationsEnabledChanged = {},
             onNotificationPreferenceChanged = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModel.kt
@@ -10,32 +10,17 @@ import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.NotificationChannelsHandler.NewOrderNotificationSoundStatus
 import com.woocommerce.android.notifications.ShowTestNotification
-import com.woocommerce.android.notifications.push.PushNotificationRepository
 import com.woocommerce.android.ui.products.ParameterRepository
-import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.MultiLiveEvent
 import com.woocommerce.android.viewmodel.ResourceProvider
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.conflate
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences
-import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreOrderPreferences
-import java.math.BigDecimal
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(FlowPreview::class)
 @HiltViewModel
 class NewOrderNotificationSettingsViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -43,9 +28,7 @@ class NewOrderNotificationSettingsViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val notificationChannelsHandler: NotificationChannelsHandler,
     private val showTestNotification: ShowTestNotification,
-    private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val pushNotificationRepository: PushNotificationRepository,
-    private val coroutineDispatchers: CoroutineDispatchers
+    private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val _viewState = MutableStateFlow(
         ViewState(
@@ -53,34 +36,7 @@ class NewOrderNotificationSettingsViewModel @Inject constructor(
             newOrderNotificationSoundStatus = notificationChannelsHandler.checkNewOrderNotificationSound()
         )
     )
-    private val saveOrderPreferencesTrigger = MutableSharedFlow<Long>(
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
-    private var savedOrderPreferences = _viewState.value.toStoreOrderPreferences()
-
     val viewState = _viewState.asLiveData()
-
-    init {
-        observeCachedNotificationPreferences()
-        observeOrderPreferencesChanges()
-    }
-
-    fun onNotificationsEnabledChanged(isEnabled: Boolean) {
-        updateOrderPreferences(_viewState.value.copy(notificationsEnabled = isEnabled))
-    }
-
-    fun onNotificationPreferenceChanged(preference: NotificationPreference) {
-        updateOrderPreferences(_viewState.value.copy(notificationPreference = preference))
-    }
-
-    fun onThresholdAmountChanged(amount: BigDecimal) {
-        updateOrderPreferences(_viewState.value.copy(thresholdAmount = amount.coerceAtLeast(MIN_THRESHOLD_AMOUNT)))
-    }
-
-    fun savePendingOrderPreferences() {
-        saveOrderPreferencesTrigger.tryEmit(0L)
-    }
 
     fun refreshNotificationSettings() {
         _viewState.update {
@@ -115,113 +71,8 @@ class NewOrderNotificationSettingsViewModel @Inject constructor(
         refreshNotificationSettings()
     }
 
-    private fun observeCachedNotificationPreferences() {
-        launch {
-            pushNotificationRepository.observeWooNotificationPreferences()
-                .mapNotNull { it?.storeOrder }
-                .distinctUntilChanged()
-                .collect { orderPreferences ->
-                    if (hasUnsavedOrderPreferences(_viewState.value.toStoreOrderPreferences())) {
-                        savedOrderPreferences = orderPreferences
-                    } else {
-                        applyOrderPreferences(orderPreferences)
-                    }
-                }
-        }
-    }
-
-    private fun updateOrderPreferences(updatedViewState: ViewState) {
-        if (updatedViewState == _viewState.value) return
-
-        _viewState.value = updatedViewState
-        saveOrderPreferencesTrigger.tryEmit(ORDER_PREFERENCES_SAVE_DEBOUNCE_MS)
-    }
-
-    private fun observeOrderPreferencesChanges() {
-        launch {
-            saveOrderPreferencesTrigger
-                .debounce { it }
-                .conflate()
-                .collect { saveOrderPreferences(_viewState.value.toStoreOrderPreferences()) }
-        }
-    }
-
-    private suspend fun saveOrderPreferences(orderPreferences: StoreOrderPreferences) {
-        if (!hasUnsavedOrderPreferences(orderPreferences)) return
-
-        // Once started, let the save request finish even if the screen is closed.
-        val result = withContext(NonCancellable + coroutineDispatchers.main) {
-            pushNotificationRepository.updateWooNotificationPreferences(
-                preferences = WooPushNotificationPreferences(storeOrder = orderPreferences)
-            )
-        }
-        val hasNewerOrderPreferences = _viewState.value.toStoreOrderPreferences() != orderPreferences
-
-        result.onSuccess { savedOrderPreferences = orderPreferences }
-            .onFailure {
-                if (!hasNewerOrderPreferences) {
-                    _viewState.update { it.copyWith(savedOrderPreferences) }
-                    showUpdateError(orderPreferences)
-                }
-            }
-    }
-
-    private fun showUpdateError(orderPreferences: StoreOrderPreferences) {
-        triggerEvent(
-            MultiLiveEvent.Event.ShowActionStringSnackbar(
-                message = resourceProvider.getString(R.string.settings_notifs_error_update),
-                actionText = resourceProvider.getString(R.string.retry),
-            ) {
-                _viewState.update { it.copyWith(orderPreferences) }
-                saveOrderPreferencesTrigger.tryEmit(0L)
-            }
-        )
-    }
-
-    private fun applyOrderPreferences(orderPreferences: StoreOrderPreferences) {
-        val updatedViewState = _viewState.value.copyWith(orderPreferences)
-        savedOrderPreferences = updatedViewState.toStoreOrderPreferences()
-        _viewState.value = updatedViewState
-    }
-
-    private fun hasUnsavedOrderPreferences(orderPreferences: StoreOrderPreferences) =
-        orderPreferences != savedOrderPreferences
-
-    private fun ViewState.copyWith(orderPreferences: StoreOrderPreferences): ViewState =
-        copy(
-            notificationsEnabled = orderPreferences.enabled ?: notificationsEnabled,
-            notificationPreference = if (orderPreferences.minAmount == null) {
-                NotificationPreference.AllOrders
-            } else {
-                NotificationPreference.HighValueOrders
-            },
-            thresholdAmount = orderPreferences.minAmount ?: thresholdAmount
-        )
-
-    private fun ViewState.toStoreOrderPreferences() = StoreOrderPreferences(
-        enabled = notificationsEnabled,
-        minAmount = when (notificationPreference) {
-            NotificationPreference.AllOrders -> null
-            NotificationPreference.HighValueOrders -> thresholdAmount
-        }
-    )
-
     data class ViewState(
-        val notificationsEnabled: Boolean = true,
-        val notificationPreference: NotificationPreference = NotificationPreference.AllOrders,
-        val thresholdAmount: BigDecimal = BigDecimal(DEFAULT_THRESHOLD_AMOUNT),
         val currencySymbol: String,
         val newOrderNotificationSoundStatus: NewOrderNotificationSoundStatus
     )
-
-    enum class NotificationPreference {
-        AllOrders,
-        HighValueOrders
-    }
-
-    companion object {
-        private const val DEFAULT_THRESHOLD_AMOUNT = 100
-        private val MIN_THRESHOLD_AMOUNT = BigDecimal.ONE
-        private const val ORDER_PREFERENCES_SAVE_DEBOUNCE_MS = 1000L
-    }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPr
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreOrderPreferences
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreReviewPreferences
 import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreStockPreferences
+import java.math.BigDecimal
 import javax.inject.Inject
 
 @OptIn(FlowPreview::class)
@@ -69,6 +70,8 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         )
     )
     val notificationTypeItems = _notificationTypeItems.asLiveData()
+    private val _newOrderNotificationSettingsViewState = MutableStateFlow(NewOrderNotificationSettingsViewState())
+    val newOrderNotificationSettingsViewState = _newOrderNotificationSettingsViewState.asLiveData()
 
     init {
         observeWooPushNotificationPreferences()
@@ -92,12 +95,33 @@ class NotificationSettingsSharedViewModel @Inject constructor(
             )
         }
 
-        applyDisplayedWooPushNotificationPreferences(updatedPreferences)
-        saveNotificationPreferencesTrigger.tryEmit(NOTIFICATION_PREFERENCES_SAVE_DEBOUNCE_MS)
+        updateDisplayedWooPushNotificationPreferences(updatedPreferences)
     }
 
     fun savePendingNotificationPreferences() {
         saveNotificationPreferencesTrigger.tryEmit(0L)
+    }
+
+    fun onNewOrderNotificationsEnabledChanged(isEnabled: Boolean) {
+        onNotificationTypeEnabledChanged(NotificationType.NEW_ORDERS, isEnabled)
+    }
+
+    fun onNewOrderNotificationPreferenceChanged(preference: NewOrderNotificationPreference) {
+        val preferences = wooPushNotificationPreferences.value ?: return
+        val updatedViewState = _newOrderNotificationSettingsViewState.value.copy(notificationPreference = preference)
+        updateDisplayedWooPushNotificationPreferences(
+            preferences.copy(storeOrder = updatedViewState.toStoreOrderPreferences())
+        )
+    }
+
+    fun onNewOrderThresholdAmountChanged(amount: BigDecimal) {
+        val preferences = wooPushNotificationPreferences.value ?: return
+        val updatedViewState = _newOrderNotificationSettingsViewState.value.copy(
+            thresholdAmount = amount.coerceAtLeast(MIN_ORDER_THRESHOLD_AMOUNT)
+        )
+        updateDisplayedWooPushNotificationPreferences(
+            preferences.copy(storeOrder = updatedViewState.toStoreOrderPreferences())
+        )
     }
 
     fun onNotificationTypeClicked(type: NotificationType) {
@@ -206,9 +230,17 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         applyDisplayedWooPushNotificationPreferences(preferences)
     }
 
+    private fun updateDisplayedWooPushNotificationPreferences(preferences: WooPushNotificationPreferences) {
+        applyDisplayedWooPushNotificationPreferences(preferences)
+        saveNotificationPreferencesTrigger.tryEmit(NOTIFICATION_PREFERENCES_SAVE_DEBOUNCE_MS)
+    }
+
     private fun applyDisplayedWooPushNotificationPreferences(preferences: WooPushNotificationPreferences) {
         wooPushNotificationPreferences.value = preferences
         _isNotificationTypeSelectionEnabled.value = true
+        preferences.storeOrder?.let { orderPreferences ->
+            _newOrderNotificationSettingsViewState.update { it.copyWith(orderPreferences) }
+        }
         _notificationTypeItems.update { items ->
             items.map { item ->
                 item.copy(isEnabled = preferences.isEnabled(item.type) ?: item.isEnabled)
@@ -239,6 +271,26 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     private fun WooPushNotificationPreferences.isEmpty(): Boolean =
         storeOrder == null && storeReview == null && storeStock == null
 
+    private fun NewOrderNotificationSettingsViewState.copyWith(
+        orderPreferences: StoreOrderPreferences
+    ): NewOrderNotificationSettingsViewState = copy(
+        notificationsEnabled = orderPreferences.enabled ?: notificationsEnabled,
+        notificationPreference = if (orderPreferences.minAmount == null) {
+            NewOrderNotificationPreference.AllOrders
+        } else {
+            NewOrderNotificationPreference.HighValueOrders
+        },
+        thresholdAmount = orderPreferences.minAmount ?: thresholdAmount
+    )
+
+    private fun NewOrderNotificationSettingsViewState.toStoreOrderPreferences() = StoreOrderPreferences(
+        enabled = notificationsEnabled,
+        minAmount = when (notificationPreference) {
+            NewOrderNotificationPreference.AllOrders -> null
+            NewOrderNotificationPreference.HighValueOrders -> thresholdAmount
+        }
+    )
+
     private fun WooPushNotificationPreferences.isEnabled(type: NotificationType): Boolean? =
         when (type) {
             NotificationType.NEW_ORDERS -> storeOrder?.enabled
@@ -257,6 +309,17 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         val isEnabled: Boolean
     )
 
+    data class NewOrderNotificationSettingsViewState(
+        val notificationsEnabled: Boolean = true,
+        val notificationPreference: NewOrderNotificationPreference = NewOrderNotificationPreference.AllOrders,
+        val thresholdAmount: BigDecimal = BigDecimal(DEFAULT_ORDER_THRESHOLD_AMOUNT)
+    )
+
+    enum class NewOrderNotificationPreference {
+        AllOrders,
+        HighValueOrders
+    }
+
     enum class NotificationType {
         NEW_ORDERS,
         STOCK,
@@ -264,6 +327,8 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     }
 
     companion object {
+        private const val DEFAULT_ORDER_THRESHOLD_AMOUNT = 100
+        private val MIN_ORDER_THRESHOLD_AMOUNT = BigDecimal.ONE
         private const val NOTIFICATION_PREFERENCES_SAVE_DEBOUNCE_MS = 1000L
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
@@ -70,8 +71,14 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         )
     )
     val notificationTypeItems = _notificationTypeItems.asLiveData()
-    private val _newOrderNotificationSettingsViewState = MutableStateFlow(NewOrderNotificationSettingsViewState())
-    val newOrderNotificationSettingsViewState = _newOrderNotificationSettingsViewState.asLiveData()
+    private val displayedOrderThresholdAmount = MutableStateFlow(BigDecimal(DEFAULT_ORDER_THRESHOLD_AMOUNT))
+    val newOrderNotificationSettingsViewState = combine(
+        wooPushNotificationPreferences,
+        displayedOrderThresholdAmount
+    ) { preferences, thresholdAmount ->
+        preferences?.toNewOrderNotificationSettingsViewState(thresholdAmount)
+            ?: NewOrderNotificationSettingsViewState(thresholdAmount = thresholdAmount)
+    }.asLiveData()
 
     init {
         observeWooPushNotificationPreferences()
@@ -108,7 +115,9 @@ class NotificationSettingsSharedViewModel @Inject constructor(
 
     fun onNewOrderNotificationPreferenceChanged(preference: NewOrderNotificationPreference) {
         val preferences = wooPushNotificationPreferences.value ?: return
-        val updatedViewState = _newOrderNotificationSettingsViewState.value.copy(notificationPreference = preference)
+        val updatedViewState = preferences.toNewOrderNotificationSettingsViewState(
+            displayedThresholdAmount = displayedOrderThresholdAmount.value
+        ).copy(notificationPreference = preference)
         updateDisplayedWooPushNotificationPreferences(
             preferences.copy(storeOrder = updatedViewState.toStoreOrderPreferences())
         )
@@ -116,9 +125,11 @@ class NotificationSettingsSharedViewModel @Inject constructor(
 
     fun onNewOrderThresholdAmountChanged(amount: BigDecimal) {
         val preferences = wooPushNotificationPreferences.value ?: return
-        val updatedViewState = _newOrderNotificationSettingsViewState.value.copy(
-            thresholdAmount = amount.coerceAtLeast(MIN_ORDER_THRESHOLD_AMOUNT)
-        )
+        val thresholdAmount = amount.coerceAtLeast(MIN_ORDER_THRESHOLD_AMOUNT)
+        val updatedViewState = preferences.toNewOrderNotificationSettingsViewState(
+            displayedThresholdAmount = displayedOrderThresholdAmount.value
+        ).copy(thresholdAmount = thresholdAmount)
+        displayedOrderThresholdAmount.value = thresholdAmount
         updateDisplayedWooPushNotificationPreferences(
             preferences.copy(storeOrder = updatedViewState.toStoreOrderPreferences())
         )
@@ -238,9 +249,7 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     private fun applyDisplayedWooPushNotificationPreferences(preferences: WooPushNotificationPreferences) {
         wooPushNotificationPreferences.value = preferences
         _isNotificationTypeSelectionEnabled.value = true
-        preferences.storeOrder?.let { orderPreferences ->
-            _newOrderNotificationSettingsViewState.update { it.copyWith(orderPreferences) }
-        }
+        preferences.storeOrder?.minAmount?.let { displayedOrderThresholdAmount.value = it }
         _notificationTypeItems.update { items ->
             items.map { item ->
                 item.copy(isEnabled = preferences.isEnabled(item.type) ?: item.isEnabled)
@@ -271,16 +280,16 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     private fun WooPushNotificationPreferences.isEmpty(): Boolean =
         storeOrder == null && storeReview == null && storeStock == null
 
-    private fun NewOrderNotificationSettingsViewState.copyWith(
-        orderPreferences: StoreOrderPreferences
-    ): NewOrderNotificationSettingsViewState = copy(
-        notificationsEnabled = orderPreferences.enabled ?: notificationsEnabled,
-        notificationPreference = if (orderPreferences.minAmount == null) {
+    private fun WooPushNotificationPreferences.toNewOrderNotificationSettingsViewState(
+        displayedThresholdAmount: BigDecimal
+    ) = NewOrderNotificationSettingsViewState(
+        notificationsEnabled = storeOrder?.enabled ?: true,
+        notificationPreference = if (storeOrder?.minAmount == null) {
             NewOrderNotificationPreference.AllOrders
         } else {
             NewOrderNotificationPreference.HighValueOrders
         },
-        thresholdAmount = orderPreferences.minAmount ?: thresholdAmount
+        thresholdAmount = storeOrder?.minAmount ?: displayedThresholdAmount
     )
 
     private fun NewOrderNotificationSettingsViewState.toStoreOrderPreferences() = StoreOrderPreferences(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -115,23 +115,31 @@ class NotificationSettingsSharedViewModel @Inject constructor(
 
     fun onNewOrderNotificationPreferenceChanged(preference: NewOrderNotificationPreference) {
         val preferences = wooPushNotificationPreferences.value ?: return
-        val updatedViewState = preferences.toNewOrderNotificationSettingsViewState(
-            displayedThresholdAmount = displayedOrderThresholdAmount.value
-        ).copy(notificationPreference = preference)
+        val minAmount = when (preference) {
+            NewOrderNotificationPreference.AllOrders -> null
+            NewOrderNotificationPreference.HighValueOrders -> displayedOrderThresholdAmount.value
+        }
         updateDisplayedWooPushNotificationPreferences(
-            preferences.copy(storeOrder = updatedViewState.toStoreOrderPreferences())
+            preferences.copy(
+                storeOrder = StoreOrderPreferences(
+                    enabled = preferences.storeOrder?.enabled ?: true,
+                    minAmount = minAmount
+                )
+            )
         )
     }
 
     fun onNewOrderThresholdAmountChanged(amount: BigDecimal) {
         val preferences = wooPushNotificationPreferences.value ?: return
         val thresholdAmount = amount.coerceAtLeast(MIN_ORDER_THRESHOLD_AMOUNT)
-        val updatedViewState = preferences.toNewOrderNotificationSettingsViewState(
-            displayedThresholdAmount = displayedOrderThresholdAmount.value
-        ).copy(thresholdAmount = thresholdAmount)
         displayedOrderThresholdAmount.value = thresholdAmount
         updateDisplayedWooPushNotificationPreferences(
-            preferences.copy(storeOrder = updatedViewState.toStoreOrderPreferences())
+            preferences.copy(
+                storeOrder = StoreOrderPreferences(
+                    enabled = preferences.storeOrder?.enabled ?: true,
+                    minAmount = preferences.storeOrder?.minAmount?.let { thresholdAmount }
+                )
+            )
         )
     }
 
@@ -290,14 +298,6 @@ class NotificationSettingsSharedViewModel @Inject constructor(
             NewOrderNotificationPreference.HighValueOrders
         },
         thresholdAmount = storeOrder?.minAmount ?: displayedThresholdAmount
-    )
-
-    private fun NewOrderNotificationSettingsViewState.toStoreOrderPreferences() = StoreOrderPreferences(
-        enabled = notificationsEnabled,
-        minAmount = when (notificationPreference) {
-            NewOrderNotificationPreference.AllOrders -> null
-            NewOrderNotificationPreference.HighValueOrders -> thresholdAmount
-        }
     )
 
     private fun WooPushNotificationPreferences.isEnabled(type: NotificationType): Boolean? =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsViewModelTest.kt
@@ -7,8 +7,6 @@ import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.ShowTestNotification
-import com.woocommerce.android.notifications.push.PushNotificationRepository
-import com.woocommerce.android.ui.prefs.notifications.NewOrderNotificationSettingsViewModel.NotificationPreference
 import com.woocommerce.android.ui.products.ParameterRepository
 import com.woocommerce.android.ui.products.models.SiteParameters
 import com.woocommerce.android.util.getOrAwaitValue
@@ -16,27 +14,15 @@ import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event
 import com.woocommerce.android.viewmodel.ResourceProvider
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runCurrent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.Mockito.mockingDetails
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doAnswer
-import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences
-import org.wordpress.android.fluxc.model.pushnotifications.WooPushNotificationPreferences.StoreOrderPreferences
-import java.math.BigDecimal
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
@@ -47,10 +33,9 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
     private val notificationChannelsHandler: NotificationChannelsHandler = mock()
     private val showTestNotification: ShowTestNotification = mock()
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
-    private val pushNotificationRepository: PushNotificationRepository = mock()
     private lateinit var viewModel: NewOrderNotificationSettingsViewModel
 
-    private suspend fun setup(prepareMocks: suspend () -> Unit = {}) {
+    private fun setup(prepareMocks: () -> Unit = {}) {
         whenever(parameterRepository.getParameters()).thenReturn(
             SiteParameters(
                 currencyCode = "USD",
@@ -63,13 +48,6 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
         )
         whenever(notificationChannelsHandler.checkNewOrderNotificationSound())
             .thenReturn(NotificationChannelsHandler.NewOrderNotificationSoundStatus.DEFAULT)
-        whenever(pushNotificationRepository.observeWooNotificationPreferences())
-            .thenReturn(flowOf(null))
-        whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
-            .doSuspendableAnswer { invocation ->
-                val preferences = invocation.getArgument<WooPushNotificationPreferences>(0)
-                Result.success(preferences)
-            }
         prepareMocks()
         viewModel = NewOrderNotificationSettingsViewModel(
             savedStateHandle = SavedStateHandle(),
@@ -77,286 +55,16 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
             resourceProvider = resourceProvider,
             notificationChannelsHandler = notificationChannelsHandler,
             showTestNotification = showTestNotification,
-            analyticsTracker = analyticsTracker,
-            pushNotificationRepository = pushNotificationRepository,
-            coroutineDispatchers = coroutinesTestRule.testDispatchers
+            analyticsTracker = analyticsTracker
         )
     }
 
     @Test
-    fun `when view is loaded, then all orders preference is selected`() = testBlocking {
+    fun `when view is loaded, then expose currency symbol`() = testBlocking {
         setup()
 
-        assertThat(viewModel.viewState.getOrAwaitValue().notificationPreference)
-            .isEqualTo(NotificationPreference.AllOrders)
+        assertThat(viewModel.viewState.getOrAwaitValue().currencySymbol).isEqualTo("$")
     }
-
-    @Test
-    fun `given cached order preferences, when view is loaded, then apply cached preferences`() = testBlocking {
-        setup {
-            whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
-                flowOf(
-                    WooPushNotificationPreferences(
-                        storeOrder = StoreOrderPreferences(enabled = false, minAmount = BigDecimal(50))
-                    )
-                )
-            )
-        }
-
-        val viewState = viewModel.viewState.getOrAwaitValue()
-
-        assertThat(viewState.notificationsEnabled).isFalse()
-        assertThat(viewState.notificationPreference).isEqualTo(NotificationPreference.HighValueOrders)
-        assertThat(viewState.thresholdAmount).isEqualTo(BigDecimal(50))
-    }
-
-    @Test
-    fun `when notifications switch is changed, then update state`() = testBlocking {
-        setup()
-
-        viewModel.onNotificationsEnabledChanged(false)
-
-        assertThat(viewModel.viewState.getOrAwaitValue().notificationsEnabled).isFalse()
-    }
-
-    @Test
-    fun `when notifications switch is changed, then save order preferences`() = testBlocking {
-        setup()
-
-        viewModel.onNotificationsEnabledChanged(false)
-        advanceUntilIdle()
-
-        val preferences = captureUpdatePreferences()
-        assertThat(preferences.storeOrder).isEqualTo(StoreOrderPreferences(enabled = false, minAmount = null))
-    }
-
-    @Test
-    fun `given order preferences are changed back, when debounce completes, then do not save`() =
-        testBlocking {
-            setup()
-
-            viewModel.onNotificationsEnabledChanged(false)
-            viewModel.onNotificationsEnabledChanged(true)
-            advanceUntilIdle()
-
-            verify(pushNotificationRepository, never()).updateWooNotificationPreferences(any())
-        }
-
-    @Test
-    fun `when high value preference is selected, then update state`() = testBlocking {
-        setup()
-
-        viewModel.onNotificationPreferenceChanged(NotificationPreference.HighValueOrders)
-
-        assertThat(viewModel.viewState.getOrAwaitValue().notificationPreference)
-            .isEqualTo(NotificationPreference.HighValueOrders)
-    }
-
-    @Test
-    fun `when all orders preference is selected, then save order preferences without amount`() = testBlocking {
-        setup {
-            whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
-                flowOf(
-                    WooPushNotificationPreferences(
-                        storeOrder = StoreOrderPreferences(enabled = true, minAmount = BigDecimal(50))
-                    )
-                )
-            )
-        }
-        runCurrent()
-
-        viewModel.onNotificationPreferenceChanged(NotificationPreference.AllOrders)
-        advanceUntilIdle()
-
-        val preferences = captureUpdatePreferences()
-        assertThat(preferences.storeOrder).isEqualTo(StoreOrderPreferences(enabled = true, minAmount = null))
-    }
-
-    @Test
-    fun `when high value threshold amount is changed, then update state`() = testBlocking {
-        setup()
-
-        viewModel.onThresholdAmountChanged(BigDecimal(750))
-
-        assertThat(viewModel.viewState.getOrAwaitValue().thresholdAmount)
-            .isEqualTo(BigDecimal(750))
-    }
-
-    @Test
-    fun `when high value threshold amount is below minimum, then use minimum amount`() = testBlocking {
-        setup()
-
-        viewModel.onThresholdAmountChanged(BigDecimal.ZERO)
-
-        assertThat(viewModel.viewState.getOrAwaitValue().thresholdAmount)
-            .isEqualTo(BigDecimal.ONE)
-    }
-
-    @Test
-    fun `when high value threshold amount is changed, then save order preferences after debounce`() = testBlocking {
-        setup()
-
-        viewModel.onNotificationPreferenceChanged(NotificationPreference.HighValueOrders)
-        advanceUntilIdle()
-        viewModel.onThresholdAmountChanged(BigDecimal(750))
-        advanceUntilIdle()
-
-        val preferences = captureLastUpdatePreferences()
-        assertThat(preferences.storeOrder).isEqualTo(StoreOrderPreferences(enabled = true, minAmount = BigDecimal(750)))
-    }
-
-    @Test
-    fun `given threshold amount save is pending, when flushing pending preferences, then save immediately`() =
-        testBlocking {
-            setup {
-                whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
-                    flowOf(
-                        WooPushNotificationPreferences(
-                            storeOrder = StoreOrderPreferences(enabled = true, minAmount = BigDecimal(50))
-                        )
-                    )
-                )
-            }
-
-            runCurrent()
-            viewModel.onThresholdAmountChanged(BigDecimal(750))
-            viewModel.savePendingOrderPreferences()
-            runCurrent()
-
-            val preferences = captureUpdatePreferences()
-            assertThat(preferences.storeOrder)
-                .isEqualTo(StoreOrderPreferences(enabled = true, minAmount = BigDecimal(750)))
-        }
-
-    @Test
-    fun `given no pending order preferences, when saving pending preferences, then do not save order preferences`() =
-        testBlocking {
-            setup()
-
-            viewModel.savePendingOrderPreferences()
-
-            verify(pushNotificationRepository, never()).updateWooNotificationPreferences(any())
-        }
-
-    @Test
-    fun `given order preferences save is in progress, when flushing same preferences, then do not save again`() =
-        testBlocking {
-            val updateGate = CompletableDeferred<Result<WooPushNotificationPreferences>>()
-            setup {
-                whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
-                    flowOf(
-                        WooPushNotificationPreferences(
-                            storeOrder = StoreOrderPreferences(enabled = true, minAmount = BigDecimal(50))
-                        )
-                    )
-                )
-                whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
-                    .doSuspendableAnswer { invocation ->
-                        val preferences = invocation.getArgument<WooPushNotificationPreferences>(0)
-                        updateGate.await().map { preferences }
-                    }
-            }
-
-            runCurrent()
-            viewModel.onThresholdAmountChanged(BigDecimal(750))
-            advanceUntilIdle()
-            viewModel.savePendingOrderPreferences()
-            runCurrent()
-            updateGate.complete(Result.success(WooPushNotificationPreferences()))
-            advanceUntilIdle()
-
-            verify(pushNotificationRepository, times(1)).updateWooNotificationPreferences(any())
-        }
-
-    @Test
-    fun `given update in progress, when order preferences change again, then save latest state`() = testBlocking {
-        val firstUpdateGate = CompletableDeferred<Result<WooPushNotificationPreferences>>()
-
-        setup {
-            whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
-                .doSuspendableAnswer { invocation ->
-                    val preferences = invocation.getArgument<WooPushNotificationPreferences>(0)
-                    val result = if (preferences.storeOrder?.enabled == false) {
-                        firstUpdateGate.await()
-                    } else {
-                        Result.success(preferences)
-                    }
-                    result
-                }
-        }
-
-        viewModel.onNotificationsEnabledChanged(false)
-        advanceUntilIdle()
-        viewModel.onNotificationsEnabledChanged(true)
-        firstUpdateGate.complete(
-            Result.success(
-                WooPushNotificationPreferences(
-                    storeOrder = StoreOrderPreferences(false)
-                )
-            )
-        )
-        advanceUntilIdle()
-
-        val preferences = captureLastUpdatePreferences()
-        assertThat(preferences.storeOrder).isEqualTo(StoreOrderPreferences(enabled = true, minAmount = null))
-    }
-
-    @Test
-    fun `given update fails, when retry is clicked, then save requested preferences again`() = testBlocking {
-        var updateFails = true
-        setup {
-            whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
-                .doSuspendableAnswer { invocation ->
-                    val preferences = invocation.getArgument<WooPushNotificationPreferences>(0)
-                    if (updateFails) {
-                        updateFails = false
-                        Result.failure(Exception())
-                    } else {
-                        Result.success(preferences)
-                    }
-                }
-        }
-
-        val event = viewModel.event.runAndCaptureValues {
-            viewModel.onNotificationsEnabledChanged(false)
-            advanceUntilIdle()
-        }.last()
-
-        (event as Event.ShowActionStringSnackbar).action.onClick(null)
-        advanceUntilIdle()
-
-        val preferencesCaptor = argumentCaptor<WooPushNotificationPreferences>()
-        verify(pushNotificationRepository, times(2))
-            .updateWooNotificationPreferences(preferencesCaptor.capture())
-        assertThat(preferencesCaptor.allValues.map { it.storeOrder }).containsOnly(
-            StoreOrderPreferences(enabled = false, minAmount = null)
-        )
-    }
-
-    @Test
-    fun `given saved order preferences, when update fails, then rollback to latest saved state`() =
-        testBlocking {
-            setup {
-                whenever(pushNotificationRepository.observeWooNotificationPreferences()).thenReturn(
-                    flowOf(
-                        WooPushNotificationPreferences(
-                            storeOrder = StoreOrderPreferences(enabled = true, minAmount = BigDecimal(50))
-                        )
-                    )
-                )
-                whenever(pushNotificationRepository.updateWooNotificationPreferences(any()))
-                    .thenReturn(Result.failure(Exception()))
-            }
-
-            runCurrent()
-            viewModel.onNotificationsEnabledChanged(false)
-            advanceUntilIdle()
-
-            val viewState = viewModel.viewState.getOrAwaitValue()
-            assertThat(viewState.notificationsEnabled).isTrue()
-            assertThat(viewState.notificationPreference).isEqualTo(NotificationPreference.HighValueOrders)
-            assertThat(viewState.thresholdAmount).isEqualTo(BigDecimal(50))
-        }
 
     @Test
     fun `given cha ching sound is modified, when view is loaded, then expose modified state`() = testBlocking {
@@ -431,18 +139,5 @@ class NewOrderNotificationSettingsViewModelTest : BaseUnitTest() {
         assertThat(invocation.arguments[0]).isInstanceOf(String::class.java)
         assertThat(invocation.arguments[1]).isInstanceOf(String::class.java)
         assertThat(invocation.arguments[2]).isEqualTo(NotificationChannelType.NEW_ORDER)
-    }
-
-    private suspend fun captureUpdatePreferences(): WooPushNotificationPreferences {
-        val preferencesCaptor = argumentCaptor<WooPushNotificationPreferences>()
-        verify(pushNotificationRepository).updateWooNotificationPreferences(preferencesCaptor.capture())
-        return preferencesCaptor.firstValue
-    }
-
-    private suspend fun captureLastUpdatePreferences(): WooPushNotificationPreferences {
-        val preferencesCaptor = argumentCaptor<WooPushNotificationPreferences>()
-        verify(pushNotificationRepository, atLeastOnce())
-            .updateWooNotificationPreferences(preferencesCaptor.capture())
-        return preferencesCaptor.lastValue
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -277,6 +277,9 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             val preferences = captureUpdatePreferences()
             assertThat(preferences.storeOrder)
                 .isEqualTo(StoreOrderPreferences(enabled = true, minAmount = null))
+
+            val orderViewState = viewModel.newOrderNotificationSettingsViewState.captureValues().last()
+            assertThat(orderViewState.thresholdAmount).isEqualTo(BigDecimal(50))
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -3,6 +3,7 @@ package com.woocommerce.android.ui.prefs.notifications
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.notifications.push.PushNotificationRepository
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NewOrderNotificationPreference
 import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NotificationType
 import com.woocommerce.android.util.captureValues
 import com.woocommerce.android.util.runAndCaptureValues
@@ -181,10 +182,10 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given fetched notification preferences, when view is loaded, then expose notification type states`() =
+    fun `given fetched notification preferences, when view is loaded, then expose notification states`() =
         testBlocking {
             val fetchedPreferences = WooPushNotificationPreferences(
-                storeOrder = StoreOrderPreferences(enabled = false),
+                storeOrder = StoreOrderPreferences(enabled = false, minAmount = BigDecimal(50)),
                 storeReview = StoreReviewPreferences(enabled = true),
                 storeStock = StoreStockPreferences(enabled = false)
             )
@@ -199,6 +200,11 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             assertThat(notificationTypeItems.first { it.type == NotificationType.NEW_ORDERS }.isEnabled).isFalse()
             assertThat(notificationTypeItems.first { it.type == NotificationType.NEW_REVIEWS }.isEnabled).isTrue()
             assertThat(notificationTypeItems.first { it.type == NotificationType.STOCK }.isEnabled).isFalse()
+
+            val orderViewState = viewModel.newOrderNotificationSettingsViewState.captureValues().last()
+            assertThat(orderViewState.notificationsEnabled).isFalse()
+            assertThat(orderViewState.notificationPreference).isEqualTo(NewOrderNotificationPreference.HighValueOrders)
+            assertThat(orderViewState.thresholdAmount).isEqualTo(BigDecimal(50))
         }
 
     @Test
@@ -230,9 +236,62 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             viewModel.onNotificationTypeEnabledChanged(NotificationType.NEW_ORDERS, false)
             advanceUntilIdle()
 
+            val orderViewState = viewModel.newOrderNotificationSettingsViewState.captureValues().last()
+            assertThat(orderViewState.notificationsEnabled).isFalse()
             val preferences = captureUpdatePreferences()
             assertThat(preferences.storeOrder)
                 .isEqualTo(StoreOrderPreferences(enabled = false, minAmount = BigDecimal(50)))
+        }
+
+    @Test
+    fun `when new order detail settings change, then save order preferences`() =
+        testBlocking {
+            setup()
+            advanceUntilIdle()
+
+            viewModel.onNewOrderNotificationsEnabledChanged(false)
+            viewModel.onNewOrderNotificationPreferenceChanged(NewOrderNotificationPreference.HighValueOrders)
+            viewModel.onNewOrderThresholdAmountChanged(BigDecimal(50))
+            advanceUntilIdle()
+
+            val preferences = captureUpdatePreferences()
+            assertThat(preferences.storeOrder)
+                .isEqualTo(StoreOrderPreferences(enabled = false, minAmount = BigDecimal(50)))
+        }
+
+    @Test
+    fun `given high value order preferences, when all orders is selected, then save preferences without threshold`() =
+        testBlocking {
+            val orderPreferences = WooPushNotificationPreferences(
+                storeOrder = StoreOrderPreferences(enabled = true, minAmount = BigDecimal(50))
+            )
+            setup {
+                notificationPreferencesFlow.value = orderPreferences
+                mockSuccessfulFetch(orderPreferences)
+            }
+            advanceUntilIdle()
+
+            viewModel.onNewOrderNotificationPreferenceChanged(NewOrderNotificationPreference.AllOrders)
+            advanceUntilIdle()
+
+            val preferences = captureUpdatePreferences()
+            assertThat(preferences.storeOrder)
+                .isEqualTo(StoreOrderPreferences(enabled = true, minAmount = null))
+        }
+
+    @Test
+    fun `when new order threshold amount is below minimum, then save minimum amount`() =
+        testBlocking {
+            setup()
+            advanceUntilIdle()
+
+            viewModel.onNewOrderNotificationPreferenceChanged(NewOrderNotificationPreference.HighValueOrders)
+            viewModel.onNewOrderThresholdAmountChanged(BigDecimal.ZERO)
+            advanceUntilIdle()
+
+            val preferences = captureUpdatePreferences()
+            assertThat(preferences.storeOrder)
+                .isEqualTo(StoreOrderPreferences(enabled = true, minAmount = BigDecimal.ONE))
         }
 
     @Test


### PR DESCRIPTION
### Description

Part of RSM-3275

This PR connects the New Order notification detail screen to the nav-graph-scoped notification settings shared ViewModel.

The New Order detail screen now reads and updates Woo notification preference state through `NotificationSettingsSharedViewModel`, so changes made on the parent notification settings screen and the New Order detail screen stay in sync immediately. The local `NewOrderNotificationSettingsViewModel` now only owns New Order screen-specific state, like the currency symbol and cha-ching sound action.

This is intentionally limited to the New Order detail screen. Review and stock detail screens will be connected in separate follow-up PRs under the same Linear issue.

Stacked on #15914.

### Test Steps

1. Enable the `SMARTER_NOTIFICATIONS` feature flag.
2. Use a site where Woo push notifications are self-driven.
3. Go to `My store > Settings > Notifications`.
4. Toggle the `New orders` row on the parent notification settings screen.
5. Open `New orders` and verify the enable switch reflects the parent value immediately.
6. Change the New Order preference between `All orders` and `High value orders`.
7. Set a high-value threshold and leave the screen.
8. Return to the parent notification settings screen and verify the `New orders` row still reflects the current enabled state.
9. Return to `New orders` and verify the selected preference and threshold are preserved.
10. Verify the cha-ching sound action still works when the device notification channel needs fixing.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
