### PR TITLE
Commit bin/woo-ai-translate so the ai_translate Fastlane lane is runnable

### DIFF
--- a/fastlane/ai_translation/bin/woo-ai-translate
+++ b/fastlane/ai_translation/bin/woo-ai-translate
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../lib/woo_ai_translation'
+
+exit WooAiTranslation::CLI.run(ARGV)

--- a/fastlane/ai_translation/spec/woo_ai_translation_test.rb
+++ b/fastlane/ai_translation/spec/woo_ai_translation_test.rb
@@ -3,6 +3,7 @@
 require 'minitest/autorun'
 require 'tmpdir'
 require 'fileutils'
+require 'English'
 require_relative '../lib/woo_ai_translation'
 
 FIXTURE = File.join(__dir__, 'fixtures', 'strings_sample.xml')
@@ -804,5 +805,23 @@ class ManifestInvalidationTest < Minitest::Test
     m.record(name: 'a', locale: 'pl', model: 'haiku', origin: 'ai', source_sha: 'sha')
     m.record(name: 'b', locale: 'pl', model: 'haiku', origin: 'ai', source_sha: 'sha')
     assert_equal %w[a b].sort, m.known_keys.sort
+  end
+end
+
+class CliShimTest < Minitest::Test
+  # The .gitignore at repo root has a blanket `bin/` rule, so the executable
+  # entry point must be force-added. These tests catch a regression where the
+  # shim is on disk locally but not committed, or loses its exec bit.
+  SHIM = File.expand_path('../bin/woo-ai-translate', __dir__)
+
+  def test_shim_is_present_and_executable
+    assert File.exist?(SHIM), "shim missing at #{SHIM} (was it force-added?)"
+    assert File.executable?(SHIM), "shim not executable at #{SHIM}"
+  end
+
+  def test_shim_boots_the_cli
+    out = IO.popen([SHIM, '--help'], err: %i[child out], &:read)
+    assert_equal 0, $CHILD_STATUS.exitstatus, "shim exited non-zero: #{out}"
+    assert_includes out, 'Usage: woo-ai-translate'
   end
 end


### PR DESCRIPTION
## Summary

- Force-adds `fastlane/ai_translation/bin/woo-ai-translate` (matched by the repo-root `bin/` ignore rule) so the `ai_translate` / `ai_translate_metadata` / `ai_translate_shadow` Fastlane lanes can actually invoke the engine on a fresh checkout. Mirrors the prior pattern used for `bin/merge-manifests`.
- Adds a `CliShimTest` minitest class that boots the binary via `--help` and asserts exit 0, so a future omission of the force-add (or a lost exec bit) fails in the engine test suite rather than at the first `bundle exec fastlane ai_translate` invocation.

Stacked on #15972 per the translation rollout plan's PR-reuse routing (cross-cutting work that isn't engine-prevention itself ⇒ new PR off `issue/woomob-translations-p8-engine-prevention`).

## Test plan

- [x] `ruby fastlane/ai_translation/spec/woo_ai_translation_test.rb` ⇒ 54 runs / 205 assertions / 0 failures
- [ ] `bundle exec fastlane ai_translate mode:prtime locales:pl` (smoke run; needs `ANTHROPIC_API_KEY` or `--claude-cli`)
- [ ] Confirm the file shows as `100755` in the GitHub diff