### PR TITLE
POS: rename Mark Order as Complete → Mark Order as Paid for iOS parity

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosPaymentMethod.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosPaymentMethod.kt
@@ -28,13 +28,13 @@ internal fun buildAllPaymentMethods(
     readerStatus: WooPosTotalsViewState.ReaderStatus,
     isTapToPayAvailable: Boolean,
     isScanToPayEnabled: Boolean,
-    isMarkOrderAsCompleteEnabled: Boolean,
+    isMarkOrderAsPaidEnabled: Boolean,
 ): List<WooPosPaymentMethod> = buildList {
     val readerConnected = readerStatus.isReaderConnected()
     if (!readerConnected && isTapToPayAvailable) add(WooPosPaymentMethod.CARD_READER)
     if (readerConnected && isTapToPayAvailable) add(WooPosPaymentMethod.TAP_TO_PAY)
     if (isScanToPayEnabled) add(WooPosPaymentMethod.SCAN_TO_PAY)
-    if (isMarkOrderAsCompleteEnabled) add(WooPosPaymentMethod.MARK_ORDER_AS_PAID)
+    if (isMarkOrderAsPaidEnabled) add(WooPosPaymentMethod.MARK_ORDER_AS_PAID)
 }
 
 private fun WooPosTotalsViewState.ReaderStatus.isReaderConnected(): Boolean = when (this) {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsScreen.kt
@@ -308,7 +308,7 @@ private fun TotalsLoaded(
             readerStatus = state.readerStatus,
             isTapToPayAvailable = state.isTapToPayAvailable,
             isScanToPayEnabled = state.isScanToPayEnabled,
-            isMarkOrderAsCompleteEnabled = state.isMarkOrderAsCompleteEnabled,
+            isMarkOrderAsPaidEnabled = state.isMarkOrderAsPaidEnabled,
         ),
         onMethodClicked = { method ->
             onUIEvent(WooPosTotalsUIEvent.OnAllPaymentMethodsVisibilityChanged(false))

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewModel.kt
@@ -1106,7 +1106,7 @@ class WooPosTotalsViewModel @Inject constructor(
             readerStatus = readerStatus,
             isTapToPayAvailable = isTapToPayAvailable(),
             isScanToPayEnabled = featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_SCAN_TO_PAY),
-            isMarkOrderAsCompleteEnabled = featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_MARK_ORDER_AS_COMPLETE),
+            isMarkOrderAsPaidEnabled = featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_MARK_ORDER_AS_PAID),
         )
     }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosTotalsViewState.kt
@@ -12,7 +12,7 @@ sealed class WooPosTotalsViewState : Parcelable {
         val readerStatus: ReaderStatus,
         val isTapToPayAvailable: Boolean = false,
         val isScanToPayEnabled: Boolean = false,
-        val isMarkOrderAsCompleteEnabled: Boolean = false,
+        val isMarkOrderAsPaidEnabled: Boolean = false,
         val isAllPaymentMethodsDialogVisible: Boolean = false,
         // UI-only rendering hint covering the TTP loading window. `Preparing` is the
         // pre-overlay phase (location lookup + SDK init + reader connect); `SdkActive`

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderascomplete/WooPosMarkOrderAsCompleteUIEvent.kt
@@ -1,6 +1,0 @@
-package com.woocommerce.android.ui.woopos.markorderascomplete
-
-sealed class WooPosMarkOrderAsCompleteUIEvent {
-    data class NoteChanged(val newNote: String) : WooPosMarkOrderAsCompleteUIEvent()
-    data object ConfirmClicked : WooPosMarkOrderAsCompleteUIEvent()
-}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidRepository.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidRepository.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.woopos.markorderascomplete
+package com.woocommerce.android.ui.woopos.markorderaspaid
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.model.WCOrderStatusModel
 import org.wordpress.android.fluxc.store.WCOrderStore
 import javax.inject.Inject
 
-class WooPosMarkOrderAsCompleteRepository @Inject constructor(
+class WooPosMarkOrderAsPaidRepository @Inject constructor(
     private val selectedSite: SelectedSite,
     private val orderStore: WCOrderStore,
     private val orderMapper: OrderMapper,
@@ -22,10 +22,10 @@ class WooPosMarkOrderAsCompleteRepository @Inject constructor(
         orderStore.getOrderByIdAndSite(orderId, selectedSite.get())?.let { orderMapper.toAppModel(it) }
     }
 
-    suspend fun markOrderAsComplete(
+    suspend fun markOrderAsPaid(
         orderId: Long,
         customerNote: String?,
-    ): MarkOrderAsCompleteOutcome = withContext(Dispatchers.IO) {
+    ): MarkOrderAsPaidOutcome = withContext(Dispatchers.IO) {
         val statusModel = orderStore.getOrderStatusForSiteAndKey(
             selectedSite.get(),
             Order.Status.Completed.value,
@@ -46,11 +46,11 @@ class WooPosMarkOrderAsCompleteRepository @Inject constructor(
 
         if (updateResult.event.isError) {
             WooLog.e(T.POS, "Mark order as complete failed - ${updateResult.event.error.message}")
-            return@withContext MarkOrderAsCompleteOutcome.Failure
+            return@withContext MarkOrderAsPaidOutcome.Failure
         }
 
         val trimmedNote = customerNote?.takeIf { it.isNotBlank() }
-            ?: return@withContext MarkOrderAsCompleteOutcome.Success
+            ?: return@withContext MarkOrderAsPaidOutcome.Success
 
         val noteResult = orderStore.postOrderNote(
             site = selectedSite.get(),
@@ -60,9 +60,9 @@ class WooPosMarkOrderAsCompleteRepository @Inject constructor(
         )
         if (noteResult.isError) {
             WooLog.e(T.POS, "Mark order as complete note post failed - ${noteResult.error?.message}")
-            MarkOrderAsCompleteOutcome.SuccessWithFailedNote
+            MarkOrderAsPaidOutcome.SuccessWithFailedNote
         } else {
-            MarkOrderAsCompleteOutcome.Success
+            MarkOrderAsPaidOutcome.Success
         }
     }
 
@@ -72,8 +72,8 @@ class WooPosMarkOrderAsCompleteRepository @Inject constructor(
     }
 }
 
-sealed class MarkOrderAsCompleteOutcome {
-    data object Success : MarkOrderAsCompleteOutcome()
-    data object SuccessWithFailedNote : MarkOrderAsCompleteOutcome()
-    data object Failure : MarkOrderAsCompleteOutcome()
+sealed class MarkOrderAsPaidOutcome {
+    data object Success : MarkOrderAsPaidOutcome()
+    data object SuccessWithFailedNote : MarkOrderAsPaidOutcome()
+    data object Failure : MarkOrderAsPaidOutcome()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidState.kt
@@ -1,14 +1,14 @@
-package com.woocommerce.android.ui.woopos.markorderascomplete
+package com.woocommerce.android.ui.woopos.markorderaspaid
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
-const val MARK_ORDER_AS_COMPLETE_ROUTE_ORDER_ID_KEY = "orderId"
+const val MARK_ORDER_AS_PAID_ROUTE_ORDER_ID_KEY = "orderId"
 
 @Parcelize
-sealed class WooPosMarkOrderAsCompleteState : Parcelable {
+sealed class WooPosMarkOrderAsPaidState : Parcelable {
     @Parcelize
-    data object Initiating : WooPosMarkOrderAsCompleteState()
+    data object Initiating : WooPosMarkOrderAsPaidState()
 
     @Parcelize
     data class Confirming(
@@ -16,7 +16,7 @@ sealed class WooPosMarkOrderAsCompleteState : Parcelable {
         val note: String,
         val errorMessage: String?,
         val button: Button,
-    ) : WooPosMarkOrderAsCompleteState() {
+    ) : WooPosMarkOrderAsPaidState() {
         @Parcelize
         data class Button(
             val text: String,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidUIEvent.kt
@@ -1,0 +1,6 @@
+package com.woocommerce.android.ui.woopos.markorderaspaid
+
+sealed class WooPosMarkOrderAsPaidUIEvent {
+    data class NoteChanged(val newNote: String) : WooPosMarkOrderAsPaidUIEvent()
+    data object ConfirmClicked : WooPosMarkOrderAsPaidUIEvent()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidViewModel.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.woopos.markorderascomplete
+package com.woocommerce.android.ui.woopos.markorderaspaid
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -10,7 +10,6 @@ import com.woocommerce.android.ui.woopos.root.navigation.WooPosNavigationEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCheckoutFromMarkAsPaid
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.MarkAsPaidConfirmed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.MarkAsPaidFailed
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.MarkAsPaidNotePostFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.MarkAsPaidSuccess
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
@@ -25,76 +24,76 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class WooPosMarkOrderAsCompleteViewModel @Inject constructor(
-    private val repository: WooPosMarkOrderAsCompleteRepository,
+class WooPosMarkOrderAsPaidViewModel @Inject constructor(
+    private val repository: WooPosMarkOrderAsPaidRepository,
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender,
     private val analyticsTracker: WooPosAnalyticsTracker,
     private val resourceProvider: ResourceProvider,
     private val priceFormat: WooPosFormatPrice,
     savedState: SavedStateHandle,
 ) : ViewModel() {
-    private val orderId: Long = requireNotNull(savedState[MARK_ORDER_AS_COMPLETE_ROUTE_ORDER_ID_KEY])
+    private val orderId: Long = requireNotNull(savedState[MARK_ORDER_AS_PAID_ROUTE_ORDER_ID_KEY])
 
     private val _navigationEvent = MutableSharedFlow<WooPosNavigationEvent>()
     val navigationEvent: SharedFlow<WooPosNavigationEvent> = _navigationEvent.asSharedFlow()
 
-    private val _state = savedState.getStateFlow<WooPosMarkOrderAsCompleteState>(
+    private val _state = savedState.getStateFlow<WooPosMarkOrderAsPaidState>(
         scope = viewModelScope,
-        initialValue = WooPosMarkOrderAsCompleteState.Initiating,
+        initialValue = WooPosMarkOrderAsPaidState.Initiating,
         key = STATE_KEY,
     )
-    val state: StateFlow<WooPosMarkOrderAsCompleteState> = _state
+    val state: StateFlow<WooPosMarkOrderAsPaidState> = _state
 
     init {
         viewModelScope.launch {
             val current = _state.value
-            if (current is WooPosMarkOrderAsCompleteState.Confirming &&
-                current.button.status == WooPosMarkOrderAsCompleteState.Confirming.Button.Status.LOADING
+            if (current is WooPosMarkOrderAsPaidState.Confirming &&
+                current.button.status == WooPosMarkOrderAsPaidState.Confirming.Button.Status.LOADING
             ) {
                 _state.value = current.copy(
                     button = current.button.copy(
-                        status = WooPosMarkOrderAsCompleteState.Confirming.Button.Status.ENABLED,
+                        status = WooPosMarkOrderAsPaidState.Confirming.Button.Status.ENABLED,
                     ),
                 )
                 return@launch
             }
-            if (current !is WooPosMarkOrderAsCompleteState.Initiating) return@launch
+            if (current !is WooPosMarkOrderAsPaidState.Initiating) return@launch
 
             val order = repository.getOrderById(orderId)
-            val buttonText = resourceProvider.getString(R.string.woopos_mark_order_as_complete_confirm_button)
+            val buttonText = resourceProvider.getString(R.string.woopos_mark_order_as_paid_confirm_button)
             _state.value = if (order != null) {
-                WooPosMarkOrderAsCompleteState.Confirming(
+                WooPosMarkOrderAsPaidState.Confirming(
                     totalText = resourceProvider.getString(
-                        R.string.woopos_mark_order_as_complete_total,
+                        R.string.woopos_mark_order_as_paid_total,
                         priceFormat(order.total),
                     ),
                     note = "",
                     errorMessage = null,
-                    button = WooPosMarkOrderAsCompleteState.Confirming.Button(
+                    button = WooPosMarkOrderAsPaidState.Confirming.Button(
                         text = buttonText,
-                        status = WooPosMarkOrderAsCompleteState.Confirming.Button.Status.ENABLED,
+                        status = WooPosMarkOrderAsPaidState.Confirming.Button.Status.ENABLED,
                     ),
                 )
             } else {
-                WooPosMarkOrderAsCompleteState.Confirming(
+                WooPosMarkOrderAsPaidState.Confirming(
                     totalText = "",
                     note = "",
                     errorMessage = resourceProvider.getString(
-                        R.string.woopos_mark_order_as_complete_order_not_found,
+                        R.string.woopos_mark_order_as_paid_order_not_found,
                     ),
-                    button = WooPosMarkOrderAsCompleteState.Confirming.Button(
+                    button = WooPosMarkOrderAsPaidState.Confirming.Button(
                         text = buttonText,
-                        status = WooPosMarkOrderAsCompleteState.Confirming.Button.Status.DISABLED,
+                        status = WooPosMarkOrderAsPaidState.Confirming.Button.Status.DISABLED,
                     ),
                 )
             }
         }
     }
 
-    fun onUIEvent(event: WooPosMarkOrderAsCompleteUIEvent) {
+    fun onUIEvent(event: WooPosMarkOrderAsPaidUIEvent) {
         when (event) {
-            is WooPosMarkOrderAsCompleteUIEvent.NoteChanged -> handleNoteChanged(event.newNote)
-            WooPosMarkOrderAsCompleteUIEvent.ConfirmClicked -> handleConfirm()
+            is WooPosMarkOrderAsPaidUIEvent.NoteChanged -> handleNoteChanged(event.newNote)
+            WooPosMarkOrderAsPaidUIEvent.ConfirmClicked -> handleConfirm()
         }
     }
 
@@ -106,35 +105,32 @@ class WooPosMarkOrderAsCompleteViewModel @Inject constructor(
     }
 
     private fun handleNoteChanged(newNote: String) {
-        val current = _state.value as? WooPosMarkOrderAsCompleteState.Confirming ?: return
+        val current = _state.value as? WooPosMarkOrderAsPaidState.Confirming ?: return
         _state.value = current.copy(note = newNote, errorMessage = null)
     }
 
     private fun handleConfirm() {
         viewModelScope.launch {
-            val current = _state.value as? WooPosMarkOrderAsCompleteState.Confirming ?: return@launch
-            if (current.button.status != WooPosMarkOrderAsCompleteState.Confirming.Button.Status.ENABLED) return@launch
+            val current = _state.value as? WooPosMarkOrderAsPaidState.Confirming ?: return@launch
+            if (current.button.status != WooPosMarkOrderAsPaidState.Confirming.Button.Status.ENABLED) return@launch
             analyticsTracker.track(MarkAsPaidConfirmed)
             _state.value = current.copy(
                 button = current.button.copy(
-                    status = WooPosMarkOrderAsCompleteState.Confirming.Button.Status.LOADING,
+                    status = WooPosMarkOrderAsPaidState.Confirming.Button.Status.LOADING,
                 ),
                 errorMessage = null,
             )
 
-            val outcome = repository.markOrderAsComplete(orderId, current.note.takeIf { it.isNotBlank() })
+            val outcome = repository.markOrderAsPaid(orderId, current.note.takeIf { it.isNotBlank() })
             when (outcome) {
-                MarkOrderAsCompleteOutcome.SuccessWithFailedNote -> {
-                    analyticsTracker.track(MarkAsPaidNotePostFailed)
-                    onMarkAsPaidSucceeded()
-                }
-                MarkOrderAsCompleteOutcome.Success -> onMarkAsPaidSucceeded()
-                MarkOrderAsCompleteOutcome.Failure -> {
+                MarkOrderAsPaidOutcome.SuccessWithFailedNote,
+                MarkOrderAsPaidOutcome.Success -> onMarkAsPaidSucceeded()
+                MarkOrderAsPaidOutcome.Failure -> {
                     analyticsTracker.track(MarkAsPaidFailed)
                     _state.value = current.copy(
-                        errorMessage = resourceProvider.getString(R.string.woopos_mark_order_as_complete_error_message),
+                        errorMessage = resourceProvider.getString(R.string.woopos_mark_order_as_paid_error_message),
                         button = current.button.copy(
-                            status = WooPosMarkOrderAsCompleteState.Confirming.Button.Status.ENABLED,
+                            status = WooPosMarkOrderAsPaidState.Confirming.Button.Status.ENABLED,
                         ),
                     )
                 }
@@ -149,6 +145,6 @@ class WooPosMarkOrderAsCompleteViewModel @Inject constructor(
     }
 
     private companion object {
-        const val STATE_KEY = "woo_pos_mark_order_as_complete_state"
+        const val STATE_KEY = "woo_pos_mark_order_as_paid_state"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/paymentsuccess/WooPosPaymentSuccessNavigation.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/paymentsuccess/WooPosPaymentSuccessNavigation.kt
@@ -23,7 +23,7 @@ enum class PaymentSuccessSource {
     CARD_BOOKINGS,
     CASH_BOOKINGS,
     SCAN_TO_PAY,
-    MARK_ORDER_AS_COMPLETE,
+    MARK_ORDER_AS_PAID,
 }
 
 fun NavController.navigateToPaymentSuccessScreen(

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/paymentsuccess/WooPosPaymentSuccessViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/paymentsuccess/WooPosPaymentSuccessViewModel.kt
@@ -58,7 +58,7 @@ class WooPosPaymentSuccessViewModel @Inject constructor(
                     PaymentSuccessSource.CARD_BOOKINGS -> R.string.woopos_totals_success_payment_card
                     PaymentSuccessSource.CASH_BOOKINGS -> R.string.woopos_totals_success_payment_cash
                     PaymentSuccessSource.SCAN_TO_PAY -> R.string.woopos_totals_success_payment_qr
-                    PaymentSuccessSource.MARK_ORDER_AS_COMPLETE -> R.string.woopos_totals_success_payment_external
+                    PaymentSuccessSource.MARK_ORDER_AS_PAID -> R.string.woopos_totals_success_payment_external
                 }
                 resourceProvider.getString(stringRes, priceText)
             } else {
@@ -74,7 +74,7 @@ class WooPosPaymentSuccessViewModel @Inject constructor(
                         }
                 PaymentSuccessSource.CASH_BOOKINGS,
                 PaymentSuccessSource.SCAN_TO_PAY,
-                PaymentSuccessSource.MARK_ORDER_AS_COMPLETE -> null
+                PaymentSuccessSource.MARK_ORDER_AS_PAID -> null
             }
             _state.value = PaymentSuccessViewState(
                 orderTotalText = orderTotalText,
@@ -113,7 +113,7 @@ class WooPosPaymentSuccessViewModel @Inject constructor(
         when (source) {
             PaymentSuccessSource.CARD_CHECKOUT,
             PaymentSuccessSource.SCAN_TO_PAY,
-            PaymentSuccessSource.MARK_ORDER_AS_COMPLETE -> {
+            PaymentSuccessSource.MARK_ORDER_AS_PAID -> {
                 _navigationEvent.emit(WooPosNavigationEvent.GoBack)
             }
             PaymentSuccessSource.CARD_BOOKINGS,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/util/analytics/WooPosAnalyticsEvent.kt
@@ -139,10 +139,6 @@ sealed class WooPosAnalyticsEvent : IAnalyticsEvent {
             override val name: String = "mark_as_paid_failed"
         }
 
-        data object MarkAsPaidNotePostFailed : Event() {
-            override val name: String = "mark_as_paid_note_post_failed"
-        }
-
         data object BackToCheckoutFromMarkAsPaid : Event() {
             override val name: String = "back_to_checkout_from_mark_as_paid"
         }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/util/FeatureFlag.kt
@@ -22,7 +22,7 @@ enum class FeatureFlag(
     WOO_POS_PHONE("woo_pos_phone", localValue = PackageUtils.isDebugBuild()),
     WOO_POS_TAP_TO_PAY("woo_pos_tap_to_pay", localValue = PackageUtils.isDebugBuild()),
     WOO_POS_SCAN_TO_PAY("woo_pos_scan_to_pay", localValue = PackageUtils.isDebugBuild()),
-    WOO_POS_MARK_ORDER_AS_COMPLETE("woo_pos_mark_order_as_complete", localValue = PackageUtils.isDebugBuild()),
+    WOO_POS_MARK_ORDER_AS_PAID("woo_pos_mark_order_as_paid", localValue = PackageUtils.isDebugBuild()),
     APP_PASSWORDS_FOR_JETPACK_SITES("woo_app_passwords_for_jetpack_sites"),
     WOO_POS_LOCAL_CATALOG_M1("woo_pos_local_catalog_m1"),
     WOO_POS_TABLET_PROMO_BANNER("woo_pos_tablet_promo_banner"),

--- a/WooCommerce/src/main/res/values/strings.xml
+++ b/WooCommerce/src/main/res/values/strings.xml
@@ -3916,10 +3916,10 @@
     <string name="woopos_payment_method_other_methods_label">Other payment methods</string>
     <string name="woopos_payment_method_scan_to_pay_label">Scan to pay</string>
     <string name="woopos_payment_method_mark_order_as_paid_label">Mark order as paid</string>
-    <string name="woopos_mark_order_as_complete_total">Order total: %1$s</string>
-    <string name="woopos_mark_order_as_complete_confirm_button">Mark order as complete</string>
-    <string name="woopos_mark_order_as_complete_error_message">Something went wrong. Please try again.</string>
-    <string name="woopos_mark_order_as_complete_order_not_found">Order could not be loaded. Go back and try again.</string>
+    <string name="woopos_mark_order_as_paid_total">Order total: %1$s</string>
+    <string name="woopos_mark_order_as_paid_confirm_button">Mark order as complete</string>
+    <string name="woopos_mark_order_as_paid_error_message">Something went wrong. Please try again.</string>
+    <string name="woopos_mark_order_as_paid_order_not_found">Order could not be loaded. Go back and try again.</string>
     <string name="woopos_payment_method_picker_dialog_title">Choose payment method</string>
     <string name="woopos_tap_to_pay_promoted_title">Tap to pay</string>
     <string name="woopos_tap_to_pay_promoted_subtitle">Use this device to accept contactless card payments.</string>

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/BuildAllPaymentMethodsTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/home/totals/BuildAllPaymentMethodsTest.kt
@@ -83,11 +83,11 @@ class BuildAllPaymentMethodsTest {
     }
 
     @Test
-    fun `given MarkOrderAsComplete disabled, when building methods, then MarkOrderAsPaid is not included`() {
+    fun `given MarkOrderAsPaid disabled, when building methods, then MarkOrderAsPaid is not included`() {
         val methods = build(
             readerStatus = disconnected,
             isTapToPayAvailable = false,
-            isMarkOrderAsCompleteEnabled = false,
+            isMarkOrderAsPaidEnabled = false,
         )
 
         assertThat(methods).doesNotContain(WooPosPaymentMethod.MARK_ORDER_AS_PAID)
@@ -100,7 +100,7 @@ class BuildAllPaymentMethodsTest {
             readerStatus = disconnected,
             isTapToPayAvailable = false,
             isScanToPayEnabled = false,
-            isMarkOrderAsCompleteEnabled = false,
+            isMarkOrderAsPaidEnabled = false,
         )
 
         assertThat(methods).doesNotContain(WooPosPaymentMethod.SCAN_TO_PAY)
@@ -111,11 +111,11 @@ class BuildAllPaymentMethodsTest {
         readerStatus: WooPosTotalsViewState.ReaderStatus,
         isTapToPayAvailable: Boolean,
         isScanToPayEnabled: Boolean = true,
-        isMarkOrderAsCompleteEnabled: Boolean = true,
+        isMarkOrderAsPaidEnabled: Boolean = true,
     ) = buildAllPaymentMethods(
         readerStatus = readerStatus,
         isTapToPayAvailable = isTapToPayAvailable,
         isScanToPayEnabled = isScanToPayEnabled,
-        isMarkOrderAsCompleteEnabled = isMarkOrderAsCompleteEnabled,
+        isMarkOrderAsPaidEnabled = isMarkOrderAsPaidEnabled,
     )
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidRepositoryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidRepositoryTest.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.woopos.markorderascomplete
+package com.woocommerce.android.ui.woopos.markorderaspaid
 
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.OrderMapper
@@ -28,7 +28,7 @@ import org.wordpress.android.fluxc.store.WCOrderStore
 import org.wordpress.android.fluxc.store.WCOrderStore.OnOrderChanged
 import org.wordpress.android.fluxc.store.WCOrderStore.UpdateOrderResult
 
-class WooPosMarkOrderAsCompleteRepositoryTest {
+class WooPosMarkOrderAsPaidRepositoryTest {
 
     private val selectedSite: SelectedSite = mock()
     private val orderStore: WCOrderStore = mock()
@@ -36,12 +36,12 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
     private val site: SiteModel = mock()
     private val statusModel = WCOrderStatusModel(statusKey = Order.Status.Completed.value)
 
-    private lateinit var repository: WooPosMarkOrderAsCompleteRepository
+    private lateinit var repository: WooPosMarkOrderAsPaidRepository
 
     @Before
     fun setUp() {
         runBlocking {
-            repository = WooPosMarkOrderAsCompleteRepository(selectedSite, orderStore, orderMapper)
+            repository = WooPosMarkOrderAsPaidRepository(selectedSite, orderStore, orderMapper)
             whenever(selectedSite.get()).thenReturn(site)
             whenever(
                 orderStore.getOrderStatusForSiteAndKey(site, Order.Status.Completed.value)
@@ -60,16 +60,16 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
     }
 
     @Test
-    fun `given remote update succeeds, when markOrderAsComplete with blank note, then payment method 'other' and no note posted`() =
+    fun `given remote update succeeds, when markOrderAsPaid with blank note, then payment method 'other' and no note posted`() =
         runTest {
             // GIVEN
             val orderId = 123L
 
             // WHEN
-            val result = repository.markOrderAsComplete(orderId, customerNote = null)
+            val result = repository.markOrderAsPaid(orderId, customerNote = null)
 
             // THEN
-            assertThat(result).isEqualTo(MarkOrderAsCompleteOutcome.Success)
+            assertThat(result).isEqualTo(MarkOrderAsPaidOutcome.Success)
             verify(orderStore).updateOrderStatusAndPaymentDetails(
                 orderId = eq(orderId),
                 site = eq(site),
@@ -87,7 +87,7 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
         }
 
     @Test
-    fun `given remote update succeeds, when markOrderAsComplete with note, then note posted as non-customer note`() =
+    fun `given remote update succeeds, when markOrderAsPaid with note, then note posted as non-customer note`() =
         runTest {
             // GIVEN
             val orderId = 123L
@@ -107,10 +107,10 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
             )
 
             // WHEN
-            val result = repository.markOrderAsComplete(orderId, customerNote = note)
+            val result = repository.markOrderAsPaid(orderId, customerNote = note)
 
             // THEN
-            assertThat(result).isEqualTo(MarkOrderAsCompleteOutcome.Success)
+            assertThat(result).isEqualTo(MarkOrderAsPaidOutcome.Success)
             verify(orderStore).postOrderNote(
                 site = eq(site),
                 orderId = eq(orderId),
@@ -120,7 +120,7 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
         }
 
     @Test
-    fun `given remote update succeeds and note post fails, when markOrderAsComplete, then outcome flags failed note`() =
+    fun `given remote update succeeds and note post fails, when markOrderAsPaid, then outcome flags failed note`() =
         runTest {
             // GIVEN
             val orderId = 123L
@@ -130,14 +130,14 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
             ).thenReturn(WooResult(WooError(WooErrorType.GENERIC_ERROR, original = mock())))
 
             // WHEN
-            val result = repository.markOrderAsComplete(orderId, customerNote = note)
+            val result = repository.markOrderAsPaid(orderId, customerNote = note)
 
             // THEN
-            assertThat(result).isEqualTo(MarkOrderAsCompleteOutcome.SuccessWithFailedNote)
+            assertThat(result).isEqualTo(MarkOrderAsPaidOutcome.SuccessWithFailedNote)
         }
 
     @Test
-    fun `given remote update fails, when markOrderAsComplete, then result is failure and no note posted`() = runTest {
+    fun `given remote update fails, when markOrderAsPaid, then result is failure and no note posted`() = runTest {
         // GIVEN
         val orderId = 123L
         whenever(
@@ -158,10 +158,10 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
         )
 
         // WHEN
-        val result = repository.markOrderAsComplete(orderId, customerNote = "Bank transfer")
+        val result = repository.markOrderAsPaid(orderId, customerNote = "Bank transfer")
 
         // THEN
-        assertThat(result).isEqualTo(MarkOrderAsCompleteOutcome.Failure)
+        assertThat(result).isEqualTo(MarkOrderAsPaidOutcome.Failure)
         verify(orderStore, never()).postOrderNote(
             site = any(),
             orderId = any(),
@@ -171,16 +171,16 @@ class WooPosMarkOrderAsCompleteRepositoryTest {
     }
 
     @Test
-    fun `given no fluxc status for completed, when markOrderAsComplete, then falls back to a synthetic status`() =
+    fun `given no fluxc status for completed, when markOrderAsPaid, then falls back to a synthetic status`() =
         runTest {
             // GIVEN
             val orderId = 321L
             whenever(orderStore.getOrderStatusForSiteAndKey(site, Order.Status.Completed.value)).thenReturn(null)
 
             // WHEN
-            val result = repository.markOrderAsComplete(orderId, customerNote = null)
+            val result = repository.markOrderAsPaid(orderId, customerNote = null)
 
             // THEN
-            assertThat(result).isEqualTo(MarkOrderAsCompleteOutcome.Success)
+            assertThat(result).isEqualTo(MarkOrderAsPaidOutcome.Success)
         }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/markorderaspaid/WooPosMarkOrderAsPaidViewModelTest.kt
@@ -1,4 +1,4 @@
-package com.woocommerce.android.ui.woopos.markorderascomplete
+package com.woocommerce.android.ui.woopos.markorderaspaid
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
@@ -12,7 +12,6 @@ import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.BackToCheckoutFromMarkAsPaid
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.MarkAsPaidConfirmed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.MarkAsPaidFailed
-import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.MarkAsPaidNotePostFailed
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent.Event.MarkAsPaidSuccess
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.ui.woopos.util.format.WooPosFormatPrice
@@ -26,14 +25,13 @@ import org.junit.Test
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class WooPosMarkOrderAsCompleteViewModelTest {
+class WooPosMarkOrderAsPaidViewModelTest {
 
     @Rule
     @JvmField
@@ -43,7 +41,7 @@ class WooPosMarkOrderAsCompleteViewModelTest {
     @JvmField
     val instantTaskRule = InstantTaskExecutorRule()
 
-    private val repository: WooPosMarkOrderAsCompleteRepository = mock()
+    private val repository: WooPosMarkOrderAsPaidRepository = mock()
     private val childrenToParentEventSender: WooPosChildrenToParentEventSender = mock()
     private val tracker: WooPosAnalyticsTracker = mock()
     private val resourceProvider: ResourceProvider = mock()
@@ -56,21 +54,21 @@ class WooPosMarkOrderAsCompleteViewModelTest {
         val testOrder = Order.getEmptyOrder(Date(), Date()).copy(id = orderId, total = BigDecimal("42.00"))
         whenever(repository.getOrderById(orderId)).thenReturn(testOrder)
         whenever(priceFormat(BigDecimal("42.00"))).thenReturn("$42.00")
-        whenever(resourceProvider.getString(R.string.woopos_mark_order_as_complete_total, "$42.00"))
+        whenever(resourceProvider.getString(R.string.woopos_mark_order_as_paid_total, "$42.00"))
             .thenReturn("Order total: $42.00")
-        whenever(resourceProvider.getString(R.string.woopos_mark_order_as_complete_confirm_button))
+        whenever(resourceProvider.getString(R.string.woopos_mark_order_as_paid_confirm_button))
             .thenReturn("Mark order as complete")
-        whenever(resourceProvider.getString(R.string.woopos_mark_order_as_complete_error_message))
+        whenever(resourceProvider.getString(R.string.woopos_mark_order_as_paid_error_message))
             .thenReturn("Something went wrong. Please try again.")
     }
 
-    private fun createViewModel() = WooPosMarkOrderAsCompleteViewModel(
+    private fun createViewModel() = WooPosMarkOrderAsPaidViewModel(
         repository = repository,
         childrenToParentEventSender = childrenToParentEventSender,
         analyticsTracker = tracker,
         resourceProvider = resourceProvider,
         priceFormat = priceFormat,
-        savedState = SavedStateHandle(mapOf(MARK_ORDER_AS_COMPLETE_ROUTE_ORDER_ID_KEY to orderId)),
+        savedState = SavedStateHandle(mapOf(MARK_ORDER_AS_PAID_ROUTE_ORDER_ID_KEY to orderId)),
     )
 
     @Test
@@ -78,16 +76,16 @@ class WooPosMarkOrderAsCompleteViewModelTest {
         runTest {
             // GIVEN
             whenever(repository.getOrderById(orderId)).thenReturn(null)
-            whenever(resourceProvider.getString(R.string.woopos_mark_order_as_complete_order_not_found))
+            whenever(resourceProvider.getString(R.string.woopos_mark_order_as_paid_order_not_found))
                 .thenReturn("Order could not be loaded. Go back and try again.")
 
             // WHEN
             val viewModel = createViewModel()
 
             // THEN
-            val state = viewModel.state.value as WooPosMarkOrderAsCompleteState.Confirming
+            val state = viewModel.state.value as WooPosMarkOrderAsPaidState.Confirming
             assertThat(state.errorMessage).isEqualTo("Order could not be loaded. Go back and try again.")
-            assertThat(state.button.status).isEqualTo(WooPosMarkOrderAsCompleteState.Confirming.Button.Status.DISABLED)
+            assertThat(state.button.status).isEqualTo(WooPosMarkOrderAsPaidState.Confirming.Button.Status.DISABLED)
             assertThat(state.totalText).isEmpty()
         }
 
@@ -98,12 +96,12 @@ class WooPosMarkOrderAsCompleteViewModelTest {
 
         // THEN
         val state = viewModel.state.value
-        assertThat(state).isInstanceOf(WooPosMarkOrderAsCompleteState.Confirming::class.java)
-        val confirming = state as WooPosMarkOrderAsCompleteState.Confirming
+        assertThat(state).isInstanceOf(WooPosMarkOrderAsPaidState.Confirming::class.java)
+        val confirming = state as WooPosMarkOrderAsPaidState.Confirming
         assertThat(confirming.totalText).isEqualTo("Order total: $42.00")
         assertThat(confirming.note).isEmpty()
         assertThat(confirming.errorMessage).isNull()
-        assertThat(confirming.button.status).isEqualTo(WooPosMarkOrderAsCompleteState.Confirming.Button.Status.ENABLED)
+        assertThat(confirming.button.status).isEqualTo(WooPosMarkOrderAsPaidState.Confirming.Button.Status.ENABLED)
     }
 
     @Test
@@ -112,10 +110,10 @@ class WooPosMarkOrderAsCompleteViewModelTest {
         val viewModel = createViewModel()
 
         // WHEN
-        viewModel.onUIEvent(WooPosMarkOrderAsCompleteUIEvent.NoteChanged("Bank transfer"))
+        viewModel.onUIEvent(WooPosMarkOrderAsPaidUIEvent.NoteChanged("Bank transfer"))
 
         // THEN
-        val updated = viewModel.state.value as WooPosMarkOrderAsCompleteState.Confirming
+        val updated = viewModel.state.value as WooPosMarkOrderAsPaidState.Confirming
         assertThat(updated.note).isEqualTo("Bank transfer")
         assertThat(updated.errorMessage).isNull()
     }
@@ -124,13 +122,13 @@ class WooPosMarkOrderAsCompleteViewModelTest {
     fun `given repo succeeds, when confirm clicked, then analytics tracked, parent event sent, GoBack emitted`() =
         runTest {
             // GIVEN
-            whenever(repository.markOrderAsComplete(eq(orderId), anyOrNull()))
-                .thenReturn(MarkOrderAsCompleteOutcome.Success)
+            whenever(repository.markOrderAsPaid(eq(orderId), anyOrNull()))
+                .thenReturn(MarkOrderAsPaidOutcome.Success)
             val viewModel = createViewModel()
 
             // WHEN / THEN
             viewModel.navigationEvent.test {
-                viewModel.onUIEvent(WooPosMarkOrderAsCompleteUIEvent.ConfirmClicked)
+                viewModel.onUIEvent(WooPosMarkOrderAsPaidUIEvent.ConfirmClicked)
                 assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
             }
             verify(tracker).track(MarkAsPaidConfirmed)
@@ -143,33 +141,33 @@ class WooPosMarkOrderAsCompleteViewModelTest {
     @Test
     fun `given repo succeeds with note, when confirm clicked, then note forwarded to repository`() = runTest {
         // GIVEN
-        whenever(repository.markOrderAsComplete(eq(orderId), eq("Bank transfer")))
-            .thenReturn(MarkOrderAsCompleteOutcome.Success)
+        whenever(repository.markOrderAsPaid(eq(orderId), eq("Bank transfer")))
+            .thenReturn(MarkOrderAsPaidOutcome.Success)
         val viewModel = createViewModel()
-        viewModel.onUIEvent(WooPosMarkOrderAsCompleteUIEvent.NoteChanged("Bank transfer"))
+        viewModel.onUIEvent(WooPosMarkOrderAsPaidUIEvent.NoteChanged("Bank transfer"))
 
         // WHEN / THEN
         viewModel.navigationEvent.test {
-            viewModel.onUIEvent(WooPosMarkOrderAsCompleteUIEvent.ConfirmClicked)
+            viewModel.onUIEvent(WooPosMarkOrderAsPaidUIEvent.ConfirmClicked)
             assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
         }
-        verify(repository).markOrderAsComplete(orderId, "Bank transfer")
+        verify(repository).markOrderAsPaid(orderId, "Bank transfer")
     }
 
     @Test
     fun `given repo fails, when confirm clicked, then state has error message and button re-enabled`() = runTest {
         // GIVEN
-        whenever(repository.markOrderAsComplete(eq(orderId), anyOrNull()))
-            .thenReturn(MarkOrderAsCompleteOutcome.Failure)
+        whenever(repository.markOrderAsPaid(eq(orderId), anyOrNull()))
+            .thenReturn(MarkOrderAsPaidOutcome.Failure)
         val viewModel = createViewModel()
 
         // WHEN
-        viewModel.onUIEvent(WooPosMarkOrderAsCompleteUIEvent.ConfirmClicked)
+        viewModel.onUIEvent(WooPosMarkOrderAsPaidUIEvent.ConfirmClicked)
 
         // THEN
-        val finalState = viewModel.state.value as WooPosMarkOrderAsCompleteState.Confirming
+        val finalState = viewModel.state.value as WooPosMarkOrderAsPaidState.Confirming
         assertThat(finalState.errorMessage).isEqualTo("Something went wrong. Please try again.")
-        assertThat(finalState.button.status).isEqualTo(WooPosMarkOrderAsCompleteState.Confirming.Button.Status.ENABLED)
+        assertThat(finalState.button.status).isEqualTo(WooPosMarkOrderAsPaidState.Confirming.Button.Status.ENABLED)
         verify(tracker).track(MarkAsPaidFailed)
     }
 
@@ -187,57 +185,43 @@ class WooPosMarkOrderAsCompleteViewModelTest {
     }
 
     @Test
-    fun `given repo succeeds with failed note, when confirm clicked, then MarkAsPaidNotePostFailed tracked`() = runTest {
+    fun `given repo succeeds with failed note, when confirm clicked, then success path same as Success`() = runTest {
         // GIVEN
-        whenever(repository.markOrderAsComplete(eq(orderId), anyOrNull()))
-            .thenReturn(MarkOrderAsCompleteOutcome.SuccessWithFailedNote)
+        whenever(repository.markOrderAsPaid(eq(orderId), anyOrNull()))
+            .thenReturn(MarkOrderAsPaidOutcome.SuccessWithFailedNote)
         val viewModel = createViewModel()
 
         // WHEN / THEN
         viewModel.navigationEvent.test {
-            viewModel.onUIEvent(WooPosMarkOrderAsCompleteUIEvent.ConfirmClicked)
+            viewModel.onUIEvent(WooPosMarkOrderAsPaidUIEvent.ConfirmClicked)
             assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
         }
-        verify(tracker).track(MarkAsPaidNotePostFailed)
         verify(tracker).track(MarkAsPaidSuccess)
+        verify(childrenToParentEventSender).sendToParent(
+            eq(ChildToParentEvent.OrderSuccessfullyPaidExternally),
+        )
     }
-
-    @Test
-    fun `given repo succeeds without failed note, when confirm clicked, then MarkAsPaidNotePostFailed not tracked`() =
-        runTest {
-            // GIVEN
-            whenever(repository.markOrderAsComplete(eq(orderId), anyOrNull()))
-                .thenReturn(MarkOrderAsCompleteOutcome.Success)
-            val viewModel = createViewModel()
-
-            // WHEN / THEN
-            viewModel.navigationEvent.test {
-                viewModel.onUIEvent(WooPosMarkOrderAsCompleteUIEvent.ConfirmClicked)
-                assertThat(awaitItem()).isEqualTo(WooPosNavigationEvent.GoBack)
-            }
-            verify(tracker, never()).track(MarkAsPaidNotePostFailed)
-        }
 
     @Test
     fun `given saved state has LOADING button, when VM restored, then button is reset to ENABLED`() = runTest {
         // GIVEN: saved state simulates process death mid-confirm
         val savedState = SavedStateHandle(
             mapOf(
-                MARK_ORDER_AS_COMPLETE_ROUTE_ORDER_ID_KEY to orderId,
-                "woo_pos_mark_order_as_complete_state" to WooPosMarkOrderAsCompleteState.Confirming(
+                MARK_ORDER_AS_PAID_ROUTE_ORDER_ID_KEY to orderId,
+                "woo_pos_mark_order_as_paid_state" to WooPosMarkOrderAsPaidState.Confirming(
                     totalText = "Order total: $42.00",
                     note = "Bank transfer",
                     errorMessage = null,
-                    button = WooPosMarkOrderAsCompleteState.Confirming.Button(
+                    button = WooPosMarkOrderAsPaidState.Confirming.Button(
                         text = "Mark order as complete",
-                        status = WooPosMarkOrderAsCompleteState.Confirming.Button.Status.LOADING,
+                        status = WooPosMarkOrderAsPaidState.Confirming.Button.Status.LOADING,
                     ),
                 ),
             )
         )
 
         // WHEN
-        val viewModel = WooPosMarkOrderAsCompleteViewModel(
+        val viewModel = WooPosMarkOrderAsPaidViewModel(
             repository = repository,
             childrenToParentEventSender = childrenToParentEventSender,
             analyticsTracker = tracker,
@@ -247,8 +231,8 @@ class WooPosMarkOrderAsCompleteViewModelTest {
         )
 
         // THEN
-        val state = viewModel.state.value as WooPosMarkOrderAsCompleteState.Confirming
-        assertThat(state.button.status).isEqualTo(WooPosMarkOrderAsCompleteState.Confirming.Button.Status.ENABLED)
+        val state = viewModel.state.value as WooPosMarkOrderAsPaidState.Confirming
+        assertThat(state.button.status).isEqualTo(WooPosMarkOrderAsPaidState.Confirming.Button.Status.ENABLED)
         assertThat(state.note).isEqualTo("Bank transfer")
     }
 }


### PR DESCRIPTION
## Summary

Renames the Mark-Order-as-Complete POS feature back to **Mark Order as Paid** to match the iOS naming convention. Discovered while planning the rebase of #15932: iOS uses `MarkAsPaid` throughout, and the trunk-side rename introduced in #15944 (`markorderascomplete/` + `MarkOrderAsComplete*` symbols) is the only divergence.

Also fixes a **real cross-platform consistency bug**: the remote feature-flag key on Android was `woo_pos_mark_order_as_complete`, while iOS reads `woo_pos_mark_order_as_paid` (see [`FeatureFlagRemote.swift`](https://github.com/woocommerce/woocommerce-ios/blob/trunk/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift)) — the two platforms were querying different keys. After this PR both platforms share `woo_pos_mark_order_as_paid`.

## Changes

- **Package**: `markorderascomplete/` → `markorderaspaid/` (4 source + 2 test files, moved with `git mv` to preserve history).
- **Symbols**: `WooPosMarkOrderAsComplete*` → `WooPosMarkOrderAsPaid*` (Repository, State, UIEvent, ViewModel + the `MarkOrderAsCompleteOutcome` sealed class → `MarkOrderAsPaidOutcome`).
- **Function**: `repository.markOrderAsComplete()` → `markOrderAsPaid()`.
- **Constants**: `MARK_ORDER_AS_COMPLETE_ROUTE_ORDER_ID_KEY` → `MARK_ORDER_AS_PAID_ROUTE_ORDER_ID_KEY`; saved-state key `"woo_pos_mark_order_as_complete_state"` → `"woo_pos_mark_order_as_paid_state"`.
- **Feature flag**: `WOO_POS_MARK_ORDER_AS_COMPLETE("woo_pos_mark_order_as_complete", …)` → `WOO_POS_MARK_ORDER_AS_PAID("woo_pos_mark_order_as_paid", …)`. The string value is the remote key and now matches iOS.
- **State field**: `isMarkOrderAsCompleteEnabled` → `isMarkOrderAsPaidEnabled` (Totals view state, payment method builder, screen wiring).
- **PaymentSuccessSource**: `MARK_ORDER_AS_COMPLETE` → `MARK_ORDER_AS_PAID` enum value.
- **Strings**: `woopos_mark_order_as_complete_*` (4 keys) → `woopos_mark_order_as_paid_*`. The user-facing copy "Mark order as complete" / "Order total" / "Something went wrong…" / "Order could not be loaded…" is unchanged — only the resource IDs.
- **Removed analytic `MarkAsPaidNotePostFailed`** (raw key `mark_as_paid_note_post_failed`) — iOS doesn't track note-post failures (see `Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift`: warning log only, no analytic). The `SuccessWithFailedNote` outcome now falls through to the regular success path in the VM, matching iOS's behaviour exactly.

## What's unchanged

- The unrelated **shipping-labels** feature in `ui/payments/changeduecalculator/` keeps its `MarkOrderAsCompleteButton` composable and `cash_payments_mark_order_as_complete` string — different feature.
- Analytics event names that were already iOS-aligned (`mark_as_paid_confirmed`, `mark_as_paid_success`, `mark_as_paid_failed`, `checkout_mark_as_paid_tapped`, `back_to_checkout_from_mark_as_paid`) — no change.
- The `MarkOrderAsCompleteOutcome.SuccessWithFailedNote` outcome itself stays as a sealed-class member (now `MarkOrderAsPaidOutcome.SuccessWithFailedNote`), since the repository genuinely returns it to distinguish the two success shapes — the VM just no longer differentiates analytics on it.

## Impact on PR #15932

This is the prerequisite for cleanly rebasing #15932. After this lands on trunk, #15932 will merge cleanly into trunk's `markorderaspaid/*` files (the branch already uses that naming) — no rename gymnastics needed.

## Test plan

- [ ] Build + run on Wasabi debug; toggle the `WOO_POS_MARK_ORDER_AS_PAID` feature flag in dev settings.
- [ ] Verify POS Checkout → Other payment methods → "Mark order as paid" still appears when the flag is on.
- [ ] Confirm a payment and watch the Tracks event log: `mark_as_paid_confirmed`, `mark_as_paid_success`, no `mark_as_paid_note_post_failed`.
- [ ] Verify locales other than `en-rUS` still pick up the renamed strings (string values unchanged, only IDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)