### PR TITLE
[RSM-3386] Support store stock notifications

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Notification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Notification.kt
@@ -83,7 +83,7 @@ fun NotificationModel.getUniqueId(): Long {
     return when (this.type) {
         NotificationModel.Kind.STORE_ORDER -> this.meta?.ids?.order ?: 0L
         NotificationModel.Kind.COMMENT -> this.meta?.ids?.comment ?: 0L
-        NotificationModel.Kind.STORE_STOCK -> this.meta?.ids?.post ?: 0L
+        NotificationModel.Kind.STORE_STOCK -> this.meta?.ids?.product ?: 0L
         NotificationModel.Kind.BLAZE_APPROVED_NOTE,
         NotificationModel.Kind.BLAZE_REJECTED_NOTE,
         NotificationModel.Kind.BLAZE_CANCELLED_NOTE,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Notification.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/model/Notification.kt
@@ -74,7 +74,7 @@ fun NotificationModel.getChannelType(): NotificationChannelType {
     return when (this.type) {
         NotificationModel.Kind.STORE_ORDER -> NotificationChannelType.NEW_ORDER
         NotificationModel.Kind.COMMENT -> NotificationChannelType.REVIEW
-        NotificationModel.Kind.STOCK -> NotificationChannelType.STOCK
+        NotificationModel.Kind.STORE_STOCK -> NotificationChannelType.STOCK
         else -> NotificationChannelType.OTHER
     }
 }
@@ -83,7 +83,7 @@ fun NotificationModel.getUniqueId(): Long {
     return when (this.type) {
         NotificationModel.Kind.STORE_ORDER -> this.meta?.ids?.order ?: 0L
         NotificationModel.Kind.COMMENT -> this.meta?.ids?.comment ?: 0L
-        NotificationModel.Kind.STOCK -> this.meta?.ids?.post ?: 0L
+        NotificationModel.Kind.STORE_STOCK -> this.meta?.ids?.post ?: 0L
         NotificationModel.Kind.BLAZE_APPROVED_NOTE,
         NotificationModel.Kind.BLAZE_REJECTED_NOTE,
         NotificationModel.Kind.BLAZE_CANCELLED_NOTE,
@@ -97,7 +97,7 @@ fun NotificationModel.getNoteTitle(resourceProvider: ResourceProvider): String {
     return when (this.type) {
         NotificationModel.Kind.STORE_ORDER -> resourceProvider.getString(R.string.notification_order_title)
         NotificationModel.Kind.COMMENT -> resourceProvider.getString(R.string.notification_review_title)
-        NotificationModel.Kind.STOCK ->
+        NotificationModel.Kind.STORE_STOCK ->
             title
                 ?: getTitleSnippet()
                 ?: resourceProvider.getString(R.string.settings_notifs_stock)
@@ -107,7 +107,7 @@ fun NotificationModel.getNoteTitle(resourceProvider: ResourceProvider): String {
 
 fun NotificationModel.getNoteMessage(resourceProvider: ResourceProvider): String? {
     return when (type) {
-        NotificationModel.Kind.STORE_ORDER, NotificationModel.Kind.STOCK -> getMessageSnippet()
+        NotificationModel.Kind.STORE_ORDER, NotificationModel.Kind.STORE_STOCK -> getMessageSnippet()
         NotificationModel.Kind.COMMENT -> "${getTitleSnippet()}: ${getMessageSnippet()}"
         NotificationModel.Kind.BLAZE_APPROVED_NOTE,
         NotificationModel.Kind.BLAZE_REJECTED_NOTE,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationType.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/WooNotificationType.kt
@@ -56,7 +56,7 @@ fun NotificationModel.getWooType(): WooNotificationType {
     return when (this.type) {
         NotificationModel.Kind.STORE_ORDER -> WooNotificationType.NewOrder
         NotificationModel.Kind.COMMENT -> WooNotificationType.ProductReview
-        NotificationModel.Kind.STOCK -> WooNotificationType.Stock
+        NotificationModel.Kind.STORE_STOCK -> WooNotificationType.Stock
         NotificationModel.Kind.BLAZE_APPROVED_NOTE -> WooNotificationType.BlazeStatusUpdate.BlazeApprovedNote
         NotificationModel.Kind.BLAZE_REJECTED_NOTE -> WooNotificationType.BlazeStatusUpdate.BlazeRejectedNote
         NotificationModel.Kind.BLAZE_CANCELLED_NOTE -> WooNotificationType.BlazeStatusUpdate.BlazeCancelledNote

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandler.kt
@@ -321,6 +321,7 @@ class NotificationMessageHandler @Inject constructor(
         val wooTypeSegment = when (noteType) {
             is WooNotificationType.NewOrder -> NotificationModel.Kind.STORE_ORDER.name
             is WooNotificationType.ProductReview -> NotificationModel.Kind.COMMENT.name
+            is WooNotificationType.Stock -> NotificationModel.Kind.STORE_STOCK.name
             else -> null
         }
         return when {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/notifications/push/NotificationMessageHandlerTest.kt
@@ -278,6 +278,44 @@ class NotificationMessageHandlerTest {
         }
 
     @Test
+    fun `given store stock notification, when notification received, then process it as stock`() =
+        runTest {
+            val payload = mapOf("type" to "store_stock")
+            val productId = 32L
+            val stockModel = NotificationModel(
+                remoteNoteId = 0L,
+                remoteSiteId = orderNotification.remoteSiteId,
+                type = NotificationModel.Kind.STORE_STOCK,
+                meta = FormattableMeta(
+                    ids = FormattableMeta.Ids(site = orderNotification.remoteSiteId, product = productId)
+                )
+            )
+            val mockParser: NotificationsParser = mock {
+                on { buildNotificationModelFromPayloadMap(any()) } doReturn stockModel
+            }
+            createNotificationMessageHandler(mockParser)
+
+            notificationMessageHandler.onNewMessageReceived(payload)
+
+            val stockNotification = stockModel.toAppModel(resourceProvider)
+            verify(dispatcher, atLeastOnce()).dispatch(any())
+            verify(notificationBuilder, atLeastOnce()).buildAndDisplayWooNotification(
+                pushId = any(),
+                notification = eq(stockNotification),
+                source = eq(NotificationSource.WOO_DRIVEN),
+                analyticsId = eq("${orderNotification.remoteSiteId}:STORE_STOCK:$productId"),
+                isGroupNotification = eq(false)
+            )
+            verify(notificationAnalyticsTracker, atLeastOnce()).trackNotificationAnalytics(
+                stat = eq(AnalyticsEvent.PUSH_NOTIFICATION_RECEIVED),
+                siteId = eq(orderNotification.remoteSiteId),
+                notificationId = eq("${orderNotification.remoteSiteId}:STORE_STOCK:$productId"),
+                noteTypeTrackingValue = eq(WooNotificationType.Stock.trackingValue),
+                source = eq(NotificationSource.WOO_DRIVEN)
+            )
+        }
+
+    @Test
     fun `when the notification payload is empty then do not process the notification`() {
         notificationMessageHandler.onNewMessageReceived(
             mapOf(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/notification/NotificationModel.kt
@@ -38,7 +38,7 @@ data class NotificationModel(
         NEW_POST,
         POST,
         STORE_ORDER,
-        STOCK,
+        STORE_STOCK,
         USER,
         REWIND_BACKUP_INITIAL,
         PLAN_SETUP_NUDGE,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/tools/FormattableContentMapper.kt
@@ -50,6 +50,7 @@ data class FormattableMeta(
         @SerializedName("user") val user: Long? = null,
         @SerializedName("comment") val comment: Long? = null,
         @SerializedName("post") val post: Long? = null,
+        @SerializedName("product") val product: Long? = null,
         @SerializedName("order") val order: Long? = null,
         @SerializedName("campaign_id") val campaignId: Long? = null
     )

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/persistence/NotificationMapperTest.kt
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/persistence/NotificationMapperTest.kt
@@ -194,6 +194,15 @@ class NotificationMapperTest {
     }
 
     @Test
+    fun `given entity with store_stock type, when toDomainModel, then maps to STORE_STOCK kind`() {
+        val entity = notificationEntity(type = "store_stock")
+
+        val model = mapper.toDomainModel(entity)
+
+        assertThat(model.type).isEqualTo(Kind.STORE_STOCK)
+    }
+
+    @Test
     fun `given entity with unknown type, when toDomainModel, then maps to UNKNOWN kind`() {
         val entity = notificationEntity(type = "some_unknown_type")
 


### PR DESCRIPTION
### Description

Fixes RSM-3386

Recognizes incoming `store_stock` notifications and handles them as stock notifications instead of treating them as unknown notifications.

The notification product id is used as the stock notification identity.

For now, tapping a stock notification only opens the app. Opening the related product screen will be handled in a follow-up PR.

### Test Steps

1. Trigger a stock notification for a test store.
2. Verify the notification is displayed as a stock notification.

### Images/gif

<img width="350"  src="https://github.com/user-attachments/assets/9137bede-8706-498d-98e6-045d7b60013f" />

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
