### PR TITLE
[WOOMOB-3076] Fix notification diagnostics analytics mapping

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatAnalyticsTracker.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/aisupportchat/AiSupportChatAnalyticsTracker.kt
@@ -249,6 +249,11 @@ private val DiagnosticTest.analyticsValue: String
         DiagnosticTest.STORE_ORDERS -> "site_orders"
         DiagnosticTest.STORE_PRODUCTS -> "loading_products"
         DiagnosticTest.ANALYTICS_SETTING -> "analytics_setting"
+        DiagnosticTest.NOTIFICATION_PERMISSION -> "notification_permission"
+        DiagnosticTest.APP_NOTIFICATIONS_ENABLED -> "app_notifications_enabled"
+        DiagnosticTest.NOTIFICATION_CHANNELS_ENABLED -> "notification_channels_enabled"
+        DiagnosticTest.PUSH_NOTIFICATION_TOKEN -> "push_notification_token"
+        DiagnosticTest.PUSH_NOTIFICATION_REGISTRATION -> "push_notification_registration"
     }
 
 private val AiSupportChatFeedbackRating.analyticsValue: String


### PR DESCRIPTION
### Description
Fixes WOOMOB-3076

Adds analytics values for the notification diagnostics introduced in #15960. Without these mappings, the existing exhaustive DiagnosticTest mapper fails compilation after the new notification diagnostic checks are added.

### Test Steps
Confirm the project builds successfully.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.