### PR TITLE
POS: surface failed-note message after Mark Order as Complete success

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeChildToParentCommunication.kt
@@ -39,6 +39,7 @@ sealed class ChildToParentEvent {
     data object GoBackToCheckoutAfterFailedPayment : ChildToParentEvent()
     data object OrderSuccessfullyPaidByCard : ChildToParentEvent()
     data object OrderSuccessfullyPaidExternally : ChildToParentEvent()
+    data object OrderSuccessfullyPaidExternallyWithFailedNote : ChildToParentEvent()
     data object ExitPosClicked : ChildToParentEvent()
     data object SetupBarcodeScannerClicked : ChildToParentEvent()
     data object CouponsValidationFailed : ChildToParentEvent()

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeParentToChildCommunication.kt
@@ -49,7 +49,10 @@ sealed class ParentToChildrenEvent {
         val itemClickedDataList: List<WooPosItemsViewModel.ItemClickedData>
     ) : ParentToChildrenEvent()
 
-    data class OrderSuccessfullyPaid(val paymentMethod: PaymentMethod) : ParentToChildrenEvent() {
+    data class OrderSuccessfullyPaid(
+        val paymentMethod: PaymentMethod,
+        val hasFailedNote: Boolean = false,
+    ) : ParentToChildrenEvent() {
         enum class PaymentMethod {
             CARD,
             CASH,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModel.kt
@@ -196,6 +196,9 @@ class WooPosHomeViewModel @Inject constructor(
                         PaymentMethod.EXTERNAL
                     )
 
+                    is ChildToParentEvent.OrderSuccessfullyPaidExternallyWithFailedNote ->
+                        onOrderSuccessfullyPaid(PaymentMethod.EXTERNAL, hasFailedNote = true)
+
                     is ChildToParentEvent.PaymentCollecting -> {
                         _state.value = _state.value.copy(
                             screenPositionState = ScreenPositionState.Checkout.CartWithTotals
@@ -317,13 +320,13 @@ class WooPosHomeViewModel @Inject constructor(
         }
     }
 
-    private fun onOrderSuccessfullyPaid(paymentMethod: PaymentMethod) {
+    private fun onOrderSuccessfullyPaid(paymentMethod: PaymentMethod, hasFailedNote: Boolean = false) {
         viewModelScope.launch {
             soundHelper.playChaChing()
         }
         _state.value = _state.value.copy(
             screenPositionState = ScreenPositionState.Checkout.FullScreenTotals
         )
-        sendEventToChildren(ParentToChildrenEvent.OrderSuccessfullyPaid(paymentMethod))
+        sendEventToChildren(ParentToChildrenEvent.OrderSuccessfullyPaid(paymentMethod, hasFailedNote))
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -655,7 +655,7 @@ class WooPosTotalsViewModel @Inject constructor(
                             // Cancel payment intent if order is marked completed by cash
                             cancelPaymentAction()
                         }
-                        showSuccessfulPaymentState(event.paymentMethod)
+                        showSuccessfulPaymentState(event.paymentMethod, event.hasFailedNote)
                         performIncrementalSyncUseCase.execute(WooPosIncrementalSyncReason.AFTER_SUCCESSFUL_PAYMENT)
                     }
 
@@ -1056,7 +1056,7 @@ class WooPosTotalsViewModel @Inject constructor(
             }
         }
 
-    private fun showSuccessfulPaymentState(paymentMethod: PaymentMethod) {
+    private fun showSuccessfulPaymentState(paymentMethod: PaymentMethod, hasFailedNote: Boolean = false) {
         viewModelScope.launch {
             val dataState = dataState.value
             checkNotNull(dataState.orderTotal)
@@ -1070,8 +1070,14 @@ class WooPosTotalsViewModel @Inject constructor(
                 template,
                 priceFormat(dataState.orderTotal)
             )
+            val secondaryMessage = if (hasFailedNote) {
+                resourceProvider.getString(R.string.woopos_totals_success_payment_note_post_failed)
+            } else {
+                null
+            }
             uiState.value = WooPosTotalsViewState.PaymentSuccess(
-                orderTotalText = orderTotalText
+                orderTotalText = orderTotalText,
+                secondaryMessage = secondaryMessage,
             )
         }
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
@@ -51,7 +51,10 @@ sealed class WooPosTotalsViewState : Parcelable {
         ) : Totals()
     }
 
-    data class PaymentSuccess(val orderTotalText: String) : WooPosTotalsViewState()
+    data class PaymentSuccess(
+        val orderTotalText: String,
+        val secondaryMessage: String? = null,
+    ) : WooPosTotalsViewState()
 
     sealed class ReaderStatus : Parcelable {
         @Parcelize

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/payment/success/WooPosTotalsPaymentSuccessScreen.kt
@@ -66,7 +66,7 @@ fun WooPosPaymentSuccessScreen(
         val textsMargin = WooPosSpacing.Small.value
 
         ConstraintLayout {
-            val (icon, title, message, buttonNewOrder, buttonEmailReceipts) = createRefs()
+            val (icon, title, message, secondaryMessage, buttonNewOrder, buttonEmailReceipts) = createRefs()
 
             WooPosSuccessCheckmark(
                 contentDescription = stringResource(R.string.woopos_payment_successful_label),
@@ -101,8 +101,22 @@ fun WooPosPaymentSuccessScreen(
                 modifier = Modifier.constrainAs(message) {
                     start.linkTo(parent.start)
                     end.linkTo(parent.end)
-                    bottom.linkTo(buttonNewOrder.top, margin = marginBetweenButtonAndText)
+                    bottom.linkTo(secondaryMessage.top, margin = textsMargin)
                 }
+            )
+
+            WooPosText(
+                text = state.secondaryMessage.orEmpty(),
+                style = WooPosTypography.BodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(horizontal = WooPosSpacing.XLarge.value)
+                    .constrainAs(secondaryMessage) {
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                        bottom.linkTo(buttonNewOrder.top, margin = marginBetweenButtonAndText)
+                    }
             )
 
             val marginBetweenButtons = WooPosSpacing.Medium.value
@@ -145,6 +159,22 @@ fun WooPosPaymentSuccessScreenPreview() {
         WooPosPaymentSuccessScreen(
             state = WooPosTotalsViewState.PaymentSuccess(
                 orderTotalText = "A payment of 13.18 was successfully made",
+            ),
+            onReceiptClicked = {},
+            onNewTransactionClicked = {},
+            onBackPressed = {},
+        )
+    }
+}
+
+@WooPosPreview
+@Composable
+fun WooPosPaymentSuccessScreenWithFailedNotePreview() {
+    WooPosTheme {
+        WooPosPaymentSuccessScreen(
+            state = WooPosTotalsViewState.PaymentSuccess(
+                orderTotalText = "Order of $42.00 was marked as complete.",
+                secondaryMessage = "The order was marked as complete, but the customer note couldn't be saved.",
             ),
             onReceiptClicked = {},
             onNewTransactionClicked = {},

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteViewModel.kt
@@ -126,9 +126,9 @@ class WooPosMarkOrderAsCompleteViewModel @Inject constructor(
             when (outcome) {
                 MarkOrderAsCompleteOutcome.SuccessWithFailedNote -> {
                     analyticsTracker.track(MarkAsPaidNotePostFailed)
-                    onMarkAsPaidSucceeded()
+                    onMarkAsPaidSucceeded(hasFailedNote = true)
                 }
-                MarkOrderAsCompleteOutcome.Success -> onMarkAsPaidSucceeded()
+                MarkOrderAsCompleteOutcome.Success -> onMarkAsPaidSucceeded(hasFailedNote = false)
                 MarkOrderAsCompleteOutcome.Failure -> {
                     analyticsTracker.track(MarkAsPaidFailed)
                     _state.value = current.copy(
@@ -142,9 +142,14 @@ class WooPosMarkOrderAsCompleteViewModel @Inject constructor(
         }
     }
 
-    private suspend fun onMarkAsPaidSucceeded() {
+    private suspend fun onMarkAsPaidSucceeded(hasFailedNote: Boolean) {
         analyticsTracker.track(MarkAsPaidSuccess)
-        childrenToParentEventSender.sendToParent(ChildToParentEvent.OrderSuccessfullyPaidExternally)
+        val event = if (hasFailedNote) {
+            ChildToParentEvent.OrderSuccessfullyPaidExternallyWithFailedNote
+        } else {
+            ChildToParentEvent.OrderSuccessfullyPaidExternally
+        }
+        childrenToParentEventSender.sendToParent(event)
         _navigationEvent.emit(WooPosNavigationEvent.GoBack)
     }
 

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3967,6 +3967,7 @@
     <string name="woopos_totals_success_payment_card">A card payment of %1$s was successfully made.</string>
     <string name="woopos_totals_success_payment_qr">A payment of %1$s was successfully received.</string>
     <string name="woopos_totals_success_payment_external">Order of %1$s was marked as complete.</string>
+    <string name="woopos_totals_success_payment_note_post_failed">The order was marked as complete, but the customer note couldn\'t be saved.</string>
 
     <string name="woopos_variations_empty_list_title">No supported variations found</string>
     <string name="woopos_variations_empty_list_message">POS currently only supports simple, variable, and virtual products – \ncreate one to get started.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/WooPosHomeViewModelTest.kt
@@ -126,7 +126,27 @@ class WooPosHomeViewModelTest {
 
             // THEN
             verify(parentToChildrenEventSender).sendToChildren(
-                ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.EXTERNAL)
+                ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.EXTERNAL, hasFailedNote = false)
+            )
+            verify(soundHelper).playChaChing()
+            assertThat(viewModel.state.value.screenPositionState)
+                .isEqualTo(WooPosHomeState.ScreenPositionState.Checkout.FullScreenTotals)
+        }
+
+    @Test
+    fun `when OrderSuccessfullyPaidExternallyWithFailedNote received, then OrderSuccessfullyPaid with EXTERNAL and hasFailedNote true is sent`() =
+        runTest {
+            // GIVEN
+            whenever(childrenToParentEventReceiver.events).thenReturn(
+                flowOf(ChildToParentEvent.OrderSuccessfullyPaidExternallyWithFailedNote)
+            )
+
+            // WHEN
+            val viewModel = createViewModel()
+
+            // THEN
+            verify(parentToChildrenEventSender).sendToChildren(
+                ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.EXTERNAL, hasFailedNote = true)
             )
             verify(soundHelper).playChaChing()
             assertThat(viewModel.state.value.screenPositionState)

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModelTest.kt
@@ -1188,6 +1188,67 @@ class WooPosTotalsViewModelTest {
         }
 
     @Test
+    fun `given EXTERNAL payment with hasFailedNote true, when OrderSuccessfullyPaid arrives, then secondaryMessage set`() =
+        runTest {
+            // GIVEN
+            whenever(resourceProvider.getString(R.string.woopos_totals_success_payment_external, "5.00$"))
+                .thenReturn("Order of 5.00$ was marked as complete.")
+            whenever(resourceProvider.getString(R.string.woopos_totals_success_payment_note_post_failed))
+                .thenReturn("The order was marked as complete, but the customer note couldn't be saved.")
+            val parentToChildrenEventFlow = MutableStateFlow<ParentToChildrenEvent>(
+                ParentToChildrenEvent.CheckoutClicked(
+                    listOf(
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 2L),
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 3L),
+                    )
+                )
+            )
+            val viewModel = createViewModelAndSetupForSuccessfulOrderCreation(
+                parentToChildrenEventFlow = parentToChildrenEventFlow,
+            )
+
+            // WHEN
+            parentToChildrenEventFlow.value = ParentToChildrenEvent.OrderSuccessfullyPaid(
+                paymentMethod = PaymentMethod.EXTERNAL,
+                hasFailedNote = true,
+            )
+
+            // THEN
+            val successState = viewModel.state.value as WooPosTotalsViewState.PaymentSuccess
+            assertThat(successState.orderTotalText).isEqualTo("Order of 5.00$ was marked as complete.")
+            assertThat(successState.secondaryMessage)
+                .isEqualTo("The order was marked as complete, but the customer note couldn't be saved.")
+        }
+
+    @Test
+    fun `given EXTERNAL payment with hasFailedNote false, when OrderSuccessfullyPaid arrives, then secondaryMessage is null`() =
+        runTest {
+            // GIVEN
+            whenever(resourceProvider.getString(R.string.woopos_totals_success_payment_external, "5.00$"))
+                .thenReturn("Order of 5.00$ was marked as complete.")
+            val parentToChildrenEventFlow = MutableStateFlow<ParentToChildrenEvent>(
+                ParentToChildrenEvent.CheckoutClicked(
+                    listOf(
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 1L),
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 2L),
+                        WooPosItemsViewModel.ItemClickedData.Product.Simple(id = 3L),
+                    )
+                )
+            )
+            val viewModel = createViewModelAndSetupForSuccessfulOrderCreation(
+                parentToChildrenEventFlow = parentToChildrenEventFlow,
+            )
+
+            // WHEN
+            parentToChildrenEventFlow.value = ParentToChildrenEvent.OrderSuccessfullyPaid(PaymentMethod.EXTERNAL)
+
+            // THEN
+            val successState = viewModel.state.value as WooPosTotalsViewState.PaymentSuccess
+            assertThat(successState.secondaryMessage).isNull()
+        }
+
+    @Test
     fun `given payment success state, when OnBackClicked, then sends OnNewTransactionStarted to parent`() =
         runTest {
             // GIVEN

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteViewModelTest.kt
@@ -187,20 +187,24 @@ class WooPosMarkOrderAsCompleteViewModelTest {
     }
 
     @Test
-    fun `given repo succeeds with failed note, when confirm clicked, then MarkAsPaidNotePostFailed tracked`() = runTest {
-        // GIVEN
-        whenever(repository.markOrderAsComplete(eq(orderId), anyOrNull()))
-            .thenReturn(MarkOrderAsCompleteOutcome.SuccessWithFailedNote)
-        val viewModel = createViewModel()
+    fun `given repo succeeds with failed note, when confirm clicked, then failed-note variant emitted and analytic tracked`() =
+        runTest {
+            // GIVEN
+            whenever(repository.markOrderAsComplete(eq(orderId), anyOrNull()))
+                .thenReturn(MarkOrderAsCompleteOutcome.SuccessWithFailedNote)
+            val viewModel = createViewModel()
 
-        // WHEN / THEN
-        viewModel.navigationEvent.test {
-            viewModel.onUIEvent(WooPosMarkOrderAsCompleteUIEvent.ConfirmClicked)
-            assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
+            // WHEN / THEN
+            viewModel.navigationEvent.test {
+                viewModel.onUIEvent(WooPosMarkOrderAsCompleteUIEvent.ConfirmClicked)
+                assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
+            }
+            verify(tracker).track(MarkAsPaidNotePostFailed)
+            verify(tracker).track(MarkAsPaidSuccess)
+            verify(childrenToParentEventSender).sendToParent(
+                eq(ChildToParentEvent.OrderSuccessfullyPaidExternallyWithFailedNote),
+            )
         }
-        verify(tracker).track(MarkAsPaidNotePostFailed)
-        verify(tracker).track(MarkAsPaidSuccess)
-    }
 
     @Test
     fun `given repo succeeds without failed note, when confirm clicked, then MarkAsPaidNotePostFailed not tracked`() =


### PR DESCRIPTION
## Summary
Addresses [malinajirka's review thread on #15944](https://github.com/woocommerce/woocommerce-android/pull/15944#discussion_r3271326689): when `MarkOrderAsCompleteOutcome.SuccessWithFailedNote` came back, the merchant only saw a clean success and the note-post failure was tracked only via analytics. This PR surfaces it to the merchant on the destination Payment Success screen, below the order-total message.

Why a parallel PR rather than #15932: the follow-up UI PR is currently rebased on a pre-rename state (still under `markorderaspaid/` package + older `Confirming(isProcessing, canConfirm)` state shape) and needs separate reconciliation. Landing the snackbar plumbing here on trunk keeps the scope clean and lets #15932 plug into existing wiring once it's rebased.

## Changes
- New child→parent event variant `OrderSuccessfullyPaidExternallyWithFailedNote` (sibling of the existing `OrderSuccessfullyPaidExternally`).
- `ParentToChildrenEvent.OrderSuccessfullyPaid` carries a new `hasFailedNote: Boolean = false` field.
- `WooPosHomeViewModel` routes the new variant through `onOrderSuccessfullyPaid(EXTERNAL, hasFailedNote = true)`.
- `WooPosTotalsViewState.PaymentSuccess` gains an optional `secondaryMessage: String?`.
- `WooPosTotalsViewModel.showSuccessfulPaymentState` populates `secondaryMessage` from a new string when `hasFailedNote = true`.
- `WooPosTotalsPaymentSuccessScreen` renders `secondaryMessage` as a `BodyMedium` line below the order-total message (uses `onSurfaceVariant` color). New `@WooPosPreview` for the failed-note variant.
- `WooPosMarkOrderAsCompleteViewModel` emits the new variant on `SuccessWithFailedNote`; existing `Success` still emits the plain variant.
- New string `woopos_totals_success_payment_note_post_failed`.

## Test plan
- [ ] Open POS, add an item, tap Other payment methods → Mark order as complete. With network available, confirm without a note: success screen renders normally (no secondary message).
- [ ] Repeat with a customer note. Force the note-post step to fail (e.g. drop network just after status is updated, or stub repo to return `SuccessWithFailedNote`). Verify the Payment Success screen now shows "The order was marked as complete, but the customer note couldn't be saved." under the total message.
- [ ] Confirm cha-ching still plays and the "New order" / "Email receipt" buttons are unchanged.

## Unit tests
- `WooPosHomeViewModelTest` covers both event variants → correct `hasFailedNote` flag in the forwarded `OrderSuccessfullyPaid`.
- `WooPosTotalsViewModelTest` covers `EXTERNAL` with `hasFailedNote = true` (secondaryMessage set) and `false` (secondaryMessage null).
- `WooPosMarkOrderAsCompleteViewModelTest` covers `SuccessWithFailedNote` → emits the new event variant + tracks `MarkAsPaidNotePostFailed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)