### PR TITLE
[RSM-2323] Add notification settings analytics

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewOrderNotificationSettingsFragment.kt
@@ -43,6 +43,7 @@ class NewOrderNotificationSettingsFragment : BaseFragment() {
     override fun onResume() {
         super.onResume()
         viewModel.refreshNotificationSettings()
+        sharedViewModel.onNotificationDetailShown(NotificationSettingsSharedViewModel.NotificationType.NEW_ORDERS)
         AnalyticsTracker.trackViewShown(this)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewReviewNotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewReviewNotificationSettingsFragment.kt
@@ -37,6 +37,7 @@ class NewReviewNotificationSettingsFragment : BaseFragment() {
 
     override fun onResume() {
         super.onResume()
+        sharedViewModel.onNotificationDetailShown(NotificationSettingsSharedViewModel.NotificationType.NEW_REVIEWS)
         AnalyticsTracker.trackViewShown(this)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NewStockNotificationSettingsFragment.kt
@@ -50,6 +50,7 @@ class NewStockNotificationSettingsFragment : BaseFragment() {
 
     override fun onResume() {
         super.onResume()
+        sharedViewModel.onNotificationDetailShown(NotificationSettingsSharedViewModel.NotificationType.STOCK)
         AnalyticsTracker.trackViewShown(this)
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsAnalyticsMappings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsAnalyticsMappings.kt
@@ -1,7 +1,10 @@
 package com.woocommerce.android.ui.prefs.notifications
 
+import com.automattic.eventhorizon.NotificationFilterOptionValue
 import com.automattic.eventhorizon.NotificationTypeValue
 import com.automattic.eventhorizon.StockNotificationOptionValue
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NewOrderNotificationPreference
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NewReviewNotificationPreference
 import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NotificationType
 import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.StockNotificationType
 
@@ -10,6 +13,18 @@ fun NotificationType.toEventHorizonValue(): NotificationTypeValue =
         NotificationType.NEW_ORDERS -> NotificationTypeValue.NewOrder
         NotificationType.NEW_REVIEWS -> NotificationTypeValue.NewReview
         NotificationType.STOCK -> NotificationTypeValue.StockAlert
+    }
+
+fun NewOrderNotificationPreference.toEventHorizonValue(): NotificationFilterOptionValue =
+    when (this) {
+        NewOrderNotificationPreference.AllOrders -> NotificationFilterOptionValue.All
+        NewOrderNotificationPreference.HighValueOrders -> NotificationFilterOptionValue.Filtered
+    }
+
+fun NewReviewNotificationPreference.toEventHorizonValue(): NotificationFilterOptionValue =
+    when (this) {
+        NewReviewNotificationPreference.AllReviews -> NotificationFilterOptionValue.All
+        NewReviewNotificationPreference.RatingFilteredReviews -> NotificationFilterOptionValue.Filtered
     }
 
 fun StockNotificationType.toEventHorizonValue(): StockNotificationOptionValue =

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsAnalyticsMappings.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsAnalyticsMappings.kt
@@ -1,0 +1,20 @@
+package com.woocommerce.android.ui.prefs.notifications
+
+import com.automattic.eventhorizon.NotificationTypeValue
+import com.automattic.eventhorizon.StockNotificationOptionValue
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.NotificationType
+import com.woocommerce.android.ui.prefs.notifications.NotificationSettingsSharedViewModel.StockNotificationType
+
+fun NotificationType.toEventHorizonValue(): NotificationTypeValue =
+    when (this) {
+        NotificationType.NEW_ORDERS -> NotificationTypeValue.NewOrder
+        NotificationType.NEW_REVIEWS -> NotificationTypeValue.NewReview
+        NotificationType.STOCK -> NotificationTypeValue.StockAlert
+    }
+
+fun StockNotificationType.toEventHorizonValue(): StockNotificationOptionValue =
+    when (this) {
+        StockNotificationType.LowStock -> StockNotificationOptionValue.LowStock
+        StockNotificationType.OutOfStock -> StockNotificationOptionValue.OutOfStock
+        StockNotificationType.Backorder -> StockNotificationOptionValue.OnBackorder
+    }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsFragment.kt
@@ -55,6 +55,7 @@ class NotificationSettingsFragment : BaseFragment() {
         viewModel.refreshNotificationSettings()
         if (navArgs.showSmarterNotifications) {
             sharedViewModel.refreshNotificationChannelSettings()
+            sharedViewModel.onNotificationSettingsShown()
         }
         AnalyticsTracker.trackViewShown(this)
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -3,6 +3,8 @@ package com.woocommerce.android.ui.prefs.notifications
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.automattic.eventhorizon.NotificationFilterOptionValue
+import com.automattic.eventhorizon.NotificationsDetailFilterOptionSelectEvent
 import com.automattic.eventhorizon.NotificationsDetailFilterValueChangeEvent
 import com.automattic.eventhorizon.NotificationsDetailPushToggleEvent
 import com.automattic.eventhorizon.NotificationsDetailViewEvent
@@ -169,7 +171,6 @@ class NotificationSettingsSharedViewModel @Inject constructor(
 
     fun onNewOrderNotificationPreferenceChanged(preference: NewOrderNotificationPreference) {
         val preferences = wooPushNotificationPreferences.value ?: return
-        // TODO: Track notifications_detail_filter_option_select when available in EventHorizon.
         val minAmount = when (preference) {
             NewOrderNotificationPreference.AllOrders -> null
             NewOrderNotificationPreference.HighValueOrders -> displayedOrderThresholdAmount.value
@@ -182,6 +183,7 @@ class NotificationSettingsSharedViewModel @Inject constructor(
                 )
             )
         )
+        trackNotificationDetailFilterOptionSelect(NotificationType.NEW_ORDERS, preference.toEventHorizonValue())
     }
 
     fun onNewOrderThresholdAmountChanged(amount: BigDecimal) {
@@ -205,13 +207,13 @@ class NotificationSettingsSharedViewModel @Inject constructor(
 
     fun onNewReviewNotificationPreferenceChanged(preference: NewReviewNotificationPreference) {
         val preferences = wooPushNotificationPreferences.value ?: return
-        // TODO: Track notifications_detail_filter_option_select when available in EventHorizon.
         val updatedViewState = preferences.toNewReviewNotificationSettingsViewState(
             displayedRating = displayedReviewRating.value
         ).copy(notificationPreference = preference)
         updateDisplayedWooPushNotificationPreferences(
             preferences.copy(storeReview = updatedViewState.toStoreReviewPreferences())
         )
+        trackNotificationDetailFilterOptionSelect(NotificationType.NEW_REVIEWS, preference.toEventHorizonValue())
     }
 
     fun onNewReviewSelectedRatingChanged(rating: Int) {
@@ -441,6 +443,18 @@ class NotificationSettingsSharedViewModel @Inject constructor(
             NotificationsDetailFilterValueChangeEvent(
                 notificationType = type.toEventHorizonValue(),
                 filterValue = value
+            )
+        )
+    }
+
+    private fun trackNotificationDetailFilterOptionSelect(
+        type: NotificationType,
+        option: NotificationFilterOptionValue
+    ) {
+        analyticsTracker.track(
+            NotificationsDetailFilterOptionSelectEvent(
+                notificationType = type.toEventHorizonValue(),
+                filterOption = option
             )
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -325,12 +325,12 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         saveInProgressWooPushNotificationPreferences = preferencesToSave
         savedPreferences.storeOrder?.minAmount?.let { savedMinAmount ->
             updateRequest.storeOrder?.minAmount?.takeIf { it != savedMinAmount }?.let {
-                trackNotificationDetailFilterValueChange(NotificationType.NEW_ORDERS, it.toLong())
+                trackNotificationDetailFilterValueChange(NotificationType.NEW_ORDERS, it.toDouble())
             }
         }
         savedPreferences.storeReview?.maxRating?.let { savedMaxRating ->
             updateRequest.storeReview?.maxRating?.takeIf { it != savedMaxRating }?.let {
-                trackNotificationDetailFilterValueChange(NotificationType.NEW_REVIEWS, it.toLong())
+                trackNotificationDetailFilterValueChange(NotificationType.NEW_REVIEWS, it.toDouble())
             }
         }
         // Once started, let the save request finish even if the screen is closed.
@@ -438,7 +438,7 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         )
     }
 
-    private fun trackNotificationDetailFilterValueChange(type: NotificationType, value: Long) {
+    private fun trackNotificationDetailFilterValueChange(type: NotificationType, value: Double) {
         analyticsTracker.track(
             NotificationsDetailFilterValueChangeEvent(
                 notificationType = type.toEventHorizonValue(),

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -3,7 +3,18 @@ package com.woocommerce.android.ui.prefs.notifications
 import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
+import com.automattic.eventhorizon.NotificationsDetailFilterValueChangeEvent
+import com.automattic.eventhorizon.NotificationsDetailPushToggleEvent
+import com.automattic.eventhorizon.NotificationsDetailViewEvent
+import com.automattic.eventhorizon.NotificationsSettingsLoadFailedEvent
+import com.automattic.eventhorizon.NotificationsSettingsLoadRetryTappedEvent
+import com.automattic.eventhorizon.NotificationsSettingsUpdateFailedEvent
+import com.automattic.eventhorizon.NotificationsSettingsUpdateRetryTappedEvent
+import com.automattic.eventhorizon.NotificationsSettingsViewEvent
+import com.automattic.eventhorizon.NotificationsStockOptionToggleEvent
+import com.automattic.eventhorizon.NotificationsTypeToggleEvent
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.push.PushNotificationRepository
@@ -40,7 +51,8 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val currencyFormatter: CurrencyFormatter,
     private val notificationChannelsHandler: NotificationChannelsHandler,
-    private val coroutineDispatchers: CoroutineDispatchers
+    private val coroutineDispatchers: CoroutineDispatchers,
+    private val analyticsTracker: AnalyticsTrackerWrapper
 ) : ScopedViewModel(savedStateHandle) {
     private val wooPushNotificationPreferences = MutableStateFlow<WooPushNotificationPreferences?>(null)
     private var savedWooPushNotificationPreferences: WooPushNotificationPreferences? = null
@@ -106,7 +118,20 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         observeNotificationPreferencesChanges()
     }
 
+    fun onNotificationSettingsShown() {
+        analyticsTracker.track(NotificationsSettingsViewEvent)
+    }
+
+    fun onNotificationDetailShown(type: NotificationType) {
+        analyticsTracker.track(NotificationsDetailViewEvent(notificationType = type.toEventHorizonValue()))
+    }
+
     fun onNotificationTypeEnabledChanged(type: NotificationType, isEnabled: Boolean) {
+        updateNotificationTypeEnabled(type, isEnabled)
+        trackNotificationTypeToggle(type, isEnabled)
+    }
+
+    private fun updateNotificationTypeEnabled(type: NotificationType, isEnabled: Boolean) {
         val preferences = wooPushNotificationPreferences.value ?: return
         val updatedPreferences = when (type) {
             NotificationType.NEW_ORDERS -> preferences.copy(
@@ -138,11 +163,13 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     }
 
     fun onNewOrderNotificationsEnabledChanged(isEnabled: Boolean) {
-        onNotificationTypeEnabledChanged(NotificationType.NEW_ORDERS, isEnabled)
+        updateNotificationTypeEnabled(NotificationType.NEW_ORDERS, isEnabled)
+        trackNotificationDetailPushToggle(NotificationType.NEW_ORDERS, isEnabled)
     }
 
     fun onNewOrderNotificationPreferenceChanged(preference: NewOrderNotificationPreference) {
         val preferences = wooPushNotificationPreferences.value ?: return
+        // TODO: Track notifications_detail_filter_option_select when available in EventHorizon.
         val minAmount = when (preference) {
             NewOrderNotificationPreference.AllOrders -> null
             NewOrderNotificationPreference.HighValueOrders -> displayedOrderThresholdAmount.value
@@ -172,11 +199,13 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     }
 
     fun onNewReviewNotificationsEnabledChanged(isEnabled: Boolean) {
-        onNotificationTypeEnabledChanged(NotificationType.NEW_REVIEWS, isEnabled)
+        updateNotificationTypeEnabled(NotificationType.NEW_REVIEWS, isEnabled)
+        trackNotificationDetailPushToggle(NotificationType.NEW_REVIEWS, isEnabled)
     }
 
     fun onNewReviewNotificationPreferenceChanged(preference: NewReviewNotificationPreference) {
         val preferences = wooPushNotificationPreferences.value ?: return
+        // TODO: Track notifications_detail_filter_option_select when available in EventHorizon.
         val updatedViewState = preferences.toNewReviewNotificationSettingsViewState(
             displayedRating = displayedReviewRating.value
         ).copy(notificationPreference = preference)
@@ -198,7 +227,8 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     }
 
     fun onStockNotificationsEnabledChanged(isEnabled: Boolean) {
-        onNotificationTypeEnabledChanged(NotificationType.STOCK, isEnabled)
+        updateNotificationTypeEnabled(NotificationType.STOCK, isEnabled)
+        trackNotificationDetailPushToggle(NotificationType.STOCK, isEnabled)
     }
 
     fun onStockNotificationSubtypeEnabledChanged(type: StockNotificationType, isEnabled: Boolean) {
@@ -217,6 +247,7 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         updateDisplayedWooPushNotificationPreferences(
             preferences.copy(storeStock = updatedViewState.toStoreStockPreferences())
         )
+        trackStockNotificationOptionToggle(type, isEnabled)
     }
 
     fun onNotificationTypeClicked(type: NotificationType) {
@@ -257,11 +288,13 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     }
 
     private fun showFetchError() {
+        analyticsTracker.track(NotificationsSettingsLoadFailedEvent)
         triggerEvent(
             MultiLiveEvent.Event.ShowActionStringSnackbar(
                 message = resourceProvider.getString(R.string.settings_notifs_error_fetch),
                 actionText = resourceProvider.getString(R.string.retry),
             ) {
+                analyticsTracker.track(NotificationsSettingsLoadRetryTappedEvent)
                 fetchWooPushNotificationPreferences()
             }
         )
@@ -288,6 +321,16 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         }
 
         saveInProgressWooPushNotificationPreferences = preferencesToSave
+        savedPreferences.storeOrder?.minAmount?.let { savedMinAmount ->
+            updateRequest.storeOrder?.minAmount?.takeIf { it != savedMinAmount }?.let {
+                trackNotificationDetailFilterValueChange(NotificationType.NEW_ORDERS, it.toLong())
+            }
+        }
+        savedPreferences.storeReview?.maxRating?.let { savedMaxRating ->
+            updateRequest.storeReview?.maxRating?.takeIf { it != savedMaxRating }?.let {
+                trackNotificationDetailFilterValueChange(NotificationType.NEW_REVIEWS, it.toLong())
+            }
+        }
         // Once started, let the save request finish even if the screen is closed.
         withContext(NonCancellable + coroutineDispatchers.main) {
             pushNotificationRepository.updateWooNotificationPreferences(
@@ -307,11 +350,13 @@ class NotificationSettingsSharedViewModel @Inject constructor(
     }
 
     private fun showUpdateError(preferencesToSave: WooPushNotificationPreferences) {
+        analyticsTracker.track(NotificationsSettingsUpdateFailedEvent)
         triggerEvent(
             MultiLiveEvent.Event.ShowActionStringSnackbar(
                 message = resourceProvider.getString(R.string.settings_notifs_error_update),
                 actionText = resourceProvider.getString(R.string.retry),
             ) {
+                analyticsTracker.track(NotificationsSettingsUpdateRetryTappedEvent)
                 applyDisplayedWooPushNotificationPreferences(preferencesToSave)
                 saveNotificationPreferencesTrigger.tryEmit(0L)
             }
@@ -372,6 +417,42 @@ class NotificationSettingsSharedViewModel @Inject constructor(
 
     private fun WooPushNotificationPreferences.isEmpty(): Boolean =
         storeOrder == null && storeReview == null && storeStock == null
+
+    private fun trackNotificationTypeToggle(type: NotificationType, isEnabled: Boolean) {
+        analyticsTracker.track(
+            NotificationsTypeToggleEvent(
+                notificationType = type.toEventHorizonValue(),
+                isEnabled = isEnabled
+            )
+        )
+    }
+
+    private fun trackNotificationDetailPushToggle(type: NotificationType, isEnabled: Boolean) {
+        analyticsTracker.track(
+            NotificationsDetailPushToggleEvent(
+                notificationType = type.toEventHorizonValue(),
+                isEnabled = isEnabled
+            )
+        )
+    }
+
+    private fun trackNotificationDetailFilterValueChange(type: NotificationType, value: Long) {
+        analyticsTracker.track(
+            NotificationsDetailFilterValueChangeEvent(
+                notificationType = type.toEventHorizonValue(),
+                filterValue = value
+            )
+        )
+    }
+
+    private fun trackStockNotificationOptionToggle(type: StockNotificationType, isEnabled: Boolean) {
+        analyticsTracker.track(
+            NotificationsStockOptionToggleEvent(
+                option = type.toEventHorizonValue(),
+                isEnabled = isEnabled
+            )
+        )
+    }
 
     private fun WooPushNotificationPreferences.toNewOrderNotificationSettingsViewState(
         displayedThresholdAmount: BigDecimal

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModel.kt
@@ -12,6 +12,8 @@ import com.automattic.eventhorizon.NotificationsSettingsLoadFailedEvent
 import com.automattic.eventhorizon.NotificationsSettingsLoadRetryTappedEvent
 import com.automattic.eventhorizon.NotificationsSettingsUpdateFailedEvent
 import com.automattic.eventhorizon.NotificationsSettingsUpdateRetryTappedEvent
+import com.automattic.eventhorizon.NotificationsSettingsUpdateStartedEvent
+import com.automattic.eventhorizon.NotificationsSettingsUpdateSuccessEvent
 import com.automattic.eventhorizon.NotificationsSettingsViewEvent
 import com.automattic.eventhorizon.NotificationsStockOptionToggleEvent
 import com.automattic.eventhorizon.NotificationsTypeToggleEvent
@@ -321,8 +323,10 @@ class NotificationSettingsSharedViewModel @Inject constructor(
         if (updateRequest.isEmpty()) {
             return
         }
+        val updatedNotificationTypes = updateRequest.changedNotificationTypes()
 
         saveInProgressWooPushNotificationPreferences = preferencesToSave
+        updatedNotificationTypes.forEach(::trackNotificationSettingsUpdateStarted)
         savedPreferences.storeOrder?.minAmount?.let { savedMinAmount ->
             updateRequest.storeOrder?.minAmount?.takeIf { it != savedMinAmount }?.let {
                 trackNotificationDetailFilterValueChange(NotificationType.NEW_ORDERS, it.toDouble())
@@ -340,25 +344,29 @@ class NotificationSettingsSharedViewModel @Inject constructor(
             )
         }.onSuccess {
             savedWooPushNotificationPreferences = preferencesToSave
+            updatedNotificationTypes.forEach(::trackNotificationSettingsUpdateSuccess)
         }.onFailure {
+            updatedNotificationTypes.forEach(::trackNotificationSettingsUpdateFailed)
             if (wooPushNotificationPreferences.value != preferencesToSave) {
                 // User changed preferences after this save started, so don't rollback over the newer state.
                 return@onFailure
             }
             rollbackNotificationPreferences()
-            showUpdateError(preferencesToSave)
+            showUpdateError(preferencesToSave, updatedNotificationTypes)
         }
         saveInProgressWooPushNotificationPreferences = null
     }
 
-    private fun showUpdateError(preferencesToSave: WooPushNotificationPreferences) {
-        analyticsTracker.track(NotificationsSettingsUpdateFailedEvent)
+    private fun showUpdateError(
+        preferencesToSave: WooPushNotificationPreferences,
+        notificationTypes: List<NotificationType>
+    ) {
         triggerEvent(
             MultiLiveEvent.Event.ShowActionStringSnackbar(
                 message = resourceProvider.getString(R.string.settings_notifs_error_update),
                 actionText = resourceProvider.getString(R.string.retry),
             ) {
-                analyticsTracker.track(NotificationsSettingsUpdateRetryTappedEvent)
+                notificationTypes.forEach(::trackNotificationSettingsUpdateRetryTapped)
                 applyDisplayedWooPushNotificationPreferences(preferencesToSave)
                 saveNotificationPreferencesTrigger.tryEmit(0L)
             }
@@ -419,6 +427,36 @@ class NotificationSettingsSharedViewModel @Inject constructor(
 
     private fun WooPushNotificationPreferences.isEmpty(): Boolean =
         storeOrder == null && storeReview == null && storeStock == null
+
+    private fun WooPushNotificationPreferences.changedNotificationTypes(): List<NotificationType> = buildList {
+        if (storeOrder != null) add(NotificationType.NEW_ORDERS)
+        if (storeReview != null) add(NotificationType.NEW_REVIEWS)
+        if (storeStock != null) add(NotificationType.STOCK)
+    }
+
+    private fun trackNotificationSettingsUpdateStarted(type: NotificationType) {
+        analyticsTracker.track(
+            NotificationsSettingsUpdateStartedEvent(notificationType = type.toEventHorizonValue())
+        )
+    }
+
+    private fun trackNotificationSettingsUpdateSuccess(type: NotificationType) {
+        analyticsTracker.track(
+            NotificationsSettingsUpdateSuccessEvent(notificationType = type.toEventHorizonValue())
+        )
+    }
+
+    private fun trackNotificationSettingsUpdateFailed(type: NotificationType) {
+        analyticsTracker.track(
+            NotificationsSettingsUpdateFailedEvent(notificationType = type.toEventHorizonValue())
+        )
+    }
+
+    private fun trackNotificationSettingsUpdateRetryTapped(type: NotificationType) {
+        analyticsTracker.track(
+            NotificationsSettingsUpdateRetryTappedEvent(notificationType = type.toEventHorizonValue())
+        )
+    }
 
     private fun trackNotificationTypeToggle(type: NotificationType, isEnabled: Boolean) {
         analyticsTracker.track(

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.automattic.eventhorizon.NotificationFilterOptionValue
 import com.automattic.eventhorizon.NotificationTypeValue
 import com.automattic.eventhorizon.NotificationsDetailFilterOptionSelectEvent
-import com.automattic.eventhorizon.NotificationsDetailFilterValueChangeEvent
 import com.automattic.eventhorizon.NotificationsDetailPushToggleEvent
 import com.automattic.eventhorizon.NotificationsDetailViewEvent
 import com.automattic.eventhorizon.NotificationsSettingsLoadFailedEvent

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -1,7 +1,9 @@
 package com.woocommerce.android.ui.prefs.notifications
 
 import androidx.lifecycle.SavedStateHandle
+import com.automattic.eventhorizon.NotificationFilterOptionValue
 import com.automattic.eventhorizon.NotificationTypeValue
+import com.automattic.eventhorizon.NotificationsDetailFilterOptionSelectEvent
 import com.automattic.eventhorizon.NotificationsDetailFilterValueChangeEvent
 import com.automattic.eventhorizon.NotificationsDetailPushToggleEvent
 import com.automattic.eventhorizon.NotificationsDetailViewEvent
@@ -410,6 +412,13 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
                         isEnabled == false
                 }
             )
+            verify(analyticsTracker).track(
+                argThat<Trackable> {
+                    this is NotificationsDetailFilterOptionSelectEvent &&
+                        notificationType == NotificationTypeValue.NewOrder &&
+                        filterOption == NotificationFilterOptionValue.Filtered
+                }
+            )
         }
 
     @Test
@@ -433,6 +442,13 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
 
             val orderViewState = viewModel.newOrderNotificationSettingsViewState.captureValues().last()
             assertThat(orderViewState.thresholdAmount).isEqualTo(BigDecimal(50))
+            verify(analyticsTracker).track(
+                argThat<Trackable> {
+                    this is NotificationsDetailFilterOptionSelectEvent &&
+                        notificationType == NotificationTypeValue.NewOrder &&
+                        filterOption == NotificationFilterOptionValue.All
+                }
+            )
         }
 
     @Test
@@ -473,6 +489,13 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
                         isEnabled == false
                 }
             )
+            verify(analyticsTracker).track(
+                argThat<Trackable> {
+                    this is NotificationsDetailFilterOptionSelectEvent &&
+                        notificationType == NotificationTypeValue.NewReview &&
+                        filterOption == NotificationFilterOptionValue.Filtered
+                }
+            )
         }
 
     @Test
@@ -498,6 +521,13 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
 
             val reviewViewState = viewModel.newReviewNotificationSettingsViewState.captureValues().last()
             assertThat(reviewViewState.selectedRating).isEqualTo(3)
+            verify(analyticsTracker).track(
+                argThat<Trackable> {
+                    this is NotificationsDetailFilterOptionSelectEvent &&
+                        notificationType == NotificationTypeValue.NewReview &&
+                        filterOption == NotificationFilterOptionValue.All
+                }
+            )
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -10,6 +10,8 @@ import com.automattic.eventhorizon.NotificationsSettingsLoadFailedEvent
 import com.automattic.eventhorizon.NotificationsSettingsLoadRetryTappedEvent
 import com.automattic.eventhorizon.NotificationsSettingsUpdateFailedEvent
 import com.automattic.eventhorizon.NotificationsSettingsUpdateRetryTappedEvent
+import com.automattic.eventhorizon.NotificationsSettingsUpdateStartedEvent
+import com.automattic.eventhorizon.NotificationsSettingsUpdateSuccessEvent
 import com.automattic.eventhorizon.NotificationsSettingsViewEvent
 import com.automattic.eventhorizon.NotificationsStockOptionToggleEvent
 import com.automattic.eventhorizon.NotificationsTypeToggleEvent
@@ -359,6 +361,18 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
                     isEnabled == false
             }
         )
+        verify(analyticsTracker).track(
+            argThat<Trackable> {
+                this is NotificationsSettingsUpdateStartedEvent &&
+                    notificationType == NotificationTypeValue.StockAlert
+            }
+        )
+        verify(analyticsTracker).track(
+            argThat<Trackable> {
+                this is NotificationsSettingsUpdateSuccessEvent &&
+                    notificationType == NotificationTypeValue.StockAlert
+            }
+        )
     }
 
     @Test
@@ -639,7 +653,12 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             val snackbar = event as Event.ShowActionStringSnackbar
             assertThat(snackbar.message).isEqualTo(resourceProvider.getString(R.string.settings_notifs_error_update))
             assertThat(snackbar.actionText).isEqualTo(resourceProvider.getString(R.string.retry))
-            verify(analyticsTracker).track(NotificationsSettingsUpdateFailedEvent)
+            verify(analyticsTracker).track(
+                argThat<Trackable> {
+                    this is NotificationsSettingsUpdateFailedEvent &&
+                        notificationType == NotificationTypeValue.StockAlert
+                }
+            )
         }
 
     @Test
@@ -668,7 +687,12 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             (event as Event.ShowActionStringSnackbar).action.onClick(null)
             advanceUntilIdle()
 
-            verify(analyticsTracker).track(NotificationsSettingsUpdateRetryTappedEvent)
+            verify(analyticsTracker).track(
+                argThat<Trackable> {
+                    this is NotificationsSettingsUpdateRetryTappedEvent &&
+                        notificationType == NotificationTypeValue.StockAlert
+                }
+            )
             val preferences = captureLastUpdatePreferences()
             assertThat(preferences.storeStock).isEqualTo(StoreStockPreferences(enabled = false))
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/prefs/notifications/NotificationSettingsSharedViewModelTest.kt
@@ -1,7 +1,21 @@
 package com.woocommerce.android.ui.prefs.notifications
 
 import androidx.lifecycle.SavedStateHandle
+import com.automattic.eventhorizon.NotificationTypeValue
+import com.automattic.eventhorizon.NotificationsDetailFilterValueChangeEvent
+import com.automattic.eventhorizon.NotificationsDetailPushToggleEvent
+import com.automattic.eventhorizon.NotificationsDetailViewEvent
+import com.automattic.eventhorizon.NotificationsSettingsLoadFailedEvent
+import com.automattic.eventhorizon.NotificationsSettingsLoadRetryTappedEvent
+import com.automattic.eventhorizon.NotificationsSettingsUpdateFailedEvent
+import com.automattic.eventhorizon.NotificationsSettingsUpdateRetryTappedEvent
+import com.automattic.eventhorizon.NotificationsSettingsViewEvent
+import com.automattic.eventhorizon.NotificationsStockOptionToggleEvent
+import com.automattic.eventhorizon.NotificationsTypeToggleEvent
+import com.automattic.eventhorizon.StockNotificationOptionValue
+import com.automattic.eventhorizon.Trackable
 import com.woocommerce.android.R
+import com.woocommerce.android.analytics.AnalyticsTrackerWrapper
 import com.woocommerce.android.notifications.NotificationChannelType
 import com.woocommerce.android.notifications.NotificationChannelsHandler
 import com.woocommerce.android.notifications.push.PushNotificationRepository
@@ -24,6 +38,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.anyVararg
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doSuspendableAnswer
@@ -67,6 +82,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             "$${it.getArgument<BigDecimal>(0).toPlainString()}"
         }
     }
+    private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private val defaultNotificationPreferences = WooPushNotificationPreferences(
         storeOrder = StoreOrderPreferences(enabled = true),
         storeReview = StoreReviewPreferences(enabled = true),
@@ -95,7 +111,8 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             resourceProvider = resourceProvider,
             currencyFormatter = currencyFormatter,
             notificationChannelsHandler = notificationChannelsHandler,
-            coroutineDispatchers = coroutinesTestRule.testDispatchers
+            coroutineDispatchers = coroutinesTestRule.testDispatchers,
+            analyticsTracker = analyticsTracker
         )
     }
 
@@ -153,6 +170,29 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
 
             assertThat(orderItem.isNotificationChannelEnabled).isTrue()
         }
+
+    @Test
+    fun `when notification settings is shown, then track notification settings view`() = testBlocking {
+        setup()
+
+        viewModel.onNotificationSettingsShown()
+
+        verify(analyticsTracker).track(NotificationsSettingsViewEvent)
+    }
+
+    @Test
+    fun `when notification detail is shown, then track notification detail view`() = testBlocking {
+        setup()
+
+        viewModel.onNotificationDetailShown(NotificationType.NEW_ORDERS)
+
+        verify(analyticsTracker).track(
+            argThat<Trackable> {
+                this is NotificationsDetailViewEvent &&
+                    notificationType == NotificationTypeValue.NewOrder
+            }
+        )
+    }
 
     @Test
     fun `when view model is loaded, then fetch notification preferences`() = testBlocking {
@@ -215,6 +255,8 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             snackbar.action.onClick(null)
             advanceUntilIdle()
 
+            verify(analyticsTracker).track(NotificationsSettingsLoadFailedEvent)
+            verify(analyticsTracker).track(NotificationsSettingsLoadRetryTappedEvent)
             verify(pushNotificationRepository, times(2)).fetchWooNotificationPreferences()
             assertThat(viewModel.isNotificationTypeSelectionEnabled.captureValues().last()).isTrue()
         }
@@ -309,6 +351,13 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
         assertThat(preferences.storeOrder).isNull()
         assertThat(preferences.storeReview).isNull()
         assertThat(preferences.storeStock).isEqualTo(StoreStockPreferences(enabled = false))
+        verify(analyticsTracker).track(
+            argThat<Trackable> {
+                this is NotificationsTypeToggleEvent &&
+                    notificationType == NotificationTypeValue.StockAlert &&
+                    isEnabled == false
+            }
+        )
     }
 
     @Test
@@ -331,6 +380,13 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             val preferences = captureUpdatePreferences()
             assertThat(preferences.storeOrder)
                 .isEqualTo(StoreOrderPreferences(enabled = false, minAmount = BigDecimal(50)))
+            verify(analyticsTracker).track(
+                argThat<Trackable> {
+                    this is NotificationsTypeToggleEvent &&
+                        notificationType == NotificationTypeValue.NewOrder &&
+                        isEnabled == false
+                }
+            )
         }
 
     @Test
@@ -347,6 +403,13 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             val preferences = captureUpdatePreferences()
             assertThat(preferences.storeOrder)
                 .isEqualTo(StoreOrderPreferences(enabled = false, minAmount = BigDecimal(50)))
+            verify(analyticsTracker).track(
+                argThat<Trackable> {
+                    this is NotificationsDetailPushToggleEvent &&
+                        notificationType == NotificationTypeValue.NewOrder &&
+                        isEnabled == false
+                }
+            )
         }
 
     @Test
@@ -403,6 +466,13 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             val preferences = captureUpdatePreferences()
             assertThat(preferences.storeReview)
                 .isEqualTo(StoreReviewPreferences(enabled = false, maxRating = 4))
+            verify(analyticsTracker).track(
+                argThat<Trackable> {
+                    this is NotificationsDetailPushToggleEvent &&
+                        notificationType == NotificationTypeValue.NewReview &&
+                        isEnabled == false
+                }
+            )
         }
 
     @Test
@@ -451,6 +521,20 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
                     outOfStock = true,
                     onBackorder = true
                 )
+            )
+            verify(analyticsTracker).track(
+                argThat<Trackable> {
+                    this is NotificationsDetailPushToggleEvent &&
+                        notificationType == NotificationTypeValue.StockAlert &&
+                        isEnabled == false
+                }
+            )
+            verify(analyticsTracker).track(
+                argThat<Trackable> {
+                    this is NotificationsStockOptionToggleEvent &&
+                        option == StockNotificationOptionValue.LowStock &&
+                        isEnabled == false
+                }
             )
         }
 
@@ -526,6 +610,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             val snackbar = event as Event.ShowActionStringSnackbar
             assertThat(snackbar.message).isEqualTo(resourceProvider.getString(R.string.settings_notifs_error_update))
             assertThat(snackbar.actionText).isEqualTo(resourceProvider.getString(R.string.retry))
+            verify(analyticsTracker).track(NotificationsSettingsUpdateFailedEvent)
         }
 
     @Test
@@ -554,6 +639,7 @@ class NotificationSettingsSharedViewModelTest : BaseUnitTest() {
             (event as Event.ShowActionStringSnackbar).action.onClick(null)
             advanceUntilIdle()
 
+            verify(analyticsTracker).track(NotificationsSettingsUpdateRetryTappedEvent)
             val preferences = captureLastUpdatePreferences()
             assertThat(preferences.storeStock).isEqualTo(StoreStockPreferences(enabled = false))
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -192,7 +192,7 @@ apache-http-client-android = { group = "org.apache.httpcomponents", name = "http
 apache-http-core = { group = "org.apache.httpcomponents", name = "httpcore", version.ref = "apache-http-core" }
 assertj-core = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 automattic-about = { group = "com.automattic", name = "about", version.ref = "automattic-about" }
-automattic-eventhorizon = "com.automattic:eventhorizon:woocommerce-2026-05-21_21-28-53"
+automattic-eventhorizon = "com.automattic:eventhorizon:woocommerce-2026-05-22_09-01-38"
 automattic-encryptedlogging = { group = "com.automattic", name = "encryptedlogging", version.ref = "automattic-encryptedlogging" }
 automattic-tracks-android = { group = "com.automattic", name = "Automattic-Tracks-Android", version.ref = "automattic-tracks" }
 automattic-tracks-experimentation = { group = "com.automattic.tracks", name = "experimentation", version.ref = "automattic-tracks" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -192,7 +192,7 @@ apache-http-client-android = { group = "org.apache.httpcomponents", name = "http
 apache-http-core = { group = "org.apache.httpcomponents", name = "httpcore", version.ref = "apache-http-core" }
 assertj-core = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 automattic-about = { group = "com.automattic", name = "about", version.ref = "automattic-about" }
-automattic-eventhorizon = "com.automattic:eventhorizon:woocommerce-2026-05-22_09-01-38"
+automattic-eventhorizon = "com.automattic:eventhorizon:woocommerce-2026-05-22_09-49-18"
 automattic-encryptedlogging = { group = "com.automattic", name = "encryptedlogging", version.ref = "automattic-encryptedlogging" }
 automattic-tracks-android = { group = "com.automattic", name = "Automattic-Tracks-Android", version.ref = "automattic-tracks" }
 automattic-tracks-experimentation = { group = "com.automattic.tracks", name = "experimentation", version.ref = "automattic-tracks" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -192,7 +192,7 @@ apache-http-client-android = { group = "org.apache.httpcomponents", name = "http
 apache-http-core = { group = "org.apache.httpcomponents", name = "httpcore", version.ref = "apache-http-core" }
 assertj-core = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 automattic-about = { group = "com.automattic", name = "about", version.ref = "automattic-about" }
-automattic-eventhorizon = "com.automattic:eventhorizon:woocommerce-2026-05-21_16-06-23"
+automattic-eventhorizon = "com.automattic:eventhorizon:woocommerce-2026-05-21_21-28-53"
 automattic-encryptedlogging = { group = "com.automattic", name = "encryptedlogging", version.ref = "automattic-encryptedlogging" }
 automattic-tracks-android = { group = "com.automattic", name = "Automattic-Tracks-Android", version.ref = "automattic-tracks" }
 automattic-tracks-experimentation = { group = "com.automattic.tracks", name = "experimentation", version.ref = "automattic-tracks" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -192,7 +192,7 @@ apache-http-client-android = { group = "org.apache.httpcomponents", name = "http
 apache-http-core = { group = "org.apache.httpcomponents", name = "httpcore", version.ref = "apache-http-core" }
 assertj-core = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 automattic-about = { group = "com.automattic", name = "about", version.ref = "automattic-about" }
-automattic-eventhorizon = "com.automattic:eventhorizon:woocommerce-2026-05-13_15-16-11"
+automattic-eventhorizon = "com.automattic:eventhorizon:woocommerce-2026-05-21_16-06-23"
 automattic-encryptedlogging = { group = "com.automattic", name = "encryptedlogging", version.ref = "automattic-encryptedlogging" }
 automattic-tracks-android = { group = "com.automattic", name = "Automattic-Tracks-Android", version.ref = "automattic-tracks" }
 automattic-tracks-experimentation = { group = "com.automattic.tracks", name = "experimentation", version.ref = "automattic-tracks" }


### PR DESCRIPTION
### Description
Fixes RSM-2323

Adds analytics tracking for the smarter notification settings flow.

| Event | Parameters | Trigger |
| --- | --- | --- |
| `notifications_settings_view` | None | Push notification settings screen is shown. |
| `notifications_type_toggle` | `notification_type`, `is_enabled` | A notification type switch is changed on the main notifications screen. |
| `notifications_detail_view` | `notification_type` | A notification detail screen is shown. |
| `notifications_detail_push_toggle` | `notification_type`, `is_enabled` | The master push switch is changed on a notification detail screen. |
| `notifications_detail_filter_option_select` | `notification_type`, `filter_option` | All vs filtered option is selected on New orders or New reviews detail. |
| `notifications_detail_filter_value_change` | `notification_type`, `filter_value` | The saved filter value changes for New orders or New reviews. |
| `notifications_stock_option_toggle` | `option`, `is_enabled` | A stock notification option switch is changed. |
| `notifications_settings_load_failed` | None | Loading notification preferences fails. |
| `notifications_settings_load_retry_tapped` | None | Retry is tapped after a load failure. |
| `notifications_settings_update_started` | `notification_type` | Saving notification preferences starts for a changed notification type. |
| `notifications_settings_update_success` | `notification_type` | Saving notification preferences succeeds for a changed notification type. |
| `notifications_settings_update_failed` | `notification_type` | Saving notification preferences fails for a changed notification type. |
| `notifications_settings_update_retry_tapped` | `notification_type` | Retry is tapped after an update failure. |

### Test Steps
Open Logcat and filter by `Tracked: woocommerceandroid_notifications`.

1. Open `Menu > Settings > Push notifications`.
   - Logcat shows `woocommerceandroid_notifications_settings_view`.

2. Toggle a notification type switch on the main screen.
   - Logcat shows `woocommerceandroid_notifications_type_toggle` with `notification_type` and `is_enabled`.
   - After the save debounce, Logcat shows `woocommerceandroid_notifications_settings_update_started` and `woocommerceandroid_notifications_settings_update_success` with `notification_type`.

3. Open New orders, New reviews, and Stock detail screens.
   - Logcat shows `woocommerceandroid_notifications_detail_view` with `notification_type`.

4. Toggle `Enable notifications` on a detail screen.
   - Logcat shows `woocommerceandroid_notifications_detail_push_toggle` with `notification_type` and `is_enabled`.
   - After the save debounce, Logcat shows `woocommerceandroid_notifications_settings_update_started` and `woocommerceandroid_notifications_settings_update_success` with `notification_type`.

5. On New orders, switch between `All new orders` and `Only high-value orders`.
   - Logcat shows `woocommerceandroid_notifications_detail_filter_option_select` with `notification_type: "new_order"` and `filter_option`.
   - After the save debounce, Logcat shows `woocommerceandroid_notifications_settings_update_started` and `woocommerceandroid_notifications_settings_update_success` with `notification_type: "new_order"`.

6. On New reviews, switch between `All new reviews` and `Only low-rated reviews`.
   - Logcat shows `woocommerceandroid_notifications_detail_filter_option_select` with `notification_type: "new_review"` and `filter_option`.
   - After the save debounce, Logcat shows `woocommerceandroid_notifications_settings_update_started` and `woocommerceandroid_notifications_settings_update_success` with `notification_type: "new_review"`.

7. On New orders, while `Only high-value orders` is selected, change the minimum value and wait for the save debounce.
   - Logcat shows `woocommerceandroid_notifications_detail_filter_value_change` with `notification_type: "new_order"` and `filter_value`.
   - Logcat also shows `woocommerceandroid_notifications_settings_update_started` and `woocommerceandroid_notifications_settings_update_success` with `notification_type: "new_order"`.

8. On New reviews, while low-rated review filtering is selected, change the selected rating and wait for the save debounce.
   - Logcat shows `woocommerceandroid_notifications_detail_filter_value_change` with `notification_type: "new_review"` and `filter_value`.
   - Logcat also shows `woocommerceandroid_notifications_settings_update_started` and `woocommerceandroid_notifications_settings_update_success` with `notification_type: "new_review"`.

9. On Stock, toggle Low stock, Out of stock, or On backorder.
   - Logcat shows `woocommerceandroid_notifications_stock_option_toggle` with `option` and `is_enabled`.
   - After the save debounce, Logcat shows `woocommerceandroid_notifications_settings_update_started` and `woocommerceandroid_notifications_settings_update_success` with `notification_type: "stock_alert"`.

### Images/gif
N/A

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.