### PR TITLE
[WOOMOB-3087] Keep QR login polling alive on Network errors, show offline indicator

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/SiteQrLoginFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/SiteQrLoginFlow.kt
@@ -51,6 +51,10 @@ internal class SiteQrLoginFlow(
 
     private var activeJob: Job? = null
     private var retainedGrant: String? = null
+    // Holds the WaitingForApproval snapshot from the most recent successful scan so a retry from
+    // a Poll-step failure can resume polling the existing session instead of re-issuing the scan.
+    // Set the moment we transition into WaitingForApproval; consulted only from retry()'s Poll branch.
+    private var retainedWaitingForApproval: FlowState.WaitingForApproval? = null
 
     override fun start() {
         if (_state.value !is FlowState.Initial) return
@@ -61,17 +65,28 @@ internal class SiteQrLoginFlow(
         activeJob?.cancel()
         activeJob = null
         retainedGrant = null
+        retainedWaitingForApproval = null
         _state.value = FlowState.Initial
     }
 
     override fun retry() {
         val failed = _state.value as? FlowState.Failed ?: return
         if (!failed.retryable) return
-        retainedGrant?.let { grant -> startExchange(grant) } ?: startScan()
+        when (failed.failedAt) {
+            FailureStep.Exchange -> retainedGrant?.let(::startExchange) ?: startScan()
+            FailureStep.Poll -> retainedWaitingForApproval?.let(::resumePolling) ?: startScan()
+            else -> startScan()
+        }
+    }
+
+    private fun resumePolling(waiting: FlowState.WaitingForApproval) {
+        _state.value = waiting
+        activeJob = scope.launch { pollUntilApprovedOrTerminal(sessionId = waiting.sessionId) }
     }
 
     private fun startScan() {
         retainedGrant = null
+        retainedWaitingForApproval = null
         _state.value = FlowState.Authenticating(AuthPhase.Scan)
         activeJob = scope.launch {
             restClient.scan(ticket.siteUrl, ticket.token).fold(
@@ -83,7 +98,7 @@ internal class SiteQrLoginFlow(
                         subtitleLabelRes = R.string.login_qr_match_host_label,
                         subtitle = ticket.siteUrl.toDisplayHost(),
                         expiresAtEpochMs = expiresAt,
-                    )
+                    ).also { retainedWaitingForApproval = it }
                     pollUntilApprovedOrTerminal(sessionId = scan.sessionId)
                 },
                 onFailure = { failure ->

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/WpComQrLoginFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/WpComQrLoginFlow.kt
@@ -91,7 +91,7 @@ internal class WpComQrLoginFlow(
                         subtitle = scan.userEmail,
                         expiresAtEpochMs = expiresAt,
                     ).also { retainedWaitingForApproval = it }
-                    pollUntilApprovedOrTerminal(sessionId = scan.sessionId, token = payload.token)
+                    pollUntilApprovedOrTerminal(sessionId = scan.sessionId)
                 },
                 onFailure = { failure ->
                     failWith(step = FailureStep.Scan, reason = failure.toScanReason())
@@ -100,12 +100,12 @@ internal class WpComQrLoginFlow(
         }
     }
 
-    private suspend fun pollUntilApprovedOrTerminal(sessionId: String, token: String) {
+    private suspend fun pollUntilApprovedOrTerminal(sessionId: String) {
         WooLog.d(WooLog.T.LOGIN, "QR login wp.com poll: starting")
         val outcome = pollUntilTerminal(
             shouldContinue = { _state.value is FlowState.WaitingForApproval },
             poll = {
-                restClient.checkSessionStatus(sessionId, token).fold(
+                restClient.checkSessionStatus(sessionId, payload.token).fold(
                     onSuccess = { it.toPollOutcome() },
                     onFailure = { it.toPollErrorOutcome() }
                 )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/WpComQrLoginFlow.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/WpComQrLoginFlow.kt
@@ -43,6 +43,10 @@ internal class WpComQrLoginFlow(
 
     private var activeJob: Job? = null
     private var retainedGrant: String? = null
+    // Holds the WaitingForApproval snapshot from the most recent successful scan so a retry from
+    // a Poll-step failure can resume polling the existing session instead of re-issuing the scan.
+    // Set the moment we transition into WaitingForApproval; consulted only from retry()'s Poll branch.
+    private var retainedWaitingForApproval: FlowState.WaitingForApproval? = null
 
     override fun start() {
         if (_state.value !is FlowState.Initial) return
@@ -53,17 +57,28 @@ internal class WpComQrLoginFlow(
         activeJob?.cancel()
         activeJob = null
         retainedGrant = null
+        retainedWaitingForApproval = null
         _state.value = FlowState.Initial
     }
 
     override fun retry() {
         val failed = _state.value as? FlowState.Failed ?: return
         if (!failed.retryable) return
-        retainedGrant?.let { grant -> startExchange(grant) } ?: startScan()
+        when (failed.failedAt) {
+            FailureStep.Exchange -> retainedGrant?.let(::startExchange) ?: startScan()
+            FailureStep.Poll -> retainedWaitingForApproval?.let(::resumePolling) ?: startScan()
+            else -> startScan()
+        }
+    }
+
+    private fun resumePolling(waiting: FlowState.WaitingForApproval) {
+        _state.value = waiting
+        activeJob = scope.launch { pollUntilApprovedOrTerminal(sessionId = waiting.sessionId) }
     }
 
     private fun startScan() {
         retainedGrant = null
+        retainedWaitingForApproval = null
         _state.value = FlowState.Authenticating(AuthPhase.Scan)
         activeJob = scope.launch {
             restClient.scan(token = payload.token, encrypted = payload.encrypted).fold(
@@ -75,7 +90,7 @@ internal class WpComQrLoginFlow(
                         subtitleLabelRes = R.string.login_qr_match_account_label,
                         subtitle = scan.userEmail,
                         expiresAtEpochMs = expiresAt,
-                    )
+                    ).also { retainedWaitingForApproval = it }
                     pollUntilApprovedOrTerminal(sessionId = scan.sessionId)
                 },
                 onFailure = { failure ->

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/SiteQrLoginFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/SiteQrLoginFlowTest.kt
@@ -295,6 +295,38 @@ class SiteQrLoginFlowTest : BaseUnitTest() {
                 .isEqualTo(FlowState.Completed(FlowCompletion.LoggedIn(localSiteId = LOCAL_SITE_ID)))
         }
 
+    @Test
+    fun `given retryable poll failure, when retry is called, then session status is polled again with same session id and scan is not re-invoked`() =
+        testBlocking {
+            whenever(restClient.scan(ticket.siteUrl, ticket.token)).thenReturn(Result.success(scanResult))
+            // Trip the poll-step bail-out (4 consecutive Network errors), then on retry let polling
+            // succeed with Approved so the flow can complete end-to-end.
+            whenever(restClient.checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token))
+                .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
+                .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
+                .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
+                .thenReturn(Result.failure(QrLoginSessionStatusException.Network))
+                .thenReturn(Result.success(QrLoginSessionStatus.Approved("grant-1")))
+            whenever(restClient.exchange(ticket.siteUrl, ticket.token, "grant-1"))
+                .thenReturn(Result.success(credentials))
+            whenever(authenticator.completeLogin(ticket, credentials)).thenReturn(Result.success(LOCAL_SITE_ID))
+            val flow = newFlow()
+            flow.start()
+            advanceUntilIdle()
+            val failed = flow.state.value as FlowState.Failed
+            assertThat(failed.failedAt).isEqualTo(FailureStep.Poll)
+            assertThat(failed.retryable).isTrue()
+
+            flow.retry()
+            advanceUntilIdle()
+
+            verify(restClient, org.mockito.kotlin.times(1)).scan(ticket.siteUrl, ticket.token)
+            verify(restClient, org.mockito.kotlin.atLeast(5))
+                .checkSessionStatus(ticket.siteUrl, scanResult.sessionId, ticket.token)
+            assertThat(flow.state.value)
+                .isEqualTo(FlowState.Completed(FlowCompletion.LoggedIn(localSiteId = LOCAL_SITE_ID)))
+        }
+
     // endregion
 
     // region failedAt diagnostic field

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/WpComQrLoginFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/WpComQrLoginFlowTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -241,6 +242,34 @@ class WpComQrLoginFlowTest : BaseUnitTest() {
         assertThat(flow.state.value)
             .isEqualTo(FlowState.Completed(FlowCompletion.OpenMagicLink(url = "https://wordpress.com/magic")))
     }
+
+    @Test
+    fun `given retryable poll failure, when retry is called, then session status is polled again with same session id and scan is not re-invoked`() =
+        testBlocking {
+            whenever(restClient.scan(payload.token, payload.encrypted)).thenReturn(Result.success(scanResult))
+            whenever(restClient.checkSessionStatus(scanResult.sessionId))
+                .thenReturn(Result.failure(WpComQrLoginSessionStatusException.Network))
+                .thenReturn(Result.failure(WpComQrLoginSessionStatusException.Network))
+                .thenReturn(Result.failure(WpComQrLoginSessionStatusException.Network))
+                .thenReturn(Result.failure(WpComQrLoginSessionStatusException.Network))
+                .thenReturn(Result.success(WpComQrLoginSessionStatus.Approved("wpc-grant-1")))
+            whenever(restClient.exchange(payload.token, payload.encrypted, "wpc-grant-1"))
+                .thenReturn(Result.success(WpComQrLoginExchangeResult(magicLinkUrl = "https://wordpress.com/magic")))
+            val flow = newFlow()
+            flow.start()
+            advanceUntilIdle()
+            val failed = flow.state.value as FlowState.Failed
+            assertThat(failed.failedAt).isEqualTo(FailureStep.Poll)
+            assertThat(failed.retryable).isTrue()
+
+            flow.retry()
+            advanceUntilIdle()
+
+            verify(restClient, times(1)).scan(payload.token, payload.encrypted)
+            verify(restClient, atLeast(5)).checkSessionStatus(scanResult.sessionId)
+            assertThat(flow.state.value)
+                .isEqualTo(FlowState.Completed(FlowCompletion.OpenMagicLink(url = "https://wordpress.com/magic")))
+        }
 
     // endregion
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/WpComQrLoginFlowTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/login/qrlogin/flow/WpComQrLoginFlowTest.kt
@@ -262,7 +262,7 @@ class WpComQrLoginFlowTest : BaseUnitTest() {
     fun `given retryable poll failure, when retry is called, then session status is polled again with same session id and scan is not re-invoked`() =
         testBlocking {
             whenever(restClient.scan(payload.token, payload.encrypted)).thenReturn(Result.success(scanResult))
-            whenever(restClient.checkSessionStatus(scanResult.sessionId))
+            whenever(restClient.checkSessionStatus(scanResult.sessionId, payload.token))
                 .thenReturn(Result.failure(WpComQrLoginSessionStatusException.Network))
                 .thenReturn(Result.failure(WpComQrLoginSessionStatusException.Network))
                 .thenReturn(Result.failure(WpComQrLoginSessionStatusException.Network))
@@ -281,7 +281,7 @@ class WpComQrLoginFlowTest : BaseUnitTest() {
             advanceUntilIdle()
 
             verify(restClient, times(1)).scan(payload.token, payload.encrypted)
-            verify(restClient, atLeast(5)).checkSessionStatus(scanResult.sessionId)
+            verify(restClient, atLeast(5)).checkSessionStatus(scanResult.sessionId, payload.token)
             assertThat(flow.state.value)
                 .isEqualTo(FlowState.Completed(FlowCompletion.OpenMagicLink(url = "https://wordpress.com/magic")))
         }


### PR DESCRIPTION
## Description

Fixes WOOMOB-3087

On the QR-login numbers-matching screen, the active flow's `retry()` previously fell through to `startScan()` whenever there was no retained exchange-grant. That's exactly the situation during a Poll-step failure — so tapping **Try Again** after a network blip discarded the in-progress session and POSTed a fresh scan request, throwing away the matching the user had already started.

This change adds a `Poll` branch to `retry()` that resumes polling the existing `sessionId` instead of re-scanning, mirroring the existing `retainedGrant` pattern used by the Exchange branch. The active flow holds a `retainedWaitingForApproval` snapshot captured at the moment we transition into `WaitingForApproval` after a successful scan; on a Poll-step retry it's restored and `pollUntilApprovedOrTerminal` is re-entered with the same session.

Applies to both `SiteQrLoginFlow` (wp-admin) and `WpComQrLoginFlow` (wp.com).

## Test Steps

1. Scan a valid QR code from either a wp-admin store or wordpress.com → reach the numbers-matching screen.
2. Enable airplane mode on the phone, wait until the "Connection error" screen appears (~8s).
3. Disable airplane mode and tap **Try Again**.
4. **Expected**: the numbers-matching screen shows the *same* real number — no new session was created. Confirm in logcat (\`WooLog.T.LOGIN\`) that no second \`QR login site scan\` / \`QR login wp.com scan\` entry was logged.
5. Approve the matching number on the desktop → sign-in completes normally.

## Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.