### PR TITLE
[WOOMOB-3072] Add AI support chat message feedback

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -213,7 +213,7 @@ private fun MessageBubble(
                 .align(if (isUser) Alignment.CenterEnd else Alignment.CenterStart)
         ) {
             Surface(
-                shape = RoundedCornerShape(16.dp),
+                shape = RoundedCornerShape(MESSAGE_BUBBLE_CORNER_RADIUS),
                 color = if (isUser) {
                     MaterialTheme.colorScheme.primary
                 } else {
@@ -262,7 +262,7 @@ private fun MessageFeedback(
             null -> {
                 IconButton(
                     onClick = { onFeedbackClicked(messageId, AiSupportChatFeedbackRating.UP) },
-                    modifier = Modifier.size(40.dp)
+                    modifier = Modifier.size(FEEDBACK_BUTTON_SIZE)
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.ic_thumb_up),
@@ -272,7 +272,7 @@ private fun MessageFeedback(
                 }
                 IconButton(
                     onClick = { onFeedbackClicked(messageId, AiSupportChatFeedbackRating.DOWN) },
-                    modifier = Modifier.size(40.dp)
+                    modifier = Modifier.size(FEEDBACK_BUTTON_SIZE)
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.ic_thumb_down),
@@ -302,7 +302,7 @@ private fun RatedFeedback(
         painter = painterResource(icon),
         contentDescription = null,
         tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.size(18.dp)
+        modifier = Modifier.size(RATED_FEEDBACK_ICON_SIZE)
     )
     Spacer(modifier = Modifier.width(dimensionResource(R.dimen.minor_50)))
     Text(
@@ -496,7 +496,7 @@ private fun TypingIndicator(modifier: Modifier = Modifier) {
     val typingDescription = stringResource(R.string.ai_support_chat_typing)
     BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
         Surface(
-            shape = RoundedCornerShape(16.dp),
+            shape = RoundedCornerShape(MESSAGE_BUBBLE_CORNER_RADIUS),
             color = MaterialTheme.colorScheme.surface,
             border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
             shadowElevation = 1.dp,
@@ -518,7 +518,7 @@ private fun TypingIndicator(modifier: Modifier = Modifier) {
                 CircularProgressIndicator(
                     strokeWidth = 2.dp,
                     color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.size(16.dp)
+                    modifier = Modifier.size(TYPING_INDICATOR_SIZE)
                 )
                 Spacer(modifier = Modifier.width(dimensionResource(R.dimen.minor_100)))
                 AnimatedTypingText()
@@ -695,3 +695,7 @@ private fun AiSupportChatScreenPreview() {
 }
 
 private const val MAX_BUBBLE_WIDTH_FRACTION = 0.88f
+private val MESSAGE_BUBBLE_CORNER_RADIUS = 16.dp
+private val FEEDBACK_BUTTON_SIZE = 48.dp
+private val RATED_FEEDBACK_ICON_SIZE = 18.dp
+private val TYPING_INDICATOR_SIZE = 16.dp

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -75,7 +75,6 @@ fun AiSupportChatScreen(viewModel: AiSupportChatViewModel) {
         onInputChanged = viewModel::onInputChanged,
         onSendClicked = viewModel::onSendClicked,
         onIssueSelected = viewModel::onIssueSelected,
-        onRetryDiagnosticsClicked = viewModel::onRetryDiagnosticsClicked,
         onContinueAfterDiagnosticsClicked = viewModel::onContinueAfterDiagnosticsClicked,
         onContactSupportClicked = { viewModel.onContactSupportClicked(HumanSupportContactSource.BANNER) },
         onContactSupportFromErrorClicked = {
@@ -92,7 +91,6 @@ fun AiSupportChatScreen(
     onInputChanged: (String) -> Unit,
     onSendClicked: () -> Unit,
     onIssueSelected: (SupportIssueType, String) -> Unit,
-    onRetryDiagnosticsClicked: () -> Unit,
     onContinueAfterDiagnosticsClicked: () -> Unit,
     onContactSupportClicked: () -> Unit,
     onContactSupportFromErrorClicked: () -> Unit,
@@ -111,7 +109,6 @@ fun AiSupportChatScreen(
             isSending = viewState.isSending,
             showDiagnosticActions = viewState.showDiagnosticActions,
             onIssueSelected = onIssueSelected,
-            onRetryDiagnosticsClicked = onRetryDiagnosticsClicked,
             onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked,
             onFeedbackClicked = onFeedbackClicked,
             modifier = Modifier
@@ -150,7 +147,6 @@ private fun MessageList(
     isSending: Boolean,
     showDiagnosticActions: Boolean,
     onIssueSelected: (SupportIssueType, String) -> Unit,
-    onRetryDiagnosticsClicked: () -> Unit,
     onContinueAfterDiagnosticsClicked: () -> Unit,
     onFeedbackClicked: (Long, AiSupportChatFeedbackRating) -> Unit,
     modifier: Modifier = Modifier
@@ -179,7 +175,6 @@ private fun MessageList(
                 feedbackRating = message.messageId?.let { messageRatings[it] },
                 showDiagnosticActions = showDiagnosticActions,
                 onIssueSelected = onIssueSelected,
-                onRetryDiagnosticsClicked = onRetryDiagnosticsClicked,
                 onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked,
                 onFeedbackClicked = onFeedbackClicked
             )
@@ -199,7 +194,6 @@ private fun MessageBubble(
     feedbackRating: AiSupportChatFeedbackRating?,
     showDiagnosticActions: Boolean,
     onIssueSelected: (SupportIssueType, String) -> Unit,
-    onRetryDiagnosticsClicked: () -> Unit,
     onContinueAfterDiagnosticsClicked: () -> Unit,
     onFeedbackClicked: (Long, AiSupportChatFeedbackRating) -> Unit,
     modifier: Modifier = Modifier
@@ -233,7 +227,6 @@ private fun MessageBubble(
                     textColor = textColor,
                     showDiagnosticActions = showDiagnosticActions,
                     onIssueSelected = onIssueSelected,
-                    onRetryDiagnosticsClicked = onRetryDiagnosticsClicked,
                     onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked
                 )
             }
@@ -325,7 +318,6 @@ private fun MessageContent(
     textColor: Color,
     showDiagnosticActions: Boolean,
     onIssueSelected: (SupportIssueType, String) -> Unit,
-    onRetryDiagnosticsClicked: () -> Unit,
     onContinueAfterDiagnosticsClicked: () -> Unit
 ) {
     when (content) {
@@ -349,14 +341,12 @@ private fun MessageContent(
             result = content.result,
             textColor = textColor,
             showDiagnosticActions = showDiagnosticActions,
-            onRetryDiagnosticsClicked = onRetryDiagnosticsClicked,
             onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked
         )
         is AiSupportChatMessageContent.DiagnosticsFailure -> DiagnosticsContent(
             result = content.result,
             textColor = textColor,
             showDiagnosticActions = showDiagnosticActions,
-            onRetryDiagnosticsClicked = onRetryDiagnosticsClicked,
             onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked
         )
     }
@@ -406,7 +396,6 @@ private fun DiagnosticsContent(
     result: DiagnosticResult,
     textColor: Color,
     showDiagnosticActions: Boolean,
-    onRetryDiagnosticsClicked: () -> Unit,
     onContinueAfterDiagnosticsClicked: () -> Unit
 ) {
     val hasFailure = result.firstFailure != null
@@ -696,7 +685,6 @@ private fun AiSupportChatScreenPreview() {
             onInputChanged = {},
             onSendClicked = {},
             onIssueSelected = { _, _ -> },
-            onRetryDiagnosticsClicked = {},
             onContinueAfterDiagnosticsClicked = {},
             onContactSupportClicked = {},
             onContactSupportFromErrorClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -44,6 +46,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
@@ -78,7 +81,8 @@ fun AiSupportChatScreen(viewModel: AiSupportChatViewModel) {
         onContactSupportFromErrorClicked = {
             viewModel.onContactSupportClicked(HumanSupportContactSource.ERROR_DIALOG)
         },
-        onSendErrorDismissed = viewModel::onSendErrorDismissed
+        onSendErrorDismissed = viewModel::onSendErrorDismissed,
+        onFeedbackClicked = viewModel::onFeedbackClicked
     )
 }
 
@@ -93,6 +97,7 @@ fun AiSupportChatScreen(
     onContactSupportClicked: () -> Unit,
     onContactSupportFromErrorClicked: () -> Unit,
     onSendErrorDismissed: () -> Unit,
+    onFeedbackClicked: (Long, AiSupportChatFeedbackRating) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -102,11 +107,13 @@ fun AiSupportChatScreen(
     ) {
         MessageList(
             messages = viewState.messages,
+            messageRatings = viewState.messageRatings,
             isSending = viewState.isSending,
             showDiagnosticActions = viewState.showDiagnosticActions,
             onIssueSelected = onIssueSelected,
             onRetryDiagnosticsClicked = onRetryDiagnosticsClicked,
             onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked,
+            onFeedbackClicked = onFeedbackClicked,
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
@@ -139,11 +146,13 @@ fun AiSupportChatScreen(
 @Composable
 private fun MessageList(
     messages: List<AiSupportChatMessage>,
+    messageRatings: Map<Long, AiSupportChatFeedbackRating>,
     isSending: Boolean,
     showDiagnosticActions: Boolean,
     onIssueSelected: (SupportIssueType, String) -> Unit,
     onRetryDiagnosticsClicked: () -> Unit,
     onContinueAfterDiagnosticsClicked: () -> Unit,
+    onFeedbackClicked: (Long, AiSupportChatFeedbackRating) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val listState = rememberLazyListState()
@@ -167,10 +176,12 @@ private fun MessageList(
         items(messages, key = { it.id }) { message ->
             MessageBubble(
                 message = message,
+                feedbackRating = message.messageId?.let { messageRatings[it] },
                 showDiagnosticActions = showDiagnosticActions,
                 onIssueSelected = onIssueSelected,
                 onRetryDiagnosticsClicked = onRetryDiagnosticsClicked,
-                onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked
+                onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked,
+                onFeedbackClicked = onFeedbackClicked
             )
         }
 
@@ -185,10 +196,12 @@ private fun MessageList(
 @Composable
 private fun MessageBubble(
     message: AiSupportChatMessage,
+    feedbackRating: AiSupportChatFeedbackRating?,
     showDiagnosticActions: Boolean,
     onIssueSelected: (SupportIssueType, String) -> Unit,
     onRetryDiagnosticsClicked: () -> Unit,
     onContinueAfterDiagnosticsClicked: () -> Unit,
+    onFeedbackClicked: (Long, AiSupportChatFeedbackRating) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val isUser = message.role == AiSupportChatMessageRole.USER
@@ -200,29 +213,110 @@ private fun MessageBubble(
     BoxWithConstraints(
         modifier = modifier.fillMaxWidth(),
     ) {
-        Surface(
-            shape = RoundedCornerShape(16.dp),
-            color = if (isUser) {
-                MaterialTheme.colorScheme.primary
-            } else {
-                MaterialTheme.colorScheme.surface
-            },
-            border = if (isUser) null else BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-            shadowElevation = if (isUser) 0.dp else 1.dp,
+        Column(
             modifier = Modifier
                 .widthIn(max = maxWidth * MAX_BUBBLE_WIDTH_FRACTION)
                 .align(if (isUser) Alignment.CenterEnd else Alignment.CenterStart)
         ) {
-            MessageContent(
-                content = message.content,
-                textColor = textColor,
-                showDiagnosticActions = showDiagnosticActions,
-                onIssueSelected = onIssueSelected,
-                onRetryDiagnosticsClicked = onRetryDiagnosticsClicked,
-                onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = if (isUser) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.surface
+                },
+                border = if (isUser) null else BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+                shadowElevation = if (isUser) 0.dp else 1.dp
+            ) {
+                MessageContent(
+                    content = message.content,
+                    textColor = textColor,
+                    showDiagnosticActions = showDiagnosticActions,
+                    onIssueSelected = onIssueSelected,
+                    onRetryDiagnosticsClicked = onRetryDiagnosticsClicked,
+                    onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked
+                )
+            }
+            if (message.canShowFeedback()) {
+                MessageFeedback(
+                    messageId = requireNotNull(message.messageId),
+                    rating = feedbackRating,
+                    onFeedbackClicked = onFeedbackClicked,
+                    modifier = Modifier.padding(top = dimensionResource(R.dimen.minor_100))
+                )
+            }
+        }
+    }
+}
+
+private fun AiSupportChatMessage.canShowFeedback(): Boolean =
+    role == AiSupportChatMessageRole.BOT &&
+        messageId != null &&
+        content is AiSupportChatMessageContent.Text
+
+@Composable
+private fun MessageFeedback(
+    messageId: Long,
+    rating: AiSupportChatFeedbackRating?,
+    onFeedbackClicked: (Long, AiSupportChatFeedbackRating) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        when (rating) {
+            null -> {
+                IconButton(
+                    onClick = { onFeedbackClicked(messageId, AiSupportChatFeedbackRating.UP) },
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_thumb_up),
+                        contentDescription = stringResource(R.string.ai_feedback_form_positive_button),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                IconButton(
+                    onClick = { onFeedbackClicked(messageId, AiSupportChatFeedbackRating.DOWN) },
+                    modifier = Modifier.size(40.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_thumb_down),
+                        contentDescription = stringResource(R.string.ai_feedback_form_negative_button),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            AiSupportChatFeedbackRating.UP -> RatedFeedback(
+                icon = R.drawable.ic_thumb_up_filled_24dp,
+                text = stringResource(R.string.ai_support_chat_feedback_helpful)
+            )
+            AiSupportChatFeedbackRating.DOWN -> RatedFeedback(
+                icon = R.drawable.ic_thumb_down_filled_24dp,
+                text = stringResource(R.string.ai_support_chat_feedback_not_helpful)
             )
         }
     }
+}
+
+@Composable
+private fun RatedFeedback(
+    icon: Int,
+    text: String
+) {
+    Icon(
+        painter = painterResource(icon),
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(18.dp)
+    )
+    Spacer(modifier = Modifier.width(dimensionResource(R.dimen.minor_50)))
+    Text(
+        text = text,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodySmall
+    )
 }
 
 @Composable
@@ -614,7 +708,8 @@ private fun AiSupportChatScreenPreview() {
             onContinueAfterDiagnosticsClicked = {},
             onContactSupportClicked = {},
             onContactSupportFromErrorClicked = {},
-            onSendErrorDismissed = {}
+            onSendErrorDismissed = {},
+            onFeedbackClicked = { _, _ -> }
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -232,12 +232,18 @@ private fun MessageBubble(
                 )
             }
             if (message.canShowFeedback()) {
-                MessageFeedback(
-                    messageId = requireNotNull(message.messageId),
-                    rating = feedbackRating,
-                    onFeedbackClicked = onFeedbackClicked,
-                    modifier = Modifier.padding(top = dimensionResource(R.dimen.minor_100))
-                )
+                if (feedbackRating == null) {
+                    MessageFeedbackActions(
+                        messageId = requireNotNull(message.messageId),
+                        onFeedbackClicked = onFeedbackClicked,
+                        modifier = Modifier.padding(top = dimensionResource(R.dimen.minor_100))
+                    )
+                } else {
+                    MessageFeedback(
+                        rating = feedbackRating,
+                        modifier = Modifier.padding(top = dimensionResource(R.dimen.minor_100))
+                    )
+                }
             }
         }
     }
@@ -249,9 +255,8 @@ private fun AiSupportChatMessage.canShowFeedback(): Boolean =
         content is AiSupportChatMessageContent.Text
 
 @Composable
-private fun MessageFeedback(
+private fun MessageFeedbackActions(
     messageId: Long,
-    rating: AiSupportChatFeedbackRating?,
     onFeedbackClicked: (Long, AiSupportChatFeedbackRating) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -259,58 +264,59 @@ private fun MessageFeedback(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        when (rating) {
-            null -> {
-                IconButton(
-                    onClick = { onFeedbackClicked(messageId, AiSupportChatFeedbackRating.UP) },
-                    modifier = Modifier.size(FEEDBACK_BUTTON_SIZE)
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_thumb_up),
-                        contentDescription = stringResource(R.string.ai_feedback_form_positive_button),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                IconButton(
-                    onClick = { onFeedbackClicked(messageId, AiSupportChatFeedbackRating.DOWN) },
-                    modifier = Modifier.size(FEEDBACK_BUTTON_SIZE)
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_thumb_down),
-                        contentDescription = stringResource(R.string.ai_feedback_form_negative_button),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-            AiSupportChatFeedbackRating.UP -> RatedFeedback(
-                icon = R.drawable.ic_thumb_up_filled_24dp,
-                text = stringResource(R.string.ai_support_chat_feedback_helpful)
+        IconButton(
+            onClick = { onFeedbackClicked(messageId, AiSupportChatFeedbackRating.UP) },
+            modifier = Modifier.size(FEEDBACK_BUTTON_SIZE)
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_thumb_up),
+                contentDescription = stringResource(R.string.ai_feedback_form_positive_button),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            AiSupportChatFeedbackRating.DOWN -> RatedFeedback(
-                icon = R.drawable.ic_thumb_down_filled_24dp,
-                text = stringResource(R.string.ai_support_chat_feedback_not_helpful)
+        }
+        IconButton(
+            onClick = { onFeedbackClicked(messageId, AiSupportChatFeedbackRating.DOWN) },
+            modifier = Modifier.size(FEEDBACK_BUTTON_SIZE)
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_thumb_down),
+                contentDescription = stringResource(R.string.ai_feedback_form_negative_button),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
     }
 }
 
 @Composable
-private fun RatedFeedback(
-    icon: Int,
-    text: String
+private fun MessageFeedback(
+    rating: AiSupportChatFeedbackRating,
+    modifier: Modifier = Modifier
 ) {
-    Icon(
-        painter = painterResource(icon),
-        contentDescription = null,
-        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.size(RATED_FEEDBACK_ICON_SIZE)
-    )
-    Spacer(modifier = Modifier.width(dimensionResource(R.dimen.minor_50)))
-    Text(
-        text = text,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        style = MaterialTheme.typography.bodySmall
-    )
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val icon = when (rating) {
+            AiSupportChatFeedbackRating.UP -> R.drawable.ic_thumb_up_filled_24dp
+            AiSupportChatFeedbackRating.DOWN -> R.drawable.ic_thumb_down_filled_24dp
+        }
+        val text = when (rating) {
+            AiSupportChatFeedbackRating.UP -> stringResource(R.string.ai_support_chat_feedback_helpful)
+            AiSupportChatFeedbackRating.DOWN -> stringResource(R.string.ai_support_chat_feedback_not_helpful)
+        }
+        Icon(
+            painter = painterResource(icon),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(RATED_FEEDBACK_ICON_SIZE)
+        )
+        Spacer(modifier = Modifier.width(dimensionResource(R.dimen.minor_50)))
+        Text(
+            text = text,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -124,7 +124,7 @@ fun AiSupportChatScreen(
                 onContactSupportClicked = onContactSupportClicked,
                 modifier = Modifier.fillMaxWidth()
             )
-            else -> InputBar(
+            viewState.showInputBar -> InputBar(
                 input = viewState.input,
                 isSending = viewState.isSending,
                 enabled = viewState.canSendMessages,
@@ -438,14 +438,6 @@ private fun DiagnosticsContent(
                 )
             }
             Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.minor_100))) {
-                if (hasFailure) {
-                    WCOutlinedButton(
-                        onClick = onRetryDiagnosticsClicked,
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        Text(text = stringResource(R.string.ai_support_chat_diagnostics_retry))
-                    }
-                }
                 WCColoredButton(
                     onClick = onContinueAfterDiagnosticsClicked,
                     text = stringResource(R.string.ai_support_chat_diagnostics_continue),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -531,6 +531,9 @@ data class AiSupportChatViewState(
     val canSendMessages: Boolean
         get() = hasProceededToChat && !hasCreatedTicket
 
+    val showInputBar: Boolean
+        get() = canSendMessages && !showHumanSupportPrompt
+
     val showDiagnosticActions: Boolean
         get() {
             val result = diagnosticResult ?: return false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -74,6 +74,29 @@ class AiSupportChatViewModel @Inject constructor(
         _viewState.update { it.copy(showSendError = false) }
     }
 
+    fun onFeedbackClicked(messageId: Long, rating: AiSupportChatFeedbackRating) {
+        val state = _viewState.value
+        val chatId = state.chatId ?: return
+        val sessionId = state.sessionId ?: return
+        if (messageId in state.messageRatings) return
+
+        _viewState.update {
+            it.copy(messageRatings = it.messageRatings + (messageId to rating))
+        }
+
+        launch {
+            repository.submitFeedback(
+                botSlug = state.botSlug,
+                chatId = chatId,
+                messageId = messageId,
+                sessionId = sessionId,
+                upvoted = rating == AiSupportChatFeedbackRating.UP
+            ).onFailure { error ->
+                WooLog.e(WooLog.T.AI, "Submitting AI support chat feedback failed", error)
+            }
+        }
+    }
+
     fun onContactSupportClicked(source: HumanSupportContactSource) {
         val state = _viewState.value
         if (state.hasCreatedTicket || state.isSending) return
@@ -360,6 +383,7 @@ class AiSupportChatViewModel @Inject constructor(
             .map { message ->
                 AiSupportChatMessage(
                     id = "${message.role.wireValue}-${message.messageId}",
+                    messageId = if (message.role == SupportChatRole.BOT) message.messageId else null,
                     role = message.role.toUiRole(),
                     content = AiSupportChatMessageContent.Text(message.content)
                 )
@@ -498,7 +522,8 @@ data class AiSupportChatViewState(
     val hasCreatedTicket: Boolean = false,
     val hasSentChatMessage: Boolean = false,
     val completedUserMessageResponseCount: Int = 0,
-    val latestSupportArea: SupportChatSupportArea? = null
+    val latestSupportArea: SupportChatSupportArea? = null,
+    val messageRatings: Map<Long, AiSupportChatFeedbackRating> = emptyMap()
 ) {
     val canUseDiagnosticActions: Boolean
         get() = !hasProceededToChat && !isSending
@@ -526,6 +551,11 @@ enum class HumanSupportContactSource {
     ERROR_DIALOG
 }
 
+enum class AiSupportChatFeedbackRating {
+    UP,
+    DOWN
+}
+
 data class ContactHumanSupport(
     val chatId: Long?,
     val transcript: String,
@@ -535,6 +565,7 @@ data class ContactHumanSupport(
 
 data class AiSupportChatMessage(
     val id: String,
+    val messageId: Long? = null,
     val role: AiSupportChatMessageRole,
     val content: AiSupportChatMessageContent
 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/SupportChatRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/SupportChatRepository.kt
@@ -49,6 +49,22 @@ class SupportChatRepository @Inject constructor(
         restClient.fetchChat(botSlug = botSlug, chatId = chatId).toResult()
     }
 
+    suspend fun submitFeedback(
+        botSlug: String,
+        chatId: Long,
+        messageId: Long,
+        sessionId: String,
+        upvoted: Boolean
+    ): Result<Unit> = withContext(dispatchers.io) {
+        restClient.submitFeedback(
+            botSlug = botSlug,
+            chatId = chatId,
+            messageId = messageId,
+            sessionId = sessionId,
+            upvoted = upvoted
+        ).toResult()
+    }
+
     suspend fun registerChat(
         chatId: Long,
         botSlug: String,
@@ -81,7 +97,7 @@ class SupportChatRepository @Inject constructor(
         bookmarkDao.delete(chatId)
     }
 
-    private fun Response<SupportChatResponse>.toResult(): Result<SupportChatResponse> =
+    private fun <T> Response<T>.toResult(): Result<T> =
         when (this) {
             is Response.Success -> Result.success(data)
             is Response.Error -> Result.failure(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/networking/SupportChatRestClient.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/networking/SupportChatRestClient.kt
@@ -61,6 +61,24 @@ class SupportChatRestClient @Inject constructor(
         authenticatedRequest = isWpComAuthenticated()
     )
 
+    suspend fun submitFeedback(
+        botSlug: String,
+        chatId: Long,
+        messageId: Long,
+        sessionId: String,
+        upvoted: Boolean
+    ): Response<Unit> = wpComGsonRequestBuilder.syncPostRequest(
+        restClient = this,
+        url = "${chatUrl(botSlug, chatId)}$messageId/feedback",
+        params = null,
+        body = mapOf(
+            SESSION_ID_KEY to sessionId,
+            RATING_VALUE_KEY to if (upvoted) UPVOTE_RATING_VALUE else DOWNVOTE_RATING_VALUE
+        ),
+        clazz = Unit::class.java,
+        authenticatedRequest = isWpComAuthenticated()
+    )
+
     private fun chatUrl(botSlug: String): String = WPCOMV2.odie.chat.bot_slug(botSlug).url
 
     private fun chatUrl(botSlug: String, chatId: Long): String = WPCOMV2.odie.chat.bot_slug(botSlug).chat(chatId).url
@@ -71,5 +89,8 @@ class SupportChatRestClient @Inject constructor(
         private const val MESSAGE_KEY = "message"
         private const val CONTEXT_KEY = "context"
         private const val SESSION_ID_KEY = "session_id"
+        private const val RATING_VALUE_KEY = "rating_value"
+        private const val UPVOTE_RATING_VALUE = 1
+        private const val DOWNVOTE_RATING_VALUE = -1
     }
 }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2449,6 +2449,8 @@
     <string name="ai_support_chat_diagnostics_status_failed">Failed</string>
     <string name="ai_support_chat_connectivity_initial_message">Help me troubleshoot my store connection.</string>
     <string name="ai_support_chat_connectivity_action">Chat with support</string>
+    <string name="ai_support_chat_feedback_helpful">Helpful</string>
+    <string name="ai_support_chat_feedback_not_helpful">Not helpful</string>
 
     <string name="support_developer_section_title" translatable="false">DEVELOPER</string>
     <string name="support_override_feature_flags" translatable="false">Override Feature Flags</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -384,6 +384,98 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given bot response has server message id, when chat updates, then bot UI message keeps message id`() =
+        testBlocking {
+            val result = createSuccessDiagnosticResult()
+            val response = createResponse(
+                messages = listOf(
+                    createMessage(messageId = 1L, role = SupportChatRole.USER, content = ISSUE_DETAILS),
+                    createMessage(messageId = BOT_MESSAGE_ID, role = SupportChatRole.BOT, content = BOT_RESPONSE)
+                )
+            )
+            whenever(diagnosticsService.runDiagnostics(SupportIssueType.LOADING_ORDERS)).thenReturn(flowOf(result))
+            whenever(contextProvider.buildInitialContext(diagnosticResult = result)).thenReturn(CONTEXT)
+            whenever(repository.sendMessage(DEFAULT_BOT_SLUG, ISSUE_DETAILS, CONTEXT, null, null))
+                .thenReturn(Result.success(response))
+
+            continueToChatAfterSuccessfulDiagnostics(result)
+            viewModel.onInputChanged(ISSUE_DETAILS)
+            viewModel.onSendClicked()
+
+            val botMessage = viewModel.viewState.value.messages.single {
+                it.content == AiSupportChatMessageContent.Text(BOT_RESPONSE)
+            }
+            assertThat(botMessage.messageId).isEqualTo(BOT_MESSAGE_ID)
+        }
+
+    @Test
+    fun `given unrated bot response, when thumbs up clicked, then rating is stored and submitted`() =
+        testBlocking {
+            startChatWithBotResponse()
+            whenever(
+                repository.submitFeedback(
+                    DEFAULT_BOT_SLUG,
+                    CHAT_ID,
+                    BOT_MESSAGE_ID,
+                    SESSION_ID,
+                    true
+                )
+            ).thenReturn(Result.success(Unit))
+
+            viewModel.onFeedbackClicked(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.UP)
+
+            assertThat(viewModel.viewState.value.messageRatings)
+                .containsEntry(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.UP)
+            verify(repository).submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, BOT_MESSAGE_ID, SESSION_ID, true)
+        }
+
+    @Test
+    fun `given unrated bot response, when thumbs down clicked, then rating is stored and submitted`() =
+        testBlocking {
+            startChatWithBotResponse()
+            whenever(
+                repository.submitFeedback(
+                    DEFAULT_BOT_SLUG,
+                    CHAT_ID,
+                    BOT_MESSAGE_ID,
+                    SESSION_ID,
+                    false
+                )
+            ).thenReturn(Result.success(Unit))
+
+            viewModel.onFeedbackClicked(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.DOWN)
+
+            assertThat(viewModel.viewState.value.messageRatings)
+                .containsEntry(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.DOWN)
+            verify(repository).submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, BOT_MESSAGE_ID, SESSION_ID, false)
+        }
+
+    @Test
+    fun `given rated bot response, when feedback clicked again, then feedback is not submitted twice`() =
+        testBlocking {
+            startChatWithBotResponse()
+            whenever(repository.submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, BOT_MESSAGE_ID, SESSION_ID, true))
+                .thenReturn(Result.success(Unit))
+
+            viewModel.onFeedbackClicked(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.UP)
+            viewModel.onFeedbackClicked(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.DOWN)
+
+            assertThat(viewModel.viewState.value.messageRatings)
+                .containsEntry(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.UP)
+            verify(repository).submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, BOT_MESSAGE_ID, SESSION_ID, true)
+            verify(repository, never()).submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, BOT_MESSAGE_ID, SESSION_ID, false)
+        }
+
+    @Test
+    fun `given chat identifiers are missing, when feedback clicked, then feedback is not submitted`() =
+        testBlocking {
+            viewModel.onFeedbackClicked(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.UP)
+
+            assertThat(viewModel.viewState.value.messageRatings).isEmpty()
+            verify(repository, never()).submitFeedback(any(), any(), any(), any(), any())
+        }
+
+    @Test
     fun `given second user message has bot response, when chat updates, then toolbar support is available`() =
         testBlocking {
             val result = createSuccessDiagnosticResult()
@@ -711,6 +803,27 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         viewModel.onSendClicked()
     }
 
+    private suspend fun startChatWithBotResponse() {
+        val result = createSuccessDiagnosticResult()
+        whenever(diagnosticsService.runDiagnostics(SupportIssueType.LOADING_ORDERS)).thenReturn(flowOf(result))
+        whenever(contextProvider.buildInitialContext(diagnosticResult = result)).thenReturn(CONTEXT)
+        whenever(repository.sendMessage(DEFAULT_BOT_SLUG, ISSUE_DETAILS, CONTEXT, null, null))
+            .thenReturn(
+                Result.success(
+                    createResponse(
+                        messages = listOf(
+                            createMessage(messageId = 1L, role = SupportChatRole.USER, content = ISSUE_DETAILS),
+                            createMessage(messageId = BOT_MESSAGE_ID, role = SupportChatRole.BOT, content = BOT_RESPONSE)
+                        )
+                    )
+                )
+            )
+
+        continueToChatAfterSuccessfulDiagnostics(result)
+        viewModel.onInputChanged(ISSUE_DETAILS)
+        viewModel.onSendClicked()
+    }
+
     private fun createSuccessDiagnosticResult(issueType: SupportIssueType = SupportIssueType.LOADING_ORDERS) =
         DiagnosticResult(
             issueType = issueType,
@@ -763,6 +876,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         const val ISSUE_LABEL = "I can't see my orders"
         const val ISSUE_DETAILS = "My latest orders are missing"
         const val FOLLOW_UP_MESSAGE = "Still broken"
+        const val BOT_MESSAGE_ID = 2L
         const val BOT_RESPONSE = "Let's troubleshoot orders."
         const val FOLLOW_UP_BOT_RESPONSE = "Let's keep troubleshooting."
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -68,6 +68,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         assertThat(state.hasProceededToChat).isFalse()
         assertThat(state.hasStartedChat).isFalse()
         assertThat(state.canUseDiagnosticActions).isTrue()
+        assertThat(state.showInputBar).isFalse()
         assertThat(state.showDiagnosticActions).isFalse()
         assertThat(state.messages.map { it.content }).containsExactly(
             AiSupportChatMessageContent.Greeting,
@@ -170,6 +171,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             assertThat(state.hasProceededToChat).isTrue()
             assertThat(state.hasStartedChat).isFalse()
             assertThat(state.canUseDiagnosticActions).isFalse()
+            assertThat(state.showInputBar).isTrue()
             assertThat(state.showDiagnosticActions).isFalse()
             assertThat(state.messages.map { it.content }).containsExactly(
                 AiSupportChatMessageContent.Greeting,
@@ -354,6 +356,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             assertThat(state.showHumanSupportPrompt).isTrue
             assertThat(state.latestSupportArea).isEqualTo(supportArea)
             assertThat(state.canContactHumanSupportFromToolbar).isFalse
+            assertThat(state.showInputBar).isFalse
             assertThat(state.completedUserMessageResponseCount).isEqualTo(1)
             assertThat(state.messages.map { it.content }).doesNotContain(AiSupportChatMessageContent.Text(BOT_RESPONSE))
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -816,7 +816,11 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
                     createResponse(
                         messages = listOf(
                             createMessage(messageId = 1L, role = SupportChatRole.USER, content = ISSUE_DETAILS),
-                            createMessage(messageId = BOT_MESSAGE_ID, role = SupportChatRole.BOT, content = BOT_RESPONSE)
+                            createMessage(
+                                messageId = BOT_MESSAGE_ID,
+                                role = SupportChatRole.BOT,
+                                content = BOT_RESPONSE
+                            )
                         )
                     )
                 )

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/SupportChatRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/SupportChatRepositoryTest.kt
@@ -143,6 +143,41 @@ class SupportChatRepositoryTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given successful feedback response, when submitting feedback, then success result is returned`() = testBlocking {
+        whenever(restClient.submitFeedback(BOT_SLUG, CHAT_ID, MESSAGE_ID, SESSION_ID, true))
+            .thenReturn(Response.Success(Unit, emptyList()))
+
+        val result = repository.submitFeedback(
+            botSlug = BOT_SLUG,
+            chatId = CHAT_ID,
+            messageId = MESSAGE_ID,
+            sessionId = SESSION_ID,
+            upvoted = true
+        )
+
+        assertThat(result.isSuccess).isTrue
+        verify(restClient).submitFeedback(BOT_SLUG, CHAT_ID, MESSAGE_ID, SESSION_ID, true)
+    }
+
+    @Test
+    fun `given failed feedback response, when submitting feedback, then failure result is returned`() = testBlocking {
+        whenever(restClient.submitFeedback(BOT_SLUG, CHAT_ID, MESSAGE_ID, SESSION_ID, false))
+            .thenReturn(Response.Error(createNetworkError()))
+
+        val result = repository.submitFeedback(
+            botSlug = BOT_SLUG,
+            chatId = CHAT_ID,
+            messageId = MESSAGE_ID,
+            sessionId = SESSION_ID,
+            upvoted = false
+        )
+
+        val exception = requireNotNull(result.exceptionOrNull()) as SupportChatRepositoryException
+        assertThat(exception.message).isEqualTo(ERROR_MESSAGE)
+        assertThat(exception.type).isEqualTo(BaseRequest.GenericErrorType.NOT_FOUND.name)
+    }
+
+    @Test
     fun `given first message, when registering chat, then bookmark is created with metadata and clamped title`() =
         testBlocking {
             stubSelectedSite()
@@ -253,6 +288,7 @@ class SupportChatRepositoryTest : BaseUnitTest() {
     private companion object {
         const val BOT_SLUG = "woo-workflow-support_mobile_inapp_all_users"
         const val CHAT_ID = 1234L
+        const val MESSAGE_ID = 5678L
         const val SESSION_ID = "session-abc-123"
         const val LOCAL_SITE_ID = 10
         const val REMOTE_SITE_ID = 20L

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/networking/SupportChatRestClientTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/networking/SupportChatRestClientTest.kt
@@ -161,7 +161,10 @@ class SupportChatRestClientTest : BaseUnitTest() {
             )
 
             assertThat(urlCaptor.firstValue)
-                .isEqualTo("https://public-api.wordpress.com/wpcom/v2/odie/chat/$BOT_SLUG/$CHAT_ID/$MESSAGE_ID/feedback")
+                .isEqualTo(
+                    "https://public-api.wordpress.com/wpcom/v2/odie/chat/" +
+                        "$BOT_SLUG/$CHAT_ID/$MESSAGE_ID/feedback"
+                )
             assertThat(bodyCaptor.firstValue).containsOnlyKeys("session_id", "rating_value")
             assertThat(bodyCaptor.firstValue["session_id"]).isEqualTo(SESSION_ID)
             assertThat(bodyCaptor.firstValue["rating_value"]).isEqualTo(1)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/networking/SupportChatRestClientTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/networking/SupportChatRestClientTest.kt
@@ -148,6 +148,53 @@ class SupportChatRestClientTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given thumbs up feedback, when submitFeedback, then posts to feedback URL with positive rating`() =
+        testBlocking {
+            stubFeedbackPostResponse()
+
+            restClient.submitFeedback(
+                botSlug = BOT_SLUG,
+                chatId = CHAT_ID,
+                messageId = MESSAGE_ID,
+                sessionId = SESSION_ID,
+                upvoted = true
+            )
+
+            assertThat(urlCaptor.firstValue)
+                .isEqualTo("https://public-api.wordpress.com/wpcom/v2/odie/chat/$BOT_SLUG/$CHAT_ID/$MESSAGE_ID/feedback")
+            assertThat(bodyCaptor.firstValue).containsOnlyKeys("session_id", "rating_value")
+            assertThat(bodyCaptor.firstValue["session_id"]).isEqualTo(SESSION_ID)
+            assertThat(bodyCaptor.firstValue["rating_value"]).isEqualTo(1)
+            assertThat(postAuthenticatedRequestCaptor.firstValue).isFalse()
+        }
+
+    @Test
+    fun `given thumbs down feedback, when submitFeedback, then posts negative rating`() =
+        testBlocking {
+            stubFeedbackPostResponse()
+
+            restClient.submitFeedback(
+                botSlug = BOT_SLUG,
+                chatId = CHAT_ID,
+                messageId = MESSAGE_ID,
+                sessionId = SESSION_ID,
+                upvoted = false
+            )
+
+            assertThat(bodyCaptor.firstValue["rating_value"]).isEqualTo(-1)
+        }
+
+    @Test
+    fun `given wpcom access token, when submitFeedback, then request is authenticated`() = testBlocking {
+        whenever(accessToken.exists()).thenReturn(true)
+        stubFeedbackPostResponse()
+
+        restClient.submitFeedback(BOT_SLUG, CHAT_ID, MESSAGE_ID, SESSION_ID, true)
+
+        assertThat(postAuthenticatedRequestCaptor.firstValue).isTrue()
+    }
+
+    @Test
     fun `given successful response, when sendMessage, then Success is propagated`() = testBlocking {
         val data = supportChatResponse()
         stubPostResponse(data = data)
@@ -220,6 +267,21 @@ class SupportChatRestClientTest : BaseUnitTest() {
         ).thenReturn(response)
     }
 
+    private suspend fun stubFeedbackPostResponse() {
+        whenever(
+            wpComGsonRequestBuilder.syncPostRequest(
+                restClient = eq(restClient),
+                url = urlCaptor.capture(),
+                params = anyOrNull(),
+                body = bodyCaptor.capture(),
+                clazz = eq(Unit::class.java),
+                retryPolicy = anyOrNull(),
+                headers = any(),
+                authenticatedRequest = postAuthenticatedRequestCaptor.capture()
+            )
+        ).thenReturn(Response.Success(Unit, emptyList()))
+    }
+
     private suspend fun stubGetResponse(
         data: SupportChatResponse = supportChatResponse(),
         error: WPComGsonNetworkError? = null
@@ -254,6 +316,7 @@ class SupportChatRestClientTest : BaseUnitTest() {
     private companion object {
         const val BOT_SLUG = "woo-workflow-support_mobile_inapp_all_users"
         const val CHAT_ID = 4242L
+        const val MESSAGE_ID = 2424L
         const val SESSION_ID = "session-abc-123"
         const val MESSAGE = "I can't load my orders"
     }


### PR DESCRIPTION
### Description
Fixes WOOMOB-3072

Adds per-message feedback to AI support chat bot responses. Bot text messages now keep their Odie server message ID, show thumbs up/down controls when feedback is available, and optimistically store the selected rating in memory for the current chat session. Feedback is submitted to the Odie feedback endpoint with the chat ID, message ID, session ID, and upvote/downvote value.

This also hides the chat input while the issue picker is shown and removes the diagnostics retry button so users continue into chat after troubleshooting.

### Test Steps
1. Open AI support chat from the Help entry point.
2. Confirm the initial issue picker is shown without the message input area.
3. Select an issue and continue into chat after diagnostics.
4. Send a message and confirm bot text responses show thumbs up/down feedback controls.
5. Tap thumbs up or thumbs down and confirm the controls change to the selected Helpful or Not helpful state.
6. Confirm tapping the selected message again does not submit another rating.

### Images/gif

[Screen_recording_20260515_160426.webm](https://github.com/user-attachments/assets/384e114a-32e6-4b63-8c46-10230afcde5d)


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.