### PR TITLE
Wire AI translation into CI (PR-time, release sweep, hotfix)

### DIFF
--- a/.buildkite/commands/ai-translate-pr.sh
+++ b/.buildkite/commands/ai-translate-pr.sh
@@ -1,0 +1,62 @@
+#!/bin/bash -eu
+
+# PR-time AI translation check.
+#
+# Translates only the keys this PR adds/changes (delta vs the committed
+# translation-manifest.json) for every supported locale, then a bot commits the
+# resulting values-*/strings.xml + manifest back to the PR branch. This keeps
+# trunk fully translated (no post-merge step) and makes the translations
+# reviewable inline in the PR diff (non-blocking spot-check).
+#
+# Idempotent: if the PR introduces no string changes (or they are already
+# translated) the engine is a no-op, nothing is committed, and the bot commit
+# carries `[skip ai-translate]` so the follow-up build does not loop.
+
+BOT_SKIP_MARKER="[skip ai-translate]"
+
+# Fork PRs / no-secret builds: no API key is injected. Skip cleanly; the
+# code-freeze sweep is the safety net for these deltas.
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "ANTHROPIC_API_KEY not available (fork PR or no secret) — skipping AI translation."
+  exit 0
+fi
+
+# Don't re-process our own bot commit.
+if git log -1 --pretty=%B | grep -qF "${BOT_SKIP_MARKER}"; then
+  echo "HEAD is a bot translation commit — nothing to do."
+  exit 0
+fi
+
+echo '--- :robot_face: Use bot for git operations'
+source use-bot-for-git
+
+echo '--- :ruby: Setup Ruby Tools'
+install_gems
+
+echo '--- :globe_with_meridians: AI translate (PR delta)'
+bundle exec fastlane ai_translate mode:prtime
+
+CHANGED=$(git status --porcelain -- 'WooCommerce/src/main/res/values-*/strings.xml' 'fastlane/ai_translation/translation-manifest.json')
+
+if [ -z "${CHANGED}" ]; then
+  echo "No translation changes — no commit, no retrigger."
+  comment_on_pr --id ai-translations --if-exist delete || true
+  exit 0
+fi
+
+echo '--- :memo: Commit translations back to the PR branch'
+git add WooCommerce/src/main/res/values-*/strings.xml fastlane/ai_translation/translation-manifest.json
+git commit -m "Update AI translations ${BOT_SKIP_MARKER}"
+git push origin "HEAD:${BUILDKITE_BRANCH}"
+
+# Non-blocking spot-check surface (decoupled from Danger; equally visible).
+comment_on_pr --id ai-translations "## :globe_with_meridians: AI translations updated
+
+This PR's new/changed strings were machine-translated for all supported
+locales and committed by the bot. Review is **sampled and non-blocking** —
+spot-check the \`values-*/strings.xml\` diff if a string is nuanced.
+
+Updated:
+\`\`\`
+${CHANGED}
+\`\`\`"

--- a/.buildkite/commands/ai-translate-pr.sh
+++ b/.buildkite/commands/ai-translate-pr.sh
@@ -45,7 +45,10 @@ if [ -z "${CHANGED}" ]; then
 fi
 
 echo '--- :memo: Commit translations back to the PR branch'
-git add WooCommerce/src/main/res/values-*/strings.xml fastlane/ai_translation/translation-manifest.json
+git add -- 'WooCommerce/src/main/res/values-*/strings.xml'
+if [ -f fastlane/ai_translation/translation-manifest.json ]; then
+  git add -- 'fastlane/ai_translation/translation-manifest.json'
+fi
 git commit -m "Update AI translations ${BOT_SKIP_MARKER}"
 git push origin "HEAD:${BUILDKITE_BRANCH}"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,6 +50,15 @@ steps:
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
+      - label: ":globe_with_meridians: AI Translations"
+        command: .buildkite/commands/ai-translate-pr.sh
+        key: ai-translations
+        if: "build.pull_request.id != null"
+        # Eased in: keep soft_fail until the PR-time job is proven stable, then
+        # remove this line to make it a hard (required) check.
+        soft_fail: true
+        plugins: [$CI_TOOLKIT]
+
       - label: "Dependency Tree Diff"
         command: comment_with_dependency_diff 'woocommerce' 'vanillaReleaseRuntimeClasspath'
         if: build.pull_request.id != null

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -57,6 +57,8 @@ steps:
         # Eased in: keep soft_fail until the PR-time job is proven stable, then
         # remove this line to make it a hard (required) check.
         soft_fail: true
+        agents:
+          queue: "mac-metal"
         plugins: [$CI_TOOLKIT]
 
       - label: "Dependency Tree Diff"

--- a/.buildkite/release-pipelines/download-release-translations.yml
+++ b/.buildkite/release-pipelines/download-release-translations.yml
@@ -1,8 +1,13 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
+# GlotPress is retired. `download_release_translations` now runs the AI
+# code-freeze reconciliation sweep (every key x every locale -- the safety net
+# for anything the PR-time job missed) plus metadata incl. per-release notes.
+# Requires ANTHROPIC_API_KEY in the agent environment (same secret used by
+# Claude Build Analysis).
 steps:
-  - label: "Download Release Translations"
+  - label: "AI Release Translations (code-freeze sweep)"
     plugins: [$CI_TOOLKIT]
     command: |
       echo '--- :robot_face: Use bot for git operations'
@@ -13,7 +18,7 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- :globe_with_meridians: Download Release Translations'
+      echo '--- :globe_with_meridians: AI Release Translations (sweep + metadata)'
       bundle exec fastlane download_release_translations skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:
         queue: "mac-metal"

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -13,6 +13,12 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
+      echo '--- :globe_with_meridians: AI Translations (hotfix sweep)'
+      # A hotfix never has to wait for a PR-time run: reconcile + commit
+      # translations on the hotfix branch before finalizing (mirrors how the
+      # code-freeze sweep sits in the normal release flow).
+      bundle exec fastlane download_release_translations skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
+
       echo '--- :fire: Finalize Hotfix Release'
       bundle exec fastlane finalize_hotfix_release skip_confirm:true include_wear_app:"${INCLUDE_WEAR_APP:-false}"
     agents:


### PR DESCRIPTION
## Summary

Wires the AI translation flow into CI and release automation:

- Adds the PR-time Buildkite AI Translations check in the Linters group.
- Translates changed source strings for all supported locales and commits generated `values-*` files plus `translation-manifest.json` back to the PR branch.
- Skips forks/no-secret builds cleanly and avoids loops via the `[skip ai-translate]` marker.
- Repoints release/code-freeze translation sweep and hotfix finalize flows to the AI engine.

## Fixes from dummy-PR validation

The dummy PR surfaced two production CI issues, both folded into this PR:

- Run the PR-time job on trusted `mac-metal` agents so `/opt/ci/common-credentials/bin/use-bot-for-git` and bot Git credentials are available.
- Stage generated translation files with symlink-safe Git pathspecs and only add the manifest when it exists, so Android legacy locale aliases such as `values-in` and `values-iw` do not break `git add`.

## Stack

Base: #15963. Next: #15965. Full map: #15961.

## Test plan

- [x] `bash -n .buildkite/commands/ai-translate-pr.sh`
- [x] Dummy PR #15984 validated that the PR-time job can create and push the generated translation commit.
- [x] Follow-up dummy run preserved the `[skip ai-translate]` loop guard.
- [x] Latest stacked Ruby suite: `82 runs / 303 assertions / 0 failures`.
