### PR TITLE
[WOOMOB-3094] Open device camera when QR scanner binding fails

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginAvailability.kt
@@ -20,10 +20,9 @@ import kotlin.random.Random
  *
  * For the in-app entry point ([isAvailable]):
  *  - The device must have a camera — we don't gate on Google Play Services: we ship the bundled
- *    ML Kit barcode scanning variant, which works on GMS-less devices. If the scanner fails at
- *    runtime,
- *    [com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel.onBindingException]
- *    surfaces a snackbar.
+ *    ML Kit barcode scanning variant, which works on GMS-less devices. If `bindToLifecycle` still
+ *    fails at runtime, [com.woocommerce.android.ui.login.qrlogin.QrLoginScannerFragment] opens the
+ *    OS camera app so the merchant can scan the QR there and tap the resulting deep link.
  *  - Each install is assigned a number in [ROLLOUT_BUCKET_MIN]..[ROLLOUT_BUCKET_MAX] on first read
  *    and persisted, so the decision is stable across restarts. Only installs in
  *    [ROLLOUT_BUCKETS_ENABLED] get the entry point. A debug override bypasses the bucket check.

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/qrlogin/QrLoginScannerFragment.kt
@@ -1,8 +1,11 @@
 package com.woocommerce.android.ui.login.qrlogin
 
 import android.Manifest
+import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
+import android.provider.MediaStore
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -15,6 +18,7 @@ import com.woocommerce.android.ui.barcodescanner.BarcodeScanningViewModel
 import com.woocommerce.android.ui.compose.composeView
 import com.woocommerce.android.ui.login.UnifiedLoginTracker
 import com.woocommerce.android.util.ChromeCustomTabUtils
+import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.util.WooPermissionUtils
 import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.Exit
 import dagger.hilt.android.AndroidEntryPoint
@@ -101,7 +105,7 @@ class QrLoginScannerFragment : Fragment() {
             uiState = uiState,
             showCamera = !isDeepLinkEntry,
             onNewFrame = scannerViewModel::onNewFrame,
-            onBindingException = scannerViewModel::onBindingException,
+            onBindingException = ::onScannerBindingException,
             onPermissionResult = { granted ->
                 scannerViewModel.updatePermissionState(
                     granted,
@@ -190,6 +194,27 @@ class QrLoginScannerFragment : Fragment() {
                 is QrLoginScannerViewModel.Dispatch.RouteToAppLoginWpComEmail ->
                     routeToAppLoginWpComEmail(event.siteUrl, event.wpComEmail)
             }
+        }
+    }
+
+    /**
+     * Camera-bind failures are rare but they're terminal — we ship the bundled ML Kit variant
+     * so even GMS-less devices reach this Fragment, and once `bindToLifecycle` throws there is
+     * no in-app retry. Open the OS camera app instead: most stock cameras detect the QR and
+     * surface the `woocommerce://qr-login?...` URL, which deep-links straight back into this
+     * Fragment in the no-camera deep-link mode. We still fire the VM's failure path first so
+     * the Error overlay is in place when the user returns from the camera (or if no camera app
+     * resolves the intent).
+     */
+    private fun onScannerBindingException(exception: Exception) {
+        scannerViewModel.onBindingException(exception)
+        val cameraIntent = Intent(MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        try {
+            startActivity(cameraIntent)
+        } catch (e: ActivityNotFoundException) {
+            WooLog.w(WooLog.T.LOGIN, "No camera app available for QR scanner fallback: ${e.message}")
         }
     }
 


### PR DESCRIPTION
### Description
Fixes [WOOMOB-3094](https://linear.app/a8c/issue/WOOMOB-3094/open-device-camera-via-external-intent-if-scanner-fails).

We ship the bundled ML Kit barcode scanning variant so QR login reaches GMS-less devices, but `CameraX.bindToLifecycle` can still throw at runtime (no camera hardware, camera held by another process, vendor quirks). Until now the only recovery was the `ErrorReason.Scanner` overlay — the merchant was stuck.

When `BarcodeScanningViewModel.onBindingException` fires inside the QR login Fragment, this PR additionally fires `MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA` so the merchant can scan the QR with the OS camera. Most stock cameras detect the embedded `woocommerce://qr-login?...` URL; tapping it deep-links back into the no-camera variant of the same Fragment and the login resumes. The Error overlay is still emitted by the ViewModel as a safety net for when the user backs out of the camera app or no camera app resolves the intent.

Behavior is gated to the QR login Fragment — the shared `BarcodeScanningViewModel` is unchanged, so product/order barcode scanners (where launching the OS camera doesn't help — barcodes aren't URLs) keep their existing failure path.

### Test Steps
The CameraX bind failure is rare in practice, so simulate it:

1. In `BarcodeScanner.kt`, add `throw RuntimeException("test")` right before the `cameraProvider.bindToLifecycle(...)` call.
2. In `QrLoginAvailability.isAvailable()`, return `true` at the top so the QR entry point is reachable on a fresh install.
3. `./gradlew :WooCommerce:installWasabiDebug`, launch Woo (Dev), tap **Log In**, **Scan QR code**, grant the camera permission.
4. Expected: the device camera app launches (e.g. `com.android.camera2`), confirmed via `adb logcat | grep ActivityTaskManager` showing `Displayed com.android.camera2/com.android.camera.CameraActivity`. No crash.
5. Back-press to the Woo app — the QR login Error overlay is in place (safety net path).
6. Revert both temporary edits before merging.

### Images/gif
N/A

- [ ] I have considered if this change warrants release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. Use the "[Internal]" label for non-user-facing changes.