### PR TITLE
Update release notes for 24.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!--
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
+## 24.8
+Say hello to your new AI Assistant—a smarter way to run your store right from your pocket. Rolling out to selected stores, it helps you stay on top of your shop with a tap. We've also smoothed out the order list so it no longer flashes when you head back from an order's details.
+
 ## 24.7
 The My Store Performance card now lets you switch between Gross, Net, and Total revenue and pick your order date type (Paid, Placed, or Completed). We also fixed POS navigation resetting on rotation, refreshed the POS Orders empty state, and squashed bugs in the product list and image loading.
 

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,4 +1,1 @@
-- [*] Fixed the order list flashing when returning from the order detail screen [https://github.com/woocommerce/woocommerce-android/pull/15886]
-- [*] Introducing the AI Assistant: a new way to run your store from your pocket. Rolling out to selected stores. [https://github.com/woocommerce/woocommerce-android/pull/15921]
-- [*] Woo POS: Use your phone as a Tap to Pay card reader for the POS tablet over Wi-Fi [https://github.com/woocommerce/woocommerce-android/pull/15781]
-- [Internal] Added REMOTE_TAP_TO_PAY feature flag (off in production) for the upcoming Woo POS Remote Tap-to-Pay feature [https://github.com/woocommerce/woocommerce-android/pull/15696]
+Say hello to your new AI Assistant—a smarter way to run your store right from your pocket. Rolling out to selected stores, it helps you stay on top of your shop with a tap. We've also smoothed out the order list so it no longer flashes when you head back from an order's details.


### PR DESCRIPTION
### Description

Polishes the customer-facing release notes for 24.8 ahead of the store submission, mirroring the workflow used for prior releases (e.g. #15803 for 24.7):

- Replaces the bullet list in `fastlane/metadata/android/en-US/changelogs/default.txt` with a single ~280-char paragraph aimed at the Google Play audience.
- Adds the same paragraph to the top of `CHANGELOG.md` under a new `## 24.8` heading.

The paragraph highlights:
- **AI Assistant** (#15921) — server-gated rollout, accurately advertised as "rolling out to selected stores".
- **Order list flash fix** (#15886) — ships enabled, no gating.

Intentionally omitted:
- **Woo POS phone-as-Tap-to-Pay over Wi-Fi** (#15781). `FeatureFlag.WOO_POS_TAP_TO_PAY.localValue = PackageUtils.isDebugBuild()`, so the feature is off in production builds for 24.8 and would mislead users if advertised. Heads-up to whoever's driving the release: if we do want to ship this in 24.8, the local flag in `WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt` needs flipping (separate PR).
- `[Internal]` REMOTE_TAP_TO_PAY (#15696) — internal flag entry, never user-facing.


### Test Steps

1. Open `fastlane/metadata/android/en-US/changelogs/default.txt` and confirm it's a single polished paragraph, well under the 500-char Play limit (~280 chars).
2. Open `CHANGELOG.md` and confirm the new `## 24.8` section sits at the top under the HTML comment, with the same copy.
3. Skim the paragraph for tone/typos.

### Images/gif

N/A — copy-only change.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.