### PR TITLE
[WOOMOB-2947] Prevent QR site URL prefill crash

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginSiteAddressFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/overrides/WooLoginSiteAddressFragment.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.login.overrides
 
 import android.os.Bundle
-import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.woocommerce.android.R
@@ -26,13 +25,15 @@ class WooLoginSiteAddressFragment : LoginSiteAddressFragment() {
         super.setupContent(rootView)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
         val prefilledSiteUrl = arguments?.getString(ARG_PREFILLED_SITE_URL)
         if (prefilledSiteUrl.isNotNullOrEmpty()) {
-            view.findViewById<WPLoginInputRow>(R.id.login_site_address_row)
+            val siteAddressEditText = view?.findViewById<WPLoginInputRow>(R.id.login_site_address_row)
                 ?.editText
-                ?.setText(prefilledSiteUrl)
+                ?: return
+            siteAddressEditText.setText(prefilledSiteUrl)
             // Auto-submit so the merchant goes from "scan QR" to the next login step with no taps,
             // mirroring WooLoginEmailFragment which calls next(prefilledEmail) on the email screen.
             discover()


### PR DESCRIPTION
### Description
Fixes WOOMOB-2947

Scanning a tokenless QR-login payload routes the app to the site-address login screen with a prefilled `siteUrl`. The Woo override was setting that text in `onViewCreated()`, before the base `LoginSiteAddressFragment` creates `mLoginSiteAddressValidator` in `onActivityCreated()`. Setting the text triggers `afterTextChanged()`, so the validator was still null and the app crashed.

This moves the prefill and auto-submit work until after the base fragment finishes `onActivityCreated()`, so the validator exists before the text watcher runs.

### Test Steps
1. Build and install the QR login branch.
2. In the WooCommerce.com mobile-login fallback (`https://woocommerce.test/mobilelogin/?wpcom_auth=missing`) for an older WooCommerce store, scan the QR code that encodes `woocommerce://qr-login?siteUrl=...`.
3. Verify the app no longer crashes when routing to site-address login.
4. Verify the prefilled site address is submitted automatically and the login flow continues.
5. Verify the normal "Enter site address" fallback still opens without a prefilled URL.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.