### PR TITLE
[RSM-3386] Open product detail from stock notifications

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivity.kt
@@ -96,6 +96,7 @@ import com.woocommerce.android.ui.main.MainActivityViewModel.ViewMyStoreStats
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderDetail
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderList
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewPayments
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewProductDetail
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewDetail
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewList
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewTapToPay
@@ -864,6 +865,7 @@ class MainActivity :
                 is ViewOrderList -> binding.bottomNav.currentPosition = ORDERS
                 is ViewOrderDetail -> showOrderDetail(event)
                 is ViewReviewDetail -> showReviewDetail(event.uniqueId, launchedFromNotification = true)
+                is ViewProductDetail -> showProductDetail(event.uniqueId)
                 is ViewReviewList -> showReviewList()
                 is ViewBlazeCampaignDetail -> showBlazeCampaignList(event.campaignId)
                 ViewBlazeCampaignList -> showBlazeCampaignList(campaignId = null)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/main/MainActivityViewModel.kt
@@ -208,7 +208,7 @@ class MainActivityViewModel @Inject constructor(
                 triggerEvent(ViewReviewDetail(notification.uniqueId))
             }
 
-            is WooNotificationType.Stock -> triggerEvent(ViewMyStoreStats)
+            is WooNotificationType.Stock -> triggerEvent(ViewProductDetail(notification.uniqueId))
 
             is WooNotificationType.BlazeStatusUpdate -> triggerEvent(
                 ViewBlazeCampaignDetail(campaignId = notification.uniqueId.toString())
@@ -376,6 +376,7 @@ class MainActivityViewModel @Inject constructor(
     data class ShowFeatureAnnouncement(val announcement: FeatureAnnouncement) : Event()
     data class ViewReviewDetail(val uniqueId: Long) : Event()
     data class ViewOrderDetail(val uniqueId: Long) : Event()
+    data class ViewProductDetail(val uniqueId: Long) : Event()
     data class ViewBlazeCampaignDetail(val campaignId: String) : Event()
     object ViewBlazeCampaignList : Event()
     data class ShowPrivacyPreferenceUpdatedFailed(val analyticsEnabled: Boolean) : Event()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/main/MainActivityViewModelTest.kt
@@ -26,6 +26,7 @@ import com.woocommerce.android.ui.main.MainActivityViewModel.ViewBlazeCampaignLi
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewMyStoreStats
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderDetail
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewOrderList
+import com.woocommerce.android.ui.main.MainActivityViewModel.ViewProductDetail
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewDetail
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewReviewList
 import com.woocommerce.android.ui.main.MainActivityViewModel.ViewTapToPay
@@ -70,6 +71,9 @@ class MainActivityViewModelTest : BaseUnitTest() {
         private const val TEST_NEW_REVIEW_ID_1 = 4418L
         private const val TEST_NEW_REVIEW_ID_2 = 4418L
 
+        private const val TEST_STOCK_REMOTE_NOTE_ID = 5604993865
+        private const val TEST_STOCK_PRODUCT_ID = 1234L
+
         private const val TEST_BLAZE_REMOTE_NOTE_ID = 5604993864
         private const val TEST_BLAZE_CAMPAIGN_ID_1 = 4418L
     }
@@ -102,6 +106,14 @@ class MainActivityViewModelTest : BaseUnitTest() {
         uniqueId = TEST_NEW_REVIEW_ID_1,
         channelType = NotificationChannelType.REVIEW,
         noteType = WooNotificationType.ProductReview
+    )
+
+    private val testStockNotification = NotificationTestUtils.generateTestNotification(
+        remoteNoteId = TEST_STOCK_REMOTE_NOTE_ID,
+        remoteSiteId = siteModel.siteId,
+        uniqueId = TEST_STOCK_PRODUCT_ID,
+        channelType = NotificationChannelType.STOCK,
+        noteType = WooNotificationType.Stock
     )
 
     private val testBlazeNotification = NotificationTestUtils.generateTestNotification(
@@ -227,6 +239,22 @@ class MainActivityViewModelTest : BaseUnitTest() {
         viewModel.onPushNotificationTapped(localPushId, testReviewNotification)
 
         verify(analyticsTrackerWrapper).track(REVIEW_OPEN)
+    }
+
+    @Test
+    fun `when a stock notification is clicked, then the product detail screen is opened`() {
+        val localPushId = 1002
+        var event: ViewProductDetail? = null
+        viewModel.event.observeForever {
+            if (it is ViewProductDetail) event = it
+        }
+
+        viewModel.onPushNotificationTapped(localPushId, testStockNotification)
+
+        verify(notificationMessageHandler, atLeastOnce()).markNotificationTapped(eq(localPushId))
+        verify(notificationMessageHandler, atLeastOnce())
+            .removeTappedNotificationAndSummaryIfNeeded(eq(localPushId), eq(testStockNotification))
+        assertThat(event).isEqualTo(ViewProductDetail(testStockNotification.uniqueId))
     }
 
     @Test


### PR DESCRIPTION
### Description

Fixes RSM-3386

Opens the related product detail screen when a stock notification is tapped.

This completes the follow-up from #15938, where stock notifications were recognized and displayed but still opened the app default screen.

### Test Steps

1. Trigger a stock notification for a test product.
2. Tap the notification.
3. Verify the app opens the related product detail screen.

### Images/gif

N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.