### PR TITLE
[RSM-3534] Sync smarter notification settings with system permissions

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/notifications/NotificationChannelsHandler.kt
@@ -46,6 +46,11 @@ class NotificationChannelsHandler @Inject constructor(
         return channel.getNewOrderNotificationSoundStatus()
     }
 
+    fun isNotificationChannelEnabled(channelType: NotificationChannelType): Boolean {
+        val channel = notificationManagerCompat.getNotificationChannel(channelType.getChannelId()) ?: return true
+        return channel.importance != NotificationManager.IMPORTANCE_NONE
+    }
+
     private fun createChannels() {
         NotificationChannelType.entries.forEach {
             createChannel(it)

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
@@ -2,6 +2,7 @@ package com.woocommerce.android.ui.prefs.notifications
 
 import android.content.Intent
 import android.os.Bundle
+import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -52,6 +53,9 @@ class NotificationSettingsFragment : BaseFragment() {
     override fun onResume() {
         super.onResume()
         viewModel.refreshNotificationSettings()
+        if (navArgs.showSmarterNotifications) {
+            sharedViewModel.refreshNotificationChannelSettings()
+        }
         AnalyticsTracker.trackViewShown(this)
     }
 
@@ -82,6 +86,8 @@ class NotificationSettingsFragment : BaseFragment() {
                 is NotificationSettingsSharedViewModel.OpenNewReviewNotificationSettings ->
                     openNewReviewNotificationSettings()
                 is NotificationSettingsSharedViewModel.OpenStockNotificationSettings -> openStockNotificationSettings()
+                is NotificationSettingsSharedViewModel.OpenNotificationChannelSettings ->
+                    openNotificationChannelSettings(event.channelId)
                 is MultiLiveEvent.Event.ShowActionStringSnackbar -> uiMessageResolver.showActionSnack(
                     event.message,
                     event.actionText,
@@ -95,6 +101,15 @@ class NotificationSettingsFragment : BaseFragment() {
         val intent = Intent().apply {
             action = "android.settings.APP_NOTIFICATION_SETTINGS"
             putExtra("android.provider.extra.APP_PACKAGE", requireActivity().packageName)
+        }
+        requireActivity().startActivity(intent)
+    }
+
+    private fun openNotificationChannelSettings(channelId: String) {
+        val intent = Intent().apply {
+            action = Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS
+            putExtra(Settings.EXTRA_APP_PACKAGE, requireActivity().packageName)
+            putExtra(Settings.EXTRA_CHANNEL_ID, channelId)
         }
         requireActivity().startActivity(intent)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -4,6 +4,8 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import com.woocommerce.android.R
+import com.woocommerce.android.notifications.NotificationChannelType
+import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.push.PushNotificationRepository
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.viewmodel.MultiLiveEvent
@@ -35,6 +37,7 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val pushNotificationRepository: PushNotificationRepository,
     private val resourceProvider: ResourceProvider,
+    private val notificationChannelsHandler: NotificationChannelsHandler,
     private val coroutineDispatchers: CoroutineDispatchers
 ) : ScopedViewModel(savedStateHandle) {
     private val wooPushNotificationPreferences = MutableStateFlow<WooPushNotificationPreferences?>(null)
@@ -55,19 +58,22 @@ class NotificationSettingsSharedViewModel @Inject constructor(
                 type = NotificationType.NEW_ORDERS,
                 title = R.string.settings_notifs_new_orders,
                 subtitle = R.string.settings_notifs_new_orders_subtitle,
-                isEnabled = true
+                isEnabled = true,
+                isNotificationChannelEnabled = NotificationType.NEW_ORDERS.isNotificationChannelEnabled()
             ),
             NotificationTypeItem(
                 type = NotificationType.NEW_REVIEWS,
                 title = R.string.settings_notifs_new_reviews,
                 subtitle = R.string.settings_notifs_new_reviews_subtitle,
-                isEnabled = true
+                isEnabled = true,
+                isNotificationChannelEnabled = NotificationType.NEW_REVIEWS.isNotificationChannelEnabled()
             ),
             NotificationTypeItem(
                 type = NotificationType.STOCK,
                 title = R.string.settings_notifs_stock,
                 subtitle = R.string.settings_notifs_stock_subtitle,
-                isEnabled = true
+                isEnabled = true,
+                isNotificationChannelEnabled = NotificationType.STOCK.isNotificationChannelEnabled()
             )
         )
     )
@@ -119,6 +125,14 @@ class NotificationSettingsSharedViewModel @Inject constructor(
 
     fun savePendingNotificationPreferences() {
         saveNotificationPreferencesTrigger.tryEmit(0L)
+    }
+
+    fun refreshNotificationChannelSettings() {
+        _notificationTypeItems.update { items ->
+            items.map { item ->
+                item.copy(isNotificationChannelEnabled = item.type.isNotificationChannelEnabled())
+            }
+        }
     }
 
     fun onNewOrderNotificationsEnabledChanged(isEnabled: Boolean) {
@@ -204,6 +218,11 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     }
 
     fun onNotificationTypeClicked(type: NotificationType) {
+        if (!type.isNotificationChannelEnabled()) {
+            triggerEvent(OpenNotificationChannelSettings(type.getNotificationChannelId()))
+            return
+        }
+
         when (type) {
             NotificationType.NEW_ORDERS -> triggerEvent(OpenNewOrderNotificationSettings)
             NotificationType.NEW_REVIEWS -> triggerEvent(OpenNewReviewNotificationSettings)
@@ -402,15 +421,31 @@ class NotificationSettingsSharedViewModel @Inject constructor(
             NotificationType.STOCK -> storeStock?.enabled
         }
 
+    private fun NotificationType.isNotificationChannelEnabled(): Boolean {
+        return notificationChannelsHandler.isNotificationChannelEnabled(toNotificationChannelType())
+    }
+
+    private fun NotificationType.getNotificationChannelId(): String =
+        with(notificationChannelsHandler) { toNotificationChannelType().getChannelId() }
+
+    private fun NotificationType.toNotificationChannelType(): NotificationChannelType =
+        when (this) {
+            NotificationType.NEW_ORDERS -> NotificationChannelType.NEW_ORDER
+            NotificationType.NEW_REVIEWS -> NotificationChannelType.REVIEW
+            NotificationType.STOCK -> NotificationChannelType.STOCK
+        }
+
     object OpenNewOrderNotificationSettings : MultiLiveEvent.Event()
     object OpenNewReviewNotificationSettings : MultiLiveEvent.Event()
     object OpenStockNotificationSettings : MultiLiveEvent.Event()
+    data class OpenNotificationChannelSettings(val channelId: String) : MultiLiveEvent.Event()
 
     data class NotificationTypeItem(
         val type: NotificationType,
         @StringRes val title: Int,
         @StringRes val subtitle: Int,
-        val isEnabled: Boolean
+        val isEnabled: Boolean,
+        val isNotificationChannelEnabled: Boolean = true
     )
 
     data class NewOrderNotificationSettingsViewState(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/WooPushNotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/WooPushNotificationSettingsScreen.kt
@@ -95,8 +95,9 @@ private fun WooPushNotificationSettingsScreen(
                 NotificationTypeRow(
                     item = item,
                     onEnabledChanged = onNotificationTypeEnabledChanged,
-                    onClick = onNotificationTypeClicked,
-                    enabled = isNotificationTypeSelectionEnabled,
+                    onClick = { onNotificationTypeClicked(item.type) },
+                    isNotificationTypeSelectionEnabled = isNotificationTypeSelectionEnabled,
+                    isNotificationChannelEnabled = item.isNotificationChannelEnabled,
                     modifier = Modifier.fillMaxWidth()
                 )
             }
@@ -156,16 +157,19 @@ private fun SystemNotificationsDisabledWarning(
 private fun NotificationTypeRow(
     item: NotificationTypeItem,
     onEnabledChanged: (NotificationType, Boolean) -> Unit,
-    onClick: (NotificationType) -> Unit,
-    enabled: Boolean,
+    onClick: () -> Unit,
+    isNotificationTypeSelectionEnabled: Boolean,
+    isNotificationChannelEnabled: Boolean,
     modifier: Modifier = Modifier
 ) {
+    val enabled = isNotificationTypeSelectionEnabled && isNotificationChannelEnabled
+    val isChannelDisabledStateVisible = isNotificationTypeSelectionEnabled && !isNotificationChannelEnabled
     Row(
         modifier = modifier
             .height(IntrinsicSize.Min)
             .padding(top = 8.dp)
             .fillMaxWidth()
-            .clickable(enabled = enabled) { onClick(item.type) },
+            .clickable(enabled = isNotificationTypeSelectionEnabled, onClick = onClick),
         verticalAlignment = Alignment.CenterVertically
     ) {
         val contentAlpha = if (enabled) 1f else 0.38f
@@ -181,17 +185,38 @@ private fun NotificationTypeRow(
                 style = MaterialTheme.typography.titleMedium,
                 color = titleColor
             )
-            Text(
-                text = stringResource(id = item.subtitle),
-                style = MaterialTheme.typography.bodyMedium,
-                color = subtitleColor,
-                modifier = Modifier.padding(top = 2.dp)
-            )
+            if (!isChannelDisabledStateVisible) {
+                Text(
+                    text = stringResource(id = item.subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = subtitleColor,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            } else {
+                Row(
+                    modifier = Modifier.padding(top = 2.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_warning_filled_24dp),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Text(
+                        text = stringResource(id = R.string.settings_notifs_channel_disabled_subtitle),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
         }
         Spacer(modifier = Modifier.width(16.dp))
         WCSwitch(
             checked = item.isEnabled,
             onCheckedChange = { onEnabledChanged(item.type, it) },
+            modifier = Modifier.clickable(enabled = isChannelDisabledStateVisible, onClick = onClick),
             enabled = enabled
         )
         Spacer(modifier = Modifier.width(16.dp))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/WooPushNotificationSettingsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/WooPushNotificationSettingsScreen.kt
@@ -49,7 +49,9 @@ fun WooPushNotificationSettingsScreen(
     val isAppNotificationsEnabled = viewModel.isAppNotificationsEnabled.observeAsState().value ?: return
     val isNotificationSettingsLoading = sharedViewModel.isNotificationSettingsLoading.observeAsState().value ?: return
     val isNotificationTypeSelectionEnabled =
-        sharedViewModel.isNotificationTypeSelectionEnabled.observeAsState().value ?: return
+        sharedViewModel.isNotificationTypeSelectionEnabled.observeAsState().value
+            ?.let { it && isAppNotificationsEnabled }
+            ?: return
 
     WooPushNotificationSettingsScreen(
         items = notificationTypeItems,
@@ -166,6 +168,9 @@ private fun NotificationTypeRow(
             .clickable(enabled = enabled) { onClick(item.type) },
         verticalAlignment = Alignment.CenterVertically
     ) {
+        val contentAlpha = if (enabled) 1f else 0.38f
+        val titleColor = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha)
+        val subtitleColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha)
         Column(
             modifier = Modifier
                 .weight(1f)
@@ -174,12 +179,12 @@ private fun NotificationTypeRow(
             Text(
                 text = stringResource(id = item.title),
                 style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface
+                color = titleColor
             )
             Text(
                 text = stringResource(id = item.subtitle),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = subtitleColor,
                 modifier = Modifier.padding(top = 2.dp)
             )
         }
@@ -193,7 +198,7 @@ private fun NotificationTypeRow(
         Icon(
             painter = painterResource(id = R.drawable.ic_chevron_right_24dp),
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            tint = subtitleColor,
             modifier = Modifier.size(24.dp)
         )
         Spacer(modifier = Modifier.width(16.dp))

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2296,6 +2296,7 @@
     <string name="settings_notifs_device">Manage notifications</string>
     <string name="settings_notifs_device_detail">Sounds, urgency, and notification dot</string>
     <string name="settings_notifs_app_notifications_disabled_warning">&lt;a href=\'\'&gt;Turn on notifications&lt;/a&gt; in your device settings to receive store notifications.</string>
+    <string name="settings_notifs_channel_disabled_subtitle">Turn on in device settings</string>
     <string name="settings_notifs_enable_title">Enable notifications</string>
     <string name="settings_notifs_error_fetch">There was an error fetching your notification settings.</string>
     <string name="settings_notifs_error_update">There was an error updating your notification settings.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.ui.prefs.notifications
 
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
+import com.woocommerce.android.notifications.NotificationChannelType
+import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.push.PushNotificationRepository
 import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NewOrderNotificationPreference
 import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NotificationType
@@ -36,6 +38,7 @@ import java.math.BigDecimal
 @OptIn(ExperimentalCoroutinesApi::class)
 class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
     private val pushNotificationRepository: PushNotificationRepository = mock()
+    private val notificationChannelsHandler: NotificationChannelsHandler = mock()
     private val resourceProvider: ResourceProvider = mock {
         on { getString(any()) } doAnswer { it.arguments[0].toString() }
     }
@@ -54,11 +57,18 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         )
         mockSuccessfulFetch(defaultNotificationPreferences)
         mockSuccessfulUpdate()
+        with(notificationChannelsHandler) {
+            NotificationChannelType.entries.forEach {
+                whenever(notificationChannelsHandler.isNotificationChannelEnabled(it)).thenReturn(true)
+                whenever(it.getChannelId()).thenReturn(it.name)
+            }
+        }
         prepareMocks()
         viewModel = NotificationSettingsSharedViewModel(
             savedStateHandle = SavedStateHandle(),
             pushNotificationRepository = pushNotificationRepository,
             resourceProvider = resourceProvider,
+            notificationChannelsHandler = notificationChannelsHandler,
             coroutineDispatchers = coroutinesTestRule.testDispatchers
         )
     }
@@ -88,6 +98,35 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             NotificationType.STOCK
         )
     }
+
+    @Test
+    fun `given notification channel is disabled, when view model is loaded, then expose disabled channel state`() =
+        testBlocking {
+            setup {
+                whenever(notificationChannelsHandler.isNotificationChannelEnabled(NotificationChannelType.REVIEW))
+                    .thenReturn(false)
+            }
+
+            val reviewItem = viewModel.notificationTypeItems.captureValues().last()
+                .first { it.type == NotificationType.NEW_REVIEWS }
+
+            assertThat(reviewItem.isNotificationChannelEnabled).isFalse()
+        }
+
+    @Test
+    fun `when device notification channel settings may have changed, then update notification channel state`() =
+        testBlocking {
+            setup {
+                whenever(notificationChannelsHandler.isNotificationChannelEnabled(NotificationChannelType.NEW_ORDER))
+                    .thenReturn(false, true)
+            }
+
+            viewModel.refreshNotificationChannelSettings()
+            val orderItem = viewModel.notificationTypeItems.captureValues().last()
+                .first { it.type == NotificationType.NEW_ORDERS }
+
+            assertThat(orderItem.isNotificationChannelEnabled).isTrue()
+        }
 
     @Test
     fun `when view model is loaded, then fetch notification preferences`() = testBlocking {
@@ -552,6 +591,26 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
 
         assertThat(event).isInstanceOf(NotificationSettingsSharedViewModel.OpenStockNotificationSettings::class.java)
     }
+
+    @Test
+    fun `given notification channel is disabled, when notification type is clicked, then open channel settings`() =
+        testBlocking {
+            val channelId = "review-channel-id"
+            setup {
+                whenever(notificationChannelsHandler.isNotificationChannelEnabled(NotificationChannelType.REVIEW))
+                    .thenReturn(false)
+                with(notificationChannelsHandler) {
+                    whenever(NotificationChannelType.REVIEW.getChannelId()).thenReturn(channelId)
+                }
+            }
+            advanceUntilIdle()
+
+            val event = viewModel.event.runAndCaptureValues {
+                viewModel.onNotificationTypeClicked(NotificationType.NEW_REVIEWS)
+            }.last()
+
+            assertThat(event).isEqualTo(NotificationSettingsSharedViewModel.OpenNotificationChannelSettings(channelId))
+        }
 
     private suspend fun captureUpdatePreferences(): WooPushNotificationPreferences {
         val preferencesCaptor = argumentCaptor<WooPushNotificationPreferences>()


### PR DESCRIPTION
### Description

Fixes RSM-3534

Updates the smarter push notification settings screen to respect system notification settings.

When app notifications are disabled, the notification type rows are disabled and the existing device settings warning remains available. When an individual notification channel is disabled from system settings, the related row is shown as disabled with a device-settings subtitle, and tapping the row or switch opens that channel’s system settings. The screen refreshes these states when returning from system settings.

### Test Steps

1. Disable app notifications from system settings, open **Push notifications**, and verify the notification type rows cannot be opened or toggled.
2. Enable app notifications, disable one notification channel from system settings, return to **Push notifications**, and verify that row is disabled with the “Turn on in device settings” subtitle.
3. Tap the disabled row or switch and verify the related system notification channel settings screen opens.
4. Re-enable the channel, return to **Push notifications**, and verify the row and switch become active again.

### Images/gif

<img width="300" alt="Screenshot_20260519_162343" src="https://github.com/user-attachments/assets/92c11b28-7669-41d5-bc0a-0e4cb0bde46c" /> <img width="300" alt="Screenshot_20260519_143203" src="https://github.com/user-attachments/assets/bfb7d861-4ec3-4e1f-9834-2e6d1f812603" /> 

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.