### PR TITLE
[RSM-3275] Connect stock detail screen to shared notification state

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import com.woocommerce.android.R
 import com.woocommerce.android.analytics.AnalyticsTracker
 import com.woocommerce.android.extensions.handleNotice
@@ -20,6 +21,9 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class NewStockNotificationSettingsFragment : BaseFragment() {
     private val viewModel: NewStockNotificationSettingsViewModel by viewModels()
+    private val sharedViewModel: NotificationSettingsSharedViewModel by hiltNavGraphViewModels(
+        R.id.nav_graph_notification_settings
+    )
 
     @Inject
     lateinit var authenticatedWebViewLauncher: AuthenticatedWebViewLauncher
@@ -31,7 +35,10 @@ class NewStockNotificationSettingsFragment : BaseFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return composeView {
-            NewStockNotificationSettingsScreen(viewModel = viewModel)
+            NewStockNotificationSettingsScreen(
+                viewModel = viewModel,
+                sharedViewModel = sharedViewModel
+            )
         }
     }
 
@@ -46,6 +53,11 @@ class NewStockNotificationSettingsFragment : BaseFragment() {
         AnalyticsTracker.trackViewShown(this)
     }
 
+    override fun onStop() {
+        super.onStop()
+        sharedViewModel.savePendingNotificationPreferences()
+    }
+
     private fun observeEvents() {
         viewModel.event.observe(viewLifecycleOwner) { event ->
             when (event) {
@@ -53,6 +65,15 @@ class NewStockNotificationSettingsFragment : BaseFragment() {
                     authenticatedWebViewLauncher.showAuthenticatedWebView(event)
 
                 is MultiLiveEvent.Event.ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+            }
+        }
+        sharedViewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is MultiLiveEvent.Event.ShowActionStringSnackbar -> uiMessageResolver.showActionSnack(
+                    event.message,
+                    event.actionText,
+                    event.action
+                )
             }
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsScreen.kt
@@ -39,27 +39,34 @@ import com.woocommerce.android.R
 import com.woocommerce.android.ui.compose.clickableAnnotatedStringRes
 import com.woocommerce.android.ui.compose.component.WCSwitch
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
-import com.woocommerce.android.ui.prefs.notifications.NewStockNotificationSettingsViewModel.StockNotificationType
 import com.woocommerce.android.ui.prefs.notifications.NewStockNotificationSettingsViewModel.ViewState
 import com.woocommerce.android.ui.prefs.notifications.compose.EnableNotificationsCard
 
 @Composable
-fun NewStockNotificationSettingsScreen(viewModel: NewStockNotificationSettingsViewModel) {
-    viewModel.viewState.observeAsState().value?.let { viewState ->
-        NewStockNotificationSettingsScreen(
-            viewState = viewState,
-            onNotificationsEnabledChanged = viewModel::onNotificationsEnabledChanged,
-            onStockNotificationEnabledChanged = viewModel::onStockNotificationEnabledChanged,
-            onEditStoreSettingsClicked = viewModel::onEditStoreSettingsClicked
-        )
-    }
+fun NewStockNotificationSettingsScreen(
+    viewModel: NewStockNotificationSettingsViewModel,
+    sharedViewModel: NotificationSettingsSharedViewModel
+) {
+    val viewState = viewModel.viewState.observeAsState().value ?: return
+    val sharedViewState = sharedViewModel.newStockNotificationSettingsViewState.observeAsState().value ?: return
+    NewStockNotificationSettingsScreen(
+        viewState = viewState,
+        sharedViewState = sharedViewState,
+        onStockNotificationsEnabledChanged = sharedViewModel::onStockNotificationsEnabledChanged,
+        onStockNotificationSubtypeEnabledChanged = sharedViewModel::onStockNotificationSubtypeEnabledChanged,
+        onEditStoreSettingsClicked = viewModel::onEditStoreSettingsClicked
+    )
 }
 
 @Composable
 private fun NewStockNotificationSettingsScreen(
     viewState: ViewState,
-    onNotificationsEnabledChanged: (Boolean) -> Unit,
-    onStockNotificationEnabledChanged: (StockNotificationType, Boolean) -> Unit,
+    sharedViewState: NotificationSettingsSharedViewModel.NewStockNotificationSettingsViewState,
+    onStockNotificationsEnabledChanged: (Boolean) -> Unit,
+    onStockNotificationSubtypeEnabledChanged: (
+        NotificationSettingsSharedViewModel.StockNotificationType,
+        Boolean
+    ) -> Unit,
     onEditStoreSettingsClicked: () -> Unit
 ) {
     Scaffold(
@@ -75,22 +82,25 @@ private fun NewStockNotificationSettingsScreen(
             EnableNotificationsCard(
                 title = stringResource(R.string.settings_notifs_stock_enable_title),
                 description = stringResource(R.string.settings_notifs_stock_enable_description),
-                isEnabled = viewState.notificationsEnabled,
-                onEnabledChanged = onNotificationsEnabledChanged
+                isEnabled = sharedViewState.notificationsEnabled,
+                onEnabledChanged = onStockNotificationsEnabledChanged
             )
             StockNotificationOption(
                 title = stringResource(R.string.settings_notifs_stock_low_stock_title),
                 description = stringResource(R.string.settings_notifs_stock_low_stock_description),
-                checked = viewState.lowStockNotificationsEnabled,
-                enabled = viewState.notificationsEnabled,
+                checked = sharedViewState.lowStockNotificationsEnabled,
+                enabled = sharedViewState.notificationsEnabled,
                 onCheckedChange = {
-                    onStockNotificationEnabledChanged(StockNotificationType.LowStock, it)
+                    onStockNotificationSubtypeEnabledChanged(
+                        NotificationSettingsSharedViewModel.StockNotificationType.LowStock,
+                        it
+                    )
                 }
             ) {
                 LowStockDetails(
                     defaultLowStockThreshold = viewState.defaultLowStockThreshold,
                     isDefaultLowStockThresholdLoading = viewState.isDefaultLowStockThresholdLoading,
-                    enabled = viewState.notificationsEnabled,
+                    enabled = sharedViewState.notificationsEnabled,
                     onEditStoreSettingsClicked = onEditStoreSettingsClicked
                 )
             }
@@ -98,20 +108,26 @@ private fun NewStockNotificationSettingsScreen(
             StockNotificationOption(
                 title = stringResource(R.string.settings_notifs_stock_out_of_stock_title),
                 description = stringResource(R.string.settings_notifs_stock_out_of_stock_description),
-                checked = viewState.outOfStockNotificationsEnabled,
-                enabled = viewState.notificationsEnabled,
+                checked = sharedViewState.outOfStockNotificationsEnabled,
+                enabled = sharedViewState.notificationsEnabled,
                 onCheckedChange = {
-                    onStockNotificationEnabledChanged(StockNotificationType.OutOfStock, it)
+                    onStockNotificationSubtypeEnabledChanged(
+                        NotificationSettingsSharedViewModel.StockNotificationType.OutOfStock,
+                        it
+                    )
                 }
             )
             HorizontalDivider()
             StockNotificationOption(
                 title = stringResource(R.string.settings_notifs_stock_backorder_title),
                 description = stringResource(R.string.settings_notifs_stock_backorder_description),
-                checked = viewState.backorderNotificationsEnabled,
-                enabled = viewState.notificationsEnabled,
+                checked = sharedViewState.backorderNotificationsEnabled,
+                enabled = sharedViewState.notificationsEnabled,
                 onCheckedChange = {
-                    onStockNotificationEnabledChanged(StockNotificationType.Backorder, it)
+                    onStockNotificationSubtypeEnabledChanged(
+                        NotificationSettingsSharedViewModel.StockNotificationType.Backorder,
+                        it
+                    )
                 }
             )
         }
@@ -272,8 +288,9 @@ private fun NewStockNotificationSettingsScreenPreview() {
     WooThemeWithBackground {
         NewStockNotificationSettingsScreen(
             viewState = ViewState(),
-            onNotificationsEnabledChanged = {},
-            onStockNotificationEnabledChanged = { _, _ -> },
+            sharedViewState = NotificationSettingsSharedViewModel.NewStockNotificationSettingsViewState(),
+            onStockNotificationsEnabledChanged = {},
+            onStockNotificationSubtypeEnabledChanged = { _, _ -> },
             onEditStoreSettingsClicked = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsViewModel.kt
@@ -29,20 +29,6 @@ class NewStockNotificationSettingsViewModel @Inject constructor(
         refreshDefaultLowStockThreshold()
     }
 
-    fun onNotificationsEnabledChanged(isEnabled: Boolean) {
-        _viewState.update { it.copy(notificationsEnabled = isEnabled) }
-    }
-
-    fun onStockNotificationEnabledChanged(type: StockNotificationType, isEnabled: Boolean) {
-        _viewState.update {
-            when (type) {
-                StockNotificationType.LowStock -> it.copy(lowStockNotificationsEnabled = isEnabled)
-                StockNotificationType.OutOfStock -> it.copy(outOfStockNotificationsEnabled = isEnabled)
-                StockNotificationType.Backorder -> it.copy(backorderNotificationsEnabled = isEnabled)
-            }
-        }
-    }
-
     fun onStoreSettingsWebViewClosed() {
         refreshDefaultLowStockThreshold()
     }
@@ -97,19 +83,9 @@ class NewStockNotificationSettingsViewModel @Inject constructor(
     }
 
     data class ViewState(
-        val notificationsEnabled: Boolean = true,
-        val lowStockNotificationsEnabled: Boolean = true,
-        val outOfStockNotificationsEnabled: Boolean = true,
-        val backorderNotificationsEnabled: Boolean = true,
         val defaultLowStockThreshold: Int? = null,
         val isDefaultLowStockThresholdLoading: Boolean = true
     )
-
-    enum class StockNotificationType {
-        LowStock,
-        OutOfStock,
-        Backorder
-    }
 
     companion object {
         private const val STOCK_SETTINGS_PATH = "admin.php?page=wc-settings&tab=products&section=inventory"

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -87,8 +88,9 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         preferences?.toNewReviewNotificationSettingsViewState(rating)
             ?: NewReviewNotificationSettingsViewState(selectedRating = rating)
     }.asLiveData()
-    private val _newStockNotificationSettingsViewState = MutableStateFlow(NewStockNotificationSettingsViewState())
-    val newStockNotificationSettingsViewState = _newStockNotificationSettingsViewState.asLiveData()
+    val newStockNotificationSettingsViewState = wooPushNotificationPreferences
+        .map { it?.storeStock?.toNewStockNotificationSettingsViewState() ?: NewStockNotificationSettingsViewState() }
+        .asLiveData()
 
     init {
         observeWooPushNotificationPreferences()
@@ -177,13 +179,15 @@ class NotificationSettingsSharedViewModel @Inject constructor(
 
     fun onStockNotificationSubtypeEnabledChanged(type: StockNotificationType, isEnabled: Boolean) {
         val preferences = wooPushNotificationPreferences.value ?: return
+        val stockViewState = preferences.storeStock?.toNewStockNotificationSettingsViewState()
+            ?: NewStockNotificationSettingsViewState()
         val updatedViewState = when (type) {
             StockNotificationType.LowStock ->
-                _newStockNotificationSettingsViewState.value.copy(lowStockNotificationsEnabled = isEnabled)
+                stockViewState.copy(lowStockNotificationsEnabled = isEnabled)
             StockNotificationType.OutOfStock ->
-                _newStockNotificationSettingsViewState.value.copy(outOfStockNotificationsEnabled = isEnabled)
+                stockViewState.copy(outOfStockNotificationsEnabled = isEnabled)
             StockNotificationType.Backorder ->
-                _newStockNotificationSettingsViewState.value.copy(backorderNotificationsEnabled = isEnabled)
+                stockViewState.copy(backorderNotificationsEnabled = isEnabled)
         }
 
         updateDisplayedWooPushNotificationPreferences(
@@ -307,9 +311,6 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         _isNotificationTypeSelectionEnabled.value = true
         preferences.storeOrder?.minAmount?.let { displayedOrderThresholdAmount.value = it }
         preferences.storeReview?.maxRating?.let { displayedReviewRating.value = it }
-        preferences.storeStock?.let { stockPreferences ->
-            _newStockNotificationSettingsViewState.update { it.copyWith(stockPreferences) }
-        }
         _notificationTypeItems.update { items ->
             items.map { item ->
                 item.copy(isEnabled = preferences.isEnabled(item.type) ?: item.isEnabled)
@@ -380,13 +381,11 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         }
     )
 
-    private fun NewStockNotificationSettingsViewState.copyWith(
-        stockPreferences: StoreStockPreferences
-    ): NewStockNotificationSettingsViewState = copy(
-        notificationsEnabled = stockPreferences.enabled ?: notificationsEnabled,
-        lowStockNotificationsEnabled = stockPreferences.lowStock ?: lowStockNotificationsEnabled,
-        outOfStockNotificationsEnabled = stockPreferences.outOfStock ?: outOfStockNotificationsEnabled,
-        backorderNotificationsEnabled = stockPreferences.onBackorder ?: backorderNotificationsEnabled
+    private fun StoreStockPreferences.toNewStockNotificationSettingsViewState() = NewStockNotificationSettingsViewState(
+        notificationsEnabled = enabled ?: true,
+        lowStockNotificationsEnabled = lowStock ?: true,
+        outOfStockNotificationsEnabled = outOfStock ?: true,
+        backorderNotificationsEnabled = onBackorder ?: true
     )
 
     private fun NewStockNotificationSettingsViewState.toStoreStockPreferences() = StoreStockPreferences(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -87,6 +87,8 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         preferences?.toNewReviewNotificationSettingsViewState(rating)
             ?: NewReviewNotificationSettingsViewState(selectedRating = rating)
     }.asLiveData()
+    private val _newStockNotificationSettingsViewState = MutableStateFlow(NewStockNotificationSettingsViewState())
+    val newStockNotificationSettingsViewState = _newStockNotificationSettingsViewState.asLiveData()
 
     init {
         observeWooPushNotificationPreferences()
@@ -166,6 +168,26 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         displayedReviewRating.value = selectedRating
         updateDisplayedWooPushNotificationPreferences(
             preferences.copy(storeReview = updatedViewState.toStoreReviewPreferences())
+        )
+    }
+
+    fun onStockNotificationsEnabledChanged(isEnabled: Boolean) {
+        onNotificationTypeEnabledChanged(NotificationType.STOCK, isEnabled)
+    }
+
+    fun onStockNotificationSubtypeEnabledChanged(type: StockNotificationType, isEnabled: Boolean) {
+        val preferences = wooPushNotificationPreferences.value ?: return
+        val updatedViewState = when (type) {
+            StockNotificationType.LowStock ->
+                _newStockNotificationSettingsViewState.value.copy(lowStockNotificationsEnabled = isEnabled)
+            StockNotificationType.OutOfStock ->
+                _newStockNotificationSettingsViewState.value.copy(outOfStockNotificationsEnabled = isEnabled)
+            StockNotificationType.Backorder ->
+                _newStockNotificationSettingsViewState.value.copy(backorderNotificationsEnabled = isEnabled)
+        }
+
+        updateDisplayedWooPushNotificationPreferences(
+            preferences.copy(storeStock = updatedViewState.toStoreStockPreferences())
         )
     }
 
@@ -285,6 +307,9 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         _isNotificationTypeSelectionEnabled.value = true
         preferences.storeOrder?.minAmount?.let { displayedOrderThresholdAmount.value = it }
         preferences.storeReview?.maxRating?.let { displayedReviewRating.value = it }
+        preferences.storeStock?.let { stockPreferences ->
+            _newStockNotificationSettingsViewState.update { it.copyWith(stockPreferences) }
+        }
         _notificationTypeItems.update { items ->
             items.map { item ->
                 item.copy(isEnabled = preferences.isEnabled(item.type) ?: item.isEnabled)
@@ -355,6 +380,22 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         }
     )
 
+    private fun NewStockNotificationSettingsViewState.copyWith(
+        stockPreferences: StoreStockPreferences
+    ): NewStockNotificationSettingsViewState = copy(
+        notificationsEnabled = stockPreferences.enabled ?: notificationsEnabled,
+        lowStockNotificationsEnabled = stockPreferences.lowStock ?: lowStockNotificationsEnabled,
+        outOfStockNotificationsEnabled = stockPreferences.outOfStock ?: outOfStockNotificationsEnabled,
+        backorderNotificationsEnabled = stockPreferences.onBackorder ?: backorderNotificationsEnabled
+    )
+
+    private fun NewStockNotificationSettingsViewState.toStoreStockPreferences() = StoreStockPreferences(
+        enabled = notificationsEnabled,
+        lowStock = lowStockNotificationsEnabled,
+        outOfStock = outOfStockNotificationsEnabled,
+        onBackorder = backorderNotificationsEnabled
+    )
+
     private fun WooPushNotificationPreferences.isEnabled(type: NotificationType): Boolean? =
         when (type) {
             NotificationType.NEW_ORDERS -> storeOrder?.enabled
@@ -393,6 +434,19 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     enum class NewReviewNotificationPreference {
         AllReviews,
         RatingFilteredReviews
+    }
+
+    data class NewStockNotificationSettingsViewState(
+        val notificationsEnabled: Boolean = true,
+        val lowStockNotificationsEnabled: Boolean = true,
+        val outOfStockNotificationsEnabled: Boolean = true,
+        val backorderNotificationsEnabled: Boolean = true
+    )
+
+    enum class StockNotificationType {
+        LowStock,
+        OutOfStock,
+        Backorder
     }
 
     enum class NotificationType {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsViewModelTest.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.model.UiString
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.prefs.notifications.NewStockNotificationSettingsViewModel.StockNotificationType
 import com.woocommerce.android.util.getOrAwaitValue
 import com.woocommerce.android.util.runAndCaptureValues
 import com.woocommerce.android.viewmodel.BaseUnitTest
@@ -49,26 +48,13 @@ class NewStockNotificationSettingsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when view is loaded, then expose default stock notification states`() = testBlocking {
+    fun `when view is loaded, then expose default low stock threshold state`() = testBlocking {
         setup()
 
         val viewState = viewModel.viewState.getOrAwaitValue()
 
-        assertThat(viewState.notificationsEnabled).isTrue()
-        assertThat(viewState.lowStockNotificationsEnabled).isTrue()
-        assertThat(viewState.outOfStockNotificationsEnabled).isTrue()
-        assertThat(viewState.backorderNotificationsEnabled).isTrue()
         assertThat(viewState.defaultLowStockThreshold).isNull()
         assertThat(viewState.isDefaultLowStockThresholdLoading).isFalse()
-    }
-
-    @Test
-    fun `when notifications switch is changed, then update state`() = testBlocking {
-        setup()
-
-        viewModel.onNotificationsEnabledChanged(false)
-
-        assertThat(viewModel.viewState.getOrAwaitValue().notificationsEnabled).isFalse()
     }
 
     @Test
@@ -172,33 +158,6 @@ class NewStockNotificationSettingsViewModelTest : BaseUnitTest() {
             assertThat(viewModel.viewState.getOrAwaitValue().defaultLowStockThreshold).isEqualTo(2)
             assertThat(viewModel.viewState.getOrAwaitValue().isDefaultLowStockThresholdLoading).isFalse()
         }
-
-    @Test
-    fun `when low stock switch is changed, then update state`() = testBlocking {
-        setup()
-
-        viewModel.onStockNotificationEnabledChanged(StockNotificationType.LowStock, false)
-
-        assertThat(viewModel.viewState.getOrAwaitValue().lowStockNotificationsEnabled).isFalse()
-    }
-
-    @Test
-    fun `when out of stock switch is changed, then update state`() = testBlocking {
-        setup()
-
-        viewModel.onStockNotificationEnabledChanged(StockNotificationType.OutOfStock, false)
-
-        assertThat(viewModel.viewState.getOrAwaitValue().outOfStockNotificationsEnabled).isFalse()
-    }
-
-    @Test
-    fun `when backorder switch is changed, then update state`() = testBlocking {
-        setup()
-
-        viewModel.onStockNotificationEnabledChanged(StockNotificationType.Backorder, false)
-
-        assertThat(viewModel.viewState.getOrAwaitValue().backorderNotificationsEnabled).isFalse()
-    }
 
     @Test
     fun `when edit store settings is clicked, then open authenticated web view`() =

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -187,7 +187,12 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             val fetchedPreferences = WooPushNotificationPreferences(
                 storeOrder = StoreOrderPreferences(enabled = false, minAmount = BigDecimal(50)),
                 storeReview = StoreReviewPreferences(enabled = false, maxRating = 3),
-                storeStock = StoreStockPreferences(enabled = false)
+                storeStock = StoreStockPreferences(
+                    enabled = false,
+                    lowStock = false,
+                    outOfStock = true,
+                    onBackorder = false
+                )
             )
             setup {
                 mockSuccessfulFetch(fetchedPreferences)
@@ -211,6 +216,12 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             assertThat(reviewViewState.notificationPreference)
                 .isEqualTo(NotificationSettingsSharedViewModel.NewReviewNotificationPreference.RatingFilteredReviews)
             assertThat(reviewViewState.selectedRating).isEqualTo(3)
+
+            val stockViewState = viewModel.newStockNotificationSettingsViewState.captureValues().last()
+            assertThat(stockViewState.notificationsEnabled).isFalse()
+            assertThat(stockViewState.lowStockNotificationsEnabled).isFalse()
+            assertThat(stockViewState.outOfStockNotificationsEnabled).isTrue()
+            assertThat(stockViewState.backorderNotificationsEnabled).isFalse()
         }
 
     @Test
@@ -344,6 +355,30 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
 
             val reviewViewState = viewModel.newReviewNotificationSettingsViewState.captureValues().last()
             assertThat(reviewViewState.selectedRating).isEqualTo(3)
+        }
+
+    @Test
+    fun `when stock detail settings change, then save stock preferences`() =
+        testBlocking {
+            setup()
+            advanceUntilIdle()
+
+            viewModel.onStockNotificationsEnabledChanged(false)
+            viewModel.onStockNotificationSubtypeEnabledChanged(
+                NotificationSettingsSharedViewModel.StockNotificationType.LowStock,
+                false
+            )
+            advanceUntilIdle()
+
+            val preferences = captureUpdatePreferences()
+            assertThat(preferences.storeStock).isEqualTo(
+                StoreStockPreferences(
+                    enabled = false,
+                    lowStock = false,
+                    outOfStock = true,
+                    onBackorder = true
+                )
+            )
         }
 
     @Test


### PR DESCRIPTION
### Description

Fixes RSM-3275

This PR connects the stock notification detail screen to `NotificationSettingsSharedViewModel`, so the stock parent row and stock detail switches use the same Woo push preference state and save flow.

The local `NewStockNotificationSettingsViewModel` still owns stock-screen-specific behavior that is not part of the shared preference model: loading the low stock threshold, opening the store settings web view, and showing threshold fetch errors. The shared ViewModel now owns the stock notification preferences themselves: the main stock notification switch plus low stock, out of stock, and backorder toggles.

This is stacked on the new review detail PR and keeps the change limited to the stock detail screen.

### Test Steps

1. Enable the smarter notifications flow.
2. Open notification settings and verify the Stock row reflects the current stock notification state.
3. Toggle the Stock row switch, open the Stock detail screen, and verify the main Stock switch matches the parent state.
4. Change the main Stock switch and the Low stock / Out of stock / Backorder switches from the Stock detail screen.
5. Navigate back to the parent screen and reopen Stock settings; verify the changes are kept without waiting for a delayed refresh.
6. Verify the low stock threshold still loads and the edit store settings action still opens the authenticated web view.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
