### PR TITLE
Test: metadata char-cap re-prompt success path (workstream 3c)

### DIFF
--- a/fastlane/ai_translation/spec/woo_ai_translation_test.rb
+++ b/fastlane/ai_translation/spec/woo_ai_translation_test.rb
@@ -476,6 +476,42 @@ class EngineTest < Minitest::Test
     end
   end
 
+  # Verbose locales (de/fi/hu/pl) routinely overflow Play's title/short caps on
+  # the first pass. This locks the re-prompt-to-fit SUCCESS path: attempt 1 is
+  # over cap, the tighter retry comes back under cap, and the engine ships the
+  # tightened translation -- NOT the English fallback, and NOT flagged.
+  def test_metadata_over_cap_field_is_fixed_by_tighter_reprompt_not_english_fallback
+    Dir.mktmpdir do |dir|
+      src = File.join(dir, 'en-US')
+      FileUtils.mkdir_p(src)
+      File.write(File.join(src, 'short_description.txt'), 'Run your store from anywhere')
+      out = File.join(dir, 'out')
+      mpath = File.join(dir, 'm.json')
+
+      # First call overflows the 80-char short_description cap; the second call
+      # (the tightened re-prompt) returns a value that fits. The stub ignores
+      # the prompt itself, so we simulate "tighter" purely by call ordering.
+      call = 0
+      over = "[de-DE] #{'W' * 90}" # 98 chars -> over cap
+      under = '[de-DE] Verkaufe ueberall' # well under cap
+      client = StubClient.new do |_loc, _src|
+        call += 1
+        call == 1 ? over : under
+      end
+
+      eng = MetadataEngine.new(translator: Translator.new(client: client),
+                               manifest: Manifest.load(mpath), manifest_path: mpath)
+      r = eng.run(source_dir: src, out_base: out, locales: %w[de-DE],
+                  include_release_notes: false).first
+
+      assert_equal under, File.read(File.join(out, 'de-DE', 'short_description.txt')),
+                   'tightened re-prompt result is shipped, not English fallback'
+      assert_empty r.fallback, 'a field rescued by the retry must not be flagged as fallback'
+      assert_equal 1, r.translated
+      assert_equal 2, client.calls, 'engine must re-prompt exactly once after the first over-cap result'
+    end
+  end
+
   def test_baseline_import_preserves_human_strings_and_ai_fills_gaps
     Dir.mktmpdir do |dir|
       FileUtils.mkdir_p(File.join(dir, 'values-fr'))


### PR DESCRIPTION
## Summary

Adds deterministic unit coverage for the Play Store metadata engine's character-cap retry path.

The metadata engine translates capped fields once, then re-prompts with a tighter budget if the first response exceeds the Play Store cap. Existing tests covered the fallback path where the retry also overflows and the engine falls back to English. This PR covers the successful retry path.

## What This Adds

`test_metadata_over_cap_field_is_fixed_by_tighter_reprompt_not_english_fallback` verifies that:

- the first translated response is over cap,
- the second, tighter prompt returns an under-cap localized value,
- the tightened localized value is written instead of English,
- the field is not reported as fallback,
- the client is called exactly twice.

This is test-only. It does not change lanes, engine behavior, CI, network behavior, or generated metadata content.

## Stack

Base: #15974.

This PR has been merged/folded into the rebuilt stack history. The open stack continues through #15983, #16004, and draft #16011.

Full stack map: #15961.

## Test Plan

- [x] `ruby fastlane/ai_translation/spec/woo_ai_translation_test.rb` on the rebuilt metadata head: `91 runs / 348 assertions / 0 failures`.
- [x] Diff from #15974 contains only `fastlane/ai_translation/spec/woo_ai_translation_test.rb`.
