### PR TITLE
[AI Support Chat] Hide contact help row when AI chat flag is enabled

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpActivity.kt
@@ -19,6 +19,7 @@ import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE_F
 import com.woocommerce.android.analytics.AnalyticsTracker.Companion.KEY_SOURCE_STEP
 import com.woocommerce.android.databinding.ActivityHelpBinding
 import com.woocommerce.android.extensions.doOnApplyWindowInsets
+import com.woocommerce.android.extensions.hide
 import com.woocommerce.android.extensions.isNotNullOrEmpty
 import com.woocommerce.android.extensions.serializable
 import com.woocommerce.android.extensions.show
@@ -93,7 +94,12 @@ class HelpActivity : AppCompatActivity() {
         supportActionBar?.setHomeButtonEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        binding.contactContainer.setOnClickListener { viewModel.contactSupport(TicketType.MobileApp) }
+        val isAiSupportChatAvailable = isAiSupportChatAvailable()
+        if (HelpAiSupportChatEntryPoint.shouldShowContactSupport(isAiSupportChatAvailable)) {
+            binding.contactContainer.setOnClickListener { viewModel.contactSupport(TicketType.MobileApp) }
+        } else {
+            binding.contactContainer.hide()
+        }
         binding.identityContainer.setOnClickListener { showIdentityDialog(TicketType.MobileApp) }
         binding.faqContainer.setOnClickListener {
             val loginFlow = intent.extras?.getString(LOGIN_FLOW_KEY)
@@ -111,7 +117,7 @@ class HelpActivity : AppCompatActivity() {
             binding.ssrContainer.setOnClickListener { showSSR() }
         }
 
-        if (isAiSupportChatAvailable()) {
+        if (isAiSupportChatAvailable) {
             binding.aiSupportChatContainer.show()
             binding.aiSupportChatContainer.setOnClickListener { showAiSupportChat() }
             binding.aiSupportChatHistoryContainer.show()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpAiSupportChatEntryPoint.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/support/help/HelpAiSupportChatEntryPoint.kt
@@ -3,5 +3,7 @@ package com.woocommerce.android.support.help
 object HelpAiSupportChatEntryPoint {
     fun isAvailable(featureFlagEnabled: Boolean): Boolean = featureFlagEnabled
 
+    fun shouldShowContactSupport(aiSupportChatAvailable: Boolean): Boolean = !aiSupportChatAvailable
+
     fun shouldUsePreLoginLaunchMode(isUserLoggedIn: Boolean): Boolean = !isUserLoggedIn
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpAiSupportChatEntryPointTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/support/help/HelpAiSupportChatEntryPointTest.kt
@@ -19,6 +19,24 @@ class HelpAiSupportChatEntryPointTest {
     }
 
     @Test
+    fun `given AI support chat unavailable, when checking contact support, then contact support is shown`() {
+        val shouldShowContactSupport = HelpAiSupportChatEntryPoint.shouldShowContactSupport(
+            aiSupportChatAvailable = false
+        )
+
+        assertThat(shouldShowContactSupport).isTrue()
+    }
+
+    @Test
+    fun `given AI support chat available, when checking contact support, then contact support is hidden`() {
+        val shouldShowContactSupport = HelpAiSupportChatEntryPoint.shouldShowContactSupport(
+            aiSupportChatAvailable = true
+        )
+
+        assertThat(shouldShowContactSupport).isFalse()
+    }
+
+    @Test
     fun `given user is logged out, when selecting launch mode, then pre-login is used`() {
         val shouldUsePreLoginLaunchMode = HelpAiSupportChatEntryPoint.shouldUsePreLoginLaunchMode(
             isUserLoggedIn = false


### PR DESCRIPTION
Closes WOOMOB-3075

### Description
When `ai_support_chat` feature flag is enabled, we only show  “Chat with support” and “Chat history” rows in Help settings, prior "Contact support" row should be hidden.

### Test Steps
- Enable/Disable the feature flag in `FeatureFlag.kt::37`
```
AI_SUPPORT_CHAT("ai_support_chat", false),
```
- Enabled: Contact support row should be hidden; “Chat with support” and “Chat history” shown.
- Disabled: Contact support row should be shown; AI chat rows hidden.

### Images/gif

| Feature off | Feature on |
|--------|--------|
| <img width="2560" height="1600" alt="Screenshot_20260520_110926" src="https://github.com/user-attachments/assets/b9cc688f-11e5-4058-a393-c3c5804974c7" /> | <img width="2560" height="1600" alt="Screenshot_20260520_110536" src="https://github.com/user-attachments/assets/3ea7d9ff-acf0-4c67-8ae5-fa33ac6e7947" /> | 


