### PR TITLE
[AI Support Chat] add swipe to delete history

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryFragment.kt
@@ -6,17 +6,23 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import com.woocommerce.android.ui.base.UIMessageResolver
 import com.woocommerce.android.ui.compose.composeView
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AiSupportChatHistoryFragment : Fragment() {
     private val viewModel: AiSupportChatHistoryViewModel by viewModels()
 
+    @Inject lateinit var uiMessageResolver: UIMessageResolver
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
         composeView {
             AiSupportChatHistoryScreen(
                 viewModel = viewModel,
+                onBookmarkDeleted = viewModel::onDeleteBookmark,
                 onBookmarkClicked = { bookmark ->
                     startActivity(
                         AiSupportChatActivity.createResumeIntent(
@@ -31,6 +37,15 @@ class AiSupportChatHistoryFragment : Fragment() {
                 }
             )
         }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.event.observe(viewLifecycleOwner) { event ->
+            when (event) {
+                is ShowSnackbar -> uiMessageResolver.showSnack(event.message)
+            }
+        }
+    }
 
     override fun onResume() {
         super.onResume()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryScreen.kt
@@ -2,7 +2,9 @@ package com.woocommerce.android.ui.aisupportchat
 
 import android.text.format.DateUtils
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,24 +15,25 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -140,7 +143,7 @@ private fun HistoryList(
         verticalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.major_100))
     ) {
         items(bookmarks, key = { it.chatId }) { bookmark ->
-            SwipeToDeleteHistoryRow(
+            HistoryRow(
                 bookmark = bookmark,
                 onDelete = { onBookmarkDeleted(bookmark) },
                 onClick = { onBookmarkClicked(bookmark) }
@@ -149,54 +152,68 @@ private fun HistoryList(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun SwipeToDeleteHistoryRow(
+private fun HistoryRow(
     bookmark: SupportChatBookmark,
     onDelete: () -> Unit,
     onClick: () -> Unit
 ) {
-    val swipeToDismissBoxState = rememberSwipeToDismissBoxState()
-    SwipeToDismissBox(
-        state = swipeToDismissBoxState,
-        enableDismissFromStartToEnd = false,
-        backgroundContent = {
-            if (swipeToDismissBoxState.dismissDirection == SwipeToDismissBoxValue.EndToStart) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_delete_filled_24dp),
-                    contentDescription = stringResource(id = R.string.delete),
-                    tint = colorResource(R.color.woo_white),
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(colorResource(R.color.woo_red_50))
-                        .wrapContentSize(Alignment.CenterEnd)
-                        .padding(end = dimensionResource(R.dimen.major_100))
+    var isContextMenuExpanded by remember { mutableStateOf(false) }
+    Box(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        HistoryRowContent(
+            bookmark = bookmark,
+            onClick = onClick,
+            onLongClick = { isContextMenuExpanded = true }
+        )
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .width(1.dp)
+        ) {
+            DropdownMenu(
+                expanded = isContextMenuExpanded,
+                onDismissRequest = { isContextMenuExpanded = false }
+            ) {
+                DropdownMenuItem(
+                    text = { Text(text = stringResource(R.string.delete)) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = ImageVector.vectorResource(R.drawable.ic_delete_filled_24dp),
+                            contentDescription = null
+                        )
+                    },
+                    onClick = {
+                        isContextMenuExpanded = false
+                        onDelete()
+                    }
                 )
             }
-        },
-        onDismiss = { value ->
-            if (value == SwipeToDismissBoxValue.EndToStart) onDelete()
-            value != SwipeToDismissBoxValue.EndToStart
         }
-    ) {
-        HistoryRow(
-            bookmark = bookmark,
-            onClick = onClick
-        )
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun HistoryRow(
+private fun HistoryRowContent(
     bookmark: SupportChatBookmark,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onLongClick: () -> Unit
 ) {
+    val deleteLabel = stringResource(R.string.delete)
     Surface(
-        onClick = onClick,
         shape = RoundedCornerShape(8.dp),
         color = MaterialTheme.colorScheme.surface,
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
         modifier = Modifier
             .fillMaxWidth()
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick,
+                onLongClickLabel = deleteLabel
+            )
     ) {
         Column(
             modifier = Modifier.padding(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -20,14 +21,20 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -40,11 +47,13 @@ import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 @Composable
 fun AiSupportChatHistoryScreen(
     viewModel: AiSupportChatHistoryViewModel,
+    onBookmarkDeleted: (SupportChatBookmark) -> Unit,
     onBookmarkClicked: (SupportChatBookmark) -> Unit
 ) {
     val viewState by viewModel.viewState.collectAsStateWithLifecycle()
     AiSupportChatHistoryScreen(
         viewState = viewState,
+        onBookmarkDeleted = onBookmarkDeleted,
         onBookmarkClicked = onBookmarkClicked
     )
 }
@@ -52,6 +61,7 @@ fun AiSupportChatHistoryScreen(
 @Composable
 fun AiSupportChatHistoryScreen(
     viewState: AiSupportChatHistoryViewState,
+    onBookmarkDeleted: (SupportChatBookmark) -> Unit,
     onBookmarkClicked: (SupportChatBookmark) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -63,6 +73,7 @@ fun AiSupportChatHistoryScreen(
         )
         else -> HistoryList(
             bookmarks = viewState.bookmarks,
+            onBookmarkDeleted = onBookmarkDeleted,
             onBookmarkClicked = onBookmarkClicked,
             modifier = modifier
         )
@@ -117,6 +128,7 @@ private fun EmptyHistory(
 @Composable
 private fun HistoryList(
     bookmarks: List<SupportChatBookmark>,
+    onBookmarkDeleted: (SupportChatBookmark) -> Unit,
     onBookmarkClicked: (SupportChatBookmark) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -128,11 +140,48 @@ private fun HistoryList(
         verticalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.major_100))
     ) {
         items(bookmarks, key = { it.chatId }) { bookmark ->
-            HistoryRow(
+            SwipeToDeleteHistoryRow(
                 bookmark = bookmark,
+                onDelete = { onBookmarkDeleted(bookmark) },
                 onClick = { onBookmarkClicked(bookmark) }
             )
         }
+    }
+}
+
+@Composable
+private fun SwipeToDeleteHistoryRow(
+    bookmark: SupportChatBookmark,
+    onDelete: () -> Unit,
+    onClick: () -> Unit
+) {
+    val swipeToDismissBoxState = rememberSwipeToDismissBoxState()
+    SwipeToDismissBox(
+        state = swipeToDismissBoxState,
+        enableDismissFromStartToEnd = false,
+        backgroundContent = {
+            if (swipeToDismissBoxState.dismissDirection == SwipeToDismissBoxValue.EndToStart) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_delete_filled_24dp),
+                    contentDescription = stringResource(id = R.string.delete),
+                    tint = colorResource(R.color.woo_white),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(colorResource(R.color.woo_red_50))
+                        .wrapContentSize(Alignment.CenterEnd)
+                        .padding(end = dimensionResource(R.dimen.major_100))
+                )
+            }
+        },
+        onDismiss = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) onDelete()
+            value != SwipeToDismissBoxValue.EndToStart
+        }
+    ) {
+        HistoryRow(
+            bookmark = bookmark,
+            onClick = onClick
+        )
     }
 }
 
@@ -214,6 +263,7 @@ private fun AiSupportChatHistoryScreenPreview() {
                     )
                 )
             ),
+            onBookmarkDeleted = {},
             onBookmarkClicked = {}
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryViewModel.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.aisupportchat
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
 import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.ScopedViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
@@ -44,6 +46,23 @@ class AiSupportChatHistoryViewModel @Inject constructor(
                             showError = true
                         )
                     }
+                }
+        }
+    }
+
+    fun onDeleteBookmark(bookmark: SupportChatBookmark) {
+        val previousBookmarks = _viewState.value.bookmarks
+        _viewState.update {
+            it.copy(bookmarks = it.bookmarks.filterNot { currentBookmark -> currentBookmark.chatId == bookmark.chatId })
+        }
+
+        launch {
+            runCatching { repository.deleteChat(bookmark.chatId) }
+                .onFailure { error ->
+                    if (error is CancellationException) throw error
+                    WooLog.e(WooLog.T.AI, "Deleting AI support chat history failed", error)
+                    _viewState.update { it.copy(bookmarks = previousBookmarks) }
+                    triggerEvent(ShowSnackbar(R.string.ai_support_chat_history_delete_error))
                 }
         }
     }

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -2420,6 +2420,7 @@
     <string name="ai_support_chat_history_title">Chat history</string>
     <string name="ai_support_chat_history_empty">You haven\'t chatted with support yet.</string>
     <string name="ai_support_chat_history_load_error">Unable to load chat history.</string>
+    <string name="ai_support_chat_history_delete_error">Unable to delete chat history.</string>
     <string name="ai_support_chat_history_default_title">Support conversation</string>
     <string name="ai_support_chat_placeholder">Coming soon</string>
     <string name="ai_support_chat_greeting">Hello! I\'m your Woo Mobile Support Bot. Is there anything I can help you with today?</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.woocommerce.android.ui.aisupportchat
 
 import androidx.lifecycle.SavedStateHandle
+import com.woocommerce.android.R
+import com.woocommerce.android.util.runAndCaptureValues
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.BaseUnitTest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -8,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 
@@ -77,8 +81,49 @@ class AiSupportChatHistoryViewModelTest : BaseUnitTest() {
         assertThat(state.bookmarks).isEmpty()
     }
 
-    private fun createBookmark() = SupportChatBookmark(
-        chatId = 1234L,
+    @Test
+    fun `given history loaded, when deleting bookmark succeeds, then bookmark is removed`() = testBlocking {
+        val bookmark = createBookmark(chatId = 1L)
+        whenever(repository.loadChatHistory()).thenReturn(listOf(bookmark))
+        viewModel.loadHistory()
+
+        viewModel.onDeleteBookmark(bookmark)
+
+        verify(repository).deleteChat(bookmark.chatId)
+        assertThat(viewModel.viewState.value.bookmarks).isEmpty()
+    }
+
+    @Test
+    fun `given multiple bookmarks loaded, when deleting bookmark succeeds, then only target bookmark is removed`() =
+        testBlocking {
+            val firstBookmark = createBookmark(chatId = 1L)
+            val secondBookmark = createBookmark(chatId = 2L)
+            whenever(repository.loadChatHistory()).thenReturn(listOf(firstBookmark, secondBookmark))
+            viewModel.loadHistory()
+
+            viewModel.onDeleteBookmark(firstBookmark)
+
+            verify(repository).deleteChat(firstBookmark.chatId)
+            assertThat(viewModel.viewState.value.bookmarks).containsExactly(secondBookmark)
+        }
+
+    @Test
+    fun `given delete fails, when deleting bookmark, then bookmark is restored and error is shown`() = testBlocking {
+        val bookmark = createBookmark(chatId = 1L)
+        whenever(repository.loadChatHistory()).thenReturn(listOf(bookmark))
+        whenever(repository.deleteChat(bookmark.chatId)).thenThrow(RuntimeException("DB unavailable"))
+        viewModel.loadHistory()
+
+        val events = viewModel.event.runAndCaptureValues {
+            viewModel.onDeleteBookmark(bookmark)
+        }
+
+        assertThat(viewModel.viewState.value.bookmarks).containsExactly(bookmark)
+        assertThat(events.last()).isEqualTo(ShowSnackbar(R.string.ai_support_chat_history_delete_error))
+    }
+
+    private fun createBookmark(chatId: Long = 1234L) = SupportChatBookmark(
+        chatId = chatId,
         localSiteId = LocalId(10),
         remoteSiteId = 20L,
         botSlug = AiSupportChatViewModel.DEFAULT_BOT_SLUG,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatHistoryViewModelTest.kt
@@ -3,8 +3,8 @@ package com.woocommerce.android.ui.aisupportchat
 import androidx.lifecycle.SavedStateHandle
 import com.woocommerce.android.R
 import com.woocommerce.android.util.runAndCaptureValues
-import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import com.woocommerce.android.viewmodel.BaseUnitTest
+import com.woocommerce.android.viewmodel.MultiLiveEvent.Event.ShowSnackbar
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat


### PR DESCRIPTION
Closes WOOMOB-3110

### Description
Adds swipe-to-delete support for AI support chat history on Android. History rows can now be swiped end-to-start to delete the local chat bookmark. Deletion is optimistic; if it fails, the row is restored and an error snackbar is shown.

### Test Steps
1. Open Help & Support.
2. Open Chat history.
3. Swipe a chat history row from right to left.
4. Verify the delete background/icon appears and the row is removed.
5. Reopen Chat history and verify the deleted chat no longer appears.

### Images/gif

https://github.com/user-attachments/assets/3e5b5da8-8e6d-4dc1-ab91-5992e69013f6

