### PR TITLE
[WOOMOB-3079] Format markdown in AI support bot responses

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.woocommerce.android.R
+import com.woocommerce.android.aiassistant.ui.markdown.AssistantMarkdownText
 import com.woocommerce.android.ui.aisupportchat.diagnostics.DiagnosticResult
 import com.woocommerce.android.ui.aisupportchat.diagnostics.DiagnosticStatus
 import com.woocommerce.android.ui.aisupportchat.diagnostics.DiagnosticTest
@@ -257,6 +258,7 @@ private fun MessageBubble(
                 MessageContent(
                     content = message.content,
                     textColor = textColor,
+                    shouldFormatMarkdown = message.role == AiSupportChatMessageRole.BOT,
                     showDiagnosticActions = showDiagnosticActions,
                     onIssueSelected = onIssueSelected,
                     onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked
@@ -355,6 +357,7 @@ private fun MessageFeedback(
 private fun MessageContent(
     content: AiSupportChatMessageContent,
     textColor: Color,
+    shouldFormatMarkdown: Boolean,
     showDiagnosticActions: Boolean,
     onIssueSelected: (SupportIssueType, String) -> Unit,
     onContinueAfterDiagnosticsClicked: () -> Unit
@@ -362,7 +365,8 @@ private fun MessageContent(
     when (content) {
         AiSupportChatMessageContent.Greeting -> TextContent(
             text = stringResource(R.string.ai_support_chat_greeting),
-            color = textColor
+            color = textColor,
+            shouldFormatMarkdown = false
         )
         AiSupportChatMessageContent.IssuePicker -> IssuePickerContent(
             textColor = textColor,
@@ -370,15 +374,18 @@ private fun MessageContent(
         )
         AiSupportChatMessageContent.PostDiagnosticsGreeting -> TextContent(
             text = stringResource(R.string.ai_support_chat_post_diagnostics_greeting),
-            color = textColor
+            color = textColor,
+            shouldFormatMarkdown = false
         )
         AiSupportChatMessageContent.ResolvedPrompt -> TextContent(
             text = stringResource(R.string.ai_support_chat_resolved_prompt),
-            color = textColor
+            color = textColor,
+            shouldFormatMarkdown = false
         )
         is AiSupportChatMessageContent.Text -> TextContent(
             text = content.text,
-            color = textColor
+            color = textColor,
+            shouldFormatMarkdown = shouldFormatMarkdown
         )
         is AiSupportChatMessageContent.DiagnosticsProgress -> DiagnosticsContent(
             result = content.result,
@@ -396,16 +403,31 @@ private fun MessageContent(
 }
 
 @Composable
-private fun TextContent(text: String, color: Color) {
-    Text(
-        text = text,
-        color = color,
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.padding(
-            horizontal = dimensionResource(R.dimen.major_100),
-            vertical = dimensionResource(R.dimen.minor_100)
-        )
+private fun TextContent(
+    text: String,
+    color: Color,
+    shouldFormatMarkdown: Boolean
+) {
+    val modifier = Modifier.padding(
+        horizontal = dimensionResource(R.dimen.major_100),
+        vertical = dimensionResource(R.dimen.minor_100)
     )
+    if (shouldFormatMarkdown) {
+        AssistantMarkdownText(
+            text = text,
+            color = color,
+            style = MaterialTheme.typography.bodyMedium,
+            linkColor = MaterialTheme.colorScheme.primary,
+            modifier = modifier
+        )
+    } else {
+        Text(
+            text = text,
+            color = color,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = modifier
+        )
+    }
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.woocommerce.android.R
-import com.woocommerce.android.aiassistant.ui.markdown.AssistantMarkdownText
 import com.woocommerce.android.ui.aisupportchat.diagnostics.DiagnosticResult
 import com.woocommerce.android.ui.aisupportchat.diagnostics.DiagnosticStatus
 import com.woocommerce.android.ui.aisupportchat.diagnostics.DiagnosticTest
@@ -68,6 +67,7 @@ import com.woocommerce.android.ui.compose.component.WCColoredButton
 import com.woocommerce.android.ui.compose.component.WCOutlinedButton
 import com.woocommerce.android.ui.compose.preview.LightDarkThemePreviews
 import com.woocommerce.android.ui.compose.theme.WooThemeWithBackground
+import com.woocommerce.commons.ui.markdown.MarkdownText
 
 @Composable
 fun AiSupportChatScreen(
@@ -413,7 +413,7 @@ private fun TextContent(
         vertical = dimensionResource(R.dimen.minor_100)
     )
     if (shouldFormatMarkdown) {
-        AssistantMarkdownText(
+        MarkdownText(
             text = text,
             color = color,
             style = MaterialTheme.typography.bodyMedium,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/AssistantChatScreen.kt
@@ -84,9 +84,9 @@ import com.woocommerce.android.aiassistant.ui.components.AssistantConfirmationCa
 import com.woocommerce.android.aiassistant.ui.components.AssistantEmptyState
 import com.woocommerce.android.aiassistant.ui.components.AssistantToolActivityPill
 import com.woocommerce.android.aiassistant.ui.components.AssistantTypingIndicator
-import com.woocommerce.android.aiassistant.ui.markdown.AssistantMarkdownText
 import com.woocommerce.android.aiassistant.ui.scroll.AssistantScrollController
 import com.woocommerce.android.aiassistant.ui.scroll.rememberAssistantScrollController
+import com.woocommerce.commons.ui.markdown.MarkdownText
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -656,7 +656,7 @@ private fun AssistantCardGroupSegment(
 @Composable
 private fun AssistantTextBubble(text: String, isUser: Boolean) {
     if (!isUser) {
-        AssistantMarkdownText(
+        MarkdownText(
             text = text,
             modifier = Modifier.fillMaxWidth(),
             color = MaterialTheme.colorScheme.onSurface,

--- a/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/markdown/AssistantMarkdownText.kt
+++ b/libs/ai-assistant/feature/src/main/kotlin/com/woocommerce/android/aiassistant/ui/markdown/AssistantMarkdownText.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
-internal fun AssistantMarkdownText(
+fun AssistantMarkdownText(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = MaterialTheme.colorScheme.onSurface,

--- a/libs/commons/build.gradle
+++ b/libs/commons/build.gradle
@@ -41,6 +41,7 @@ android {
 }
 
 dependencies {
+    implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.annotation)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.compose.ui.main)
@@ -51,6 +52,8 @@ dependencies {
     implementation(libs.androidx.preference.ktx)
     implementation(libs.eventbus.android)
     implementation(libs.google.dagger.hilt.android.main)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.wordpress.utils)
     implementation(libs.apache.commons.text)
     implementation(project(":libs:fluxc"))

--- a/libs/commons/src/main/java/com/woocommerce/commons/ui/markdown/MarkdownParser.kt
+++ b/libs/commons/src/main/java/com/woocommerce/commons/ui/markdown/MarkdownParser.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.aiassistant.ui.markdown
+package com.woocommerce.commons.ui.markdown
 
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
@@ -10,7 +10,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withLink
 
-internal object AssistantMarkdownParser {
+internal object MarkdownParser {
     fun parse(
         markdown: String,
         linkStyles: TextLinkStyles? = null,

--- a/libs/commons/src/main/java/com/woocommerce/commons/ui/markdown/MarkdownText.kt
+++ b/libs/commons/src/main/java/com/woocommerce/commons/ui/markdown/MarkdownText.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.aiassistant.ui.markdown
+package com.woocommerce.commons.ui.markdown
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -16,7 +16,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
-fun AssistantMarkdownText(
+fun MarkdownText(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = MaterialTheme.colorScheme.onSurface,
@@ -37,7 +37,7 @@ fun AssistantMarkdownText(
         )
     )
     val annotatedText = remember(text, linkColor, linkInteractionListener) {
-        AssistantMarkdownParser.parse(
+        MarkdownParser.parse(
             markdown = text,
             linkStyles = linkStyles,
             linkInteractionListener = linkInteractionListener,
@@ -54,8 +54,8 @@ fun AssistantMarkdownText(
 
 @Preview(showBackground = true, widthDp = 390)
 @Composable
-private fun AssistantMarkdownTextPreview() {
-    AssistantMarkdownText(
+private fun MarkdownTextPreview() {
+    MarkdownText(
         text = "Read the [WooCommerce mobile documentation]" +
             "(https://woocommerce.com/documentation/woocommerce/mobile/) for **setup** and *support*.",
     )

--- a/libs/commons/src/test/kotlin/com/woocommerce/commons/ui/markdown/MarkdownParserTest.kt
+++ b/libs/commons/src/test/kotlin/com/woocommerce/commons/ui/markdown/MarkdownParserTest.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.aiassistant.ui.markdown
+package com.woocommerce.commons.ui.markdown
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.LinkAnnotation
@@ -10,11 +10,11 @@ import androidx.compose.ui.text.style.TextDecoration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
-class AssistantMarkdownParserTest {
+class MarkdownParserTest {
     @Test
     fun `given markdown link, when parsed, then label text and url annotation are emitted`() {
         // WHEN
-        val parsed = AssistantMarkdownParser.parse(
+        val parsed = MarkdownParser.parse(
             "Read [docs](https://woocommerce.com/documentation/woocommerce/mobile/) today."
         )
 
@@ -27,7 +27,7 @@ class AssistantMarkdownParserTest {
     @Test
     fun `given markdown link with unsupported scheme, when parsed, then source text is preserved`() {
         // WHEN
-        val parsed = AssistantMarkdownParser.parse("Open [docs](javascript:alert) today.")
+        val parsed = MarkdownParser.parse("Open [docs](javascript:alert) today.")
 
         // THEN
         assertThat(parsed.text).isEqualTo("Open [docs](javascript:alert) today.")
@@ -37,7 +37,7 @@ class AssistantMarkdownParserTest {
     @Test
     fun `given bold and italic markdown, when parsed, then markers are removed and styles are applied`() {
         // WHEN
-        val parsed = AssistantMarkdownParser.parse("This is ***bold italic***, **bold**, and *italic*.")
+        val parsed = MarkdownParser.parse("This is ***bold italic***, **bold**, and *italic*.")
 
         // THEN
         assertThat(parsed.text).isEqualTo("This is bold italic, bold, and italic.")
@@ -56,7 +56,7 @@ class AssistantMarkdownParserTest {
     @Test
     fun `given malformed markdown, when parsed, then source text is preserved`() {
         // WHEN
-        val parsed = AssistantMarkdownParser.parse("Broken [docs]( and **bold")
+        val parsed = MarkdownParser.parse("Broken [docs]( and **bold")
 
         // THEN
         assertThat(parsed.text).isEqualTo("Broken [docs]( and **bold")
@@ -75,7 +75,7 @@ class AssistantMarkdownParserTest {
         )
 
         // WHEN
-        val parsed = AssistantMarkdownParser.parse("[docs](https://example.com)", linkStyles = linkStyles)
+        val parsed = MarkdownParser.parse("[docs](https://example.com)", linkStyles = linkStyles)
 
         // THEN
         val link = parsed.getLinkAnnotations(0, parsed.length).single().item as LinkAnnotation.Url
@@ -85,7 +85,7 @@ class AssistantMarkdownParserTest {
     @Test
     fun `given bold and italic markdown in link label, when parsed, then label markers are removed`() {
         // WHEN
-        val parsed = AssistantMarkdownParser.parse("[***docs***](https://example.com)")
+        val parsed = MarkdownParser.parse("[***docs***](https://example.com)")
 
         // THEN
         assertThat(parsed.text).isEqualTo("docs")


### PR DESCRIPTION
### Description
Fixes WOOMOB-3079

AI support chat bot responses can include Markdown for emphasis and links, but the support chat screen rendered those responses as plain text. This reuses the existing AI assistant Markdown renderer for bot text messages in AI support chat, while keeping user messages and static support chat prompts as plain text.

### Test Steps
1. Open Help & Support and start an AI support chat.
2. Send a prompt that returns a bot response containing Markdown, such as a link or bold/italic text.
3. Confirm the bot response renders formatted Markdown and links are tappable.
4. Confirm user-sent messages still render as plain text.

### Images/gif
<img width="320" alt="image" src="https://github.com/user-attachments/assets/fb8dd2ca-d81d-404e-93d5-44fe63960738" />

- [ ] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.