### PR TITLE
[WOOMOB-3091] Persist AI support chat session states

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatActivity.kt
@@ -57,11 +57,13 @@ class AiSupportChatActivity : AppCompatActivity() {
             context: Context,
             chatId: Long,
             botSlug: String,
-            sessionId: String?
+            sessionId: String?,
+            isResolved: Boolean = false
         ): Intent = Intent(context, AiSupportChatActivity::class.java).apply {
             putExtra(EXTRA_CHAT_ID, chatId)
             putExtra(EXTRA_BOT_SLUG, botSlug)
             putExtra(EXTRA_SESSION_ID, sessionId)
+            putExtra(EXTRA_IS_RESOLVED, isResolved)
         }
 
         fun createConnectivityToolIntent(
@@ -80,7 +82,8 @@ class AiSupportChatActivity : AppCompatActivity() {
                 extras.containsKey(EXTRA_CHAT_ID) -> AiSupportChatLaunchMode.Resume(
                     chatId = extras.getLong(EXTRA_CHAT_ID),
                     botSlug = extras.getString(EXTRA_BOT_SLUG) ?: AiSupportChatViewModel.DEFAULT_BOT_SLUG,
-                    sessionId = extras.getString(EXTRA_SESSION_ID)
+                    sessionId = extras.getString(EXTRA_SESSION_ID),
+                    isResolved = extras.getBoolean(EXTRA_IS_RESOLVED, false)
                 )
                 else -> AiSupportChatLaunchMode.Help
             }
@@ -91,5 +94,6 @@ class AiSupportChatActivity : AppCompatActivity() {
         private const val EXTRA_CHAT_ID = "extra_chat_id"
         private const val EXTRA_BOT_SLUG = "extra_bot_slug"
         private const val EXTRA_SESSION_ID = "extra_session_id"
+        private const val EXTRA_IS_RESOLVED = "extra_is_resolved"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatActivity.kt
@@ -58,11 +58,13 @@ class AiSupportChatActivity : AppCompatActivity() {
             chatId: Long,
             botSlug: String,
             sessionId: String?,
+            hasCreatedTicket: Boolean = false,
             isResolved: Boolean = false
         ): Intent = Intent(context, AiSupportChatActivity::class.java).apply {
             putExtra(EXTRA_CHAT_ID, chatId)
             putExtra(EXTRA_BOT_SLUG, botSlug)
             putExtra(EXTRA_SESSION_ID, sessionId)
+            putExtra(EXTRA_HAS_CREATED_TICKET, hasCreatedTicket)
             putExtra(EXTRA_IS_RESOLVED, isResolved)
         }
 
@@ -83,6 +85,7 @@ class AiSupportChatActivity : AppCompatActivity() {
                     chatId = extras.getLong(EXTRA_CHAT_ID),
                     botSlug = extras.getString(EXTRA_BOT_SLUG) ?: AiSupportChatViewModel.DEFAULT_BOT_SLUG,
                     sessionId = extras.getString(EXTRA_SESSION_ID),
+                    hasCreatedTicket = extras.getBoolean(EXTRA_HAS_CREATED_TICKET, false),
                     isResolved = extras.getBoolean(EXTRA_IS_RESOLVED, false)
                 )
                 else -> AiSupportChatLaunchMode.Help
@@ -94,6 +97,7 @@ class AiSupportChatActivity : AppCompatActivity() {
         private const val EXTRA_CHAT_ID = "extra_chat_id"
         private const val EXTRA_BOT_SLUG = "extra_bot_slug"
         private const val EXTRA_SESSION_ID = "extra_session_id"
+        private const val EXTRA_HAS_CREATED_TICKET = "extra_has_created_ticket"
         private const val EXTRA_IS_RESOLVED = "extra_is_resolved"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryFragment.kt
@@ -24,6 +24,7 @@ class AiSupportChatHistoryFragment : Fragment() {
                             chatId = bookmark.chatId,
                             botSlug = bookmark.botSlug,
                             sessionId = bookmark.sessionId,
+                            hasCreatedTicket = bookmark.hasCreatedTicket,
                             isResolved = bookmark.isResolved
                         )
                     )

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryFragment.kt
@@ -23,7 +23,8 @@ class AiSupportChatHistoryFragment : Fragment() {
                             context = requireContext(),
                             chatId = bookmark.chatId,
                             botSlug = bookmark.botSlug,
-                            sessionId = bookmark.sessionId
+                            sessionId = bookmark.sessionId,
+                            isResolved = bookmark.isResolved
                         )
                     )
                 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatLaunchMode.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatLaunchMode.kt
@@ -14,6 +14,7 @@ sealed interface AiSupportChatLaunchMode {
     data class Resume(
         val chatId: Long,
         val botSlug: String,
-        val sessionId: String?
+        val sessionId: String?,
+        val isResolved: Boolean = false
     ) : AiSupportChatLaunchMode
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatLaunchMode.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatLaunchMode.kt
@@ -15,6 +15,7 @@ sealed interface AiSupportChatLaunchMode {
         val chatId: Long,
         val botSlug: String,
         val sessionId: String?,
+        val hasCreatedTicket: Boolean = false,
         val isResolved: Boolean = false
     ) : AiSupportChatLaunchMode
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatScreen.kt
@@ -264,7 +264,7 @@ private fun MessageBubble(
                     onContinueAfterDiagnosticsClicked = onContinueAfterDiagnosticsClicked
                 )
             }
-            if (message.canShowFeedback()) {
+            if (message.shouldShowFeedback) {
                 if (feedbackRating == null) {
                     MessageFeedbackActions(
                         messageId = requireNotNull(message.messageId),
@@ -281,12 +281,6 @@ private fun MessageBubble(
         }
     }
 }
-
-private fun AiSupportChatMessage.canShowFeedback(): Boolean =
-    role == AiSupportChatMessageRole.BOT &&
-        messageId != null &&
-        !isResolved &&
-        content is AiSupportChatMessageContent.Text
 
 @Composable
 private fun MessageFeedbackActions(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -127,6 +127,7 @@ class AiSupportChatViewModel @Inject constructor(
     }
 
     fun onMarkResolvedConfirmed() {
+        val chatId = _viewState.value.chatId
         _viewState.update {
             it.copy(
                 isChatResolved = true,
@@ -135,6 +136,17 @@ class AiSupportChatViewModel @Inject constructor(
                 showSendError = false,
                 input = ""
             )
+        }
+
+        if (chatId != null) {
+            launch {
+                runCatching {
+                    repository.markChatAsResolved(chatId)
+                }.onFailure { error ->
+                    if (error is CancellationException) throw error
+                    WooLog.e(WooLog.T.AI, "Marking AI support chat as resolved failed", error)
+                }
+            }
         }
     }
 
@@ -265,6 +277,7 @@ class AiSupportChatViewModel @Inject constructor(
                 botSlug = launchMode.botSlug,
                 hasProceededToChat = true,
                 hasStartedChat = true,
+                isChatResolved = launchMode.isResolved,
                 isLoadingHistory = true,
                 showSendError = false,
                 showLoadHistoryError = false

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -169,6 +169,7 @@ class AiSupportChatViewModel @Inject constructor(
     }
 
     fun onSupportTicketCreated() {
+        val chatId = _viewState.value.chatId
         _viewState.update {
             it.copy(
                 input = "",
@@ -176,6 +177,17 @@ class AiSupportChatViewModel @Inject constructor(
                 showHumanSupportPrompt = false,
                 showSendError = false
             )
+        }
+
+        if (chatId != null) {
+            launch {
+                runCatching {
+                    repository.markChatAsTicketCreated(chatId)
+                }.onFailure { error ->
+                    if (error is CancellationException) throw error
+                    WooLog.e(WooLog.T.AI, "Marking AI support chat as ticket created failed", error)
+                }
+            }
         }
     }
 
@@ -277,6 +289,7 @@ class AiSupportChatViewModel @Inject constructor(
                 botSlug = launchMode.botSlug,
                 hasProceededToChat = true,
                 hasStartedChat = true,
+                hasCreatedTicket = launchMode.hasCreatedTicket,
                 isChatResolved = launchMode.isResolved,
                 isLoadingHistory = true,
                 showSendError = false,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -292,7 +292,7 @@ class AiSupportChatViewModel @Inject constructor(
 
     private suspend fun handleResumeSuccess(response: SupportChatResponse) {
         _viewState.update {
-            val remoteMessages = response.messages.toUiMessages()
+            val remoteMessages = response.messages.toUiMessages(isNewInSession = false)
             val shouldPromptHumanSupport = response.messages.shouldPromptHumanSupport()
             it.copy(
                 chatId = response.chatId,
@@ -388,7 +388,7 @@ class AiSupportChatViewModel @Inject constructor(
         wasInitialMessage: Boolean
     ) {
         _viewState.update {
-            val remoteMessages = response.messages.toUiMessages()
+            val remoteMessages = response.messages.toUiMessages(isNewInSession = true)
             val latestSupportArea = response.messages.latestSupportArea() ?: it.latestSupportArea
             val shouldPromptHumanSupport = response.messages.shouldPromptHumanSupport()
             val completedUserMessageResponseCount = it.completedUserMessageResponseCount +
@@ -499,7 +499,7 @@ class AiSupportChatViewModel @Inject constructor(
         }
     }
 
-    private fun List<SupportChatMessage>.toUiMessages(): List<AiSupportChatMessage> =
+    private fun List<SupportChatMessage>.toUiMessages(isNewInSession: Boolean): List<AiSupportChatMessage> =
         filterNot { it.isBotEscalationPrompt() }
             .map { message ->
                 AiSupportChatMessage(
@@ -507,6 +507,7 @@ class AiSupportChatViewModel @Inject constructor(
                     messageId = if (message.role == SupportChatRole.BOT) message.messageId else null,
                     role = message.role.toUiRole(),
                     isResolved = message.context?.isResolved == true,
+                    isNewInSession = isNewInSession,
                     content = AiSupportChatMessageContent.Text(message.content)
                 )
             }
@@ -824,8 +825,16 @@ data class AiSupportChatMessage(
     val messageId: Long? = null,
     val role: AiSupportChatMessageRole,
     val isResolved: Boolean = false,
+    val isNewInSession: Boolean = false,
     val content: AiSupportChatMessageContent
-)
+) {
+    val shouldShowFeedback: Boolean
+        get() = role == AiSupportChatMessageRole.BOT &&
+            isNewInSession &&
+            !isResolved &&
+            messageId != null &&
+            content is AiSupportChatMessageContent.Text
+}
 
 enum class AiSupportChatMessageRole {
     USER,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModel.kt
@@ -815,7 +815,7 @@ data class AiSupportChatViewState(
         }
 
     private companion object {
-        const val MIN_USER_MESSAGE_RESPONSES_FOR_TOOLBAR = 2
+        const val MIN_USER_MESSAGE_RESPONSES_FOR_TOOLBAR = 1
         const val MIN_BOT_RESPONSES_FOR_RESOLUTION_ACTION = 2
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -976,6 +976,43 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given ticket is created for chat, when state updates, then ticket created state is persisted`() =
+        testBlocking {
+            val result = createSuccessDiagnosticResult()
+            startChat(result)
+
+            viewModel.onSupportTicketCreated()
+
+            verify(repository).markChatAsTicketCreated(CHAT_ID)
+        }
+
+    @Test
+    fun `given chat id is missing, when ticket is created, then ticket created state is not persisted`() =
+        testBlocking {
+            viewModel.onSupportTicketCreated()
+
+            val state = viewModel.viewState.value
+            assertThat(state.hasCreatedTicket).isTrue
+            verify(repository, never()).markChatAsTicketCreated(any())
+        }
+
+    @Test
+    fun `given persisting ticket created state fails, when ticket is created, then chat remains ticket created`() =
+        testBlocking {
+            val result = createSuccessDiagnosticResult()
+            startChat(result)
+            whenever(repository.markChatAsTicketCreated(CHAT_ID)).thenThrow(RuntimeException("Bookmark update failed"))
+
+            viewModel.onSupportTicketCreated()
+
+            val state = viewModel.viewState.value
+            assertThat(state.hasCreatedTicket).isTrue
+            assertThat(state.canSendMessages).isFalse
+            assertThat(state.canContactHumanSupportFromToolbar).isFalse
+            verify(repository).markChatAsTicketCreated(CHAT_ID)
+        }
+
+    @Test
     fun `given connectivity launch mode, when loaded, then chat waits for user input with connectivity context`() =
         testBlocking {
             val checks = listOf(
@@ -1097,6 +1134,32 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         assertThat(state.isChatResolved).isTrue
         assertThat(state.canSendMessages).isFalse
         assertThat(state.showInputBar).isFalse
+        assertThat(state.shouldShowResolvedButton).isFalse
+    }
+
+    @Test
+    fun `given resumed chat has created ticket, when loaded, then ticket created state is restored`() = testBlocking {
+        val response = createResponse(
+            messages = listOf(
+                createMessage(messageId = 1L, role = SupportChatRole.USER, content = ISSUE_DETAILS),
+                createMessage(messageId = 2L, role = SupportChatRole.BOT, content = BOT_RESPONSE)
+            )
+        )
+        whenever(repository.fetchChat(DEFAULT_BOT_SLUG, CHAT_ID, SESSION_ID)).thenReturn(Result.success(response))
+
+        viewModel.onLaunchModeLoaded(
+            AiSupportChatLaunchMode.Resume(
+                chatId = CHAT_ID,
+                botSlug = DEFAULT_BOT_SLUG,
+                sessionId = SESSION_ID,
+                hasCreatedTicket = true
+            )
+        )
+
+        val state = viewModel.viewState.value
+        assertThat(state.hasCreatedTicket).isTrue
+        assertThat(state.canSendMessages).isFalse
+        assertThat(state.canContactHumanSupportFromToolbar).isFalse
         assertThat(state.shouldShowResolvedButton).isFalse
     }
 

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -702,6 +702,34 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             assertThat(state.showInputBar).isFalse
             assertThat(state.shouldShowResolvedButton).isFalse
             assertThat(state.canContactHumanSupportFromToolbar).isFalse
+            verify(repository).markChatAsResolved(CHAT_ID)
+        }
+
+    @Test
+    fun `given chat id is missing, when mark resolved confirmed, then resolved state is not persisted`() =
+        testBlocking {
+            viewModel.onMarkResolvedClicked()
+            viewModel.onMarkResolvedConfirmed()
+
+            val state = viewModel.viewState.value
+            assertThat(state.isChatResolved).isTrue
+            assertThat(state.showMarkResolvedConfirmation).isFalse
+            verify(repository, never()).markChatAsResolved(any())
+        }
+
+    @Test
+    fun `given persisting resolved state fails, when mark resolved confirmed, then chat remains resolved`() =
+        testBlocking {
+            startChatWithBotResponse()
+            whenever(repository.markChatAsResolved(CHAT_ID)).thenThrow(RuntimeException("Bookmark update failed"))
+
+            viewModel.onMarkResolvedClicked()
+            viewModel.onMarkResolvedConfirmed()
+
+            val state = viewModel.viewState.value
+            assertThat(state.isChatResolved).isTrue
+            assertThat(state.showMarkResolvedConfirmation).isFalse
+            verify(repository).markChatAsResolved(CHAT_ID)
         }
 
     @Test
@@ -1044,6 +1072,32 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         assertThat(botMessage.shouldShowFeedback).isFalse()
         verify(repository).fetchChat(DEFAULT_BOT_SLUG, CHAT_ID, SESSION_ID)
         verify(repository).markChatAsUpdated(CHAT_ID, SESSION_ID)
+    }
+
+    @Test
+    fun `given resumed chat is resolved, when loaded, then resolved state is restored`() = testBlocking {
+        val response = createResponse(
+            messages = listOf(
+                createMessage(messageId = 1L, role = SupportChatRole.USER, content = ISSUE_DETAILS),
+                createMessage(messageId = 2L, role = SupportChatRole.BOT, content = BOT_RESPONSE)
+            )
+        )
+        whenever(repository.fetchChat(DEFAULT_BOT_SLUG, CHAT_ID, SESSION_ID)).thenReturn(Result.success(response))
+
+        viewModel.onLaunchModeLoaded(
+            AiSupportChatLaunchMode.Resume(
+                chatId = CHAT_ID,
+                botSlug = DEFAULT_BOT_SLUG,
+                sessionId = SESSION_ID,
+                isResolved = true
+            )
+        )
+
+        val state = viewModel.viewState.value
+        assertThat(state.isChatResolved).isTrue
+        assertThat(state.canSendMessages).isFalse
+        assertThat(state.showInputBar).isFalse
+        assertThat(state.shouldShowResolvedButton).isFalse
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -358,14 +358,14 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             val state = viewModel.viewState.value
             assertThat(state.showHumanSupportPrompt).isTrue
             assertThat(state.latestSupportArea).isEqualTo(supportArea)
-            assertThat(state.canContactHumanSupportFromToolbar).isFalse
+            assertThat(state.canContactHumanSupportFromToolbar).isTrue
             assertThat(state.showInputBar).isFalse
             assertThat(state.completedUserMessageResponseCount).isEqualTo(1)
             assertThat(state.messages.map { it.content }).doesNotContain(AiSupportChatMessageContent.Text(BOT_RESPONSE))
         }
 
     @Test
-    fun `given first user message has bot response, when chat updates, then toolbar support is unavailable`() =
+    fun `given first user message has bot response, when chat updates, then toolbar support is available`() =
         testBlocking {
             val result = createSuccessDiagnosticResult()
             val response = createResponse(
@@ -386,7 +386,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             val state = viewModel.viewState.value
             assertThat(state.hasSentChatMessage).isTrue
             assertThat(state.completedUserMessageResponseCount).isEqualTo(1)
-            assertThat(state.canContactHumanSupportFromToolbar).isFalse
+            assertThat(state.canContactHumanSupportFromToolbar).isTrue
         }
 
     @Test
@@ -599,7 +599,7 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given second user message has bot response, when chat updates, then toolbar support is available`() =
+    fun `given second user message has bot response, when chat updates, then toolbar support remains available`() =
         testBlocking {
             val result = createSuccessDiagnosticResult()
             whenever(diagnosticsService.runDiagnostics(SupportIssueType.LOADING_ORDERS)).thenReturn(flowOf(result))

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatViewModelTest.kt
@@ -415,6 +415,19 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `given bot response is received after sending message, when chat updates, then feedback can be shown`() =
+        testBlocking {
+            startChatWithBotResponse()
+
+            val botMessage = viewModel.viewState.value.messages.single {
+                it.content == AiSupportChatMessageContent.Text(BOT_RESPONSE)
+            }
+
+            assertThat(botMessage.isNewInSession).isTrue()
+            assertThat(botMessage.shouldShowFeedback).isTrue()
+        }
+
+    @Test
     fun `given unrated bot response, when thumbs up clicked, then rating is stored and submitted`() =
         testBlocking {
             startChatWithBotResponse()
@@ -1026,6 +1039,9 @@ class AiSupportChatViewModelTest : BaseUnitTest() {
             AiSupportChatMessageContent.Text(ISSUE_DETAILS),
             AiSupportChatMessageContent.Text(BOT_RESPONSE)
         )
+        val botMessage = state.messages.single { it.content == AiSupportChatMessageContent.Text(BOT_RESPONSE) }
+        assertThat(botMessage.isNewInSession).isFalse()
+        assertThat(botMessage.shouldShowFeedback).isFalse()
         verify(repository).fetchChat(DEFAULT_BOT_SLUG, CHAT_ID, SESSION_ID)
         verify(repository).markChatAsUpdated(CHAT_ID, SESSION_ID)
     }


### PR DESCRIPTION
### Description
Closes WOOMOB-3091

This PR keeps AI support chat session UI state consistent when merchants return to a saved chat.

It updates bot-response feedback controls so they only appear for bot messages received during the current active session, matching the iOS behavior and avoiding feedback buttons on messages loaded from history.

It also persists the session states that are driven by explicit merchant actions: marking a chat resolved and successfully creating a support ticket. Those stored flags are now passed through the history resume flow so reopened chats continue to hide input/escalation controls and show the appropriate resolved or ticket-created state.

Also enables Contact Support button after first bot response to avoid blocking users from escalating.

### Test Steps
1. Open AI support chat and send a message that receives a bot response.
2. Confirm feedback controls are available on the newly received bot response.
3. Leave the chat, reopen it from support chat history, and confirm feedback controls are not shown on the loaded historical bot response.
4. Mark a chat as resolved, reopen it from history, and confirm the chat remains resolved with input/actions hidden.
5. Create a support ticket from a chat, reopen it from history, and confirm the ticket-created state is restored with escalation/input actions hidden.

### Images/gif
[Screen_recording_20260519_174437.webm](https://github.com/user-attachments/assets/5ed489da-2d9e-422b-9fa7-ae797ecf51e5)


- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.