### PR TITLE
Gate QR login entry point on 10% rollout bucket

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefs.kt
@@ -223,7 +223,9 @@ object AppPrefs {
 
         WOO_POS_SURVEY_NOTIFICATION_POTENTIAL_USER_SHOWN,
 
-        IS_USER_AGE_ELIGIBLE_FOR_APP_USE
+        IS_USER_AGE_ELIGIBLE_FOR_APP_USE,
+
+        QR_LOGIN_ROLLOUT_BUCKET
     }
 
     fun init(context: Context) {
@@ -335,6 +337,14 @@ object AppPrefs {
     var isUserAgeEligibleForAppUse: Boolean
         get() = getBoolean(key = UndeletablePrefKey.IS_USER_AGE_ELIGIBLE_FOR_APP_USE, default = true)
         set(value) = setBoolean(key = UndeletablePrefKey.IS_USER_AGE_ELIGIBLE_FOR_APP_USE, value = value)
+
+    var qrLoginRolloutBucket: Int?
+        get() = UndeletablePrefKey.QR_LOGIN_ROLLOUT_BUCKET
+            .takeIf { exists(it) }
+            ?.let { getInt(it) }
+        set(value) {
+            value?.let { setInt(UndeletablePrefKey.QR_LOGIN_ROLLOUT_BUCKET, it) }
+        }
 
     private const val FEATURE_FLAG_OVERRIDE_PREFIX = "feature_flag_override"
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/AppPrefsWrapper.kt
@@ -44,6 +44,8 @@ open class AppPrefsWrapper @Inject constructor() {
 
     var isUserAgeEligibleForAppUse by AppPrefs::isUserAgeEligibleForAppUse
 
+    var qrLoginRolloutBucket by AppPrefs::qrLoginRolloutBucket
+
     open var orderSummaryMigrated by AppPrefs::orderSummaryMigrated
     open var gatewayMigrated by AppPrefs::gatewayMigrated
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -210,9 +210,6 @@ class LoginActivity :
             savedInstanceState == null &&
                 intent?.action == Intent.ACTION_VIEW &&
                 intent.data?.authority == QR_LOGIN_AUTHORITY -> {
-                // Gate the deep link on the feature flag + camera, but bypass the rollout bucket:
-                // the bucket only restricts in-app discovery. A user arriving here already chose
-                // to scan a QR (e.g. from wp-admin with a 3rd-party camera), so honor that intent.
                 if (qrLoginAvailability.isAvailableForDeepLink()) {
                     intent.data?.let { uri -> handleQrLoginUri(uri) }
                 } else {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/LoginActivity.kt
@@ -210,9 +210,10 @@ class LoginActivity :
             savedInstanceState == null &&
                 intent?.action == Intent.ACTION_VIEW &&
                 intent.data?.authority == QR_LOGIN_AUTHORITY -> {
-                // Gate the deep link on the same availability check as the in-app entry, so
-                // the system camera / 3rd-party scanner path cannot bypass the feature flag.
-                if (qrLoginAvailability.isAvailable()) {
+                // Gate the deep link on the feature flag + camera, but bypass the rollout bucket:
+                // the bucket only restricts in-app discovery. A user arriving here already chose
+                // to scan a QR (e.g. from wp-admin with a 3rd-party camera), so honor that intent.
+                if (qrLoginAvailability.isAvailableForDeepLink()) {
                     intent.data?.let { uri -> handleQrLoginUri(uri) }
                 } else {
                     loginAnalyticsListener.trackLoginAccessed()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.login.qrlogin
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
 import com.woocommerce.android.util.WooLog
 import javax.inject.Inject
+import kotlin.random.Random
 
 /**
  * Decides whether the QR login entry point should be offered on this device.
@@ -14,13 +16,31 @@ import javax.inject.Inject
  * work on GMS-less devices. If the scanner fails at runtime (binding error, model init, etc.),
  * [com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel.onBindingException] already
  * surfaces a snackbar, so offering the entry point optimistically is safe.
+ *
+ * We require an explicit remote=true (a null/not-yet-loaded remote
+ * value is treated as off) since this is in the login flow so the remote might not be loaded yet.
+ * Each install is assigned a number in
+ * [ROLLOUT_BUCKET_MIN]..[ROLLOUT_BUCKET_MAX] on first read and persisted, so the decision is stable
+ * across restarts. Only installs in [ROLLOUT_BUCKETS_ENABLED] get the entry point. A debug override
+ * on the flag bypasses both the remote check and the bucket check.
  */
 class QrLoginAvailability @Inject constructor(
     private val featureFlagRepository: FeatureFlagRepository,
-    private val deviceFeatures: DeviceFeatures
+    private val deviceFeatures: DeviceFeatures,
+    private val appPrefsWrapper: AppPrefsWrapper,
 ) {
     fun isAvailable(): Boolean {
-        if (!featureFlagRepository.isEnabled(FeatureFlag.QR_LOGIN)) return false
+        val flagState = featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)
+        val override = flagState.overrideValue
+        if (override != null) {
+            if (!override) return false
+        } else {
+            if (flagState.remoteValue != true) return false
+            if (getOrAssignRolloutBucket() !in ROLLOUT_BUCKETS_ENABLED) {
+                WooLog.d(WooLog.T.LOGIN, "QR login unavailable: outside rollout bucket")
+                return false
+            }
+        }
 
         if (!deviceFeatures.hasCamera()) {
             WooLog.d(WooLog.T.LOGIN, "QR login unavailable: device has no camera")
@@ -28,5 +48,15 @@ class QrLoginAvailability @Inject constructor(
         }
 
         return true
+    }
+
+    private fun getOrAssignRolloutBucket(): Int =
+        appPrefsWrapper.qrLoginRolloutBucket ?: Random.nextInt(ROLLOUT_BUCKET_MIN, ROLLOUT_BUCKET_MAX + 1)
+            .also { appPrefsWrapper.qrLoginRolloutBucket = it }
+
+    companion object {
+        const val ROLLOUT_BUCKET_MIN = 1
+        const val ROLLOUT_BUCKET_MAX = 10
+        val ROLLOUT_BUCKETS_ENABLED = 1..1
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.ui.login.qrlogin
 
 import com.woocommerce.android.AppPrefsWrapper
+import com.woocommerce.android.ui.login.qrlogin.QrLoginAvailability.Companion.ROLLOUT_BUCKETS_ENABLED
+import com.woocommerce.android.ui.login.qrlogin.QrLoginAvailability.Companion.ROLLOUT_BUCKET_MAX
+import com.woocommerce.android.ui.login.qrlogin.QrLoginAvailability.Companion.ROLLOUT_BUCKET_MIN
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
@@ -21,22 +24,32 @@ import kotlin.random.Random
  * value is treated as off) since this is in the login flow so the remote might not be loaded yet.
  * Each install is assigned a number in
  * [ROLLOUT_BUCKET_MIN]..[ROLLOUT_BUCKET_MAX] on first read and persisted, so the decision is stable
- * across restarts. Only installs in [ROLLOUT_BUCKETS_ENABLED] get the entry point. A debug override
- * on the flag bypasses both the remote check and the bucket check.
+ * across restarts. Only installs in [ROLLOUT_BUCKETS_ENABLED] get the in-app entry point via
+ * [isAvailable].
+ *
+ * The bucket only gates discovery from within the app. If the user is already in the flow from
+ * elsewhere (e.g. scanned a QR from wp-admin with a 3rd-party camera), use
+ * [isAvailableForDeepLink], which still respects the feature flag and camera check but ignores the
+ * rollout bucket.
  */
 class QrLoginAvailability @Inject constructor(
     private val featureFlagRepository: FeatureFlagRepository,
     private val deviceFeatures: DeviceFeatures,
     private val appPrefsWrapper: AppPrefsWrapper,
 ) {
-    fun isAvailable(): Boolean {
+    fun isAvailable(): Boolean = isAvailable(applyRolloutBucket = true)
+
+    fun isAvailableForDeepLink(): Boolean = isAvailable(applyRolloutBucket = false)
+
+    @Suppress("ReturnCount")
+    private fun isAvailable(applyRolloutBucket: Boolean): Boolean {
         val flagState = featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)
         val override = flagState.overrideValue
         if (override != null) {
             if (!override) return false
         } else {
             if (flagState.remoteValue != true) return false
-            if (getOrAssignRolloutBucket() !in ROLLOUT_BUCKETS_ENABLED) {
+            if (applyRolloutBucket && getOrAssignRolloutBucket() !in ROLLOUT_BUCKETS_ENABLED) {
                 WooLog.d(WooLog.T.LOGIN, "QR login unavailable: outside rollout bucket")
                 return false
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
@@ -12,44 +12,40 @@ import javax.inject.Inject
 import kotlin.random.Random
 
 /**
- * Decides whether the QR login entry point should be offered on this device.
+ * Decides whether the QR login flow should be offered.
  *
- * Hard requirement: the device needs a camera — there's no QR flow without one. We don't gate on
- * Google Play Services: we ship the bundled ML Kit barcode scanning variant, which is designed to
- * work on GMS-less devices. If the scanner fails at runtime (binding error, model init, etc.),
- * [com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel.onBindingException] already
- * surfaces a snackbar, so offering the entry point optimistically is safe.
+ * The remote feature flag gates both entry points: we require an explicit `remoteValue == true`
+ * (a `null`/not-yet-loaded remote value is treated as off) since this runs in the login flow before
+ * remote flags are guaranteed to have loaded. Only a debug override bypasses this.
  *
- * We require an explicit remote=true (a null/not-yet-loaded remote
- * value is treated as off) since this is in the login flow so the remote might not be loaded yet.
- * Each install is assigned a number in
- * [ROLLOUT_BUCKET_MIN]..[ROLLOUT_BUCKET_MAX] on first read and persisted, so the decision is stable
- * across restarts. Only installs in [ROLLOUT_BUCKETS_ENABLED] get the in-app entry point via
- * [isAvailable].
+ * For the in-app entry point ([isAvailable]):
+ *  - The device must have a camera — we don't gate on Google Play Services: we ship the bundled
+ *    ML Kit barcode scanning variant, which works on GMS-less devices. If the scanner fails at
+ *    runtime,
+ *    [com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel.onBindingException]
+ *    surfaces a snackbar.
+ *  - Each install is assigned a number in [ROLLOUT_BUCKET_MIN]..[ROLLOUT_BUCKET_MAX] on first read
+ *    and persisted, so the decision is stable across restarts. Only installs in
+ *    [ROLLOUT_BUCKETS_ENABLED] get the entry point. A debug override bypasses the bucket check.
  *
- * The bucket only gates discovery from within the app. If the user is already in the flow from
- * elsewhere (e.g. scanned a QR from wp-admin with a 3rd-party camera), use
- * [isAvailableForDeepLink], which still respects the feature flag and camera check but ignores the
- * rollout bucket.
+ * For deep-link entry ([isAvailableForDeepLink]), e.g. scanning a QR from wp-admin with a
+ * 3rd-party camera: the bucket is bypassed (the user already chose this flow), and the camera
+ * check is skipped (they already have the token; no scanning needed in-app).
  */
 class QrLoginAvailability @Inject constructor(
     private val featureFlagRepository: FeatureFlagRepository,
     private val deviceFeatures: DeviceFeatures,
     private val appPrefsWrapper: AppPrefsWrapper,
 ) {
-    fun isAvailable(): Boolean = isAvailable(applyRolloutBucket = true)
-
-    fun isAvailableForDeepLink(): Boolean = isAvailable(applyRolloutBucket = false)
-
     @Suppress("ReturnCount")
-    private fun isAvailable(applyRolloutBucket: Boolean): Boolean {
+    fun isAvailable(): Boolean {
         val flagState = featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)
         val override = flagState.overrideValue
         if (override != null) {
             if (!override) return false
         } else {
             if (flagState.remoteValue != true) return false
-            if (applyRolloutBucket && getOrAssignRolloutBucket() !in ROLLOUT_BUCKETS_ENABLED) {
+            if (getOrAssignRolloutBucket() !in ROLLOUT_BUCKETS_ENABLED) {
                 WooLog.d(WooLog.T.LOGIN, "QR login unavailable: outside rollout bucket")
                 return false
             }
@@ -61,6 +57,11 @@ class QrLoginAvailability @Inject constructor(
         }
 
         return true
+    }
+
+    fun isAvailableForDeepLink(): Boolean {
+        val flagState = featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)
+        return flagState.overrideValue ?: (flagState.remoteValue == true)
     }
 
     private fun getOrAssignRolloutBucket(): Int =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -32,5 +32,5 @@ enum class FeatureFlag(
     BOOKINGS_RESCHEDULE("bookings_reschedule", localValue = PackageUtils.isDebugBuild()),
     WOO_SELF_DRIVEN_PUSH_NOTIFICATIONS_M1("woo_self_driven_push_notifications_m1", localValue = false),
     LOGGED_OUT_FF_PANEL("logged_out_ff_panel", localValue = PackageUtils.isDebugBuild()),
-    QR_LOGIN("qr_login", localValue = PackageUtils.isDebugBuild()),
+    QR_LOGIN("woo_qr_code_login", localValue = true),
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
@@ -1,14 +1,18 @@
 package com.woocommerce.android.ui.login.qrlogin
 
+import com.woocommerce.android.AppPrefsWrapper
 import com.woocommerce.android.util.DeviceFeatures
 import com.woocommerce.android.util.FeatureFlag
 import com.woocommerce.android.util.FeatureFlagRepository
+import com.woocommerce.android.util.FeatureFlagRepository.FeatureFlagState
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -16,23 +20,32 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
 
     private val featureFlagRepository: FeatureFlagRepository = mock()
     private val deviceFeatures: DeviceFeatures = mock()
+    private val appPrefsWrapper: AppPrefsWrapper = mock()
 
-    private val availability = QrLoginAvailability(featureFlagRepository, deviceFeatures)
+    private val availability = QrLoginAvailability(featureFlagRepository, deviceFeatures, appPrefsWrapper)
 
     @Before
     fun setUp() {
-        whenever(featureFlagRepository.isEnabled(FeatureFlag.QR_LOGIN)).thenReturn(true)
+        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)).thenReturn(flagState(remote = true))
         whenever(deviceFeatures.hasCamera()).thenReturn(true)
+        whenever(appPrefsWrapper.qrLoginRolloutBucket).thenReturn(1)
     }
 
     @Test
-    fun `given flag enabled and camera present, when isAvailable, then true`() {
+    fun `given flag enabled, bucket in rollout, camera present, when isAvailable, then true`() {
         assertThat(availability.isAvailable()).isTrue()
     }
 
     @Test
-    fun `given feature flag disabled, when isAvailable, then false`() {
-        whenever(featureFlagRepository.isEnabled(FeatureFlag.QR_LOGIN)).thenReturn(false)
+    fun `given remote flag false, when isAvailable, then false`() {
+        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)).thenReturn(flagState(remote = false))
+
+        assertThat(availability.isAvailable()).isFalse()
+    }
+
+    @Test
+    fun `given remote flag not loaded, when isAvailable, then false`() {
+        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)).thenReturn(flagState(remote = null))
 
         assertThat(availability.isAvailable()).isFalse()
     }
@@ -43,4 +56,43 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
 
         assertThat(availability.isAvailable()).isFalse()
     }
+
+    @Test
+    fun `given bucket outside rollout, when isAvailable, then false`() {
+        whenever(appPrefsWrapper.qrLoginRolloutBucket).thenReturn(2)
+
+        assertThat(availability.isAvailable()).isFalse()
+    }
+
+    @Test
+    fun `given override enabled and remote disabled, when isAvailable, then true`() {
+        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN))
+            .thenReturn(flagState(remote = false, override = true))
+
+        assertThat(availability.isAvailable()).isTrue()
+    }
+
+    @Test
+    fun `given override disabled, when isAvailable, then false even if bucket in rollout`() {
+        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN))
+            .thenReturn(flagState(remote = true, override = false))
+
+        assertThat(availability.isAvailable()).isFalse()
+    }
+
+    @Test
+    fun `given no bucket assigned, when isAvailable, then bucket is generated and persisted`() {
+        whenever(appPrefsWrapper.qrLoginRolloutBucket).thenReturn(null)
+
+        availability.isAvailable()
+
+        verify(appPrefsWrapper).qrLoginRolloutBucket = argThat<Int> { this in 1..10 }
+    }
+
+    private fun flagState(remote: Boolean?, override: Boolean? = null) = FeatureFlagState(
+        flag = FeatureFlag.QR_LOGIN,
+        localValue = FeatureFlag.QR_LOGIN.localValue,
+        remoteValue = remote,
+        overrideValue = override
+    )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
@@ -120,10 +120,10 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given no camera, when isAvailableForDeepLink, then false`() {
-        whenever(deviceFeatures.hasCamera()).thenReturn(false)
+    fun `when isAvailableForDeepLink, then camera presence is not checked`() {
+        availability.isAvailableForDeepLink()
 
-        assertThat(availability.isAvailableForDeepLink()).isFalse()
+        verify(deviceFeatures, never()).hasCamera()
     }
 
     private fun flagState(remote: Boolean?, override: Boolean? = null) = FeatureFlagState(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailabilityTest.kt
@@ -12,6 +12,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -87,6 +88,42 @@ class QrLoginAvailabilityTest : BaseUnitTest() {
         availability.isAvailable()
 
         verify(appPrefsWrapper).qrLoginRolloutBucket = argThat<Int> { this in 1..10 }
+    }
+
+    @Test
+    fun `given remote true, when isAvailableForDeepLink, then true regardless of bucket`() {
+        assertThat(availability.isAvailableForDeepLink()).isTrue()
+
+        verify(appPrefsWrapper, never()).qrLoginRolloutBucket
+    }
+
+    @Test
+    fun `given remote false, when isAvailableForDeepLink, then false`() {
+        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)).thenReturn(flagState(remote = false))
+
+        assertThat(availability.isAvailableForDeepLink()).isFalse()
+    }
+
+    @Test
+    fun `given remote not loaded, when isAvailableForDeepLink, then false`() {
+        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN)).thenReturn(flagState(remote = null))
+
+        assertThat(availability.isAvailableForDeepLink()).isFalse()
+    }
+
+    @Test
+    fun `given override disabled, when isAvailableForDeepLink, then false`() {
+        whenever(featureFlagRepository.getFlagState(FeatureFlag.QR_LOGIN))
+            .thenReturn(flagState(remote = true, override = false))
+
+        assertThat(availability.isAvailableForDeepLink()).isFalse()
+    }
+
+    @Test
+    fun `given no camera, when isAvailableForDeepLink, then false`() {
+        whenever(deviceFeatures.hasCamera()).thenReturn(false)
+
+        assertThat(availability.isAvailableForDeepLink()).isFalse()
     }
 
     private fun flagState(remote: Boolean?, override: Boolean? = null) = FeatureFlagState(


### PR DESCRIPTION
### Description

Adds a per-install rollout bucket so only ~10% of installs see the in-app QR login entry point when the remote feature flag is on. The bucket is generated once (1–10) and persisted in `SharedPreferences`, so the decision is stable across restarts.

**Default-off when the remote flag is unknown.** Because the entry point lives in the login flow, the remote FF may not have loaded yet on a cold start. `QrLoginAvailability` now requires an explicit `remoteValue == true` — `null` (not yet loaded) and `false` both gate the feature off. Only a dev override bypasses this.

The bucket only restricts in-app discovery. The deep-link path (`isAvailableForDeepLink`) bypasses the bucket: if a user is already in the flow from elsewhere (scanned a QR from wp-admin with a 3rd-party camera), we honor that intent. The camera check is also skipped on this path — the user already has the token, no in-app scanning needed. The remote-flag default-off behavior still applies.

### Test Steps

1. Fresh install, remote `woo_qr_code_login` = `false` (or not yet loaded) → no QR entry point on the login prologue; scanning a wp-admin QR via 3rd-party camera should *not* enter the flow.
2. Remote `true`, no override:
   - Repeat install until your bucket is 1 → entry point appears.
   - Bucket ≠ 1 → entry point hidden.
   - From either case, scanning a QR via 3rd-party camera enters the flow (deep-link bypasses bucket).
3. Set a debug override = `true` on `QR_LOGIN` → entry point appears regardless of remote/bucket.
4. Wipe app data, open the app once → bucket is generated and persisted (verify via subsequent reads being stable).

### AI Test Results
Results of running the different combinations on emulator:

<img width="1000" height="701" alt="Screenshot 2026-05-15 at 12 27 02" src="https://github.com/user-attachments/assets/6a137e32-ff01-43d3-b638-c3a6443d54cd" />

### Images/gif

N/A — no UI change.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.