### PR TITLE
[WOOMOB-3073] Add resolved chat state to AI support chat

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatActivity.kt
@@ -19,8 +19,11 @@ import dagger.hilt.android.AndroidEntryPoint
 class AiSupportChatActivity : AppCompatActivity() {
     private lateinit var binding: ActivityAiSupportChatBinding
     private var contactSupportMenuItem: MenuItem? = null
+    private var markResolvedMenuItem: MenuItem? = null
     private var isContactSupportActionVisible = false
+    private var isMarkResolvedActionVisible = false
     var onContactSupportClicked: (() -> Unit)? = null
+    var onMarkResolvedClicked: (() -> Unit)? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -44,7 +47,9 @@ class AiSupportChatActivity : AppCompatActivity() {
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu_ai_support_chat, menu)
         contactSupportMenuItem = menu.findItem(R.id.menu_contact_support)
+        markResolvedMenuItem = menu.findItem(R.id.menu_mark_resolved)
         contactSupportMenuItem?.isVisible = isContactSupportActionVisible
+        markResolvedMenuItem?.isVisible = isMarkResolvedActionVisible
         return true
     }
 
@@ -58,6 +63,10 @@ class AiSupportChatActivity : AppCompatActivity() {
                 onContactSupportClicked?.invoke()
                 return true
             }
+            R.id.menu_mark_resolved -> {
+                onMarkResolvedClicked?.invoke()
+                return true
+            }
         }
         return super.onOptionsItemSelected(item)
     }
@@ -65,6 +74,11 @@ class AiSupportChatActivity : AppCompatActivity() {
     fun setContactSupportActionVisible(isVisible: Boolean) {
         isContactSupportActionVisible = isVisible
         contactSupportMenuItem?.isVisible = isVisible
+    }
+
+    fun setMarkResolvedActionVisible(isVisible: Boolean) {
+        isMarkResolvedActionVisible = isVisible
+        markResolvedMenuItem?.isVisible = isVisible
     }
 
     companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatFragment.kt
@@ -62,7 +62,9 @@ class AiSupportChatFragment : Fragment() {
         super.onDestroyView()
         (activity as? AiSupportChatActivity)?.apply {
             onContactSupportClicked = null
+            onMarkResolvedClicked = null
             setContactSupportActionVisible(false)
+            setMarkResolvedActionVisible(false)
         }
         hideProgressDialog()
     }
@@ -71,6 +73,7 @@ class AiSupportChatFragment : Fragment() {
         (activity as? AiSupportChatActivity)?.onContactSupportClicked = {
             viewModel.onContactSupportClicked(HumanSupportContactSource.TOOLBAR)
         }
+        (activity as? AiSupportChatActivity)?.onMarkResolvedClicked = viewModel::onMarkResolvedClicked
     }
 
     private fun observeViewState() {
@@ -79,6 +82,8 @@ class AiSupportChatFragment : Fragment() {
                 viewModel.viewState.collect { state ->
                     (activity as? AiSupportChatActivity)
                         ?.setContactSupportActionVisible(state.canContactHumanSupportFromToolbar)
+                    (activity as? AiSupportChatActivity)
+                        ?.setMarkResolvedActionVisible(state.shouldShowResolvedButton)
                 }
             }
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -633,7 +633,7 @@ private fun SendErrorDialog(
             onClick = onContactSupportClicked
         ),
         negativeButton = DialogState.DialogButton(
-            text = R.string.ai_support_chat_mark_resolved_cancel,
+            text = R.string.ai_support_chat_error_dismiss,
             onClick = onDismiss
         ),
         isCancelable = false,
@@ -654,7 +654,7 @@ private fun MarkResolvedConfirmationDialog(
             onClick = onConfirm
         ),
         negativeButton = DialogState.DialogButton(
-            text = R.string.ai_support_chat_error_dismiss,
+            text = R.string.ai_support_chat_mark_resolved_cancel,
             onClick = onDismiss
         ),
         isCancelable = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -633,7 +633,7 @@ private fun SendErrorDialog(
             onClick = onContactSupportClicked
         ),
         negativeButton = DialogState.DialogButton(
-            text = R.string.ai_support_chat_error_dismiss,
+            text = R.string.ai_support_chat_mark_resolved_cancel,
             onClick = onDismiss
         ),
         isCancelable = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -37,7 +36,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -62,6 +60,8 @@ import com.woocommerce.android.ui.aisupportchat.diagnostics.DiagnosticStatus
 import com.woocommerce.android.ui.aisupportchat.diagnostics.DiagnosticTest
 import com.woocommerce.android.ui.aisupportchat.diagnostics.SupportIssueType
 import com.woocommerce.android.ui.aisupportchat.diagnostics.TestStatus
+import com.woocommerce.android.ui.compose.DialogState
+import com.woocommerce.android.ui.compose.Render
 import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
@@ -81,6 +81,8 @@ fun AiSupportChatScreen(viewModel: AiSupportChatViewModel) {
             viewModel.onContactSupportClicked(HumanSupportContactSource.ERROR_DIALOG)
         },
         onSendErrorDismissed = viewModel::onSendErrorDismissed,
+        onMarkResolvedConfirmed = viewModel::onMarkResolvedConfirmed,
+        onMarkResolvedDismissed = viewModel::onMarkResolvedDismissed,
         onFeedbackClicked = viewModel::onFeedbackClicked
     )
 }
@@ -95,6 +97,8 @@ fun AiSupportChatScreen(
     onContactSupportClicked: () -> Unit,
     onContactSupportFromErrorClicked: () -> Unit,
     onSendErrorDismissed: () -> Unit,
+    onMarkResolvedConfirmed: () -> Unit,
+    onMarkResolvedDismissed: () -> Unit,
     onFeedbackClicked: (Long, AiSupportChatFeedbackRating) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -117,6 +121,7 @@ fun AiSupportChatScreen(
         )
         when {
             viewState.hasCreatedTicket -> TicketCreatedBanner(modifier = Modifier.fillMaxWidth())
+            viewState.isChatResolved -> ChatResolvedBanner(modifier = Modifier.fillMaxWidth())
             viewState.showHumanSupportPrompt -> HumanSupportBanner(
                 onContactSupportClicked = onContactSupportClicked,
                 modifier = Modifier.fillMaxWidth()
@@ -136,6 +141,13 @@ fun AiSupportChatScreen(
         SendErrorDialog(
             onContactSupportClicked = onContactSupportFromErrorClicked,
             onDismiss = onSendErrorDismissed
+        )
+    }
+
+    if (viewState.showMarkResolvedConfirmation) {
+        MarkResolvedConfirmationDialog(
+            onConfirm = onMarkResolvedConfirmed,
+            onDismiss = onMarkResolvedDismissed
         )
     }
 }
@@ -245,6 +257,7 @@ private fun MessageBubble(
 private fun AiSupportChatMessage.canShowFeedback(): Boolean =
     role == AiSupportChatMessageRole.BOT &&
         messageId != null &&
+        !isResolved &&
         content is AiSupportChatMessageContent.Text
 
 @Composable
@@ -331,6 +344,10 @@ private fun MessageContent(
         )
         AiSupportChatMessageContent.PostDiagnosticsGreeting -> TextContent(
             text = stringResource(R.string.ai_support_chat_post_diagnostics_greeting),
+            color = textColor
+        )
+        AiSupportChatMessageContent.ResolvedPrompt -> TextContent(
+            text = stringResource(R.string.ai_support_chat_resolved_prompt),
             color = textColor
         )
         is AiSupportChatMessageContent.Text -> TextContent(
@@ -564,6 +581,22 @@ private fun TicketCreatedBanner(modifier: Modifier = Modifier) {
 }
 
 @Composable
+private fun ChatResolvedBanner(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.surface
+    ) {
+        Text(
+            text = stringResource(R.string.ai_support_chat_resolved_message),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodySmall,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(dimensionResource(R.dimen.major_100))
+        )
+    }
+}
+
+@Composable
 private fun HumanSupportBanner(
     onContactSupportClicked: () -> Unit,
     modifier: Modifier = Modifier
@@ -592,21 +625,41 @@ private fun SendErrorDialog(
     onContactSupportClicked: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(text = stringResource(R.string.ai_support_chat_error_title)) },
-        text = { Text(text = stringResource(R.string.ai_support_chat_send_error)) },
-        confirmButton = {
-            TextButton(onClick = onContactSupportClicked) {
-                Text(text = stringResource(R.string.ai_support_chat_contact_support))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(text = stringResource(R.string.ai_support_chat_error_dismiss))
-            }
-        }
-    )
+    DialogState(
+        title = R.string.ai_support_chat_error_title,
+        message = R.string.ai_support_chat_send_error,
+        positiveButton = DialogState.DialogButton(
+            text = R.string.ai_support_chat_contact_support,
+            onClick = onContactSupportClicked
+        ),
+        negativeButton = DialogState.DialogButton(
+            text = R.string.ai_support_chat_error_dismiss,
+            onClick = onDismiss
+        ),
+        isCancelable = false,
+        onDismiss = onDismiss
+    ).Render()
+}
+
+@Composable
+private fun MarkResolvedConfirmationDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    DialogState(
+        title = R.string.ai_support_chat_mark_resolved_confirmation_title,
+        message = R.string.ai_support_chat_mark_resolved_confirmation_message,
+        positiveButton = DialogState.DialogButton(
+            text = R.string.ai_support_chat_mark_resolved,
+            onClick = onConfirm
+        ),
+        negativeButton = DialogState.DialogButton(
+            text = R.string.ai_support_chat_error_dismiss,
+            onClick = onDismiss
+        ),
+        isCancelable = false,
+        onDismiss = onDismiss
+    ).Render()
 }
 
 @Composable
@@ -689,6 +742,8 @@ private fun AiSupportChatScreenPreview() {
             onContactSupportClicked = {},
             onContactSupportFromErrorClicked = {},
             onSendErrorDismissed = {},
+            onMarkResolvedConfirmed = {},
+            onMarkResolvedDismissed = {},
             onFeedbackClicked = { _, _ -> }
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -613,9 +613,10 @@ data class AiSupportChatViewState(
                 it.role == AiSupportChatMessageRole.BOT && it.messageId != null
             }
             val latestBotResponse = botResponses.lastOrNull() ?: return false
-            return latestBotResponse.isResolved ||
-                messageRatings[latestBotResponse.messageId] == AiSupportChatFeedbackRating.UP ||
-                botResponses.size >= MIN_BOT_RESPONSES_FOR_RESOLUTION_ACTION
+            val latestResponseResolved = latestBotResponse.isResolved
+            val latestResponseUpvoted = messageRatings[latestBotResponse.messageId] == AiSupportChatFeedbackRating.UP
+            val hasEnoughBotResponses = botResponses.size >= MIN_BOT_RESPONSES_FOR_RESOLUTION_ACTION
+            return latestResponseResolved || latestResponseUpvoted || hasEnoughBotResponses
         }
 
     private companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -81,7 +81,18 @@ class AiSupportChatViewModel @Inject constructor(
         if (messageId in state.messageRatings) return
 
         _viewState.update {
-            it.copy(messageRatings = it.messageRatings + (messageId to rating))
+            val updatedRatings = it.messageRatings + (messageId to rating)
+            it.copy(
+                messageRatings = updatedRatings,
+                messages = if (
+                    rating == AiSupportChatFeedbackRating.UP &&
+                    it.messages.latestBotResponse?.messageId == messageId
+                ) {
+                    it.messages.appendResolvedPromptIfNeeded()
+                } else {
+                    it.messages
+                }
+            )
         }
 
         launch {
@@ -94,6 +105,26 @@ class AiSupportChatViewModel @Inject constructor(
             ).onFailure { error ->
                 WooLog.e(WooLog.T.AI, "Submitting AI support chat feedback failed", error)
             }
+        }
+    }
+
+    fun onMarkResolvedClicked() {
+        _viewState.update { it.copy(showMarkResolvedConfirmation = true) }
+    }
+
+    fun onMarkResolvedDismissed() {
+        _viewState.update { it.copy(showMarkResolvedConfirmation = false) }
+    }
+
+    fun onMarkResolvedConfirmed() {
+        _viewState.update {
+            it.copy(
+                isChatResolved = true,
+                showMarkResolvedConfirmation = false,
+                showHumanSupportPrompt = false,
+                showSendError = false,
+                input = ""
+            )
         }
     }
 
@@ -292,6 +323,20 @@ class AiSupportChatViewModel @Inject constructor(
             val shouldPromptHumanSupport = response.messages.shouldPromptHumanSupport()
             val completedUserMessageResponseCount = it.completedUserMessageResponseCount +
                 if (response.messages.hasBotResponse()) 1 else 0
+            val messages = if (remoteMessages.isEmpty()) {
+                it.messages
+            } else {
+                it.messages.supportMessages() + it.messages.threadMessages().mergeWithRemoteMessages(
+                    remoteMessages = remoteMessages,
+                    optimisticMessage = optimisticMessage
+                )
+            }.let { messages ->
+                if (!shouldPromptHumanSupport && messages.latestBotResponse?.isResolved == true) {
+                    messages.appendResolvedPromptIfNeeded()
+                } else {
+                    messages
+                }
+            }
             it.copy(
                 chatId = response.chatId,
                 sessionId = response.sessionId,
@@ -301,14 +346,7 @@ class AiSupportChatViewModel @Inject constructor(
                 completedUserMessageResponseCount = completedUserMessageResponseCount,
                 latestSupportArea = latestSupportArea,
                 showHumanSupportPrompt = shouldPromptHumanSupport && !it.hasCreatedTicket,
-                messages = if (remoteMessages.isEmpty()) {
-                    it.messages
-                } else {
-                    it.messages.supportMessages() + it.messages.threadMessages().mergeWithRemoteMessages(
-                        remoteMessages = remoteMessages,
-                        optimisticMessage = optimisticMessage
-                    )
-                },
+                messages = messages,
                 isSending = false,
                 showSendError = false
             )
@@ -385,6 +423,7 @@ class AiSupportChatViewModel @Inject constructor(
                     id = "${message.role.wireValue}-${message.messageId}",
                     messageId = if (message.role == SupportChatRole.BOT) message.messageId else null,
                     role = message.role.toUiRole(),
+                    isResolved = message.context?.isResolved == true,
                     content = AiSupportChatMessageContent.Text(message.content)
                 )
             }
@@ -400,12 +439,30 @@ class AiSupportChatViewModel @Inject constructor(
                 is AiSupportChatMessageContent.DiagnosticsFailure,
                 is AiSupportChatMessageContent.DiagnosticsProgress -> true
                 AiSupportChatMessageContent.IssuePicker,
+                AiSupportChatMessageContent.ResolvedPrompt,
                 is AiSupportChatMessageContent.Text -> false
             }
         }
 
     private fun List<AiSupportChatMessage>.threadMessages(): List<AiSupportChatMessage> =
-        filter { it.content is AiSupportChatMessageContent.Text }
+        filter {
+            it.content is AiSupportChatMessageContent.Text ||
+                it.content == AiSupportChatMessageContent.ResolvedPrompt
+        }
+
+    private val List<AiSupportChatMessage>.latestBotResponse: AiSupportChatMessage?
+        get() = lastOrNull { it.role == AiSupportChatMessageRole.BOT && it.messageId != null }
+
+    private fun List<AiSupportChatMessage>.appendResolvedPromptIfNeeded(): List<AiSupportChatMessage> =
+        if (any { it.content == AiSupportChatMessageContent.ResolvedPrompt }) {
+            this
+        } else {
+            this + AiSupportChatMessage(
+                id = RESOLVED_PROMPT_MESSAGE_ID,
+                role = AiSupportChatMessageRole.BOT,
+                content = AiSupportChatMessageContent.ResolvedPrompt
+            )
+        }
 
     private fun List<AiSupportChatMessage>.appendPostDiagnosticsGreeting(): List<AiSupportChatMessage> =
         if (any { it.id == POST_DIAGNOSTICS_GREETING_MESSAGE_ID }) {
@@ -471,6 +528,9 @@ class AiSupportChatViewModel @Inject constructor(
             AiSupportChatMessageContent.Greeting -> ""
             AiSupportChatMessageContent.IssuePicker -> "[Issue picker shown]"
             AiSupportChatMessageContent.PostDiagnosticsGreeting -> "Please describe your issue in more detail."
+            AiSupportChatMessageContent.ResolvedPrompt ->
+                "Please mark the chat as resolved if your problem is resolved, " +
+                    "or leave a message if you have other questions."
             is AiSupportChatMessageContent.Text -> when (role) {
                 AiSupportChatMessageRole.USER -> content.text
                 AiSupportChatMessageRole.BOT -> content.text.trimToFirstParagraph()
@@ -500,6 +560,7 @@ class AiSupportChatViewModel @Inject constructor(
         const val DEFAULT_BOT_SLUG = "woo-workflow-support_mobile_inapp_all_users"
 
         private const val POST_DIAGNOSTICS_GREETING_MESSAGE_ID = "post-diagnostics-greeting"
+        private const val RESOLVED_PROMPT_MESSAGE_ID = "resolved-prompt"
     }
 }
 
@@ -520,6 +581,8 @@ data class AiSupportChatViewState(
     val showSendError: Boolean = false,
     val showHumanSupportPrompt: Boolean = false,
     val hasCreatedTicket: Boolean = false,
+    val isChatResolved: Boolean = false,
+    val showMarkResolvedConfirmation: Boolean = false,
     val hasSentChatMessage: Boolean = false,
     val completedUserMessageResponseCount: Int = 0,
     val latestSupportArea: SupportChatSupportArea? = null,
@@ -529,7 +592,7 @@ data class AiSupportChatViewState(
         get() = !hasProceededToChat && !isSending
 
     val canSendMessages: Boolean
-        get() = hasProceededToChat && !hasCreatedTicket
+        get() = hasProceededToChat && !hasCreatedTicket && !isChatResolved
 
     val showInputBar: Boolean
         get() = canSendMessages && !showHumanSupportPrompt
@@ -543,8 +606,21 @@ data class AiSupportChatViewState(
     val canContactHumanSupportFromToolbar: Boolean
         get() = canSendMessages && completedUserMessageResponseCount >= MIN_USER_MESSAGE_RESPONSES_FOR_TOOLBAR
 
+    val shouldShowResolvedButton: Boolean
+        get() {
+            if (showHumanSupportPrompt || isChatResolved) return false
+            val botResponses = messages.filter {
+                it.role == AiSupportChatMessageRole.BOT && it.messageId != null
+            }
+            val latestBotResponse = botResponses.lastOrNull() ?: return false
+            return latestBotResponse.isResolved ||
+                messageRatings[latestBotResponse.messageId] == AiSupportChatFeedbackRating.UP ||
+                botResponses.size >= MIN_BOT_RESPONSES_FOR_RESOLUTION_ACTION
+        }
+
     private companion object {
         const val MIN_USER_MESSAGE_RESPONSES_FOR_TOOLBAR = 2
+        const val MIN_BOT_RESPONSES_FOR_RESOLUTION_ACTION = 2
     }
 }
 
@@ -570,6 +646,7 @@ data class AiSupportChatMessage(
     val id: String,
     val messageId: Long? = null,
     val role: AiSupportChatMessageRole,
+    val isResolved: Boolean = false,
     val content: AiSupportChatMessageContent
 )
 
@@ -582,6 +659,7 @@ sealed interface AiSupportChatMessageContent {
     data object Greeting : AiSupportChatMessageContent
     data object IssuePicker : AiSupportChatMessageContent
     data object PostDiagnosticsGreeting : AiSupportChatMessageContent
+    data object ResolvedPrompt : AiSupportChatMessageContent
     data class Text(val text: String) : AiSupportChatMessageContent
     data class DiagnosticsProgress(val result: DiagnosticResult) : AiSupportChatMessageContent
     data class DiagnosticsFailure(val result: DiagnosticResult) : AiSupportChatMessageContent

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -622,7 +622,7 @@ data class AiSupportChatViewState(
 
     val shouldShowResolvedButton: Boolean
         get() {
-            if (showHumanSupportPrompt || isChatResolved) return false
+            if (!canSendMessages || showHumanSupportPrompt) return false
             val botResponses = messages.filter {
                 it.role == AiSupportChatMessageRole.BOT && it.messageId != null
             }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -453,16 +453,22 @@ class AiSupportChatViewModel @Inject constructor(
     private val List<AiSupportChatMessage>.latestBotResponse: AiSupportChatMessage?
         get() = lastOrNull { it.role == AiSupportChatMessageRole.BOT && it.messageId != null }
 
-    private fun List<AiSupportChatMessage>.appendResolvedPromptIfNeeded(): List<AiSupportChatMessage> =
-        if (any { it.content == AiSupportChatMessageContent.ResolvedPrompt }) {
-            this
-        } else {
-            this + AiSupportChatMessage(
-                id = RESOLVED_PROMPT_MESSAGE_ID,
-                role = AiSupportChatMessageRole.BOT,
-                content = AiSupportChatMessageContent.ResolvedPrompt
-            )
+    private fun List<AiSupportChatMessage>.appendResolvedPromptIfNeeded(): List<AiSupportChatMessage> {
+        val messagesWithoutPrompt = filterNot { it.content == AiSupportChatMessageContent.ResolvedPrompt }
+        val latestBotResponseIndex = messagesWithoutPrompt.indexOfLast {
+            it.role == AiSupportChatMessageRole.BOT && it.messageId != null
         }
+        if (latestBotResponseIndex == -1) return messagesWithoutPrompt
+
+        val resolvedPrompt = AiSupportChatMessage(
+            id = RESOLVED_PROMPT_MESSAGE_ID,
+            role = AiSupportChatMessageRole.BOT,
+            content = AiSupportChatMessageContent.ResolvedPrompt
+        )
+        return messagesWithoutPrompt.toMutableList().apply {
+            add(latestBotResponseIndex + 1, resolvedPrompt)
+        }
+    }
 
     private fun List<AiSupportChatMessage>.appendPostDiagnosticsGreeting(): List<AiSupportChatMessage> =
         if (any { it.id == POST_DIAGNOSTICS_GREETING_MESSAGE_ID }) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/networking/model/SupportChatMessageContext.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/networking/model/SupportChatMessageContext.kt
@@ -5,5 +5,6 @@ import com.google.gson.annotations.SerializedName
 data class SupportChatMessageContext(
     @SerializedName("sources") val sources: List<SupportChatSource> = emptyList(),
     @SerializedName("flags") val flags: SupportChatFlags? = null,
-    @SerializedName("support_area") val supportArea: SupportChatSupportArea? = null
+    @SerializedName("support_area") val supportArea: SupportChatSupportArea? = null,
+    @SerializedName("is_resolved") val isResolved: Boolean = false
 )

--- a/WooCommerce/src/main/res/menu/menu_ai_support_chat.xml
+++ b/WooCommerce/src/main/res/menu/menu_ai_support_chat.xml
@@ -9,4 +9,12 @@
         android:title="@string/ai_support_chat_toolbar_contact_support"
         android:visible="false"
         app:showAsAction="always" />
+
+    <item
+        android:id="@+id/menu_mark_resolved"
+        android:contentDescription="@string/ai_support_chat_mark_resolved"
+        android:icon="@drawable/ic_check_24dp"
+        android:title="@string/ai_support_chat_mark_resolved"
+        android:visible="false"
+        app:showAsAction="always" />
 </menu>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2427,6 +2427,7 @@
     <string name="ai_support_chat_resolved_message">This chat has been marked as resolved.</string>
     <string name="ai_support_chat_toolbar_contact_support">Contact Support</string>
     <string name="ai_support_chat_mark_resolved">Mark Resolved</string>
+    <string name="ai_support_chat_mark_resolved_cancel">Cancel</string>
     <string name="ai_support_chat_mark_resolved_confirmation_title">Mark chat as resolved?</string>
     <string name="ai_support_chat_mark_resolved_confirmation_message">This will close the chat actions for this conversation.</string>
     <string name="ai_support_chat_escalation_transcript_header">Following is the transcript of an in-app AI support chat session:</string>

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2424,7 +2424,11 @@
     <string name="ai_support_chat_human_support_message">It looks like you might need additional help. Would you like to contact our support team?</string>
     <string name="ai_support_chat_contact_support">Contact Support</string>
     <string name="ai_support_chat_ticket_created_message">A support ticket has been created for this chat. We\'ll respond via email.</string>
+    <string name="ai_support_chat_resolved_message">This chat has been marked as resolved.</string>
     <string name="ai_support_chat_toolbar_contact_support">Contact Support</string>
+    <string name="ai_support_chat_mark_resolved">Mark Resolved</string>
+    <string name="ai_support_chat_mark_resolved_confirmation_title">Mark chat as resolved?</string>
+    <string name="ai_support_chat_mark_resolved_confirmation_message">This will close the chat actions for this conversation.</string>
     <string name="ai_support_chat_escalation_transcript_header">Following is the transcript of an in-app AI support chat session:</string>
     <string name="ai_support_chat_support_request_subject_mobile_app">Mobile App Support Request</string>
     <string name="ai_support_chat_support_request_subject_card_reader">Card Reader Support Request</string>
@@ -2432,6 +2436,7 @@
     <string name="ai_support_chat_support_request_subject_woo_plugin">WooCommerce Plugin Support Request</string>
     <string name="ai_support_chat_support_request_subject_other_plugin">Plugin Support Request</string>
     <string name="ai_support_chat_post_diagnostics_greeting">Please describe your issue in more detail so I can help.</string>
+    <string name="ai_support_chat_resolved_prompt">Please mark the chat as resolved if your problem is resolved, or leave a message if you have other questions.</string>
     <string name="ai_support_chat_issue_picker_title">What would you like to troubleshoot?</string>
     <string name="ai_support_chat_issue_loading_orders">I can\'t see my orders</string>
     <string name="ai_support_chat_issue_loading_products">I can\'t see my products</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -536,6 +536,44 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given resolved prompt exists, when later bot response is upvoted, then prompt moves after latest response`() =
+        testBlocking {
+            val latestBotMessageId = 4L
+            startChatWithBotResponse()
+            whenever(repository.submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, BOT_MESSAGE_ID, SESSION_ID, true))
+                .thenReturn(Result.success(Unit))
+            whenever(repository.sendMessage(DEFAULT_BOT_SLUG, FOLLOW_UP_MESSAGE, JsonObject(), CHAT_ID, SESSION_ID))
+                .thenReturn(
+                    Result.success(
+                        createResponse(
+                            messages = listOf(
+                                createMessage(messageId = 3L, role = SupportChatRole.USER, content = FOLLOW_UP_MESSAGE),
+                                createMessage(
+                                    messageId = latestBotMessageId,
+                                    role = SupportChatRole.BOT,
+                                    content = FOLLOW_UP_BOT_RESPONSE
+                                )
+                            )
+                        )
+                    )
+                )
+            whenever(repository.submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, latestBotMessageId, SESSION_ID, true))
+                .thenReturn(Result.success(Unit))
+
+            viewModel.onFeedbackClicked(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.UP)
+            viewModel.onInputChanged(FOLLOW_UP_MESSAGE)
+            viewModel.onSendClicked()
+            viewModel.onFeedbackClicked(latestBotMessageId, AiSupportChatFeedbackRating.UP)
+
+            val contents = viewModel.viewState.value.messages.map { it.content }
+            assertThat(contents.count { it == AiSupportChatMessageContent.ResolvedPrompt }).isEqualTo(1)
+            assertThat(contents).endsWith(
+                AiSupportChatMessageContent.Text(FOLLOW_UP_BOT_RESPONSE),
+                AiSupportChatMessageContent.ResolvedPrompt
+            )
+        }
+
+    @Test
     fun `given chat identifiers are missing, when feedback clicked, then feedback is not submitted`() =
         testBlocking {
             viewModel.onFeedbackClicked(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.UP)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -749,6 +749,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         assertThat(state.hasCreatedTicket).isTrue
         assertThat(state.canSendMessages).isFalse
         assertThat(state.canContactHumanSupportFromToolbar).isFalse
+        assertThat(state.shouldShowResolvedButton).isFalse
         assertThat(state.showSendError).isFalse
         assertThat(state.showHumanSupportPrompt).isFalse
     }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -1003,7 +1003,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         messageId = messageId,
         role = role,
         content = content,
-        context = context ?: SupportChatMessageContext(isResolved = isResolved)
+        context = context ?: if (isResolved) SupportChatMessageContext(isResolved = true) else null
     )
 
     private companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -433,6 +433,22 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given latest bot response is upvoted, when feedback clicked, then resolved prompt is appended`() =
+        testBlocking {
+            startChatWithBotResponse()
+            whenever(repository.submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, BOT_MESSAGE_ID, SESSION_ID, true))
+                .thenReturn(Result.success(Unit))
+
+            viewModel.onFeedbackClicked(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.UP)
+
+            assertThat(viewModel.viewState.value.shouldShowResolvedButton).isTrue
+            assertThat(viewModel.viewState.value.messages.map { it.content }).endsWith(
+                AiSupportChatMessageContent.Text(BOT_RESPONSE),
+                AiSupportChatMessageContent.ResolvedPrompt
+            )
+        }
+
+    @Test
     fun `given unrated bot response, when thumbs down clicked, then rating is stored and submitted`() =
         testBlocking {
             startChatWithBotResponse()
@@ -454,6 +470,41 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given latest bot response is resolved, when message succeeds, then resolved prompt is appended`() =
+        testBlocking {
+            val result = createSuccessDiagnosticResult()
+            val response = createResponse(
+                messages = listOf(
+                    createMessage(messageId = 1L, role = SupportChatRole.USER, content = ISSUE_DETAILS),
+                    createMessage(
+                        messageId = BOT_MESSAGE_ID,
+                        role = SupportChatRole.BOT,
+                        content = BOT_RESPONSE,
+                        isResolved = true
+                    )
+                )
+            )
+            whenever(diagnosticsService.runDiagnostics(SupportIssueType.LOADING_ORDERS)).thenReturn(flowOf(result))
+            whenever(contextProvider.buildInitialContext(diagnosticResult = result)).thenReturn(CONTEXT)
+            whenever(repository.sendMessage(DEFAULT_BOT_SLUG, ISSUE_DETAILS, CONTEXT, null, null))
+                .thenReturn(Result.success(response))
+
+            continueToChatAfterSuccessfulDiagnostics(result)
+            viewModel.onInputChanged(ISSUE_DETAILS)
+            viewModel.onSendClicked()
+
+            val state = viewModel.viewState.value
+            assertThat(state.shouldShowResolvedButton).isTrue
+            assertThat(state.messages.map { it.content }).endsWith(
+                AiSupportChatMessageContent.Text(BOT_RESPONSE),
+                AiSupportChatMessageContent.ResolvedPrompt
+            )
+            val botMessage = state.messages.single { it.content == AiSupportChatMessageContent.Text(BOT_RESPONSE) }
+            assertThat(botMessage.isResolved)
+                .isTrue
+        }
+
+    @Test
     fun `given rated bot response, when feedback clicked again, then feedback is not submitted twice`() =
         testBlocking {
             startChatWithBotResponse()
@@ -467,6 +518,21 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
                 .containsEntry(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.UP)
             verify(repository).submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, BOT_MESSAGE_ID, SESSION_ID, true)
             verify(repository, never()).submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, BOT_MESSAGE_ID, SESSION_ID, false)
+        }
+
+    @Test
+    fun `given resolved prompt exists, when latest bot response is upvoted again, then prompt is not duplicated`() =
+        testBlocking {
+            startChatWithBotResponse()
+            whenever(repository.submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, BOT_MESSAGE_ID, SESSION_ID, true))
+                .thenReturn(Result.success(Unit))
+
+            viewModel.onFeedbackClicked(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.UP)
+            viewModel.onFeedbackClicked(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.DOWN)
+
+            assertThat(
+                viewModel.viewState.value.messages.count { it.content == AiSupportChatMessageContent.ResolvedPrompt }
+            ).isEqualTo(1)
         }
 
     @Test
@@ -520,6 +586,68 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             val state = viewModel.viewState.value
             assertThat(state.completedUserMessageResponseCount).isEqualTo(2)
             assertThat(state.canContactHumanSupportFromToolbar).isTrue
+        }
+
+    @Test
+    fun `given two bot responses, when chat updates, then resolved button is available`() =
+        testBlocking {
+            val result = createSuccessDiagnosticResult()
+            whenever(diagnosticsService.runDiagnostics(SupportIssueType.LOADING_ORDERS)).thenReturn(flowOf(result))
+            whenever(contextProvider.buildInitialContext(diagnosticResult = result)).thenReturn(CONTEXT)
+            whenever(repository.sendMessage(DEFAULT_BOT_SLUG, ISSUE_DETAILS, CONTEXT, null, null))
+                .thenReturn(
+                    Result.success(
+                        createResponse(
+                            messages = listOf(
+                                createMessage(messageId = 1L, role = SupportChatRole.USER, content = ISSUE_DETAILS),
+                                createMessage(messageId = 2L, role = SupportChatRole.BOT, content = BOT_RESPONSE)
+                            )
+                        )
+                    )
+                )
+            whenever(repository.sendMessage(DEFAULT_BOT_SLUG, FOLLOW_UP_MESSAGE, JsonObject(), CHAT_ID, SESSION_ID))
+                .thenReturn(
+                    Result.success(
+                        createResponse(
+                            messages = listOf(
+                                createMessage(messageId = 3L, role = SupportChatRole.USER, content = FOLLOW_UP_MESSAGE),
+                                createMessage(
+                                    messageId = 4L,
+                                    role = SupportChatRole.BOT,
+                                    content = FOLLOW_UP_BOT_RESPONSE
+                                )
+                            )
+                        )
+                    )
+                )
+
+            continueToChatAfterSuccessfulDiagnostics(result)
+            viewModel.onInputChanged(ISSUE_DETAILS)
+            viewModel.onSendClicked()
+            viewModel.onInputChanged(FOLLOW_UP_MESSAGE)
+            viewModel.onSendClicked()
+
+            assertThat(viewModel.viewState.value.shouldShowResolvedButton).isTrue
+        }
+
+    @Test
+    fun `given resolved button shown, when mark resolved confirmed, then chat actions are hidden`() =
+        testBlocking {
+            startChatWithBotResponse()
+            whenever(repository.submitFeedback(DEFAULT_BOT_SLUG, CHAT_ID, BOT_MESSAGE_ID, SESSION_ID, true))
+                .thenReturn(Result.success(Unit))
+
+            viewModel.onFeedbackClicked(BOT_MESSAGE_ID, AiSupportChatFeedbackRating.UP)
+            viewModel.onMarkResolvedClicked()
+            viewModel.onMarkResolvedConfirmed()
+
+            val state = viewModel.viewState.value
+            assertThat(state.isChatResolved).isTrue
+            assertThat(state.showMarkResolvedConfirmation).isFalse
+            assertThat(state.canSendMessages).isFalse
+            assertThat(state.showInputBar).isFalse
+            assertThat(state.shouldShowResolvedButton).isFalse
+            assertThat(state.canContactHumanSupportFromToolbar).isFalse
         }
 
     @Test
@@ -869,12 +997,13 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         messageId: Long,
         role: SupportChatRole,
         content: String = BOT_RESPONSE,
-        context: SupportChatMessageContext? = null
+        context: SupportChatMessageContext? = null,
+        isResolved: Boolean = false
     ): SupportChatMessage = SupportChatMessage(
         messageId = messageId,
         role = role,
         content = content,
-        context = context
+        context = context ?: SupportChatMessageContext(isResolved = isResolved)
     )
 
     private companion object {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/networking/SupportChatResponseDeserializationTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/networking/SupportChatResponseDeserializationTest.kt
@@ -83,6 +83,30 @@ class SupportChatResponseDeserializationTest {
     }
 
     @Test
+    fun `given is resolved in response, when decoded, then context exposes resolved state`() {
+        val json = """
+            {
+              "chat_id": 1,
+              "messages": [
+                {
+                  "message_id": 1,
+                  "role": "bot",
+                  "content": "ok",
+                  "context": {
+                    "is_resolved": true
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val response = gson.fromJson(json, SupportChatResponse::class.java)
+        val context = requireNotNull(response.messages.single().context)
+
+        assertThat(context.isResolved).isTrue
+    }
+
+    @Test
     fun `given unknown support area values, when decoded, then defaults match iOS`() {
         val json = """
             {


### PR DESCRIPTION
### Description
Fixes WOOMOB-3073

Adds the resolved-chat flow to AI support chat on top of the per-message feedback branch. The chat now decodes the `is_resolved` flag from bot message context, appends the resolved prompt when the latest answer is resolved or upvoted, and exposes a toolbar action to mark the conversation resolved.

Marking a chat resolved is local UI state for now: it hides chat actions and the input bar, shows a resolved banner, and does not add analytics or persistence. The dialog uses the shared Compose `DialogState.Render()` pattern used by recent main-app Compose screens.

### Test Steps
1. Open AI support chat and continue into the free-chat phase.
2. Send a message and receive a bot response.
3. Upvote the latest bot response and confirm the resolved prompt appears.
4. Tap the toolbar checkmark, dismiss the confirmation, then tap it again and confirm.
5. Confirm the input bar and support actions are hidden and the resolved banner is shown.

### Images/gif
[Screen_recording_20260515_165729.webm](https://github.com/user-attachments/assets/cc776ad6-beca-4452-9997-eb7f3b8537bd)


- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.