### PR TITLE
POS [4/4]: add Scan to Pay payment method

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosQrCode.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosQrCode.kt
@@ -45,5 +45,5 @@ private fun encodeToBitmap(data: String, sizePx: Int): Bitmap {
             pixels[y * sizePx + x] = if (matrix.get(x, y)) Color.BLACK else Color.WHITE
         }
     }
-    return Bitmap.createBitmap(pixels, sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    return Bitmap.createBitmap(pixels, sizePx, sizePx, Bitmap.Config.RGB_565)
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosQrCode.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/common/composeui/component/WooPosQrCode.kt
@@ -1,0 +1,49 @@
+package com.woocommerce.android.ui.woopos.common.composeui.component
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
+
+@Composable
+fun WooPosQrCode(
+    data: String,
+    size: Dp,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
+    val sizePx = with(LocalDensity.current) { size.roundToPx() }
+    val bitmap = remember(data, sizePx) { encodeToBitmap(data, sizePx) }
+    Image(
+        bitmap = bitmap.asImageBitmap(),
+        contentDescription = contentDescription,
+        modifier = modifier.size(size),
+        // QR codes are inherently pixelated; disable filtering so edges stay sharp.
+        filterQuality = FilterQuality.None,
+    )
+}
+
+private fun encodeToBitmap(data: String, sizePx: Int): Bitmap {
+    val hints = mapOf(
+        com.google.zxing.EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M,
+        com.google.zxing.EncodeHintType.MARGIN to 1,
+    )
+    val matrix = QRCodeWriter().encode(data, BarcodeFormat.QR_CODE, sizePx, sizePx, hints)
+    val pixels = IntArray(sizePx * sizePx)
+    for (y in 0 until sizePx) {
+        for (x in 0 until sizePx) {
+            pixels[y * sizePx + x] = if (matrix.get(x, y)) Color.BLACK else Color.WHITE
+        }
+    }
+    return Bitmap.createBitmap(pixels, sizePx, sizePx, Bitmap.Config.ARGB_8888)
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
@@ -58,6 +58,7 @@ sealed class ChildToParentEvent {
     sealed class NavigationEvent : ChildToParentEvent() {
         data class ToCashPayment(val orderId: Long) : NavigationEvent()
         data class ToMarkOrderAsComplete(val orderId: Long) : NavigationEvent()
+        data class ToScanToPay(val orderId: Long) : NavigationEvent()
         data class ToEmailReceipt(val orderId: Long) : NavigationEvent()
         data object ReturnHomeFromCashWhenCardPaymentStarted : NavigationEvent()
         data object ExitPos : NavigationEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -361,7 +361,7 @@ private fun CheckoutPaymentButtons(
 private fun WooPosPaymentMethod.toUIEvent(): WooPosTotalsUIEvent? = when (this) {
     WooPosPaymentMethod.CARD_READER -> WooPosTotalsUIEvent.ConnectReaderClicked
     WooPosPaymentMethod.TAP_TO_PAY -> WooPosTotalsUIEvent.OnTapToPayClicked
-    WooPosPaymentMethod.SCAN_TO_PAY -> null
+    WooPosPaymentMethod.SCAN_TO_PAY -> WooPosTotalsUIEvent.OnScanToPayClicked
     WooPosPaymentMethod.MARK_ORDER_AS_PAID -> WooPosTotalsUIEvent.OnMarkOrderAsCompleteClicked
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsUIEvent.kt
@@ -13,6 +13,7 @@ sealed class WooPosTotalsUIEvent {
     data object OnCashPaymentClicked : WooPosTotalsUIEvent()
     data object OnTapToPayClicked : WooPosTotalsUIEvent()
     data object OnMarkOrderAsCompleteClicked : WooPosTotalsUIEvent()
+    data object OnScanToPayClicked : WooPosTotalsUIEvent()
     data class OnFineLocationPermissionResult(val granted: Boolean) : WooPosTotalsUIEvent()
     data class OnAllPaymentMethodsVisibilityChanged(val isVisible: Boolean) : WooPosTotalsUIEvent()
     data object ConnectReaderClicked : WooPosTotalsUIEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -33,6 +33,7 @@ import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToCashPayment
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToEmailReceipt
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToMarkOrderAsComplete
+import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.NavigationEvent.ToScanToPay
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.OnNewTransactionStarted
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.OrderSuccessfullyPaidByCard
 import com.woocommerce.android.ui.woopos.home.ChildToParentEvent.ToastMessageDisplayed
@@ -248,6 +249,8 @@ class WooPosTotalsViewModel @Inject constructor(
 
             WooPosTotalsUIEvent.OnMarkOrderAsCompleteClicked -> handleMarkOrderAsCompleteClicked()
 
+            WooPosTotalsUIEvent.OnScanToPayClicked -> handleScanToPayClicked()
+
             is WooPosTotalsUIEvent.OnFineLocationPermissionResult ->
                 onFineLocationPermissionResult(event.granted)
 
@@ -300,6 +303,16 @@ class WooPosTotalsViewModel @Inject constructor(
         }
         totalsAnalyticsTracker.trackCheckoutMarkAsPaidTapped()
         childrenToParentEventSender.sendToParent(ToMarkOrderAsComplete(orderId))
+    }
+
+    private fun handleScanToPayClicked() = viewModelScope.launch {
+        val orderId = dataState.value.orderId
+        if (orderId == EMPTY_ORDER_ID) {
+            wooPosLogWrapper.e("Scan to pay tapped before order draft was created")
+            return@launch
+        }
+        totalsAnalyticsTracker.trackCheckoutScanToPayPaymentTapped()
+        childrenToParentEventSender.sendToParent(ToScanToPay(orderId))
     }
 
     private fun handleAllPaymentMethodsVisibilityChanged(isVisible: Boolean) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosMainFlowGraph.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosMainFlowGraph.kt
@@ -16,6 +16,7 @@ import com.woocommerce.android.ui.woopos.orders.details.refund.issueRefundScreen
 import com.woocommerce.android.ui.woopos.orders.details.refund.refundReasonScreen
 import com.woocommerce.android.ui.woopos.orders.ordersScreen
 import com.woocommerce.android.ui.woopos.paymentsuccess.paymentSuccessScreen
+import com.woocommerce.android.ui.woopos.scantopay.scanToPayScreen
 import com.woocommerce.android.ui.woopos.settings.settingsScreen
 import com.woocommerce.android.ui.woopos.splash.SPLASH_ROUTE
 import com.woocommerce.android.ui.woopos.splash.splashScreen
@@ -35,6 +36,7 @@ fun NavGraphBuilder.mainGraph(
         cardPaymentScreen(onNavigationEvent = onNavigationEvent)
         cashPaymentScreen(onNavigationEvent = onNavigationEvent)
         markOrderAsCompleteScreen(onNavigationEvent = onNavigationEvent)
+        scanToPayScreen(onNavigationEvent = onNavigationEvent)
         emailReceiptScreen(onNavigationEvent = onNavigationEvent)
         eligibilityScreen(onNavigationEvent = onNavigationEvent)
         settingsScreen(onNavigationEvent = onNavigationEvent)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEvent.kt
@@ -15,6 +15,7 @@ sealed class WooPosNavigationEvent {
         val source: CashPaymentSource = CashPaymentSource.CHECKOUT,
     ) : WooPosNavigationEvent()
     data class OpenMarkOrderAsComplete(val orderId: Long) : WooPosNavigationEvent()
+    data class OpenScanToPay(val orderId: Long) : WooPosNavigationEvent()
     data class OpenCardPayment(
         val orderId: Long,
         val source: CardPaymentSource = CardPaymentSource.CHECKOUT,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosNavigationEventHandler.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.ui.woopos.orders.details.refund.navigateToRefundR
 import com.woocommerce.android.ui.woopos.orders.navigateToOrderDetailsScreen
 import com.woocommerce.android.ui.woopos.orders.navigateToOrdersScreen
 import com.woocommerce.android.ui.woopos.paymentsuccess.navigateToPaymentSuccessScreen
+import com.woocommerce.android.ui.woopos.scantopay.navigateToScanToPayScreen
 import com.woocommerce.android.ui.woopos.settings.navigateToSettingsScreen
 import com.woocommerce.android.ui.woopos.splash.navigateToSplashScreen
 
@@ -35,6 +36,7 @@ fun NavHostController.handleNavigationEvent(
         is WooPosNavigationEvent.OpenHomeFromSplash -> navigateToHomeScreen()
         is WooPosNavigationEvent.OpenCashPayment -> navigateToCashPaymentScreen(event.orderId, event.source)
         is WooPosNavigationEvent.OpenMarkOrderAsComplete -> navigateToMarkOrderAsCompleteScreen(event.orderId)
+        is WooPosNavigationEvent.OpenScanToPay -> navigateToScanToPayScreen(event.orderId)
 
         is WooPosNavigationEvent.OpenCardPayment ->
             navigateToCardPaymentScreen(event.orderId, event.source, event.showCashPaymentButton)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosRootHost.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/root/navigation/WooPosRootHost.kt
@@ -14,6 +14,7 @@ import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.O
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenEmailReceipt
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenMarkOrderAsComplete
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenOrders
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenScanToPay
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.OpenSettings
 import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent.ReturnHomeFromCashPayment
 
@@ -29,6 +30,7 @@ fun WooPosRootHost(
             when (it) {
                 is NavigationEvent.ToCashPayment -> onNavigationEvent(OpenCashPayment(it.orderId))
                 is NavigationEvent.ToMarkOrderAsComplete -> onNavigationEvent(OpenMarkOrderAsComplete(it.orderId))
+                is NavigationEvent.ToScanToPay -> onNavigationEvent(OpenScanToPay(it.orderId))
                 is NavigationEvent.ToEmailReceipt -> onNavigationEvent(OpenEmailReceipt(it.orderId))
                 NavigationEvent.ExitPos -> onNavigationEvent(ExitPosClicked)
                 NavigationEvent.ReturnHomeFromCashWhenCardPaymentStarted -> onNavigationEvent(ReturnHomeFromCashPayment)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayNavigation.kt
@@ -1,0 +1,49 @@
+package com.woocommerce.android.ui.woopos.scantopay
+
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.woocommerce.android.ui.woopos.home.HOME_ROUTE
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.root.navigation.navigateOnce
+
+const val SCAN_TO_PAY_ROUTE_ORDER_ID_KEY = "orderId"
+const val SCAN_TO_PAY_ROUTE = "$HOME_ROUTE/scan_to_pay/{$SCAN_TO_PAY_ROUTE_ORDER_ID_KEY}"
+
+fun NavController.navigateToScanToPayScreen(orderId: Long) {
+    navigateOnce(
+        SCAN_TO_PAY_ROUTE.replace("{$SCAN_TO_PAY_ROUTE_ORDER_ID_KEY}", orderId.toString())
+    )
+}
+
+fun NavGraphBuilder.scanToPayScreen(
+    onNavigationEvent: (WooPosNavigationEvent) -> Unit,
+) {
+    composable(
+        route = SCAN_TO_PAY_ROUTE,
+        arguments = listOf(
+            navArgument(SCAN_TO_PAY_ROUTE_ORDER_ID_KEY) { type = NavType.LongType },
+        ),
+        enterTransition = {
+            slideInHorizontally(
+                initialOffsetX = { fullWidth -> fullWidth },
+            )
+        },
+        exitTransition = {
+            slideOutHorizontally(
+                targetOffsetX = { fullWidth -> -fullWidth },
+            )
+        },
+        popExitTransition = {
+            slideOutHorizontally(
+                targetOffsetX = { fullWidth -> fullWidth },
+            )
+        },
+    ) {
+        WooPosScanToPayScreen(onNavigationEvent = onNavigationEvent)
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayRepository.kt
@@ -1,0 +1,76 @@
+package com.woocommerce.android.ui.woopos.scantopay
+
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.OrderMapper
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.util.WooLog.T
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.store.WCOrderStore
+import javax.inject.Inject
+
+class WooPosScanToPayRepository @Inject constructor(
+    private val selectedSite: SelectedSite,
+    private val orderStore: WCOrderStore,
+    private val orderMapper: OrderMapper,
+) {
+    suspend fun promoteOrderToPending(orderId: Long): Result<Unit> = withContext(Dispatchers.IO) {
+        val statusModel = orderStore.getOrderStatusForSiteAndKey(
+            selectedSite.get(),
+            Order.Status.Pending.value,
+        ) ?: WCOrderStatusModel(
+            statusKey = Order.Status.Pending.value,
+            label = Order.Status.Pending.value,
+        )
+
+        orderStore.updateOrderStatus(
+            orderId = orderId,
+            site = selectedSite.get(),
+            newStatus = statusModel,
+        )
+            .filterIsInstance<WCOrderStore.UpdateOrderResult.RemoteUpdateResult>()
+            .map { result ->
+                if (result.event.isError) {
+                    WooLog.e(T.POS, "Scan to Pay: promote to pending failed - ${result.event.error.message}")
+                    Result.failure(Exception(result.event.error.message))
+                } else {
+                    Result.success(Unit)
+                }
+            }
+            .first()
+    }
+
+    suspend fun fetchOrderSnapshot(orderId: Long): Order? = withContext(Dispatchers.IO) {
+        val result = orderStore.fetchSingleOrderSync(selectedSite.get(), orderId)
+        if (result.isError) {
+            WooLog.e(T.POS, "Scan to Pay: fetch failed - ${result.error?.message}")
+            null
+        } else {
+            result.model?.let { orderMapper.toAppModel(it) }
+        }
+    }
+
+    suspend fun getCachedOrder(orderId: Long): Order? = withContext(Dispatchers.IO) {
+        orderStore.getOrderByIdAndSite(orderId, selectedSite.get())?.let { orderMapper.toAppModel(it) }
+    }
+
+    suspend fun addOrderNote(orderId: Long, note: String): Result<Unit> = withContext(Dispatchers.IO) {
+        val noteResult = orderStore.postOrderNote(
+            site = selectedSite.get(),
+            orderId = orderId,
+            note = note,
+            isCustomerNote = false,
+        )
+        if (noteResult.isError) {
+            WooLog.e(T.POS, "Scan to Pay: post note failed - ${noteResult.error?.message}")
+            Result.failure(Exception(noteResult.error?.message ?: "post order note failed"))
+        } else {
+            Result.success(Unit)
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayScreen.kt
@@ -1,0 +1,224 @@
+package com.woocommerce.android.ui.woopos.scantopay
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.WindowManager
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.woocommerce.android.R
+import com.woocommerce.android.ui.woopos.common.composeui.WooPosPreview
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosCircularLoadingIndicator
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosOutlinedButton
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosQrCode
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosText
+import com.woocommerce.android.ui.woopos.common.composeui.component.WooPosToolbar
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosSpacing
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTheme
+import com.woocommerce.android.ui.woopos.common.composeui.designsystem.WooPosTypography
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.util.WooPosTestTags
+
+@Composable
+fun WooPosScanToPayScreen(onNavigationEvent: (WooPosNavigationEvent) -> Unit) {
+    val viewModel = hiltViewModel<WooPosScanToPayViewModel>()
+    val state = viewModel.state.collectAsState().value
+
+    LaunchedEffect(Unit) {
+        viewModel.navigationEvent.collect { onNavigationEvent(it) }
+    }
+
+    val isQrVisible = state is WooPosScanToPayState.ShowingQR
+    MaxBrightnessWhen(active = isQrVisible)
+
+    WooPosScanToPayScreen(
+        state = state,
+        onCancelClicked = { viewModel.onBackClicked() },
+        onRetryClicked = { viewModel.onUIEvent(WooPosScanToPayUIEvent.RetryClicked) },
+    )
+    BackHandler { viewModel.onBackClicked() }
+}
+
+@Composable
+private fun WooPosScanToPayScreen(
+    state: WooPosScanToPayState,
+    onCancelClicked: () -> Unit,
+    onRetryClicked: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        WooPosToolbar(
+            titleText = stringResource(R.string.woopos_scan_to_pay_title),
+            onBackClicked = onCancelClicked,
+        )
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            when (state) {
+                WooPosScanToPayState.Loading,
+                WooPosScanToPayState.PaymentDetected -> WooPosCircularLoadingIndicator()
+
+                is WooPosScanToPayState.ShowingQR -> ShowingQR(state = state, onCancelClicked = onCancelClicked)
+
+                is WooPosScanToPayState.Failed -> Failed(
+                    state = state,
+                    onRetryClicked = onRetryClicked,
+                    onCancelClicked = onCancelClicked,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ShowingQR(
+    state: WooPosScanToPayState.ShowingQR,
+    onCancelClicked: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WooPosSpacing.Large.value),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top,
+    ) {
+        if (state.totalText.isNotBlank()) {
+            WooPosText(
+                text = state.totalText,
+                style = WooPosTypography.Heading,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(WooPosSpacing.Large.value))
+        }
+        WooPosText(
+            text = stringResource(R.string.woopos_scan_to_pay_subtitle),
+            style = WooPosTypography.BodyLarge,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
+        @Suppress("WooPosDesignSystemComponentSizeUsageRule")
+        WooPosQrCode(
+            data = state.paymentUrl,
+            size = 320.dp,
+            modifier = Modifier.testTag(WooPosTestTags.SCAN_TO_PAY_QR_CODE),
+        )
+        Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
+        WooPosOutlinedButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(WooPosTestTags.SCAN_TO_PAY_CANCEL_BUTTON),
+            text = stringResource(R.string.woopos_scan_to_pay_cancel),
+            onClick = onCancelClicked,
+        )
+    }
+}
+
+@Composable
+private fun Failed(
+    state: WooPosScanToPayState.Failed,
+    onRetryClicked: () -> Unit,
+    onCancelClicked: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(WooPosSpacing.Large.value),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        WooPosText(
+            text = state.message,
+            style = WooPosTypography.Heading,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(WooPosSpacing.XLarge.value))
+        if (state.retryable) {
+            WooPosButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(R.string.woopos_scan_to_pay_retry),
+                onClick = onRetryClicked,
+            )
+            Spacer(modifier = Modifier.height(WooPosSpacing.Medium.value))
+        }
+        WooPosOutlinedButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.woopos_scan_to_pay_cancel),
+            onClick = onCancelClicked,
+        )
+    }
+}
+
+@Composable
+private fun MaxBrightnessWhen(active: Boolean) {
+    val window = LocalContext.current.findActivity()?.window ?: return
+    DisposableEffect(active) {
+        val previous = window.attributes.screenBrightness
+        if (active) {
+            window.attributes = window.attributes.apply {
+                screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_FULL
+            }
+        }
+        onDispose {
+            window.attributes = window.attributes.apply { screenBrightness = previous }
+        }
+    }
+}
+
+private fun Context.findActivity(): Activity? {
+    var ctx: Context? = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
+}
+
+@WooPosPreview
+@Composable
+private fun WooPosScanToPayShowingQrPreview() {
+    WooPosTheme {
+        WooPosScanToPayScreen(
+            state = WooPosScanToPayState.ShowingQR(
+                paymentUrl = "https://example.com/checkout/pay/abc123",
+                totalText = "Order total: $42.00",
+            ),
+            onCancelClicked = {},
+            onRetryClicked = {},
+        )
+    }
+}
+
+@WooPosPreview
+@Composable
+private fun WooPosScanToPayFailedPreview() {
+    WooPosTheme {
+        WooPosScanToPayScreen(
+            state = WooPosScanToPayState.Failed(
+                message = "Something went wrong. Please try again.",
+                retryable = true,
+            ),
+            onCancelClicked = {},
+            onRetryClicked = {},
+        )
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -55,7 +56,7 @@ fun WooPosScanToPayScreen(onNavigationEvent: (WooPosNavigationEvent) -> Unit) {
 
     WooPosScanToPayScreen(
         state = state,
-        onCancelClicked = { viewModel.onBackClicked() },
+        onCancelClicked = { viewModel.onUIEvent(WooPosScanToPayUIEvent.CancelClicked) },
         onRetryClicked = { viewModel.onUIEvent(WooPosScanToPayUIEvent.RetryClicked) },
     )
     BackHandler { viewModel.onBackClicked() }
@@ -171,15 +172,18 @@ private fun Failed(
 @Composable
 private fun MaxBrightnessWhen(active: Boolean) {
     val window = LocalContext.current.findActivity()?.window ?: return
+    // Capture the user's brightness once. Re-reading it inside DisposableEffect(active)
+    // would observe our own FULL override on a true→false→true cycle and lock the app
+    // to max brightness even after the screen closes.
+    val originalBrightness = remember { window.attributes.screenBrightness }
     DisposableEffect(active) {
-        val previous = window.attributes.screenBrightness
         if (active) {
             window.attributes = window.attributes.apply {
                 screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_FULL
             }
         }
         onDispose {
-            window.attributes = window.attributes.apply { screenBrightness = previous }
+            window.attributes = window.attributes.apply { screenBrightness = originalBrightness }
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayState.kt
@@ -1,0 +1,25 @@
+package com.woocommerce.android.ui.woopos.scantopay
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+sealed class WooPosScanToPayState : Parcelable {
+    @Parcelize
+    data object Loading : WooPosScanToPayState()
+
+    @Parcelize
+    data class ShowingQR(
+        val paymentUrl: String,
+        val totalText: String,
+    ) : WooPosScanToPayState()
+
+    @Parcelize
+    data object PaymentDetected : WooPosScanToPayState()
+
+    @Parcelize
+    data class Failed(
+        val message: String,
+        val retryable: Boolean,
+    ) : WooPosScanToPayState()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayUIEvent.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.ui.woopos.scantopay
+
+sealed class WooPosScanToPayUIEvent {
+    data object RetryClicked : WooPosScanToPayUIEvent()
+    data object CancelClicked : WooPosScanToPayUIEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
@@ -123,8 +123,11 @@ class WooPosScanToPayViewModel @Inject constructor(
     private suspend fun onPaymentDetected() {
         analyticsTracker.track(ScanToPayPaymentDetectedViaPolling)
         _state.value = WooPosScanToPayState.PaymentDetected
-        // Best-effort audit note; failures are logged in the repo and ignored.
-        repository.addOrderNote(orderId, resourceProvider.getString(R.string.woopos_scan_to_pay_order_note))
+        // Best-effort audit note. The success transition must not block on it, so we
+        // fire it off independently — failures are logged in the repo and ignored.
+        viewModelScope.launch {
+            repository.addOrderNote(orderId, resourceProvider.getString(R.string.woopos_scan_to_pay_order_note))
+        }
         analyticsTracker.track(ScanToPayCollectPaymentSuccess)
         parentToChildrenEventSender.sendToChildren(
             ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.SCAN_TO_PAY),
@@ -154,10 +157,12 @@ class WooPosScanToPayViewModel @Inject constructor(
         // 15 fast (30s) + 60 slow (300s) ≈ 5.5 min total ceiling before we give up.
         const val MAX_POLL_ATTEMPTS = 75
 
+        // OnHold is intentionally excluded: on-hold means the gateway is awaiting verification
+        // (e.g. delayed-capture, manual BACS) — not a confirmed payment. Treating it as paid
+        // would post a "Customer paid via Scan to Pay" note before the customer actually did.
         val PAID_STATUSES: Set<Order.Status> = setOf(
             Order.Status.Processing,
             Order.Status.Completed,
-            Order.Status.OnHold,
         )
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModel.kt
@@ -1,0 +1,163 @@
+package com.woocommerce.android.ui.woopos.scantopay
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
+import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventSender
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCheckoutFromScanToPay
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ScanToPayCollectPaymentSuccess
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ScanToPayPaymentDetectedViaPolling
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ScanToPayPaymentFailed
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.viewmodel.ResourceProvider
+import com.woocommerce.android.viewmodel.getStateFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WooPosScanToPayViewModel @Inject constructor(
+    private val repository: WooPosScanToPayRepository,
+    private val parentToChildrenEventSender: WooPosParentToChildrenEventSender,
+    private val analyticsTracker: WooPosAnalyticsTracker,
+    private val resourceProvider: ResourceProvider,
+    private val priceFormat: WooPosFormatPrice,
+    savedState: SavedStateHandle,
+) : ViewModel() {
+    private val orderId: Long = requireNotNull(savedState[SCAN_TO_PAY_ROUTE_ORDER_ID_KEY])
+
+    private val _navigationEvent = MutableSharedFlow<WooPosNavigationEvent>()
+    val navigationEvent: SharedFlow<WooPosNavigationEvent> = _navigationEvent.asSharedFlow()
+
+    private val _state = savedState.getStateFlow<WooPosScanToPayState>(
+        scope = viewModelScope,
+        initialValue = WooPosScanToPayState.Loading,
+        key = STATE_KEY,
+    )
+    val state: StateFlow<WooPosScanToPayState> = _state
+
+    private var pollingJob: Job? = null
+
+    init {
+        viewModelScope.launch { prepareAndShowQr() }
+    }
+
+    fun onUIEvent(event: WooPosScanToPayUIEvent) {
+        when (event) {
+            WooPosScanToPayUIEvent.RetryClicked -> viewModelScope.launch {
+                _state.value = WooPosScanToPayState.Loading
+                prepareAndShowQr()
+            }
+            WooPosScanToPayUIEvent.CancelClicked -> onBackClicked()
+        }
+    }
+
+    fun onBackClicked() {
+        viewModelScope.launch {
+            analyticsTracker.track(BackToCheckoutFromScanToPay)
+            pollingJob?.cancel()
+            _navigationEvent.emit(WooPosNavigationEvent.GoBack)
+        }
+    }
+
+    private suspend fun prepareAndShowQr() {
+        val promote = repository.promoteOrderToPending(orderId)
+        if (promote.isFailure) {
+            _state.value = failedState(retryable = true)
+            return
+        }
+
+        val paymentUrl = readPaymentUrlWithRetry()
+        if (paymentUrl.isNullOrBlank()) {
+            _state.value = failedState(retryable = true)
+            return
+        }
+
+        val totalText = repository.getCachedOrder(orderId)?.total?.let {
+            resourceProvider.getString(R.string.woopos_scan_to_pay_total, priceFormat(it))
+        }.orEmpty()
+
+        _state.value = WooPosScanToPayState.ShowingQR(paymentUrl = paymentUrl, totalText = totalText)
+        startPolling()
+    }
+
+    private suspend fun readPaymentUrlWithRetry(): String? {
+        repository.fetchOrderSnapshot(orderId)?.paymentUrl?.takeIf { it.isNotBlank() }?.let { return it }
+        // Some gateways need a moment to populate payment_url after the status flip.
+        delay(POST_PROMOTION_DELAY_MS)
+        return repository.fetchOrderSnapshot(orderId)?.paymentUrl?.takeIf { it.isNotBlank() }
+    }
+
+    private fun startPolling() {
+        pollingJob?.cancel()
+        pollingJob = viewModelScope.launch {
+            // ~30s of fast polling (15 × 2s), then back off to 5s intervals up to a ~5min ceiling.
+            for (attempt in 0 until MAX_POLL_ATTEMPTS) {
+                val intervalMs = if (attempt < FAST_POLL_ATTEMPTS) FAST_POLL_INTERVAL_MS else SLOW_POLL_INTERVAL_MS
+                delay(intervalMs)
+
+                val snapshot = repository.fetchOrderSnapshot(orderId) ?: continue
+                if (snapshot.isPaid()) {
+                    onPaymentDetected()
+                    return@launch
+                }
+            }
+            // Exhausted attempts without detecting payment.
+            analyticsTracker.track(ScanToPayPaymentFailed)
+            _state.value = failedState(retryable = true)
+        }
+    }
+
+    private suspend fun onPaymentDetected() {
+        analyticsTracker.track(ScanToPayPaymentDetectedViaPolling)
+        _state.value = WooPosScanToPayState.PaymentDetected
+        // Best-effort audit note; failures are logged in the repo and ignored.
+        repository.addOrderNote(orderId, resourceProvider.getString(R.string.woopos_scan_to_pay_order_note))
+        analyticsTracker.track(ScanToPayCollectPaymentSuccess)
+        parentToChildrenEventSender.sendToChildren(
+            ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.SCAN_TO_PAY),
+        )
+        _navigationEvent.emit(WooPosNavigationEvent.GoBack)
+    }
+
+    private fun failedState(retryable: Boolean) = WooPosScanToPayState.Failed(
+        message = resourceProvider.getString(R.string.woopos_scan_to_pay_error_message),
+        retryable = retryable,
+    )
+
+    private fun Order.isPaid(): Boolean = datePaid != null || status in PAID_STATUSES
+
+    override fun onCleared() {
+        pollingJob?.cancel()
+        super.onCleared()
+    }
+
+    private companion object {
+        const val STATE_KEY = "woo_pos_scan_to_pay_state"
+        const val POST_PROMOTION_DELAY_MS = 1_000L
+        const val FAST_POLL_INTERVAL_MS = 2_000L
+        const val SLOW_POLL_INTERVAL_MS = 5_000L
+        const val FAST_POLL_ATTEMPTS = 15 // ~30 s at 2 s cadence before backing off
+
+        // 15 fast (30s) + 60 slow (300s) ≈ 5.5 min total ceiling before we give up.
+        const val MAX_POLL_ATTEMPTS = 75
+
+        val PAID_STATUSES: Set<Order.Status> = setOf(
+            Order.Status.Processing,
+            Order.Status.Completed,
+            Order.Status.OnHold,
+        )
+    }
+}

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3855,6 +3855,13 @@
     <string name="woopos_mark_order_as_complete_note_hint">e.g. Bank transfer, gift card</string>
     <string name="woopos_mark_order_as_complete_confirm_button">Mark order as complete</string>
     <string name="woopos_mark_order_as_complete_error_message">Something went wrong. Please try again.</string>
+    <string name="woopos_scan_to_pay_title">Scan to pay</string>
+    <string name="woopos_scan_to_pay_subtitle">Show this code to the customer to let them pay from their phone.</string>
+    <string name="woopos_scan_to_pay_total">Order total: %1$s</string>
+    <string name="woopos_scan_to_pay_error_message">We couldn\'t prepare the payment. Please try again.</string>
+    <string name="woopos_scan_to_pay_retry">Try again</string>
+    <string name="woopos_scan_to_pay_cancel">Cancel</string>
+    <string name="woopos_scan_to_pay_order_note">Customer paid via Scan to Pay</string>
     <string name="woopos_payment_method_picker_dialog_title">Choose payment method</string>
     <string name="woopos_tap_to_pay_promoted_title">Tap to pay</string>
     <string name="woopos_tap_to_pay_promoted_subtitle">Use this device to accept contactless card payments.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -780,6 +780,41 @@ class WooPosTotalsViewModelTest {
     }
 
     @Test
+    fun `given order draft created, when OnScanToPayClicked, then track analytic and emit ToScanToPay`() = runTest {
+        // GIVEN
+        val viewModel = createViewModelAndSetupForSuccessfulOrderCreation()
+        assertThat(viewModel.state.value).isInstanceOf(WooPosTotalsViewState.Checkout::class.java)
+
+        // WHEN
+        viewModel.onUIEvent(WooPosTotalsUIEvent.OnScanToPayClicked)
+
+        // THEN
+        verify(analyticsTracker).track(
+            com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.CheckoutScanToPayPaymentTapped,
+        )
+        verify(childrenToParentEventSender).sendToParent(
+            isA<ChildToParentEvent.NavigationEvent.ToScanToPay>(),
+        )
+    }
+
+    @Test
+    fun `given no order draft, when OnScanToPayClicked, then do not emit navigation event`() = runTest {
+        // GIVEN
+        val parentToChildrenEventReceiver: WooPosParentToChildrenEventReceiver = mock {
+            on { events }.thenReturn(MutableStateFlow(ParentToChildrenEvent.BackFromCheckoutToCartClicked))
+        }
+        val viewModel = createViewModel(parentToChildrenEventReceiver = parentToChildrenEventReceiver)
+
+        // WHEN
+        viewModel.onUIEvent(WooPosTotalsUIEvent.OnScanToPayClicked)
+
+        // THEN
+        verify(childrenToParentEventSender, never()).sendToParent(
+            isA<ChildToParentEvent.NavigationEvent.ToScanToPay>(),
+        )
+    }
+
+    @Test
     fun `given order draft created, when reader connects, then start payment automatically`() = runTest {
         // GIVEN
         whenever(networkStatus.isConnected()).thenReturn(true)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayRepositoryTest.kt
@@ -13,6 +13,8 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
+import org.wordpress.android.fluxc.model.LocalOrRemoteId.RemoteId
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
@@ -23,6 +25,7 @@ import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
 import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult
+import java.util.Date
 
 class WooPosScanToPayRepositoryTest {
 
@@ -43,7 +46,7 @@ class WooPosScanToPayRepositoryTest {
         val orderId = 123L
         val site: SiteModel = mock()
         val statusModel = WCOrderStatusModel(statusKey = Order.Status.Pending.value)
-        val updateResult = UpdateOrderResult.RemoteUpdateResult(mock { on { isError }.thenReturn(false) })
+        val updateResult = UpdateOrderResult.RemoteUpdateResult(OnOrderChanged())
 
         whenever(selectedSite.get()).thenReturn(site)
         whenever(orderStore.getOrderStatusForSiteAndKey(site, Order.Status.Pending.value)).thenReturn(statusModel)
@@ -86,8 +89,8 @@ class WooPosScanToPayRepositoryTest {
         // GIVEN
         val orderId = 123L
         val site: SiteModel = mock()
-        val entity: OrderEntity = mock()
-        val order: Order = mock()
+        val entity = OrderEntity(localSiteId = LocalId(1), orderId = orderId)
+        val order = Order.getEmptyOrder(Date(), Date()).copy(id = orderId)
 
         whenever(selectedSite.get()).thenReturn(site)
         whenever(orderStore.fetchSingleOrderSync(site, orderId)).thenReturn(WooResult(entity))
@@ -126,7 +129,17 @@ class WooPosScanToPayRepositoryTest {
         whenever(
             orderStore.postOrderNote(site = eq(site), orderId = eq(orderId), note = any(), isCustomerNote = eq(false))
         )
-            .thenReturn(WooResult(mock<OrderNoteEntity>()))
+            .thenReturn(
+                WooResult(
+                    OrderNoteEntity(
+                        localSiteId = LocalId(1),
+                        noteId = RemoteId(1L),
+                        orderId = RemoteId(orderId),
+                        isSystemNote = false,
+                        isCustomerNote = false,
+                    )
+                )
+            )
 
         // WHEN
         val result = repository.addOrderNote(orderId, "Customer paid via Scan to Pay")

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayRepositoryTest.kt
@@ -1,0 +1,161 @@
+package com.woocommerce.android.ui.woopos.scantopay
+
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.model.OrderMapper
+import com.woocommerce.android.tools.SelectedSite
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.WCOrderStatusModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.persistence.entity.OrderEntity
+import org.wordpress.android.fluxc.persistence.entity.OrderNoteEntity
+import org.wordpress.android.fluxc.store.WCOrderStore
+import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
+import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult
+
+class WooPosScanToPayRepositoryTest {
+
+    private val selectedSite: SelectedSite = mock()
+    private val orderStore: WCOrderStore = mock()
+    private val orderMapper: OrderMapper = mock()
+
+    private lateinit var repository: WooPosScanToPayRepository
+
+    @Before
+    fun setUp() {
+        repository = WooPosScanToPayRepository(selectedSite, orderStore, orderMapper)
+    }
+
+    @Test
+    fun `given remote update succeeds, when promoteOrderToPending, then status is set to pending`() = runTest {
+        // GIVEN
+        val orderId = 123L
+        val site: SiteModel = mock()
+        val statusModel = WCOrderStatusModel(statusKey = Order.Status.Pending.value)
+        val updateResult = UpdateOrderResult.RemoteUpdateResult(mock { on { isError }.thenReturn(false) })
+
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(orderStore.getOrderStatusForSiteAndKey(site, Order.Status.Pending.value)).thenReturn(statusModel)
+        whenever(orderStore.updateOrderStatus(orderId = orderId, site = site, newStatus = statusModel))
+            .thenReturn(flowOf(updateResult))
+
+        // WHEN
+        val result = repository.promoteOrderToPending(orderId)
+
+        // THEN
+        assertThat(result.isSuccess).isTrue()
+        verify(orderStore).updateOrderStatus(orderId = eq(orderId), site = eq(site), newStatus = eq(statusModel))
+    }
+
+    @Test
+    fun `given remote update fails, when promoteOrderToPending, then result is failure`() = runTest {
+        // GIVEN
+        val orderId = 123L
+        val site: SiteModel = mock()
+        val statusModel = WCOrderStatusModel(statusKey = Order.Status.Pending.value)
+        val updateResult = UpdateOrderResult.RemoteUpdateResult(
+            event = OnOrderChanged(orderError = WCOrderStore.OrderError(message = "boom")),
+        )
+
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(orderStore.getOrderStatusForSiteAndKey(site, Order.Status.Pending.value)).thenReturn(statusModel)
+        whenever(orderStore.updateOrderStatus(orderId = orderId, site = site, newStatus = statusModel))
+            .thenReturn(flowOf(updateResult))
+
+        // WHEN
+        val result = repository.promoteOrderToPending(orderId)
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()?.message).isEqualTo("boom")
+    }
+
+    @Test
+    fun `given fetch succeeds, when fetchOrderSnapshot, then mapped Order returned`() = runTest {
+        // GIVEN
+        val orderId = 123L
+        val site: SiteModel = mock()
+        val entity: OrderEntity = mock()
+        val order: Order = mock()
+
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(orderStore.fetchSingleOrderSync(site, orderId)).thenReturn(WooResult(entity))
+        whenever(orderMapper.toAppModel(entity)).thenReturn(order)
+
+        // WHEN
+        val result = repository.fetchOrderSnapshot(orderId)
+
+        // THEN
+        assertThat(result).isEqualTo(order)
+    }
+
+    @Test
+    fun `given fetch errors, when fetchOrderSnapshot, then null returned`() = runTest {
+        // GIVEN
+        val orderId = 123L
+        val site: SiteModel = mock()
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(orderStore.fetchSingleOrderSync(site, orderId)).thenReturn(
+            WooResult(WooError(WooErrorType.GENERIC_ERROR, original = mock())),
+        )
+
+        // WHEN
+        val result = repository.fetchOrderSnapshot(orderId)
+
+        // THEN
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `given postOrderNote succeeds, when addOrderNote, then success`() = runTest {
+        // GIVEN
+        val orderId = 123L
+        val site: SiteModel = mock()
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(
+            orderStore.postOrderNote(site = eq(site), orderId = eq(orderId), note = any(), isCustomerNote = eq(false))
+        )
+            .thenReturn(WooResult(mock<OrderNoteEntity>()))
+
+        // WHEN
+        val result = repository.addOrderNote(orderId, "Customer paid via Scan to Pay")
+
+        // THEN
+        assertThat(result.isSuccess).isTrue()
+        verify(orderStore).postOrderNote(
+            site = eq(site),
+            orderId = eq(orderId),
+            note = eq("Customer paid via Scan to Pay"),
+            isCustomerNote = eq(false),
+        )
+    }
+
+    @Test
+    fun `given postOrderNote fails, when addOrderNote, then failure with message`() = runTest {
+        // GIVEN
+        val orderId = 123L
+        val site: SiteModel = mock()
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(
+            orderStore.postOrderNote(site = eq(site), orderId = eq(orderId), note = any(), isCustomerNote = eq(false))
+        )
+            .thenReturn(WooResult(WooError(WooErrorType.GENERIC_ERROR, original = mock(), message = "no note")))
+
+        // WHEN
+        val result = repository.addOrderNote(orderId, "Customer paid via Scan to Pay")
+
+        // THEN
+        assertThat(result.isFailure).isTrue()
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
@@ -74,10 +74,11 @@ class WooPosScanToPayViewModelTest {
     @Test
     fun `given promote succeeds and paymentUrl available, when VM initializes, then state ShowingQR`() = runTest {
         // GIVEN
-        val cached: Order = mock { on { total }.thenReturn(BigDecimal("42.00")) }
-        val pendingOrder: Order = mock {
-            on { paymentUrl }.thenReturn("https://example.com/pay/abc")
-        }
+        val cached = Order.getEmptyOrder(Date(), Date()).copy(id = orderId, total = BigDecimal("42.00"))
+        val pendingOrder = Order.getEmptyOrder(Date(), Date()).copy(
+            id = orderId,
+            paymentUrl = "https://example.com/pay/abc",
+        )
         whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
         whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(pendingOrder)
         whenever(repository.getCachedOrder(orderId)).thenReturn(cached)
@@ -112,7 +113,7 @@ class WooPosScanToPayViewModelTest {
     @Test
     fun `given paymentUrl blank after retry, when VM initializes, then state Failed retryable`() = runTest {
         // GIVEN
-        val blankOrder: Order = mock { on { paymentUrl }.thenReturn("") }
+        val blankOrder = Order.getEmptyOrder(Date(), Date()).copy(id = orderId, paymentUrl = "")
         whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
         whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(blankOrder)
 
@@ -130,15 +131,14 @@ class WooPosScanToPayViewModelTest {
     fun `given QR shown, when polling detects paid order, then analytics tracked, parent event sent and GoBack emitted`() =
         runTest {
             // GIVEN
-            val cached: Order = mock { on { total }.thenReturn(BigDecimal("42.00")) }
-            val pendingOrder: Order = mock {
-                on { paymentUrl }.thenReturn("https://example.com/pay/abc")
-                on { datePaid }.thenReturn(null)
-                on { status }.thenReturn(Order.Status.Pending)
-            }
-            val paidOrder: Order = mock {
-                on { datePaid }.thenReturn(Date())
-            }
+            val cached = Order.getEmptyOrder(Date(), Date()).copy(id = orderId, total = BigDecimal("42.00"))
+            val pendingOrder = Order.getEmptyOrder(Date(), Date()).copy(
+                id = orderId,
+                paymentUrl = "https://example.com/pay/abc",
+                datePaid = null,
+                status = Order.Status.Pending,
+            )
+            val paidOrder = Order.getEmptyOrder(Date(), Date()).copy(id = orderId, datePaid = Date())
             whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
             whenever(repository.fetchOrderSnapshot(orderId))
                 .thenReturn(pendingOrder) // initial paymentUrl fetch
@@ -183,10 +183,11 @@ class WooPosScanToPayViewModelTest {
     @Test
     fun `given Failed state, when RetryClicked, then attempts to prepare again`() = runTest {
         // GIVEN: first attempt fails, second succeeds
-        val cached: Order = mock { on { total }.thenReturn(BigDecimal("42.00")) }
-        val pendingOrder: Order = mock {
-            on { paymentUrl }.thenReturn("https://example.com/pay/abc")
-        }
+        val cached = Order.getEmptyOrder(Date(), Date()).copy(id = orderId, total = BigDecimal("42.00"))
+        val pendingOrder = Order.getEmptyOrder(Date(), Date()).copy(
+            id = orderId,
+            paymentUrl = "https://example.com/pay/abc",
+        )
         whenever(repository.promoteOrderToPending(orderId))
             .thenReturn(Result.failure(Exception("boom")))
             .thenReturn(Result.success(Unit))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
@@ -13,6 +13,7 @@ import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCheckoutFromScanToPay
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ScanToPayCollectPaymentSuccess
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ScanToPayPaymentDetectedViaPolling
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ScanToPayPaymentFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
 import com.woocommerce.android.viewmodel.ResourceProvider
@@ -27,6 +28,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
@@ -178,6 +180,93 @@ class WooPosScanToPayViewModelTest {
             assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
         }
         verify(tracker).track(BackToCheckoutFromScanToPay)
+    }
+
+    @Test
+    fun `given QR shown, when polling sees Processing status, then payment detected`() = runTest {
+        // GIVEN
+        val pendingOrder = Order.getEmptyOrder(Date(), Date()).copy(
+            id = orderId,
+            paymentUrl = "https://example.com/pay/abc",
+            status = Order.Status.Pending,
+        )
+        val processingOrder = Order.getEmptyOrder(Date(), Date()).copy(
+            id = orderId,
+            datePaid = null,
+            status = Order.Status.Processing,
+        )
+        whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
+        whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(pendingOrder, processingOrder)
+        whenever(repository.getCachedOrder(orderId)).thenReturn(pendingOrder)
+        whenever(repository.addOrderNote(eq(orderId), any())).thenReturn(Result.success(Unit))
+
+        // WHEN
+        val viewModel = createViewModel()
+        runCurrent()
+
+        // THEN
+        viewModel.navigationEvent.test {
+            assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
+        }
+        verify(tracker).track(ScanToPayPaymentDetectedViaPolling)
+    }
+
+    @Test
+    fun `given QR shown, when polling sees OnHold status, then payment not detected`() = runTest {
+        // GIVEN: OnHold means awaiting verification, not paid — we should keep waiting
+        val pendingOrder = Order.getEmptyOrder(Date(), Date()).copy(
+            id = orderId,
+            paymentUrl = "https://example.com/pay/abc",
+            status = Order.Status.Pending,
+        )
+        val onHoldOrder = Order.getEmptyOrder(Date(), Date()).copy(
+            id = orderId,
+            datePaid = null,
+            status = Order.Status.OnHold,
+        )
+        whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
+        whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(pendingOrder, onHoldOrder)
+        whenever(repository.getCachedOrder(orderId)).thenReturn(pendingOrder)
+
+        // WHEN
+        val viewModel = createViewModel()
+        runCurrent()
+        // Allow at least one poll cycle
+        advanceTimeBy(2_500)
+        runCurrent()
+
+        // THEN
+        verify(tracker, never()).track(ScanToPayPaymentDetectedViaPolling)
+        assertThat(viewModel.state.value).isInstanceOf(WooPosScanToPayState.ShowingQR::class.java)
+    }
+
+    @Test
+    fun `given non-paid order, when polling exhausts MAX_POLL_ATTEMPTS, then ScanToPayPaymentFailed tracked`() = runTest {
+        // GIVEN
+        val pendingOrder = Order.getEmptyOrder(Date(), Date()).copy(
+            id = orderId,
+            paymentUrl = "https://example.com/pay/abc",
+            status = Order.Status.Pending,
+        )
+        val nonPaidOrder = Order.getEmptyOrder(Date(), Date()).copy(
+            id = orderId,
+            datePaid = null,
+            status = Order.Status.Pending,
+        )
+        whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
+        whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(pendingOrder, nonPaidOrder)
+        whenever(repository.getCachedOrder(orderId)).thenReturn(pendingOrder)
+
+        // WHEN
+        val viewModel = createViewModel()
+        runCurrent()
+        // Advance past the 5.5-min ceiling (15 × 2s + 60 × 5s = 330s)
+        advanceTimeBy(340_000)
+        runCurrent()
+
+        // THEN
+        verify(tracker).track(ScanToPayPaymentFailed)
+        assertThat(viewModel.state.value).isInstanceOf(WooPosScanToPayState.Failed::class.java)
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/scantopay/WooPosScanToPayViewModelTest.kt
@@ -1,0 +1,207 @@
+package com.woocommerce.android.ui.woopos.scantopay
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent
+import com.woocommerce.android.ui.woopos.home.ParentToChildrenEvent.OrderSuccessfullyPaid.PaymentMethod
+import com.woocommerce.android.ui.woopos.home.WooPosParentToChildrenEventSender
+import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCheckoutFromScanToPay
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ScanToPayCollectPaymentSuccess
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.ScanToPayPaymentDetectedViaPolling
+import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
+import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.util.Date
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosScanToPayViewModelTest {
+
+    @Rule
+    @JvmField
+    val coroutinesTestRule = WooPosCoroutineTestRule()
+
+    @Rule
+    @JvmField
+    val instantTaskRule = InstantTaskExecutorRule()
+
+    private val repository: WooPosScanToPayRepository = mock()
+    private val parentToChildrenEventSender: WooPosParentToChildrenEventSender = mock()
+    private val tracker: WooPosAnalyticsTracker = mock()
+    private val resourceProvider: ResourceProvider = mock()
+    private val priceFormat: WooPosFormatPrice = mock()
+
+    private val orderId = 123L
+
+    @Before
+    fun setUp() = runTest {
+        whenever(resourceProvider.getString(eq(R.string.woopos_scan_to_pay_total), any()))
+            .thenReturn("Order total: $42.00")
+        whenever(resourceProvider.getString(R.string.woopos_scan_to_pay_error_message))
+            .thenReturn("Something went wrong. Please try again.")
+        whenever(resourceProvider.getString(R.string.woopos_scan_to_pay_order_note))
+            .thenReturn("Customer paid via Scan to Pay")
+        whenever(priceFormat(BigDecimal("42.00"))).thenReturn("$42.00")
+    }
+
+    private fun createViewModel() = WooPosScanToPayViewModel(
+        repository = repository,
+        parentToChildrenEventSender = parentToChildrenEventSender,
+        analyticsTracker = tracker,
+        resourceProvider = resourceProvider,
+        priceFormat = priceFormat,
+        savedState = SavedStateHandle(mapOf(SCAN_TO_PAY_ROUTE_ORDER_ID_KEY to orderId)),
+    )
+
+    @Test
+    fun `given promote succeeds and paymentUrl available, when VM initializes, then state ShowingQR`() = runTest {
+        // GIVEN
+        val cached: Order = mock { on { total }.thenReturn(BigDecimal("42.00")) }
+        val pendingOrder: Order = mock {
+            on { paymentUrl }.thenReturn("https://example.com/pay/abc")
+        }
+        whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
+        whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(pendingOrder)
+        whenever(repository.getCachedOrder(orderId)).thenReturn(cached)
+
+        // WHEN
+        val viewModel = createViewModel()
+        runCurrent()
+
+        // THEN
+        val state = viewModel.state.value
+        assertThat(state).isInstanceOf(WooPosScanToPayState.ShowingQR::class.java)
+        val showing = state as WooPosScanToPayState.ShowingQR
+        assertThat(showing.paymentUrl).isEqualTo("https://example.com/pay/abc")
+        assertThat(showing.totalText).isEqualTo("Order total: $42.00")
+    }
+
+    @Test
+    fun `given promote fails, when VM initializes, then state Failed retryable`() = runTest {
+        // GIVEN
+        whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.failure(Exception("boom")))
+
+        // WHEN
+        val viewModel = createViewModel()
+        runCurrent()
+
+        // THEN
+        val state = viewModel.state.value as WooPosScanToPayState.Failed
+        assertThat(state.retryable).isTrue()
+        assertThat(state.message).isEqualTo("Something went wrong. Please try again.")
+    }
+
+    @Test
+    fun `given paymentUrl blank after retry, when VM initializes, then state Failed retryable`() = runTest {
+        // GIVEN
+        val blankOrder: Order = mock { on { paymentUrl }.thenReturn("") }
+        whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
+        whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(blankOrder)
+
+        // WHEN
+        val viewModel = createViewModel()
+        advanceTimeBy(2_000)
+        runCurrent()
+
+        // THEN
+        val state = viewModel.state.value as WooPosScanToPayState.Failed
+        assertThat(state.retryable).isTrue()
+    }
+
+    @Test
+    fun `given QR shown, when polling detects paid order, then analytics tracked, parent event sent and GoBack emitted`() =
+        runTest {
+            // GIVEN
+            val cached: Order = mock { on { total }.thenReturn(BigDecimal("42.00")) }
+            val pendingOrder: Order = mock {
+                on { paymentUrl }.thenReturn("https://example.com/pay/abc")
+                on { datePaid }.thenReturn(null)
+                on { status }.thenReturn(Order.Status.Pending)
+            }
+            val paidOrder: Order = mock {
+                on { datePaid }.thenReturn(Date())
+            }
+            whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.success(Unit))
+            whenever(repository.fetchOrderSnapshot(orderId))
+                .thenReturn(pendingOrder) // initial paymentUrl fetch
+                .thenReturn(paidOrder) // polling detects payment
+            whenever(repository.getCachedOrder(orderId)).thenReturn(cached)
+            whenever(repository.addOrderNote(eq(orderId), any())).thenReturn(Result.success(Unit))
+
+            // WHEN
+            val viewModel = createViewModel()
+            runCurrent()
+
+            viewModel.navigationEvent.test {
+                advanceTimeBy(2_500) // poll once
+                runCurrent()
+                assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
+            }
+
+            // THEN
+            verify(tracker).track(ScanToPayPaymentDetectedViaPolling)
+            verify(tracker).track(ScanToPayCollectPaymentSuccess)
+            verify(parentToChildrenEventSender).sendToChildren(
+                eq(ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.SCAN_TO_PAY)),
+            )
+            verify(repository).addOrderNote(orderId, "Customer paid via Scan to Pay")
+        }
+
+    @Test
+    fun `when cancel clicked, then BackToCheckoutFromScanToPay tracked and GoBack emitted`() = runTest {
+        // GIVEN
+        whenever(repository.promoteOrderToPending(orderId)).thenReturn(Result.failure(Exception("boom")))
+        val viewModel = createViewModel()
+        runCurrent()
+
+        // WHEN / THEN
+        viewModel.navigationEvent.test {
+            viewModel.onUIEvent(WooPosScanToPayUIEvent.CancelClicked)
+            assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
+        }
+        verify(tracker).track(BackToCheckoutFromScanToPay)
+    }
+
+    @Test
+    fun `given Failed state, when RetryClicked, then attempts to prepare again`() = runTest {
+        // GIVEN: first attempt fails, second succeeds
+        val cached: Order = mock { on { total }.thenReturn(BigDecimal("42.00")) }
+        val pendingOrder: Order = mock {
+            on { paymentUrl }.thenReturn("https://example.com/pay/abc")
+        }
+        whenever(repository.promoteOrderToPending(orderId))
+            .thenReturn(Result.failure(Exception("boom")))
+            .thenReturn(Result.success(Unit))
+        whenever(repository.fetchOrderSnapshot(orderId)).thenReturn(pendingOrder)
+        whenever(repository.getCachedOrder(orderId)).thenReturn(cached)
+
+        val viewModel = createViewModel()
+        runCurrent()
+        assertThat(viewModel.state.value).isInstanceOf(WooPosScanToPayState.Failed::class.java)
+
+        // WHEN
+        viewModel.onUIEvent(WooPosScanToPayUIEvent.RetryClicked)
+        runCurrent()
+
+        // THEN
+        assertThat(viewModel.state.value).isInstanceOf(WooPosScanToPayState.ShowingQR::class.java)
+    }
+}

--- a/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
+++ b/libs/pos/src/main/java/com/woocommerce/android/ui/woopos/util/WooPosTestTags.kt
@@ -12,6 +12,8 @@ object WooPosTestTags {
     const val MARK_ORDER_AS_PAID_PAYMENT_BUTTON = "woo_pos_mark_order_as_paid_payment_button"
     const val MARK_ORDER_AS_PAID_CONFIRM_BUTTON = "woo_pos_mark_order_as_paid_confirm_button"
     const val MARK_ORDER_AS_PAID_NOTE_FIELD = "woo_pos_mark_order_as_paid_note_field"
+    const val SCAN_TO_PAY_QR_CODE = "woo_pos_scan_to_pay_qr_code"
+    const val SCAN_TO_PAY_CANCEL_BUTTON = "woo_pos_scan_to_pay_cancel_button"
     const val TAP_TO_PAY_PROMOTED_BUTTON = "woo_pos_tap_to_pay_promoted_button"
     const val COMPLETE_PAYMENT_BUTTON = "woo_pos_complete_payment_button"
     const val NEW_ORDER_BUTTON = "woo_pos_new_order_button"


### PR DESCRIPTION
### Stack

This PR is part of a **4-PR series** adding two iOS-parity payment methods to Woo POS:

1. [#15928](https://github.com/woocommerce/woocommerce-android/pull/15928) — Scaffold (base: `trunk`)
2. [#15944](https://github.com/woocommerce/woocommerce-android/pull/15944) — Mark Order as Complete domain layer (base: `feature/woopos-new-payment-methods-scaffold`)
3. [#15932](https://github.com/woocommerce/woocommerce-android/pull/15932) — Mark Order as Complete UI + integration (base: #15944's branch)
4. 👉 **[#15934](https://github.com/woocommerce/woocommerce-android/pull/15934) — Scan to Pay** (this PR, base: `feature/woopos-mark-order-as-complete`)

> Related (not stacked): [#15931](https://github.com/woocommerce/woocommerce-android/pull/15931) — converts the "Other payment methods" picker to a bottom sheet.

### Description

**PR-4 of the 4-PR series** above. This PR adds the **Scan to Pay** flow — the QR-code-based payment option that lets the customer pay directly from their phone.

Stacks on top of [#15932](https://github.com/woocommerce/woocommerce-android/pull/15932) (Mark Order as Complete UI + integration), which stacks on [#15944](https://github.com/woocommerce/woocommerce-android/pull/15944) (MOC domain), which stacks on [#15928](https://github.com/woocommerce/woocommerce-android/pull/15928) (shared scaffold). This is the final PR in the series.

Matches iOS `pointOfSaleScanToPay`:
- Merchant taps **Other payment methods** → **Scan to pay** in the totals checkout pane (visible only in debug builds for now, behind `WOO_POS_SCAN_TO_PAY`).
- A dedicated full-screen route opens (under `ui/woopos/scantopay/`).
- ViewModel promotes the order from auto-draft to `pending` via `WCOrderStore.updateOrderStatus` so the backend populates `payment_url`. Re-fetches the order once (with a brief retry for gateways that populate `payment_url` asynchronously).
- Renders the URL as a QR code via the new `WooPosQrCode` composable (zxing-backed). Screen brightness is boosted to maximum while the QR is visible so it scans cleanly even on a glossy display.
- Polls the order on a fast/slow schedule (15 × 2s, then up to 60 × 5s — ~5.5 min total ceiling) until `Order.datePaid` is set or `status` flips to `processing` / `completed`. (OnHold is intentionally excluded because it indicates awaiting verification, not confirmed payment.)
- On detection, posts a `Customer paid via Scan to Pay` order note (fire-and-forget so the navigation isn't blocked), emits `ParentToChildrenEvent.OrderSuccessfullyPaid(SCAN_TO_PAY)` so the totals VM transitions to its `PaymentSuccess` state, and pops back to the totals view.
- On failure (status promotion failed, blank `payment_url`, or polling timed out) shows a retryable error.

#### Files

- New package `ui/woopos/scantopay/`: Navigation, State, UIEvent, Repository, ViewModel, Screen.
- New shared component `common/composeui/component/WooPosQrCode.kt` — `@Composable fun WooPosQrCode(data, size, modifier, contentDescription)` using `com.google.zxing:core` (already in deps). `FilterQuality.None` keeps QR edges sharp; `Bitmap.Config.RGB_565` halves memory vs. ARGB_8888.
- Wires `WooPosPaymentMethod.SCAN_TO_PAY` to the new `OnScanToPayClicked` UI event in `WooPosTotalsScreen.toUIEvent()` and the matching handler in `WooPosTotalsViewModel`.
- Adds `ChildToParentEvent.NavigationEvent.ToScanToPay` and `WooPosNavigationEvent.OpenScanToPay`; routes them through `WooPosRootHost` and `WooPosNavigationEventHandler`.
- Registers the route in `WooPosMainFlowGraph.mainGraph`.
- 7 new strings, 2 new test tags.
- ViewModel + Repository unit tests covering: promote-success → QR shown, promote-failure → retryable error, blank payment URL after retry → retryable error, polling detects paid → analytics + parent event + GoBack, polling detects Processing status, OnHold non-detection, exhaustion → ScanToPayPaymentFailed, cancel, retry.

### Test Steps

You'll need two devices to test end-to-end: the POS device + a phone with a QR scanner.

1. Install a **wasabi debug** build on a tablet running POS.
2. In POS, add an item to the cart, tap **Checkout**, then tap **Other payment methods** → **Scan to pay**.
3. Verify the route opens, the brightness goes to max, and a QR code renders with the order total above it.
4. Scan the QR with another device → it should open the WooCommerce hosted checkout page. Complete the payment there (or flip the order to `processing` from the WP admin).
5. The POS should auto-advance within ~5 s of the gateway webhook hitting the site. The order in WP admin should now have a "Customer paid via Scan to Pay" private note.
6. Tap the back arrow on the QR screen → confirm `BackToCheckoutFromScanToPay` is logged and you return to totals.
7. Flip the network off on the POS device just after tapping **Scan to pay** → confirm the retryable error screen renders. Re-enable network, tap **Try again** → it should successfully show the QR.
8. Toggle `WOO_POS_SCAN_TO_PAY` to `false` in `FeatureFlag.kt`, rebuild, and confirm the row disappears from the **Other payment methods** dialog.
9. Run the existing Card / Tap to Pay / Cash / Mark as Complete flows once each to confirm no regression.

### Images/gif

N/A — UI flow visible by following Test Steps. (QR code + brightness boost is the centerpiece.)

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
