### PR TITLE
Enable Canada POS and extract refund submission processor

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooPosModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooPosModule.kt
@@ -2,8 +2,6 @@ package com.woocommerce.android.di
 
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsInMemoryCache
-import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundSubmissionProcessor
-import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundSubmissionProcessorImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -16,9 +14,4 @@ abstract class WooPosModule {
     @Binds
     @Singleton
     abstract fun provideWooPosProductsCache(implementation: WooPosProductsInMemoryCache): WooPosProductsCache
-
-    @Binds
-    abstract fun provideWooPosRefundSubmissionProcessor(
-        implementation: WooPosRefundSubmissionProcessorImpl
-    ): WooPosRefundSubmissionProcessor
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooPosModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooPosModule.kt
@@ -2,6 +2,8 @@ package com.woocommerce.android.di
 
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsInMemoryCache
+import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundSubmissionProcessor
+import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundSubmissionProcessorImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -14,4 +16,9 @@ abstract class WooPosModule {
     @Binds
     @Singleton
     abstract fun provideWooPosProductsCache(implementation: WooPosProductsInMemoryCache): WooPosProductsCache
+
+    @Binds
+    abstract fun provideWooPosRefundSubmissionProcessor(
+        implementation: WooPosRefundSubmissionProcessorImpl
+    ): WooPosRefundSubmissionProcessor
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
@@ -1,7 +1,6 @@
 package com.woocommerce.android.ui.woopos.orders.details.refund
 
 import com.woocommerce.android.R
-import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.orders.WooPosLoadPaymentGateway
 import com.woocommerce.android.util.WooLog
@@ -9,38 +8,17 @@ import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
 import org.wordpress.android.fluxc.store.WCRefundStore
-import java.math.BigDecimal
 import javax.inject.Inject
 
-interface WooPosRefundSubmissionProcessor {
-    fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState>
-}
-
-data class WooPosRefundSubmissionRequest(
-    val order: Order,
-    val refundAmount: BigDecimal,
-    val refundReason: String,
-    val refundItems: List<RefundRequestItem>,
-) {
-    val orderId: Long = order.id
-}
-
-sealed class WooPosRefundSubmissionState {
-    data object Processing : WooPosRefundSubmissionState()
-    data object Success : WooPosRefundSubmissionState()
-    data class Failure(val message: String) : WooPosRefundSubmissionState()
-}
-
-class WooPosRefundSubmissionProcessorImpl @Inject constructor(
+class WooPosRefundSubmissionProcessor @Inject constructor(
     private val refundStore: WCRefundStore,
     private val selectedSite: SelectedSite,
     private val loadPaymentGateway: WooPosLoadPaymentGateway,
     private val resourceProvider: ResourceProvider,
-) : WooPosRefundSubmissionProcessor {
+) {
     @Suppress("TooGenericExceptionCaught")
-    override fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState> = flow {
+    fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState> = flow {
         try {
             WooLog.i(
                 WooLog.T.POS,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
@@ -1,0 +1,105 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import com.woocommerce.android.R
+import com.woocommerce.android.model.Order
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.orders.WooPosLoadPaymentGateway
+import com.woocommerce.android.util.WooLog
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
+import org.wordpress.android.fluxc.store.WCRefundStore
+import java.math.BigDecimal
+import javax.inject.Inject
+
+interface WooPosRefundSubmissionProcessor {
+    fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState>
+}
+
+data class WooPosRefundSubmissionRequest(
+    val order: Order,
+    val refundAmount: BigDecimal,
+    val refundReason: String,
+    val refundItems: List<RefundRequestItem>,
+) {
+    val orderId: Long = order.id
+}
+
+sealed class WooPosRefundSubmissionState {
+    data object Processing : WooPosRefundSubmissionState()
+    data object Success : WooPosRefundSubmissionState()
+    data class Failure(val message: String) : WooPosRefundSubmissionState()
+}
+
+class WooPosRefundSubmissionProcessorImpl @Inject constructor(
+    private val refundStore: WCRefundStore,
+    private val selectedSite: SelectedSite,
+    private val loadPaymentGateway: WooPosLoadPaymentGateway,
+    private val resourceProvider: ResourceProvider,
+) : WooPosRefundSubmissionProcessor {
+    @Suppress("TooGenericExceptionCaught")
+    override fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState> = flow {
+        try {
+            WooLog.i(
+                WooLog.T.POS,
+                "WooPosRefund: submission started " +
+                    "orderId=${request.orderId}, " +
+                    "amount=${request.refundAmount}, " +
+                    "itemCount=${request.refundItems.size}"
+            )
+
+            emit(WooPosRefundSubmissionState.Processing)
+
+            val paymentGatewayResult = loadPaymentGateway(request.order)
+            if (paymentGatewayResult.isFailure) {
+                WooLog.e(
+                    WooLog.T.POS,
+                    "WooPosRefund: failed to load payment gateway orderId=${request.orderId}",
+                    paymentGatewayResult.exceptionOrNull()
+                )
+                emit(
+                    WooPosRefundSubmissionState.Failure(
+                        message = resourceProvider.getString(R.string.woopos_refund_error_gateway_not_found),
+                    )
+                )
+                return@flow
+            }
+            val paymentGateway = paymentGatewayResult.getOrThrow()
+
+            val result = refundStore.createItemsRefund(
+                site = selectedSite.get(),
+                orderId = request.orderId,
+                amount = request.refundAmount,
+                reason = request.refundReason,
+                restockItems = true,
+                autoRefund = paymentGateway.supportsRefunds,
+                items = request.refundItems
+            )
+
+            if (result.isError) {
+                emit(
+                    WooPosRefundSubmissionState.Failure(
+                        message = result.error.message ?: resourceProvider.getString(R.string.error_generic),
+                    )
+                )
+            } else {
+                emit(WooPosRefundSubmissionState.Success)
+            }
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            WooLog.e(
+                WooLog.T.POS,
+                "WooPosRefund: submission failed unexpectedly orderId=${request.orderId}",
+                exception
+            )
+            emit(
+                WooPosRefundSubmissionState.Failure(
+                    message = resourceProvider.getString(R.string.error_generic),
+                )
+            )
+        }
+    }
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionRequest.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionRequest.kt
@@ -1,0 +1,14 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import com.woocommerce.android.model.Order
+import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
+import java.math.BigDecimal
+
+data class WooPosRefundSubmissionRequest(
+    val order: Order,
+    val refundAmount: BigDecimal,
+    val refundReason: String,
+    val refundItems: List<RefundRequestItem>,
+) {
+    val orderId: Long = order.id
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionState.kt
@@ -1,0 +1,7 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+sealed class WooPosRefundSubmissionState {
+    data object Processing : WooPosRefundSubmissionState()
+    data object Success : WooPosRefundSubmissionState()
+    data class Failure(val message: String) : WooPosRefundSubmissionState()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.model.Refund
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
 import com.woocommerce.android.ui.woopos.orders.WooPosGetPaymentMethod
-import com.woocommerce.android.ui.woopos.orders.WooPosLoadPaymentGateway
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
@@ -25,7 +24,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.store.WCRefundStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.RoundingMode
 
@@ -41,12 +39,11 @@ class WooPosRefundViewModel @AssistedInject constructor(
     private val calculateRefundTax: WooPosCalculateRefundTax,
     private val resourceProvider: ResourceProvider,
     private val currencyFormatter: CurrencyFormatter,
-    private val refundStore: WCRefundStore,
     private val selectedSite: SelectedSite,
     private val wooCommerceStore: WooCommerceStore,
-    private val loadPaymentGateway: WooPosLoadPaymentGateway,
     private val getPaymentMethod: WooPosGetPaymentMethod,
-    private val analyticsTracker: WooPosAnalyticsTracker
+    private val refundSubmissionProcessor: WooPosRefundSubmissionProcessor,
+    private val analyticsTracker: WooPosAnalyticsTracker,
 ) : ViewModel() {
 
     @AssistedFactory
@@ -62,6 +59,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
     private var cachedNumberOfDecimalPoints: Int? = null
     private var cachedTaxRoundAtSubtotal: Boolean? = null
     private var contentStateBeforeRefund: WooPosRefundState.Content? = null
+    private var refundJob: Job? = null
 
     private suspend fun fetchSiteSettings(): Result<Int> {
         val siteSettingsResult = wooCommerceStore.fetchSiteGeneralSettings(selectedSite.get())
@@ -210,8 +208,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
 
     fun onDismissRequest(): Boolean {
         val currentState = _state.value
-        val isProcessing = currentState is WooPosRefundState.Content &&
-            currentState.step == WooPosRefundState.Content.RefundStep.Processing
+        val isProcessing = currentState is WooPosRefundState.Content && currentState.step.isNonCancelable()
 
         // Don't allow dismissal during processing to ensure user sees the result
         return !isProcessing
@@ -233,7 +230,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
                     )
                 }
             }
-            WooPosRefundUIEvent.CancelRefund -> Unit
+            WooPosRefundUIEvent.CancelRefund -> cancelRefundSubmission()
             else -> {
                 val currentState = _state.value as? WooPosRefundState.Content ?: return
                 handleContentStateEvent(event, currentState)
@@ -244,14 +241,14 @@ class WooPosRefundViewModel @AssistedInject constructor(
     private fun handleRefundFlowDismissed() {
         val currentState = _state.value
         if (currentState is WooPosRefundState.Content &&
-            currentState.step != WooPosRefundState.Content.RefundStep.Processing
+            !currentState.step.isNonCancelable()
         ) {
             val refundStep = when (currentState.step) {
                 WooPosRefundState.Content.RefundStep.SelectItems -> "select_items"
                 WooPosRefundState.Content.RefundStep.ReviewRefund -> "review_refund"
                 WooPosRefundState.Content.RefundStep.ConfirmRefund -> "confirm_refund"
                 WooPosRefundState.Content.RefundStep.Processing ->
-                    error("Processing step should be unreachable in handleRefundFlowDismissed")
+                    error("Non-cancelable step should be unreachable in handleRefundFlowDismissed")
             }
 
             viewModelScope.launch {
@@ -261,6 +258,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
             }
         }
 
+        cancelRefundSubmission()
         _state.value = WooPosRefundState.Loading
         loadingJob?.cancel()
     }
@@ -361,10 +359,9 @@ class WooPosRefundViewModel @AssistedInject constructor(
         ).copy(step = currentState.step)
     }
 
-    @Suppress("LongMethod")
     private fun processRefund(contentState: WooPosRefundState.Content) {
         viewModelScope.launch {
-            if (contentState.step == WooPosRefundState.Content.RefundStep.Processing) {
+            if (refundJob?.isActive == true || contentState.step.isNonCancelable()) {
                 return@launch
             }
 
@@ -400,52 +397,69 @@ class WooPosRefundViewModel @AssistedInject constructor(
             val selectedItems = contentState.refundableItems.filter { it.uniqueId in contentState.selectedItemIds }
             val refundItems = groupRefundItems(selectedItems, order, numberOfDecimalPoints)
 
-            val paymentGatewayResult = loadPaymentGateway(order)
-            if (paymentGatewayResult.isFailure) {
-                WooLog.e(
-                    WooLog.T.POS,
-                    "${paymentGatewayResult.exceptionOrNull()?.message}"
+            submitRefund(
+                contentState = contentState,
+                request = WooPosRefundSubmissionRequest(
+                    order = order,
+                    refundAmount = contentState.total,
+                    refundReason = contentState.refundReason,
+                    refundItems = refundItems,
                 )
-                _state.value = WooPosRefundState.Error(
-                    message = resourceProvider.getString(R.string.woopos_refund_error_gateway_not_found),
-                    errorType = WooPosRefundState.Error.ErrorType.Processing
-                )
-                return@launch
-            }
-
-            val paymentGateway = paymentGatewayResult.getOrThrow()
-
-            val result = refundStore.createItemsRefund(
-                site = selectedSite.get(),
-                orderId = contentState.orderId,
-                amount = contentState.total,
-                reason = contentState.refundReason,
-                restockItems = true,
-                autoRefund = paymentGateway.supportsRefunds,
-                items = refundItems
             )
+        }
+    }
 
-            if (result.isError) {
-                analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingFailed)
-                _state.value = WooPosRefundState.Error(
-                    message = result.error.message ?: resourceProvider.getString(R.string.error_generic),
-                    errorType = WooPosRefundState.Error.ErrorType.Processing
-                )
-            } else {
-                analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingSuccess)
-                val receiptSentMessage = currentOrder?.billingAddress?.email
-                    ?.takeIf { it.isNotBlank() }
-                    ?.let { email ->
-                        resourceProvider.getString(R.string.woopos_receipt_sent_to_customer, email)
+    private fun submitRefund(
+        contentState: WooPosRefundState.Content,
+        request: WooPosRefundSubmissionRequest,
+    ) {
+        refundJob?.cancel()
+        refundJob = viewModelScope.launch {
+            refundSubmissionProcessor.submit(request).collect { submissionState ->
+                when (submissionState) {
+                    WooPosRefundSubmissionState.Processing -> {
+                        _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.Processing)
                     }
-                _state.value = WooPosRefundState.RefundSuccess(
-                    orderId = contentState.orderId,
-                    orderNumber = contentState.orderNumber,
-                    refundedAmount = contentState.formattedTotal,
-                    paymentMethod = contentState.paymentMethod,
-                    receiptSentMessage = receiptSentMessage
-                )
+
+                    WooPosRefundSubmissionState.Success -> {
+                        analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingSuccess)
+                        val receiptSentMessage = request.order.billingAddress.email
+                            .takeIf { it.isNotBlank() }
+                            ?.let { email ->
+                                resourceProvider.getString(R.string.woopos_receipt_sent_to_customer, email)
+                            }
+                        _state.value = WooPosRefundState.RefundSuccess(
+                            orderId = contentState.orderId,
+                            orderNumber = contentState.orderNumber,
+                            refundedAmount = contentState.formattedTotal,
+                            paymentMethod = contentState.paymentMethod,
+                            receiptSentMessage = receiptSentMessage
+                        )
+                    }
+
+                    is WooPosRefundSubmissionState.Failure -> {
+                        analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingFailed)
+                        _state.value = WooPosRefundState.Error(
+                            message = submissionState.message,
+                            errorType = WooPosRefundState.Error.ErrorType.Processing
+                        )
+                    }
+                }
             }
+        }
+    }
+
+    private fun cancelRefundSubmission() {
+        refundJob?.cancel()
+        refundJob = null
+    }
+
+    private fun WooPosRefundState.Content.RefundStep.isNonCancelable(): Boolean {
+        return when (this) {
+            WooPosRefundState.Content.RefundStep.Processing -> true
+            WooPosRefundState.Content.RefundStep.SelectItems,
+            WooPosRefundState.Content.RefundStep.ReviewRefund,
+            WooPosRefundState.Content.RefundStep.ConfirmRefund -> false
         }
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosIsCountryAllowed.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosIsCountryAllowed.kt
@@ -30,7 +30,7 @@ class WooPosIsCountryAllowed @Inject constructor(
 
     private companion object {
         val SUPPORTED_COUNTRIES = setOf(
-            "US", "PR", "GB",
+            "US", "PR", "GB", "CA",
             "FR", "DE", "IE", "NL", "AT", "BE", "FI", "IT", "LU", "PT", "ES",
             "SG", "NZ",
             "AU",

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosIsCountryAllowed.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosIsCountryAllowed.kt
@@ -12,8 +12,8 @@ import javax.inject.Inject
  * - When [FeatureFlag.WOO_POS_ALL_COUNTRIES] is enabled, every country is allowed.
  * - Otherwise, POS is restricted to the IPP-supported card-payment countries listed below.
  *
- * Inside POS, per-country card-payment gating still applies (CA, JP, etc. fall back to
- * a Cash-only checkout); this gate only decides whether POS is reachable at all.
+ * Inside POS, card-payment availability is still checked separately from launch eligibility;
+ * this gate only decides whether POS is reachable at all.
  */
 class WooPosIsCountryAllowed @Inject constructor(
     private val selectedSite: SelectedSite,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosIsCardPaymentEnabledForCountryTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/cardpayment/WooPosIsCardPaymentEnabledForCountryTest.kt
@@ -44,11 +44,11 @@ class WooPosIsCardPaymentEnabledForCountryTest {
     }
 
     @Test
-    fun `given CA, when invoke, then returns false even though IPP is supported`() = runTest {
+    fun `given CA, when invoke, then returns true`() = runTest {
         whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn("CA")
         whenever(countryConfigProvider.provideCountryConfigFor("CA")).thenReturn(CardReaderConfigForCanada)
 
-        assertThat(sut()).isFalse
+        assertThat(sut()).isTrue()
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -1,0 +1,228 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import app.cash.turbine.test
+import com.woocommerce.android.R
+import com.woocommerce.android.model.PaymentGateway
+import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.woopos.orders.WooPosLoadPaymentGateway
+import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel
+import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
+import org.wordpress.android.fluxc.store.WCRefundStore
+import java.math.BigDecimal
+import java.util.Date
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WooPosRefundSubmissionProcessorTest {
+    @Rule
+    @JvmField
+    val coroutineTestRule = WooPosCoroutineTestRule()
+
+    private val refundStore: WCRefundStore = mock()
+    private val selectedSite: SelectedSite = mock()
+    private val loadPaymentGateway: WooPosLoadPaymentGateway = mock()
+    private val resourceProvider: ResourceProvider = mock()
+
+    private val site = SiteModel().apply { id = 1 }
+    private val refundAmount = BigDecimal("22.00")
+    private val refundItems = listOf(
+        RefundRequestItem(
+            itemId = 1L,
+            quantity = 1,
+            refundTotal = BigDecimal("20.00"),
+            refundTax = emptyList()
+        )
+    )
+    private val order = OrderTestUtils.generateTestOrder(orderId = 123L)
+    private val request = WooPosRefundSubmissionRequest(
+        order = order,
+        refundAmount = refundAmount,
+        refundReason = "Customer request",
+        refundItems = refundItems
+    )
+    private val refundModel = WCRefundModel(
+        id = 1L,
+        dateCreated = Date(),
+        amount = refundAmount,
+        reason = "",
+        automaticGatewayRefund = false,
+        items = emptyList(),
+        shippingLineItems = emptyList(),
+        feeLineItems = emptyList()
+    )
+
+    private lateinit var processor: WooPosRefundSubmissionProcessor
+
+    @Before
+    fun setUp() = runTest {
+        whenever(selectedSite.get()).thenReturn(site)
+        whenever(resourceProvider.getString(R.string.error_generic)).thenReturn("Something went wrong")
+        whenever(resourceProvider.getString(R.string.woopos_refund_error_gateway_not_found))
+            .thenReturn("Unable to process refund.")
+        whenever(loadPaymentGateway.invoke(any())).thenReturn(
+            Result.success(
+                PaymentGateway(
+                    title = "WooPayments",
+                    description = "",
+                    isEnabled = true,
+                    methodTitle = "WooPayments",
+                    methodDescription = "",
+                    supportsRefunds = true
+                )
+            )
+        )
+        whenever(
+            refundStore.createItemsRefund(
+                site = any(),
+                orderId = any(),
+                amount = any(),
+                reason = any(),
+                restockItems = any(),
+                autoRefund = any(),
+                items = any()
+            )
+        ).thenReturn(WooResult(refundModel))
+
+        processor = WooPosRefundSubmissionProcessorImpl(
+            refundStore = refundStore,
+            selectedSite = selectedSite,
+            loadPaymentGateway = loadPaymentGateway,
+            resourceProvider = resourceProvider,
+        )
+    }
+
+    @Test
+    fun `given refund request, when submitted, then backend refund is created`() = runTest {
+        processor.submit(request).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Success)
+            awaitComplete()
+        }
+
+        verify(refundStore).createItemsRefund(
+            site = eq(site),
+            orderId = eq(order.id),
+            amount = eq(refundAmount),
+            reason = eq("Customer request"),
+            restockItems = eq(true),
+            autoRefund = eq(true),
+            items = eq(refundItems)
+        )
+    }
+
+    @Test
+    fun `given payment gateway does not support refunds, when submitted, then backend refund is created manually`() =
+        runTest {
+            whenever(loadPaymentGateway.invoke(any())).thenReturn(
+                Result.success(
+                    PaymentGateway(
+                        title = "Manual gateway",
+                        description = "",
+                        isEnabled = true,
+                        methodTitle = "Manual gateway",
+                        methodDescription = "",
+                        supportsRefunds = false
+                    )
+                )
+            )
+
+            processor.submit(request).test {
+                assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+                assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Success)
+                awaitComplete()
+            }
+
+            verify(refundStore).createItemsRefund(
+                site = eq(site),
+                orderId = eq(order.id),
+                amount = eq(refundAmount),
+                reason = eq("Customer request"),
+                restockItems = eq(true),
+                autoRefund = eq(false),
+                items = eq(refundItems)
+            )
+        }
+
+    @Test
+    fun `given payment gateway load fails, when submitted, then failure is emitted`() = runTest {
+        whenever(loadPaymentGateway.invoke(any())).thenReturn(Result.failure(IllegalStateException("missing")))
+
+        processor.submit(request).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+            assertThat(awaitItem()).isEqualTo(
+                WooPosRefundSubmissionState.Failure("Unable to process refund.")
+            )
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `given selected site lookup fails, when submitted, then generic failure is emitted`() = runTest {
+        whenever(selectedSite.get()).thenThrow(IllegalStateException("missing site"))
+
+        processor.submit(request).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Failure("Something went wrong"))
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `given submission is cancelled, when submitted, then cancellation is rethrown`() = runTest {
+        val cancellation = CancellationException("cancelled")
+        whenever(selectedSite.get()).thenThrow(cancellation)
+
+        processor.submit(request).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+            assertThat(awaitError()).isSameAs(cancellation)
+        }
+    }
+
+    @Test
+    fun `given backend refund fails, when submitted, then failure message is emitted`() = runTest {
+        whenever(
+            refundStore.createItemsRefund(
+                site = any(),
+                orderId = any(),
+                amount = any(),
+                reason = any(),
+                restockItems = any(),
+                autoRefund = any(),
+                items = any()
+            )
+        ).thenReturn(
+            WooResult(
+                WooError(
+                    type = WooErrorType.GENERIC_ERROR,
+                    original = GenericErrorType.UNKNOWN,
+                    message = "Refund failed"
+                )
+            )
+        )
+
+        processor.submit(request).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Failure("Refund failed"))
+            awaitComplete()
+        }
+    }
+}

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -102,7 +102,7 @@ class WooPosRefundSubmissionProcessorTest {
             )
         ).thenReturn(WooResult(refundModel))
 
-        processor = WooPosRefundSubmissionProcessorImpl(
+        processor = WooPosRefundSubmissionProcessor(
             refundStore = refundStore,
             selectedSite = selectedSite,
             loadPaymentGateway = loadPaymentGateway,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -8,7 +8,6 @@ import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
 import com.woocommerce.android.ui.woopos.orders.WooPosGetPaymentMethod
-import com.woocommerce.android.ui.woopos.orders.WooPosLoadPaymentGateway
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsEvent
@@ -16,6 +15,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -30,14 +30,9 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
-import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.model.settings.CurrencyPosition
 import org.wordpress.android.fluxc.model.settings.Settings
-import org.wordpress.android.fluxc.network.BaseRequest.GenericErrorType
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooError
-import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooErrorType
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
-import org.wordpress.android.fluxc.store.WCRefundStore
 import org.wordpress.android.fluxc.store.WooCommerceStore
 import java.math.BigDecimal
 import java.util.Date
@@ -57,12 +52,11 @@ class WooPosRefundViewModelTest {
     private val calculateRefundTax = WooPosCalculateRefundTax()
     private val resourceProvider: ResourceProvider = mock()
     private val currencyFormatter: CurrencyFormatter = mock()
-    private val refundStore: WCRefundStore = mock()
     private val selectedSite: SelectedSite = mock()
     private val wooCommerceStore: WooCommerceStore = mock()
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
-    private val loadPaymentGateway: WooPosLoadPaymentGateway = mock()
     private val loadPaymentMethod: WooPosGetPaymentMethod = mock()
+    private val refundSubmissionProcessor: WooPosRefundSubmissionProcessor = mock()
 
     private val testOrderId = 123L
     private val testOrder = OrderTestUtils.generateTestOrder(orderId = testOrderId).copy(
@@ -105,17 +99,6 @@ class WooPosRefundViewModelTest {
 
     private val testSite = SiteModel().apply { id = 1 }
 
-    private val testRefundModel = WCRefundModel(
-        id = 1L,
-        dateCreated = Date(),
-        amount = BigDecimal("22.00"),
-        reason = "",
-        automaticGatewayRefund = false,
-        items = emptyList(),
-        shippingLineItems = emptyList(),
-        feeLineItems = emptyList()
-    )
-
     @Before
     fun setUp() = runTest {
         val testSettings = Settings(
@@ -140,16 +123,13 @@ class WooPosRefundViewModelTest {
         whenever(wooCommerceStore.fetchSiteGeneralSettings(testSite)).thenReturn(WooResult(testSettings))
         whenever(wooCommerceStore.fetchSiteSettingsTaxRoundAtSubtotal(testSite)).thenReturn(WooResult(false))
 
-        val defaultGateway = com.woocommerce.android.model.PaymentGateway(
-            title = "Default",
-            description = "",
-            isEnabled = true,
-            methodTitle = "Default",
-            methodDescription = "",
-            supportsRefunds = false
-        )
-        whenever(loadPaymentGateway.invoke(any())).thenReturn(Result.success(defaultGateway))
         whenever(loadPaymentMethod.invoke(any())).thenReturn(Result.success("Manual refund"))
+        whenever(refundSubmissionProcessor.submit(any())).thenReturn(
+            flowOf(
+                WooPosRefundSubmissionState.Processing,
+                WooPosRefundSubmissionState.Success
+            )
+        )
     }
 
     private fun createViewModel(): WooPosRefundViewModel {
@@ -163,11 +143,10 @@ class WooPosRefundViewModelTest {
             calculateRefundTax = calculateRefundTax,
             resourceProvider = resourceProvider,
             currencyFormatter = currencyFormatter,
-            refundStore = refundStore,
             selectedSite = selectedSite,
             wooCommerceStore = wooCommerceStore,
-            loadPaymentGateway = loadPaymentGateway,
             getPaymentMethod = loadPaymentMethod,
+            refundSubmissionProcessor = refundSubmissionProcessor,
             analyticsTracker = analyticsTracker
         )
     }
@@ -761,18 +740,6 @@ class WooPosRefundViewModelTest {
             whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
             whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
             whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
-            whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(WooResult(testRefundModel))
-
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
@@ -791,7 +758,7 @@ class WooPosRefundViewModelTest {
         }
 
     @Test
-    fun `given valid refund request without reason, when refund confirmed, then refund store called with empty reason`() =
+    fun `given valid refund request without reason, when refund confirmed, then processor receives empty reason`() =
         runTest {
             // GIVEN
             val refundableItems = listOf(testRefundableItem)
@@ -808,18 +775,6 @@ class WooPosRefundViewModelTest {
             whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
             whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
             whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
-            whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(WooResult(testRefundModel))
-
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
@@ -829,19 +784,18 @@ class WooPosRefundViewModelTest {
             advanceUntilIdle()
 
             // THEN
-            verify(refundStore).createItemsRefund(
-                site = eq(testSite),
-                orderId = eq(testOrderId),
-                amount = argThat { this.compareTo(BigDecimal("22.00")) == 0 },
-                reason = eq(""),
-                restockItems = eq(true),
-                autoRefund = eq(false),
-                items = eq(groupedItems)
+            verify(refundSubmissionProcessor).submit(
+                argThat {
+                    orderId == testOrderId &&
+                        refundAmount.compareTo(BigDecimal("22.00")) == 0 &&
+                        refundReason == "" &&
+                        refundItems == groupedItems
+                }
             )
         }
 
     @Test
-    fun `given valid refund request with reason, when refund confirmed, then refund store called with provided reason`() =
+    fun `given valid refund request with reason, when refund confirmed, then processor receives provided reason`() =
         runTest {
             // GIVEN
             val testReason = "Customer bought wrong item"
@@ -859,18 +813,6 @@ class WooPosRefundViewModelTest {
             whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
             whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
             whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
-            whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(WooResult(testRefundModel))
-
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
@@ -881,14 +823,13 @@ class WooPosRefundViewModelTest {
             advanceUntilIdle()
 
             // THEN
-            verify(refundStore).createItemsRefund(
-                site = eq(testSite),
-                orderId = eq(testOrderId),
-                amount = argThat { this.compareTo(BigDecimal("22.00")) == 0 },
-                reason = eq(testReason),
-                restockItems = eq(true),
-                autoRefund = eq(false),
-                items = eq(groupedItems)
+            verify(refundSubmissionProcessor).submit(
+                argThat {
+                    orderId == testOrderId &&
+                        refundAmount.compareTo(BigDecimal("22.00")) == 0 &&
+                        refundReason == testReason &&
+                        refundItems == groupedItems
+                }
             )
         }
 
@@ -910,18 +851,6 @@ class WooPosRefundViewModelTest {
             whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
             whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
             whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
-            whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(WooResult(testRefundModel))
-
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
@@ -932,15 +861,7 @@ class WooPosRefundViewModelTest {
             advanceUntilIdle()
 
             // THEN - verify only called once despite two events
-            verify(refundStore).createItemsRefund(
-                site = any(),
-                orderId = any(),
-                amount = any(),
-                reason = any(),
-                restockItems = any(),
-                autoRefund = any(),
-                items = any()
-            )
+            verify(refundSubmissionProcessor).submit(any())
         }
 
     @Test
@@ -1492,18 +1413,6 @@ class WooPosRefundViewModelTest {
             whenever(
                 groupRefundItems.invoke(eq(selectedItems), eq(orderWithThreeItems), any())
             ).thenReturn(groupedItems)
-            whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(WooResult(testRefundModel))
-
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
@@ -1519,14 +1428,13 @@ class WooPosRefundViewModelTest {
 
             // THEN
             verify(groupRefundItems).invoke(eq(selectedItems), eq(orderWithThreeItems), any())
-            verify(refundStore).createItemsRefund(
-                site = eq(testSite),
-                orderId = eq(testOrderId),
-                amount = argThat { this.compareTo(BigDecimal("27.50")) == 0 },
-                reason = eq(""),
-                restockItems = eq(true),
-                autoRefund = eq(false),
-                items = eq(groupedItems)
+            verify(refundSubmissionProcessor).submit(
+                argThat {
+                    orderId == testOrderId &&
+                        refundAmount.compareTo(BigDecimal("27.50")) == 0 &&
+                        refundReason == "" &&
+                        refundItems == groupedItems
+                }
             )
         }
 
@@ -1603,18 +1511,6 @@ class WooPosRefundViewModelTest {
             whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
             whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
             whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
-            whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(WooResult(testRefundModel))
-
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
@@ -1676,18 +1572,6 @@ class WooPosRefundViewModelTest {
             whenever(retrieveOrderRefunds.invoke(eq(orderWithTwoItems), any())).thenReturn(Result.success(emptyList()))
             whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
             whenever(groupRefundItems.invoke(eq(selectedItems), eq(orderWithTwoItems), any())).thenReturn(groupedItems)
-            whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(WooResult(testRefundModel))
-
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
@@ -1722,18 +1606,6 @@ class WooPosRefundViewModelTest {
             whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
             whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
             whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
-            whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(WooResult(testRefundModel))
-
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
@@ -1761,18 +1633,6 @@ class WooPosRefundViewModelTest {
             whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
             whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
             whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
-            whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(WooResult(testRefundModel))
-
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()
@@ -1800,23 +1660,10 @@ class WooPosRefundViewModelTest {
             whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
             whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
             whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
-            whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(
-                WooResult(
-                    error = WooError(
-                        type = WooErrorType.GENERIC_ERROR,
-                        original = GenericErrorType.UNKNOWN,
-                        message = "Refund failed"
-                    )
+            whenever(refundSubmissionProcessor.submit(any())).thenReturn(
+                flowOf(
+                    WooPosRefundSubmissionState.Processing,
+                    WooPosRefundSubmissionState.Failure("Refund failed")
                 )
             )
 
@@ -1924,17 +1771,6 @@ class WooPosRefundViewModelTest {
             whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
             whenever(groupRefundItems.invoke(eq(refundableItems), eq(orderWithEmail), any())).thenReturn(groupedItems)
             whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(WooResult(testRefundModel))
-            whenever(
                 resourceProvider.getString(R.string.woopos_receipt_sent_to_customer, "customer@example.com")
             ).thenReturn("A receipt has been sent to customer@example.com.")
 
@@ -1969,18 +1805,6 @@ class WooPosRefundViewModelTest {
             whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
             whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
             whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
-            whenever(
-                refundStore.createItemsRefund(
-                    site = any(),
-                    orderId = any(),
-                    amount = any(),
-                    reason = any(),
-                    restockItems = any(),
-                    autoRefund = any(),
-                    items = any()
-                )
-            ).thenReturn(WooResult(testRefundModel))
-
             viewModel = createViewModel()
             viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
             advanceUntilIdle()

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosIsCountryAllowedTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/tab/WooPosIsCountryAllowedTest.kt
@@ -41,6 +41,14 @@ class WooPosIsCountryAllowedTest {
     }
 
     @Test
+    fun `given flag disabled and Canadian country, when invoked, then returns true`() {
+        whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
+        whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn("CA")
+
+        assertThat(sut()).isTrue
+    }
+
+    @Test
     fun `given flag disabled and lowercase country code, when invoked, then matches case-insensitively`() {
         whenever(featureFlagRepository.isEnabled(FeatureFlag.WOO_POS_ALL_COUNTRIES)).thenReturn(false)
         whenever(wooCommerceStore.getStoreCountryCode(site)).thenReturn("gb")

--- a/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfig.kt
+++ b/libs/cardreader/src/main/java/com/woocommerce/android/cardreader/config/CardReaderConfig.kt
@@ -20,15 +20,7 @@ sealed class CardReaderConfigForSupportedCountry(
     val minimumAllowedChargeAmount: BigDecimal,
     val maximumTTPAllowedChargeAmountWithoutPin: BigDecimal?,
 ) : CardReaderConfig() {
-    // Remove the CA exclusion once Interac is supported in POS. CA is a fully-supported
-    // IPP country (external reader + TTP) for the rest of the app, but POS card payments
-    // are blocked here until Interac lands.
-    override val isPosCardPaymentEnabled: Boolean
-        get() = countryCode != POS_DISABLED_COUNTRY_CA
-
-    private companion object {
-        const val POS_DISABLED_COUNTRY_CA = "CA"
-    }
+    override val isPosCardPaymentEnabled: Boolean get() = true
 }
 
 fun CardReaderConfigForSupportedCountry.isExtensionSupported(type: SupportedExtensionType) =

--- a/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigIsPosCardPaymentEnabledTest.kt
+++ b/libs/cardreader/src/test/java/com/woocommerce/android/cardreader/internal/config/CardReaderConfigIsPosCardPaymentEnabledTest.kt
@@ -1,8 +1,6 @@
 package com.woocommerce.android.cardreader.internal.config
 
 import com.woocommerce.android.cardreader.config.CardReaderConfigFactory
-import com.woocommerce.android.cardreader.config.CardReaderConfigForCanada
-import com.woocommerce.android.cardreader.config.CardReaderConfigForSupportedCountry
 import com.woocommerce.android.cardreader.config.CardReaderConfigForUnsupportedCountry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -25,7 +23,7 @@ class CardReaderConfigIsPosCardPaymentEnabledTest {
             @JvmStatic
             @Parameterized.Parameters(name = "country: {0}")
             fun data(): List<String> = listOf(
-                "US", "PR", "GB",
+                "US", "PR", "GB", "CA",
                 "FR", "DE", "IE", "NL", "AT", "BE", "FI", "IT", "LU", "PT", "ES",
                 "SG", "NZ",
                 "AU",
@@ -48,18 +46,6 @@ class CardReaderConfigIsPosCardPaymentEnabledTest {
             @JvmStatic
             @Parameterized.Parameters(name = "country: {0}")
             fun data(): List<String> = listOf("JP", "MX", "IN", "BR", "invalid")
-        }
-    }
-
-    class CanadaOverrideTest {
-
-        @Test
-        fun `given country CA, when isPosCardPaymentEnabled is read, then it returns false even though IPP is supported`() {
-            val config = CardReaderConfigFactory().getCardReaderConfigFor("CA")
-
-            assertThat(config).isInstanceOf(CardReaderConfigForCanada::class.java)
-            assertThat(config).isInstanceOf(CardReaderConfigForSupportedCountry::class.java)
-            assertThat(config.isPosCardPaymentEnabled).isFalse
         }
     }
 }


### PR DESCRIPTION
Part of: RSM-645
Part of: RSM-644

### Description
- Enable Canada/CAD POS eligibility and cover Canada in the POS tab and launchability checks.
- Keep Interac-present payment support flowing through the Canada card-reader config.
- Extract POS refund submission behind a processor while preserving the existing backend refund path.

### Stack
Base: trunk
Next branch: issue/android-pos-interac-refunds-02-reader-routing

### Test Steps
- Unit tests pass.
- On a Canada/CAD WooPayments store, verify POS can be launched and card payments can still start from POS.
- For end-to-end payment/refund validation, test from the tip of the stack: #15996.

### Images/gif
N/A. This PR is foundation/refactor work with no standalone UI changes.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
