### PR TITLE
Route POS Interac refunds through card reader

### DIFF
--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooPosModule.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/di/WooPosModule.kt
@@ -2,8 +2,6 @@ package com.woocommerce.android.di
 
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsCache
 import com.woocommerce.android.ui.woopos.common.data.WooPosProductsInMemoryCache
-import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundSubmissionProcessor
-import com.woocommerce.android.ui.woopos.orders.details.refund.WooPosRefundSubmissionProcessorImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -16,9 +14,4 @@ abstract class WooPosModule {
     @Binds
     @Singleton
     abstract fun provideWooPosProductsCache(implementation: WooPosProductsInMemoryCache): WooPosProductsCache
-
-    @Binds
-    abstract fun provideWooPosRefundSubmissionProcessor(
-        implementation: WooPosRefundSubmissionProcessorImpl
-    ): WooPosRefundSubmissionProcessor
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
@@ -87,9 +87,7 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
     fun createRefund(
         orderId: Long,
         refundAmount: BigDecimal,
-        cardReaderType: CardReaderType = CardReaderType.EXTERNAL,
         isTTPPaymentInProgress: KMutableProperty0<Boolean>,
-        allowCancelledStatus: Boolean = false,
     ): CardReaderPaymentController = CardReaderPaymentController(
         cardReaderManager = cardReaderManager,
         orderRepository = orderRepository,
@@ -114,8 +112,8 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
             orderId = orderId,
             refundAmount = refundAmount
         ),
-        cardReaderType = cardReaderType,
+        cardReaderType = CardReaderType.EXTERNAL,
         isTTPPaymentInProgress = isTTPPaymentInProgress,
-        allowCancelledStatus = allowCancelledStatus,
+        allowCancelledStatus = false,
     )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/home/totals/WooPosCardReaderPaymentControllerFactory.kt
@@ -24,6 +24,7 @@ import com.woocommerce.android.ui.payments.tracking.PaymentsFlowTracker
 import com.woocommerce.android.util.CoroutineDispatchers
 import com.woocommerce.android.util.CurrencyFormatter
 import org.wordpress.android.fluxc.store.WooCommerceStore
+import java.math.BigDecimal
 import javax.inject.Inject
 import kotlin.reflect.KMutableProperty0
 
@@ -77,6 +78,41 @@ class WooPosCardReaderPaymentControllerFactory @Inject constructor(
         paymentOrRefund = PaymentOrRefund.Payment(
             orderId = orderId,
             paymentType = paymentType
+        ),
+        cardReaderType = cardReaderType,
+        isTTPPaymentInProgress = isTTPPaymentInProgress,
+        allowCancelledStatus = allowCancelledStatus,
+    )
+
+    fun createRefund(
+        orderId: Long,
+        refundAmount: BigDecimal,
+        cardReaderType: CardReaderType = CardReaderType.EXTERNAL,
+        isTTPPaymentInProgress: KMutableProperty0<Boolean>,
+        allowCancelledStatus: Boolean = false,
+    ): CardReaderPaymentController = CardReaderPaymentController(
+        cardReaderManager = cardReaderManager,
+        orderRepository = orderRepository,
+        selectedSite = selectedSite,
+        appPrefs = appPrefs,
+        paymentCollectibilityChecker = paymentCollectibilityChecker,
+        interacRefundableChecker = interacRefundableChecker,
+        tracker = tracker,
+        trackCancelledFlow = trackCancelledFlow,
+        currencyFormatter = currencyFormatter,
+        errorMapper = errorMapper,
+        interacRefundErrorMapper = interacRefundErrorMapper,
+        wooStore = wooStore,
+        dispatchers = dispatchers,
+        cardReaderTrackingInfoKeeper = cardReaderTrackingInfoKeeper,
+        paymentStateProvider = paymentStateProvider,
+        cardReaderPaymentOrderHelper = cardReaderPaymentOrderHelper,
+        paymentReceiptHelper = paymentReceiptHelper,
+        cardReaderOnboardingChecker = cardReaderOnboardingChecker,
+        paymentReceiptShare = paymentReceiptShare,
+        paymentOrRefund = PaymentOrRefund.Refund(
+            orderId = orderId,
+            refundAmount = refundAmount
         ),
         cardReaderType = cardReaderType,
         isTTPPaymentInProgress = isTTPPaymentInProgress,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -270,6 +270,7 @@ private fun RefundScreenHeader(
 }
 
 @Composable
+@Suppress("CyclomaticComplexMethod")
 private fun RefundScreenButtons(
     state: WooPosRefundState,
     onDismiss: () -> Unit,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -370,20 +370,22 @@ private fun RefundScreenButtons(
                 }
             }
             is WooPosRefundState.Error -> {
-                WooPosButton(
-                    text = stringResource(R.string.retry),
-                    onClick = {
-                        onEvent(
-                            when (state.errorType) {
-                                WooPosRefundState.Error.ErrorType.Loading ->
-                                    WooPosRefundUIEvent.RetryLoadRefundableItems
-                                WooPosRefundState.Error.ErrorType.Processing ->
-                                    WooPosRefundUIEvent.RetryCreateRefund
-                            }
-                        )
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
+                if (state.canRetry) {
+                    WooPosButton(
+                        text = stringResource(R.string.retry),
+                        onClick = {
+                            onEvent(
+                                when (state.errorType) {
+                                    WooPosRefundState.Error.ErrorType.Loading ->
+                                        WooPosRefundUIEvent.RetryLoadRefundableItems
+                                    WooPosRefundState.Error.ErrorType.Processing ->
+                                        WooPosRefundUIEvent.RetryCreateRefund
+                                }
+                            )
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
                 WooPosOutlinedButton(
                     text = stringResource(R.string.cancel),
                     onClick = {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -270,7 +270,6 @@ private fun RefundScreenHeader(
 }
 
 @Composable
-@Suppress("CyclomaticComplexMethod")
 private fun RefundScreenButtons(
     state: WooPosRefundState,
     onDismiss: () -> Unit,
@@ -288,113 +287,17 @@ private fun RefundScreenButtons(
                 enabled = false,
                 onClick = {},
             )
-            is WooPosRefundState.Content -> when (state.step) {
-                WooPosRefundState.Content.RefundStep.SelectItems -> ContinueToReviewButton(
-                    enabled = state.selectedItemIds.isNotEmpty(),
-                    onClick = { onEvent(WooPosRefundUIEvent.ContinueToReviewClicked) },
-                )
-                WooPosRefundState.Content.RefundStep.ReviewRefund -> {
-                    WooPosButton(
-                        text = stringResource(R.string.continue_button),
-                        onClick = {
-                            onEvent(WooPosRefundUIEvent.ContinueToConfirmRefundClicked)
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    if (!disablePartialRefund) {
-                        WooPosOutlinedButton(
-                            text = stringResource(R.string.woopos_orders_edit_refund),
-                            onClick = {
-                                onEvent(WooPosRefundUIEvent.BackToSelectItemsClicked)
-                            },
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-                }
-                WooPosRefundState.Content.RefundStep.ConfirmRefund -> {
-                    WooPosButton(
-                        text = stringResource(R.string.woopos_orders_yes_proceed),
-                        onClick = { onEvent(WooPosRefundUIEvent.OnRefundConfirmed) },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    WooPosOutlinedButton(
-                        text = stringResource(R.string.back),
-                        onClick = {
-                            onEvent(WooPosRefundUIEvent.BackToReviewClicked)
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-                WooPosRefundState.Content.RefundStep.Processing -> {
-                    WooPosButton(
-                        text = stringResource(R.string.woopos_orders_yes_proceed),
-                        onClick = {},
-                        state = WooPosButtonState.LOADING,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    WooPosOutlinedButton(
-                        text = stringResource(R.string.back),
-                        onClick = {},
-                        state = WooPosButtonState.DISABLED,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-                WooPosRefundState.Content.RefundStep.PreparingReader,
-                is WooPosRefundState.Content.RefundStep.ReadyForRefund -> {
-                    WooPosOutlinedButton(
-                        text = stringResource(R.string.cancel),
-                        onClick = onDismiss,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-                WooPosRefundState.Content.RefundStep.ReaderDisconnected -> {
-                    WooPosButton(
-                        text = stringResource(R.string.retry),
-                        onClick = { onEvent(WooPosRefundUIEvent.ConnectReaderClicked) },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    WooPosOutlinedButton(
-                        text = stringResource(R.string.cancel),
-                        onClick = onDismiss,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-                WooPosRefundState.Content.RefundStep.ProcessingRefund,
-                WooPosRefundState.Content.RefundStep.NotifyingStore -> {
-                    WooPosButton(
-                        text = stringResource(R.string.woopos_orders_yes_proceed),
-                        onClick = {},
-                        state = WooPosButtonState.LOADING,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-            }
-            is WooPosRefundState.Error -> {
-                if (state.canRetry) {
-                    WooPosButton(
-                        text = stringResource(R.string.retry),
-                        onClick = {
-                            onEvent(
-                                when (state.errorType) {
-                                    WooPosRefundState.Error.ErrorType.Loading ->
-                                        WooPosRefundUIEvent.RetryLoadRefundableItems
-                                    WooPosRefundState.Error.ErrorType.Processing ->
-                                        WooPosRefundUIEvent.RetryCreateRefund
-                                }
-                            )
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-                WooPosOutlinedButton(
-                    text = stringResource(R.string.cancel),
-                    onClick = {
-                        onEvent(WooPosRefundUIEvent.CancelRefund)
-                        onDismiss()
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
+            is WooPosRefundState.Content -> RefundContentStepButtons(
+                state = state,
+                onDismiss = onDismiss,
+                onEvent = onEvent,
+                disablePartialRefund = disablePartialRefund,
+            )
+            is WooPosRefundState.Error -> RefundErrorButtons(
+                state = state,
+                onDismiss = onDismiss,
+                onEvent = onEvent,
+            )
             is WooPosRefundState.NoRefundableItems -> {
                 WooPosButton(
                     text = stringResource(R.string.close),
@@ -402,27 +305,160 @@ private fun RefundScreenButtons(
                     modifier = Modifier.fillMaxWidth()
                 )
             }
-            is WooPosRefundState.RefundSuccess -> {
-                WooPosButton(
-                    text = stringResource(R.string.done),
-                    onClick = { onDismiss() },
-                    modifier = Modifier.fillMaxWidth()
-                )
+            is WooPosRefundState.RefundSuccess -> RefundSuccessButtons(
+                state = state,
+                onDismiss = onDismiss,
+                onNavigationEvent = onNavigationEvent,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RefundContentStepButtons(
+    state: WooPosRefundState.Content,
+    onDismiss: () -> Unit,
+    onEvent: (WooPosRefundUIEvent) -> Unit,
+    disablePartialRefund: Boolean,
+) {
+    when (state.step) {
+        WooPosRefundState.Content.RefundStep.SelectItems -> ContinueToReviewButton(
+            enabled = state.selectedItemIds.isNotEmpty(),
+            onClick = { onEvent(WooPosRefundUIEvent.ContinueToReviewClicked) },
+        )
+        WooPosRefundState.Content.RefundStep.ReviewRefund -> {
+            WooPosButton(
+                text = stringResource(R.string.continue_button),
+                onClick = {
+                    onEvent(WooPosRefundUIEvent.ContinueToConfirmRefundClicked)
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+            if (!disablePartialRefund) {
                 WooPosOutlinedButton(
-                    text = stringResource(R.string.woopos_receipt_button),
+                    text = stringResource(R.string.woopos_orders_edit_refund),
                     onClick = {
-                        onNavigationEvent(
-                            WooPosNavigationEvent.OpenEmailReceipt(
-                                orderId = state.orderId,
-                                receiptAlreadySent = state.receiptSentMessage != null,
-                            )
-                        )
+                        onEvent(WooPosRefundUIEvent.BackToSelectItemsClicked)
                     },
                     modifier = Modifier.fillMaxWidth()
                 )
             }
         }
+        WooPosRefundState.Content.RefundStep.ConfirmRefund -> {
+            WooPosButton(
+                text = stringResource(R.string.woopos_orders_yes_proceed),
+                onClick = { onEvent(WooPosRefundUIEvent.OnRefundConfirmed) },
+                modifier = Modifier.fillMaxWidth()
+            )
+            WooPosOutlinedButton(
+                text = stringResource(R.string.back),
+                onClick = {
+                    onEvent(WooPosRefundUIEvent.BackToReviewClicked)
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        WooPosRefundState.Content.RefundStep.Processing -> {
+            WooPosButton(
+                text = stringResource(R.string.woopos_orders_yes_proceed),
+                onClick = {},
+                state = WooPosButtonState.LOADING,
+                modifier = Modifier.fillMaxWidth()
+            )
+            WooPosOutlinedButton(
+                text = stringResource(R.string.back),
+                onClick = {},
+                state = WooPosButtonState.DISABLED,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        WooPosRefundState.Content.RefundStep.PreparingReader,
+        is WooPosRefundState.Content.RefundStep.ReadyForRefund -> {
+            WooPosOutlinedButton(
+                text = stringResource(R.string.cancel),
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        WooPosRefundState.Content.RefundStep.ReaderDisconnected -> {
+            WooPosButton(
+                text = stringResource(R.string.retry),
+                onClick = { onEvent(WooPosRefundUIEvent.ConnectReaderClicked) },
+                modifier = Modifier.fillMaxWidth()
+            )
+            WooPosOutlinedButton(
+                text = stringResource(R.string.cancel),
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        WooPosRefundState.Content.RefundStep.ProcessingRefund,
+        WooPosRefundState.Content.RefundStep.NotifyingStore -> {
+            WooPosButton(
+                text = stringResource(R.string.woopos_orders_yes_proceed),
+                onClick = {},
+                state = WooPosButtonState.LOADING,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
     }
+}
+
+@Composable
+private fun RefundErrorButtons(
+    state: WooPosRefundState.Error,
+    onDismiss: () -> Unit,
+    onEvent: (WooPosRefundUIEvent) -> Unit,
+) {
+    if (state.canRetry) {
+        WooPosButton(
+            text = stringResource(R.string.retry),
+            onClick = {
+                onEvent(
+                    when (state.errorType) {
+                        WooPosRefundState.Error.ErrorType.Loading ->
+                            WooPosRefundUIEvent.RetryLoadRefundableItems
+                        WooPosRefundState.Error.ErrorType.Processing ->
+                            WooPosRefundUIEvent.RetryCreateRefund
+                    }
+                )
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+    WooPosOutlinedButton(
+        text = stringResource(R.string.cancel),
+        onClick = {
+            onEvent(WooPosRefundUIEvent.CancelRefund)
+            onDismiss()
+        },
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@Composable
+private fun RefundSuccessButtons(
+    state: WooPosRefundState.RefundSuccess,
+    onDismiss: () -> Unit,
+    onNavigationEvent: (WooPosNavigationEvent) -> Unit,
+) {
+    WooPosButton(
+        text = stringResource(R.string.done),
+        onClick = { onDismiss() },
+        modifier = Modifier.fillMaxWidth()
+    )
+    WooPosOutlinedButton(
+        text = stringResource(R.string.woopos_receipt_button),
+        onClick = {
+            onNavigationEvent(
+                WooPosNavigationEvent.OpenEmailReceipt(
+                    orderId = state.orderId,
+                    receiptAlreadySent = state.receiptSentMessage != null,
+                )
+            )
+        },
+        modifier = Modifier.fillMaxWidth()
+    )
 }
 
 @Composable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -135,7 +135,7 @@ fun WooPosIssueRefundScreen(
 
     val currentState = state
     val isProcessing = currentState is WooPosRefundState.Content &&
-        currentState.step == WooPosRefundState.Content.RefundStep.Processing
+        currentState.step.isNonCancelable()
 
     Column(
         modifier = modifier
@@ -210,7 +210,12 @@ private fun resolveToolbarTitle(state: WooPosRefundState): String {
             WooPosRefundState.Content.RefundStep.ReviewRefund ->
                 stringResource(R.string.woopos_orders_review_refund)
             WooPosRefundState.Content.RefundStep.ConfirmRefund,
-            WooPosRefundState.Content.RefundStep.Processing ->
+            WooPosRefundState.Content.RefundStep.Processing,
+            WooPosRefundState.Content.RefundStep.PreparingReader,
+            WooPosRefundState.Content.RefundStep.ReaderDisconnected,
+            is WooPosRefundState.Content.RefundStep.ReadyForRefund,
+            WooPosRefundState.Content.RefundStep.ProcessingRefund,
+            WooPosRefundState.Content.RefundStep.NotifyingStore ->
                 stringResource(R.string.woopos_orders_confirm_refund_title, state.formattedTotal)
         }
         is WooPosRefundState.Error,
@@ -333,6 +338,35 @@ private fun RefundScreenButtons(
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
+                WooPosRefundState.Content.RefundStep.PreparingReader,
+                is WooPosRefundState.Content.RefundStep.ReadyForRefund -> {
+                    WooPosOutlinedButton(
+                        text = stringResource(R.string.cancel),
+                        onClick = onDismiss,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+                WooPosRefundState.Content.RefundStep.ReaderDisconnected -> {
+                    WooPosButton(
+                        text = stringResource(R.string.retry),
+                        onClick = { onEvent(WooPosRefundUIEvent.ConnectReaderClicked) },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    WooPosOutlinedButton(
+                        text = stringResource(R.string.cancel),
+                        onClick = onDismiss,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+                WooPosRefundState.Content.RefundStep.ProcessingRefund,
+                WooPosRefundState.Content.RefundStep.NotifyingStore -> {
+                    WooPosButton(
+                        text = stringResource(R.string.woopos_orders_yes_proceed),
+                        onClick = {},
+                        state = WooPosButtonState.LOADING,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
             }
             is WooPosRefundState.Error -> {
                 WooPosButton(
@@ -417,6 +451,11 @@ private fun ContentStateHandler(
             when (step) {
                 WooPosRefundState.Content.RefundStep.ConfirmRefund,
                 WooPosRefundState.Content.RefundStep.Processing -> "confirm"
+                WooPosRefundState.Content.RefundStep.PreparingReader -> "reader_preparing"
+                WooPosRefundState.Content.RefundStep.ReaderDisconnected -> "reader_disconnected"
+                is WooPosRefundState.Content.RefundStep.ReadyForRefund -> "reader_ready"
+                WooPosRefundState.Content.RefundStep.ProcessingRefund -> "reader_processing"
+                WooPosRefundState.Content.RefundStep.NotifyingStore -> "notifying_store"
                 else -> step
             }
         },
@@ -448,6 +487,14 @@ private fun ContentStateHandler(
 
             WooPosRefundState.Content.RefundStep.ConfirmRefund,
             WooPosRefundState.Content.RefundStep.Processing -> {
+                ConfirmRefundContent(state = state)
+            }
+
+            WooPosRefundState.Content.RefundStep.PreparingReader,
+            WooPosRefundState.Content.RefundStep.ReaderDisconnected,
+            is WooPosRefundState.Content.RefundStep.ReadyForRefund,
+            WooPosRefundState.Content.RefundStep.ProcessingRefund,
+            WooPosRefundState.Content.RefundStep.NotifyingStore -> {
                 ConfirmRefundContent(state = state)
             }
         }
@@ -959,6 +1006,20 @@ private fun ConfirmRefundContent(
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
         )
+    }
+}
+
+private fun WooPosRefundState.Content.RefundStep.isNonCancelable(): Boolean {
+    return when (this) {
+        WooPosRefundState.Content.RefundStep.Processing,
+        WooPosRefundState.Content.RefundStep.ProcessingRefund,
+        WooPosRefundState.Content.RefundStep.NotifyingStore -> true
+        WooPosRefundState.Content.RefundStep.SelectItems,
+        WooPosRefundState.Content.RefundStep.ReviewRefund,
+        WooPosRefundState.Content.RefundStep.ConfirmRefund,
+        WooPosRefundState.Content.RefundStep.PreparingReader,
+        WooPosRefundState.Content.RefundStep.ReaderDisconnected,
+        is WooPosRefundState.Content.RefundStep.ReadyForRefund -> false
     }
 }
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosIssueRefundScreen.kt
@@ -1010,20 +1010,6 @@ private fun ConfirmRefundContent(
     }
 }
 
-private fun WooPosRefundState.Content.RefundStep.isNonCancelable(): Boolean {
-    return when (this) {
-        WooPosRefundState.Content.RefundStep.Processing,
-        WooPosRefundState.Content.RefundStep.ProcessingRefund,
-        WooPosRefundState.Content.RefundStep.NotifyingStore -> true
-        WooPosRefundState.Content.RefundStep.SelectItems,
-        WooPosRefundState.Content.RefundStep.ReviewRefund,
-        WooPosRefundState.Content.RefundStep.ConfirmRefund,
-        WooPosRefundState.Content.RefundStep.PreparingReader,
-        WooPosRefundState.Content.RefundStep.ReaderDisconnected,
-        is WooPosRefundState.Content.RefundStep.ReadyForRefund -> false
-    }
-}
-
 @WooPosPreview
 @Composable
 fun SelectItemsContentPreview() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
@@ -32,6 +32,20 @@ sealed class WooPosRefundState {
 
         @Immutable
         sealed class RefundStep {
+            fun isNonCancelable(): Boolean {
+                return when (this) {
+                    Processing,
+                    ProcessingRefund,
+                    NotifyingStore -> true
+                    SelectItems,
+                    ReviewRefund,
+                    ConfirmRefund,
+                    PreparingReader,
+                    ReaderDisconnected,
+                    is ReadyForRefund -> false
+                }
+            }
+
             @Immutable
             data object SelectItems : RefundStep()
 

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundState.kt
@@ -1,5 +1,6 @@
 package com.woocommerce.android.ui.woopos.orders.details.refund
 
+import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
 import java.math.BigDecimal
 
@@ -42,13 +43,29 @@ sealed class WooPosRefundState {
 
             @Immutable
             data object Processing : RefundStep()
+
+            @Immutable
+            data object PreparingReader : RefundStep()
+
+            @Immutable
+            data object ReaderDisconnected : RefundStep()
+
+            @Immutable
+            data class ReadyForRefund(@StringRes val cardReaderHint: Int? = null) : RefundStep()
+
+            @Immutable
+            data object ProcessingRefund : RefundStep()
+
+            @Immutable
+            data object NotifyingStore : RefundStep()
         }
     }
 
     @Immutable
     data class Error(
         val message: String,
-        val errorType: ErrorType
+        val errorType: ErrorType,
+        val canRetry: Boolean = true,
     ) : WooPosRefundState() {
 
         @Immutable

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
@@ -1,9 +1,6 @@
 package com.woocommerce.android.ui.woopos.orders.details.refund
 
 import com.woocommerce.android.R
-import com.woocommerce.android.extensions.WOOCOMMERCE_BOOKINGS_PAYMENT_TYPE
-import com.woocommerce.android.extensions.WOOCOMMERCE_PAYMENTS_PAYMENT_TYPE
-import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
@@ -116,14 +113,6 @@ class WooPosRefundSubmissionProcessor @Inject constructor(
         request: WooPosRefundSubmissionRequest
     ): RefundSubmissionPath {
         val chargeId = request.order.chargeId ?: run {
-            if (request.order.requiresChargeMetadataForRefund()) {
-                WooLog.w(
-                    WooLog.T.POS,
-                    "WooPosRefund: card refund order has no charge id; failing refund " +
-                        "orderId=${request.orderId}, paymentMethod=${request.order.paymentMethod}"
-                )
-                return RefundSubmissionPath.PaymentMetadataUnavailable
-            }
             WooLog.w(
                 WooLog.T.POS,
                 "WooPosRefund: order has no charge id; using backend refund path orderId=${request.orderId}"
@@ -153,12 +142,6 @@ class WooPosRefundSubmissionProcessor @Inject constructor(
                 }
             }
         }
-    }
-
-    private fun Order.requiresChargeMetadataForRefund(): Boolean {
-        return paymentMethod.isBlank() ||
-            paymentMethod == WOOCOMMERCE_PAYMENTS_PAYMENT_TYPE ||
-            paymentMethod == WOOCOMMERCE_BOOKINGS_PAYMENT_TYPE
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
@@ -76,51 +76,35 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val uiStringParser: UiStringParser,
 ) : WooPosRefundSubmissionProcessor {
-    @Suppress("TooGenericExceptionCaught")
     override fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState> = channelFlow {
-        try {
-            logSubmissionStarted(request)
+        logSubmissionStarted(request)
 
-            if (request.cardRefundAlreadySucceeded) {
+        if (request.cardRefundAlreadySucceeded) {
+            WooLog.i(
+                WooLog.T.POS,
+                "WooPosRefund: card refund already succeeded; notifying backend only " +
+                    "orderId=${request.orderId}"
+            )
+            notifyBackend(request, retryBackendNotificationOnly = true)
+            return@channelFlow
+        }
+
+        when (val submissionPath = resolveSubmissionPath(request)) {
+            RefundSubmissionPath.Interac -> {
                 WooLog.i(
                     WooLog.T.POS,
-                    "WooPosRefund: card refund already succeeded; notifying backend only " +
-                        "orderId=${request.orderId}"
+                    "WooPosRefund: routing Interac refund through reader orderId=${request.orderId}"
                 )
-                notifyBackend(request, retryBackendNotificationOnly = true)
-                return@channelFlow
+                submitInteracRefund(request)
             }
-
-            when (val submissionPath = resolveSubmissionPath(request)) {
-                RefundSubmissionPath.Interac -> {
-                    WooLog.i(
-                        WooLog.T.POS,
-                        "WooPosRefund: routing Interac refund through reader orderId=${request.orderId}"
-                    )
-                    submitInteracRefund(request)
-                }
-                is RefundSubmissionPath.Backend -> {
-                    WooLog.i(
-                        WooLog.T.POS,
-                        "WooPosRefund: using backend refund path " +
-                            "orderId=${request.orderId}, paymentMethodType=${submissionPath.paymentMethodType}"
-                    )
-                    notifyBackend(request, retryBackendNotificationOnly = false)
-                }
-            }
-        } catch (exception: CancellationException) {
-            throw exception
-        } catch (exception: Exception) {
-            WooLog.e(
-                WooLog.T.POS,
-                "WooPosRefund: submission failed unexpectedly orderId=${request.orderId}",
-                exception
-            )
-            trySendState(
-                WooPosRefundSubmissionState.Failure(
-                    message = resourceProvider.getString(R.string.error_generic),
+            is RefundSubmissionPath.Backend -> {
+                WooLog.i(
+                    WooLog.T.POS,
+                    "WooPosRefund: using backend refund path " +
+                        "orderId=${request.orderId}, paymentMethodType=${submissionPath.paymentMethodType}"
                 )
-            )
+                notifyBackend(request, retryBackendNotificationOnly = false)
+            }
         }
     }
 
@@ -197,6 +181,10 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
         } catch (exception: CancellationException) {
             throw exception
         } catch (exception: Exception) {
+            if (!retryBackendNotificationOnly) {
+                throw exception
+            }
+            // The Terminal refund already succeeded; expose this as backend-only retry so POS never re-runs it.
             WooLog.e(
                 WooLog.T.POS,
                 "WooPosRefund: backend refund creation failed unexpectedly " +

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
@@ -1,10 +1,10 @@
 package com.woocommerce.android.ui.woopos.orders.details.refund
 
-import androidx.annotation.StringRes
 import com.woocommerce.android.R
+import com.woocommerce.android.extensions.WOOCOMMERCE_BOOKINGS_PAYMENT_TYPE
+import com.woocommerce.android.extensions.WOOCOMMERCE_PAYMENTS_PAYMENT_TYPE
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState
@@ -24,50 +24,19 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
-import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
 import org.wordpress.android.fluxc.model.refunds.WCRefundModel
 import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCRefundStore
-import java.math.BigDecimal
 import javax.inject.Inject
-
-interface WooPosRefundSubmissionProcessor {
-    fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState>
-}
-
-data class WooPosRefundSubmissionRequest(
-    val order: Order,
-    val refundAmount: BigDecimal,
-    val refundReason: String,
-    val refundItems: List<RefundRequestItem>,
-    val cardRefundAlreadySucceeded: Boolean = false,
-) {
-    val orderId: Long = order.id
-}
-
-sealed class WooPosRefundSubmissionState {
-    data object Processing : WooPosRefundSubmissionState()
-    data object PreparingReader : WooPosRefundSubmissionState()
-    data object ReaderConnectionRequired : WooPosRefundSubmissionState()
-    data class WaitingForCard(@StringRes val cardReaderHint: Int? = null) : WooPosRefundSubmissionState()
-    data object ProcessingReaderRefund : WooPosRefundSubmissionState()
-    data object NotifyingStore : WooPosRefundSubmissionState()
-    data object Success : WooPosRefundSubmissionState()
-    data class Failure(
-        val message: String,
-        val retryBackendNotificationOnly: Boolean = false,
-        val retryCardRefund: Boolean = false,
-        val canRetry: Boolean = !retryBackendNotificationOnly,
-    ) : WooPosRefundSubmissionState()
-}
 
 private sealed class RefundSubmissionPath {
     data object Interac : RefundSubmissionPath()
     data class Backend(val paymentMethodType: String?) : RefundSubmissionPath()
+    data object PaymentMetadataUnavailable : RefundSubmissionPath()
 }
 
 @Suppress("LongParameterList")
-class WooPosRefundSubmissionProcessorImpl @Inject constructor(
+class WooPosRefundSubmissionProcessor @Inject constructor(
     private val refundStore: WCRefundStore,
     private val selectedSite: SelectedSite,
     private val paymentChargeRepository: PaymentChargeRepository,
@@ -75,36 +44,59 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
     private val cardReaderPaymentControllerFactory: WooPosCardReaderPaymentControllerFactory,
     private val resourceProvider: ResourceProvider,
     private val uiStringParser: UiStringParser,
-) : WooPosRefundSubmissionProcessor {
-    override fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState> = channelFlow {
-        logSubmissionStarted(request)
+) {
+    @Suppress("TooGenericExceptionCaught")
+    fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState> = channelFlow {
+        try {
+            logSubmissionStarted(request)
 
-        if (request.cardRefundAlreadySucceeded) {
-            WooLog.i(
+            if (request.cardRefundAlreadySucceeded) {
+                WooLog.i(
+                    WooLog.T.POS,
+                    "WooPosRefund: card refund already succeeded; notifying backend only " +
+                        "orderId=${request.orderId}"
+                )
+                notifyBackend(request, retryBackendNotificationOnly = true)
+                return@channelFlow
+            }
+
+            when (val submissionPath = resolveSubmissionPath(request)) {
+                RefundSubmissionPath.Interac -> {
+                    WooLog.i(
+                        WooLog.T.POS,
+                        "WooPosRefund: routing Interac refund through reader orderId=${request.orderId}"
+                    )
+                    submitInteracRefund(request)
+                }
+                is RefundSubmissionPath.Backend -> {
+                    WooLog.i(
+                        WooLog.T.POS,
+                        "WooPosRefund: using backend refund path " +
+                            "orderId=${request.orderId}, paymentMethodType=${submissionPath.paymentMethodType}"
+                    )
+                    notifyBackend(request, retryBackendNotificationOnly = false)
+                }
+                RefundSubmissionPath.PaymentMetadataUnavailable -> {
+                    trySendState(
+                        WooPosRefundSubmissionState.Failure(
+                            message = resourceProvider.getString(R.string.error_generic),
+                        )
+                    )
+                }
+            }
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            WooLog.e(
                 WooLog.T.POS,
-                "WooPosRefund: card refund already succeeded; notifying backend only " +
-                    "orderId=${request.orderId}"
+                "WooPosRefund: submission failed unexpectedly orderId=${request.orderId}",
+                exception
             )
-            notifyBackend(request, retryBackendNotificationOnly = true)
-            return@channelFlow
-        }
-
-        when (val submissionPath = resolveSubmissionPath(request)) {
-            RefundSubmissionPath.Interac -> {
-                WooLog.i(
-                    WooLog.T.POS,
-                    "WooPosRefund: routing Interac refund through reader orderId=${request.orderId}"
+            trySendState(
+                WooPosRefundSubmissionState.Failure(
+                    message = resourceProvider.getString(R.string.error_generic),
                 )
-                submitInteracRefund(request)
-            }
-            is RefundSubmissionPath.Backend -> {
-                WooLog.i(
-                    WooLog.T.POS,
-                    "WooPosRefund: using backend refund path " +
-                        "orderId=${request.orderId}, paymentMethodType=${submissionPath.paymentMethodType}"
-                )
-                notifyBackend(request, retryBackendNotificationOnly = false)
-            }
+            )
         }
     }
 
@@ -124,6 +116,14 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
         request: WooPosRefundSubmissionRequest
     ): RefundSubmissionPath {
         val chargeId = request.order.chargeId ?: run {
+            if (request.order.requiresChargeMetadataForRefund()) {
+                WooLog.w(
+                    WooLog.T.POS,
+                    "WooPosRefund: card refund order has no charge id; failing refund " +
+                        "orderId=${request.orderId}, paymentMethod=${request.order.paymentMethod}"
+                )
+                return RefundSubmissionPath.PaymentMetadataUnavailable
+            }
             WooLog.w(
                 WooLog.T.POS,
                 "WooPosRefund: order has no charge id; using backend refund path orderId=${request.orderId}"
@@ -135,10 +135,10 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
             PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Error -> {
                 WooLog.w(
                     WooLog.T.POS,
-                    "WooPosRefund: failed to fetch payment charge metadata; using backend refund path " +
+                    "WooPosRefund: failed to fetch payment charge metadata; failing refund " +
                         "orderId=${request.orderId}"
                 )
-                RefundSubmissionPath.Backend(paymentMethodType = null)
+                RefundSubmissionPath.PaymentMetadataUnavailable
             }
             is PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success -> {
                 WooLog.i(
@@ -153,6 +153,12 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun Order.requiresChargeMetadataForRefund(): Boolean {
+        return paymentMethod.isBlank() ||
+            paymentMethod == WOOCOMMERCE_PAYMENTS_PAYMENT_TYPE ||
+            paymentMethod == WOOCOMMERCE_BOOKINGS_PAYMENT_TYPE
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -181,10 +187,6 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
         } catch (exception: CancellationException) {
             throw exception
         } catch (exception: Exception) {
-            if (!retryBackendNotificationOnly) {
-                throw exception
-            }
-            // The Terminal refund already succeeded; expose this as backend-only retry so POS never re-runs it.
             WooLog.e(
                 WooLog.T.POS,
                 "WooPosRefund: backend refund creation failed unexpectedly " +
@@ -331,7 +333,6 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
         return cardReaderPaymentControllerFactory.createRefund(
             orderId = request.orderId,
             refundAmount = request.refundAmount,
-            cardReaderType = CardReaderType.EXTERNAL,
             isTTPPaymentInProgress = ttpPaymentProgress::isInProgress,
         )
     }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
@@ -14,8 +14,11 @@ import com.woocommerce.android.ui.woopos.orders.WooPosLoadPaymentGateway
 import com.woocommerce.android.util.UiStringParser
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
@@ -64,153 +67,191 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val uiStringParser: UiStringParser,
 ) : WooPosRefundSubmissionProcessor {
-    private var isTTPPaymentInProgress = false
-
+    @Suppress("LongMethod", "TooGenericExceptionCaught")
     override fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState> = channelFlow {
-        WooLog.i(
-            WooLog.T.POS,
-            "WooPosRefund: submission started " +
-                "orderId=${request.orderId}, " +
-                "amount=${request.refundAmount}, " +
-                "itemCount=${request.refundItems.size}, " +
-                "hasChargeId=${request.order.chargeId != null}, " +
-                "backendOnlyRetry=${request.cardRefundAlreadySucceeded}"
-        )
-
-        if (request.cardRefundAlreadySucceeded) {
+        try {
             WooLog.i(
                 WooLog.T.POS,
-                "WooPosRefund: card refund already succeeded; retrying backend notification only " +
-                    "orderId=${request.orderId}"
+                "WooPosRefund: submission started " +
+                    "orderId=${request.orderId}, " +
+                    "amount=${request.refundAmount}, " +
+                    "itemCount=${request.refundItems.size}, " +
+                    "hasChargeId=${request.order.chargeId != null}, " +
+                    "backendOnlyRetry=${request.cardRefundAlreadySucceeded}"
             )
-            notifyBackend(request, retryBackendNotificationOnly = true)
-            return@channelFlow
-        }
 
-        val paymentMethodType = request.order.chargeId?.let { chargeId ->
-            when (val result = paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)) {
-                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Error -> {
-                    WooLog.w(
-                        WooLog.T.POS,
-                        "WooPosRefund: failed to fetch payment charge metadata orderId=${request.orderId}"
-                    )
-                    null
-                }
-                is PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success -> {
-                    WooLog.i(
-                        WooLog.T.POS,
-                        "WooPosRefund: fetched payment charge metadata " +
-                            "orderId=${request.orderId}, paymentMethodType=${result.paymentMethodType}"
-                    )
-                    result.paymentMethodType
-                }
+            if (request.cardRefundAlreadySucceeded) {
+                WooLog.i(
+                    WooLog.T.POS,
+                    "WooPosRefund: card refund already succeeded; notifying backend only " +
+                        "orderId=${request.orderId}"
+                )
+                notifyBackend(request, retryBackendNotificationOnly = true)
+                return@channelFlow
             }
-        } ?: run {
-            WooLog.w(
-                WooLog.T.POS,
-                "WooPosRefund: order has no charge id; using backend refund path orderId=${request.orderId}"
-            )
-            null
-        }
 
-        if (paymentMethodType == INTERAC_PRESENT) {
-            WooLog.i(WooLog.T.POS, "WooPosRefund: routing Interac refund through reader orderId=${request.orderId}")
-            submitInteracRefund(request)
-        } else {
-            WooLog.i(
+            val chargeId = request.order.chargeId
+            val paymentMethodType = if (chargeId != null) {
+                when (val result = paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)) {
+                    PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Error -> {
+                        WooLog.w(
+                            WooLog.T.POS,
+                            "WooPosRefund: failed to fetch payment charge metadata; using backend refund path " +
+                                "orderId=${request.orderId}"
+                        )
+                        null
+                    }
+                    is PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success -> {
+                        WooLog.i(
+                            WooLog.T.POS,
+                            "WooPosRefund: fetched payment charge metadata " +
+                                "orderId=${request.orderId}, paymentMethodType=${result.paymentMethodType}"
+                        )
+                        result.paymentMethodType
+                    }
+                }
+            } else {
+                WooLog.w(
+                    WooLog.T.POS,
+                    "WooPosRefund: order has no charge id; using backend refund path orderId=${request.orderId}"
+                )
+                null
+            }
+
+            if (paymentMethodType == INTERAC_PRESENT) {
+                WooLog.i(WooLog.T.POS, "WooPosRefund: routing Interac refund through reader orderId=${request.orderId}")
+                submitInteracRefund(request)
+            } else {
+                WooLog.i(
+                    WooLog.T.POS,
+                    "WooPosRefund: using backend refund path " +
+                        "orderId=${request.orderId}, paymentMethodType=$paymentMethodType"
+                )
+                notifyBackend(request, retryBackendNotificationOnly = false)
+            }
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            WooLog.e(
                 WooLog.T.POS,
-                "WooPosRefund: using backend refund path " +
-                    "orderId=${request.orderId}, paymentMethodType=$paymentMethodType"
+                "WooPosRefund: submission failed unexpectedly orderId=${request.orderId}",
+                exception
             )
-            notifyBackend(request, retryBackendNotificationOnly = false)
+            trySendState(
+                WooPosRefundSubmissionState.Failure(
+                    message = resourceProvider.getString(R.string.error_generic),
+                )
+            )
         }
     }
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "TooGenericExceptionCaught")
     private suspend fun ProducerScope<WooPosRefundSubmissionState>.notifyBackend(
         request: WooPosRefundSubmissionRequest,
         retryBackendNotificationOnly: Boolean,
     ) {
-        send(
-            if (retryBackendNotificationOnly) {
-                WooPosRefundSubmissionState.NotifyingStore
+        try {
+            trySendState(
+                if (retryBackendNotificationOnly) {
+                    WooPosRefundSubmissionState.NotifyingStore
+                } else {
+                    WooPosRefundSubmissionState.Processing
+                }
+            )
+
+            val shouldAutoRefund = if (retryBackendNotificationOnly) {
+                false
             } else {
-                WooPosRefundSubmissionState.Processing
+                val paymentGatewayResult = loadPaymentGateway(request.order)
+                if (paymentGatewayResult.isFailure) {
+                    WooLog.e(
+                        WooLog.T.POS,
+                        "WooPosRefund: failed to load payment gateway " +
+                            "orderId=${request.orderId}, backendOnlyRetry=false",
+                        paymentGatewayResult.exceptionOrNull()
+                    )
+                    trySendState(
+                        WooPosRefundSubmissionState.Failure(
+                            message = resourceProvider.getString(R.string.woopos_refund_error_gateway_not_found),
+                        )
+                    )
+                    return
+                }
+                paymentGatewayResult.getOrThrow().supportsRefunds
             }
-        )
 
-        val paymentGatewayResult = loadPaymentGateway(request.order)
-        if (paymentGatewayResult.isFailure) {
-            WooLog.e(
-                WooLog.T.POS,
-                "WooPosRefund: failed to load payment gateway " +
-                    "orderId=${request.orderId}, backendOnlyRetry=$retryBackendNotificationOnly",
-                paymentGatewayResult.exceptionOrNull()
-            )
-            send(
-                WooPosRefundSubmissionState.Failure(
-                    message = resourceProvider.getString(R.string.woopos_refund_error_gateway_not_found),
-                    retryBackendNotificationOnly = retryBackendNotificationOnly,
-                )
-            )
-            return
-        }
-        val paymentGateway = paymentGatewayResult.getOrThrow()
-
-        WooLog.i(
-            WooLog.T.POS,
-            "WooPosRefund: creating backend refund " +
-                "orderId=${request.orderId}, " +
-                "amount=${request.refundAmount}, " +
-                "itemCount=${request.refundItems.size}, " +
-                "autoRefund=${paymentGateway.supportsRefunds}, " +
-                "backendOnlyRetry=$retryBackendNotificationOnly"
-        )
-
-        val result = refundStore.createItemsRefund(
-            site = selectedSite.get(),
-            orderId = request.orderId,
-            amount = request.refundAmount,
-            reason = request.refundReason,
-            restockItems = true,
-            autoRefund = paymentGateway.supportsRefunds,
-            items = request.refundItems
-        )
-
-        if (result.isError) {
-            val error = result.error
-            WooLog.e(
-                WooLog.T.POS,
-                "WooPosRefund: backend refund creation failed " +
-                    "orderId=${request.orderId}, " +
-                    "backendOnlyRetry=$retryBackendNotificationOnly, " +
-                    "type=${error.type}, " +
-                    "original=${error.original}, " +
-                    "apiErrorCode=${error.apiErrorCode}, " +
-                    "message=${error.message}, " +
-                    "errorData=${error.errorData}"
-            )
-            send(
-                WooPosRefundSubmissionState.Failure(
-                    message = result.error.message ?: resourceProvider.getString(R.string.error_generic),
-                    retryBackendNotificationOnly = retryBackendNotificationOnly,
-                )
-            )
-        } else {
             WooLog.i(
                 WooLog.T.POS,
-                "WooPosRefund: backend refund creation succeeded " +
-                    "orderId=${request.orderId}, backendOnlyRetry=$retryBackendNotificationOnly"
+                "WooPosRefund: creating backend refund " +
+                    "orderId=${request.orderId}, " +
+                    "amount=${request.refundAmount}, " +
+                    "itemCount=${request.refundItems.size}, " +
+                    "autoRefund=$shouldAutoRefund, " +
+                    "backendOnlyRetry=$retryBackendNotificationOnly"
             )
-            send(WooPosRefundSubmissionState.Success)
+
+            val result = refundStore.createItemsRefund(
+                site = selectedSite.get(),
+                orderId = request.orderId,
+                amount = request.refundAmount,
+                reason = request.refundReason,
+                restockItems = true,
+                autoRefund = shouldAutoRefund,
+                items = request.refundItems
+            )
+
+            if (result.isError) {
+                val error = result.error
+                WooLog.e(
+                    WooLog.T.POS,
+                    "WooPosRefund: backend refund creation failed " +
+                        "orderId=${request.orderId}, " +
+                        "backendOnlyRetry=$retryBackendNotificationOnly, " +
+                        "type=${error.type}, " +
+                        "original=${error.original}, " +
+                        "apiErrorCode=${error.apiErrorCode}, " +
+                        "message=${error.message}, " +
+                        "errorData=${error.errorData}"
+                )
+                trySendState(
+                    WooPosRefundSubmissionState.Failure(
+                        message = result.error.message ?: resourceProvider.getString(R.string.error_generic),
+                        retryBackendNotificationOnly = retryBackendNotificationOnly,
+                    )
+                )
+            } else {
+                WooLog.i(
+                    WooLog.T.POS,
+                    "WooPosRefund: backend refund creation succeeded " +
+                        "orderId=${request.orderId}, backendOnlyRetry=$retryBackendNotificationOnly"
+                )
+                trySendState(WooPosRefundSubmissionState.Success)
+            }
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            WooLog.e(
+                WooLog.T.POS,
+                "WooPosRefund: backend refund creation failed unexpectedly " +
+                    "orderId=${request.orderId}, backendOnlyRetry=$retryBackendNotificationOnly",
+                exception
+            )
+            trySendState(
+                WooPosRefundSubmissionState.Failure(
+                    message = resourceProvider.getString(R.string.error_generic),
+                    retryBackendNotificationOnly = retryBackendNotificationOnly,
+                )
+            )
         }
     }
 
-    @Suppress("LongMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     private suspend fun ProducerScope<WooPosRefundSubmissionState>.submitInteracRefund(
         request: WooPosRefundSubmissionRequest,
     ) {
-        isTTPPaymentInProgress = false
+        val ttpPaymentProgress = object {
+            var isInProgress = false
+        }
         WooLog.i(
             WooLog.T.POS,
             "WooPosRefund: creating Interac reader refund controller orderId=${request.orderId}"
@@ -219,9 +260,17 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
             orderId = request.orderId,
             refundAmount = request.refundAmount,
             cardReaderType = CardReaderType.EXTERNAL,
-            isTTPPaymentInProgress = ::isTTPPaymentInProgress,
+            isTTPPaymentInProgress = ttpPaymentProgress::isInProgress,
         )
         var terminalRefundSucceeded = false
+        var terminalStateSent = false
+        var exitFallbackJob: Job? = null
+
+        fun markTerminalStateSent() {
+            terminalStateSent = true
+            exitFallbackJob?.cancel()
+            exitFallbackJob = null
+        }
 
         val stateJob = launch {
             controller.paymentState.collect { state ->
@@ -256,6 +305,7 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
                                 request = request.copy(cardRefundAlreadySucceeded = true),
                                 retryBackendNotificationOnly = true
                             )
+                            markTerminalStateSent()
                             close()
                         }
                     }
@@ -272,8 +322,10 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
                             WooPosRefundSubmissionState.Failure(
                                 message = uiStringParser.asString(state.errorType.message),
                                 retryCardRefund = state.onRetry != null,
+                                canRetry = state.onRetry != null,
                             )
                         )
+                        markTerminalStateSent()
                         close()
                     }
 
@@ -295,6 +347,7 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
                                 message = resourceProvider.getString(R.string.error_generic),
                             )
                         )
+                        markTerminalStateSent()
                         close()
                     }
                 }
@@ -325,6 +378,7 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
                                 )
                             )
                         }
+                        markTerminalStateSent()
                         close()
                     }
 
@@ -340,14 +394,43 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
                                 message = message,
                             )
                         )
+                        markTerminalStateSent()
                         close()
                     }
 
                     CardReaderPaymentEvent.Exit -> {
+                        if (terminalStateSent || terminalRefundSucceeded) {
+                            WooLog.i(
+                                WooLog.T.POS,
+                                "WooPosRefund: reader refund controller exit event ignored orderId=${request.orderId}"
+                            )
+                            return@collect
+                        }
                         WooLog.i(
                             WooLog.T.POS,
-                            "WooPosRefund: reader refund controller exit event ignored orderId=${request.orderId}"
+                            "WooPosRefund: reader refund controller exit event received; " +
+                                "waiting for paired error orderId=${request.orderId}"
                         )
+                        exitFallbackJob?.cancel()
+                        exitFallbackJob = launch {
+                            delay(EXIT_EVENT_FALLBACK_DELAY_MS)
+                            if (!terminalStateSent && !terminalRefundSucceeded) {
+                                WooLog.w(
+                                    WooLog.T.POS,
+                                    "WooPosRefund: reader refund controller exited without terminal state " +
+                                        "orderId=${request.orderId}"
+                                )
+                                terminalStateSent = true
+                                exitFallbackJob = null
+                                trySendState(
+                                    WooPosRefundSubmissionState.Failure(
+                                        message = resourceProvider.getString(R.string.error_generic),
+                                        canRetry = false,
+                                    )
+                                )
+                                close()
+                            }
+                        }
                     }
 
                     CardReaderPaymentEvent.InteracRefundSuccessful,
@@ -367,6 +450,7 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
             WooLog.i(WooLog.T.POS, "WooPosRefund: closing Interac reader refund orderId=${request.orderId}")
             stateJob.cancel()
             eventJob.cancel()
+            exitFallbackJob?.cancel()
             controller.stop()
         }
     }
@@ -379,5 +463,6 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
 
     private companion object {
         private const val INTERAC_PRESENT = "interac_present"
+        private const val EXIT_EVENT_FALLBACK_DELAY_MS = 100L
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
@@ -1,14 +1,24 @@
 package com.woocommerce.android.ui.woopos.orders.details.refund
 
+import androidx.annotation.StringRes
 import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderInteracRefundState
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
+import com.woocommerce.android.ui.payments.refunds.PaymentChargeRepository
+import com.woocommerce.android.ui.woopos.home.totals.WooPosCardReaderPaymentControllerFactory
 import com.woocommerce.android.ui.woopos.orders.WooPosLoadPaymentGateway
+import com.woocommerce.android.util.UiStringParser
 import com.woocommerce.android.util.WooLog
 import com.woocommerce.android.viewmodel.ResourceProvider
-import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
 import org.wordpress.android.fluxc.store.WCRefundStore
 import java.math.BigDecimal
@@ -23,83 +33,351 @@ data class WooPosRefundSubmissionRequest(
     val refundAmount: BigDecimal,
     val refundReason: String,
     val refundItems: List<RefundRequestItem>,
+    val cardRefundAlreadySucceeded: Boolean = false,
 ) {
     val orderId: Long = order.id
 }
 
 sealed class WooPosRefundSubmissionState {
     data object Processing : WooPosRefundSubmissionState()
+    data object PreparingReader : WooPosRefundSubmissionState()
+    data object ReaderConnectionRequired : WooPosRefundSubmissionState()
+    data class WaitingForCard(@StringRes val cardReaderHint: Int? = null) : WooPosRefundSubmissionState()
+    data object ProcessingReaderRefund : WooPosRefundSubmissionState()
+    data object NotifyingStore : WooPosRefundSubmissionState()
     data object Success : WooPosRefundSubmissionState()
-    data class Failure(val message: String) : WooPosRefundSubmissionState()
+    data class Failure(
+        val message: String,
+        val retryBackendNotificationOnly: Boolean = false,
+        val retryCardRefund: Boolean = false,
+        val canRetry: Boolean = !retryBackendNotificationOnly,
+    ) : WooPosRefundSubmissionState()
 }
 
+@Suppress("LongParameterList")
 class WooPosRefundSubmissionProcessorImpl @Inject constructor(
     private val refundStore: WCRefundStore,
     private val selectedSite: SelectedSite,
+    private val paymentChargeRepository: PaymentChargeRepository,
     private val loadPaymentGateway: WooPosLoadPaymentGateway,
+    private val cardReaderPaymentControllerFactory: WooPosCardReaderPaymentControllerFactory,
     private val resourceProvider: ResourceProvider,
+    private val uiStringParser: UiStringParser,
 ) : WooPosRefundSubmissionProcessor {
-    @Suppress("TooGenericExceptionCaught")
-    override fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState> = flow {
-        try {
+    private var isTTPPaymentInProgress = false
+
+    override fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState> = channelFlow {
+        WooLog.i(
+            WooLog.T.POS,
+            "WooPosRefund: submission started " +
+                "orderId=${request.orderId}, " +
+                "amount=${request.refundAmount}, " +
+                "itemCount=${request.refundItems.size}, " +
+                "hasChargeId=${request.order.chargeId != null}, " +
+                "backendOnlyRetry=${request.cardRefundAlreadySucceeded}"
+        )
+
+        if (request.cardRefundAlreadySucceeded) {
             WooLog.i(
                 WooLog.T.POS,
-                "WooPosRefund: submission started " +
-                    "orderId=${request.orderId}, " +
-                    "amount=${request.refundAmount}, " +
-                    "itemCount=${request.refundItems.size}"
+                "WooPosRefund: card refund already succeeded; retrying backend notification only " +
+                    "orderId=${request.orderId}"
             )
+            notifyBackend(request, retryBackendNotificationOnly = true)
+            return@channelFlow
+        }
 
-            emit(WooPosRefundSubmissionState.Processing)
-
-            val paymentGatewayResult = loadPaymentGateway(request.order)
-            if (paymentGatewayResult.isFailure) {
-                WooLog.e(
-                    WooLog.T.POS,
-                    "WooPosRefund: failed to load payment gateway orderId=${request.orderId}",
-                    paymentGatewayResult.exceptionOrNull()
-                )
-                emit(
-                    WooPosRefundSubmissionState.Failure(
-                        message = resourceProvider.getString(R.string.woopos_refund_error_gateway_not_found),
+        val paymentMethodType = request.order.chargeId?.let { chargeId ->
+            when (val result = paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)) {
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Error -> {
+                    WooLog.w(
+                        WooLog.T.POS,
+                        "WooPosRefund: failed to fetch payment charge metadata orderId=${request.orderId}"
                     )
-                )
-                return@flow
+                    null
+                }
+                is PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success -> {
+                    WooLog.i(
+                        WooLog.T.POS,
+                        "WooPosRefund: fetched payment charge metadata " +
+                            "orderId=${request.orderId}, paymentMethodType=${result.paymentMethodType}"
+                    )
+                    result.paymentMethodType
+                }
             }
-            val paymentGateway = paymentGatewayResult.getOrThrow()
-
-            val result = refundStore.createItemsRefund(
-                site = selectedSite.get(),
-                orderId = request.orderId,
-                amount = request.refundAmount,
-                reason = request.refundReason,
-                restockItems = true,
-                autoRefund = paymentGateway.supportsRefunds,
-                items = request.refundItems
+        } ?: run {
+            WooLog.w(
+                WooLog.T.POS,
+                "WooPosRefund: order has no charge id; using backend refund path orderId=${request.orderId}"
             )
+            null
+        }
 
-            if (result.isError) {
-                emit(
-                    WooPosRefundSubmissionState.Failure(
-                        message = result.error.message ?: resourceProvider.getString(R.string.error_generic),
-                    )
-                )
+        if (paymentMethodType == INTERAC_PRESENT) {
+            WooLog.i(WooLog.T.POS, "WooPosRefund: routing Interac refund through reader orderId=${request.orderId}")
+            submitInteracRefund(request)
+        } else {
+            WooLog.i(
+                WooLog.T.POS,
+                "WooPosRefund: using backend refund path " +
+                    "orderId=${request.orderId}, paymentMethodType=$paymentMethodType"
+            )
+            notifyBackend(request, retryBackendNotificationOnly = false)
+        }
+    }
+
+    @Suppress("LongMethod")
+    private suspend fun ProducerScope<WooPosRefundSubmissionState>.notifyBackend(
+        request: WooPosRefundSubmissionRequest,
+        retryBackendNotificationOnly: Boolean,
+    ) {
+        send(
+            if (retryBackendNotificationOnly) {
+                WooPosRefundSubmissionState.NotifyingStore
             } else {
-                emit(WooPosRefundSubmissionState.Success)
+                WooPosRefundSubmissionState.Processing
             }
-        } catch (exception: CancellationException) {
-            throw exception
-        } catch (exception: Exception) {
+        )
+
+        val paymentGatewayResult = loadPaymentGateway(request.order)
+        if (paymentGatewayResult.isFailure) {
             WooLog.e(
                 WooLog.T.POS,
-                "WooPosRefund: submission failed unexpectedly orderId=${request.orderId}",
-                exception
+                "WooPosRefund: failed to load payment gateway " +
+                    "orderId=${request.orderId}, backendOnlyRetry=$retryBackendNotificationOnly",
+                paymentGatewayResult.exceptionOrNull()
             )
-            emit(
+            send(
                 WooPosRefundSubmissionState.Failure(
-                    message = resourceProvider.getString(R.string.error_generic),
+                    message = resourceProvider.getString(R.string.woopos_refund_error_gateway_not_found),
+                    retryBackendNotificationOnly = retryBackendNotificationOnly,
                 )
             )
+            return
         }
+        val paymentGateway = paymentGatewayResult.getOrThrow()
+
+        WooLog.i(
+            WooLog.T.POS,
+            "WooPosRefund: creating backend refund " +
+                "orderId=${request.orderId}, " +
+                "amount=${request.refundAmount}, " +
+                "itemCount=${request.refundItems.size}, " +
+                "autoRefund=${paymentGateway.supportsRefunds}, " +
+                "backendOnlyRetry=$retryBackendNotificationOnly"
+        )
+
+        val result = refundStore.createItemsRefund(
+            site = selectedSite.get(),
+            orderId = request.orderId,
+            amount = request.refundAmount,
+            reason = request.refundReason,
+            restockItems = true,
+            autoRefund = paymentGateway.supportsRefunds,
+            items = request.refundItems
+        )
+
+        if (result.isError) {
+            val error = result.error
+            WooLog.e(
+                WooLog.T.POS,
+                "WooPosRefund: backend refund creation failed " +
+                    "orderId=${request.orderId}, " +
+                    "backendOnlyRetry=$retryBackendNotificationOnly, " +
+                    "type=${error.type}, " +
+                    "original=${error.original}, " +
+                    "apiErrorCode=${error.apiErrorCode}, " +
+                    "message=${error.message}, " +
+                    "errorData=${error.errorData}"
+            )
+            send(
+                WooPosRefundSubmissionState.Failure(
+                    message = result.error.message ?: resourceProvider.getString(R.string.error_generic),
+                    retryBackendNotificationOnly = retryBackendNotificationOnly,
+                )
+            )
+        } else {
+            WooLog.i(
+                WooLog.T.POS,
+                "WooPosRefund: backend refund creation succeeded " +
+                    "orderId=${request.orderId}, backendOnlyRetry=$retryBackendNotificationOnly"
+            )
+            send(WooPosRefundSubmissionState.Success)
+        }
+    }
+
+    @Suppress("LongMethod")
+    private suspend fun ProducerScope<WooPosRefundSubmissionState>.submitInteracRefund(
+        request: WooPosRefundSubmissionRequest,
+    ) {
+        isTTPPaymentInProgress = false
+        WooLog.i(
+            WooLog.T.POS,
+            "WooPosRefund: creating Interac reader refund controller orderId=${request.orderId}"
+        )
+        val controller = cardReaderPaymentControllerFactory.createRefund(
+            orderId = request.orderId,
+            refundAmount = request.refundAmount,
+            cardReaderType = CardReaderType.EXTERNAL,
+            isTTPPaymentInProgress = ::isTTPPaymentInProgress,
+        )
+        var terminalRefundSucceeded = false
+
+        val stateJob = launch {
+            controller.paymentState.collect { state ->
+                when (state) {
+                    is CardReaderInteracRefundState.LoadingData -> {
+                        WooLog.i(WooLog.T.POS, "WooPosRefund: reader refund loading data orderId=${request.orderId}")
+                        trySendState(WooPosRefundSubmissionState.PreparingReader)
+                    }
+
+                    is CardReaderInteracRefundState.CollectingInteracRefund -> {
+                        WooLog.i(
+                            WooLog.T.POS,
+                            "WooPosRefund: reader refund collecting card " +
+                                "orderId=${request.orderId}, hint=${state.cardReaderHint}"
+                        )
+                        trySendState(WooPosRefundSubmissionState.WaitingForCard(state.cardReaderHint))
+                    }
+
+                    is CardReaderInteracRefundState.ProcessingInteracRefund -> {
+                        WooLog.i(WooLog.T.POS, "WooPosRefund: reader refund processing orderId=${request.orderId}")
+                        trySendState(WooPosRefundSubmissionState.ProcessingReaderRefund)
+                    }
+
+                    is CardReaderInteracRefundState.InteracRefundSuccessful -> {
+                        if (!terminalRefundSucceeded) {
+                            WooLog.i(
+                                WooLog.T.POS,
+                                "WooPosRefund: reader refund succeeded; notifying backend orderId=${request.orderId}"
+                            )
+                            terminalRefundSucceeded = true
+                            notifyBackend(
+                                request = request.copy(cardRefundAlreadySucceeded = true),
+                                retryBackendNotificationOnly = true
+                            )
+                            close()
+                        }
+                    }
+
+                    is CardReaderInteracRefundState.InteracRefundFailure -> {
+                        WooLog.e(
+                            WooLog.T.POS,
+                            "WooPosRefund: reader refund failed " +
+                                "orderId=${request.orderId}, " +
+                                "errorType=${state.errorType}, " +
+                                "retryable=${state.onRetry != null}"
+                        )
+                        trySendState(
+                            WooPosRefundSubmissionState.Failure(
+                                message = uiStringParser.asString(state.errorType.message),
+                                retryCardRefund = state.onRetry != null,
+                            )
+                        )
+                        close()
+                    }
+
+                    is CardReaderPaymentState.LoadingData -> {
+                        WooLog.i(
+                            WooLog.T.POS,
+                            "WooPosRefund: ignoring initial payment loading state for refund orderId=${request.orderId}"
+                        )
+                    }
+
+                    is CardReaderPaymentState -> {
+                        WooLog.e(
+                            WooLog.T.POS,
+                            "WooPosRefund: payment state emitted during refund " +
+                                "orderId=${request.orderId}, state=${state::class.simpleName}"
+                        )
+                        trySendState(
+                            WooPosRefundSubmissionState.Failure(
+                                message = resourceProvider.getString(R.string.error_generic),
+                            )
+                        )
+                        close()
+                    }
+                }
+            }
+        }
+
+        val eventJob = launch {
+            controller.event.collect { event ->
+                when (event) {
+                    is CardReaderPaymentEvent.ShowErrorMessage -> {
+                        val message = resourceProvider.getString(event.message)
+                        if (event.message == R.string.card_reader_payment_reader_not_connected) {
+                            WooLog.i(
+                                WooLog.T.POS,
+                                "WooPosRefund: reader connection required for refund " +
+                                    "orderId=${request.orderId}, messageRes=${event.message}, message=$message"
+                            )
+                            trySendState(WooPosRefundSubmissionState.ReaderConnectionRequired)
+                        } else {
+                            WooLog.e(
+                                WooLog.T.POS,
+                                "WooPosRefund: reader refund controller error event " +
+                                    "orderId=${request.orderId}, messageRes=${event.message}, message=$message"
+                            )
+                            trySendState(
+                                WooPosRefundSubmissionState.Failure(
+                                    message = message,
+                                )
+                            )
+                        }
+                        close()
+                    }
+
+                    is CardReaderPaymentEvent.ShowPaymentErrorMessage -> {
+                        val message = resourceProvider.getString(event.message)
+                        WooLog.e(
+                            WooLog.T.POS,
+                            "WooPosRefund: reader refund controller payment error event " +
+                                "orderId=${request.orderId}, messageRes=${event.message}, message=$message"
+                        )
+                        trySendState(
+                            WooPosRefundSubmissionState.Failure(
+                                message = message,
+                            )
+                        )
+                        close()
+                    }
+
+                    CardReaderPaymentEvent.Exit -> {
+                        WooLog.i(
+                            WooLog.T.POS,
+                            "WooPosRefund: reader refund controller exit event ignored orderId=${request.orderId}"
+                        )
+                    }
+
+                    CardReaderPaymentEvent.InteracRefundSuccessful,
+                    CardReaderPaymentEvent.PlaySuccessfulPaymentSound,
+                    is CardReaderPaymentEvent.ContactSupportTapped,
+                    is CardReaderPaymentEvent.EnableNfcTapped,
+                    is CardReaderPaymentEvent.PrintReceiptTapped,
+                    is CardReaderPaymentEvent.PurchaseCardReaderTapped -> Unit
+                }
+            }
+        }
+
+        WooLog.i(WooLog.T.POS, "WooPosRefund: starting Interac reader refund orderId=${request.orderId}")
+        controller.start()
+
+        awaitClose {
+            WooLog.i(WooLog.T.POS, "WooPosRefund: closing Interac reader refund orderId=${request.orderId}")
+            stateJob.cancel()
+            eventJob.cancel()
+            controller.stop()
+        }
+    }
+
+    private fun ProducerScope<WooPosRefundSubmissionState>.trySendState(
+        state: WooPosRefundSubmissionState
+    ) {
+        trySend(state)
+    }
+
+    private companion object {
+        private const val INTERAC_PRESENT = "interac_present"
     }
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessor.kt
@@ -5,7 +5,9 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.payments.cardreader.onboarding.CardReaderType
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderInteracRefundState
 import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
 import com.woocommerce.android.ui.payments.refunds.PaymentChargeRepository
@@ -23,6 +25,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
+import org.wordpress.android.fluxc.model.refunds.WCRefundModel
+import org.wordpress.android.fluxc.network.rest.wpcom.wc.WooResult
 import org.wordpress.android.fluxc.store.WCRefundStore
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -57,6 +61,11 @@ sealed class WooPosRefundSubmissionState {
     ) : WooPosRefundSubmissionState()
 }
 
+private sealed class RefundSubmissionPath {
+    data object Interac : RefundSubmissionPath()
+    data class Backend(val paymentMethodType: String?) : RefundSubmissionPath()
+}
+
 @Suppress("LongParameterList")
 class WooPosRefundSubmissionProcessorImpl @Inject constructor(
     private val refundStore: WCRefundStore,
@@ -67,18 +76,10 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
     private val resourceProvider: ResourceProvider,
     private val uiStringParser: UiStringParser,
 ) : WooPosRefundSubmissionProcessor {
-    @Suppress("LongMethod", "TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught")
     override fun submit(request: WooPosRefundSubmissionRequest): Flow<WooPosRefundSubmissionState> = channelFlow {
         try {
-            WooLog.i(
-                WooLog.T.POS,
-                "WooPosRefund: submission started " +
-                    "orderId=${request.orderId}, " +
-                    "amount=${request.refundAmount}, " +
-                    "itemCount=${request.refundItems.size}, " +
-                    "hasChargeId=${request.order.chargeId != null}, " +
-                    "backendOnlyRetry=${request.cardRefundAlreadySucceeded}"
-            )
+            logSubmissionStarted(request)
 
             if (request.cardRefundAlreadySucceeded) {
                 WooLog.i(
@@ -90,44 +91,22 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
                 return@channelFlow
             }
 
-            val chargeId = request.order.chargeId
-            val paymentMethodType = if (chargeId != null) {
-                when (val result = paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)) {
-                    PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Error -> {
-                        WooLog.w(
-                            WooLog.T.POS,
-                            "WooPosRefund: failed to fetch payment charge metadata; using backend refund path " +
-                                "orderId=${request.orderId}"
-                        )
-                        null
-                    }
-                    is PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success -> {
-                        WooLog.i(
-                            WooLog.T.POS,
-                            "WooPosRefund: fetched payment charge metadata " +
-                                "orderId=${request.orderId}, paymentMethodType=${result.paymentMethodType}"
-                        )
-                        result.paymentMethodType
-                    }
+            when (val submissionPath = resolveSubmissionPath(request)) {
+                RefundSubmissionPath.Interac -> {
+                    WooLog.i(
+                        WooLog.T.POS,
+                        "WooPosRefund: routing Interac refund through reader orderId=${request.orderId}"
+                    )
+                    submitInteracRefund(request)
                 }
-            } else {
-                WooLog.w(
-                    WooLog.T.POS,
-                    "WooPosRefund: order has no charge id; using backend refund path orderId=${request.orderId}"
-                )
-                null
-            }
-
-            if (paymentMethodType == INTERAC_PRESENT) {
-                WooLog.i(WooLog.T.POS, "WooPosRefund: routing Interac refund through reader orderId=${request.orderId}")
-                submitInteracRefund(request)
-            } else {
-                WooLog.i(
-                    WooLog.T.POS,
-                    "WooPosRefund: using backend refund path " +
-                        "orderId=${request.orderId}, paymentMethodType=$paymentMethodType"
-                )
-                notifyBackend(request, retryBackendNotificationOnly = false)
+                is RefundSubmissionPath.Backend -> {
+                    WooLog.i(
+                        WooLog.T.POS,
+                        "WooPosRefund: using backend refund path " +
+                            "orderId=${request.orderId}, paymentMethodType=${submissionPath.paymentMethodType}"
+                    )
+                    notifyBackend(request, retryBackendNotificationOnly = false)
+                }
             }
         } catch (exception: CancellationException) {
             throw exception
@@ -145,88 +124,76 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
         }
     }
 
-    @Suppress("LongMethod", "TooGenericExceptionCaught")
+    private fun logSubmissionStarted(request: WooPosRefundSubmissionRequest) {
+        WooLog.i(
+            WooLog.T.POS,
+            "WooPosRefund: submission started " +
+                "orderId=${request.orderId}, " +
+                "amount=${request.refundAmount}, " +
+                "itemCount=${request.refundItems.size}, " +
+                "hasChargeId=${request.order.chargeId != null}, " +
+                "backendOnlyRetry=${request.cardRefundAlreadySucceeded}"
+        )
+    }
+
+    private suspend fun resolveSubmissionPath(
+        request: WooPosRefundSubmissionRequest
+    ): RefundSubmissionPath {
+        val chargeId = request.order.chargeId ?: run {
+            WooLog.w(
+                WooLog.T.POS,
+                "WooPosRefund: order has no charge id; using backend refund path orderId=${request.orderId}"
+            )
+            return RefundSubmissionPath.Backend(paymentMethodType = null)
+        }
+
+        return when (val result = paymentChargeRepository.fetchCardDataUsedForOrderPayment(chargeId)) {
+            PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Error -> {
+                WooLog.w(
+                    WooLog.T.POS,
+                    "WooPosRefund: failed to fetch payment charge metadata; using backend refund path " +
+                        "orderId=${request.orderId}"
+                )
+                RefundSubmissionPath.Backend(paymentMethodType = null)
+            }
+            is PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success -> {
+                WooLog.i(
+                    WooLog.T.POS,
+                    "WooPosRefund: fetched payment charge metadata " +
+                        "orderId=${request.orderId}, paymentMethodType=${result.paymentMethodType}"
+                )
+                if (result.paymentMethodType == INTERAC_PRESENT) {
+                    RefundSubmissionPath.Interac
+                } else {
+                    RefundSubmissionPath.Backend(paymentMethodType = result.paymentMethodType)
+                }
+            }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun ProducerScope<WooPosRefundSubmissionState>.notifyBackend(
         request: WooPosRefundSubmissionRequest,
         retryBackendNotificationOnly: Boolean,
     ) {
         try {
-            trySendState(
-                if (retryBackendNotificationOnly) {
-                    WooPosRefundSubmissionState.NotifyingStore
-                } else {
-                    WooPosRefundSubmissionState.Processing
-                }
+            sendBackendNotificationStarted(retryBackendNotificationOnly)
+
+            val shouldAutoRefund = resolveShouldAutoRefund(
+                request = request,
+                retryBackendNotificationOnly = retryBackendNotificationOnly
+            ) ?: return
+
+            val result = createBackendRefund(
+                request = request,
+                shouldAutoRefund = shouldAutoRefund,
+                retryBackendNotificationOnly = retryBackendNotificationOnly
             )
-
-            val shouldAutoRefund = if (retryBackendNotificationOnly) {
-                false
-            } else {
-                val paymentGatewayResult = loadPaymentGateway(request.order)
-                if (paymentGatewayResult.isFailure) {
-                    WooLog.e(
-                        WooLog.T.POS,
-                        "WooPosRefund: failed to load payment gateway " +
-                            "orderId=${request.orderId}, backendOnlyRetry=false",
-                        paymentGatewayResult.exceptionOrNull()
-                    )
-                    trySendState(
-                        WooPosRefundSubmissionState.Failure(
-                            message = resourceProvider.getString(R.string.woopos_refund_error_gateway_not_found),
-                        )
-                    )
-                    return
-                }
-                paymentGatewayResult.getOrThrow().supportsRefunds
-            }
-
-            WooLog.i(
-                WooLog.T.POS,
-                "WooPosRefund: creating backend refund " +
-                    "orderId=${request.orderId}, " +
-                    "amount=${request.refundAmount}, " +
-                    "itemCount=${request.refundItems.size}, " +
-                    "autoRefund=$shouldAutoRefund, " +
-                    "backendOnlyRetry=$retryBackendNotificationOnly"
+            handleBackendRefundResult(
+                request = request,
+                result = result,
+                retryBackendNotificationOnly = retryBackendNotificationOnly
             )
-
-            val result = refundStore.createItemsRefund(
-                site = selectedSite.get(),
-                orderId = request.orderId,
-                amount = request.refundAmount,
-                reason = request.refundReason,
-                restockItems = true,
-                autoRefund = shouldAutoRefund,
-                items = request.refundItems
-            )
-
-            if (result.isError) {
-                val error = result.error
-                WooLog.e(
-                    WooLog.T.POS,
-                    "WooPosRefund: backend refund creation failed " +
-                        "orderId=${request.orderId}, " +
-                        "backendOnlyRetry=$retryBackendNotificationOnly, " +
-                        "type=${error.type}, " +
-                        "original=${error.original}, " +
-                        "apiErrorCode=${error.apiErrorCode}, " +
-                        "message=${error.message}, " +
-                        "errorData=${error.errorData}"
-                )
-                trySendState(
-                    WooPosRefundSubmissionState.Failure(
-                        message = result.error.message ?: resourceProvider.getString(R.string.error_generic),
-                        retryBackendNotificationOnly = retryBackendNotificationOnly,
-                    )
-                )
-            } else {
-                WooLog.i(
-                    WooLog.T.POS,
-                    "WooPosRefund: backend refund creation succeeded " +
-                        "orderId=${request.orderId}, backendOnlyRetry=$retryBackendNotificationOnly"
-                )
-                trySendState(WooPosRefundSubmissionState.Success)
-            }
         } catch (exception: CancellationException) {
             throw exception
         } catch (exception: Exception) {
@@ -245,10 +212,127 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
         }
     }
 
-    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    private fun ProducerScope<WooPosRefundSubmissionState>.sendBackendNotificationStarted(
+        retryBackendNotificationOnly: Boolean,
+    ) {
+        trySendState(
+            if (retryBackendNotificationOnly) {
+                WooPosRefundSubmissionState.NotifyingStore
+            } else {
+                WooPosRefundSubmissionState.Processing
+            }
+        )
+    }
+
+    private suspend fun ProducerScope<WooPosRefundSubmissionState>.resolveShouldAutoRefund(
+        request: WooPosRefundSubmissionRequest,
+        retryBackendNotificationOnly: Boolean,
+    ): Boolean? {
+        if (retryBackendNotificationOnly) {
+            return false
+        }
+
+        val paymentGatewayResult = loadPaymentGateway(request.order)
+        if (paymentGatewayResult.isFailure) {
+            WooLog.e(
+                WooLog.T.POS,
+                "WooPosRefund: failed to load payment gateway " +
+                    "orderId=${request.orderId}, backendOnlyRetry=false",
+                paymentGatewayResult.exceptionOrNull()
+            )
+            trySendState(
+                WooPosRefundSubmissionState.Failure(
+                    message = resourceProvider.getString(R.string.woopos_refund_error_gateway_not_found),
+                )
+            )
+            return null
+        }
+        return paymentGatewayResult.getOrThrow().supportsRefunds
+    }
+
+    private suspend fun createBackendRefund(
+        request: WooPosRefundSubmissionRequest,
+        shouldAutoRefund: Boolean,
+        retryBackendNotificationOnly: Boolean,
+    ): WooResult<WCRefundModel> {
+        WooLog.i(
+            WooLog.T.POS,
+            "WooPosRefund: creating backend refund " +
+                "orderId=${request.orderId}, " +
+                "amount=${request.refundAmount}, " +
+                "itemCount=${request.refundItems.size}, " +
+                "autoRefund=$shouldAutoRefund, " +
+                "backendOnlyRetry=$retryBackendNotificationOnly"
+        )
+
+        return refundStore.createItemsRefund(
+            site = selectedSite.get(),
+            orderId = request.orderId,
+            amount = request.refundAmount,
+            reason = request.refundReason,
+            restockItems = true,
+            autoRefund = shouldAutoRefund,
+            items = request.refundItems
+        )
+    }
+
+    private fun ProducerScope<WooPosRefundSubmissionState>.handleBackendRefundResult(
+        request: WooPosRefundSubmissionRequest,
+        result: WooResult<WCRefundModel>,
+        retryBackendNotificationOnly: Boolean,
+    ) {
+        if (result.isError) {
+            val error = result.error
+            WooLog.e(
+                WooLog.T.POS,
+                "WooPosRefund: backend refund creation failed " +
+                    "orderId=${request.orderId}, " +
+                    "backendOnlyRetry=$retryBackendNotificationOnly, " +
+                    "type=${error.type}, " +
+                    "original=${error.original}, " +
+                    "apiErrorCode=${error.apiErrorCode}, " +
+                    "message=${error.message}, " +
+                    "errorData=${error.errorData}"
+            )
+            trySendState(
+                WooPosRefundSubmissionState.Failure(
+                    message = result.error.message ?: resourceProvider.getString(R.string.error_generic),
+                    retryBackendNotificationOnly = retryBackendNotificationOnly,
+                )
+            )
+        } else {
+            WooLog.i(
+                WooLog.T.POS,
+                "WooPosRefund: backend refund creation succeeded " +
+                    "orderId=${request.orderId}, backendOnlyRetry=$retryBackendNotificationOnly"
+            )
+            trySendState(WooPosRefundSubmissionState.Success)
+        }
+    }
+
     private suspend fun ProducerScope<WooPosRefundSubmissionState>.submitInteracRefund(
         request: WooPosRefundSubmissionRequest,
     ) {
+        val controller = createInteracRefundController(request)
+        val refundSessionState = InteracRefundSessionState()
+        val stateJob = listenToInteracRefundState(request, controller, refundSessionState)
+        val eventJob = listenToInteracRefundEvents(request, controller, refundSessionState)
+
+        WooLog.i(WooLog.T.POS, "WooPosRefund: starting Interac reader refund orderId=${request.orderId}")
+        controller.start()
+
+        awaitClose {
+            WooLog.i(WooLog.T.POS, "WooPosRefund: closing Interac reader refund orderId=${request.orderId}")
+            stateJob.cancel()
+            eventJob.cancel()
+            refundSessionState.exitFallbackJob?.cancel()
+            controller.stop()
+        }
+    }
+
+    private fun createInteracRefundController(
+        request: WooPosRefundSubmissionRequest,
+    ): CardReaderPaymentController {
         val ttpPaymentProgress = object {
             var isInProgress = false
         }
@@ -256,12 +340,269 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
             WooLog.T.POS,
             "WooPosRefund: creating Interac reader refund controller orderId=${request.orderId}"
         )
-        val controller = cardReaderPaymentControllerFactory.createRefund(
+        return cardReaderPaymentControllerFactory.createRefund(
             orderId = request.orderId,
             refundAmount = request.refundAmount,
             cardReaderType = CardReaderType.EXTERNAL,
             isTTPPaymentInProgress = ttpPaymentProgress::isInProgress,
         )
+    }
+
+    private fun ProducerScope<WooPosRefundSubmissionState>.listenToInteracRefundState(
+        request: WooPosRefundSubmissionRequest,
+        controller: CardReaderPaymentController,
+        refundSessionState: InteracRefundSessionState,
+    ): Job {
+        return launch {
+            controller.paymentState.collect { state ->
+                handleInteracRefundState(request, state, refundSessionState)
+            }
+        }
+    }
+
+    private suspend fun ProducerScope<WooPosRefundSubmissionState>.handleInteracRefundState(
+        request: WooPosRefundSubmissionRequest,
+        state: CardReaderPaymentOrRefundState,
+        refundSessionState: InteracRefundSessionState,
+    ) {
+        when (state) {
+            is CardReaderInteracRefundState.LoadingData -> {
+                WooLog.i(WooLog.T.POS, "WooPosRefund: reader refund loading data orderId=${request.orderId}")
+                trySendState(WooPosRefundSubmissionState.PreparingReader)
+            }
+
+            is CardReaderInteracRefundState.CollectingInteracRefund -> {
+                WooLog.i(
+                    WooLog.T.POS,
+                    "WooPosRefund: reader refund collecting card " +
+                        "orderId=${request.orderId}, hint=${state.cardReaderHint}"
+                )
+                trySendState(WooPosRefundSubmissionState.WaitingForCard(state.cardReaderHint))
+            }
+
+            is CardReaderInteracRefundState.ProcessingInteracRefund -> {
+                WooLog.i(WooLog.T.POS, "WooPosRefund: reader refund processing orderId=${request.orderId}")
+                trySendState(WooPosRefundSubmissionState.ProcessingReaderRefund)
+            }
+
+            is CardReaderInteracRefundState.InteracRefundSuccessful -> {
+                handleSuccessfulInteracRefund(request, refundSessionState)
+            }
+
+            is CardReaderInteracRefundState.InteracRefundFailure -> {
+                handleFailedInteracRefund(request, state, refundSessionState)
+            }
+
+            is CardReaderPaymentState.LoadingData -> {
+                WooLog.i(
+                    WooLog.T.POS,
+                    "WooPosRefund: ignoring initial payment loading state for refund orderId=${request.orderId}"
+                )
+            }
+
+            is CardReaderPaymentState -> {
+                handleUnexpectedPaymentState(request, state, refundSessionState)
+            }
+        }
+    }
+
+    private suspend fun ProducerScope<WooPosRefundSubmissionState>.handleSuccessfulInteracRefund(
+        request: WooPosRefundSubmissionRequest,
+        refundSessionState: InteracRefundSessionState,
+    ) {
+        if (refundSessionState.terminalRefundSucceeded) {
+            return
+        }
+
+        WooLog.i(
+            WooLog.T.POS,
+            "WooPosRefund: reader refund succeeded; notifying backend orderId=${request.orderId}"
+        )
+        refundSessionState.terminalRefundSucceeded = true
+        notifyBackend(
+            request = request.copy(cardRefundAlreadySucceeded = true),
+            retryBackendNotificationOnly = true
+        )
+        refundSessionState.markTerminalStateSent()
+        close()
+    }
+
+    private fun ProducerScope<WooPosRefundSubmissionState>.handleFailedInteracRefund(
+        request: WooPosRefundSubmissionRequest,
+        state: CardReaderInteracRefundState.InteracRefundFailure,
+        refundSessionState: InteracRefundSessionState,
+    ) {
+        WooLog.e(
+            WooLog.T.POS,
+            "WooPosRefund: reader refund failed " +
+                "orderId=${request.orderId}, " +
+                "errorType=${state.errorType}, " +
+                "retryable=${state.onRetry != null}"
+        )
+        trySendState(
+            WooPosRefundSubmissionState.Failure(
+                message = uiStringParser.asString(state.errorType.message),
+                retryCardRefund = state.onRetry != null,
+                canRetry = state.onRetry != null,
+            )
+        )
+        refundSessionState.markTerminalStateSent()
+        close()
+    }
+
+    private fun ProducerScope<WooPosRefundSubmissionState>.handleUnexpectedPaymentState(
+        request: WooPosRefundSubmissionRequest,
+        state: CardReaderPaymentState,
+        refundSessionState: InteracRefundSessionState,
+    ) {
+        WooLog.e(
+            WooLog.T.POS,
+            "WooPosRefund: payment state emitted during refund " +
+                "orderId=${request.orderId}, state=${state::class.simpleName}"
+        )
+        trySendState(
+            WooPosRefundSubmissionState.Failure(
+                message = resourceProvider.getString(R.string.error_generic),
+            )
+        )
+        refundSessionState.markTerminalStateSent()
+        close()
+    }
+
+    private fun ProducerScope<WooPosRefundSubmissionState>.listenToInteracRefundEvents(
+        request: WooPosRefundSubmissionRequest,
+        controller: CardReaderPaymentController,
+        refundSessionState: InteracRefundSessionState,
+    ): Job {
+        return launch {
+            controller.event.collect { event ->
+                handleInteracRefundEvent(request, event, refundSessionState)
+            }
+        }
+    }
+
+    private fun ProducerScope<WooPosRefundSubmissionState>.handleInteracRefundEvent(
+        request: WooPosRefundSubmissionRequest,
+        event: CardReaderPaymentEvent,
+        refundSessionState: InteracRefundSessionState,
+    ) {
+        when (event) {
+            is CardReaderPaymentEvent.ShowErrorMessage -> {
+                handleReaderErrorEvent(request, event, refundSessionState)
+            }
+
+            is CardReaderPaymentEvent.ShowPaymentErrorMessage -> {
+                handleReaderPaymentErrorEvent(request, event, refundSessionState)
+            }
+
+            CardReaderPaymentEvent.Exit -> {
+                handleReaderExitEvent(request, refundSessionState)
+            }
+
+            CardReaderPaymentEvent.InteracRefundSuccessful,
+            CardReaderPaymentEvent.PlaySuccessfulPaymentSound,
+            is CardReaderPaymentEvent.ContactSupportTapped,
+            is CardReaderPaymentEvent.EnableNfcTapped,
+            is CardReaderPaymentEvent.PrintReceiptTapped,
+            is CardReaderPaymentEvent.PurchaseCardReaderTapped -> Unit
+        }
+    }
+
+    private fun ProducerScope<WooPosRefundSubmissionState>.handleReaderErrorEvent(
+        request: WooPosRefundSubmissionRequest,
+        event: CardReaderPaymentEvent.ShowErrorMessage,
+        refundSessionState: InteracRefundSessionState,
+    ) {
+        val message = resourceProvider.getString(event.message)
+        if (event.message == R.string.card_reader_payment_reader_not_connected) {
+            WooLog.i(
+                WooLog.T.POS,
+                "WooPosRefund: reader connection required for refund " +
+                    "orderId=${request.orderId}, messageRes=${event.message}, message=$message"
+            )
+            trySendState(WooPosRefundSubmissionState.ReaderConnectionRequired)
+        } else {
+            WooLog.e(
+                WooLog.T.POS,
+                "WooPosRefund: reader refund controller error event " +
+                    "orderId=${request.orderId}, messageRes=${event.message}, message=$message"
+            )
+            trySendState(
+                WooPosRefundSubmissionState.Failure(
+                    message = message,
+                )
+            )
+        }
+        refundSessionState.markTerminalStateSent()
+        close()
+    }
+
+    private fun ProducerScope<WooPosRefundSubmissionState>.handleReaderPaymentErrorEvent(
+        request: WooPosRefundSubmissionRequest,
+        event: CardReaderPaymentEvent.ShowPaymentErrorMessage,
+        refundSessionState: InteracRefundSessionState,
+    ) {
+        val message = resourceProvider.getString(event.message)
+        WooLog.e(
+            WooLog.T.POS,
+            "WooPosRefund: reader refund controller payment error event " +
+                "orderId=${request.orderId}, messageRes=${event.message}, message=$message"
+        )
+        trySendState(
+            WooPosRefundSubmissionState.Failure(
+                message = message,
+            )
+        )
+        refundSessionState.markTerminalStateSent()
+        close()
+    }
+
+    private fun ProducerScope<WooPosRefundSubmissionState>.handleReaderExitEvent(
+        request: WooPosRefundSubmissionRequest,
+        refundSessionState: InteracRefundSessionState,
+    ) {
+        if (refundSessionState.terminalStateSent || refundSessionState.terminalRefundSucceeded) {
+            WooLog.i(
+                WooLog.T.POS,
+                "WooPosRefund: reader refund controller exit event ignored orderId=${request.orderId}"
+            )
+            return
+        }
+
+        WooLog.i(
+            WooLog.T.POS,
+            "WooPosRefund: reader refund controller exit event received; " +
+                "waiting for paired error orderId=${request.orderId}"
+        )
+        refundSessionState.exitFallbackJob?.cancel()
+        refundSessionState.exitFallbackJob = launch {
+            delay(EXIT_EVENT_FALLBACK_DELAY_MS)
+            if (!refundSessionState.terminalStateSent && !refundSessionState.terminalRefundSucceeded) {
+                WooLog.w(
+                    WooLog.T.POS,
+                    "WooPosRefund: reader refund controller exited without terminal state " +
+                        "orderId=${request.orderId}"
+                )
+                refundSessionState.terminalStateSent = true
+                refundSessionState.exitFallbackJob = null
+                trySendState(
+                    WooPosRefundSubmissionState.Failure(
+                        message = resourceProvider.getString(R.string.error_generic),
+                        canRetry = false,
+                    )
+                )
+                close()
+            }
+        }
+    }
+
+    private fun ProducerScope<WooPosRefundSubmissionState>.trySendState(
+        state: WooPosRefundSubmissionState
+    ) {
+        trySend(state)
+    }
+
+    private class InteracRefundSessionState {
         var terminalRefundSucceeded = false
         var terminalStateSent = false
         var exitFallbackJob: Job? = null
@@ -271,194 +612,6 @@ class WooPosRefundSubmissionProcessorImpl @Inject constructor(
             exitFallbackJob?.cancel()
             exitFallbackJob = null
         }
-
-        val stateJob = launch {
-            controller.paymentState.collect { state ->
-                when (state) {
-                    is CardReaderInteracRefundState.LoadingData -> {
-                        WooLog.i(WooLog.T.POS, "WooPosRefund: reader refund loading data orderId=${request.orderId}")
-                        trySendState(WooPosRefundSubmissionState.PreparingReader)
-                    }
-
-                    is CardReaderInteracRefundState.CollectingInteracRefund -> {
-                        WooLog.i(
-                            WooLog.T.POS,
-                            "WooPosRefund: reader refund collecting card " +
-                                "orderId=${request.orderId}, hint=${state.cardReaderHint}"
-                        )
-                        trySendState(WooPosRefundSubmissionState.WaitingForCard(state.cardReaderHint))
-                    }
-
-                    is CardReaderInteracRefundState.ProcessingInteracRefund -> {
-                        WooLog.i(WooLog.T.POS, "WooPosRefund: reader refund processing orderId=${request.orderId}")
-                        trySendState(WooPosRefundSubmissionState.ProcessingReaderRefund)
-                    }
-
-                    is CardReaderInteracRefundState.InteracRefundSuccessful -> {
-                        if (!terminalRefundSucceeded) {
-                            WooLog.i(
-                                WooLog.T.POS,
-                                "WooPosRefund: reader refund succeeded; notifying backend orderId=${request.orderId}"
-                            )
-                            terminalRefundSucceeded = true
-                            notifyBackend(
-                                request = request.copy(cardRefundAlreadySucceeded = true),
-                                retryBackendNotificationOnly = true
-                            )
-                            markTerminalStateSent()
-                            close()
-                        }
-                    }
-
-                    is CardReaderInteracRefundState.InteracRefundFailure -> {
-                        WooLog.e(
-                            WooLog.T.POS,
-                            "WooPosRefund: reader refund failed " +
-                                "orderId=${request.orderId}, " +
-                                "errorType=${state.errorType}, " +
-                                "retryable=${state.onRetry != null}"
-                        )
-                        trySendState(
-                            WooPosRefundSubmissionState.Failure(
-                                message = uiStringParser.asString(state.errorType.message),
-                                retryCardRefund = state.onRetry != null,
-                                canRetry = state.onRetry != null,
-                            )
-                        )
-                        markTerminalStateSent()
-                        close()
-                    }
-
-                    is CardReaderPaymentState.LoadingData -> {
-                        WooLog.i(
-                            WooLog.T.POS,
-                            "WooPosRefund: ignoring initial payment loading state for refund orderId=${request.orderId}"
-                        )
-                    }
-
-                    is CardReaderPaymentState -> {
-                        WooLog.e(
-                            WooLog.T.POS,
-                            "WooPosRefund: payment state emitted during refund " +
-                                "orderId=${request.orderId}, state=${state::class.simpleName}"
-                        )
-                        trySendState(
-                            WooPosRefundSubmissionState.Failure(
-                                message = resourceProvider.getString(R.string.error_generic),
-                            )
-                        )
-                        markTerminalStateSent()
-                        close()
-                    }
-                }
-            }
-        }
-
-        val eventJob = launch {
-            controller.event.collect { event ->
-                when (event) {
-                    is CardReaderPaymentEvent.ShowErrorMessage -> {
-                        val message = resourceProvider.getString(event.message)
-                        if (event.message == R.string.card_reader_payment_reader_not_connected) {
-                            WooLog.i(
-                                WooLog.T.POS,
-                                "WooPosRefund: reader connection required for refund " +
-                                    "orderId=${request.orderId}, messageRes=${event.message}, message=$message"
-                            )
-                            trySendState(WooPosRefundSubmissionState.ReaderConnectionRequired)
-                        } else {
-                            WooLog.e(
-                                WooLog.T.POS,
-                                "WooPosRefund: reader refund controller error event " +
-                                    "orderId=${request.orderId}, messageRes=${event.message}, message=$message"
-                            )
-                            trySendState(
-                                WooPosRefundSubmissionState.Failure(
-                                    message = message,
-                                )
-                            )
-                        }
-                        markTerminalStateSent()
-                        close()
-                    }
-
-                    is CardReaderPaymentEvent.ShowPaymentErrorMessage -> {
-                        val message = resourceProvider.getString(event.message)
-                        WooLog.e(
-                            WooLog.T.POS,
-                            "WooPosRefund: reader refund controller payment error event " +
-                                "orderId=${request.orderId}, messageRes=${event.message}, message=$message"
-                        )
-                        trySendState(
-                            WooPosRefundSubmissionState.Failure(
-                                message = message,
-                            )
-                        )
-                        markTerminalStateSent()
-                        close()
-                    }
-
-                    CardReaderPaymentEvent.Exit -> {
-                        if (terminalStateSent || terminalRefundSucceeded) {
-                            WooLog.i(
-                                WooLog.T.POS,
-                                "WooPosRefund: reader refund controller exit event ignored orderId=${request.orderId}"
-                            )
-                            return@collect
-                        }
-                        WooLog.i(
-                            WooLog.T.POS,
-                            "WooPosRefund: reader refund controller exit event received; " +
-                                "waiting for paired error orderId=${request.orderId}"
-                        )
-                        exitFallbackJob?.cancel()
-                        exitFallbackJob = launch {
-                            delay(EXIT_EVENT_FALLBACK_DELAY_MS)
-                            if (!terminalStateSent && !terminalRefundSucceeded) {
-                                WooLog.w(
-                                    WooLog.T.POS,
-                                    "WooPosRefund: reader refund controller exited without terminal state " +
-                                        "orderId=${request.orderId}"
-                                )
-                                terminalStateSent = true
-                                exitFallbackJob = null
-                                trySendState(
-                                    WooPosRefundSubmissionState.Failure(
-                                        message = resourceProvider.getString(R.string.error_generic),
-                                        canRetry = false,
-                                    )
-                                )
-                                close()
-                            }
-                        }
-                    }
-
-                    CardReaderPaymentEvent.InteracRefundSuccessful,
-                    CardReaderPaymentEvent.PlaySuccessfulPaymentSound,
-                    is CardReaderPaymentEvent.ContactSupportTapped,
-                    is CardReaderPaymentEvent.EnableNfcTapped,
-                    is CardReaderPaymentEvent.PrintReceiptTapped,
-                    is CardReaderPaymentEvent.PurchaseCardReaderTapped -> Unit
-                }
-            }
-        }
-
-        WooLog.i(WooLog.T.POS, "WooPosRefund: starting Interac reader refund orderId=${request.orderId}")
-        controller.start()
-
-        awaitClose {
-            WooLog.i(WooLog.T.POS, "WooPosRefund: closing Interac reader refund orderId=${request.orderId}")
-            stateJob.cancel()
-            eventJob.cancel()
-            exitFallbackJob?.cancel()
-            controller.stop()
-        }
-    }
-
-    private fun ProducerScope<WooPosRefundSubmissionState>.trySendState(
-        state: WooPosRefundSubmissionState
-    ) {
-        trySend(state)
     }
 
     private companion object {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionRequest.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionRequest.kt
@@ -1,0 +1,15 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import com.woocommerce.android.model.Order
+import org.wordpress.android.fluxc.model.refunds.RefundRequestItem
+import java.math.BigDecimal
+
+data class WooPosRefundSubmissionRequest(
+    val order: Order,
+    val refundAmount: BigDecimal,
+    val refundReason: String,
+    val refundItems: List<RefundRequestItem>,
+    val cardRefundAlreadySucceeded: Boolean = false,
+) {
+    val orderId: Long = order.id
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionState.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionState.kt
@@ -1,0 +1,19 @@
+package com.woocommerce.android.ui.woopos.orders.details.refund
+
+import androidx.annotation.StringRes
+
+sealed class WooPosRefundSubmissionState {
+    data object Processing : WooPosRefundSubmissionState()
+    data object PreparingReader : WooPosRefundSubmissionState()
+    data object ReaderConnectionRequired : WooPosRefundSubmissionState()
+    data class WaitingForCard(@StringRes val cardReaderHint: Int? = null) : WooPosRefundSubmissionState()
+    data object ProcessingReaderRefund : WooPosRefundSubmissionState()
+    data object NotifyingStore : WooPosRefundSubmissionState()
+    data object Success : WooPosRefundSubmissionState()
+    data class Failure(
+        val message: String,
+        val retryBackendNotificationOnly: Boolean = false,
+        val retryCardRefund: Boolean = false,
+        val canRetry: Boolean = !retryBackendNotificationOnly,
+    ) : WooPosRefundSubmissionState()
+}

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundUIEvent.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundUIEvent.kt
@@ -13,5 +13,6 @@ sealed class WooPosRefundUIEvent {
     data object RefundFlowDismissed : WooPosRefundUIEvent()
     data object RetryLoadRefundableItems : WooPosRefundUIEvent()
     data object RetryCreateRefund : WooPosRefundUIEvent()
+    data object ConnectReaderClicked : WooPosRefundUIEvent()
     data object CancelRefund : WooPosRefundUIEvent()
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -63,7 +63,6 @@ class WooPosRefundViewModel @AssistedInject constructor(
     private var cachedTaxRoundAtSubtotal: Boolean? = null
     private var contentStateBeforeRefund: WooPosRefundState.Content? = null
     private var refundJob: Job? = null
-    private var backendNotificationRetryRequest: WooPosRefundSubmissionRequest? = null
     private var pendingReaderConnectionRefund: PendingReaderConnectionRefund? = null
 
     init {
@@ -229,11 +228,8 @@ class WooPosRefundViewModel @AssistedInject constructor(
             WooPosRefundUIEvent.RefundFlowDismissed -> handleRefundFlowDismissed()
             WooPosRefundUIEvent.RetryLoadRefundableItems -> loadRefundableItems()
             WooPosRefundUIEvent.RetryCreateRefund -> {
-                val retryRequest = backendNotificationRetryRequest
                 val contentState = contentStateBeforeRefund
-                if (retryRequest != null && contentState != null) {
-                    submitRefund(contentState, retryRequest)
-                } else if (contentState != null) {
+                if (contentState != null) {
                     processRefund(contentState)
                 } else {
                     WooLog.w(
@@ -388,7 +384,6 @@ class WooPosRefundViewModel @AssistedInject constructor(
             }
 
             contentStateBeforeRefund = contentState
-            backendNotificationRetryRequest = null
             _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.Processing)
 
             analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingStarted)
@@ -479,7 +474,6 @@ class WooPosRefundViewModel @AssistedInject constructor(
                     }
 
                     WooPosRefundSubmissionState.Success -> {
-                        backendNotificationRetryRequest = null
                         analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingSuccess)
                         val receiptSentMessage = request.order.billingAddress.email
                             .takeIf { it.isNotBlank() }
@@ -496,14 +490,6 @@ class WooPosRefundViewModel @AssistedInject constructor(
                     }
 
                     is WooPosRefundSubmissionState.Failure -> {
-                        backendNotificationRetryRequest = if (
-                            submissionState.retryBackendNotificationOnly &&
-                            submissionState.canRetry
-                        ) {
-                            request.copy(cardRefundAlreadySucceeded = true)
-                        } else {
-                            null
-                        }
                         analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingFailed)
                         _state.value = WooPosRefundState.Error(
                             message = submissionState.message,

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -427,7 +427,6 @@ class WooPosRefundViewModel @AssistedInject constructor(
         }
     }
 
-    @Suppress("LongMethod")
     private fun submitRefund(
         contentState: WooPosRefundState.Content,
         request: WooPosRefundSubmissionRequest,
@@ -435,71 +434,99 @@ class WooPosRefundViewModel @AssistedInject constructor(
         refundJob?.cancel()
         refundJob = viewModelScope.launch {
             refundSubmissionProcessor.submit(request).collect { submissionState ->
-                when (submissionState) {
-                    WooPosRefundSubmissionState.Processing -> {
-                        _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.Processing)
-                    }
-
-                    WooPosRefundSubmissionState.PreparingReader -> {
-                        _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.PreparingReader)
-                    }
-
-                    WooPosRefundSubmissionState.ReaderConnectionRequired -> {
-                        pendingReaderConnectionRefund = PendingReaderConnectionRefund(
-                            contentState = contentState,
-                            request = request,
-                        )
-                        _state.value = contentState.copy(
-                            step = WooPosRefundState.Content.RefundStep.ReaderDisconnected
-                        )
-                        resumePendingRefundIfReaderConnected()
-                    }
-
-                    is WooPosRefundSubmissionState.WaitingForCard -> {
-                        _state.value = contentState.copy(
-                            step = WooPosRefundState.Content.RefundStep.ReadyForRefund(
-                                submissionState.cardReaderHint
-                            )
-                        )
-                    }
-
-                    WooPosRefundSubmissionState.ProcessingReaderRefund -> {
-                        _state.value = contentState.copy(
-                            step = WooPosRefundState.Content.RefundStep.ProcessingRefund
-                        )
-                    }
-
-                    WooPosRefundSubmissionState.NotifyingStore -> {
-                        _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.NotifyingStore)
-                    }
-
-                    WooPosRefundSubmissionState.Success -> {
-                        analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingSuccess)
-                        val receiptSentMessage = request.order.billingAddress.email
-                            .takeIf { it.isNotBlank() }
-                            ?.let { email ->
-                                resourceProvider.getString(R.string.woopos_receipt_sent_to_customer, email)
-                            }
-                        _state.value = WooPosRefundState.RefundSuccess(
-                            orderId = contentState.orderId,
-                            orderNumber = contentState.orderNumber,
-                            refundedAmount = contentState.formattedTotal,
-                            paymentMethod = contentState.paymentMethod,
-                            receiptSentMessage = receiptSentMessage
-                        )
-                    }
-
-                    is WooPosRefundSubmissionState.Failure -> {
-                        analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingFailed)
-                        _state.value = WooPosRefundState.Error(
-                            message = submissionState.message,
-                            errorType = WooPosRefundState.Error.ErrorType.Processing,
-                            canRetry = submissionState.canRetry,
-                        )
-                    }
-                }
+                handleRefundSubmissionState(
+                    contentState = contentState,
+                    request = request,
+                    submissionState = submissionState,
+                )
             }
         }
+    }
+
+    private suspend fun handleRefundSubmissionState(
+        contentState: WooPosRefundState.Content,
+        request: WooPosRefundSubmissionRequest,
+        submissionState: WooPosRefundSubmissionState,
+    ) {
+        when (submissionState) {
+            WooPosRefundSubmissionState.Processing -> {
+                _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.Processing)
+            }
+
+            WooPosRefundSubmissionState.PreparingReader -> {
+                _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.PreparingReader)
+            }
+
+            WooPosRefundSubmissionState.ReaderConnectionRequired -> {
+                handleReaderConnectionRequired(contentState, request)
+            }
+
+            is WooPosRefundSubmissionState.WaitingForCard -> {
+                _state.value = contentState.copy(
+                    step = WooPosRefundState.Content.RefundStep.ReadyForRefund(
+                        submissionState.cardReaderHint
+                    )
+                )
+            }
+
+            WooPosRefundSubmissionState.ProcessingReaderRefund -> {
+                _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.ProcessingRefund)
+            }
+
+            WooPosRefundSubmissionState.NotifyingStore -> {
+                _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.NotifyingStore)
+            }
+
+            WooPosRefundSubmissionState.Success -> {
+                handleRefundSubmissionSuccess(contentState, request)
+            }
+
+            is WooPosRefundSubmissionState.Failure -> {
+                handleRefundSubmissionFailure(submissionState)
+            }
+        }
+    }
+
+    private fun handleReaderConnectionRequired(
+        contentState: WooPosRefundState.Content,
+        request: WooPosRefundSubmissionRequest,
+    ) {
+        pendingReaderConnectionRefund = PendingReaderConnectionRefund(
+            contentState = contentState,
+            request = request,
+        )
+        _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.ReaderDisconnected)
+        resumePendingRefundIfReaderConnected()
+    }
+
+    private suspend fun handleRefundSubmissionSuccess(
+        contentState: WooPosRefundState.Content,
+        request: WooPosRefundSubmissionRequest,
+    ) {
+        analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingSuccess)
+        val receiptSentMessage = request.order.billingAddress.email
+            .takeIf { it.isNotBlank() }
+            ?.let { email ->
+                resourceProvider.getString(R.string.woopos_receipt_sent_to_customer, email)
+            }
+        _state.value = WooPosRefundState.RefundSuccess(
+            orderId = contentState.orderId,
+            orderNumber = contentState.orderNumber,
+            refundedAmount = contentState.formattedTotal,
+            paymentMethod = contentState.paymentMethod,
+            receiptSentMessage = receiptSentMessage
+        )
+    }
+
+    private suspend fun handleRefundSubmissionFailure(
+        submissionState: WooPosRefundSubmissionState.Failure,
+    ) {
+        analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingFailed)
+        _state.value = WooPosRefundState.Error(
+            message = submissionState.message,
+            errorType = WooPosRefundState.Error.ErrorType.Processing,
+            canRetry = submissionState.canRetry,
+        )
     }
 
     private fun cancelRefundSubmission() {

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -3,9 +3,11 @@ package com.woocommerce.android.ui.woopos.orders.details.refund
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.connection.CardReaderStatus.Connected
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
 import com.woocommerce.android.ui.woopos.orders.WooPosGetPaymentMethod
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource
@@ -44,6 +46,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
     private val getPaymentMethod: WooPosGetPaymentMethod,
     private val refundSubmissionProcessor: WooPosRefundSubmissionProcessor,
     private val analyticsTracker: WooPosAnalyticsTracker,
+    private val cardReaderFacade: WooPosCardReaderFacade,
 ) : ViewModel() {
 
     @AssistedFactory
@@ -60,6 +63,12 @@ class WooPosRefundViewModel @AssistedInject constructor(
     private var cachedTaxRoundAtSubtotal: Boolean? = null
     private var contentStateBeforeRefund: WooPosRefundState.Content? = null
     private var refundJob: Job? = null
+    private var backendNotificationRetryRequest: WooPosRefundSubmissionRequest? = null
+    private var pendingReaderConnectionRefund: PendingReaderConnectionRefund? = null
+
+    init {
+        observeReaderConnectionForPendingRefund()
+    }
 
     private suspend fun fetchSiteSettings(): Result<Int> {
         val siteSettingsResult = wooCommerceStore.fetchSiteGeneralSettings(selectedSite.get())
@@ -220,8 +229,11 @@ class WooPosRefundViewModel @AssistedInject constructor(
             WooPosRefundUIEvent.RefundFlowDismissed -> handleRefundFlowDismissed()
             WooPosRefundUIEvent.RetryLoadRefundableItems -> loadRefundableItems()
             WooPosRefundUIEvent.RetryCreateRefund -> {
+                val retryRequest = backendNotificationRetryRequest
                 val contentState = contentStateBeforeRefund
-                if (contentState != null) {
+                if (retryRequest != null && contentState != null) {
+                    submitRefund(contentState, retryRequest)
+                } else if (contentState != null) {
                     processRefund(contentState)
                 } else {
                     WooLog.w(
@@ -247,7 +259,12 @@ class WooPosRefundViewModel @AssistedInject constructor(
                 WooPosRefundState.Content.RefundStep.SelectItems -> "select_items"
                 WooPosRefundState.Content.RefundStep.ReviewRefund -> "review_refund"
                 WooPosRefundState.Content.RefundStep.ConfirmRefund -> "confirm_refund"
-                WooPosRefundState.Content.RefundStep.Processing ->
+                WooPosRefundState.Content.RefundStep.PreparingReader -> "preparing_reader"
+                WooPosRefundState.Content.RefundStep.ReaderDisconnected -> "reader_disconnected"
+                is WooPosRefundState.Content.RefundStep.ReadyForRefund -> "ready_for_refund"
+                WooPosRefundState.Content.RefundStep.Processing,
+                WooPosRefundState.Content.RefundStep.ProcessingRefund,
+                WooPosRefundState.Content.RefundStep.NotifyingStore ->
                     error("Non-cancelable step should be unreachable in handleRefundFlowDismissed")
             }
 
@@ -280,6 +297,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
                 _state.value = currentState.copy(step = WooPosRefundState.Content.RefundStep.ConfirmRefund)
             WooPosRefundUIEvent.BackToReviewClicked ->
                 _state.value = currentState.copy(step = WooPosRefundState.Content.RefundStep.ReviewRefund)
+            WooPosRefundUIEvent.ConnectReaderClicked -> handleConnectReaderClicked()
             WooPosRefundUIEvent.OnRefundConfirmed -> {
                 trackConfirmRefundTapped(currentState)
                 processRefund(currentState)
@@ -290,6 +308,10 @@ class WooPosRefundViewModel @AssistedInject constructor(
             WooPosRefundUIEvent.RetryCreateRefund,
             WooPosRefundUIEvent.CancelRefund -> Unit
         }
+    }
+
+    private fun handleConnectReaderClicked() {
+        resumePendingRefundIfReaderConnected()
     }
 
     private fun trackConfirmRefundTapped(currentState: WooPosRefundState.Content) {
@@ -366,6 +388,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
             }
 
             contentStateBeforeRefund = contentState
+            backendNotificationRetryRequest = null
             _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.Processing)
 
             analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingStarted)
@@ -409,6 +432,7 @@ class WooPosRefundViewModel @AssistedInject constructor(
         }
     }
 
+    @Suppress("LongMethod")
     private fun submitRefund(
         contentState: WooPosRefundState.Content,
         request: WooPosRefundSubmissionRequest,
@@ -421,7 +445,41 @@ class WooPosRefundViewModel @AssistedInject constructor(
                         _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.Processing)
                     }
 
+                    WooPosRefundSubmissionState.PreparingReader -> {
+                        _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.PreparingReader)
+                    }
+
+                    WooPosRefundSubmissionState.ReaderConnectionRequired -> {
+                        pendingReaderConnectionRefund = PendingReaderConnectionRefund(
+                            contentState = contentState,
+                            request = request,
+                        )
+                        _state.value = contentState.copy(
+                            step = WooPosRefundState.Content.RefundStep.ReaderDisconnected
+                        )
+                        resumePendingRefundIfReaderConnected()
+                    }
+
+                    is WooPosRefundSubmissionState.WaitingForCard -> {
+                        _state.value = contentState.copy(
+                            step = WooPosRefundState.Content.RefundStep.ReadyForRefund(
+                                submissionState.cardReaderHint
+                            )
+                        )
+                    }
+
+                    WooPosRefundSubmissionState.ProcessingReaderRefund -> {
+                        _state.value = contentState.copy(
+                            step = WooPosRefundState.Content.RefundStep.ProcessingRefund
+                        )
+                    }
+
+                    WooPosRefundSubmissionState.NotifyingStore -> {
+                        _state.value = contentState.copy(step = WooPosRefundState.Content.RefundStep.NotifyingStore)
+                    }
+
                     WooPosRefundSubmissionState.Success -> {
+                        backendNotificationRetryRequest = null
                         analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingSuccess)
                         val receiptSentMessage = request.order.billingAddress.email
                             .takeIf { it.isNotBlank() }
@@ -438,10 +496,19 @@ class WooPosRefundViewModel @AssistedInject constructor(
                     }
 
                     is WooPosRefundSubmissionState.Failure -> {
+                        backendNotificationRetryRequest = if (
+                            submissionState.retryBackendNotificationOnly &&
+                            submissionState.canRetry
+                        ) {
+                            request.copy(cardRefundAlreadySucceeded = true)
+                        } else {
+                            null
+                        }
                         analyticsTracker.track(WooPosAnalyticsEvent.Event.RefundProcessingFailed)
                         _state.value = WooPosRefundState.Error(
                             message = submissionState.message,
-                            errorType = WooPosRefundState.Error.ErrorType.Processing
+                            errorType = WooPosRefundState.Error.ErrorType.Processing,
+                            canRetry = submissionState.canRetry,
                         )
                     }
                 }
@@ -452,14 +519,45 @@ class WooPosRefundViewModel @AssistedInject constructor(
     private fun cancelRefundSubmission() {
         refundJob?.cancel()
         refundJob = null
+        pendingReaderConnectionRefund = null
+    }
+
+    private fun observeReaderConnectionForPendingRefund() {
+        viewModelScope.launch {
+            cardReaderFacade.readerStatus.collect { readerStatus ->
+                if (readerStatus is Connected) {
+                    resumePendingRefundIfReaderConnected()
+                }
+            }
+        }
+    }
+
+    private fun resumePendingRefundIfReaderConnected() {
+        if (cardReaderFacade.readerStatus.value !is Connected) return
+        val pending = pendingReaderConnectionRefund ?: return
+        pendingReaderConnectionRefund = null
+        submitRefund(
+            contentState = pending.contentState,
+            request = pending.request,
+        )
     }
 
     private fun WooPosRefundState.Content.RefundStep.isNonCancelable(): Boolean {
         return when (this) {
-            WooPosRefundState.Content.RefundStep.Processing -> true
+            WooPosRefundState.Content.RefundStep.Processing,
+            WooPosRefundState.Content.RefundStep.ProcessingRefund,
+            WooPosRefundState.Content.RefundStep.NotifyingStore -> true
             WooPosRefundState.Content.RefundStep.SelectItems,
             WooPosRefundState.Content.RefundStep.ReviewRefund,
-            WooPosRefundState.Content.RefundStep.ConfirmRefund -> false
+            WooPosRefundState.Content.RefundStep.ConfirmRefund,
+            WooPosRefundState.Content.RefundStep.PreparingReader,
+            WooPosRefundState.Content.RefundStep.ReaderDisconnected,
+            is WooPosRefundState.Content.RefundStep.ReadyForRefund -> false
         }
     }
+
+    private data class PendingReaderConnectionRefund(
+        val contentState: WooPosRefundState.Content,
+        val request: WooPosRefundSubmissionRequest,
+    )
 }

--- a/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
+++ b/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModel.kt
@@ -542,20 +542,6 @@ class WooPosRefundViewModel @AssistedInject constructor(
         )
     }
 
-    private fun WooPosRefundState.Content.RefundStep.isNonCancelable(): Boolean {
-        return when (this) {
-            WooPosRefundState.Content.RefundStep.Processing,
-            WooPosRefundState.Content.RefundStep.ProcessingRefund,
-            WooPosRefundState.Content.RefundStep.NotifyingStore -> true
-            WooPosRefundState.Content.RefundStep.SelectItems,
-            WooPosRefundState.Content.RefundStep.ReviewRefund,
-            WooPosRefundState.Content.RefundStep.ConfirmRefund,
-            WooPosRefundState.Content.RefundStep.PreparingReader,
-            WooPosRefundState.Content.RefundStep.ReaderDisconnected,
-            is WooPosRefundState.Content.RefundStep.ReadyForRefund -> false
-        }
-    }
-
     private data class PendingReaderConnectionRefund(
         val contentState: WooPosRefundState.Content,
         val request: WooPosRefundSubmissionRequest,

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -123,7 +123,7 @@ class WooPosRefundSubmissionProcessorTest {
             )
         ).thenReturn(WooResult(refundModel))
 
-        processor = WooPosRefundSubmissionProcessorImpl(
+        processor = WooPosRefundSubmissionProcessor(
             refundStore = refundStore,
             selectedSite = selectedSite,
             paymentChargeRepository = paymentChargeRepository,
@@ -150,7 +150,7 @@ class WooPosRefundSubmissionProcessorTest {
             awaitComplete()
         }
 
-        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any(), any(), any())
+        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any())
         verify(refundStore).createItemsRefund(
             site = eq(site),
             orderId = eq(order.id),
@@ -203,31 +203,44 @@ class WooPosRefundSubmissionProcessorTest {
         }
 
     @Test
-    fun `given charge metadata lookup fails, when submitted, then backend refund is created directly`() = runTest {
+    fun `given charge metadata lookup fails, when submitted, then failure is emitted`() = runTest {
         whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
             PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Error
         )
 
         processor.submit(request).test {
-            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
-            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Success)
+            val failure = awaitItem() as WooPosRefundSubmissionState.Failure
+            assertThat(failure.message).isEqualTo("Something went wrong")
+            assertThat(failure.retryBackendNotificationOnly).isFalse()
+            assertThat(failure.canRetry).isTrue()
             awaitComplete()
         }
 
-        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any(), any(), any())
-        verify(refundStore).createItemsRefund(
-            site = eq(site),
-            orderId = eq(order.id),
-            amount = eq(refundAmount),
-            reason = eq("Customer request"),
-            restockItems = eq(true),
-            autoRefund = eq(true),
-            items = eq(refundItems)
-        )
+        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any())
+        verify(refundStore, never()).createItemsRefund(any(), any(), any(), any(), any(), any(), any())
     }
 
     @Test
-    fun `given selected site lookup fails during normal refund, when submitted, then exception is propagated`() = runTest {
+    fun `given card refund has no charge id, when submitted, then failure is emitted`() = runTest {
+        val requestWithoutChargeId = request.copy(
+            order = order.copy(chargeId = null, paymentMethod = "woocommerce_payments")
+        )
+
+        processor.submit(requestWithoutChargeId).test {
+            val failure = awaitItem() as WooPosRefundSubmissionState.Failure
+            assertThat(failure.message).isEqualTo("Something went wrong")
+            assertThat(failure.retryBackendNotificationOnly).isFalse()
+            assertThat(failure.canRetry).isTrue()
+            awaitComplete()
+        }
+
+        verify(paymentChargeRepository, never()).fetchCardDataUsedForOrderPayment(any())
+        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any())
+        verify(refundStore, never()).createItemsRefund(any(), any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `given selected site lookup fails during normal refund, when submitted, then failure is emitted`() = runTest {
         whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
             PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
                 cardBrand = "visa",
@@ -239,9 +252,11 @@ class WooPosRefundSubmissionProcessorTest {
 
         processor.submit(request).test {
             assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
-            assertThat(awaitError())
-                .isInstanceOf(IllegalStateException::class.java)
-                .hasMessage("missing site")
+            val failure = awaitItem() as WooPosRefundSubmissionState.Failure
+            assertThat(failure.message).isEqualTo("Something went wrong")
+            assertThat(failure.retryBackendNotificationOnly).isFalse()
+            assertThat(failure.canRetry).isTrue()
+            awaitComplete()
         }
     }
 
@@ -278,7 +293,7 @@ class WooPosRefundSubmissionProcessorTest {
                 paymentMethodType = INTERAC_PRESENT
             )
         )
-        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any()))
             .thenReturn(controller)
 
         processor.submit(request).test {
@@ -323,7 +338,7 @@ class WooPosRefundSubmissionProcessorTest {
                     paymentMethodType = INTERAC_PRESENT
                 )
             )
-            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any()))
                 .thenReturn(controller)
 
             processor.submit(request).test {
@@ -353,7 +368,7 @@ class WooPosRefundSubmissionProcessorTest {
                 paymentMethodType = INTERAC_PRESENT
             )
         )
-        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any()))
             .thenReturn(controller)
         whenever(
             refundStore.createItemsRefund(
@@ -402,7 +417,7 @@ class WooPosRefundSubmissionProcessorTest {
             awaitComplete()
         }
 
-        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any(), any(), any())
+        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any())
         verify(paymentChargeRepository, never()).fetchCardDataUsedForOrderPayment(any())
         verify(loadPaymentGateway, never()).invoke(any())
         verify(refundStore).createItemsRefund(
@@ -432,7 +447,7 @@ class WooPosRefundSubmissionProcessorTest {
             awaitComplete()
         }
 
-        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any(), any(), any())
+        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any())
         verify(paymentChargeRepository, never()).fetchCardDataUsedForOrderPayment(any())
         verify(loadPaymentGateway, never()).invoke(any())
     }
@@ -450,7 +465,7 @@ class WooPosRefundSubmissionProcessorTest {
                 paymentMethodType = INTERAC_PRESENT
             )
         )
-        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any()))
             .thenReturn(controller)
         whenever(uiStringParser.asString(InteracRefundFlowError.Generic.message)).thenReturn("Reader failed")
 
@@ -488,7 +503,7 @@ class WooPosRefundSubmissionProcessorTest {
                 paymentMethodType = INTERAC_PRESENT
             )
         )
-        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any()))
             .thenReturn(controller)
         whenever(uiStringParser.asString(InteracRefundFlowError.Generic.message)).thenReturn("Reader failed")
 
@@ -530,7 +545,7 @@ class WooPosRefundSubmissionProcessorTest {
                     paymentMethodType = INTERAC_PRESENT
                 )
             )
-            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any()))
                 .thenReturn(controller)
 
             processor.submit(request).test {
@@ -565,7 +580,7 @@ class WooPosRefundSubmissionProcessorTest {
                     paymentMethodType = INTERAC_PRESENT
                 )
             )
-            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any()))
                 .thenReturn(controller)
 
             processor.submit(request).test {
@@ -597,7 +612,7 @@ class WooPosRefundSubmissionProcessorTest {
                     paymentMethodType = INTERAC_PRESENT
                 )
             )
-            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any()))
                 .thenReturn(controller)
 
             processor.submit(request).test {

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -227,7 +227,7 @@ class WooPosRefundSubmissionProcessorTest {
     }
 
     @Test
-    fun `given selected site lookup fails, when submitted, then generic failure is emitted`() = runTest {
+    fun `given selected site lookup fails during normal refund, when submitted, then exception is propagated`() = runTest {
         whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
             PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
                 cardBrand = "visa",
@@ -239,10 +239,9 @@ class WooPosRefundSubmissionProcessorTest {
 
         processor.submit(request).test {
             assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
-            assertThat(awaitItem()).isEqualTo(
-                WooPosRefundSubmissionState.Failure("Something went wrong")
-            )
-            awaitComplete()
+            assertThat(awaitError())
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessage("missing site")
         }
     }
 
@@ -415,6 +414,27 @@ class WooPosRefundSubmissionProcessorTest {
             autoRefund = eq(false),
             items = eq(refundItems)
         )
+    }
+
+    @Test
+    fun `given backend-only notification throws, when submitted, then backend retry failure is emitted`() = runTest {
+        val retryRequest = request.copy(cardRefundAlreadySucceeded = true)
+        whenever(selectedSite.get()).thenThrow(IllegalStateException("missing site"))
+
+        processor.submit(retryRequest).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.NotifyingStore)
+
+            val failure = awaitItem() as WooPosRefundSubmissionState.Failure
+            assertThat(failure.message).isEqualTo("Something went wrong")
+            assertThat(failure.retryBackendNotificationOnly).isTrue()
+            assertThat(failure.retryCardRefund).isFalse()
+            assertThat(failure.canRetry).isFalse()
+            awaitComplete()
+        }
+
+        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any(), any(), any())
+        verify(paymentChargeRepository, never()).fetchCardDataUsedForOrderPayment(any())
+        verify(loadPaymentGateway, never()).invoke(any())
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -17,6 +17,7 @@ import com.woocommerce.android.ui.woopos.orders.WooPosLoadPaymentGateway
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
 import com.woocommerce.android.util.UiStringParser
 import com.woocommerce.android.viewmodel.ResourceProvider
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -202,6 +203,70 @@ class WooPosRefundSubmissionProcessorTest {
         }
 
     @Test
+    fun `given charge metadata lookup fails, when submitted, then backend refund is created directly`() = runTest {
+        whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+            PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Error
+        )
+
+        processor.submit(request).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Success)
+            awaitComplete()
+        }
+
+        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any(), any(), any())
+        verify(refundStore).createItemsRefund(
+            site = eq(site),
+            orderId = eq(order.id),
+            amount = eq(refundAmount),
+            reason = eq("Customer request"),
+            restockItems = eq(true),
+            autoRefund = eq(true),
+            items = eq(refundItems)
+        )
+    }
+
+    @Test
+    fun `given selected site lookup fails, when submitted, then generic failure is emitted`() = runTest {
+        whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+            PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                cardBrand = "visa",
+                cardLast4 = "1234",
+                paymentMethodType = CARD_PRESENT
+            )
+        )
+        whenever(selectedSite.get()).thenThrow(IllegalStateException("missing site"))
+
+        processor.submit(request).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+            assertThat(awaitItem()).isEqualTo(
+                WooPosRefundSubmissionState.Failure("Something went wrong")
+            )
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `given submission is cancelled, when submitted, then cancellation is rethrown`() = runTest {
+        val cancellation = CancellationException("cancelled")
+        whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+            PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                cardBrand = "visa",
+                cardLast4 = "1234",
+                paymentMethodType = CARD_PRESENT
+            )
+        )
+        whenever(selectedSite.get()).thenThrow(cancellation)
+
+        processor.submit(request).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+            assertThat(awaitError())
+                .isInstanceOf(CancellationException::class.java)
+                .hasMessage("cancelled")
+        }
+    }
+
+    @Test
     fun `given interac refund, when reader succeeds, then backend is notified once`() = runTest {
         val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
             CardReaderInteracRefundState.LoadingData {}
@@ -233,13 +298,14 @@ class WooPosRefundSubmissionProcessorTest {
         }
 
         verify(controller).start()
+        verify(loadPaymentGateway, never()).invoke(any())
         verify(refundStore).createItemsRefund(
             site = eq(site),
             orderId = eq(order.id),
             amount = eq(refundAmount),
             reason = eq("Customer request"),
             restockItems = eq(true),
-            autoRefund = eq(true),
+            autoRefund = eq(false),
             items = eq(refundItems)
         )
     }
@@ -323,10 +389,12 @@ class WooPosRefundSubmissionProcessorTest {
             assertThat(failure.canRetry).isFalse()
             awaitComplete()
         }
+
+        verify(loadPaymentGateway, never()).invoke(any())
     }
 
     @Test
-    fun `given backend-only retry request, when submitted, then card reader is not started`() = runTest {
+    fun `given backend-only notification request, when submitted, then card reader is not started`() = runTest {
         val retryRequest = request.copy(cardRefundAlreadySucceeded = true)
 
         processor.submit(retryRequest).test {
@@ -337,6 +405,16 @@ class WooPosRefundSubmissionProcessorTest {
 
         verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any(), any(), any())
         verify(paymentChargeRepository, never()).fetchCardDataUsedForOrderPayment(any())
+        verify(loadPaymentGateway, never()).invoke(any())
+        verify(refundStore).createItemsRefund(
+            site = eq(site),
+            orderId = eq(order.id),
+            amount = eq(refundAmount),
+            reason = eq("Customer request"),
+            restockItems = eq(true),
+            autoRefund = eq(false),
+            items = eq(refundItems)
+        )
     }
 
     @Test
@@ -370,6 +448,7 @@ class WooPosRefundSubmissionProcessorTest {
             assertThat(failure.message).isEqualTo("Reader failed")
             assertThat(failure.retryBackendNotificationOnly).isFalse()
             assertThat(failure.retryCardRefund).isTrue()
+            assertThat(failure.canRetry).isTrue()
             awaitComplete()
         }
 
@@ -377,17 +456,52 @@ class WooPosRefundSubmissionProcessorTest {
     }
 
     @Test
-    fun `given controller exit arrives before error event, when submitted, then failure is emitted without crashing`() =
+    fun `given non retryable interac reader failure, when submitted, then failure cannot retry card refund`() = runTest {
+        val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
+            CardReaderInteracRefundState.LoadingData {}
+        )
+        val controller = mockController(paymentState)
+        whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+            PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                cardBrand = "interac",
+                cardLast4 = "1234",
+                paymentMethodType = INTERAC_PRESENT
+            )
+        )
+        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+            .thenReturn(controller)
+        whenever(uiStringParser.asString(InteracRefundFlowError.Generic.message)).thenReturn("Reader failed")
+
+        processor.submit(request).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.PreparingReader)
+
+            paymentState.value = CardReaderInteracRefundState.InteracRefundFailure.Cancelable(
+                amountWithCurrencyLabel = "$22.00",
+                errorType = InteracRefundFlowError.Generic,
+                onRetry = null,
+                onCancel = {},
+            )
+
+            val failure = awaitItem() as WooPosRefundSubmissionState.Failure
+            assertThat(failure.message).isEqualTo("Reader failed")
+            assertThat(failure.retryBackendNotificationOnly).isFalse()
+            assertThat(failure.retryCardRefund).isFalse()
+            assertThat(failure.canRetry).isFalse()
+            awaitComplete()
+        }
+
+        verify(refundStore, never()).createItemsRefund(any(), any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `given controller exit arrives without error, when submitted, then non retryable failure is emitted`() =
         runTest {
             val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
-                CardReaderInteracRefundState.LoadingData {}
+                CardReaderPaymentState.LoadingData {}
             )
             val controller = mockController(
                 paymentState = paymentState,
-                eventFlow = flowOf(
-                    CardReaderPaymentEvent.Exit,
-                    CardReaderPaymentEvent.ShowErrorMessage(R.string.error_generic)
-                )
+                eventFlow = flowOf(CardReaderPaymentEvent.Exit)
             )
             whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
                 PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
@@ -400,16 +514,42 @@ class WooPosRefundSubmissionProcessorTest {
                 .thenReturn(controller)
 
             processor.submit(request).test {
-                val firstItem = awaitItem()
-                val failure = if (firstItem is WooPosRefundSubmissionState.Failure) {
-                    firstItem
-                } else {
-                    awaitItem() as WooPosRefundSubmissionState.Failure
-                }
-
+                advanceUntilIdle()
+                val failure = awaitItem() as WooPosRefundSubmissionState.Failure
                 assertThat(failure.message).isEqualTo("Something went wrong")
-                assertThat(failure.retryBackendNotificationOnly).isFalse()
-                assertThat(failure.retryCardRefund).isFalse()
+                assertThat(failure.canRetry).isFalse()
+                awaitComplete()
+            }
+        }
+
+    @Test
+    fun `given controller exit arrives before reader not connected error, when submitted, then reader connection is required`() =
+        runTest {
+            val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
+                CardReaderPaymentState.LoadingData {}
+            )
+            val controller = mockController(
+                paymentState = paymentState,
+                eventFlow = flowOf(
+                    CardReaderPaymentEvent.Exit,
+                    CardReaderPaymentEvent.ShowErrorMessage(R.string.card_reader_payment_reader_not_connected)
+                )
+            )
+            whenever(
+                resourceProvider.getString(R.string.card_reader_payment_reader_not_connected)
+            ).thenReturn("Please make sure that the card reader is connected.")
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = "interac",
+                    cardLast4 = "1234",
+                    paymentMethodType = INTERAC_PRESENT
+                )
+            )
+            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+                .thenReturn(controller)
+
+            processor.submit(request).test {
+                assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.ReaderConnectionRequired)
                 awaitComplete()
             }
         }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -5,11 +5,24 @@ import com.woocommerce.android.R
 import com.woocommerce.android.model.PaymentGateway
 import com.woocommerce.android.tools.SelectedSite
 import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.payments.cardreader.payment.InteracRefundFlowError
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentController
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentEvent
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderInteracRefundState
+import com.woocommerce.android.ui.payments.cardreader.payment.controller.CardReaderPaymentOrRefundState.CardReaderPaymentState
+import com.woocommerce.android.ui.payments.refunds.PaymentChargeRepository
+import com.woocommerce.android.ui.woopos.home.totals.WooPosCardReaderPaymentControllerFactory
 import com.woocommerce.android.ui.woopos.orders.WooPosLoadPaymentGateway
 import com.woocommerce.android.ui.woopos.util.WooPosCoroutineTestRule
+import com.woocommerce.android.util.UiStringParser
 import com.woocommerce.android.viewmodel.ResourceProvider
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -18,6 +31,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -39,8 +53,11 @@ class WooPosRefundSubmissionProcessorTest {
 
     private val refundStore: WCRefundStore = mock()
     private val selectedSite: SelectedSite = mock()
+    private val paymentChargeRepository: PaymentChargeRepository = mock()
     private val loadPaymentGateway: WooPosLoadPaymentGateway = mock()
+    private val cardReaderPaymentControllerFactory: WooPosCardReaderPaymentControllerFactory = mock()
     private val resourceProvider: ResourceProvider = mock()
+    private val uiStringParser: UiStringParser = mock()
 
     private val site = SiteModel().apply { id = 1 }
     private val refundAmount = BigDecimal("22.00")
@@ -52,7 +69,10 @@ class WooPosRefundSubmissionProcessorTest {
             refundTax = emptyList()
         )
     )
-    private val order = OrderTestUtils.generateTestOrder(orderId = 123L)
+    private val order = OrderTestUtils.generateTestOrder(orderId = 123L).copy(
+        chargeId = "ch_123",
+        currency = "CAD"
+    )
     private val request = WooPosRefundSubmissionRequest(
         order = order,
         refundAmount = refundAmount,
@@ -105,19 +125,31 @@ class WooPosRefundSubmissionProcessorTest {
         processor = WooPosRefundSubmissionProcessorImpl(
             refundStore = refundStore,
             selectedSite = selectedSite,
+            paymentChargeRepository = paymentChargeRepository,
             loadPaymentGateway = loadPaymentGateway,
+            cardReaderPaymentControllerFactory = cardReaderPaymentControllerFactory,
             resourceProvider = resourceProvider,
+            uiStringParser = uiStringParser
         )
     }
 
     @Test
-    fun `given refund request, when submitted, then backend refund is created`() = runTest {
+    fun `given card present refund, when submitted, then backend refund is created directly`() = runTest {
+        whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+            PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                cardBrand = "visa",
+                cardLast4 = "1234",
+                paymentMethodType = CARD_PRESENT
+            )
+        )
+
         processor.submit(request).test {
             assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
             assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Success)
             awaitComplete()
         }
 
+        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any(), any(), any())
         verify(refundStore).createItemsRefund(
             site = eq(site),
             orderId = eq(order.id),
@@ -132,6 +164,13 @@ class WooPosRefundSubmissionProcessorTest {
     @Test
     fun `given payment gateway does not support refunds, when submitted, then backend refund is created manually`() =
         runTest {
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = "visa",
+                    cardLast4 = "1234",
+                    paymentMethodType = CARD_PRESENT
+                )
+            )
             whenever(loadPaymentGateway.invoke(any())).thenReturn(
                 Result.success(
                     PaymentGateway(
@@ -163,42 +202,94 @@ class WooPosRefundSubmissionProcessorTest {
         }
 
     @Test
-    fun `given payment gateway load fails, when submitted, then failure is emitted`() = runTest {
-        whenever(loadPaymentGateway.invoke(any())).thenReturn(Result.failure(IllegalStateException("missing")))
-
-        processor.submit(request).test {
-            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
-            assertThat(awaitItem()).isEqualTo(
-                WooPosRefundSubmissionState.Failure("Unable to process refund.")
+    fun `given interac refund, when reader succeeds, then backend is notified once`() = runTest {
+        val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
+            CardReaderInteracRefundState.LoadingData {}
+        )
+        val controller = mockController(paymentState)
+        whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+            PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                cardBrand = "interac",
+                cardLast4 = "1234",
+                paymentMethodType = INTERAC_PRESENT
             )
-            awaitComplete()
-        }
-    }
-
-    @Test
-    fun `given selected site lookup fails, when submitted, then generic failure is emitted`() = runTest {
-        whenever(selectedSite.get()).thenThrow(IllegalStateException("missing site"))
+        )
+        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+            .thenReturn(controller)
 
         processor.submit(request).test {
-            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
-            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Failure("Something went wrong"))
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.PreparingReader)
+
+            paymentState.value = CardReaderInteracRefundState.CollectingInteracRefund("$22.00", {})
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.WaitingForCard())
+
+            paymentState.value = CardReaderInteracRefundState.ProcessingInteracRefund("$22.00")
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.ProcessingReaderRefund)
+
+            paymentState.value = CardReaderInteracRefundState.InteracRefundSuccessful("$22.00")
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.NotifyingStore)
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Success)
             awaitComplete()
         }
+
+        verify(controller).start()
+        verify(refundStore).createItemsRefund(
+            site = eq(site),
+            orderId = eq(order.id),
+            amount = eq(refundAmount),
+            reason = eq("Customer request"),
+            restockItems = eq(true),
+            autoRefund = eq(true),
+            items = eq(refundItems)
+        )
     }
 
     @Test
-    fun `given submission is cancelled, when submitted, then cancellation is rethrown`() = runTest {
-        val cancellation = CancellationException("cancelled")
-        whenever(selectedSite.get()).thenThrow(cancellation)
+    fun `given interac refund controller starts with payment loading state, when submitted, then state is ignored`() =
+        runTest {
+            val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
+                CardReaderPaymentState.LoadingData {}
+            )
+            val controller = mockController(paymentState)
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = "interac",
+                    cardLast4 = "1234",
+                    paymentMethodType = INTERAC_PRESENT
+                )
+            )
+            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+                .thenReturn(controller)
 
-        processor.submit(request).test {
-            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
-            assertThat(awaitError()).isSameAs(cancellation)
+            processor.submit(request).test {
+                advanceUntilIdle()
+                expectNoEvents()
+
+                paymentState.value = CardReaderInteracRefundState.LoadingData {}
+                assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.PreparingReader)
+
+                paymentState.value = CardReaderInteracRefundState.InteracRefundSuccessful("$22.00")
+                assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.NotifyingStore)
+                assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Success)
+                awaitComplete()
+            }
         }
-    }
 
     @Test
-    fun `given backend refund fails, when submitted, then failure message is emitted`() = runTest {
+    fun `given backend notification fails after interac success, when refund is submitted, then failure is backend retry only`() = runTest {
+        val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
+            CardReaderInteracRefundState.LoadingData {}
+        )
+        val controller = mockController(paymentState)
+        whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+            PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                cardBrand = "interac",
+                cardLast4 = "1234",
+                paymentMethodType = INTERAC_PRESENT
+            )
+        )
+        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+            .thenReturn(controller)
         whenever(
             refundStore.createItemsRefund(
                 site = any(),
@@ -211,18 +302,162 @@ class WooPosRefundSubmissionProcessorTest {
             )
         ).thenReturn(
             WooResult(
-                WooError(
+                error = WooError(
                     type = WooErrorType.GENERIC_ERROR,
                     original = GenericErrorType.UNKNOWN,
-                    message = "Refund failed"
+                    message = "Backend failed"
                 )
             )
         )
 
         processor.submit(request).test {
-            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
-            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Failure("Refund failed"))
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.PreparingReader)
+
+            paymentState.value = CardReaderInteracRefundState.InteracRefundSuccessful("$22.00")
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.NotifyingStore)
+
+            val failure = awaitItem() as WooPosRefundSubmissionState.Failure
+            assertThat(failure.message).isEqualTo("Backend failed")
+            assertThat(failure.retryBackendNotificationOnly).isTrue()
+            assertThat(failure.retryCardRefund).isFalse()
+            assertThat(failure.canRetry).isFalse()
             awaitComplete()
         }
+    }
+
+    @Test
+    fun `given backend-only retry request, when submitted, then card reader is not started`() = runTest {
+        val retryRequest = request.copy(cardRefundAlreadySucceeded = true)
+
+        processor.submit(retryRequest).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.NotifyingStore)
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Success)
+            awaitComplete()
+        }
+
+        verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any(), any(), any())
+        verify(paymentChargeRepository, never()).fetchCardDataUsedForOrderPayment(any())
+    }
+
+    @Test
+    fun `given interac reader failure, when submitted, then failure can retry card refund`() = runTest {
+        val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
+            CardReaderInteracRefundState.LoadingData {}
+        )
+        val controller = mockController(paymentState)
+        whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+            PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                cardBrand = "interac",
+                cardLast4 = "1234",
+                paymentMethodType = INTERAC_PRESENT
+            )
+        )
+        whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+            .thenReturn(controller)
+        whenever(uiStringParser.asString(InteracRefundFlowError.Generic.message)).thenReturn("Reader failed")
+
+        processor.submit(request).test {
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.PreparingReader)
+
+            paymentState.value = CardReaderInteracRefundState.InteracRefundFailure.Cancelable(
+                amountWithCurrencyLabel = "$22.00",
+                errorType = InteracRefundFlowError.Generic,
+                onRetry = {},
+                onCancel = {},
+            )
+
+            val failure = awaitItem() as WooPosRefundSubmissionState.Failure
+            assertThat(failure.message).isEqualTo("Reader failed")
+            assertThat(failure.retryBackendNotificationOnly).isFalse()
+            assertThat(failure.retryCardRefund).isTrue()
+            awaitComplete()
+        }
+
+        verify(refundStore, never()).createItemsRefund(any(), any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `given controller exit arrives before error event, when submitted, then failure is emitted without crashing`() =
+        runTest {
+            val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
+                CardReaderInteracRefundState.LoadingData {}
+            )
+            val controller = mockController(
+                paymentState = paymentState,
+                eventFlow = flowOf(
+                    CardReaderPaymentEvent.Exit,
+                    CardReaderPaymentEvent.ShowErrorMessage(R.string.error_generic)
+                )
+            )
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = "interac",
+                    cardLast4 = "1234",
+                    paymentMethodType = INTERAC_PRESENT
+                )
+            )
+            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+                .thenReturn(controller)
+
+            processor.submit(request).test {
+                val firstItem = awaitItem()
+                val failure = if (firstItem is WooPosRefundSubmissionState.Failure) {
+                    firstItem
+                } else {
+                    awaitItem() as WooPosRefundSubmissionState.Failure
+                }
+
+                assertThat(failure.message).isEqualTo("Something went wrong")
+                assertThat(failure.retryBackendNotificationOnly).isFalse()
+                assertThat(failure.retryCardRefund).isFalse()
+                awaitComplete()
+            }
+        }
+
+    @Test
+    fun `given reader is not connected for interac refund, when submitted, then reader connection is required`() =
+        runTest {
+            val paymentState = MutableStateFlow<CardReaderPaymentOrRefundState>(
+                CardReaderPaymentState.LoadingData {}
+            )
+            val controller = mockController(
+                paymentState = paymentState,
+                eventFlow = flowOf(
+                    CardReaderPaymentEvent.ShowErrorMessage(R.string.card_reader_payment_reader_not_connected),
+                    CardReaderPaymentEvent.Exit
+                )
+            )
+            whenever(
+                resourceProvider.getString(R.string.card_reader_payment_reader_not_connected)
+            ).thenReturn("Please make sure that the card reader is connected.")
+            whenever(paymentChargeRepository.fetchCardDataUsedForOrderPayment("ch_123")).thenReturn(
+                PaymentChargeRepository.CardDataUsedForOrderPaymentResult.Success(
+                    cardBrand = "interac",
+                    cardLast4 = "1234",
+                    paymentMethodType = INTERAC_PRESENT
+                )
+            )
+            whenever(cardReaderPaymentControllerFactory.createRefund(any(), any(), any(), any(), any()))
+                .thenReturn(controller)
+
+            processor.submit(request).test {
+                assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.ReaderConnectionRequired)
+                awaitComplete()
+            }
+        }
+
+    private fun mockController(
+        paymentState: MutableStateFlow<CardReaderPaymentOrRefundState>,
+        eventFlow: Flow<CardReaderPaymentEvent> = MutableSharedFlow()
+    ): CardReaderPaymentController {
+        return mock {
+            on { this.paymentState }.thenReturn(paymentState)
+            on { event }.thenReturn(eventFlow)
+        }
+    }
+
+    private companion object {
+        private const val INTERAC_PRESENT = "interac_present"
+        private const val CARD_PRESENT = "card_present"
     }
 }

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundSubmissionProcessorTest.kt
@@ -221,22 +221,28 @@ class WooPosRefundSubmissionProcessorTest {
     }
 
     @Test
-    fun `given card refund has no charge id, when submitted, then failure is emitted`() = runTest {
+    fun `given card refund has no charge id, when submitted, then backend refund is created`() = runTest {
         val requestWithoutChargeId = request.copy(
             order = order.copy(chargeId = null, paymentMethod = "woocommerce_payments")
         )
 
         processor.submit(requestWithoutChargeId).test {
-            val failure = awaitItem() as WooPosRefundSubmissionState.Failure
-            assertThat(failure.message).isEqualTo("Something went wrong")
-            assertThat(failure.retryBackendNotificationOnly).isFalse()
-            assertThat(failure.canRetry).isTrue()
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Processing)
+            assertThat(awaitItem()).isEqualTo(WooPosRefundSubmissionState.Success)
             awaitComplete()
         }
 
         verify(paymentChargeRepository, never()).fetchCardDataUsedForOrderPayment(any())
         verify(cardReaderPaymentControllerFactory, never()).createRefund(any(), any(), any())
-        verify(refundStore, never()).createItemsRefund(any(), any(), any(), any(), any(), any(), any())
+        verify(refundStore).createItemsRefund(
+            site = eq(site),
+            orderId = eq(order.id),
+            amount = eq(refundAmount),
+            reason = eq("Customer request"),
+            restockItems = eq(true),
+            autoRefund = eq(true),
+            items = eq(refundItems)
+        )
     }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -1,10 +1,12 @@
 package com.woocommerce.android.ui.woopos.orders.details.refund
 
 import com.woocommerce.android.R
+import com.woocommerce.android.cardreader.connection.CardReaderStatus
 import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.tools.SelectedSite
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.orders.OrderTestUtils
 import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
 import com.woocommerce.android.ui.woopos.orders.WooPosGetPaymentMethod
@@ -15,6 +17,7 @@ import com.woocommerce.android.ui.woopos.util.analytics.WooPosAnalyticsTracker
 import com.woocommerce.android.util.CurrencyFormatter
 import com.woocommerce.android.viewmodel.ResourceProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -26,6 +29,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
@@ -57,6 +61,8 @@ class WooPosRefundViewModelTest {
     private val analyticsTracker: WooPosAnalyticsTracker = mock()
     private val loadPaymentMethod: WooPosGetPaymentMethod = mock()
     private val refundSubmissionProcessor: WooPosRefundSubmissionProcessor = mock()
+    private val cardReaderFacade: WooPosCardReaderFacade = mock()
+    private val readerStatus = MutableStateFlow<CardReaderStatus>(CardReaderStatus.NotConnected())
 
     private val testOrderId = 123L
     private val testOrder = OrderTestUtils.generateTestOrder(orderId = testOrderId).copy(
@@ -122,6 +128,7 @@ class WooPosRefundViewModelTest {
         whenever(currencyFormatter.formatCurrency(any<BigDecimal>(), any<String>(), any<Boolean>())).thenReturn("$0.00")
         whenever(wooCommerceStore.fetchSiteGeneralSettings(testSite)).thenReturn(WooResult(testSettings))
         whenever(wooCommerceStore.fetchSiteSettingsTaxRoundAtSubtotal(testSite)).thenReturn(WooResult(false))
+        whenever(cardReaderFacade.readerStatus).thenReturn(readerStatus)
 
         whenever(loadPaymentMethod.invoke(any())).thenReturn(Result.success("Manual refund"))
         whenever(refundSubmissionProcessor.submit(any())).thenReturn(
@@ -147,7 +154,8 @@ class WooPosRefundViewModelTest {
             wooCommerceStore = wooCommerceStore,
             getPaymentMethod = loadPaymentMethod,
             refundSubmissionProcessor = refundSubmissionProcessor,
-            analyticsTracker = analyticsTracker
+            analyticsTracker = analyticsTracker,
+            cardReaderFacade = cardReaderFacade
         )
     }
 
@@ -755,6 +763,48 @@ class WooPosRefundViewModelTest {
             val successState = finalState as WooPosRefundState.RefundSuccess
             assertThat(successState.orderId).isEqualTo(testOrderId)
             assertThat(successState.orderNumber).isEqualTo("#456")
+        }
+
+    @Test
+    fun `given interac refund requires reader connection, when reader connects, then refund resumes`() =
+        runTest {
+            val refundableItems = listOf(testRefundableItem)
+            val groupedItems = listOf(
+                RefundRequestItem(
+                    itemId = 1L,
+                    quantity = 1,
+                    refundTotal = BigDecimal("20.00"),
+                    refundTax = emptyList()
+                )
+            )
+
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
+            whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
+            whenever(refundSubmissionProcessor.submit(any())).thenReturn(
+                flowOf(WooPosRefundSubmissionState.ReaderConnectionRequired),
+                flowOf(
+                    WooPosRefundSubmissionState.PreparingReader,
+                    WooPosRefundSubmissionState.Success
+                )
+            )
+
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+
+            viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
+            advanceUntilIdle()
+
+            val waitingState = viewModel.state.value as WooPosRefundState.Content
+            assertThat(waitingState.step).isEqualTo(WooPosRefundState.Content.RefundStep.ReaderDisconnected)
+
+            readerStatus.value = CardReaderStatus.Connected(mock())
+            advanceUntilIdle()
+
+            verify(refundSubmissionProcessor, times(2)).submit(any())
+            assertThat(viewModel.state.value).isInstanceOf(WooPosRefundState.RefundSuccess::class.java)
         }
 
     @Test
@@ -1675,6 +1725,48 @@ class WooPosRefundViewModelTest {
             advanceUntilIdle()
 
             verify(analyticsTracker).track(WooPosAnalyticsEvent.Event.RefundProcessingFailed)
+            val errorState = viewModel.state.value as WooPosRefundState.Error
+            assertThat(errorState.canRetry).isTrue()
+        }
+
+    @Test
+    fun `given backend notification fails after terminal refund succeeds, when API call completes, then error is not retryable`() =
+        runTest {
+            val refundableItems = listOf(testRefundableItem)
+            val groupedItems = listOf(
+                RefundRequestItem(
+                    itemId = 1L,
+                    quantity = 1,
+                    refundTotal = BigDecimal("20.00"),
+                    refundTax = emptyList()
+                )
+            )
+
+            whenever(ordersDataSource.refreshOrderById(testOrderId)).thenReturn(Result.success(testOrder))
+            whenever(retrieveOrderRefunds.invoke(eq(testOrder), any())).thenReturn(Result.success(emptyList()))
+            whenever(getRefundableItems.invoke(any(), any())).thenReturn(refundableItems)
+            whenever(groupRefundItems.invoke(eq(refundableItems), eq(testOrder), any())).thenReturn(groupedItems)
+            whenever(refundSubmissionProcessor.submit(any())).thenReturn(
+                flowOf(
+                    WooPosRefundSubmissionState.ProcessingReaderRefund,
+                    WooPosRefundSubmissionState.NotifyingStore,
+                    WooPosRefundSubmissionState.Failure(
+                        message = "Backend failed",
+                        retryBackendNotificationOnly = true,
+                    )
+                )
+            )
+
+            viewModel = createViewModel()
+            viewModel.onUIEvent(WooPosRefundUIEvent.RefundFlowOpened)
+            advanceUntilIdle()
+
+            viewModel.onUIEvent(WooPosRefundUIEvent.OnRefundConfirmed)
+            advanceUntilIdle()
+
+            val errorState = viewModel.state.value as WooPosRefundState.Error
+            assertThat(errorState.message).isEqualTo("Backend failed")
+            assertThat(errorState.canRetry).isFalse()
         }
 
     @Test

--- a/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
+++ b/WooCommerce/src/test/kotlin/com/woocommerce/android/ui/woopos/orders/details/refund/WooPosRefundViewModelTest.kt
@@ -6,8 +6,8 @@ import com.woocommerce.android.model.Address
 import com.woocommerce.android.model.Order
 import com.woocommerce.android.model.Refund
 import com.woocommerce.android.tools.SelectedSite
-import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.orders.OrderTestUtils
+import com.woocommerce.android.ui.woopos.cardreader.WooPosCardReaderFacade
 import com.woocommerce.android.ui.woopos.common.data.WooPosRetrieveOrderRefunds
 import com.woocommerce.android.ui.woopos.orders.WooPosGetPaymentMethod
 import com.woocommerce.android.ui.woopos.orders.WooPosOrdersDataSource


### PR DESCRIPTION
Part of: RSM-645

### Description
- Add a POS refund controller factory path that builds `PaymentOrRefund.Refund`.
- Detect `interac_present` charges and route those refunds through the card reader before backend notification.
- Keep `card_present` and manual refunds on the existing backend-only refund path.

### Stack
Previous PR: #15992
Base branch: issue/android-pos-interac-refunds-01-foundation
Next branch: issue/android-pos-interac-refunds-03-reader-ui

### Test Steps
- Unit tests pass.
- From the tip of the stack (#15996), refund an Interac-present POS payment and verify the card-reader refund runs before backend refund creation.
- Refund a non-Interac card-present POS payment and a manual/backend refund path, and verify they still submit directly through the existing backend refund flow.

### Images/gif
N/A. This PR routes refund submission logic but does not add the POS-native reader UI yet.

- [x] I have considered if this change warrants release notes and have added them to `RELEASE-NOTES.txt` if necessary. Use the "[Internal]" label for non-user-facing changes.
